### PR TITLE
Matter add copy to Path

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path_0.be
@@ -36,6 +36,14 @@ class Matter_Path
   var log                     # any string that needs to be logged (used to show significant parameters for commands)
   var msg                     # reference of the original message
 
+  # copy from an aobject that has also endpoint/cluster/attribute variables
+  def copy(c)
+    self.reset()
+    self.endpoint = c.endpoint
+    self.cluster = c.cluster
+    self.attribute = c.attribute
+  end
+
   # reset the object, allows reuse of the same object
   def reset()
     var n = nil         # it's actually more compact code to load `nil` into a register and assign all members

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
@@ -124,6 +124,44 @@ be_local_closure(class_Matter_Path_tostring,   /* name */
 
 
 /********************************************************************
+** Solidified function: copy
+********************************************************************/
+extern const bclass be_class_Matter_Path;
+be_local_closure(class_Matter_Path_copy,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Path, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(reset),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    }),
+    be_str_weak(copy),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080301,  //  0002  GETMBR	R2	R1	K1
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0x88080302,  //  0004  GETMBR	R2	R1	K2
+      0x90020402,  //  0005  SETMBR	R0	K2	R2
+      0x88080303,  //  0006  GETMBR	R2	R1	K3
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: reset
 ********************************************************************/
 extern const bclass be_class_Matter_Path;
@@ -172,18 +210,19 @@ be_local_closure(class_Matter_Path_reset,   /* name */
 be_local_class(Matter_Path,
     8,
     NULL,
-    be_nested_map(10,
+    be_nested_map(11,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(attribute, -1), be_const_var(2) },
-        { be_const_key_weak(log, 0), be_const_var(6) },
-        { be_const_key_weak(fabric_filtered, 6), be_const_var(3) },
         { be_const_key_weak(command, -1), be_const_var(4) },
-        { be_const_key_weak(msg, -1), be_const_var(7) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_Matter_Path_tostring_closure) },
+        { be_const_key_weak(cluster, 5), be_const_var(1) },
+        { be_const_key_weak(attribute, -1), be_const_var(2) },
+        { be_const_key_weak(tostring, 9), be_const_closure(class_Matter_Path_tostring_closure) },
+        { be_const_key_weak(log, -1), be_const_var(6) },
+        { be_const_key_weak(status, 2), be_const_var(5) },
+        { be_const_key_weak(endpoint, -1), be_const_var(0) },
+        { be_const_key_weak(msg, 6), be_const_var(7) },
+        { be_const_key_weak(fabric_filtered, -1), be_const_var(3) },
+        { be_const_key_weak(copy, -1), be_const_closure(class_Matter_Path_copy_closure) },
         { be_const_key_weak(reset, -1), be_const_closure(class_Matter_Path_reset_closure) },
-        { be_const_key_weak(cluster, -1), be_const_var(1) },
-        { be_const_key_weak(endpoint, 3), be_const_var(0) },
-        { be_const_key_weak(status, -1), be_const_var(5) },
     })),
     be_str_weak(Matter_Path)
 );


### PR DESCRIPTION
## Description:

Matter, prepare for forthcoming improvements, add `copy()` to `matter.Path()` to simplify creating a Path object from a TLV request.
No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
