### PR TITLE
make Tasmota compatible for Arduino espressif32 based on IDF 5.2.2

### DIFF
--- a/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
+++ b/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
@@ -152,7 +152,7 @@ void TasmotaSerial::setTransmitEnablePin(int tx_enable_pin) {
 bool TasmotaSerial::freeUart(void) {
   for (uint32_t i = SOC_UART_NUM -1; i >= 0; i--) {
     if (0 == bitRead(tasmota_serial_uart_bitmap, i)) {
-      m_uart = i;
+      m_uart = uart_port_t(i);
       bitSet(tasmota_serial_uart_bitmap, m_uart);
       return true;
     }

--- a/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.h
+++ b/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.h
@@ -109,7 +109,7 @@ class TasmotaSerial : public Stream {
     uint32_t m_speed;
     uint32_t m_config;
     HardwareSerial *TSerial;
-    int m_uart = 0;
+    uart_port_t m_uart = uart_port_t(0);
 #endif
 
 };

--- a/lib/lib_div/ArduinoNTPd/NTPServer.cpp
+++ b/lib/lib_div/ArduinoNTPd/NTPServer.cpp
@@ -23,7 +23,7 @@ bool NtpServer::beginListening()
   return false;
 }
 
-bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs) 
+bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
 {
   // millisecs is millis() at the time of the last iTOW reception, where iTOW%1000 == 0
   uint32_t refMillis = millis()-millisecs;
@@ -33,7 +33,7 @@ bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
   }
 
   bool processed = false;
-  
+
   int packetDataSize = timeServerPort_.parsePacket();
   if (packetDataSize && packetDataSize >= NtpPacket::PACKET_SIZE)
   {
@@ -54,7 +54,7 @@ bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
       // TODO: verify packet.
 
       // Populate response.
-      packet.swapEndian();        
+      packet.swapEndian();
       packet.leapIndicator(0);
       packet.versionNumber(4);
       packet.mode(4);
@@ -73,16 +73,17 @@ bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
       packet.originTimestampFraction = packet.transmitTimestampFraction;
       packet.receiveTimestampSeconds = recvSecs;
       packet.receiveTimestampFraction = recvFract;
-      
+
       // ...and the transmit time.
-      // the latency has been between 135 and 175 microseconds in internal testing, so we harcode 150 
-      uint32_t transFract = recvFract+(150*(10^3)/(2^32)); // microsec/((10^3)/(2^32))
+      // the latency has been between 135 and 175 microseconds in internal testing, so we harcode 150
+      //uint32_t transFract = recvFract+(150*(10^3)/(2^32)); // microsec/((10^3)/(2^32))
+      uint32_t transFract = recvFract+(150000/429496729); // 150 microsec/((10^3)/(2^32))
       if (recvFract>transFract){
         recvSecs++; //overflow
       }
       packet.transmitTimestampSeconds = recvSecs;
-      packet.transmitTimestampFraction = transFract; 
-      
+      packet.transmitTimestampFraction = transFract;
+
       // Now transmit the response to the client.
       packet.swapEndian();
 
@@ -91,7 +92,7 @@ bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
       timeServerPort_.endPacket();
 
       processed = true;
-  } 
-  
+  }
+
   return processed;
 }

--- a/lib/lib_div/ArduinoNTPd/NTPServer.cpp
+++ b/lib/lib_div/ArduinoNTPd/NTPServer.cpp
@@ -75,9 +75,9 @@ bool NtpServer::processOneRequest(uint32_t utc, uint32_t millisecs)
       packet.receiveTimestampFraction = recvFract;
 
       // ...and the transmit time.
-      // the latency has been between 135 and 175 microseconds in internal testing, so we harcode 150
-      //uint32_t transFract = recvFract+(150*(10^3)/(2^32)); // microsec/((10^3)/(2^32))
-      uint32_t transFract = recvFract+(150000/429496729); // 150 microsec/((10^3)/(2^32))
+      // the latency has been between 135 and 175 microseconds in internal testing, so we hardcode 150
+      constexpr uint32_t latency = (150*1000) / (1LL << 32);
+      uint32_t transFract = recvFract + latency;
       if (recvFract>transFract){
         recvSecs++; //overflow
       }

--- a/lib/libesp32/ESP-Mail-Client/src/SSLClient/client/BSSL_SSL_Client.h
+++ b/lib/libesp32/ESP-Mail-Client/src/SSLClient/client/BSSL_SSL_Client.h
@@ -96,6 +96,10 @@ public:
 
     int connect(const char *host, uint16_t port) override;
 
+    int connect(IPAddress ip, uint16_t port, int32_t timeout) { return connect(ip, port, 0);}
+
+    int connect(const char *host, uint16_t port, int32_t timeout) { return connect(host, port, 0);}
+
     uint8_t connected() override;
 
     void validate(const char *host, uint16_t port);

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -183,5 +183,19 @@ typedef int SerConfu8;
 
 #define STATION_IF 0
 
+
+// ESP32 needed define to support IDF 5.2 based Arduino builds
+
+// Name has changed
+#ifdef LCD_CAM_LCD_UPDATE_M
+#define LCD_CAM_LCD_UPDATE_REG LCD_CAM_LCD_UPDATE_M
+#endif // LCD_CAM_LCD_UPDATE_M
+
+// IDF 5.2 has changed counting UART channels, SOC_UART_NUM includes now LP UARTS too
+#ifdef SOC_UART_HP_NUM
+#undef SOC_UART_NUM
+#define SOC_UART_NUM SOC_UART_HP_NUM
+#endif
+
 #endif // ESP32
 #endif // __ESP8266TOESP32_H__

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -77,7 +77,8 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 [env:tasmota32_base]
 ; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
-;platform                = https://github.com/tasmota/platform-espressif32.git
+;platform                = https://github.com/Jason2866/platform-espressif32/releases/download/2024.07.20/platform-espressif32.zip
+
 ;platform_packages       = framework-arduinoespressif32 @ 
 ;                          framework-arduino-solo1 @ 
 ;                          framework-arduino-ITEAD @ 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/Jason2866/platform-espressif32/releases/download/2024.07.20/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.11/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.11/platform-espressif32.zip
+platform                    = https://github.com/Jason2866/platform-espressif32/releases/download/2024.07.20/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -166,7 +166,11 @@ void CrashDumpClear(void)
 // extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack, uint32_t stack_end )
 // esp_err_t IRAM_ATTR esp_backtrace_print(int depth)
 
+#if defined __has_include && __has_include("xtensa_api.h")
+#include "xtensa_api.h"
+#else
 #include "freertos/xtensa_api.h"
+#endif
 #include "esp_debug_helpers.h"
 #include "esp_cpu_utils.h"
 extern "C" {


### PR DESCRIPTION
## Description:

with the changes Tasmota can use the Arduino espressif32 framework based on Tasmota IDF 5.2.2

The alternative framework can be enabled in `platformio override.ini` by uncommenting the entry `;platform = https://github.com/Jason2866/platform-espressif32/releases/download/2024.07.20/platform-espressif32.zip`

The framework uses the newer GCC 13.2 toolchain. The benefit is smaller flash usage.
The S3 safeboot (as example) reduces 7kbyte in size.

Thx @Staars for fixing the last issues left ;-)

@arendst @s-hadinger and everyone who likes testing new stuff (greetings to @TD-er ;-))

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
