### PR TITLE
NeoPool add data validation and statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Berry `FUNC_ANY_KEY` event calling `any_key()` (#21708)
 - Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes and once per second (#21711)
 - Support for Sonoff POWCT Ring (#21131)
+- NeoPool add data validation and communication statistics (default enabled for ESP32 only)
 
 ### Breaking Changed
 


### PR DESCRIPTION
## Description:

Adds NeoPool data validation for some sensors and communication statistics (default enabled for ESP32, default disabled for ESP8266, to enable it on ESP8266 define `NEOPOOL_RANGE_CHECKS` and `NEOPOOL_CONNSTAT`).

### Data validation
The following controller measurements are checked against a min/max range, values outside the range are discarded:

- Ionization level [0..100] (%)
- Hydrolysis intensity level [0..x] (% or g/h), x is system-dependent
- pH level [0..14]
- Redox level [0..1000] (mV)
- Chlorine level [0..10.0] (ppm)
- Conductivity level [0..100] (%)
- Temperature sensor [0..65] (°C)

### Communication statistics

add the following stats to NeoPool SENSOR topic

```json
    "Connection": {
      "Time": "2024-07-03T15:00:00",
      "MBRequests": 36103,
      "MBNoError": 34888,
      "MBIllegalFunc": 0,
      "MBIllegalDataAddr": 0,
      "MBIllegalDataValue": 0,
      "MBSlaveError": 0,
      "MBAck": 0,
      "MBSlaveBusy": 0,
      "MBNotEnoughData": 0,
      "MBMemParityErr": 0,
      "MBCRCErr": 0,
      "MBGWPath": 0,
      "MBGWTarget": 0,
      "MBRegErr": 0,
      "MBRegData": 0,
      "MBTooManyReg": 0,
      "MBUnknownErr": 0,
      "MBNoResponse": 1215,
      "DataOutOfRange": 0
    }
```
- `MBRequests` is the total number of system request
- `MBNoError` is the total number of system responses without error
- `MBNoResponse` is the number of `MBRequests` having no repsonse
- `DataOutOfRange` is the total number of values outside the valid range
- All other `MB...` items are Modbus response errors (Modbus error 1..14)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
