### PR TITLE
Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes and once per second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Berry `tasmota.rtc("config_time")` (#21698)
 - Berry `math.min()` and `math.max()` (#21705)
 - Berry `FUNC_ANY_KEY` event calling `any_key()` (#21708)
-- Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes
+- Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes and once per second
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -947,13 +947,17 @@ bool Xdrv52(uint32_t function)
       result = callBerryEventDispatcher(PSTR("set_power_handler"), nullptr, XdrvMailbox.index, nullptr);
       break;
     case FUNC_BUTTON_PRESSED:
-      // XdrvMailbox.index = button_index;
-      // XdrvMailbox.payload = button;
-      // XdrvMailbox.command_code = Button.last_state[button_index];
-      if (XdrvMailbox.payload != XdrvMailbox.command_code) {    // fire event only when state changes
-        result = callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 
-                                              (XdrvMailbox.payload & 0xFF) << 16 | (XdrvMailbox.command_code & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
-                                              nullptr);
+      {
+        static uint32_t timer_last_button_sent = 0;
+        // XdrvMailbox.index = button_index;
+        // XdrvMailbox.payload = button;
+        // XdrvMailbox.command_code = Button.last_state[button_index];
+        if ((XdrvMailbox.payload != XdrvMailbox.command_code) || TimeReached(timer_last_button_sent)) {    // fire event only when state changes
+          timer_last_button_sent = millis() + 1000;     // wait for 1 second
+          result = callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 
+                                                (XdrvMailbox.payload & 0xFF) << 16 | (XdrvMailbox.command_code & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
+                                                nullptr);
+        }
       }
       break;
     case FUNC_BUTTON_MULTI_PRESSED:


### PR DESCRIPTION
## Description:

Change from #21709, now `button_pressed` from `FUNC_BUTTON_PRESSED` is called when the state changes, and at least once per second (instead of every tick, i.e. 20 times per second)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
