### PR TITLE
No Ethernet support for the C2

### DIFF
--- a/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
+++ b/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
@@ -75,7 +75,7 @@
 
 #if !defined(ESP_MAIL_DISABLE_NATIVE_ETHERNET)
 
-#if defined(ESP32) && __has_include(<ETH.h>)
+#if defined(ESP32) && __has_include(<"esp_eth_driver.h">)
 #include <ETH.h>
 #define ESP_MAIL_ETH_IS_AVAILABLE
 #elif defined(ESP8266) && defined(ESP8266_CORE_SDK_V3_X_X)

--- a/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
+++ b/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
@@ -75,7 +75,7 @@
 
 #if !defined(ESP_MAIL_DISABLE_NATIVE_ETHERNET)
 
-#if defined(ESP32) && __has_include(<"esp_eth_driver.h">)
+#if defined(ESP32) && __has_include(<esp_eth_driver.h>)
 #include <ETH.h>
 #define ESP_MAIL_ETH_IS_AVAILABLE
 #elif defined(ESP8266) && defined(ESP8266_CORE_SDK_V3_X_X)

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -825,5 +825,13 @@
 
 #endif // USE_MATTER_DEVICE
 
+/*********************************************************************************************\
+ * Post-process compile options for esp32-c2
+\*********************************************************************************************/
+
+#ifdef CONFIG_IDF_TARGET_ESP32C2
+  #undef USE_ETHERNET
+#endif  // CONFIG_IDF_TARGET_ESP32C2
+
 #endif  // ESP32
 #endif  // _TASMOTA_CONFIGURATIONS_ESP32_H_

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -18,7 +18,7 @@
 */
 
 #ifdef ESP32
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 
+#ifndef CONFIG_IDF_TARGET_ESP32C2
 #ifdef USE_ETHERNET
 /*********************************************************************************************\
  * Ethernet support for ESP32
@@ -445,5 +445,5 @@ bool Xdrv82(uint32_t function) {
 }
 
 #endif  // USE_ETHERNET
-#endif  // CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 
+#endif  // CONFIG_IDF_TARGET_ESP32C2
 #endif  // ESP32

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -18,7 +18,7 @@
 */
 
 #ifdef ESP32
-//#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 
 #ifdef USE_ETHERNET
 /*********************************************************************************************\
  * Ethernet support for ESP32
@@ -445,5 +445,5 @@ bool Xdrv82(uint32_t function) {
 }
 
 #endif  // USE_ETHERNET
-//#endif  // CONFIG_IDF_TARGET_ESP32
+#endif  // CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 
 #endif  // ESP32


### PR DESCRIPTION
## Description:

to lower "footprint".  Ethernet support for the C2 will be removed in the next Tasmota framework.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
