### PR TITLE
Berry `bytes.resize()` for large sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 TM1621 number overflow from "9999" to "12E3" (#21131)
 
 ### Fixed
+- Berry `bytes.resize()` for large sizes
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -223,7 +223,7 @@ static unsigned int decode_base64(unsigned char input[], unsigned char output[])
 // shrink or increase. If increase, fill with zeores. Cannot go beyond `size`
 static void buf_set_len(buf_impl* attr, const size_t len)
 {
-    uint16_t old_len = attr->len;
+    int32_t old_len = attr->len;
     attr->len = ((int32_t)len <= attr->size) ? (int32_t)len : attr->size;
     if (old_len < attr->len) {
         memset((void*) &attr->bufptr[old_len], 0, attr->len - old_len);

--- a/lib/libesp32/berry/src/be_filelib.c
+++ b/lib/libesp32/berry/src/be_filelib.c
@@ -79,15 +79,17 @@ static int i_readbytes(bvm *vm)
             be_call(vm, 2); /* call b.resize(size) */
             be_pop(vm, 3);  /* bytes() instance is at top */
 
-            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internam buffer of size 'size' */
-            size = be_fread(fh, buffer, size);
+            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internal buffer of size 'size' */
+            size_t read_size = be_fread(fh, buffer, size);
 
-            /* resize if something went wrong */
-            be_getmember(vm, -1, "resize");
-            be_pushvalue(vm, -2);
-            be_pushint(vm, size);
-            be_call(vm, 2); /* call b.resize(size) */
-            be_pop(vm, 3);  /* bytes() instance is at top */
+            if (size != read_size) {
+                /* resize if something went wrong */
+                be_getmember(vm, -1, "resize");
+                be_pushvalue(vm, -2);
+                be_pushint(vm, read_size);
+                be_call(vm, 2); /* call b.resize(size) */
+                be_pop(vm, 3);  /* bytes() instance is at top */
+            }
         } else {
             be_pushbytes(vm, NULL, 0);
         }


### PR DESCRIPTION
## Description:

Fix from upstream https://github.com/berry-lang/berry/pull/438

`bytes.resize()` would fail for size above 65535 bytes, due to wrong `uint16_t` variable.

This replaces #21657

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
