### PR TITLE
Berry `FUNC_ANY_KEY` event calling `any_key()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 support for power and energy limit checks, like ``MaxEnergy2`` per phase (#21695)
 - Berry `tasmota.rtc("config_time")` (#21698)
 - Berry `math.min()` and `math.max()`
+- Berry `FUNC_ANY_KEY` event calling `any_key()`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -946,6 +946,28 @@ bool Xdrv52(uint32_t function)
     case FUNC_SET_DEVICE_POWER:
       result = callBerryEventDispatcher(PSTR("set_power_handler"), nullptr, XdrvMailbox.index, nullptr);
       break;
+    case FUNC_ANY_KEY:
+      // XdrvMailbox.payload = device_save << 24 | key << 16 | state << 8 | device;
+      // key 0 = KEY_BUTTON = button_topic
+      // key 1 = KEY_SWITCH = switch_topic
+      // state 0 = POWER_OFF = off
+      // state 1 = POWER_ON = on
+      // state 2 = POWER_TOGGLE = toggle
+      // state 3 = POWER_HOLD = hold
+      // state 4 = POWER_INCREMENT = button still pressed
+      // state 5 = POWER_INV = button released
+      // state 6 = POWER_CLEAR = button released
+      // state 7 = POWER_RELEASE = button released
+      // state 9 = CLEAR_RETAIN = clear retain flag
+      // state 10 = POWER_DELAYED = button released delayed
+      // Button Multipress
+      // state 10 = SINGLE
+      // state 11 = DOUBLE
+      // state 12 = TRIPLE
+      // state 13 = QUAD
+      // state 14 = PENTA
+      result = callBerryEventDispatcher("any_key", nullptr, XdrvMailbox.payload, nullptr);
+      break;
 #ifdef USE_WEBSERVER
     case FUNC_WEB_ADD_CONSOLE_BUTTON:
       if (XdrvMailbox.index) {


### PR DESCRIPTION
## Description:

Berry, add new event handler to drivers capturing `FUNC_ANY_KEY` event, and calling `any_key()` method of a driver.

This is used to react to real-time events from Buttons and Switches

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
