### PR TITLE
Matter add ack in attribute response

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -74,7 +74,7 @@ class Matter_IM
     if   opcode == 0x01   # Status Response
       return self.process_status_response(msg, val)
     elif opcode == 0x02   # Read Request
-      # self.send_ack_now(msg)      # to improve latency, we don't automatically Ack on invoke request
+      self.send_ack_now(msg)
       return self.process_read_request_pull(msg, val)
     elif opcode == 0x03   # Subscribe Request
       self.send_ack_now(msg)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -220,6 +220,17 @@ class Matter_IM_ReportData_Pull : Matter_IM_Message
   end
 
   #################################################################################
+  # Status Report OK received for previous message, proceed to next (if any)
+  # return true if we manage the ack ourselves, false if it needs to be done upper
+  def status_ok_received(msg)
+    super(self).status_ok_received(msg)
+    if !self.finishing
+      msg.session._message_handler.send_encrypted_ack(msg, false #-not reliable-#)
+    end
+    return true
+  end
+
+  #################################################################################
   # set_subscription_id
   #
   # Sets the SubscriptionId of the exchange (to be used by subclasses)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -904,9 +904,9 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
     /* K11  */  be_nested_str_weak(parse),
     /* K12  */  be_const_int(1),
     /* K13  */  be_nested_str_weak(process_status_response),
-    /* K14  */  be_nested_str_weak(process_read_request_pull),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(send_ack_now),
+    /* K14  */  be_nested_str_weak(send_ack_now),
+    /* K15  */  be_nested_str_weak(process_read_request_pull),
+    /* K16  */  be_const_int(3),
     /* K17  */  be_nested_str_weak(subscribe_request),
     /* K18  */  be_nested_str_weak(process_write_request),
     /* K19  */  be_nested_str_weak(process_write_response),
@@ -915,7 +915,7 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[124]) {  /* code */
+    ( &(const binstruction[127]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0x1C0C0501,  //  0001  EQ	R3	R2	K1
       0x780E000D,  //  0002  JMPF	R3	#0011
@@ -962,84 +962,87 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
       0x5C1C0600,  //  002B  MOVE	R7	R3
       0x7C100600,  //  002C  CALL	R4	3
       0x80040800,  //  002D  RET	1	R4
-      0x7002004A,  //  002E  JMP		#007A
+      0x7002004D,  //  002E  JMP		#007D
       0x1C100501,  //  002F  EQ	R4	R2	K1
-      0x78120005,  //  0030  JMPF	R4	#0037
+      0x78120008,  //  0030  JMPF	R4	#003A
       0x8C10010E,  //  0031  GETMET	R4	R0	K14
       0x5C180200,  //  0032  MOVE	R6	R1
-      0x5C1C0600,  //  0033  MOVE	R7	R3
-      0x7C100600,  //  0034  CALL	R4	3
-      0x80040800,  //  0035  RET	1	R4
-      0x70020042,  //  0036  JMP		#007A
-      0x1C10050F,  //  0037  EQ	R4	R2	K15
-      0x78120008,  //  0038  JMPF	R4	#0042
-      0x8C100110,  //  0039  GETMET	R4	R0	K16
-      0x5C180200,  //  003A  MOVE	R6	R1
-      0x7C100400,  //  003B  CALL	R4	2
-      0x8C100111,  //  003C  GETMET	R4	R0	K17
+      0x7C100400,  //  0033  CALL	R4	2
+      0x8C10010F,  //  0034  GETMET	R4	R0	K15
+      0x5C180200,  //  0035  MOVE	R6	R1
+      0x5C1C0600,  //  0036  MOVE	R7	R3
+      0x7C100600,  //  0037  CALL	R4	3
+      0x80040800,  //  0038  RET	1	R4
+      0x70020042,  //  0039  JMP		#007D
+      0x1C100510,  //  003A  EQ	R4	R2	K16
+      0x78120008,  //  003B  JMPF	R4	#0045
+      0x8C10010E,  //  003C  GETMET	R4	R0	K14
       0x5C180200,  //  003D  MOVE	R6	R1
-      0x5C1C0600,  //  003E  MOVE	R7	R3
-      0x7C100600,  //  003F  CALL	R4	3
-      0x80040800,  //  0040  RET	1	R4
-      0x70020037,  //  0041  JMP		#007A
-      0x54120003,  //  0042  LDINT	R4	4
-      0x1C100404,  //  0043  EQ	R4	R2	R4
-      0x78120002,  //  0044  JMPF	R4	#0048
-      0x50100000,  //  0045  LDBOOL	R4	0	0
-      0x80040800,  //  0046  RET	1	R4
-      0x70020031,  //  0047  JMP		#007A
-      0x54120004,  //  0048  LDINT	R4	5
-      0x1C100404,  //  0049  EQ	R4	R2	R4
-      0x78120002,  //  004A  JMPF	R4	#004E
-      0x50100000,  //  004B  LDBOOL	R4	0	0
-      0x80040800,  //  004C  RET	1	R4
-      0x7002002B,  //  004D  JMP		#007A
-      0x54120005,  //  004E  LDINT	R4	6
-      0x1C100404,  //  004F  EQ	R4	R2	R4
-      0x78120008,  //  0050  JMPF	R4	#005A
-      0x8C100110,  //  0051  GETMET	R4	R0	K16
-      0x5C180200,  //  0052  MOVE	R6	R1
-      0x7C100400,  //  0053  CALL	R4	2
-      0x8C100112,  //  0054  GETMET	R4	R0	K18
+      0x7C100400,  //  003E  CALL	R4	2
+      0x8C100111,  //  003F  GETMET	R4	R0	K17
+      0x5C180200,  //  0040  MOVE	R6	R1
+      0x5C1C0600,  //  0041  MOVE	R7	R3
+      0x7C100600,  //  0042  CALL	R4	3
+      0x80040800,  //  0043  RET	1	R4
+      0x70020037,  //  0044  JMP		#007D
+      0x54120003,  //  0045  LDINT	R4	4
+      0x1C100404,  //  0046  EQ	R4	R2	R4
+      0x78120002,  //  0047  JMPF	R4	#004B
+      0x50100000,  //  0048  LDBOOL	R4	0	0
+      0x80040800,  //  0049  RET	1	R4
+      0x70020031,  //  004A  JMP		#007D
+      0x54120004,  //  004B  LDINT	R4	5
+      0x1C100404,  //  004C  EQ	R4	R2	R4
+      0x78120002,  //  004D  JMPF	R4	#0051
+      0x50100000,  //  004E  LDBOOL	R4	0	0
+      0x80040800,  //  004F  RET	1	R4
+      0x7002002B,  //  0050  JMP		#007D
+      0x54120005,  //  0051  LDINT	R4	6
+      0x1C100404,  //  0052  EQ	R4	R2	R4
+      0x78120008,  //  0053  JMPF	R4	#005D
+      0x8C10010E,  //  0054  GETMET	R4	R0	K14
       0x5C180200,  //  0055  MOVE	R6	R1
-      0x5C1C0600,  //  0056  MOVE	R7	R3
-      0x7C100600,  //  0057  CALL	R4	3
-      0x80040800,  //  0058  RET	1	R4
-      0x7002001F,  //  0059  JMP		#007A
-      0x54120006,  //  005A  LDINT	R4	7
-      0x1C100404,  //  005B  EQ	R4	R2	R4
-      0x78120005,  //  005C  JMPF	R4	#0063
-      0x8C100113,  //  005D  GETMET	R4	R0	K19
-      0x5C180200,  //  005E  MOVE	R6	R1
-      0x5C1C0600,  //  005F  MOVE	R7	R3
-      0x7C100600,  //  0060  CALL	R4	3
-      0x80040800,  //  0061  RET	1	R4
-      0x70020016,  //  0062  JMP		#007A
-      0x54120007,  //  0063  LDINT	R4	8
-      0x1C100404,  //  0064  EQ	R4	R2	R4
-      0x78120005,  //  0065  JMPF	R4	#006C
-      0x8C100114,  //  0066  GETMET	R4	R0	K20
-      0x5C180200,  //  0067  MOVE	R6	R1
-      0x5C1C0600,  //  0068  MOVE	R7	R3
-      0x7C100600,  //  0069  CALL	R4	3
-      0x80040800,  //  006A  RET	1	R4
-      0x7002000D,  //  006B  JMP		#007A
-      0x54120008,  //  006C  LDINT	R4	9
-      0x1C100404,  //  006D  EQ	R4	R2	R4
-      0x78120002,  //  006E  JMPF	R4	#0072
-      0x50100000,  //  006F  LDBOOL	R4	0	0
-      0x80040800,  //  0070  RET	1	R4
-      0x70020007,  //  0071  JMP		#007A
-      0x54120009,  //  0072  LDINT	R4	10
-      0x1C100404,  //  0073  EQ	R4	R2	R4
-      0x78120004,  //  0074  JMPF	R4	#007A
-      0x8C100115,  //  0075  GETMET	R4	R0	K21
-      0x5C180200,  //  0076  MOVE	R6	R1
-      0x5C1C0600,  //  0077  MOVE	R7	R3
-      0x7C100600,  //  0078  CALL	R4	3
-      0x80040800,  //  0079  RET	1	R4
-      0x50100000,  //  007A  LDBOOL	R4	0	0
-      0x80040800,  //  007B  RET	1	R4
+      0x7C100400,  //  0056  CALL	R4	2
+      0x8C100112,  //  0057  GETMET	R4	R0	K18
+      0x5C180200,  //  0058  MOVE	R6	R1
+      0x5C1C0600,  //  0059  MOVE	R7	R3
+      0x7C100600,  //  005A  CALL	R4	3
+      0x80040800,  //  005B  RET	1	R4
+      0x7002001F,  //  005C  JMP		#007D
+      0x54120006,  //  005D  LDINT	R4	7
+      0x1C100404,  //  005E  EQ	R4	R2	R4
+      0x78120005,  //  005F  JMPF	R4	#0066
+      0x8C100113,  //  0060  GETMET	R4	R0	K19
+      0x5C180200,  //  0061  MOVE	R6	R1
+      0x5C1C0600,  //  0062  MOVE	R7	R3
+      0x7C100600,  //  0063  CALL	R4	3
+      0x80040800,  //  0064  RET	1	R4
+      0x70020016,  //  0065  JMP		#007D
+      0x54120007,  //  0066  LDINT	R4	8
+      0x1C100404,  //  0067  EQ	R4	R2	R4
+      0x78120005,  //  0068  JMPF	R4	#006F
+      0x8C100114,  //  0069  GETMET	R4	R0	K20
+      0x5C180200,  //  006A  MOVE	R6	R1
+      0x5C1C0600,  //  006B  MOVE	R7	R3
+      0x7C100600,  //  006C  CALL	R4	3
+      0x80040800,  //  006D  RET	1	R4
+      0x7002000D,  //  006E  JMP		#007D
+      0x54120008,  //  006F  LDINT	R4	9
+      0x1C100404,  //  0070  EQ	R4	R2	R4
+      0x78120002,  //  0071  JMPF	R4	#0075
+      0x50100000,  //  0072  LDBOOL	R4	0	0
+      0x80040800,  //  0073  RET	1	R4
+      0x70020007,  //  0074  JMP		#007D
+      0x54120009,  //  0075  LDINT	R4	10
+      0x1C100404,  //  0076  EQ	R4	R2	R4
+      0x78120004,  //  0077  JMPF	R4	#007D
+      0x8C100115,  //  0078  GETMET	R4	R0	K21
+      0x5C180200,  //  0079  MOVE	R6	R1
+      0x5C1C0600,  //  007A  MOVE	R7	R3
+      0x7C100600,  //  007B  CALL	R4	3
+      0x80040800,  //  007C  RET	1	R4
+      0x50100000,  //  007D  LDBOOL	R4	0	0
+      0x80040800,  //  007E  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -554,73 +554,6 @@ be_local_class(Matter_IM_WriteResponse,
 extern const bclass be_class_Matter_IM_ReportData_Pull;
 
 /********************************************************************
-** Solidified function: set_subscription_id
-********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
-be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subscription_id),
-    }),
-    be_str_weak(set_subscription_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
-be_local_closure(class_Matter_IM_ReportData_Pull_init,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(generator_or_arr),
-    /* K2   */  be_nested_str_weak(event_generator_or_arr),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x541E0004,  //  0005  LDINT	R7	5
-      0x50200200,  //  0006  LDBOOL	R8	1	0
-      0x7C100800,  //  0007  CALL	R4	4
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x90020403,  //  0009  SETMBR	R0	K2	R3
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
 extern const bclass be_class_Matter_IM_ReportData_Pull;
@@ -1004,6 +937,80 @@ be_local_closure(class_Matter_IM_ReportData_Pull_send_im,   /* name */
 
 
 /********************************************************************
+** Solidified function: status_ok_received
+********************************************************************/
+extern const bclass be_class_Matter_IM_ReportData_Pull;
+be_local_closure(class_Matter_IM_ReportData_Pull_status_ok_received,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM_ReportData_Pull, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(status_ok_received),
+    /* K1   */  be_nested_str_weak(finishing),
+    /* K2   */  be_nested_str_weak(session),
+    /* K3   */  be_nested_str_weak(_message_handler),
+    /* K4   */  be_nested_str_weak(send_encrypted_ack),
+    }),
+    be_str_weak(status_ok_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x740A0005,  //  0007  JMPT	R2	#000E
+      0x88080302,  //  0008  GETMBR	R2	R1	K2
+      0x88080503,  //  0009  GETMBR	R2	R2	K3
+      0x8C080504,  //  000A  GETMET	R2	R2	K4
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x50140000,  //  000C  LDBOOL	R5	0	0
+      0x7C080600,  //  000D  CALL	R2	3
+      0x50080200,  //  000E  LDBOOL	R2	1	0
+      0x80040400,  //  000F  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_subscription_id
+********************************************************************/
+extern const bclass be_class_Matter_IM_ReportData_Pull;
+be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM_ReportData_Pull, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subscription_id),
+    }),
+    be_str_weak(set_subscription_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: set_suppress_response
 ********************************************************************/
 extern const bclass be_class_Matter_IM_ReportData_Pull;
@@ -1032,24 +1039,64 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_suppress_response,   /* nam
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_IM_ReportData_Pull;
+be_local_closure(class_Matter_IM_ReportData_Pull_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM_ReportData_Pull, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(generator_or_arr),
+    /* K2   */  be_nested_str_weak(event_generator_or_arr),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x541E0004,  //  0005  LDINT	R7	5
+      0x50200200,  //  0006  LDBOOL	R8	1	0
+      0x7C100800,  //  0007  CALL	R4	4
+      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x90020403,  //  0009  SETMBR	R0	K2	R3
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_IM_ReportData_Pull
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message;
 be_local_class(Matter_IM_ReportData_Pull,
     5,
     &be_class_Matter_IM_Message,
-    be_nested_map(10,
+    be_nested_map(11,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(set_suppress_response, 2), be_const_closure(class_Matter_IM_ReportData_Pull_set_suppress_response_closure) },
-        { be_const_key_weak(data_ev, -1), be_const_var(4) },
-        { be_const_key_weak(event_generator_or_arr, -1), be_const_var(1) },
-        { be_const_key_weak(MAX_MESSAGE, -1), be_const_int(1200) },
-        { be_const_key_weak(subscription_id, -1), be_const_var(2) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_IM_ReportData_Pull_init_closure) },
-        { be_const_key_weak(generator_or_arr, 9), be_const_var(0) },
-        { be_const_key_weak(set_subscription_id, 0), be_const_closure(class_Matter_IM_ReportData_Pull_set_subscription_id_closure) },
         { be_const_key_weak(send_im, -1), be_const_closure(class_Matter_IM_ReportData_Pull_send_im_closure) },
-        { be_const_key_weak(suppress_response, -1), be_const_var(3) },
+        { be_const_key_weak(status_ok_received, -1), be_const_closure(class_Matter_IM_ReportData_Pull_status_ok_received_closure) },
+        { be_const_key_weak(data_ev, -1), be_const_var(4) },
+        { be_const_key_weak(suppress_response, 8), be_const_var(3) },
+        { be_const_key_weak(MAX_MESSAGE, -1), be_const_int(1200) },
+        { be_const_key_weak(set_suppress_response, -1), be_const_closure(class_Matter_IM_ReportData_Pull_set_suppress_response_closure) },
+        { be_const_key_weak(set_subscription_id, -1), be_const_closure(class_Matter_IM_ReportData_Pull_set_subscription_id_closure) },
+        { be_const_key_weak(generator_or_arr, 5), be_const_var(0) },
+        { be_const_key_weak(event_generator_or_arr, 4), be_const_var(1) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_IM_ReportData_Pull_init_closure) },
+        { be_const_key_weak(subscription_id, -1), be_const_var(2) },
     })),
     be_str_weak(Matter_IM_ReportData_Pull)
 );


### PR DESCRIPTION
## Description:

Now that read requests for multiple attributes are lazily evaluated, the time between responses can exceed the retry time from the sender and cause multiple retries of packets that were not acked quickly enough.

This PR adds fast Ack to interleaved with attribute responses, and reduces the amount of duplicate packets from controller.

No functional impact nor performance impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
