### PR TITLE
`FUNC_BUTTON_PRESSED` now contains `press_counter` encoded in `XdrvMailbox.command_code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Berry `FUNC_ANY_KEY` event calling `any_key()` (#21708)
 - Berry `FUNC_BUTTON_MULTI_PRESSED` event and make `FUNC_BUTTON_PRESSED` called only on state changes and once per second (#21711)
 - Support for Sonoff POWCT Ring (#21131)
+- `FUNC_BUTTON_PRESSED` now contains `press_counter` encoded in `XdrvMailbox.command_code`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_support/support_button_v4.ino
+++ b/tasmota/tasmota_support/support_button_v4.ino
@@ -419,7 +419,7 @@ void ButtonHandler(void) {
 
     XdrvMailbox.index = button_index;
     XdrvMailbox.payload = button;
-    XdrvMailbox.command_code = Button.last_state[button_index];
+    XdrvMailbox.command_code = (Button.last_state[button_index] & 0xFF) | ((Button.press_counter[button_index] & 0xFF) << 8);
     if (XdrvCall(FUNC_BUTTON_PRESSED)) {
       // Serviced
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -952,10 +952,12 @@ bool Xdrv52(uint32_t function)
         // XdrvMailbox.index = button_index;
         // XdrvMailbox.payload = button;
         // XdrvMailbox.command_code = Button.last_state[button_index];
-        if ((XdrvMailbox.payload != XdrvMailbox.command_code) || TimeReached(timer_last_button_sent)) {    // fire event only when state changes
+        uint8_t state = (XdrvMailbox.command_code & 0xFF);
+        uint8_t multipress_state = (XdrvMailbox.command_code >> 8) & 0xFF;
+        if ((XdrvMailbox.payload != state) || TimeReached(timer_last_button_sent)) {    // fire event only when state changes
           timer_last_button_sent = millis() + 1000;     // wait for 1 second
           result = callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 
-                                                (XdrvMailbox.payload & 0xFF) << 16 | (XdrvMailbox.command_code & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
+                                                (multipress_state & 0xFF) << 24 | (XdrvMailbox.payload & 0xFF) << 16 | (XdrvMailbox.command_code & 0xFF) << 8 | (XdrvMailbox.index & 0xFF) ,
                                                 nullptr);
         }
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_88_esp32_shelly_pro.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_88_esp32_shelly_pro.ino
@@ -91,7 +91,7 @@ bool ShellyProButton(void) {
   if (button_index > 2) { return false; }           // Only support Up, Down, Ok
 
   uint32_t button = XdrvMailbox.payload;
-  uint32_t last_state = XdrvMailbox.command_code;
+  uint32_t last_state = (XdrvMailbox.command_code & 0xFF);
   if ((PRESSED == button) && (NOT_PRESSED == last_state)) {  // Button pressed
 
     AddLog(LOG_LEVEL_DEBUG, PSTR("SHP: Button %d pressed"), button_index +1);

--- a/tasmota/tasmota_xdrv_driver/xdrv_88_esp32_shelly_pro_v2.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_88_esp32_shelly_pro_v2.ino
@@ -307,7 +307,7 @@ bool ShellyProButton(void) {
   if (button_index > 2) { return false; }           // Only support Up, Down, Ok
 
   uint32_t button = XdrvMailbox.payload;
-  uint32_t last_state = XdrvMailbox.command_code;
+  uint32_t last_state = (XdrvMailbox.command_code & 0xFF);
   if ((PRESSED == button) && (NOT_PRESSED == last_state)) {  // Button pressed
 
     AddLog(LOG_LEVEL_DEBUG, PSTR("SHP: Button %d pressed"), button_index +1);


### PR DESCRIPTION
## Description:

Matter Generic Switch support requires to report the current number of presses in a multipress event. This PR adds `press_counter` to `XdrvMailbox.command_code` encoded in 8 bits.

The only driver using `XdrvMailbox.command_code` for `FUNC_BUTTON_PRESSED` event is Shelly Pro, they have been patched accordingly.

@arendst for your review before merging.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
