### PR TITLE
Berry improve solidification of bytes

### DIFF
--- a/lib/libesp32/berry/src/be_constobj.h
+++ b/lib/libesp32/berry/src/be_constobj.h
@@ -28,23 +28,38 @@ extern "C" {
     .type = (_t),                                               \
     .marked = GC_CONST
 
-#define be_define_const_bytes(_name, ...)                       \
-    const uint8_t be_const_bin_##_name[] = { __VA_ARGS__ }
+#define be_define_const_bytes(_name, ...)                               \
+    const binstance_arg3 be_const_instance_##_name = {                  \
+        be_const_header(BE_INSTANCE),                                   \
+        .super = NULL,                                                  \
+        .sub = NULL,                                                    \
+        ._class = (bclass*) &be_class_bytes,                            \
+        .members = {                                                    \
+            {.v.c = (const void*) & (const uint8_t[]) { __VA_ARGS__ },  \
+            .type = BE_COMPTR },                                        \
+            be_const_int(sizeof(#_name) / 2),                           \
+            be_const_int(BYTES_SIZE_SOLIDIFIED)                         \
+        }                                                               \
+    }
 
-#define be_const_bytes_instance(_bytes) {                       \
-    .v.c = (                                                    \
-        & (const binstance_arg3)  {                             \
-            be_const_header(BE_INSTANCE),                       \
-            .super = NULL,                                      \
-            .sub = NULL,                                        \
-            ._class = (bclass*) &be_class_bytes,                \
-            .members = {                                        \
-                be_const_comptr(&be_const_bin_##_bytes),        \
-                be_const_int(sizeof(#_bytes) / 2),              \
-                be_const_int(BYTES_SIZE_SOLIDIFIED)             \
-            }                                                   \
-        }),                                                     \
-    .type = BE_INSTANCE                                         \
+/* special version to define a default empty bytes */
+#define be_define_const_bytes_empty()                                   \
+    const binstance_arg3 be_const_instance_ = {                         \
+        be_const_header(BE_INSTANCE),                                   \
+        .super = NULL,                                                  \
+        .sub = NULL,                                                    \
+        ._class = (bclass*) &be_class_bytes,                            \
+        .members = {                                                    \
+            {.v.c = (const void*) & (const uint8_t[]) { 0x00 },         \
+            .type = BE_COMPTR },                                        \
+            be_const_int(0),                                            \
+            be_const_int(BYTES_SIZE_SOLIDIFIED)                         \
+        }                                                               \
+    }
+
+#define be_const_bytes_instance(_bytes) {                               \
+    .v.c = &be_const_instance_##_bytes,                                 \
+    .type = BE_INSTANCE                                                 \
 }
 
 #define be_define_const_str_weak(_name, _s, _len)               \
@@ -339,8 +354,8 @@ const bntvmodule_t be_native_module(_module) = {                  \
 
 #else
 
-#define be_define_const_bytes(_name, ...)                    \
-    const uint8_t be_const_bin_##_name[] = { __VA_ARGS__ }
+// #define be_define_const_bytes(_name, ...)                    \
+//     const uint8_t be_const_bin_##_name[] = { __VA_ARGS__ }
 
 #define be_define_const_str_weak(_name, _s, _len)               \
 const bcstring be_const_str_##_name = {                         \

--- a/lib/libesp32/berry/tools/coc/bytes_build.py
+++ b/lib/libesp32/berry/tools/coc/bytes_build.py
@@ -23,7 +23,7 @@ class bytes_build:
     def build_bytes_def(self):
         ostr = ""
         ostr += "/* binary arrays */\n"
-        ostr += "be_define_const_bytes(,);\n"
+        ostr += "be_define_const_bytes_empty();\n"
         for k in self.map:
             ostr += "be_define_const_bytes("
             ostr += k + ", " + ", ".join( [ "0x" + k[i:i+2] for i in range(0, len(k), 2)] )
@@ -34,8 +34,8 @@ class bytes_build:
     def build_bytes_ext(self):
         ostr = ""
         ostr += "/* extern binary arrays */\n"
-        ostr += "extern const uint8_t be_const_bin_[];\n"
+        ostr += "extern const binstance_arg3 be_const_instance_;\n"
         for k in self.map:
-            ostr += "extern const uint8_t be_const_bin_" + k + "[];\n"
+            ostr += "extern const binstance_arg3 be_const_instance_" + k + ";\n"
 
         return ostr


### PR DESCRIPTION
## Description:

Now Berry `bytes()` instances are shared across instances, instead of just the binary buffer.

No functional change

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
