### PR TITLE
Berry `int64` added `low32()` and `high32()` methods, used in Matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Support for Sonoff POWCT Ring (#21131)
 - NeoPool data validation and communication statistics default enabled for ESP32 only (#21721)
 - `FUNC_BUTTON_PRESSED` now contains `press_counter` encoded in `XdrvMailbox.command_code` (#21724)
+- Berry `int64` added `low32()` and `high32()` methods, used in Matter
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_int64/src/be_int64_class.c
+++ b/lib/libesp32/berry_int64/src/be_int64_class.c
@@ -212,6 +212,16 @@ int64_t* int64_frombytes(bvm *vm, uint8_t* ptr, size_t len, int32_t idx) {
 }
 BE_FUNC_CTYPE_DECLARE(int64_frombytes, "int64", "@(bytes)~[i]")
 
+int32_t int64_low32(int64_t *i64) {
+  return (int32_t) *i64;
+}
+BE_FUNC_CTYPE_DECLARE(int64_low32, "i", "(int64)")
+
+int32_t int64_high32(int64_t *i64) {
+  return (int32_t) (*i64 >> 32);
+}
+BE_FUNC_CTYPE_DECLARE(int64_high32, "i", "(int64)")
+
 /*
 
 def toint64(i)
@@ -305,5 +315,8 @@ class be_class_int64 (scope: global, name: int64) {
 
   tobytes, ctype_func(int64_tobytes)
   frombytes, static_ctype_func(int64_frombytes)
+
+  low32, ctype_func(int64_low32)        // return low 32 bits as int
+  high32, ctype_func(int64_high32)      // return high 32 bits as int
 }
 @const_object_info_end */


### PR DESCRIPTION
## Description:

Berry `int64` class has now `low32()` and `high32()` to get the low/high 32 bits as native `int`, without allocating any new object. This is used to encode 64 bits int as bytes.

```berry
var i64 = int64.fromstring("1234605616436508552")   # 0x1122334455667788
print(i64.high32())
# 287454020 = 0x11223344
print(i64.low32())
# 1432778632 = 0x55667788
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
