### PR TITLE
remove compile flag for risc-v MCUs which is only valid for xtensa MCUs

### DIFF
--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -12,5 +12,5 @@ build_flags = env['BUILD_FLAGS']
 chip = env.get("BOARD_MCU").lower()
 
 if "c" in chip:
-  popped_item = build_flags.pop(build_flags.index("-mno-target-align"))
-  popped_item = build_flags.pop(build_flags.index("-mtarget-align"))
+  build_flags.pop(build_flags.index("-mno-target-align"))
+  build_flags.pop(build_flags.index("-mtarget-align"))

--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -8,21 +8,9 @@ env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declarat
 
 
 # Remove build flags which are not valid for risc-v
-build_flags = " ".join(env['BUILD_FLAGS'])
+build_flags = env['BUILD_FLAGS']
 chip = env.get("BOARD_MCU").lower()
 
-print("build_flags: ", build_flags)
-#print(env.Dump())
-
 if "c" in chip:
-  print("**************** risc-v *****************")
-  build_flags = build_flags.replace(" -mno-target-align", "")
-  build_flags = build_flags.replace(" -mtarget-align", "")
-
-new_buildflags = build_flags.split()
-print("build_flags: ", build_flags)
-
-
-env.Replace(
-  BUILD_FLAGS=new_buildflags
-)
+  popped_item = build_flags.pop(build_flags.index("-mno-target-align"))
+  popped_item = build_flags.pop(build_flags.index("-mtarget-align"))

--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -5,3 +5,24 @@ env.Append(CXXFLAGS=["-Wno-volatile"])
 
 # General options that are passed to the C compiler (C only; not C++).
 env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declaration", "-Wno-incompatible-pointer-types"])
+
+
+# Remove build flags which are not valid for risc-v
+build_flags = " ".join(env['BUILD_FLAGS'])
+chip = env.get("BOARD_MCU").lower()
+
+print("build_flags: ", build_flags)
+#print(env.Dump())
+
+if "c" in chip:
+  print("**************** risc-v *****************")
+  build_flags = build_flags.replace(" -mno-target-align", "")
+  build_flags = build_flags.replace(" -mtarget-align", "")
+
+new_buildflags = build_flags.split()
+print("build_flags: ", build_flags)
+
+
+env.Replace(
+  BUILD_FLAGS=new_buildflags
+)

--- a/pio-tools/strip-floats.py
+++ b/pio-tools/strip-floats.py
@@ -3,10 +3,6 @@ Import('env')
 link_flags = " ".join(env['LINKFLAGS'])
 build_flags = " ".join(env['BUILD_FLAGS'])
 
-print("---------------------------------------")
-
-print("build_flags: ", build_flags)
-
 #
 # Dump build environment (for debug)
 #print(env.Dump())

--- a/pio-tools/strip-floats.py
+++ b/pio-tools/strip-floats.py
@@ -1,21 +1,26 @@
 Import('env')
 
-build_flags = " ".join(env.GetProjectOption("build_flags"))
+link_flags = " ".join(env['LINKFLAGS'])
+build_flags = " ".join(env['BUILD_FLAGS'])
+
+print("---------------------------------------")
+
+print("build_flags: ", build_flags)
 
 #
 # Dump build environment (for debug)
-#print env.Dump()
+#print(env.Dump())
 #
 
-flags = " ".join(env['LINKFLAGS'])
-flags = flags.replace("-u _printf_float", "")
-flags = flags.replace("-u _scanf_float", "")
+link_flags = link_flags.replace("-u _printf_float", "")
+link_flags = link_flags.replace("-u _scanf_float", "")
 if "FIRMWARE_SAFEBOOT" in build_flags:
   # Crash Recorder is not included in safeboot firmware -> remove Linker wrap
-  flags = flags.replace("-Wl,--wrap=panicHandler", "")
-  flags = flags.replace("-Wl,--wrap=xt_unhandled_exception", "")
-newflags = flags.split()
+  link_flags = link_flags.replace("-Wl,--wrap=panicHandler", "")
+  link_flags = link_flags.replace("-Wl,--wrap=xt_unhandled_exception", "")
+
+new_link_flags = link_flags.split()
 
 env.Replace(
-  LINKFLAGS=newflags
+  LINKFLAGS=new_link_flags
 )

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -81,8 +81,6 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 [env:tasmota32c3-bluetooth]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-build_unflags               = ${env:tasmota32_base.build_unflags}
-                              -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
 ;                              -DUSE_EQ3_ESP32
@@ -111,8 +109,6 @@ lib_ignore                  = Micro-RTSP
 [env:tasmota32c3-mi32]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-build_unflags               = ${env:tasmota32_base.build_unflags}
-                              -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
@@ -133,8 +129,6 @@ lib_ignore                  = Micro-RTSP
 [env:tasmota32c6-mi32]
 extends                     = env:tasmota32_base
 board                       = esp32c6
-build_unflags               = ${env:tasmota32_base.build_unflags}
-                              -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -71,8 +71,6 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c2
 board_build.app_partition_name = safeboot
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2-safeboot.bin"'
@@ -83,8 +81,6 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c3
 board_build.app_partition_name = safeboot
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
@@ -95,8 +91,6 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c3ser
 board_build.app_partition_name = safeboot
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3ser-safeboot.bin"'
@@ -117,8 +111,6 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c6
 board_build.app_partition_name = safeboot
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6-safeboot.bin"'
@@ -129,8 +121,6 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c6ser
 board_build.app_partition_name = safeboot
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6ser-safeboot.bin"'
@@ -187,8 +177,6 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 [env:tasmota32c2]
 extends                 = env:tasmota32_base
 board                   = esp32c2
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
@@ -198,8 +186,6 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 [env:tasmota32c3]
 extends                 = env:tasmota32_base
 board                   = esp32c3
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
@@ -209,8 +195,6 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 [env:tasmota32c6]
 extends                 = env:tasmota32_base
 board                   = esp32c6
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6.bin"'


### PR DESCRIPTION
## Description:

simplify and less error prone setup for all MCUs.
Small refactor of `strip-floats.py`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
