### PR TITLE
Berry `tasmota.rtc("config_time")`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [14.1.0.3]
 ### Added
 - ESP32 support for power and energy limit checks, like ``MaxEnergy2`` per phase (#21695)
+- Berry `tasmota.rtc("config_time")`
 
 ### Breaking Changed
 


### PR DESCRIPTION
## Description:

Berry add `tasmota.rtc("config_time")` that returns teh epoch time when the configuration was last saved. This is a rought estimate of the time, useful to have some credible timestamps before NTP got the new time.

This is used for example in TLS to check the time of the server certificate before NTP; or for Matter to have event timestamps before NTP.

The feature was actually mistakenly included in #21698

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
