### PR TITLE
Do not abort compile when safeboot firmware can not be downloaded

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -184,9 +184,13 @@ def esp32_fetch_safeboot_bin(tasmota_platform):
         return
     print("Will download safeboot binary from URL:")
     print(safeboot_fw_url)
-    response = requests.get(safeboot_fw_url)
-    open(safeboot_fw_name, "wb").write(response.content)
-    print("safeboot binary written to variants dir.")
+    try:
+        response = requests.get(safeboot_fw_url)
+        open(safeboot_fw_name, "wb").write(response.content)
+        print("safeboot binary written to variants dir.")
+    except:
+        print(Fore.RED + "Download of safeboot binary failed. Check your Internet connection.")
+        print(Fore.RED + "Creation of Tasmota" + tasmota_platform + "-factory.bin failed")
 
 def esp32_copy_new_safeboot_bin(tasmota_platform,new_local_safeboot_fw):
     print("Copy new local safeboot firmware to variants dir -> using it for further flashing operations")


### PR DESCRIPTION
## Description:

fixes #21682 

currently the compile process aborts ungracefully when safeboot firmware is not in place and can not be downloaded.
With the PR an colored info is printed and the compile process does not abort.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
