### PR TITLE
Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Berry `tasmota.rtc("config_time")` (#21698)
 - Berry `math.min()` and `math.max()` (#21705)
 - Berry `FUNC_ANY_KEY` event calling `any_key()` (#21708)
+- Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -946,6 +946,23 @@ bool Xdrv52(uint32_t function)
     case FUNC_SET_DEVICE_POWER:
       result = callBerryEventDispatcher(PSTR("set_power_handler"), nullptr, XdrvMailbox.index, nullptr);
       break;
+    case FUNC_BUTTON_PRESSED:
+      // XdrvMailbox.index = button_index;
+      // XdrvMailbox.payload = button;
+      // XdrvMailbox.command_code = Button.last_state[button_index];
+      if (XdrvMailbox.payload != XdrvMailbox.command_code) {    // fire event only when state changes
+        result = callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 
+                                              (XdrvMailbox.payload & 0xFF) << 16 | (XdrvMailbox.command_code & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
+                                              nullptr);
+      }
+      break;
+    case FUNC_BUTTON_MULTI_PRESSED:
+      // XdrvMailbox.index = button_index;
+      // XdrvMailbox.payload = Button.press_counter[button_index];
+      result = callBerryEventDispatcher(PSTR("button_multi_pressed"), nullptr, 
+                                             (XdrvMailbox.payload & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
+                                             nullptr);
+      break;
     case FUNC_ANY_KEY:
       // XdrvMailbox.payload = device_save << 24 | key << 16 | state << 8 | device;
       // key 0 = KEY_BUTTON = button_topic
@@ -1012,10 +1029,6 @@ bool Xdrv52(uint32_t function)
       break;
     case FUNC_AFTER_TELEPERIOD:
       callBerryEventDispatcher(PSTR("after_teleperiod"), nullptr, 0, nullptr);
-      break;
-
-    case FUNC_BUTTON_PRESSED:
-      callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 0, nullptr);
       break;
 
     case FUNC_ACTIVE:


### PR DESCRIPTION
## Description:

Berry, new event handler to drivers capturing `FUNC_BUTTON_MULTI_PRESSED` event, and calling `button_multi_pressed()` method of a driver.

Changed handling of `FUNC_BUTTON_PRESSED` to call the Berry driver only when the state of the button changed. Otherwise I realized that Berry was called at each tick once for each button, which makes a potentially high traffic in Berry.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
