### PR TITLE
Matter comment code used only by controler

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -89,7 +89,8 @@ class Matter_IM
       self.send_ack_now(msg)
       return self.process_write_request(msg, val)
     elif opcode == 0x07   # Write Response
-      return self.process_write_response(msg, val)
+      # return self.process_write_response(msg, val)  # not implemented for Matter device
+      return false
     elif opcode == 0x08   # Invoke Request
       # self.send_ack_now(msg)      # to improve latency, we don't automatically Ack on invoke request
       return self.process_invoke_request(msg, val)
@@ -1160,11 +1161,11 @@ class Matter_IM
   #############################################################
   # process IM 0x07 Write Response
   #
-  def process_write_response(msg, val)
-    var query = matter.WriteResponseMessage().from_TLV(val)
-    # log("MTR: received WriteResponseMessage=" + str(query), 4)
-    return false
-  end
+  # def process_write_response(msg, val)
+  #   var query = matter.WriteResponseMessage().from_TLV(val)
+  #   # log("MTR: received WriteResponseMessage=" + str(query), 4)
+  #   return false
+  # end
 
   #############################################################
   # process IM 0x09 Invoke Response

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
@@ -615,17 +615,18 @@ class Matter_ReadRequestMessage : Matter_IM_Message_base
     return self
   end
 
-  def to_TLV()
-    var TLV = matter.TLV
-    var s = TLV.Matter_TLV_struct()
-    self.to_TLV_array(s, 0, self.attributes_requests)
-    self.to_TLV_array(s, 1, self.event_requests)
-    self.to_TLV_array(s, 2, self.event_filters)
-    s.add_TLV(3, TLV.BOOL, self.fabric_filtered)
-    self.to_TLV_array(s, 4, self.data_version_filters)
-    s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
-    return s
-  end
+  # to_TLV not used in Matter Device
+  # def to_TLV()
+  #   var TLV = matter.TLV
+  #   var s = TLV.Matter_TLV_struct()
+  #   self.to_TLV_array(s, 0, self.attributes_requests)
+  #   self.to_TLV_array(s, 1, self.event_requests)
+  #   self.to_TLV_array(s, 2, self.event_filters)
+  #   s.add_TLV(3, TLV.BOOL, self.fabric_filtered)
+  #   self.to_TLV_array(s, 4, self.data_version_filters)
+  #   s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
+  #   return s
+  # end
 end
 matter.ReadRequestMessage = Matter_ReadRequestMessage
 
@@ -872,15 +873,16 @@ class Matter_ReportDataMessage : Matter_IM_Message_base
   var suppress_response           # bool
 
   # decode from TLV
-  def from_TLV(val)
-    if val == nil     return nil end
-    self.subscription_id = val.findsubval(0)
-    self.attribute_reports = self.from_TLV_array(val.findsubval(1), matter.AttributeReportIB)
-    self.event_reports = self.from_TLV_array(val.findsubval(2), matter.EventReportIB)
-    self.more_chunked_messages = val.findsubval(3)
-    self.suppress_response = val.findsubval(4)
-    return self
-  end
+  # from_TLV not used in Matter Device
+  # def from_TLV(val)
+  #   if val == nil     return nil end
+  #   self.subscription_id = val.findsubval(0)
+  #   self.attribute_reports = self.from_TLV_array(val.findsubval(1), matter.AttributeReportIB)
+  #   self.event_reports = self.from_TLV_array(val.findsubval(2), matter.EventReportIB)
+  #   self.more_chunked_messages = val.findsubval(3)
+  #   self.suppress_response = val.findsubval(4)
+  #   return self
+  # end
 
   def to_TLV()
     var TLV = matter.TLV
@@ -923,20 +925,21 @@ class Matter_SubscribeRequestMessage : Matter_IM_Message_base
     return self
   end
 
-  def to_TLV()
-    var TLV = matter.TLV
-    var s = TLV.Matter_TLV_struct()
-    s.add_TLV(0, TLV.BOOL, self.keep_subscriptions)
-    s.add_TLV(1, TLV.U2, self.min_interval_floor)
-    s.add_TLV(2, TLV.U2, self.max_interval_ceiling)
-    self.to_TLV_array(s, 3, self.attributes_requests)
-    self.to_TLV_array(s, 4, self.event_requests)
-    self.to_TLV_array(s, 5, self.event_filters)
-    s.add_TLV(7, TLV.BOOL, self.fabric_filtered)
-    self.to_TLV_array(s, 8, self.data_version_filters)
-    s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
-    return s
-  end
+  # to_TLV not used in Matter Device
+  # def to_TLV()
+  #   var TLV = matter.TLV
+  #   var s = TLV.Matter_TLV_struct()
+  #   s.add_TLV(0, TLV.BOOL, self.keep_subscriptions)
+  #   s.add_TLV(1, TLV.U2, self.min_interval_floor)
+  #   s.add_TLV(2, TLV.U2, self.max_interval_ceiling)
+  #   self.to_TLV_array(s, 3, self.attributes_requests)
+  #   self.to_TLV_array(s, 4, self.event_requests)
+  #   self.to_TLV_array(s, 5, self.event_filters)
+  #   s.add_TLV(7, TLV.BOOL, self.fabric_filtered)
+  #   self.to_TLV_array(s, 8, self.data_version_filters)
+  #   s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
+  #   return s
+  # end
 end
 matter.SubscribeRequestMessage = Matter_SubscribeRequestMessage
 
@@ -948,12 +951,13 @@ class Matter_SubscribeResponseMessage : Matter_IM_Message_base
   var max_interval                # u16
 
   # decode from TLV
-  def from_TLV(val)
-    if val == nil     return nil end
-    self.subscription_id = val.findsubval(0)
-    self.max_interval = val.findsubval(2)
-    return self
-  end
+  # from_TLV not used in Matter Device
+  # def from_TLV(val)
+  #   if val == nil     return nil end
+  #   self.subscription_id = val.findsubval(0)
+  #   self.max_interval = val.findsubval(2)
+  #   return self
+  # end
 
   def to_TLV()
     var TLV = matter.TLV
@@ -985,16 +989,17 @@ class Matter_WriteRequestMessage : Matter_IM_Message_base
     return self
   end
 
-  def to_TLV()
-    var TLV = matter.TLV
-    var s = TLV.Matter_TLV_struct()
-    s.add_TLV(0, TLV.BOOL, self.suppress_response)
-    s.add_TLV(1, TLV.BOOL, self.timed_request)
-    self.to_TLV_array(s, 2, self.write_requests)
-    s.add_TLV(3, TLV.BOOL, self.more_chunked_messages)
-    s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
-    return s
-  end
+  # to_TLV not used in Matter Device
+  # def to_TLV()
+  #   var TLV = matter.TLV
+  #   var s = TLV.Matter_TLV_struct()
+  #   s.add_TLV(0, TLV.BOOL, self.suppress_response)
+  #   s.add_TLV(1, TLV.BOOL, self.timed_request)
+  #   self.to_TLV_array(s, 2, self.write_requests)
+  #   s.add_TLV(3, TLV.BOOL, self.more_chunked_messages)
+  #   s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
+  #   return s
+  # end
 end
 matter.WriteRequestMessage = Matter_WriteRequestMessage
 
@@ -1005,11 +1010,12 @@ class Matter_WriteResponseMessage : Matter_IM_Message_base
   var write_responses             # array of AttributeStatusIB
 
   # decode from TLV
-  def from_TLV(val)
-    if val == nil     return nil end
-    self.write_requests = self.from_TLV_array(val.findsubval(0), matter.AttributeStatusIB)
-    return self
-  end
+  # from_TLV not used in Matter Device
+  # def from_TLV(val)
+  #   if val == nil     return nil end
+  #   self.write_requests = self.from_TLV_array(val.findsubval(0), matter.AttributeStatusIB)
+  #   return self
+  # end
 
   def to_TLV()
     var TLV = matter.TLV
@@ -1034,13 +1040,14 @@ class Matter_TimedRequestMessage : Matter_IM_Message_base
     return self
   end
 
-  def to_TLV()
-    var TLV = matter.TLV
-    var s = TLV.Matter_TLV_struct()
-    s.add_TLV(0, TLV.U2, self.timeout)
-    s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
-    return s
-  end
+  # to_TLV not used in Matter Device
+  # def to_TLV()
+  #   var TLV = matter.TLV
+  #   var s = TLV.Matter_TLV_struct()
+  #   s.add_TLV(0, TLV.U2, self.timeout)
+  #   s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
+  #   return s
+  # end
 end
 matter.TimedRequestMessage = Matter_TimedRequestMessage
 
@@ -1061,15 +1068,16 @@ class Matter_InvokeRequestMessage : Matter_IM_Message_base
     return self
   end
 
-  def to_TLV()
-    var TLV = matter.TLV
-    var s = TLV.Matter_TLV_struct()
-    s.add_TLV(0, TLV.BOOL, self.suppress_response)
-    s.add_TLV(1, TLV.BOOL, self.timed_request)
-    self.to_TLV_array(s, 2, self.invoke_requests)
-    s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
-    return s
-  end
+  # to_TLV not used in Matter Device
+  # def to_TLV()
+  #   var TLV = matter.TLV
+  #   var s = TLV.Matter_TLV_struct()
+  #   s.add_TLV(0, TLV.BOOL, self.suppress_response)
+  #   s.add_TLV(1, TLV.BOOL, self.timed_request)
+  #   self.to_TLV_array(s, 2, self.invoke_requests)
+  #   s.add_TLV(0xFF, TLV.U1, self.InteractionModelRevision)
+  #   return s
+  # end
 end
 matter.InvokeRequestMessage = Matter_InvokeRequestMessage
 
@@ -1081,12 +1089,13 @@ class Matter_InvokeResponseMessage : Matter_IM_Message_base
   var invoke_responses            # array of InvokeResponseIB
 
   # decode from TLV
-  def from_TLV(val)
-    if val == nil     return nil end
-    self.suppress_response = val.findsubval(0)
-    self.invoke_responses = self.from_TLV_array(val.findsubval(1), matter.InvokeResponseIB)
-    return self
-  end
+  # from_TLV not used in Matter Device
+  # def from_TLV(val)
+  #   if val == nil     return nil end
+  #   self.suppress_response = val.findsubval(0)
+  #   self.invoke_responses = self.from_TLV_array(val.findsubval(1), matter.InvokeResponseIB)
+  #   return self
+  # end
 
   def to_TLV()
     var TLV = matter.TLV

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -235,21 +235,22 @@ class Matter_Device
   #############################################################
   # Stop PASE commissioning, mostly called when CASE is about to start
   def stop_basic_commissioning()
+    var n = nil
     if self.is_root_commissioning_open()
       tasmota.publish_result('{"Matter":{"Commissioning":0}}', 'Matter')
     end
-    self.commissioning_open = nil
+    self.commissioning_open = n
 
     self.mdns_remove_PASE()
 
     # clear any PBKDF information to free memory
-    self.commissioning_iterations = nil
-    self.commissioning_discriminator = nil
-    self.commissioning_salt = nil
-    self.commissioning_w0 = nil
+    self.commissioning_iterations = n
+    self.commissioning_discriminator = n
+    self.commissioning_salt = n
+    self.commissioning_w0 = n
     # self.commissioning_w1 = nil
-    self.commissioning_L = nil
-    self.commissioning_admin_fabric = nil
+    self.commissioning_L = n
+    self.commissioning_admin_fabric = n
   end
   def is_commissioning_open()
     return self.commissioning_open != nil

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -7,6 +7,523 @@
 extern const bclass be_class_Matter_IM;
 
 /********************************************************************
+** Solidified function: process_write_request
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_process_write_request,   /* name */
+  be_nested_proto(
+    21,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[41]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(WriteRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(Path),
+    /* K4   */  be_nested_str_weak(suppress_response),
+    /* K5   */  be_nested_str_weak(write_requests),
+    /* K6   */  be_nested_str_weak(WriteResponseMessage),
+    /* K7   */  be_nested_str_weak(write_responses),
+    /* K8   */  be_nested_str_weak(PathGenerator),
+    /* K9   */  be_nested_str_weak(device),
+    /* K10  */  be_nested_str_weak(path),
+    /* K11  */  be_nested_str_weak(data),
+    /* K12  */  be_nested_str_weak(copy),
+    /* K13  */  be_nested_str_weak(cluster),
+    /* K14  */  be_nested_str_weak(attribute),
+    /* K15  */  be_nested_str_weak(status),
+    /* K16  */  be_nested_str_weak(INVALID_ACTION),
+    /* K17  */  be_nested_str_weak(write_single_attribute_status_to_bytes),
+    /* K18  */  be_nested_str_weak(endpoint),
+    /* K19  */  be_nested_str_weak(tasmota),
+    /* K20  */  be_nested_str_weak(loglevel),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(get_attribute_name),
+    /* K23  */  be_nested_str_weak(log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K25  */  be_nested_str_weak(_X20_X28),
+    /* K26  */  be_nested_str_weak(_X29),
+    /* K27  */  be_nested_str_weak(),
+    /* K28  */  be_nested_str_weak(start),
+    /* K29  */  be_nested_str_weak(is_direct),
+    /* K30  */  be_nested_str_weak(next_attribute),
+    /* K31  */  be_nested_str_weak(msg),
+    /* K32  */  be_nested_str_weak(get_pi),
+    /* K33  */  be_nested_str_weak(UNSUPPORTED_WRITE),
+    /* K34  */  be_nested_str_weak(write_attribute),
+    /* K35  */  be_nested_str_weak(session),
+    /* K36  */  be_nested_str_weak(SUCCESS),
+    /* K37  */  be_nested_str_weak(stop_iteration),
+    /* K38  */  be_nested_str_weak(send_queue),
+    /* K39  */  be_nested_str_weak(push),
+    /* K40  */  be_nested_str_weak(IM_WriteResponse),
+    }),
+    be_str_weak(process_write_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[145]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0xB8120000,  //  0006  GETNGBL	R4	K0
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140704,  //  0009  GETMBR	R5	R3	K4
+      0x88180705,  //  000A  GETMBR	R6	R3	K5
+      0x4C1C0000,  //  000B  LDNIL	R7
+      0x20180C07,  //  000C  NE	R6	R6	R7
+      0x781A0080,  //  000D  JMPF	R6	#008F
+      0xB81A0000,  //  000E  GETNGBL	R6	K0
+      0x8C180D06,  //  000F  GETMET	R6	R6	K6
+      0x7C180200,  //  0010  CALL	R6	1
+      0x601C0012,  //  0011  GETGBL	R7	G18
+      0x7C1C0000,  //  0012  CALL	R7	0
+      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
+      0xB81E0000,  //  0014  GETNGBL	R7	K0
+      0x8C1C0F08,  //  0015  GETMET	R7	R7	K8
+      0x88240109,  //  0016  GETMBR	R9	R0	K9
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x60200010,  //  0018  GETGBL	R8	G16
+      0x88240705,  //  0019  GETMBR	R9	R3	K5
+      0x7C200200,  //  001A  CALL	R8	1
+      0xA8020065,  //  001B  EXBLK	0	#0082
+      0x5C241000,  //  001C  MOVE	R9	R8
+      0x7C240000,  //  001D  CALL	R9	0
+      0x8828130A,  //  001E  GETMBR	R10	R9	K10
+      0x882C130B,  //  001F  GETMBR	R11	R9	K11
+      0x8C30090C,  //  0020  GETMET	R12	R4	K12
+      0x5C381400,  //  0021  MOVE	R14	R10
+      0x7C300400,  //  0022  CALL	R12	2
+      0x8830150D,  //  0023  GETMBR	R12	R10	K13
+      0x4C340000,  //  0024  LDNIL	R13
+      0x1C30180D,  //  0025  EQ	R12	R12	R13
+      0x74320003,  //  0026  JMPT	R12	#002B
+      0x8830150E,  //  0027  GETMBR	R12	R10	K14
+      0x4C340000,  //  0028  LDNIL	R13
+      0x1C30180D,  //  0029  EQ	R12	R12	R13
+      0x78320008,  //  002A  JMPF	R12	#0034
+      0xB8320000,  //  002B  GETNGBL	R12	K0
+      0x88301910,  //  002C  GETMBR	R12	R12	K16
+      0x90121E0C,  //  002D  SETMBR	R4	K15	R12
+      0x8C300111,  //  002E  GETMET	R12	R0	K17
+      0x5C380C00,  //  002F  MOVE	R14	R6
+      0x5C3C0800,  //  0030  MOVE	R15	R4
+      0x4C400000,  //  0031  LDNIL	R16
+      0x7C300800,  //  0032  CALL	R12	4
+      0x7001FFE7,  //  0033  JMP		#001C
+      0x88301512,  //  0034  GETMBR	R12	R10	K18
+      0x4C340000,  //  0035  LDNIL	R13
+      0x1C30180D,  //  0036  EQ	R12	R12	R13
+      0x78320016,  //  0037  JMPF	R12	#004F
+      0xB8322600,  //  0038  GETNGBL	R12	K19
+      0x8C301914,  //  0039  GETMET	R12	R12	K20
+      0x58380015,  //  003A  LDCONST	R14	K21
+      0x7C300400,  //  003B  CALL	R12	2
+      0x78320011,  //  003C  JMPF	R12	#004F
+      0xB8320000,  //  003D  GETNGBL	R12	K0
+      0x8C301916,  //  003E  GETMET	R12	R12	K22
+      0x8838150D,  //  003F  GETMBR	R14	R10	K13
+      0x883C150E,  //  0040  GETMBR	R15	R10	K14
+      0x7C300600,  //  0041  CALL	R12	3
+      0xB8362E00,  //  0042  GETNGBL	R13	K23
+      0x60380008,  //  0043  GETGBL	R14	G8
+      0x5C3C0800,  //  0044  MOVE	R15	R4
+      0x7C380200,  //  0045  CALL	R14	1
+      0x003A300E,  //  0046  ADD	R14	K24	R14
+      0x78320002,  //  0047  JMPF	R12	#004B
+      0x003E320C,  //  0048  ADD	R15	K25	R12
+      0x003C1F1A,  //  0049  ADD	R15	R15	K26
+      0x70020000,  //  004A  JMP		#004C
+      0x583C001B,  //  004B  LDCONST	R15	K27
+      0x00381C0F,  //  004C  ADD	R14	R14	R15
+      0x583C0015,  //  004D  LDCONST	R15	K21
+      0x7C340400,  //  004E  CALL	R13	2
+      0x8C300F1C,  //  004F  GETMET	R12	R7	K28
+      0x88381512,  //  0050  GETMBR	R14	R10	K18
+      0x883C150D,  //  0051  GETMBR	R15	R10	K13
+      0x8840150E,  //  0052  GETMBR	R16	R10	K14
+      0x7C300800,  //  0053  CALL	R12	4
+      0x8C300F1D,  //  0054  GETMET	R12	R7	K29
+      0x7C300200,  //  0055  CALL	R12	1
+      0x4C340000,  //  0056  LDNIL	R13
+      0x8C380F1E,  //  0057  GETMET	R14	R7	K30
+      0x7C380200,  //  0058  CALL	R14	1
+      0x5C341C00,  //  0059  MOVE	R13	R14
+      0x783A0025,  //  005A  JMPF	R14	#0081
+      0x90363E01,  //  005B  SETMBR	R13	K31	R1
+      0x88381B0F,  //  005C  GETMBR	R14	R13	K15
+      0x4C3C0000,  //  005D  LDNIL	R15
+      0x20381C0F,  //  005E  NE	R14	R14	R15
+      0x783A0007,  //  005F  JMPF	R14	#0068
+      0x4C380000,  //  0060  LDNIL	R14
+      0x90361E0E,  //  0061  SETMBR	R13	K15	R14
+      0x8C380111,  //  0062  GETMET	R14	R0	K17
+      0x5C400C00,  //  0063  MOVE	R16	R6
+      0x5C441A00,  //  0064  MOVE	R17	R13
+      0x5C481600,  //  0065  MOVE	R18	R11
+      0x7C380800,  //  0066  CALL	R14	4
+      0x70020017,  //  0067  JMP		#0080
+      0x8C380F20,  //  0068  GETMET	R14	R7	K32
+      0x7C380200,  //  0069  CALL	R14	1
+      0xB83E0000,  //  006A  GETNGBL	R15	K0
+      0x883C1F21,  //  006B  GETMBR	R15	R15	K33
+      0x90361E0F,  //  006C  SETMBR	R13	K15	R15
+      0x4C3C0000,  //  006D  LDNIL	R15
+      0x203C1C0F,  //  006E  NE	R15	R14	R15
+      0x783E0005,  //  006F  JMPF	R15	#0076
+      0x8C3C1D22,  //  0070  GETMET	R15	R14	K34
+      0x88440323,  //  0071  GETMBR	R17	R1	K35
+      0x5C481A00,  //  0072  MOVE	R18	R13
+      0x5C4C1600,  //  0073  MOVE	R19	R11
+      0x7C3C0800,  //  0074  CALL	R15	4
+      0x70020000,  //  0075  JMP		#0077
+      0x4C3C0000,  //  0076  LDNIL	R15
+      0x783E0002,  //  0077  JMPF	R15	#007B
+      0xB8420000,  //  0078  GETNGBL	R16	K0
+      0x88402124,  //  0079  GETMBR	R16	R16	K36
+      0x90361E10,  //  007A  SETMBR	R13	K15	R16
+      0x8C400111,  //  007B  GETMET	R16	R0	K17
+      0x5C480C00,  //  007C  MOVE	R18	R6
+      0x5C4C1A00,  //  007D  MOVE	R19	R13
+      0x5C501600,  //  007E  MOVE	R20	R11
+      0x7C400800,  //  007F  CALL	R16	4
+      0x7001FFD5,  //  0080  JMP		#0057
+      0x7001FF99,  //  0081  JMP		#001C
+      0x58200025,  //  0082  LDCONST	R8	K37
+      0xAC200200,  //  0083  CATCH	R8	1	0
+      0xB0080000,  //  0084  RAISE	2	R0	R0
+      0x5C200A00,  //  0085  MOVE	R8	R5
+      0x74220007,  //  0086  JMPT	R8	#008F
+      0x88200126,  //  0087  GETMBR	R8	R0	K38
+      0x8C201127,  //  0088  GETMET	R8	R8	K39
+      0xB82A0000,  //  0089  GETNGBL	R10	K0
+      0x8C281528,  //  008A  GETMET	R10	R10	K40
+      0x5C300200,  //  008B  MOVE	R12	R1
+      0x5C340C00,  //  008C  MOVE	R13	R6
+      0x7C280600,  //  008D  CALL	R10	3
+      0x7C200400,  //  008E  CALL	R8	2
+      0x50180200,  //  008F  LDBOOL	R6	1	0
+      0x80040C00,  //  0090  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: path2raw
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_path2raw,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(add),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(cluster),
+    /* K5   */  be_nested_str_weak(attribute),
+    }),
+    be_str_weak(path2raw),
+    &be_const_str_solidified,
+    ( &(const binstruction[107]) {  /* code */
+      0x8C140300,  //  0000  GETMET	R5	R1	K0
+      0x541E0036,  //  0001  LDINT	R7	55
+      0x58200001,  //  0002  LDCONST	R8	K1
+      0x7C140600,  //  0003  CALL	R5	3
+      0x8C140300,  //  0004  GETMET	R5	R1	K0
+      0x5C1C0600,  //  0005  MOVE	R7	R3
+      0x58200001,  //  0006  LDCONST	R8	K1
+      0x7C140600,  //  0007  CALL	R5	3
+      0x88140502,  //  0008  GETMBR	R5	R2	K2
+      0x541A00FE,  //  0009  LDINT	R6	255
+      0x18140A06,  //  000A  LE	R5	R5	R6
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x8C140300,  //  000C  GETMET	R5	R1	K0
+      0x541E2401,  //  000D  LDINT	R7	9218
+      0x5421FFFD,  //  000E  LDINT	R8	-2
+      0x7C140600,  //  000F  CALL	R5	3
+      0x8C140300,  //  0010  GETMET	R5	R1	K0
+      0x881C0502,  //  0011  GETMBR	R7	R2	K2
+      0x58200001,  //  0012  LDCONST	R8	K1
+      0x7C140600,  //  0013  CALL	R5	3
+      0x70020007,  //  0014  JMP		#001D
+      0x8C140300,  //  0015  GETMET	R5	R1	K0
+      0x541E2501,  //  0016  LDINT	R7	9474
+      0x5421FFFD,  //  0017  LDINT	R8	-2
+      0x7C140600,  //  0018  CALL	R5	3
+      0x8C140300,  //  0019  GETMET	R5	R1	K0
+      0x881C0502,  //  001A  GETMBR	R7	R2	K2
+      0x58200003,  //  001B  LDCONST	R8	K3
+      0x7C140600,  //  001C  CALL	R5	3
+      0x88140504,  //  001D  GETMBR	R5	R2	K4
+      0x541A00FE,  //  001E  LDINT	R6	255
+      0x18140A06,  //  001F  LE	R5	R5	R6
+      0x78160008,  //  0020  JMPF	R5	#002A
+      0x8C140300,  //  0021  GETMET	R5	R1	K0
+      0x541E2402,  //  0022  LDINT	R7	9219
+      0x5421FFFD,  //  0023  LDINT	R8	-2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C140300,  //  0025  GETMET	R5	R1	K0
+      0x881C0504,  //  0026  GETMBR	R7	R2	K4
+      0x58200001,  //  0027  LDCONST	R8	K1
+      0x7C140600,  //  0028  CALL	R5	3
+      0x70020014,  //  0029  JMP		#003F
+      0x88140504,  //  002A  GETMBR	R5	R2	K4
+      0x541AFFFE,  //  002B  LDINT	R6	65535
+      0x18140A06,  //  002C  LE	R5	R5	R6
+      0x78160008,  //  002D  JMPF	R5	#0037
+      0x8C140300,  //  002E  GETMET	R5	R1	K0
+      0x541E2502,  //  002F  LDINT	R7	9475
+      0x5421FFFD,  //  0030  LDINT	R8	-2
+      0x7C140600,  //  0031  CALL	R5	3
+      0x8C140300,  //  0032  GETMET	R5	R1	K0
+      0x881C0504,  //  0033  GETMBR	R7	R2	K4
+      0x58200003,  //  0034  LDCONST	R8	K3
+      0x7C140600,  //  0035  CALL	R5	3
+      0x70020007,  //  0036  JMP		#003F
+      0x8C140300,  //  0037  GETMET	R5	R1	K0
+      0x541E2602,  //  0038  LDINT	R7	9731
+      0x5421FFFD,  //  0039  LDINT	R8	-2
+      0x7C140600,  //  003A  CALL	R5	3
+      0x8C140300,  //  003B  GETMET	R5	R1	K0
+      0x881C0504,  //  003C  GETMBR	R7	R2	K4
+      0x54220003,  //  003D  LDINT	R8	4
+      0x7C140600,  //  003E  CALL	R5	3
+      0x88140505,  //  003F  GETMBR	R5	R2	K5
+      0x541A00FE,  //  0040  LDINT	R6	255
+      0x18140A06,  //  0041  LE	R5	R5	R6
+      0x78160008,  //  0042  JMPF	R5	#004C
+      0x8C140300,  //  0043  GETMET	R5	R1	K0
+      0x541E2403,  //  0044  LDINT	R7	9220
+      0x5421FFFD,  //  0045  LDINT	R8	-2
+      0x7C140600,  //  0046  CALL	R5	3
+      0x8C140300,  //  0047  GETMET	R5	R1	K0
+      0x881C0505,  //  0048  GETMBR	R7	R2	K5
+      0x58200001,  //  0049  LDCONST	R8	K1
+      0x7C140600,  //  004A  CALL	R5	3
+      0x70020014,  //  004B  JMP		#0061
+      0x88140505,  //  004C  GETMBR	R5	R2	K5
+      0x541AFFFE,  //  004D  LDINT	R6	65535
+      0x18140A06,  //  004E  LE	R5	R5	R6
+      0x78160008,  //  004F  JMPF	R5	#0059
+      0x8C140300,  //  0050  GETMET	R5	R1	K0
+      0x541E2503,  //  0051  LDINT	R7	9476
+      0x5421FFFD,  //  0052  LDINT	R8	-2
+      0x7C140600,  //  0053  CALL	R5	3
+      0x8C140300,  //  0054  GETMET	R5	R1	K0
+      0x881C0505,  //  0055  GETMBR	R7	R2	K5
+      0x58200003,  //  0056  LDCONST	R8	K3
+      0x7C140600,  //  0057  CALL	R5	3
+      0x70020007,  //  0058  JMP		#0061
+      0x8C140300,  //  0059  GETMET	R5	R1	K0
+      0x541E2603,  //  005A  LDINT	R7	9732
+      0x5421FFFD,  //  005B  LDINT	R8	-2
+      0x7C140600,  //  005C  CALL	R5	3
+      0x8C140300,  //  005D  GETMET	R5	R1	K0
+      0x881C0505,  //  005E  GETMBR	R7	R2	K5
+      0x54220003,  //  005F  LDINT	R8	4
+      0x7C140600,  //  0060  CALL	R5	3
+      0x78120003,  //  0061  JMPF	R4	#0066
+      0x8C140300,  //  0062  GETMET	R5	R1	K0
+      0x541E3404,  //  0063  LDINT	R7	13317
+      0x5421FFFD,  //  0064  LDINT	R8	-2
+      0x7C140600,  //  0065  CALL	R5	3
+      0x8C140300,  //  0066  GETMET	R5	R1	K0
+      0x541E0017,  //  0067  LDINT	R7	24
+      0x58200001,  //  0068  LDCONST	R8	K1
+      0x7C140600,  //  0069  CALL	R5	3
+      0x80000000,  //  006A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attributedata2raw
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(add),
+    /* K1   */  be_const_int(355795236),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(path2raw),
+    /* K4   */  be_nested_str_weak(tag_sub),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(tlv2raw),
+    }),
+    be_str_weak(attributedata2raw),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x8C140300,  //  0000  GETMET	R5	R1	K0
+      0x581C0001,  //  0001  LDCONST	R7	K1
+      0x5421FFFB,  //  0002  LDINT	R8	-4
+      0x7C140600,  //  0003  CALL	R5	3
+      0x8C140300,  //  0004  GETMET	R5	R1	K0
+      0x581C0002,  //  0005  LDCONST	R7	K2
+      0x5421FFFD,  //  0006  LDINT	R8	-2
+      0x7C140600,  //  0007  CALL	R5	3
+      0x8C140103,  //  0008  GETMET	R5	R0	K3
+      0x5C1C0200,  //  0009  MOVE	R7	R1
+      0x5C200400,  //  000A  MOVE	R8	R2
+      0x58240002,  //  000B  LDCONST	R9	K2
+      0x5C280800,  //  000C  MOVE	R10	R4
+      0x7C140A00,  //  000D  CALL	R5	5
+      0x900E0905,  //  000E  SETMBR	R3	K4	K5
+      0x8C140706,  //  000F  GETMET	R5	R3	K6
+      0x5C1C0200,  //  0010  MOVE	R7	R1
+      0x7C140400,  //  0011  CALL	R5	2
+      0x8C140300,  //  0012  GETMET	R5	R1	K0
+      0x541E1817,  //  0013  LDINT	R7	6168
+      0x5421FFFD,  //  0014  LDINT	R8	-2
+      0x7C140600,  //  0015  CALL	R5	3
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_subscribe_update
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(ReadRequestMessage),
+    /* K3   */  be_nested_str_weak(fabric_filtered),
+    /* K4   */  be_nested_str_weak(attributes_requests),
+    /* K5   */  be_nested_str_weak(updates),
+    /* K6   */  be_nested_str_weak(AttributePathIB),
+    /* K7   */  be_nested_str_weak(endpoint),
+    /* K8   */  be_nested_str_weak(cluster),
+    /* K9   */  be_nested_str_weak(attribute),
+    /* K10  */  be_nested_str_weak(push),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K14  */  be_nested_str_weak(local_session_id),
+    /* K15  */  be_nested_str_weak(subscription_id),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(is_keep_alive),
+    /* K18  */  be_nested_str_weak(process_read_or_subscribe_request_pull),
+    /* K19  */  be_nested_str_weak(update_event_generator_array),
+    /* K20  */  be_nested_str_weak(IM_ReportDataSubscribed_Pull),
+    /* K21  */  be_nested_str_weak(_message_handler),
+    /* K22  */  be_nested_str_weak(send_queue),
+    /* K23  */  be_nested_str_weak(send_enqueued),
+    }),
+    be_str_weak(send_subscribe_update),
+    &be_const_str_solidified,
+    ( &(const binstruction[64]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x50100000,  //  0004  LDBOOL	R4	0	0
+      0x900E0604,  //  0005  SETMBR	R3	K3	R4
+      0x60100012,  //  0006  GETGBL	R4	G18
+      0x7C100000,  //  0007  CALL	R4	0
+      0x900E0804,  //  0008  SETMBR	R3	K4	R4
+      0x60100010,  //  0009  GETGBL	R4	G16
+      0x88140305,  //  000A  GETMBR	R5	R1	K5
+      0x7C100200,  //  000B  CALL	R4	1
+      0xA802000F,  //  000C  EXBLK	0	#001D
+      0x5C140800,  //  000D  MOVE	R5	R4
+      0x7C140000,  //  000E  CALL	R5	0
+      0xB81A0200,  //  000F  GETNGBL	R6	K1
+      0x8C180D06,  //  0010  GETMET	R6	R6	K6
+      0x7C180200,  //  0011  CALL	R6	1
+      0x881C0B07,  //  0012  GETMBR	R7	R5	K7
+      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
+      0x881C0B08,  //  0014  GETMBR	R7	R5	K8
+      0x901A1007,  //  0015  SETMBR	R6	K8	R7
+      0x881C0B09,  //  0016  GETMBR	R7	R5	K9
+      0x901A1207,  //  0017  SETMBR	R6	K9	R7
+      0x881C0704,  //  0018  GETMBR	R7	R3	K4
+      0x8C1C0F0A,  //  0019  GETMET	R7	R7	K10
+      0x5C240C00,  //  001A  MOVE	R9	R6
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x7001FFEF,  //  001C  JMP		#000D
+      0x5810000B,  //  001D  LDCONST	R4	K11
+      0xAC100200,  //  001E  CATCH	R4	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0xB8121800,  //  0020  GETNGBL	R4	K12
+      0x60140018,  //  0021  GETGBL	R5	G24
+      0x5818000D,  //  0022  LDCONST	R6	K13
+      0x881C050E,  //  0023  GETMBR	R7	R2	K14
+      0x8820030F,  //  0024  GETMBR	R8	R1	K15
+      0x7C140600,  //  0025  CALL	R5	3
+      0x58180010,  //  0026  LDCONST	R6	K16
+      0x7C100400,  //  0027  CALL	R4	2
+      0x50100000,  //  0028  LDBOOL	R4	0	0
+      0x90062204,  //  0029  SETMBR	R1	K17	R4
+      0x8C100112,  //  002A  GETMET	R4	R0	K18
+      0x5C180600,  //  002B  MOVE	R6	R3
+      0x4C1C0000,  //  002C  LDNIL	R7
+      0x7C100600,  //  002D  CALL	R4	3
+      0x8C140313,  //  002E  GETMET	R5	R1	K19
+      0x7C140200,  //  002F  CALL	R5	1
+      0xB81A0200,  //  0030  GETNGBL	R6	K1
+      0x8C180D14,  //  0031  GETMET	R6	R6	K20
+      0x88200515,  //  0032  GETMBR	R8	R2	K21
+      0x5C240400,  //  0033  MOVE	R9	R2
+      0x5C280800,  //  0034  MOVE	R10	R4
+      0x5C2C0A00,  //  0035  MOVE	R11	R5
+      0x5C300200,  //  0036  MOVE	R12	R1
+      0x7C180C00,  //  0037  CALL	R6	6
+      0x881C0116,  //  0038  GETMBR	R7	R0	K22
+      0x8C1C0F0A,  //  0039  GETMET	R7	R7	K10
+      0x5C240C00,  //  003A  MOVE	R9	R6
+      0x7C1C0400,  //  003B  CALL	R7	2
+      0x8C1C0117,  //  003C  GETMET	R7	R0	K23
+      0x88240515,  //  003D  GETMBR	R9	R2	K21
+      0x7C1C0400,  //  003E  CALL	R7	2
+      0x80000000,  //  003F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: process_read_request_pull
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
@@ -65,44 +582,253 @@ be_local_closure(class_Matter_IM_process_read_request_pull,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_incoming_ack
+** Solidified function: process_read_or_subscribe_request_pull
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
+be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
+    16,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    /* K2   */  be_nested_str_weak(ack_received),
-    /* K3   */  be_nested_str_weak(finished),
-    /* K4   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attributes_requests),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(PathGenerator),
+    /* K5   */  be_nested_str_weak(device),
+    /* K6   */  be_nested_str_weak(start),
+    /* K7   */  be_nested_str_weak(endpoint),
+    /* K8   */  be_nested_str_weak(cluster),
+    /* K9   */  be_nested_str_weak(attribute),
+    /* K10  */  be_nested_str_weak(fabric_filtered),
+    /* K11  */  be_nested_str_weak(push),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(loglevel),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(Path),
+    /* K16  */  be_nested_str_weak(get_attribute_name),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K19  */  be_nested_str_weak(session),
+    /* K20  */  be_nested_str_weak(local_session_id),
+    /* K21  */  be_nested_str_weak(_X20_X28),
+    /* K22  */  be_nested_str_weak(_X29),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(process_incoming_ack),
+    be_str_weak(process_read_or_subscribe_request_pull),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x88100301,  //  0001  GETMBR	R4	R1	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x780A0008,  //  0003  JMPF	R2	#000D
-      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x88100503,  //  0007  GETMBR	R4	R2	K3
-      0x78120002,  //  0008  JMPF	R4	#000C
-      0x8C100104,  //  0009  GETMET	R4	R0	K4
-      0x88180301,  //  000A  GETMBR	R6	R1	K1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x80040600,  //  000C  RET	1	R3
-      0x500C0000,  //  000D  LDBOOL	R3	0	0
-      0x80040600,  //  000E  RET	1	R3
+    ( &(const binstruction[115]) {  /* code */
+      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x200C0604,  //  0002  NE	R3	R3	R4
+      0x780E006C,  //  0003  JMPF	R3	#0071
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x88100300,  //  0005  GETMBR	R4	R1	K0
+      0x78120003,  //  0006  JMPF	R4	#000B
+      0x6010000C,  //  0007  GETGBL	R4	G12
+      0x88140300,  //  0008  GETMBR	R5	R1	K0
+      0x7C100200,  //  0009  CALL	R4	1
+      0x70020000,  //  000A  JMP		#000C
+      0x58100001,  //  000B  LDCONST	R4	K1
+      0x24140902,  //  000C  GT	R5	R4	K2
+      0x78160002,  //  000D  JMPF	R5	#0011
+      0x60140012,  //  000E  GETGBL	R5	G18
+      0x7C140000,  //  000F  CALL	R5	0
+      0x5C0C0A00,  //  0010  MOVE	R3	R5
+      0x60140010,  //  0011  GETGBL	R5	G16
+      0x88180300,  //  0012  GETMBR	R6	R1	K0
+      0x7C140200,  //  0013  CALL	R5	1
+      0xA8020057,  //  0014  EXBLK	0	#006D
+      0x5C180A00,  //  0015  MOVE	R6	R5
+      0x7C180000,  //  0016  CALL	R6	0
+      0xB81E0600,  //  0017  GETNGBL	R7	K3
+      0x8C1C0F04,  //  0018  GETMET	R7	R7	K4
+      0x88240105,  //  0019  GETMBR	R9	R0	K5
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0x8C200F06,  //  001B  GETMET	R8	R7	K6
+      0x88280D07,  //  001C  GETMBR	R10	R6	K7
+      0x882C0D08,  //  001D  GETMBR	R11	R6	K8
+      0x88300D09,  //  001E  GETMBR	R12	R6	K9
+      0x8834030A,  //  001F  GETMBR	R13	R1	K10
+      0x7C200A00,  //  0020  CALL	R8	5
+      0x24200902,  //  0021  GT	R8	R4	K2
+      0x78220003,  //  0022  JMPF	R8	#0027
+      0x8C20070B,  //  0023  GETMET	R8	R3	K11
+      0x5C280E00,  //  0024  MOVE	R10	R7
+      0x7C200400,  //  0025  CALL	R8	2
+      0x70020000,  //  0026  JMP		#0028
+      0x5C0C0E00,  //  0027  MOVE	R3	R7
+      0xB8221800,  //  0028  GETNGBL	R8	K12
+      0x8C20110D,  //  0029  GETMET	R8	R8	K13
+      0x5828000E,  //  002A  LDCONST	R10	K14
+      0x7C200400,  //  002B  CALL	R8	2
+      0x7822003E,  //  002C  JMPF	R8	#006C
+      0x88200D07,  //  002D  GETMBR	R8	R6	K7
+      0x4C240000,  //  002E  LDNIL	R9
+      0x1C201009,  //  002F  EQ	R8	R8	R9
+      0x74220007,  //  0030  JMPT	R8	#0039
+      0x88200D08,  //  0031  GETMBR	R8	R6	K8
+      0x4C240000,  //  0032  LDNIL	R9
+      0x1C201009,  //  0033  EQ	R8	R8	R9
+      0x74220003,  //  0034  JMPT	R8	#0039
+      0x88200D09,  //  0035  GETMBR	R8	R6	K9
+      0x4C240000,  //  0036  LDNIL	R9
+      0x1C201009,  //  0037  EQ	R8	R8	R9
+      0x78220032,  //  0038  JMPF	R8	#006C
+      0xB8220600,  //  0039  GETNGBL	R8	K3
+      0x8C20110F,  //  003A  GETMET	R8	R8	K15
+      0x7C200200,  //  003B  CALL	R8	1
+      0x88240D07,  //  003C  GETMBR	R9	R6	K7
+      0x90220E09,  //  003D  SETMBR	R8	K7	R9
+      0x88240D08,  //  003E  GETMBR	R9	R6	K8
+      0x90221009,  //  003F  SETMBR	R8	K8	R9
+      0x88240D09,  //  0040  GETMBR	R9	R6	K9
+      0x90221209,  //  0041  SETMBR	R8	K9	R9
+      0x8824030A,  //  0042  GETMBR	R9	R1	K10
+      0x90221409,  //  0043  SETMBR	R8	K10	R9
+      0x60240008,  //  0044  GETGBL	R9	G8
+      0x5C281000,  //  0045  MOVE	R10	R8
+      0x7C240200,  //  0046  CALL	R9	1
+      0x88280D08,  //  0047  GETMBR	R10	R6	K8
+      0x4C2C0000,  //  0048  LDNIL	R11
+      0x2028140B,  //  0049  NE	R10	R10	R11
+      0x782A0017,  //  004A  JMPF	R10	#0063
+      0x88280D09,  //  004B  GETMBR	R10	R6	K9
+      0x4C2C0000,  //  004C  LDNIL	R11
+      0x2028140B,  //  004D  NE	R10	R10	R11
+      0x782A0013,  //  004E  JMPF	R10	#0063
+      0xB82A0600,  //  004F  GETNGBL	R10	K3
+      0x8C281510,  //  0050  GETMET	R10	R10	K16
+      0x88300D08,  //  0051  GETMBR	R12	R6	K8
+      0x88340D09,  //  0052  GETMBR	R13	R6	K9
+      0x7C280600,  //  0053  CALL	R10	3
+      0xB82E2200,  //  0054  GETNGBL	R11	K17
+      0x60300018,  //  0055  GETGBL	R12	G24
+      0x58340012,  //  0056  LDCONST	R13	K18
+      0x88380513,  //  0057  GETMBR	R14	R2	K19
+      0x88381D14,  //  0058  GETMBR	R14	R14	K20
+      0x782A0002,  //  0059  JMPF	R10	#005D
+      0x003E2A0A,  //  005A  ADD	R15	K21	R10
+      0x003C1F16,  //  005B  ADD	R15	R15	K22
+      0x70020000,  //  005C  JMP		#005E
+      0x583C0017,  //  005D  LDCONST	R15	K23
+      0x003C120F,  //  005E  ADD	R15	R9	R15
+      0x7C300600,  //  005F  CALL	R12	3
+      0x5834000E,  //  0060  LDCONST	R13	K14
+      0x7C2C0400,  //  0061  CALL	R11	2
+      0x70020008,  //  0062  JMP		#006C
+      0xB82A2200,  //  0063  GETNGBL	R10	K17
+      0x602C0018,  //  0064  GETGBL	R11	G24
+      0x58300012,  //  0065  LDCONST	R12	K18
+      0x88340513,  //  0066  GETMBR	R13	R2	K19
+      0x88341B14,  //  0067  GETMBR	R13	R13	K20
+      0x5C381200,  //  0068  MOVE	R14	R9
+      0x7C2C0600,  //  0069  CALL	R11	3
+      0x5830000E,  //  006A  LDCONST	R12	K14
+      0x7C280400,  //  006B  CALL	R10	2
+      0x7001FFA7,  //  006C  JMP		#0015
+      0x58140018,  //  006D  LDCONST	R5	K24
+      0xAC140200,  //  006E  CATCH	R5	1	0
+      0xB0080000,  //  006F  RAISE	2	R0	R0
+      0x80040600,  //  0070  RET	1	R3
+      0x4C0C0000,  //  0071  LDNIL	R3
+      0x80040600,  //  0072  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_timed_request
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_process_timed_request,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TimedRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
+    /* K5   */  be_nested_str_weak(session),
+    /* K6   */  be_nested_str_weak(local_session_id),
+    /* K7   */  be_nested_str_weak(timeout),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(send_status),
+    /* K10  */  be_nested_str_weak(SUCCESS),
+    }),
+    be_str_weak(process_timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0x60140018,  //  0007  GETGBL	R5	G24
+      0x58180004,  //  0008  LDCONST	R6	K4
+      0x881C0305,  //  0009  GETMBR	R7	R1	K5
+      0x881C0F06,  //  000A  GETMBR	R7	R7	K6
+      0x88200707,  //  000B  GETMBR	R8	R3	K7
+      0x7C140600,  //  000C  CALL	R5	3
+      0x58180008,  //  000D  LDCONST	R6	K8
+      0x7C100400,  //  000E  CALL	R4	2
+      0x8C100109,  //  000F  GETMET	R4	R0	K9
+      0x5C180200,  //  0010  MOVE	R6	R1
+      0xB81E0000,  //  0011  GETNGBL	R7	K0
+      0x881C0F0A,  //  0012  GETMBR	R7	R7	K10
+      0x7C100600,  //  0013  CALL	R4	3
+      0x50100200,  //  0014  LDBOOL	R4	1	0
+      0x80040800,  //  0015  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs_shop),
+    /* K1   */  be_nested_str_weak(every_50ms),
+    }),
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -398,135 +1124,254 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: write_single_attribute_status_to_bytes
+** Solidified function: process_read_or_subscribe_request_event_pull
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* name */
+be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
-    4,                          /* argc */
+    24,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(get_attribute_name),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(_X20_X28),
-    /* K6   */  be_nested_str_weak(_X29),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(status),
-    /* K9   */  be_nested_str_weak(AttributeStatusIB),
-    /* K10  */  be_nested_str_weak(path),
-    /* K11  */  be_nested_str_weak(AttributePathIB),
-    /* K12  */  be_nested_str_weak(StatusIB),
-    /* K13  */  be_nested_str_weak(endpoint),
-    /* K14  */  be_nested_str_weak(write_responses),
-    /* K15  */  be_nested_str_weak(push),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20_X25s_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-    /* K18  */  be_nested_str_weak(SUCCESS),
-    /* K19  */  be_const_int(0),
-    /* K20  */  be_const_int(2),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(tasmota),
-    /* K23  */  be_nested_str_weak(loglevel),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20IGNORED),
+    ( &(const bvalue[31]) {     /* constants */
+    /* K0   */  be_nested_str_weak(event_requests),
+    /* K1   */  be_nested_str_weak(get_node_id),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(parse_event_filters_min_no),
+    /* K5   */  be_nested_str_weak(event_filters),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(EventGenerator),
+    /* K8   */  be_nested_str_weak(device),
+    /* K9   */  be_nested_str_weak(start),
+    /* K10  */  be_nested_str_weak(endpoint),
+    /* K11  */  be_nested_str_weak(cluster),
+    /* K12  */  be_nested_str_weak(event),
+    /* K13  */  be_nested_str_weak(push),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(loglevel),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(),
+    /* K18  */  be_nested_str_weak(get_event_name),
+    /* K19  */  be_nested_str_weak(_X28),
+    /* K20  */  be_nested_str_weak(_X29_X20),
+    /* K21  */  be_nested_str_weak(_X2502X),
+    /* K22  */  be_nested_str_weak(_X2A_X2A),
+    /* K23  */  be_nested_str_weak(_X2504X),
+    /* K24  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+    /* K25  */  be_nested_str_weak(_X20_X28_X3E_X25s_X29),
+    /* K26  */  be_nested_str_weak(log),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X29_X20_X5B_X25s_X5D_X25s_X2F_X25s_X20_X25s_X25s),
+    /* K28  */  be_nested_str_weak(session),
+    /* K29  */  be_nested_str_weak(local_session_id),
+    /* K30  */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(write_single_attribute_status_to_bytes),
+    be_str_weak(process_read_or_subscribe_request_event_pull),
     &be_const_str_solidified,
-    ( &(const binstruction[86]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0xB8160000,  //  0002  GETNGBL	R5	K0
-      0x8C140B02,  //  0003  GETMET	R5	R5	K2
-      0x881C0503,  //  0004  GETMBR	R7	R2	K3
-      0x88200504,  //  0005  GETMBR	R8	R2	K4
-      0x7C140600,  //  0006  CALL	R5	3
-      0x78160002,  //  0007  JMPF	R5	#000B
-      0x001A0A05,  //  0008  ADD	R6	K5	R5
-      0x00180D06,  //  0009  ADD	R6	R6	K6
+    ( &(const binstruction[140]) {  /* code */
+      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x200C0604,  //  0002  NE	R3	R3	R4
+      0x780E0085,  //  0003  JMPF	R3	#008A
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x4C100000,  //  0005  LDNIL	R4
+      0x20100404,  //  0006  NE	R4	R2	R4
+      0x78120002,  //  0007  JMPF	R4	#000B
+      0x8C100501,  //  0008  GETMET	R4	R2	K1
+      0x7C100200,  //  0009  CALL	R4	1
       0x70020000,  //  000A  JMP		#000C
-      0x58180007,  //  000B  LDCONST	R6	K7
-      0x5C140C00,  //  000C  MOVE	R5	R6
-      0x88180508,  //  000D  GETMBR	R6	R2	K8
-      0x4C1C0000,  //  000E  LDNIL	R7
-      0x20180C07,  //  000F  NE	R6	R6	R7
-      0x781A0034,  //  0010  JMPF	R6	#0046
-      0xB81A0000,  //  0011  GETNGBL	R6	K0
-      0x8C180D09,  //  0012  GETMET	R6	R6	K9
-      0x7C180200,  //  0013  CALL	R6	1
-      0xB81E0000,  //  0014  GETNGBL	R7	K0
-      0x8C1C0F0B,  //  0015  GETMET	R7	R7	K11
-      0x7C1C0200,  //  0016  CALL	R7	1
-      0x901A1407,  //  0017  SETMBR	R6	K10	R7
-      0xB81E0000,  //  0018  GETNGBL	R7	K0
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
-      0x7C1C0200,  //  001A  CALL	R7	1
-      0x901A1007,  //  001B  SETMBR	R6	K8	R7
-      0x881C0D0A,  //  001C  GETMBR	R7	R6	K10
-      0x8820050D,  //  001D  GETMBR	R8	R2	K13
-      0x901E1A08,  //  001E  SETMBR	R7	K13	R8
-      0x881C0D0A,  //  001F  GETMBR	R7	R6	K10
-      0x88200503,  //  0020  GETMBR	R8	R2	K3
-      0x901E0608,  //  0021  SETMBR	R7	K3	R8
-      0x881C0D0A,  //  0022  GETMBR	R7	R6	K10
-      0x88200504,  //  0023  GETMBR	R8	R2	K4
-      0x901E0808,  //  0024  SETMBR	R7	K4	R8
-      0x881C0D08,  //  0025  GETMBR	R7	R6	K8
-      0x88200508,  //  0026  GETMBR	R8	R2	K8
-      0x901E1008,  //  0027  SETMBR	R7	K8	R8
-      0x881C030E,  //  0028  GETMBR	R7	R1	K14
-      0x8C1C0F0F,  //  0029  GETMET	R7	R7	K15
-      0x5C240C00,  //  002A  MOVE	R9	R6
-      0x7C1C0400,  //  002B  CALL	R7	2
-      0xB81E2000,  //  002C  GETNGBL	R7	K16
-      0x60200018,  //  002D  GETGBL	R8	G24
-      0x58240011,  //  002E  LDCONST	R9	K17
-      0x60280008,  //  002F  GETGBL	R10	G8
-      0x5C2C0400,  //  0030  MOVE	R11	R2
-      0x7C280200,  //  0031  CALL	R10	1
-      0x5C2C0A00,  //  0032  MOVE	R11	R5
-      0x5C300600,  //  0033  MOVE	R12	R3
-      0x88340508,  //  0034  GETMBR	R13	R2	K8
-      0x88380508,  //  0035  GETMBR	R14	R2	K8
-      0xB83E0000,  //  0036  GETNGBL	R15	K0
-      0x883C1F12,  //  0037  GETMBR	R15	R15	K18
-      0x1C381C0F,  //  0038  EQ	R14	R14	R15
-      0x783A0001,  //  0039  JMPF	R14	#003C
-      0x58380012,  //  003A  LDCONST	R14	K18
-      0x70020000,  //  003B  JMP		#003D
-      0x58380007,  //  003C  LDCONST	R14	K7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0x8824050D,  //  003E  GETMBR	R9	R2	K13
-      0x20241313,  //  003F  NE	R9	R9	K19
-      0x78260001,  //  0040  JMPF	R9	#0043
-      0x58240014,  //  0041  LDCONST	R9	K20
-      0x70020000,  //  0042  JMP		#0044
-      0x58240015,  //  0043  LDCONST	R9	K21
-      0x7C1C0400,  //  0044  CALL	R7	2
-      0x7002000E,  //  0045  JMP		#0055
-      0xB81A2C00,  //  0046  GETNGBL	R6	K22
-      0x8C180D17,  //  0047  GETMET	R6	R6	K23
-      0x58200015,  //  0048  LDCONST	R8	K21
-      0x7C180400,  //  0049  CALL	R6	2
-      0x781A0009,  //  004A  JMPF	R6	#0055
-      0xB81A2000,  //  004B  GETNGBL	R6	K16
-      0x601C0018,  //  004C  GETGBL	R7	G24
-      0x58200018,  //  004D  LDCONST	R8	K24
-      0x60240008,  //  004E  GETGBL	R9	G8
-      0x5C280400,  //  004F  MOVE	R10	R2
-      0x7C240200,  //  0050  CALL	R9	1
-      0x5C280A00,  //  0051  MOVE	R10	R5
-      0x7C1C0600,  //  0052  CALL	R7	3
-      0x58200015,  //  0053  LDCONST	R8	K21
-      0x7C180400,  //  0054  CALL	R6	2
-      0x80000000,  //  0055  RET	0
+      0x4C100000,  //  000B  LDNIL	R4
+      0x88140300,  //  000C  GETMBR	R5	R1	K0
+      0x78160003,  //  000D  JMPF	R5	#0012
+      0x6014000C,  //  000E  GETGBL	R5	G12
+      0x88180300,  //  000F  GETMBR	R6	R1	K0
+      0x7C140200,  //  0010  CALL	R5	1
+      0x70020000,  //  0011  JMP		#0013
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x24180B03,  //  0013  GT	R6	R5	K3
+      0x781A0002,  //  0014  JMPF	R6	#0018
+      0x60180012,  //  0015  GETGBL	R6	G18
+      0x7C180000,  //  0016  CALL	R6	0
+      0x5C0C0C00,  //  0017  MOVE	R3	R6
+      0x8C180104,  //  0018  GETMET	R6	R0	K4
+      0x88200305,  //  0019  GETMBR	R8	R1	K5
+      0x5C240800,  //  001A  MOVE	R9	R4
+      0x7C180600,  //  001B  CALL	R6	3
+      0x881C0300,  //  001C  GETMBR	R7	R1	K0
+      0x781E006A,  //  001D  JMPF	R7	#0089
+      0x601C0010,  //  001E  GETGBL	R7	G16
+      0x88200300,  //  001F  GETMBR	R8	R1	K0
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0xA8020063,  //  0021  EXBLK	0	#0086
+      0x5C200E00,  //  0022  MOVE	R8	R7
+      0x7C200000,  //  0023  CALL	R8	0
+      0xB8260C00,  //  0024  GETNGBL	R9	K6
+      0x8C241307,  //  0025  GETMET	R9	R9	K7
+      0x882C0108,  //  0026  GETMBR	R11	R0	K8
+      0x7C240400,  //  0027  CALL	R9	2
+      0x8C281309,  //  0028  GETMET	R10	R9	K9
+      0x8830110A,  //  0029  GETMBR	R12	R8	K10
+      0x8834110B,  //  002A  GETMBR	R13	R8	K11
+      0x8838110C,  //  002B  GETMBR	R14	R8	K12
+      0x5C3C0C00,  //  002C  MOVE	R15	R6
+      0x7C280A00,  //  002D  CALL	R10	5
+      0x24280B03,  //  002E  GT	R10	R5	K3
+      0x782A0003,  //  002F  JMPF	R10	#0034
+      0x8C28070D,  //  0030  GETMET	R10	R3	K13
+      0x5C301200,  //  0031  MOVE	R12	R9
+      0x7C280400,  //  0032  CALL	R10	2
+      0x70020000,  //  0033  JMP		#0035
+      0x5C0C1200,  //  0034  MOVE	R3	R9
+      0xB82A1C00,  //  0035  GETNGBL	R10	K14
+      0x8C28150F,  //  0036  GETMET	R10	R10	K15
+      0x58300010,  //  0037  LDCONST	R12	K16
+      0x7C280400,  //  0038  CALL	R10	2
+      0x782A004A,  //  0039  JMPF	R10	#0085
+      0x58280011,  //  003A  LDCONST	R10	K17
+      0x882C110B,  //  003B  GETMBR	R11	R8	K11
+      0x4C300000,  //  003C  LDNIL	R12
+      0x202C160C,  //  003D  NE	R11	R11	R12
+      0x782E0011,  //  003E  JMPF	R11	#0051
+      0x882C110C,  //  003F  GETMBR	R11	R8	K12
+      0x4C300000,  //  0040  LDNIL	R12
+      0x202C160C,  //  0041  NE	R11	R11	R12
+      0x782E000D,  //  0042  JMPF	R11	#0051
+      0xB82E0C00,  //  0043  GETNGBL	R11	K6
+      0x8C2C1712,  //  0044  GETMET	R11	R11	K18
+      0x8834110B,  //  0045  GETMBR	R13	R8	K11
+      0x8838110C,  //  0046  GETMBR	R14	R8	K12
+      0x7C2C0600,  //  0047  CALL	R11	3
+      0x5C281600,  //  0048  MOVE	R10	R11
+      0x4C2C0000,  //  0049  LDNIL	R11
+      0x202C140B,  //  004A  NE	R11	R10	R11
+      0x782E0002,  //  004B  JMPF	R11	#004F
+      0x002E260A,  //  004C  ADD	R11	K19	R10
+      0x002C1714,  //  004D  ADD	R11	R11	K20
+      0x70020000,  //  004E  JMP		#0050
+      0x582C0011,  //  004F  LDCONST	R11	K17
+      0x5C281600,  //  0050  MOVE	R10	R11
+      0x882C110A,  //  0051  GETMBR	R11	R8	K10
+      0x4C300000,  //  0052  LDNIL	R12
+      0x202C160C,  //  0053  NE	R11	R11	R12
+      0x782E0004,  //  0054  JMPF	R11	#005A
+      0x602C0018,  //  0055  GETGBL	R11	G24
+      0x58300015,  //  0056  LDCONST	R12	K21
+      0x8834110A,  //  0057  GETMBR	R13	R8	K10
+      0x7C2C0400,  //  0058  CALL	R11	2
+      0x70020000,  //  0059  JMP		#005B
+      0x582C0016,  //  005A  LDCONST	R11	K22
+      0x8830110B,  //  005B  GETMBR	R12	R8	K11
+      0x4C340000,  //  005C  LDNIL	R13
+      0x2030180D,  //  005D  NE	R12	R12	R13
+      0x78320004,  //  005E  JMPF	R12	#0064
+      0x60300018,  //  005F  GETGBL	R12	G24
+      0x58340017,  //  0060  LDCONST	R13	K23
+      0x8838110B,  //  0061  GETMBR	R14	R8	K11
+      0x7C300400,  //  0062  CALL	R12	2
+      0x70020000,  //  0063  JMP		#0065
+      0x58300018,  //  0064  LDCONST	R12	K24
+      0x8834110C,  //  0065  GETMBR	R13	R8	K12
+      0x4C380000,  //  0066  LDNIL	R14
+      0x20341A0E,  //  0067  NE	R13	R13	R14
+      0x78360004,  //  0068  JMPF	R13	#006E
+      0x60340018,  //  0069  GETGBL	R13	G24
+      0x58380015,  //  006A  LDCONST	R14	K21
+      0x883C110C,  //  006B  GETMBR	R15	R8	K12
+      0x7C340400,  //  006C  CALL	R13	2
+      0x70020000,  //  006D  JMP		#006F
+      0x58340016,  //  006E  LDCONST	R13	K22
+      0x4C380000,  //  006F  LDNIL	R14
+      0x20380C0E,  //  0070  NE	R14	R6	R14
+      0x783A0004,  //  0071  JMPF	R14	#0077
+      0x60380018,  //  0072  GETGBL	R14	G24
+      0x583C0019,  //  0073  LDCONST	R15	K25
+      0x5C400C00,  //  0074  MOVE	R16	R6
+      0x7C380400,  //  0075  CALL	R14	2
+      0x70020000,  //  0076  JMP		#0078
+      0x58380011,  //  0077  LDCONST	R14	K17
+      0xB83E3400,  //  0078  GETNGBL	R15	K26
+      0x60400018,  //  0079  GETGBL	R16	G24
+      0x5844001B,  //  007A  LDCONST	R17	K27
+      0x8848051C,  //  007B  GETMBR	R18	R2	K28
+      0x8848251D,  //  007C  GETMBR	R18	R18	K29
+      0x5C4C1600,  //  007D  MOVE	R19	R11
+      0x5C501800,  //  007E  MOVE	R20	R12
+      0x5C541A00,  //  007F  MOVE	R21	R13
+      0x5C581400,  //  0080  MOVE	R22	R10
+      0x5C5C1C00,  //  0081  MOVE	R23	R14
+      0x7C400E00,  //  0082  CALL	R16	7
+      0x58440010,  //  0083  LDCONST	R17	K16
+      0x7C3C0400,  //  0084  CALL	R15	2
+      0x7001FF9B,  //  0085  JMP		#0022
+      0x581C001E,  //  0086  LDCONST	R7	K30
+      0xAC1C0200,  //  0087  CATCH	R7	1	0
+      0xB0080000,  //  0088  RAISE	2	R0	R0
+      0x80040600,  //  0089  RET	1	R3
+      0x4C0C0000,  //  008A  LDNIL	R3
+      0x80040600,  //  008B  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_enqueued
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_send_enqueued,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(finished),
+    /* K3   */  be_nested_str_weak(ready),
+    /* K4   */  be_nested_str_weak(send_im),
+    /* K5   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    /* K6   */  be_nested_str_weak(resp),
+    /* K7   */  be_nested_str_weak(exchange_id),
+    /* K8   */  be_const_int(1),
+    }),
+    be_str_weak(send_enqueued),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0011,  //  0005  JMPF	R3	#0018
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x88100702,  //  0008  GETMBR	R4	R3	K2
+      0x74120004,  //  0009  JMPT	R4	#000F
+      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x78120002,  //  000B  JMPF	R4	#000F
+      0x8C100704,  //  000C  GETMET	R4	R3	K4
+      0x5C180200,  //  000D  MOVE	R6	R1
+      0x7C100400,  //  000E  CALL	R4	2
+      0x88100702,  //  000F  GETMBR	R4	R3	K2
+      0x78120004,  //  0010  JMPF	R4	#0016
+      0x8C100105,  //  0011  GETMET	R4	R0	K5
+      0x88180706,  //  0012  GETMBR	R6	R3	K6
+      0x88180D07,  //  0013  GETMBR	R6	R6	K7
+      0x7C100400,  //  0014  CALL	R4	2
+      0x70020000,  //  0015  JMP		#0017
+      0x00080508,  //  0016  ADD	R2	R2	K8
+      0x7001FFE8,  //  0017  JMP		#0001
+      0x80000000,  //  0018  RET	0
     })
   )
 );
@@ -690,177 +1535,12 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_read_or_subscribe_request_pull
+** Solidified function: send_ack_now
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* name */
+be_local_closure(class_Matter_IM_send_ack_now,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attributes_requests),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(PathGenerator),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(start),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(fabric_filtered),
-    /* K11  */  be_nested_str_weak(push),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(loglevel),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(Path),
-    /* K16  */  be_nested_str_weak(get_attribute_name),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K19  */  be_nested_str_weak(session),
-    /* K20  */  be_nested_str_weak(local_session_id),
-    /* K21  */  be_nested_str_weak(_X20_X28),
-    /* K22  */  be_nested_str_weak(_X29),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(process_read_or_subscribe_request_pull),
-    &be_const_str_solidified,
-    ( &(const binstruction[115]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x200C0604,  //  0002  NE	R3	R3	R4
-      0x780E006C,  //  0003  JMPF	R3	#0071
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x88100300,  //  0005  GETMBR	R4	R1	K0
-      0x78120003,  //  0006  JMPF	R4	#000B
-      0x6010000C,  //  0007  GETGBL	R4	G12
-      0x88140300,  //  0008  GETMBR	R5	R1	K0
-      0x7C100200,  //  0009  CALL	R4	1
-      0x70020000,  //  000A  JMP		#000C
-      0x58100001,  //  000B  LDCONST	R4	K1
-      0x24140902,  //  000C  GT	R5	R4	K2
-      0x78160002,  //  000D  JMPF	R5	#0011
-      0x60140012,  //  000E  GETGBL	R5	G18
-      0x7C140000,  //  000F  CALL	R5	0
-      0x5C0C0A00,  //  0010  MOVE	R3	R5
-      0x60140010,  //  0011  GETGBL	R5	G16
-      0x88180300,  //  0012  GETMBR	R6	R1	K0
-      0x7C140200,  //  0013  CALL	R5	1
-      0xA8020057,  //  0014  EXBLK	0	#006D
-      0x5C180A00,  //  0015  MOVE	R6	R5
-      0x7C180000,  //  0016  CALL	R6	0
-      0xB81E0600,  //  0017  GETNGBL	R7	K3
-      0x8C1C0F04,  //  0018  GETMET	R7	R7	K4
-      0x88240105,  //  0019  GETMBR	R9	R0	K5
-      0x7C1C0400,  //  001A  CALL	R7	2
-      0x8C200F06,  //  001B  GETMET	R8	R7	K6
-      0x88280D07,  //  001C  GETMBR	R10	R6	K7
-      0x882C0D08,  //  001D  GETMBR	R11	R6	K8
-      0x88300D09,  //  001E  GETMBR	R12	R6	K9
-      0x8834030A,  //  001F  GETMBR	R13	R1	K10
-      0x7C200A00,  //  0020  CALL	R8	5
-      0x24200902,  //  0021  GT	R8	R4	K2
-      0x78220003,  //  0022  JMPF	R8	#0027
-      0x8C20070B,  //  0023  GETMET	R8	R3	K11
-      0x5C280E00,  //  0024  MOVE	R10	R7
-      0x7C200400,  //  0025  CALL	R8	2
-      0x70020000,  //  0026  JMP		#0028
-      0x5C0C0E00,  //  0027  MOVE	R3	R7
-      0xB8221800,  //  0028  GETNGBL	R8	K12
-      0x8C20110D,  //  0029  GETMET	R8	R8	K13
-      0x5828000E,  //  002A  LDCONST	R10	K14
-      0x7C200400,  //  002B  CALL	R8	2
-      0x7822003E,  //  002C  JMPF	R8	#006C
-      0x88200D07,  //  002D  GETMBR	R8	R6	K7
-      0x4C240000,  //  002E  LDNIL	R9
-      0x1C201009,  //  002F  EQ	R8	R8	R9
-      0x74220007,  //  0030  JMPT	R8	#0039
-      0x88200D08,  //  0031  GETMBR	R8	R6	K8
-      0x4C240000,  //  0032  LDNIL	R9
-      0x1C201009,  //  0033  EQ	R8	R8	R9
-      0x74220003,  //  0034  JMPT	R8	#0039
-      0x88200D09,  //  0035  GETMBR	R8	R6	K9
-      0x4C240000,  //  0036  LDNIL	R9
-      0x1C201009,  //  0037  EQ	R8	R8	R9
-      0x78220032,  //  0038  JMPF	R8	#006C
-      0xB8220600,  //  0039  GETNGBL	R8	K3
-      0x8C20110F,  //  003A  GETMET	R8	R8	K15
-      0x7C200200,  //  003B  CALL	R8	1
-      0x88240D07,  //  003C  GETMBR	R9	R6	K7
-      0x90220E09,  //  003D  SETMBR	R8	K7	R9
-      0x88240D08,  //  003E  GETMBR	R9	R6	K8
-      0x90221009,  //  003F  SETMBR	R8	K8	R9
-      0x88240D09,  //  0040  GETMBR	R9	R6	K9
-      0x90221209,  //  0041  SETMBR	R8	K9	R9
-      0x8824030A,  //  0042  GETMBR	R9	R1	K10
-      0x90221409,  //  0043  SETMBR	R8	K10	R9
-      0x60240008,  //  0044  GETGBL	R9	G8
-      0x5C281000,  //  0045  MOVE	R10	R8
-      0x7C240200,  //  0046  CALL	R9	1
-      0x88280D08,  //  0047  GETMBR	R10	R6	K8
-      0x4C2C0000,  //  0048  LDNIL	R11
-      0x2028140B,  //  0049  NE	R10	R10	R11
-      0x782A0017,  //  004A  JMPF	R10	#0063
-      0x88280D09,  //  004B  GETMBR	R10	R6	K9
-      0x4C2C0000,  //  004C  LDNIL	R11
-      0x2028140B,  //  004D  NE	R10	R10	R11
-      0x782A0013,  //  004E  JMPF	R10	#0063
-      0xB82A0600,  //  004F  GETNGBL	R10	K3
-      0x8C281510,  //  0050  GETMET	R10	R10	K16
-      0x88300D08,  //  0051  GETMBR	R12	R6	K8
-      0x88340D09,  //  0052  GETMBR	R13	R6	K9
-      0x7C280600,  //  0053  CALL	R10	3
-      0xB82E2200,  //  0054  GETNGBL	R11	K17
-      0x60300018,  //  0055  GETGBL	R12	G24
-      0x58340012,  //  0056  LDCONST	R13	K18
-      0x88380513,  //  0057  GETMBR	R14	R2	K19
-      0x88381D14,  //  0058  GETMBR	R14	R14	K20
-      0x782A0002,  //  0059  JMPF	R10	#005D
-      0x003E2A0A,  //  005A  ADD	R15	K21	R10
-      0x003C1F16,  //  005B  ADD	R15	R15	K22
-      0x70020000,  //  005C  JMP		#005E
-      0x583C0017,  //  005D  LDCONST	R15	K23
-      0x003C120F,  //  005E  ADD	R15	R9	R15
-      0x7C300600,  //  005F  CALL	R12	3
-      0x5834000E,  //  0060  LDCONST	R13	K14
-      0x7C2C0400,  //  0061  CALL	R11	2
-      0x70020008,  //  0062  JMP		#006C
-      0xB82A2200,  //  0063  GETNGBL	R10	K17
-      0x602C0018,  //  0064  GETGBL	R11	G24
-      0x58300012,  //  0065  LDCONST	R12	K18
-      0x88340513,  //  0066  GETMBR	R13	R2	K19
-      0x88341B14,  //  0067  GETMBR	R13	R13	K20
-      0x5C381200,  //  0068  MOVE	R14	R9
-      0x7C2C0600,  //  0069  CALL	R11	3
-      0x5830000E,  //  006A  LDCONST	R12	K14
-      0x7C280400,  //  006B  CALL	R10	2
-      0x7001FFA7,  //  006C  JMP		#0015
-      0x58140018,  //  006D  LDCONST	R5	K24
-      0xAC140200,  //  006E  CATCH	R5	1	0
-      0xB0080000,  //  006F  RAISE	2	R0	R0
-      0x80040600,  //  0070  RET	1	R3
-      0x4C0C0000,  //  0071  LDNIL	R3
-      0x80040600,  //  0072  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_incoming
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_incoming,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -868,160 +1548,406 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(opcode),
-    /* K1   */  be_const_int(2),
-    /* K2   */  be_nested_str_weak(read_request_solo),
-    /* K3   */  be_nested_str_weak(from_raw),
-    /* K4   */  be_nested_str_weak(raw),
-    /* K5   */  be_nested_str_weak(app_payload_idx),
-    /* K6   */  be_nested_str_weak(process_read_request_solo),
-    /* K7   */  be_nested_str_weak(invoke_request_solo),
-    /* K8   */  be_nested_str_weak(process_invoke_request_solo),
-    /* K9   */  be_nested_str_weak(matter),
-    /* K10  */  be_nested_str_weak(TLV),
-    /* K11  */  be_nested_str_weak(parse),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(process_status_response),
-    /* K14  */  be_nested_str_weak(send_ack_now),
-    /* K15  */  be_nested_str_weak(process_read_request_pull),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(subscribe_request),
-    /* K18  */  be_nested_str_weak(process_write_request),
-    /* K19  */  be_nested_str_weak(process_write_response),
-    /* K20  */  be_nested_str_weak(process_invoke_request),
-    /* K21  */  be_nested_str_weak(process_timed_request),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(_message_handler),
+    /* K2   */  be_nested_str_weak(send_encrypted_ack),
     }),
-    be_str_weak(process_incoming),
+    be_str_weak(send_ack_now),
     &be_const_str_solidified,
-    ( &(const binstruction[127]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x1C0C0501,  //  0001  EQ	R3	R2	K1
-      0x780E000D,  //  0002  JMPF	R3	#0011
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
-      0x88140304,  //  0005  GETMBR	R5	R1	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x4C100000,  //  0008  LDNIL	R4
-      0x20100604,  //  0009  NE	R4	R3	R4
-      0x78120004,  //  000A  JMPF	R4	#0010
-      0x8C100106,  //  000B  GETMET	R4	R0	K6
-      0x5C180200,  //  000C  MOVE	R6	R1
-      0x5C1C0600,  //  000D  MOVE	R7	R3
-      0x7C100600,  //  000E  CALL	R4	3
-      0x80040800,  //  000F  RET	1	R4
-      0x7002000F,  //  0010  JMP		#0021
-      0x540E0007,  //  0011  LDINT	R3	8
-      0x1C0C0403,  //  0012  EQ	R3	R2	R3
-      0x780E000C,  //  0013  JMPF	R3	#0021
-      0x880C0107,  //  0014  GETMBR	R3	R0	K7
-      0x8C0C0703,  //  0015  GETMET	R3	R3	K3
-      0x88140304,  //  0016  GETMBR	R5	R1	K4
-      0x88180305,  //  0017  GETMBR	R6	R1	K5
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x4C100000,  //  0019  LDNIL	R4
-      0x20100604,  //  001A  NE	R4	R3	R4
-      0x78120004,  //  001B  JMPF	R4	#0021
-      0x8C100108,  //  001C  GETMET	R4	R0	K8
-      0x5C180200,  //  001D  MOVE	R6	R1
-      0x5C1C0600,  //  001E  MOVE	R7	R3
-      0x7C100600,  //  001F  CALL	R4	3
-      0x80040800,  //  0020  RET	1	R4
-      0xB80E1200,  //  0021  GETNGBL	R3	K9
-      0x880C070A,  //  0022  GETMBR	R3	R3	K10
-      0x8C0C070B,  //  0023  GETMET	R3	R3	K11
-      0x88140304,  //  0024  GETMBR	R5	R1	K4
-      0x88180305,  //  0025  GETMBR	R6	R1	K5
-      0x7C0C0600,  //  0026  CALL	R3	3
-      0x1C10050C,  //  0027  EQ	R4	R2	K12
-      0x78120005,  //  0028  JMPF	R4	#002F
-      0x8C10010D,  //  0029  GETMET	R4	R0	K13
-      0x5C180200,  //  002A  MOVE	R6	R1
-      0x5C1C0600,  //  002B  MOVE	R7	R3
-      0x7C100600,  //  002C  CALL	R4	3
-      0x80040800,  //  002D  RET	1	R4
-      0x7002004D,  //  002E  JMP		#007D
-      0x1C100501,  //  002F  EQ	R4	R2	K1
-      0x78120008,  //  0030  JMPF	R4	#003A
-      0x8C10010E,  //  0031  GETMET	R4	R0	K14
-      0x5C180200,  //  0032  MOVE	R6	R1
-      0x7C100400,  //  0033  CALL	R4	2
-      0x8C10010F,  //  0034  GETMET	R4	R0	K15
-      0x5C180200,  //  0035  MOVE	R6	R1
-      0x5C1C0600,  //  0036  MOVE	R7	R3
-      0x7C100600,  //  0037  CALL	R4	3
-      0x80040800,  //  0038  RET	1	R4
-      0x70020042,  //  0039  JMP		#007D
-      0x1C100510,  //  003A  EQ	R4	R2	K16
-      0x78120008,  //  003B  JMPF	R4	#0045
-      0x8C10010E,  //  003C  GETMET	R4	R0	K14
-      0x5C180200,  //  003D  MOVE	R6	R1
-      0x7C100400,  //  003E  CALL	R4	2
-      0x8C100111,  //  003F  GETMET	R4	R0	K17
-      0x5C180200,  //  0040  MOVE	R6	R1
-      0x5C1C0600,  //  0041  MOVE	R7	R3
-      0x7C100600,  //  0042  CALL	R4	3
-      0x80040800,  //  0043  RET	1	R4
-      0x70020037,  //  0044  JMP		#007D
-      0x54120003,  //  0045  LDINT	R4	4
-      0x1C100404,  //  0046  EQ	R4	R2	R4
-      0x78120002,  //  0047  JMPF	R4	#004B
-      0x50100000,  //  0048  LDBOOL	R4	0	0
-      0x80040800,  //  0049  RET	1	R4
-      0x70020031,  //  004A  JMP		#007D
-      0x54120004,  //  004B  LDINT	R4	5
-      0x1C100404,  //  004C  EQ	R4	R2	R4
-      0x78120002,  //  004D  JMPF	R4	#0051
-      0x50100000,  //  004E  LDBOOL	R4	0	0
-      0x80040800,  //  004F  RET	1	R4
-      0x7002002B,  //  0050  JMP		#007D
-      0x54120005,  //  0051  LDINT	R4	6
-      0x1C100404,  //  0052  EQ	R4	R2	R4
-      0x78120008,  //  0053  JMPF	R4	#005D
-      0x8C10010E,  //  0054  GETMET	R4	R0	K14
-      0x5C180200,  //  0055  MOVE	R6	R1
-      0x7C100400,  //  0056  CALL	R4	2
-      0x8C100112,  //  0057  GETMET	R4	R0	K18
-      0x5C180200,  //  0058  MOVE	R6	R1
-      0x5C1C0600,  //  0059  MOVE	R7	R3
-      0x7C100600,  //  005A  CALL	R4	3
-      0x80040800,  //  005B  RET	1	R4
-      0x7002001F,  //  005C  JMP		#007D
-      0x54120006,  //  005D  LDINT	R4	7
-      0x1C100404,  //  005E  EQ	R4	R2	R4
-      0x78120005,  //  005F  JMPF	R4	#0066
-      0x8C100113,  //  0060  GETMET	R4	R0	K19
-      0x5C180200,  //  0061  MOVE	R6	R1
-      0x5C1C0600,  //  0062  MOVE	R7	R3
-      0x7C100600,  //  0063  CALL	R4	3
-      0x80040800,  //  0064  RET	1	R4
-      0x70020016,  //  0065  JMP		#007D
-      0x54120007,  //  0066  LDINT	R4	8
-      0x1C100404,  //  0067  EQ	R4	R2	R4
-      0x78120005,  //  0068  JMPF	R4	#006F
-      0x8C100114,  //  0069  GETMET	R4	R0	K20
-      0x5C180200,  //  006A  MOVE	R6	R1
-      0x5C1C0600,  //  006B  MOVE	R7	R3
-      0x7C100600,  //  006C  CALL	R4	3
-      0x80040800,  //  006D  RET	1	R4
-      0x7002000D,  //  006E  JMP		#007D
-      0x54120008,  //  006F  LDINT	R4	9
-      0x1C100404,  //  0070  EQ	R4	R2	R4
-      0x78120002,  //  0071  JMPF	R4	#0075
-      0x50100000,  //  0072  LDBOOL	R4	0	0
-      0x80040800,  //  0073  RET	1	R4
-      0x70020007,  //  0074  JMP		#007D
-      0x54120009,  //  0075  LDINT	R4	10
-      0x1C100404,  //  0076  EQ	R4	R2	R4
-      0x78120004,  //  0077  JMPF	R4	#007D
-      0x8C100115,  //  0078  GETMET	R4	R0	K21
-      0x5C180200,  //  0079  MOVE	R6	R1
-      0x5C1C0600,  //  007A  MOVE	R7	R3
-      0x7C100600,  //  007B  CALL	R4	3
-      0x80040800,  //  007C  RET	1	R4
-      0x50100000,  //  007D  LDBOOL	R4	0	0
-      0x80040800,  //  007E  RET	1	R4
+    ( &(const binstruction[11]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x88080300,  //  0004  GETMBR	R2	R1	K0
+      0x88080501,  //  0005  GETMBR	R2	R2	K1
+      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x50140000,  //  0008  LDBOOL	R5	0	0
+      0x7C080600,  //  0009  CALL	R2	3
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: expire_sendqueue
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(time_reached),
+    /* K4   */  be_nested_str_weak(expiration),
+    /* K5   */  be_nested_str_weak(reached_timeout),
+    /* K6   */  be_nested_str_weak(remove),
+    /* K7   */  be_const_int(1),
+    }),
+    be_str_weak(expire_sendqueue),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x14080202,  //  0004  LT	R2	R1	R2
+      0x780A000F,  //  0005  JMPF	R2	#0016
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x94080401,  //  0007  GETIDX	R2	R2	R1
+      0xB80E0400,  //  0008  GETNGBL	R3	K2
+      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
+      0x88140504,  //  000A  GETMBR	R5	R2	K4
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x8C0C0505,  //  000D  GETMET	R3	R2	K5
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x880C0101,  //  000F  GETMBR	R3	R0	K1
+      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x5C140200,  //  0011  MOVE	R5	R1
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x70020000,  //  0013  JMP		#0015
+      0x00040307,  //  0014  ADD	R1	R1	K7
+      0x7001FFEA,  //  0015  JMP		#0001
+      0x4C080000,  //  0016  LDNIL	R2
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_incoming_ack
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K1   */  be_nested_str_weak(exchange_id),
+    /* K2   */  be_nested_str_weak(ack_received),
+    /* K3   */  be_nested_str_weak(finished),
+    /* K4   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    }),
+    be_str_weak(process_incoming_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x780A0008,  //  0003  JMPF	R2	#000D
+      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x88100503,  //  0007  GETMBR	R4	R2	K3
+      0x78120002,  //  0008  JMPF	R4	#000C
+      0x8C100104,  //  0009  GETMET	R4	R0	K4
+      0x88180301,  //  000A  GETMBR	R6	R1	K1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x80040600,  //  000C  RET	1	R3
+      0x500C0000,  //  000D  LDBOOL	R3	0	0
+      0x80040600,  //  000E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_sendqueue_by_exchangeid
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(get_exchangeid),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(remove_sendqueue_by_exchangeid),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x58080000,  //  0004  LDCONST	R2	K0
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E000C,  //  0009  JMPF	R3	#0017
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x940C0602,  //  000B  GETIDX	R3	R3	R2
+      0x8C0C0702,  //  000C  GETMET	R3	R3	K2
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x1C0C0601,  //  000E  EQ	R3	R3	R1
+      0x780E0004,  //  000F  JMPF	R3	#0015
+      0x880C0101,  //  0010  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
+      0x5C140400,  //  0012  MOVE	R5	R2
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x70020000,  //  0014  JMP		#0016
+      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x7001FFED,  //  0016  JMP		#0005
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: write_single_attribute_status_to_bytes
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(get_attribute_name),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(_X20_X28),
+    /* K6   */  be_nested_str_weak(_X29),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(status),
+    /* K9   */  be_nested_str_weak(AttributeStatusIB),
+    /* K10  */  be_nested_str_weak(path),
+    /* K11  */  be_nested_str_weak(AttributePathIB),
+    /* K12  */  be_nested_str_weak(StatusIB),
+    /* K13  */  be_nested_str_weak(endpoint),
+    /* K14  */  be_nested_str_weak(write_responses),
+    /* K15  */  be_nested_str_weak(push),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20_X25s_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+    /* K18  */  be_nested_str_weak(SUCCESS),
+    /* K19  */  be_const_int(0),
+    /* K20  */  be_const_int(2),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(tasmota),
+    /* K23  */  be_nested_str_weak(loglevel),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20IGNORED),
+    }),
+    be_str_weak(write_single_attribute_status_to_bytes),
+    &be_const_str_solidified,
+    ( &(const binstruction[86]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0xB8160000,  //  0002  GETNGBL	R5	K0
+      0x8C140B02,  //  0003  GETMET	R5	R5	K2
+      0x881C0503,  //  0004  GETMBR	R7	R2	K3
+      0x88200504,  //  0005  GETMBR	R8	R2	K4
+      0x7C140600,  //  0006  CALL	R5	3
+      0x78160002,  //  0007  JMPF	R5	#000B
+      0x001A0A05,  //  0008  ADD	R6	K5	R5
+      0x00180D06,  //  0009  ADD	R6	R6	K6
+      0x70020000,  //  000A  JMP		#000C
+      0x58180007,  //  000B  LDCONST	R6	K7
+      0x5C140C00,  //  000C  MOVE	R5	R6
+      0x88180508,  //  000D  GETMBR	R6	R2	K8
+      0x4C1C0000,  //  000E  LDNIL	R7
+      0x20180C07,  //  000F  NE	R6	R6	R7
+      0x781A0034,  //  0010  JMPF	R6	#0046
+      0xB81A0000,  //  0011  GETNGBL	R6	K0
+      0x8C180D09,  //  0012  GETMET	R6	R6	K9
+      0x7C180200,  //  0013  CALL	R6	1
+      0xB81E0000,  //  0014  GETNGBL	R7	K0
+      0x8C1C0F0B,  //  0015  GETMET	R7	R7	K11
+      0x7C1C0200,  //  0016  CALL	R7	1
+      0x901A1407,  //  0017  SETMBR	R6	K10	R7
+      0xB81E0000,  //  0018  GETNGBL	R7	K0
+      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
+      0x7C1C0200,  //  001A  CALL	R7	1
+      0x901A1007,  //  001B  SETMBR	R6	K8	R7
+      0x881C0D0A,  //  001C  GETMBR	R7	R6	K10
+      0x8820050D,  //  001D  GETMBR	R8	R2	K13
+      0x901E1A08,  //  001E  SETMBR	R7	K13	R8
+      0x881C0D0A,  //  001F  GETMBR	R7	R6	K10
+      0x88200503,  //  0020  GETMBR	R8	R2	K3
+      0x901E0608,  //  0021  SETMBR	R7	K3	R8
+      0x881C0D0A,  //  0022  GETMBR	R7	R6	K10
+      0x88200504,  //  0023  GETMBR	R8	R2	K4
+      0x901E0808,  //  0024  SETMBR	R7	K4	R8
+      0x881C0D08,  //  0025  GETMBR	R7	R6	K8
+      0x88200508,  //  0026  GETMBR	R8	R2	K8
+      0x901E1008,  //  0027  SETMBR	R7	K8	R8
+      0x881C030E,  //  0028  GETMBR	R7	R1	K14
+      0x8C1C0F0F,  //  0029  GETMET	R7	R7	K15
+      0x5C240C00,  //  002A  MOVE	R9	R6
+      0x7C1C0400,  //  002B  CALL	R7	2
+      0xB81E2000,  //  002C  GETNGBL	R7	K16
+      0x60200018,  //  002D  GETGBL	R8	G24
+      0x58240011,  //  002E  LDCONST	R9	K17
+      0x60280008,  //  002F  GETGBL	R10	G8
+      0x5C2C0400,  //  0030  MOVE	R11	R2
+      0x7C280200,  //  0031  CALL	R10	1
+      0x5C2C0A00,  //  0032  MOVE	R11	R5
+      0x5C300600,  //  0033  MOVE	R12	R3
+      0x88340508,  //  0034  GETMBR	R13	R2	K8
+      0x88380508,  //  0035  GETMBR	R14	R2	K8
+      0xB83E0000,  //  0036  GETNGBL	R15	K0
+      0x883C1F12,  //  0037  GETMBR	R15	R15	K18
+      0x1C381C0F,  //  0038  EQ	R14	R14	R15
+      0x783A0001,  //  0039  JMPF	R14	#003C
+      0x58380012,  //  003A  LDCONST	R14	K18
+      0x70020000,  //  003B  JMP		#003D
+      0x58380007,  //  003C  LDCONST	R14	K7
+      0x7C200C00,  //  003D  CALL	R8	6
+      0x8824050D,  //  003E  GETMBR	R9	R2	K13
+      0x20241313,  //  003F  NE	R9	R9	K19
+      0x78260001,  //  0040  JMPF	R9	#0043
+      0x58240014,  //  0041  LDCONST	R9	K20
+      0x70020000,  //  0042  JMP		#0044
+      0x58240015,  //  0043  LDCONST	R9	K21
+      0x7C1C0400,  //  0044  CALL	R7	2
+      0x7002000E,  //  0045  JMP		#0055
+      0xB81A2C00,  //  0046  GETNGBL	R6	K22
+      0x8C180D17,  //  0047  GETMET	R6	R6	K23
+      0x58200015,  //  0048  LDCONST	R8	K21
+      0x7C180400,  //  0049  CALL	R6	2
+      0x781A0009,  //  004A  JMPF	R6	#0055
+      0xB81A2000,  //  004B  GETNGBL	R6	K16
+      0x601C0018,  //  004C  GETGBL	R7	G24
+      0x58200018,  //  004D  LDCONST	R8	K24
+      0x60240008,  //  004E  GETGBL	R9	G8
+      0x5C280400,  //  004F  MOVE	R10	R2
+      0x7C240200,  //  0050  CALL	R9	1
+      0x5C280A00,  //  0051  MOVE	R10	R5
+      0x7C1C0600,  //  0052  CALL	R7	3
+      0x58200015,  //  0053  LDCONST	R8	K21
+      0x7C180400,  //  0054  CALL	R6	2
+      0x80000000,  //  0055  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(subs_shop),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
+    /* K5   */  be_nested_str_weak(read_request_solo),
+    /* K6   */  be_nested_str_weak(ReadRequestMessage_solo),
+    /* K7   */  be_nested_str_weak(invoke_request_solo),
+    /* K8   */  be_nested_str_weak(InvokeRequestMessage_solo),
+    /* K9   */  be_nested_str_weak(tlv_solo),
+    /* K10  */  be_nested_str_weak(TLV),
+    /* K11  */  be_nested_str_weak(Matter_TLV_item),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0xB80A0600,  //  0004  GETNGBL	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0xB80A0600,  //  0009  GETNGBL	R2	K3
+      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020A02,  //  000C  SETMBR	R0	K5	R2
+      0xB80A0600,  //  000D  GETNGBL	R2	K3
+      0x8C080508,  //  000E  GETMET	R2	R2	K8
+      0x7C080200,  //  000F  CALL	R2	1
+      0x90020E02,  //  0010  SETMBR	R0	K7	R2
+      0xB80A0600,  //  0011  GETNGBL	R2	K3
+      0x8808050A,  //  0012  GETMBR	R2	R2	K10
+      0x8C08050B,  //  0013  GETMET	R2	R2	K11
+      0x7C080200,  //  0014  CALL	R2	1
+      0x90021202,  //  0015  SETMBR	R0	K9	R2
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expire_sendqueue),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -1280,253 +2206,12 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
 
 
 /********************************************************************
-** Solidified function: invokeresponse2raw
+** Solidified function: send_subscribe_heartbeat
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
+be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(command),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(SUCCESS),
-    /* K9   */  be_nested_str_weak(tag_sub),
-    /* K10  */  be_nested_str_weak(tlv2raw),
-    }),
-    be_str_weak(invokeresponse2raw),
-    &be_const_str_solidified,
-    ( &(const binstruction[148]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
-      0x541A0014,  //  0001  LDINT	R6	21
-      0x581C0001,  //  0002  LDCONST	R7	K1
-      0x7C100600,  //  0003  CALL	R4	3
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120004,  //  0006  JMPF	R4	#000C
-      0x8C100300,  //  0007  GETMET	R4	R1	K0
-      0x541A3500,  //  0008  LDINT	R6	13569
-      0x541DFFFD,  //  0009  LDINT	R7	-2
-      0x7C100600,  //  000A  CALL	R4	3
-      0x70020003,  //  000B  JMP		#0010
-      0x8C100300,  //  000C  GETMET	R4	R1	K0
-      0x541A34FF,  //  000D  LDINT	R6	13568
-      0x541DFFFD,  //  000E  LDINT	R7	-2
-      0x7C100600,  //  000F  CALL	R4	3
-      0x8C100300,  //  0010  GETMET	R4	R1	K0
-      0x541A36FF,  //  0011  LDINT	R6	14080
-      0x541DFFFD,  //  0012  LDINT	R7	-2
-      0x7C100600,  //  0013  CALL	R4	3
-      0x88100502,  //  0014  GETMBR	R4	R2	K2
-      0x541600FE,  //  0015  LDINT	R5	255
-      0x18100805,  //  0016  LE	R4	R4	R5
-      0x78120008,  //  0017  JMPF	R4	#0021
-      0x8C100300,  //  0018  GETMET	R4	R1	K0
-      0x541A23FF,  //  0019  LDINT	R6	9216
-      0x541DFFFD,  //  001A  LDINT	R7	-2
-      0x7C100600,  //  001B  CALL	R4	3
-      0x8C100300,  //  001C  GETMET	R4	R1	K0
-      0x88180502,  //  001D  GETMBR	R6	R2	K2
-      0x581C0001,  //  001E  LDCONST	R7	K1
-      0x7C100600,  //  001F  CALL	R4	3
-      0x70020007,  //  0020  JMP		#0029
-      0x8C100300,  //  0021  GETMET	R4	R1	K0
-      0x541A24FF,  //  0022  LDINT	R6	9472
-      0x541DFFFD,  //  0023  LDINT	R7	-2
-      0x7C100600,  //  0024  CALL	R4	3
-      0x8C100300,  //  0025  GETMET	R4	R1	K0
-      0x88180502,  //  0026  GETMBR	R6	R2	K2
-      0x581C0003,  //  0027  LDCONST	R7	K3
-      0x7C100600,  //  0028  CALL	R4	3
-      0x88100504,  //  0029  GETMBR	R4	R2	K4
-      0x541600FE,  //  002A  LDINT	R5	255
-      0x18100805,  //  002B  LE	R4	R4	R5
-      0x78120008,  //  002C  JMPF	R4	#0036
-      0x8C100300,  //  002D  GETMET	R4	R1	K0
-      0x541A2400,  //  002E  LDINT	R6	9217
-      0x541DFFFD,  //  002F  LDINT	R7	-2
-      0x7C100600,  //  0030  CALL	R4	3
-      0x8C100300,  //  0031  GETMET	R4	R1	K0
-      0x88180504,  //  0032  GETMBR	R6	R2	K4
-      0x581C0001,  //  0033  LDCONST	R7	K1
-      0x7C100600,  //  0034  CALL	R4	3
-      0x70020014,  //  0035  JMP		#004B
-      0x88100504,  //  0036  GETMBR	R4	R2	K4
-      0x5416FFFE,  //  0037  LDINT	R5	65535
-      0x18100805,  //  0038  LE	R4	R4	R5
-      0x78120008,  //  0039  JMPF	R4	#0043
-      0x8C100300,  //  003A  GETMET	R4	R1	K0
-      0x541A2500,  //  003B  LDINT	R6	9473
-      0x541DFFFD,  //  003C  LDINT	R7	-2
-      0x7C100600,  //  003D  CALL	R4	3
-      0x8C100300,  //  003E  GETMET	R4	R1	K0
-      0x88180504,  //  003F  GETMBR	R6	R2	K4
-      0x581C0003,  //  0040  LDCONST	R7	K3
-      0x7C100600,  //  0041  CALL	R4	3
-      0x70020007,  //  0042  JMP		#004B
-      0x8C100300,  //  0043  GETMET	R4	R1	K0
-      0x541A2600,  //  0044  LDINT	R6	9729
-      0x541DFFFD,  //  0045  LDINT	R7	-2
-      0x7C100600,  //  0046  CALL	R4	3
-      0x8C100300,  //  0047  GETMET	R4	R1	K0
-      0x88180504,  //  0048  GETMBR	R6	R2	K4
-      0x541E0003,  //  0049  LDINT	R7	4
-      0x7C100600,  //  004A  CALL	R4	3
-      0x88100505,  //  004B  GETMBR	R4	R2	K5
-      0x541600FE,  //  004C  LDINT	R5	255
-      0x18100805,  //  004D  LE	R4	R4	R5
-      0x78120008,  //  004E  JMPF	R4	#0058
-      0x8C100300,  //  004F  GETMET	R4	R1	K0
-      0x541A2401,  //  0050  LDINT	R6	9218
-      0x541DFFFD,  //  0051  LDINT	R7	-2
-      0x7C100600,  //  0052  CALL	R4	3
-      0x8C100300,  //  0053  GETMET	R4	R1	K0
-      0x88180505,  //  0054  GETMBR	R6	R2	K5
-      0x581C0001,  //  0055  LDCONST	R7	K1
-      0x7C100600,  //  0056  CALL	R4	3
-      0x70020014,  //  0057  JMP		#006D
-      0x88100505,  //  0058  GETMBR	R4	R2	K5
-      0x5416FFFE,  //  0059  LDINT	R5	65535
-      0x18100805,  //  005A  LE	R4	R4	R5
-      0x78120008,  //  005B  JMPF	R4	#0065
-      0x8C100300,  //  005C  GETMET	R4	R1	K0
-      0x541A2501,  //  005D  LDINT	R6	9474
-      0x541DFFFD,  //  005E  LDINT	R7	-2
-      0x7C100600,  //  005F  CALL	R4	3
-      0x8C100300,  //  0060  GETMET	R4	R1	K0
-      0x88180505,  //  0061  GETMBR	R6	R2	K5
-      0x581C0003,  //  0062  LDCONST	R7	K3
-      0x7C100600,  //  0063  CALL	R4	3
-      0x70020007,  //  0064  JMP		#006D
-      0x8C100300,  //  0065  GETMET	R4	R1	K0
-      0x541A2601,  //  0066  LDINT	R6	9730
-      0x541DFFFD,  //  0067  LDINT	R7	-2
-      0x7C100600,  //  0068  CALL	R4	3
-      0x8C100300,  //  0069  GETMET	R4	R1	K0
-      0x88180505,  //  006A  GETMBR	R6	R2	K5
-      0x541E0003,  //  006B  LDINT	R7	4
-      0x7C100600,  //  006C  CALL	R4	3
-      0x8C100300,  //  006D  GETMET	R4	R1	K0
-      0x541A0017,  //  006E  LDINT	R6	24
-      0x581C0001,  //  006F  LDCONST	R7	K1
-      0x7C100600,  //  0070  CALL	R4	3
-      0x4C100000,  //  0071  LDNIL	R4
-      0x1C100604,  //  0072  EQ	R4	R3	R4
-      0x78120016,  //  0073  JMPF	R4	#008B
-      0x88100506,  //  0074  GETMBR	R4	R2	K6
-      0x4C140000,  //  0075  LDNIL	R5
-      0x1C140805,  //  0076  EQ	R5	R4	R5
-      0x78160001,  //  0077  JMPF	R5	#007A
-      0xB8160E00,  //  0078  GETNGBL	R5	K7
-      0x88100B08,  //  0079  GETMBR	R4	R5	K8
-      0x8C140300,  //  007A  GETMET	R5	R1	K0
-      0x541E3500,  //  007B  LDINT	R7	13569
-      0x5421FFFD,  //  007C  LDINT	R8	-2
-      0x7C140600,  //  007D  CALL	R5	3
-      0x8C140300,  //  007E  GETMET	R5	R1	K0
-      0x541E23FF,  //  007F  LDINT	R7	9216
-      0x5421FFFD,  //  0080  LDINT	R8	-2
-      0x7C140600,  //  0081  CALL	R5	3
-      0x8C140300,  //  0082  GETMET	R5	R1	K0
-      0x881C0506,  //  0083  GETMBR	R7	R2	K6
-      0x58200001,  //  0084  LDCONST	R8	K1
-      0x7C140600,  //  0085  CALL	R5	3
-      0x8C140300,  //  0086  GETMET	R5	R1	K0
-      0x541E0017,  //  0087  LDINT	R7	24
-      0x58200001,  //  0088  LDCONST	R8	K1
-      0x7C140600,  //  0089  CALL	R5	3
-      0x70020003,  //  008A  JMP		#008F
-      0x900E1301,  //  008B  SETMBR	R3	K9	K1
-      0x8C10070A,  //  008C  GETMET	R4	R3	K10
-      0x5C180200,  //  008D  MOVE	R6	R1
-      0x7C100400,  //  008E  CALL	R4	2
-      0x8C100300,  //  008F  GETMET	R4	R1	K0
-      0x541A1817,  //  0090  LDINT	R6	6168
-      0x541DFFFD,  //  0091  LDINT	R7	-2
-      0x7C100600,  //  0092  CALL	R4	3
-      0x80000000,  //  0093  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: expire_sendqueue
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(reached_timeout),
-    /* K6   */  be_nested_str_weak(remove),
-    /* K7   */  be_const_int(1),
-    }),
-    be_str_weak(expire_sendqueue),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A000F,  //  0005  JMPF	R2	#0016
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E0006,  //  000C  JMPF	R3	#0014
-      0x8C0C0505,  //  000D  GETMET	R3	R2	K5
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
-      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
-      0x5C140200,  //  0011  MOVE	R5	R1
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x70020000,  //  0013  JMP		#0015
-      0x00040307,  //  0014  ADD	R1	R1	K7
-      0x7001FFEA,  //  0015  JMP		#0001
-      0x4C080000,  //  0016  LDNIL	R2
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_enqueued
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_send_enqueued,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1534,45 +2219,55 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(finished),
-    /* K3   */  be_nested_str_weak(ready),
-    /* K4   */  be_nested_str_weak(send_im),
-    /* K5   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    /* K6   */  be_nested_str_weak(resp),
-    /* K7   */  be_nested_str_weak(exchange_id),
-    /* K8   */  be_const_int(1),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(loglevel),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25s),
+    /* K6   */  be_nested_str_weak(local_session_id),
+    /* K7   */  be_nested_str_weak(subscription_id),
+    /* K8   */  be_nested_str_weak(is_keep_alive),
+    /* K9   */  be_nested_str_weak(send_queue),
+    /* K10  */  be_nested_str_weak(push),
+    /* K11  */  be_nested_str_weak(matter),
+    /* K12  */  be_nested_str_weak(IM_SubscribedHeartbeat),
+    /* K13  */  be_nested_str_weak(_message_handler),
+    /* K14  */  be_nested_str_weak(send_enqueued),
     }),
-    be_str_weak(send_enqueued),
+    be_str_weak(send_subscribe_heartbeat),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0011,  //  0005  JMPF	R3	#0018
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x88100702,  //  0008  GETMBR	R4	R3	K2
-      0x74120004,  //  0009  JMPT	R4	#000F
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
-      0x78120002,  //  000B  JMPF	R4	#000F
-      0x8C100704,  //  000C  GETMET	R4	R3	K4
-      0x5C180200,  //  000D  MOVE	R6	R1
-      0x7C100400,  //  000E  CALL	R4	2
-      0x88100702,  //  000F  GETMBR	R4	R3	K2
-      0x78120004,  //  0010  JMPF	R4	#0016
-      0x8C100105,  //  0011  GETMET	R4	R0	K5
-      0x88180706,  //  0012  GETMBR	R6	R3	K6
-      0x88180D07,  //  0013  GETMBR	R6	R6	K7
-      0x7C100400,  //  0014  CALL	R4	2
-      0x70020000,  //  0015  JMP		#0017
-      0x00080508,  //  0016  ADD	R2	R2	K8
-      0x7001FFE8,  //  0017  JMP		#0001
-      0x80000000,  //  0018  RET	0
+    ( &(const binstruction[29]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x780E0007,  //  0005  JMPF	R3	#000E
+      0xB80E0800,  //  0006  GETNGBL	R3	K4
+      0x60100018,  //  0007  GETGBL	R4	G24
+      0x58140005,  //  0008  LDCONST	R5	K5
+      0x88180506,  //  0009  GETMBR	R6	R2	K6
+      0x881C0307,  //  000A  GETMBR	R7	R1	K7
+      0x7C100600,  //  000B  CALL	R4	3
+      0x58140003,  //  000C  LDCONST	R5	K3
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x500C0200,  //  000E  LDBOOL	R3	1	0
+      0x90061003,  //  000F  SETMBR	R1	K8	R3
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
+      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
+      0xB8161600,  //  0012  GETNGBL	R5	K11
+      0x8C140B0C,  //  0013  GETMET	R5	R5	K12
+      0x881C050D,  //  0014  GETMBR	R7	R2	K13
+      0x5C200400,  //  0015  MOVE	R8	R2
+      0x5C240200,  //  0016  MOVE	R9	R1
+      0x7C140800,  //  0017  CALL	R5	4
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
+      0x8814050D,  //  001A  GETMBR	R5	R2	K13
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x80000000,  //  001C  RET	0
     })
   )
 );
@@ -1580,210 +2275,50 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_write_request
+** Solidified function: find_sendqueue_by_exchangeid
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_write_request,   /* name */
+be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
   be_nested_proto(
-    21,                          /* nstack */
-    3,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(WriteRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(Path),
-    /* K4   */  be_nested_str_weak(suppress_response),
-    /* K5   */  be_nested_str_weak(write_requests),
-    /* K6   */  be_nested_str_weak(WriteResponseMessage),
-    /* K7   */  be_nested_str_weak(write_responses),
-    /* K8   */  be_nested_str_weak(PathGenerator),
-    /* K9   */  be_nested_str_weak(device),
-    /* K10  */  be_nested_str_weak(path),
-    /* K11  */  be_nested_str_weak(data),
-    /* K12  */  be_nested_str_weak(copy),
-    /* K13  */  be_nested_str_weak(cluster),
-    /* K14  */  be_nested_str_weak(attribute),
-    /* K15  */  be_nested_str_weak(status),
-    /* K16  */  be_nested_str_weak(INVALID_ACTION),
-    /* K17  */  be_nested_str_weak(write_single_attribute_status_to_bytes),
-    /* K18  */  be_nested_str_weak(endpoint),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(loglevel),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(get_attribute_name),
-    /* K23  */  be_nested_str_weak(log),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K25  */  be_nested_str_weak(_X20_X28),
-    /* K26  */  be_nested_str_weak(_X29),
-    /* K27  */  be_nested_str_weak(),
-    /* K28  */  be_nested_str_weak(start),
-    /* K29  */  be_nested_str_weak(is_direct),
-    /* K30  */  be_nested_str_weak(next_attribute),
-    /* K31  */  be_nested_str_weak(msg),
-    /* K32  */  be_nested_str_weak(get_pi),
-    /* K33  */  be_nested_str_weak(UNSUPPORTED_WRITE),
-    /* K34  */  be_nested_str_weak(write_attribute),
-    /* K35  */  be_nested_str_weak(session),
-    /* K36  */  be_nested_str_weak(SUCCESS),
-    /* K37  */  be_nested_str_weak(stop_iteration),
-    /* K38  */  be_nested_str_weak(send_queue),
-    /* K39  */  be_nested_str_weak(push),
-    /* K40  */  be_nested_str_weak(IM_WriteResponse),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(get_exchangeid),
+    /* K3   */  be_const_int(1),
     }),
-    be_str_weak(process_write_request),
+    be_str_weak(find_sendqueue_by_exchangeid),
     &be_const_str_solidified,
-    ( &(const binstruction[145]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0xB8120000,  //  0006  GETNGBL	R4	K0
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140704,  //  0009  GETMBR	R5	R3	K4
-      0x88180705,  //  000A  GETMBR	R6	R3	K5
-      0x4C1C0000,  //  000B  LDNIL	R7
-      0x20180C07,  //  000C  NE	R6	R6	R7
-      0x781A0080,  //  000D  JMPF	R6	#008F
-      0xB81A0000,  //  000E  GETNGBL	R6	K0
-      0x8C180D06,  //  000F  GETMET	R6	R6	K6
-      0x7C180200,  //  0010  CALL	R6	1
-      0x601C0012,  //  0011  GETGBL	R7	G18
-      0x7C1C0000,  //  0012  CALL	R7	0
-      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
-      0xB81E0000,  //  0014  GETNGBL	R7	K0
-      0x8C1C0F08,  //  0015  GETMET	R7	R7	K8
-      0x88240109,  //  0016  GETMBR	R9	R0	K9
-      0x7C1C0400,  //  0017  CALL	R7	2
-      0x60200010,  //  0018  GETGBL	R8	G16
-      0x88240705,  //  0019  GETMBR	R9	R3	K5
-      0x7C200200,  //  001A  CALL	R8	1
-      0xA8020065,  //  001B  EXBLK	0	#0082
-      0x5C241000,  //  001C  MOVE	R9	R8
-      0x7C240000,  //  001D  CALL	R9	0
-      0x8828130A,  //  001E  GETMBR	R10	R9	K10
-      0x882C130B,  //  001F  GETMBR	R11	R9	K11
-      0x8C30090C,  //  0020  GETMET	R12	R4	K12
-      0x5C381400,  //  0021  MOVE	R14	R10
-      0x7C300400,  //  0022  CALL	R12	2
-      0x8830150D,  //  0023  GETMBR	R12	R10	K13
-      0x4C340000,  //  0024  LDNIL	R13
-      0x1C30180D,  //  0025  EQ	R12	R12	R13
-      0x74320003,  //  0026  JMPT	R12	#002B
-      0x8830150E,  //  0027  GETMBR	R12	R10	K14
-      0x4C340000,  //  0028  LDNIL	R13
-      0x1C30180D,  //  0029  EQ	R12	R12	R13
-      0x78320008,  //  002A  JMPF	R12	#0034
-      0xB8320000,  //  002B  GETNGBL	R12	K0
-      0x88301910,  //  002C  GETMBR	R12	R12	K16
-      0x90121E0C,  //  002D  SETMBR	R4	K15	R12
-      0x8C300111,  //  002E  GETMET	R12	R0	K17
-      0x5C380C00,  //  002F  MOVE	R14	R6
-      0x5C3C0800,  //  0030  MOVE	R15	R4
-      0x4C400000,  //  0031  LDNIL	R16
-      0x7C300800,  //  0032  CALL	R12	4
-      0x7001FFE7,  //  0033  JMP		#001C
-      0x88301512,  //  0034  GETMBR	R12	R10	K18
-      0x4C340000,  //  0035  LDNIL	R13
-      0x1C30180D,  //  0036  EQ	R12	R12	R13
-      0x78320016,  //  0037  JMPF	R12	#004F
-      0xB8322600,  //  0038  GETNGBL	R12	K19
-      0x8C301914,  //  0039  GETMET	R12	R12	K20
-      0x58380015,  //  003A  LDCONST	R14	K21
-      0x7C300400,  //  003B  CALL	R12	2
-      0x78320011,  //  003C  JMPF	R12	#004F
-      0xB8320000,  //  003D  GETNGBL	R12	K0
-      0x8C301916,  //  003E  GETMET	R12	R12	K22
-      0x8838150D,  //  003F  GETMBR	R14	R10	K13
-      0x883C150E,  //  0040  GETMBR	R15	R10	K14
-      0x7C300600,  //  0041  CALL	R12	3
-      0xB8362E00,  //  0042  GETNGBL	R13	K23
-      0x60380008,  //  0043  GETGBL	R14	G8
-      0x5C3C0800,  //  0044  MOVE	R15	R4
-      0x7C380200,  //  0045  CALL	R14	1
-      0x003A300E,  //  0046  ADD	R14	K24	R14
-      0x78320002,  //  0047  JMPF	R12	#004B
-      0x003E320C,  //  0048  ADD	R15	K25	R12
-      0x003C1F1A,  //  0049  ADD	R15	R15	K26
-      0x70020000,  //  004A  JMP		#004C
-      0x583C001B,  //  004B  LDCONST	R15	K27
-      0x00381C0F,  //  004C  ADD	R14	R14	R15
-      0x583C0015,  //  004D  LDCONST	R15	K21
-      0x7C340400,  //  004E  CALL	R13	2
-      0x8C300F1C,  //  004F  GETMET	R12	R7	K28
-      0x88381512,  //  0050  GETMBR	R14	R10	K18
-      0x883C150D,  //  0051  GETMBR	R15	R10	K13
-      0x8840150E,  //  0052  GETMBR	R16	R10	K14
-      0x7C300800,  //  0053  CALL	R12	4
-      0x8C300F1D,  //  0054  GETMET	R12	R7	K29
-      0x7C300200,  //  0055  CALL	R12	1
-      0x4C340000,  //  0056  LDNIL	R13
-      0x8C380F1E,  //  0057  GETMET	R14	R7	K30
-      0x7C380200,  //  0058  CALL	R14	1
-      0x5C341C00,  //  0059  MOVE	R13	R14
-      0x783A0025,  //  005A  JMPF	R14	#0081
-      0x90363E01,  //  005B  SETMBR	R13	K31	R1
-      0x88381B0F,  //  005C  GETMBR	R14	R13	K15
-      0x4C3C0000,  //  005D  LDNIL	R15
-      0x20381C0F,  //  005E  NE	R14	R14	R15
-      0x783A0007,  //  005F  JMPF	R14	#0068
-      0x4C380000,  //  0060  LDNIL	R14
-      0x90361E0E,  //  0061  SETMBR	R13	K15	R14
-      0x8C380111,  //  0062  GETMET	R14	R0	K17
-      0x5C400C00,  //  0063  MOVE	R16	R6
-      0x5C441A00,  //  0064  MOVE	R17	R13
-      0x5C481600,  //  0065  MOVE	R18	R11
-      0x7C380800,  //  0066  CALL	R14	4
-      0x70020017,  //  0067  JMP		#0080
-      0x8C380F20,  //  0068  GETMET	R14	R7	K32
-      0x7C380200,  //  0069  CALL	R14	1
-      0xB83E0000,  //  006A  GETNGBL	R15	K0
-      0x883C1F21,  //  006B  GETMBR	R15	R15	K33
-      0x90361E0F,  //  006C  SETMBR	R13	K15	R15
-      0x4C3C0000,  //  006D  LDNIL	R15
-      0x203C1C0F,  //  006E  NE	R15	R14	R15
-      0x783E0005,  //  006F  JMPF	R15	#0076
-      0x8C3C1D22,  //  0070  GETMET	R15	R14	K34
-      0x88440323,  //  0071  GETMBR	R17	R1	K35
-      0x5C481A00,  //  0072  MOVE	R18	R13
-      0x5C4C1600,  //  0073  MOVE	R19	R11
-      0x7C3C0800,  //  0074  CALL	R15	4
-      0x70020000,  //  0075  JMP		#0077
-      0x4C3C0000,  //  0076  LDNIL	R15
-      0x783E0002,  //  0077  JMPF	R15	#007B
-      0xB8420000,  //  0078  GETNGBL	R16	K0
-      0x88402124,  //  0079  GETMBR	R16	R16	K36
-      0x90361E10,  //  007A  SETMBR	R13	K15	R16
-      0x8C400111,  //  007B  GETMET	R16	R0	K17
-      0x5C480C00,  //  007C  MOVE	R18	R6
-      0x5C4C1A00,  //  007D  MOVE	R19	R13
-      0x5C501600,  //  007E  MOVE	R20	R11
-      0x7C400800,  //  007F  CALL	R16	4
-      0x7001FFD5,  //  0080  JMP		#0057
-      0x7001FF99,  //  0081  JMP		#001C
-      0x58200025,  //  0082  LDCONST	R8	K37
-      0xAC200200,  //  0083  CATCH	R8	1	0
-      0xB0080000,  //  0084  RAISE	2	R0	R0
-      0x5C200A00,  //  0085  MOVE	R8	R5
-      0x74220007,  //  0086  JMPT	R8	#008F
-      0x88200126,  //  0087  GETMBR	R8	R0	K38
-      0x8C201127,  //  0088  GETMET	R8	R8	K39
-      0xB82A0000,  //  0089  GETNGBL	R10	K0
-      0x8C281528,  //  008A  GETMET	R10	R10	K40
-      0x5C300200,  //  008B  MOVE	R12	R1
-      0x5C340C00,  //  008C  MOVE	R13	R6
-      0x7C280600,  //  008D  CALL	R10	3
-      0x7C200400,  //  008E  CALL	R8	2
-      0x50180200,  //  008F  LDBOOL	R6	1	0
-      0x80040C00,  //  0090  RET	1	R6
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x58080000,  //  0005  LDCONST	R2	K0
+      0x600C000C,  //  0006  GETGBL	R3	G12
+      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x140C0403,  //  0009  LT	R3	R2	R3
+      0x780E0008,  //  000A  JMPF	R3	#0014
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x940C0602,  //  000C  GETIDX	R3	R3	R2
+      0x8C100702,  //  000D  GETMET	R4	R3	K2
+      0x7C100200,  //  000E  CALL	R4	1
+      0x1C100801,  //  000F  EQ	R4	R4	R1
+      0x78120000,  //  0010  JMPF	R4	#0012
+      0x80040600,  //  0011  RET	1	R3
+      0x00080503,  //  0012  ADD	R2	R2	K3
+      0x7001FFF1,  //  0013  JMP		#0006
+      0x4C0C0000,  //  0014  LDNIL	R3
+      0x80040600,  //  0015  RET	1	R3
     })
   )
 );
@@ -2110,112 +2645,85 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_subscribe_update
+** Solidified function: parse_event_filters_min_no
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
+be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    14,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ReadRequestMessage),
-    /* K3   */  be_nested_str_weak(fabric_filtered),
-    /* K4   */  be_nested_str_weak(attributes_requests),
-    /* K5   */  be_nested_str_weak(updates),
-    /* K6   */  be_nested_str_weak(AttributePathIB),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K14  */  be_nested_str_weak(local_session_id),
-    /* K15  */  be_nested_str_weak(subscription_id),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(is_keep_alive),
-    /* K18  */  be_nested_str_weak(process_read_or_subscribe_request_pull),
-    /* K19  */  be_nested_str_weak(update_event_generator_array),
-    /* K20  */  be_nested_str_weak(IM_ReportDataSubscribed_Pull),
-    /* K21  */  be_nested_str_weak(_message_handler),
-    /* K22  */  be_nested_str_weak(send_queue),
-    /* K23  */  be_nested_str_weak(send_enqueued),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_IM),
+    /* K1   */  be_nested_str_weak(int64),
+    /* K2   */  be_nested_str_weak(toint64),
+    /* K3   */  be_nested_str_weak(node),
+    /* K4   */  be_nested_str_weak(tobytes),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20node_id_X20filter_X20_X25s_X20doesn_X27t_X20match_X20_X25s),
+    /* K8   */  be_nested_str_weak(tohex),
+    /* K9   */  be_nested_str_weak(event_min),
+    /* K10  */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(send_subscribe_update),
+    be_str_weak(parse_event_filters_min_no),
     &be_const_str_solidified,
-    ( &(const binstruction[64]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x50100000,  //  0004  LDBOOL	R4	0	0
-      0x900E0604,  //  0005  SETMBR	R3	K3	R4
-      0x60100012,  //  0006  GETGBL	R4	G18
-      0x7C100000,  //  0007  CALL	R4	0
-      0x900E0804,  //  0008  SETMBR	R3	K4	R4
-      0x60100010,  //  0009  GETGBL	R4	G16
-      0x88140305,  //  000A  GETMBR	R5	R1	K5
-      0x7C100200,  //  000B  CALL	R4	1
-      0xA802000F,  //  000C  EXBLK	0	#001D
-      0x5C140800,  //  000D  MOVE	R5	R4
-      0x7C140000,  //  000E  CALL	R5	0
-      0xB81A0200,  //  000F  GETNGBL	R6	K1
-      0x8C180D06,  //  0010  GETMET	R6	R6	K6
-      0x7C180200,  //  0011  CALL	R6	1
-      0x881C0B07,  //  0012  GETMBR	R7	R5	K7
-      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
-      0x881C0B08,  //  0014  GETMBR	R7	R5	K8
-      0x901A1007,  //  0015  SETMBR	R6	K8	R7
-      0x881C0B09,  //  0016  GETMBR	R7	R5	K9
-      0x901A1207,  //  0017  SETMBR	R6	K9	R7
-      0x881C0704,  //  0018  GETMBR	R7	R3	K4
-      0x8C1C0F0A,  //  0019  GETMET	R7	R7	K10
-      0x5C240C00,  //  001A  MOVE	R9	R6
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x7001FFEF,  //  001C  JMP		#000D
-      0x5810000B,  //  001D  LDCONST	R4	K11
-      0xAC100200,  //  001E  CATCH	R4	1	0
-      0xB0080000,  //  001F  RAISE	2	R0	R0
-      0xB8121800,  //  0020  GETNGBL	R4	K12
-      0x60140018,  //  0021  GETGBL	R5	G24
-      0x5818000D,  //  0022  LDCONST	R6	K13
-      0x881C050E,  //  0023  GETMBR	R7	R2	K14
-      0x8820030F,  //  0024  GETMBR	R8	R1	K15
-      0x7C140600,  //  0025  CALL	R5	3
-      0x58180010,  //  0026  LDCONST	R6	K16
-      0x7C100400,  //  0027  CALL	R4	2
-      0x50100000,  //  0028  LDBOOL	R4	0	0
-      0x90062204,  //  0029  SETMBR	R1	K17	R4
-      0x8C100112,  //  002A  GETMET	R4	R0	K18
-      0x5C180600,  //  002B  MOVE	R6	R3
-      0x4C1C0000,  //  002C  LDNIL	R7
-      0x7C100600,  //  002D  CALL	R4	3
-      0x8C140313,  //  002E  GETMET	R5	R1	K19
-      0x7C140200,  //  002F  CALL	R5	1
-      0xB81A0200,  //  0030  GETNGBL	R6	K1
-      0x8C180D14,  //  0031  GETMET	R6	R6	K20
-      0x88200515,  //  0032  GETMBR	R8	R2	K21
-      0x5C240400,  //  0033  MOVE	R9	R2
-      0x5C280800,  //  0034  MOVE	R10	R4
-      0x5C2C0A00,  //  0035  MOVE	R11	R5
-      0x5C300200,  //  0036  MOVE	R12	R1
-      0x7C180C00,  //  0037  CALL	R6	6
-      0x881C0116,  //  0038  GETMBR	R7	R0	K22
-      0x8C1C0F0A,  //  0039  GETMET	R7	R7	K10
-      0x5C240C00,  //  003A  MOVE	R9	R6
-      0x7C1C0400,  //  003B  CALL	R7	2
-      0x8C1C0117,  //  003C  GETMET	R7	R0	K23
-      0x88240515,  //  003D  GETMBR	R9	R2	K21
-      0x7C1C0400,  //  003E  CALL	R7	2
-      0x80000000,  //  003F  RET	0
+    ( &(const binstruction[50]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x4C100000,  //  0002  LDNIL	R4
+      0x20100004,  //  0003  NE	R4	R0	R4
+      0x7812002B,  //  0004  JMPF	R4	#0031
+      0x60100010,  //  0005  GETGBL	R4	G16
+      0x5C140000,  //  0006  MOVE	R5	R0
+      0x7C100200,  //  0007  CALL	R4	1
+      0xA8020024,  //  0008  EXBLK	0	#002E
+      0x5C140800,  //  0009  MOVE	R5	R4
+      0x7C140000,  //  000A  CALL	R5	0
+      0xB81A0200,  //  000B  GETNGBL	R6	K1
+      0x8C180D02,  //  000C  GETMET	R6	R6	K2
+      0x88200B03,  //  000D  GETMBR	R8	R5	K3
+      0x7C180400,  //  000E  CALL	R6	2
+      0x781A0012,  //  000F  JMPF	R6	#0023
+      0x78060011,  //  0010  JMPF	R1	#0023
+      0x881C0B03,  //  0011  GETMBR	R7	R5	K3
+      0x8C1C0F04,  //  0012  GETMET	R7	R7	K4
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x201C0E01,  //  0014  NE	R7	R7	R1
+      0x781E000C,  //  0015  JMPF	R7	#0023
+      0xB81E0A00,  //  0016  GETNGBL	R7	K5
+      0x8C1C0F06,  //  0017  GETMET	R7	R7	K6
+      0x60240018,  //  0018  GETGBL	R9	G24
+      0x58280007,  //  0019  LDCONST	R10	K7
+      0x8C2C0D04,  //  001A  GETMET	R11	R6	K4
+      0x7C2C0200,  //  001B  CALL	R11	1
+      0x8C2C1708,  //  001C  GETMET	R11	R11	K8
+      0x7C2C0200,  //  001D  CALL	R11	1
+      0x8C300308,  //  001E  GETMET	R12	R1	K8
+      0x7C300200,  //  001F  CALL	R12	1
+      0x7C240600,  //  0020  CALL	R9	3
+      0x7C1C0400,  //  0021  CALL	R7	2
+      0x7001FFE5,  //  0022  JMP		#0009
+      0xB81E0200,  //  0023  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0024  GETMET	R7	R7	K2
+      0x88240B09,  //  0025  GETMBR	R9	R5	K9
+      0x7C1C0400,  //  0026  CALL	R7	2
+      0x4C200000,  //  0027  LDNIL	R8
+      0x1C200608,  //  0028  EQ	R8	R3	R8
+      0x74220001,  //  0029  JMPT	R8	#002C
+      0x14200607,  //  002A  LT	R8	R3	R7
+      0x78220000,  //  002B  JMPF	R8	#002D
+      0x5C0C0E00,  //  002C  MOVE	R3	R7
+      0x7001FFDA,  //  002D  JMP		#0009
+      0x5810000A,  //  002E  LDCONST	R4	K10
+      0xAC100200,  //  002F  CATCH	R4	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040600,  //  0031  RET	1	R3
     })
   )
 );
@@ -2223,112 +2731,196 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_subscribe_heartbeat
+** Solidified function: invokeresponse2raw
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
+be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_IM, 
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(add),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(cluster),
+    /* K5   */  be_nested_str_weak(command),
+    /* K6   */  be_nested_str_weak(status),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(SUCCESS),
+    /* K9   */  be_nested_str_weak(tag_sub),
+    /* K10  */  be_nested_str_weak(tlv2raw),
+    }),
+    be_str_weak(invokeresponse2raw),
+    &be_const_str_solidified,
+    ( &(const binstruction[148]) {  /* code */
+      0x8C100300,  //  0000  GETMET	R4	R1	K0
+      0x541A0014,  //  0001  LDINT	R6	21
+      0x581C0001,  //  0002  LDCONST	R7	K1
+      0x7C100600,  //  0003  CALL	R4	3
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120004,  //  0006  JMPF	R4	#000C
+      0x8C100300,  //  0007  GETMET	R4	R1	K0
+      0x541A3500,  //  0008  LDINT	R6	13569
+      0x541DFFFD,  //  0009  LDINT	R7	-2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x70020003,  //  000B  JMP		#0010
+      0x8C100300,  //  000C  GETMET	R4	R1	K0
+      0x541A34FF,  //  000D  LDINT	R6	13568
+      0x541DFFFD,  //  000E  LDINT	R7	-2
+      0x7C100600,  //  000F  CALL	R4	3
+      0x8C100300,  //  0010  GETMET	R4	R1	K0
+      0x541A36FF,  //  0011  LDINT	R6	14080
+      0x541DFFFD,  //  0012  LDINT	R7	-2
+      0x7C100600,  //  0013  CALL	R4	3
+      0x88100502,  //  0014  GETMBR	R4	R2	K2
+      0x541600FE,  //  0015  LDINT	R5	255
+      0x18100805,  //  0016  LE	R4	R4	R5
+      0x78120008,  //  0017  JMPF	R4	#0021
+      0x8C100300,  //  0018  GETMET	R4	R1	K0
+      0x541A23FF,  //  0019  LDINT	R6	9216
+      0x541DFFFD,  //  001A  LDINT	R7	-2
+      0x7C100600,  //  001B  CALL	R4	3
+      0x8C100300,  //  001C  GETMET	R4	R1	K0
+      0x88180502,  //  001D  GETMBR	R6	R2	K2
+      0x581C0001,  //  001E  LDCONST	R7	K1
+      0x7C100600,  //  001F  CALL	R4	3
+      0x70020007,  //  0020  JMP		#0029
+      0x8C100300,  //  0021  GETMET	R4	R1	K0
+      0x541A24FF,  //  0022  LDINT	R6	9472
+      0x541DFFFD,  //  0023  LDINT	R7	-2
+      0x7C100600,  //  0024  CALL	R4	3
+      0x8C100300,  //  0025  GETMET	R4	R1	K0
+      0x88180502,  //  0026  GETMBR	R6	R2	K2
+      0x581C0003,  //  0027  LDCONST	R7	K3
+      0x7C100600,  //  0028  CALL	R4	3
+      0x88100504,  //  0029  GETMBR	R4	R2	K4
+      0x541600FE,  //  002A  LDINT	R5	255
+      0x18100805,  //  002B  LE	R4	R4	R5
+      0x78120008,  //  002C  JMPF	R4	#0036
+      0x8C100300,  //  002D  GETMET	R4	R1	K0
+      0x541A2400,  //  002E  LDINT	R6	9217
+      0x541DFFFD,  //  002F  LDINT	R7	-2
+      0x7C100600,  //  0030  CALL	R4	3
+      0x8C100300,  //  0031  GETMET	R4	R1	K0
+      0x88180504,  //  0032  GETMBR	R6	R2	K4
+      0x581C0001,  //  0033  LDCONST	R7	K1
+      0x7C100600,  //  0034  CALL	R4	3
+      0x70020014,  //  0035  JMP		#004B
+      0x88100504,  //  0036  GETMBR	R4	R2	K4
+      0x5416FFFE,  //  0037  LDINT	R5	65535
+      0x18100805,  //  0038  LE	R4	R4	R5
+      0x78120008,  //  0039  JMPF	R4	#0043
+      0x8C100300,  //  003A  GETMET	R4	R1	K0
+      0x541A2500,  //  003B  LDINT	R6	9473
+      0x541DFFFD,  //  003C  LDINT	R7	-2
+      0x7C100600,  //  003D  CALL	R4	3
+      0x8C100300,  //  003E  GETMET	R4	R1	K0
+      0x88180504,  //  003F  GETMBR	R6	R2	K4
+      0x581C0003,  //  0040  LDCONST	R7	K3
+      0x7C100600,  //  0041  CALL	R4	3
+      0x70020007,  //  0042  JMP		#004B
+      0x8C100300,  //  0043  GETMET	R4	R1	K0
+      0x541A2600,  //  0044  LDINT	R6	9729
+      0x541DFFFD,  //  0045  LDINT	R7	-2
+      0x7C100600,  //  0046  CALL	R4	3
+      0x8C100300,  //  0047  GETMET	R4	R1	K0
+      0x88180504,  //  0048  GETMBR	R6	R2	K4
+      0x541E0003,  //  0049  LDINT	R7	4
+      0x7C100600,  //  004A  CALL	R4	3
+      0x88100505,  //  004B  GETMBR	R4	R2	K5
+      0x541600FE,  //  004C  LDINT	R5	255
+      0x18100805,  //  004D  LE	R4	R4	R5
+      0x78120008,  //  004E  JMPF	R4	#0058
+      0x8C100300,  //  004F  GETMET	R4	R1	K0
+      0x541A2401,  //  0050  LDINT	R6	9218
+      0x541DFFFD,  //  0051  LDINT	R7	-2
+      0x7C100600,  //  0052  CALL	R4	3
+      0x8C100300,  //  0053  GETMET	R4	R1	K0
+      0x88180505,  //  0054  GETMBR	R6	R2	K5
+      0x581C0001,  //  0055  LDCONST	R7	K1
+      0x7C100600,  //  0056  CALL	R4	3
+      0x70020014,  //  0057  JMP		#006D
+      0x88100505,  //  0058  GETMBR	R4	R2	K5
+      0x5416FFFE,  //  0059  LDINT	R5	65535
+      0x18100805,  //  005A  LE	R4	R4	R5
+      0x78120008,  //  005B  JMPF	R4	#0065
+      0x8C100300,  //  005C  GETMET	R4	R1	K0
+      0x541A2501,  //  005D  LDINT	R6	9474
+      0x541DFFFD,  //  005E  LDINT	R7	-2
+      0x7C100600,  //  005F  CALL	R4	3
+      0x8C100300,  //  0060  GETMET	R4	R1	K0
+      0x88180505,  //  0061  GETMBR	R6	R2	K5
+      0x581C0003,  //  0062  LDCONST	R7	K3
+      0x7C100600,  //  0063  CALL	R4	3
+      0x70020007,  //  0064  JMP		#006D
+      0x8C100300,  //  0065  GETMET	R4	R1	K0
+      0x541A2601,  //  0066  LDINT	R6	9730
+      0x541DFFFD,  //  0067  LDINT	R7	-2
+      0x7C100600,  //  0068  CALL	R4	3
+      0x8C100300,  //  0069  GETMET	R4	R1	K0
+      0x88180505,  //  006A  GETMBR	R6	R2	K5
+      0x541E0003,  //  006B  LDINT	R7	4
+      0x7C100600,  //  006C  CALL	R4	3
+      0x8C100300,  //  006D  GETMET	R4	R1	K0
+      0x541A0017,  //  006E  LDINT	R6	24
+      0x581C0001,  //  006F  LDCONST	R7	K1
+      0x7C100600,  //  0070  CALL	R4	3
+      0x4C100000,  //  0071  LDNIL	R4
+      0x1C100604,  //  0072  EQ	R4	R3	R4
+      0x78120016,  //  0073  JMPF	R4	#008B
+      0x88100506,  //  0074  GETMBR	R4	R2	K6
+      0x4C140000,  //  0075  LDNIL	R5
+      0x1C140805,  //  0076  EQ	R5	R4	R5
+      0x78160001,  //  0077  JMPF	R5	#007A
+      0xB8160E00,  //  0078  GETNGBL	R5	K7
+      0x88100B08,  //  0079  GETMBR	R4	R5	K8
+      0x8C140300,  //  007A  GETMET	R5	R1	K0
+      0x541E3500,  //  007B  LDINT	R7	13569
+      0x5421FFFD,  //  007C  LDINT	R8	-2
+      0x7C140600,  //  007D  CALL	R5	3
+      0x8C140300,  //  007E  GETMET	R5	R1	K0
+      0x541E23FF,  //  007F  LDINT	R7	9216
+      0x5421FFFD,  //  0080  LDINT	R8	-2
+      0x7C140600,  //  0081  CALL	R5	3
+      0x8C140300,  //  0082  GETMET	R5	R1	K0
+      0x881C0506,  //  0083  GETMBR	R7	R2	K6
+      0x58200001,  //  0084  LDCONST	R8	K1
+      0x7C140600,  //  0085  CALL	R5	3
+      0x8C140300,  //  0086  GETMET	R5	R1	K0
+      0x541E0017,  //  0087  LDINT	R7	24
+      0x58200001,  //  0088  LDCONST	R8	K1
+      0x7C140600,  //  0089  CALL	R5	3
+      0x70020003,  //  008A  JMP		#008F
+      0x900E1301,  //  008B  SETMBR	R3	K9	K1
+      0x8C10070A,  //  008C  GETMET	R4	R3	K10
+      0x5C180200,  //  008D  MOVE	R6	R1
+      0x7C100400,  //  008E  CALL	R4	2
+      0x8C100300,  //  008F  GETMET	R4	R1	K0
+      0x541A1817,  //  0090  LDINT	R6	6168
+      0x541DFFFD,  //  0091  LDINT	R7	-2
+      0x7C100600,  //  0092  CALL	R4	3
+      0x80000000,  //  0093  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_status_response
+********************************************************************/
+extern const bclass be_class_Matter_IM;
+be_local_closure(class_Matter_IM_process_status_response,   /* name */
   be_nested_proto(
     10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(loglevel),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25s),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(subscription_id),
-    /* K8   */  be_nested_str_weak(is_keep_alive),
-    /* K9   */  be_nested_str_weak(send_queue),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(IM_SubscribedHeartbeat),
-    /* K13  */  be_nested_str_weak(_message_handler),
-    /* K14  */  be_nested_str_weak(send_enqueued),
-    }),
-    be_str_weak(send_subscribe_heartbeat),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x780E0007,  //  0005  JMPF	R3	#000E
-      0xB80E0800,  //  0006  GETNGBL	R3	K4
-      0x60100018,  //  0007  GETGBL	R4	G24
-      0x58140005,  //  0008  LDCONST	R5	K5
-      0x88180506,  //  0009  GETMBR	R6	R2	K6
-      0x881C0307,  //  000A  GETMBR	R7	R1	K7
-      0x7C100600,  //  000B  CALL	R4	3
-      0x58140003,  //  000C  LDCONST	R5	K3
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x500C0200,  //  000E  LDBOOL	R3	1	0
-      0x90061003,  //  000F  SETMBR	R1	K8	R3
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
-      0xB8161600,  //  0012  GETNGBL	R5	K11
-      0x8C140B0C,  //  0013  GETMET	R5	R5	K12
-      0x881C050D,  //  0014  GETMBR	R7	R2	K13
-      0x5C200400,  //  0015  MOVE	R8	R2
-      0x5C240200,  //  0016  MOVE	R9	R1
-      0x7C140800,  //  0017  CALL	R5	4
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
-      0x8814050D,  //  001A  GETMBR	R5	R2	K13
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x80000000,  //  001C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_50ms
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_every_50ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs_shop),
-    /* K1   */  be_nested_str_weak(every_50ms),
-    }),
-    be_str_weak(every_50ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_write_response
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_write_response,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2336,22 +2928,69 @@ be_local_closure(class_Matter_IM_process_write_response,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(WriteResponseMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(findsubval),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K3   */  be_nested_str_weak(exchange_id),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(SUCCESS),
+    /* K6   */  be_nested_str_weak(status_ok_received),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(local_session_id),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(status_error_received),
+    /* K14  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
     }),
-    be_str_weak(process_write_response),
+    be_str_weak(process_status_response),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x50100000,  //  0006  LDBOOL	R4	0	0
-      0x80040800,  //  0007  RET	1	R4
+    ( &(const binstruction[43]) {  /* code */
+      0x8C0C0500,  //  0000  GETMET	R3	R2	K0
+      0x58140001,  //  0001  LDCONST	R5	K1
+      0x541A00FE,  //  0002  LDINT	R6	255
+      0x7C0C0600,  //  0003  CALL	R3	3
+      0x8C100102,  //  0004  GETMET	R4	R0	K2
+      0x88180303,  //  0005  GETMBR	R6	R1	K3
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x88140B05,  //  0008  GETMBR	R5	R5	K5
+      0x1C140605,  //  0009  EQ	R5	R3	R5
+      0x7816000F,  //  000A  JMPF	R5	#001B
+      0x78120004,  //  000B  JMPF	R4	#0011
+      0x8C140906,  //  000C  GETMET	R5	R4	K6
+      0x5C1C0200,  //  000D  MOVE	R7	R1
+      0x7C140400,  //  000E  CALL	R5	2
+      0x80040A00,  //  000F  RET	1	R5
+      0x70020008,  //  0010  JMP		#001A
+      0xB8160E00,  //  0011  GETNGBL	R5	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x88200309,  //  0014  GETMBR	R8	R1	K9
+      0x8820110A,  //  0015  GETMBR	R8	R8	K10
+      0x88240303,  //  0016  GETMBR	R9	R1	K3
+      0x7C180600,  //  0017  CALL	R6	3
+      0x541E0003,  //  0018  LDINT	R7	4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x7002000D,  //  001A  JMP		#0029
+      0xB8160E00,  //  001B  GETNGBL	R5	K7
+      0x60180018,  //  001C  GETGBL	R6	G24
+      0x581C000B,  //  001D  LDCONST	R7	K11
+      0x5C200600,  //  001E  MOVE	R8	R3
+      0x7C180400,  //  001F  CALL	R6	2
+      0x581C000C,  //  0020  LDCONST	R7	K12
+      0x7C140400,  //  0021  CALL	R5	2
+      0x78120005,  //  0022  JMPF	R4	#0029
+      0x8C14090D,  //  0023  GETMET	R5	R4	K13
+      0x5C1C0200,  //  0024  MOVE	R7	R1
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C14010E,  //  0026  GETMET	R5	R0	K14
+      0x881C0303,  //  0027  GETMBR	R7	R1	K3
+      0x7C140400,  //  0028  CALL	R5	2
+      0x50140000,  //  0029  LDBOOL	R5	0	0
+      0x80040A00,  //  002A  RET	1	R5
     })
   )
 );
@@ -2359,98 +2998,77 @@ be_local_closure(class_Matter_IM_process_write_response,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: attributestatus2raw
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_init,   /* name */
+be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(subs_shop),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
-    /* K5   */  be_nested_str_weak(read_request_solo),
-    /* K6   */  be_nested_str_weak(ReadRequestMessage_solo),
-    /* K7   */  be_nested_str_weak(invoke_request_solo),
-    /* K8   */  be_nested_str_weak(InvokeRequestMessage_solo),
-    /* K9   */  be_nested_str_weak(tlv_solo),
-    /* K10  */  be_nested_str_weak(TLV),
-    /* K11  */  be_nested_str_weak(Matter_TLV_item),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(add),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(path2raw),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(status),
+    /* K5   */  be_const_int(2),
     }),
-    be_str_weak(init),
+    be_str_weak(attributestatus2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0xB80A0600,  //  0004  GETNGBL	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x7C080200,  //  000B  CALL	R2	1
-      0x90020A02,  //  000C  SETMBR	R0	K5	R2
-      0xB80A0600,  //  000D  GETNGBL	R2	K3
-      0x8C080508,  //  000E  GETMET	R2	R2	K8
-      0x7C080200,  //  000F  CALL	R2	1
-      0x90020E02,  //  0010  SETMBR	R0	K7	R2
-      0xB80A0600,  //  0011  GETNGBL	R2	K3
-      0x8808050A,  //  0012  GETMBR	R2	R2	K10
-      0x8C08050B,  //  0013  GETMET	R2	R2	K11
-      0x7C080200,  //  0014  CALL	R2	1
-      0x90021202,  //  0015  SETMBR	R0	K9	R2
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_ack_now
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_send_ack_now,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(_message_handler),
-    /* K2   */  be_nested_str_weak(send_encrypted_ack),
-    }),
-    be_str_weak(send_ack_now),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x88080300,  //  0004  GETMBR	R2	R1	K0
-      0x88080501,  //  0005  GETMBR	R2	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x50140000,  //  0008  LDBOOL	R5	0	0
-      0x7C080600,  //  0009  CALL	R2	3
-      0x80000000,  //  000A  RET	0
+    ( &(const binstruction[47]) {  /* code */
+      0x8C100300,  //  0000  GETMET	R4	R1	K0
+      0x541A0014,  //  0001  LDINT	R6	21
+      0x581C0001,  //  0002  LDCONST	R7	K1
+      0x7C100600,  //  0003  CALL	R4	3
+      0x8C100300,  //  0004  GETMET	R4	R1	K0
+      0x541A34FF,  //  0005  LDINT	R6	13568
+      0x541DFFFD,  //  0006  LDINT	R7	-2
+      0x7C100600,  //  0007  CALL	R4	3
+      0x8C100102,  //  0008  GETMET	R4	R0	K2
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x58200003,  //  000B  LDCONST	R8	K3
+      0x7C100800,  //  000C  CALL	R4	4
+      0x8C100300,  //  000D  GETMET	R4	R1	K0
+      0x541A3500,  //  000E  LDINT	R6	13569
+      0x541DFFFD,  //  000F  LDINT	R7	-2
+      0x7C100600,  //  0010  CALL	R4	3
+      0x88100504,  //  0011  GETMBR	R4	R2	K4
+      0x541600FE,  //  0012  LDINT	R5	255
+      0x18100805,  //  0013  LE	R4	R4	R5
+      0x78120008,  //  0014  JMPF	R4	#001E
+      0x8C100300,  //  0015  GETMET	R4	R1	K0
+      0x541A23FF,  //  0016  LDINT	R6	9216
+      0x541DFFFD,  //  0017  LDINT	R7	-2
+      0x7C100600,  //  0018  CALL	R4	3
+      0x8C100300,  //  0019  GETMET	R4	R1	K0
+      0x88180504,  //  001A  GETMBR	R6	R2	K4
+      0x581C0001,  //  001B  LDCONST	R7	K1
+      0x7C100600,  //  001C  CALL	R4	3
+      0x70020007,  //  001D  JMP		#0026
+      0x8C100300,  //  001E  GETMET	R4	R1	K0
+      0x541A24FF,  //  001F  LDINT	R6	9472
+      0x541DFFFD,  //  0020  LDINT	R7	-2
+      0x7C100600,  //  0021  CALL	R4	3
+      0x8C100300,  //  0022  GETMET	R4	R1	K0
+      0x88180504,  //  0023  GETMBR	R6	R2	K4
+      0x581C0005,  //  0024  LDCONST	R7	K5
+      0x7C100600,  //  0025  CALL	R4	3
+      0x8C100300,  //  0026  GETMET	R4	R1	K0
+      0x541A1817,  //  0027  LDINT	R6	6168
+      0x541DFFFD,  //  0028  LDINT	R7	-2
+      0x7C100600,  //  0029  CALL	R4	3
+      0x8C100300,  //  002A  GETMET	R4	R1	K0
+      0x541A0017,  //  002B  LDINT	R6	24
+      0x581C0001,  //  002C  LDCONST	R7	K1
+      0x7C100600,  //  002D  CALL	R4	3
+      0x80000000,  //  002E  RET	0
     })
   )
 );
@@ -2679,273 +3297,6 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
 
 
 /********************************************************************
-** Solidified function: attributedata2raw
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(355795236),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(path2raw),
-    /* K4   */  be_nested_str_weak(tag_sub),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(tlv2raw),
-    }),
-    be_str_weak(attributedata2raw),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x8C140300,  //  0000  GETMET	R5	R1	K0
-      0x581C0001,  //  0001  LDCONST	R7	K1
-      0x5421FFFB,  //  0002  LDINT	R8	-4
-      0x7C140600,  //  0003  CALL	R5	3
-      0x8C140300,  //  0004  GETMET	R5	R1	K0
-      0x581C0002,  //  0005  LDCONST	R7	K2
-      0x5421FFFD,  //  0006  LDINT	R8	-2
-      0x7C140600,  //  0007  CALL	R5	3
-      0x8C140103,  //  0008  GETMET	R5	R0	K3
-      0x5C1C0200,  //  0009  MOVE	R7	R1
-      0x5C200400,  //  000A  MOVE	R8	R2
-      0x58240002,  //  000B  LDCONST	R9	K2
-      0x5C280800,  //  000C  MOVE	R10	R4
-      0x7C140A00,  //  000D  CALL	R5	5
-      0x900E0905,  //  000E  SETMBR	R3	K4	K5
-      0x8C140706,  //  000F  GETMET	R5	R3	K6
-      0x5C1C0200,  //  0010  MOVE	R7	R1
-      0x7C140400,  //  0011  CALL	R5	2
-      0x8C140300,  //  0012  GETMET	R5	R1	K0
-      0x541E1817,  //  0013  LDINT	R7	6168
-      0x5421FFFD,  //  0014  LDINT	R8	-2
-      0x7C140600,  //  0015  CALL	R5	3
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attributestatus2raw
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(path2raw),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(status),
-    /* K5   */  be_const_int(2),
-    }),
-    be_str_weak(attributestatus2raw),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
-      0x541A0014,  //  0001  LDINT	R6	21
-      0x581C0001,  //  0002  LDCONST	R7	K1
-      0x7C100600,  //  0003  CALL	R4	3
-      0x8C100300,  //  0004  GETMET	R4	R1	K0
-      0x541A34FF,  //  0005  LDINT	R6	13568
-      0x541DFFFD,  //  0006  LDINT	R7	-2
-      0x7C100600,  //  0007  CALL	R4	3
-      0x8C100102,  //  0008  GETMET	R4	R0	K2
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x58200003,  //  000B  LDCONST	R8	K3
-      0x7C100800,  //  000C  CALL	R4	4
-      0x8C100300,  //  000D  GETMET	R4	R1	K0
-      0x541A3500,  //  000E  LDINT	R6	13569
-      0x541DFFFD,  //  000F  LDINT	R7	-2
-      0x7C100600,  //  0010  CALL	R4	3
-      0x88100504,  //  0011  GETMBR	R4	R2	K4
-      0x541600FE,  //  0012  LDINT	R5	255
-      0x18100805,  //  0013  LE	R4	R4	R5
-      0x78120008,  //  0014  JMPF	R4	#001E
-      0x8C100300,  //  0015  GETMET	R4	R1	K0
-      0x541A23FF,  //  0016  LDINT	R6	9216
-      0x541DFFFD,  //  0017  LDINT	R7	-2
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C100300,  //  0019  GETMET	R4	R1	K0
-      0x88180504,  //  001A  GETMBR	R6	R2	K4
-      0x581C0001,  //  001B  LDCONST	R7	K1
-      0x7C100600,  //  001C  CALL	R4	3
-      0x70020007,  //  001D  JMP		#0026
-      0x8C100300,  //  001E  GETMET	R4	R1	K0
-      0x541A24FF,  //  001F  LDINT	R6	9472
-      0x541DFFFD,  //  0020  LDINT	R7	-2
-      0x7C100600,  //  0021  CALL	R4	3
-      0x8C100300,  //  0022  GETMET	R4	R1	K0
-      0x88180504,  //  0023  GETMBR	R6	R2	K4
-      0x581C0005,  //  0024  LDCONST	R7	K5
-      0x7C100600,  //  0025  CALL	R4	3
-      0x8C100300,  //  0026  GETMET	R4	R1	K0
-      0x541A1817,  //  0027  LDINT	R6	6168
-      0x541DFFFD,  //  0028  LDINT	R7	-2
-      0x7C100600,  //  0029  CALL	R4	3
-      0x8C100300,  //  002A  GETMET	R4	R1	K0
-      0x541A0017,  //  002B  LDINT	R6	24
-      0x581C0001,  //  002C  LDCONST	R7	K1
-      0x7C100600,  //  002D  CALL	R4	3
-      0x80000000,  //  002E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_status_response
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_status_response,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(findsubval),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K3   */  be_nested_str_weak(exchange_id),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(SUCCESS),
-    /* K6   */  be_nested_str_weak(status_ok_received),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(local_session_id),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(status_error_received),
-    /* K14  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    }),
-    be_str_weak(process_status_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0x8C0C0500,  //  0000  GETMET	R3	R2	K0
-      0x58140001,  //  0001  LDCONST	R5	K1
-      0x541A00FE,  //  0002  LDINT	R6	255
-      0x7C0C0600,  //  0003  CALL	R3	3
-      0x8C100102,  //  0004  GETMET	R4	R0	K2
-      0x88180303,  //  0005  GETMBR	R6	R1	K3
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x88140B05,  //  0008  GETMBR	R5	R5	K5
-      0x1C140605,  //  0009  EQ	R5	R3	R5
-      0x7816000F,  //  000A  JMPF	R5	#001B
-      0x78120004,  //  000B  JMPF	R4	#0011
-      0x8C140906,  //  000C  GETMET	R5	R4	K6
-      0x5C1C0200,  //  000D  MOVE	R7	R1
-      0x7C140400,  //  000E  CALL	R5	2
-      0x80040A00,  //  000F  RET	1	R5
-      0x70020008,  //  0010  JMP		#001A
-      0xB8160E00,  //  0011  GETNGBL	R5	K7
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x88200309,  //  0014  GETMBR	R8	R1	K9
-      0x8820110A,  //  0015  GETMBR	R8	R8	K10
-      0x88240303,  //  0016  GETMBR	R9	R1	K3
-      0x7C180600,  //  0017  CALL	R6	3
-      0x541E0003,  //  0018  LDINT	R7	4
-      0x7C140400,  //  0019  CALL	R5	2
-      0x7002000D,  //  001A  JMP		#0029
-      0xB8160E00,  //  001B  GETNGBL	R5	K7
-      0x60180018,  //  001C  GETGBL	R6	G24
-      0x581C000B,  //  001D  LDCONST	R7	K11
-      0x5C200600,  //  001E  MOVE	R8	R3
-      0x7C180400,  //  001F  CALL	R6	2
-      0x581C000C,  //  0020  LDCONST	R7	K12
-      0x7C140400,  //  0021  CALL	R5	2
-      0x78120005,  //  0022  JMPF	R4	#0029
-      0x8C14090D,  //  0023  GETMET	R5	R4	K13
-      0x5C1C0200,  //  0024  MOVE	R7	R1
-      0x7C140400,  //  0025  CALL	R5	2
-      0x8C14010E,  //  0026  GETMET	R5	R0	K14
-      0x881C0303,  //  0027  GETMBR	R7	R1	K3
-      0x7C140400,  //  0028  CALL	R5	2
-      0x50140000,  //  0029  LDBOOL	R5	0	0
-      0x80040A00,  //  002A  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_sendqueue_by_exchangeid
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(get_exchangeid),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_sendqueue_by_exchangeid),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x58080000,  //  0005  LDCONST	R2	K0
-      0x600C000C,  //  0006  GETGBL	R3	G12
-      0x88100101,  //  0007  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x140C0403,  //  0009  LT	R3	R2	R3
-      0x780E0008,  //  000A  JMPF	R3	#0014
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x940C0602,  //  000C  GETIDX	R3	R3	R2
-      0x8C100702,  //  000D  GETMET	R4	R3	K2
-      0x7C100200,  //  000E  CALL	R4	1
-      0x1C100801,  //  000F  EQ	R4	R4	R1
-      0x78120000,  //  0010  JMPF	R4	#0012
-      0x80040600,  //  0011  RET	1	R3
-      0x00080503,  //  0012  ADD	R2	R2	K3
-      0x7001FFF1,  //  0013  JMP		#0006
-      0x4C0C0000,  //  0014  LDNIL	R3
-      0x80040600,  //  0015  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: send_status
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
@@ -2984,560 +3335,169 @@ be_local_closure(class_Matter_IM_send_status,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_timed_request
+** Solidified function: process_incoming
 ********************************************************************/
 extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_timed_request,   /* name */
+be_local_closure(class_Matter_IM_process_incoming,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TimedRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(timeout),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(send_status),
-    /* K10  */  be_nested_str_weak(SUCCESS),
-    }),
-    be_str_weak(process_timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0xB8120600,  //  0006  GETNGBL	R4	K3
-      0x60140018,  //  0007  GETGBL	R5	G24
-      0x58180004,  //  0008  LDCONST	R6	K4
-      0x881C0305,  //  0009  GETMBR	R7	R1	K5
-      0x881C0F06,  //  000A  GETMBR	R7	R7	K6
-      0x88200707,  //  000B  GETMBR	R8	R3	K7
-      0x7C140600,  //  000C  CALL	R5	3
-      0x58180008,  //  000D  LDCONST	R6	K8
-      0x7C100400,  //  000E  CALL	R4	2
-      0x8C100109,  //  000F  GETMET	R4	R0	K9
-      0x5C180200,  //  0010  MOVE	R6	R1
-      0xB81E0000,  //  0011  GETNGBL	R7	K0
-      0x881C0F0A,  //  0012  GETMBR	R7	R7	K10
-      0x7C100600,  //  0013  CALL	R4	3
-      0x50100200,  //  0014  LDBOOL	R4	1	0
-      0x80040800,  //  0015  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_read_or_subscribe_request_event_pull
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,   /* name */
-  be_nested_proto(
-    24,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_requests),
-    /* K1   */  be_nested_str_weak(get_node_id),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(parse_event_filters_min_no),
-    /* K5   */  be_nested_str_weak(event_filters),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(EventGenerator),
-    /* K8   */  be_nested_str_weak(device),
-    /* K9   */  be_nested_str_weak(start),
-    /* K10  */  be_nested_str_weak(endpoint),
-    /* K11  */  be_nested_str_weak(cluster),
-    /* K12  */  be_nested_str_weak(event),
-    /* K13  */  be_nested_str_weak(push),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(loglevel),
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(opcode),
+    /* K1   */  be_const_int(2),
+    /* K2   */  be_nested_str_weak(read_request_solo),
+    /* K3   */  be_nested_str_weak(from_raw),
+    /* K4   */  be_nested_str_weak(raw),
+    /* K5   */  be_nested_str_weak(app_payload_idx),
+    /* K6   */  be_nested_str_weak(process_read_request_solo),
+    /* K7   */  be_nested_str_weak(invoke_request_solo),
+    /* K8   */  be_nested_str_weak(process_invoke_request_solo),
+    /* K9   */  be_nested_str_weak(matter),
+    /* K10  */  be_nested_str_weak(TLV),
+    /* K11  */  be_nested_str_weak(parse),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(process_status_response),
+    /* K14  */  be_nested_str_weak(send_ack_now),
+    /* K15  */  be_nested_str_weak(process_read_request_pull),
     /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(),
-    /* K18  */  be_nested_str_weak(get_event_name),
-    /* K19  */  be_nested_str_weak(_X28),
-    /* K20  */  be_nested_str_weak(_X29_X20),
-    /* K21  */  be_nested_str_weak(_X2502X),
-    /* K22  */  be_nested_str_weak(_X2A_X2A),
-    /* K23  */  be_nested_str_weak(_X2504X),
-    /* K24  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K25  */  be_nested_str_weak(_X20_X28_X3E_X25s_X29),
-    /* K26  */  be_nested_str_weak(log),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X29_X20_X5B_X25s_X5D_X25s_X2F_X25s_X20_X25s_X25s),
-    /* K28  */  be_nested_str_weak(session),
-    /* K29  */  be_nested_str_weak(local_session_id),
-    /* K30  */  be_nested_str_weak(stop_iteration),
+    /* K17  */  be_nested_str_weak(subscribe_request),
+    /* K18  */  be_nested_str_weak(process_write_request),
+    /* K19  */  be_nested_str_weak(process_invoke_request),
+    /* K20  */  be_nested_str_weak(process_timed_request),
     }),
-    be_str_weak(process_read_or_subscribe_request_event_pull),
+    be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[140]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x200C0604,  //  0002  NE	R3	R3	R4
-      0x780E0085,  //  0003  JMPF	R3	#008A
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x4C100000,  //  0005  LDNIL	R4
-      0x20100404,  //  0006  NE	R4	R2	R4
-      0x78120002,  //  0007  JMPF	R4	#000B
-      0x8C100501,  //  0008  GETMET	R4	R2	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x70020000,  //  000A  JMP		#000C
-      0x4C100000,  //  000B  LDNIL	R4
-      0x88140300,  //  000C  GETMBR	R5	R1	K0
-      0x78160003,  //  000D  JMPF	R5	#0012
-      0x6014000C,  //  000E  GETGBL	R5	G12
-      0x88180300,  //  000F  GETMBR	R6	R1	K0
-      0x7C140200,  //  0010  CALL	R5	1
-      0x70020000,  //  0011  JMP		#0013
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x24180B03,  //  0013  GT	R6	R5	K3
-      0x781A0002,  //  0014  JMPF	R6	#0018
-      0x60180012,  //  0015  GETGBL	R6	G18
-      0x7C180000,  //  0016  CALL	R6	0
-      0x5C0C0C00,  //  0017  MOVE	R3	R6
-      0x8C180104,  //  0018  GETMET	R6	R0	K4
-      0x88200305,  //  0019  GETMBR	R8	R1	K5
-      0x5C240800,  //  001A  MOVE	R9	R4
-      0x7C180600,  //  001B  CALL	R6	3
-      0x881C0300,  //  001C  GETMBR	R7	R1	K0
-      0x781E006A,  //  001D  JMPF	R7	#0089
-      0x601C0010,  //  001E  GETGBL	R7	G16
-      0x88200300,  //  001F  GETMBR	R8	R1	K0
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0xA8020063,  //  0021  EXBLK	0	#0086
-      0x5C200E00,  //  0022  MOVE	R8	R7
-      0x7C200000,  //  0023  CALL	R8	0
-      0xB8260C00,  //  0024  GETNGBL	R9	K6
-      0x8C241307,  //  0025  GETMET	R9	R9	K7
-      0x882C0108,  //  0026  GETMBR	R11	R0	K8
-      0x7C240400,  //  0027  CALL	R9	2
-      0x8C281309,  //  0028  GETMET	R10	R9	K9
-      0x8830110A,  //  0029  GETMBR	R12	R8	K10
-      0x8834110B,  //  002A  GETMBR	R13	R8	K11
-      0x8838110C,  //  002B  GETMBR	R14	R8	K12
-      0x5C3C0C00,  //  002C  MOVE	R15	R6
-      0x7C280A00,  //  002D  CALL	R10	5
-      0x24280B03,  //  002E  GT	R10	R5	K3
-      0x782A0003,  //  002F  JMPF	R10	#0034
-      0x8C28070D,  //  0030  GETMET	R10	R3	K13
-      0x5C301200,  //  0031  MOVE	R12	R9
-      0x7C280400,  //  0032  CALL	R10	2
-      0x70020000,  //  0033  JMP		#0035
-      0x5C0C1200,  //  0034  MOVE	R3	R9
-      0xB82A1C00,  //  0035  GETNGBL	R10	K14
-      0x8C28150F,  //  0036  GETMET	R10	R10	K15
-      0x58300010,  //  0037  LDCONST	R12	K16
-      0x7C280400,  //  0038  CALL	R10	2
-      0x782A004A,  //  0039  JMPF	R10	#0085
-      0x58280011,  //  003A  LDCONST	R10	K17
-      0x882C110B,  //  003B  GETMBR	R11	R8	K11
-      0x4C300000,  //  003C  LDNIL	R12
-      0x202C160C,  //  003D  NE	R11	R11	R12
-      0x782E0011,  //  003E  JMPF	R11	#0051
-      0x882C110C,  //  003F  GETMBR	R11	R8	K12
-      0x4C300000,  //  0040  LDNIL	R12
-      0x202C160C,  //  0041  NE	R11	R11	R12
-      0x782E000D,  //  0042  JMPF	R11	#0051
-      0xB82E0C00,  //  0043  GETNGBL	R11	K6
-      0x8C2C1712,  //  0044  GETMET	R11	R11	K18
-      0x8834110B,  //  0045  GETMBR	R13	R8	K11
-      0x8838110C,  //  0046  GETMBR	R14	R8	K12
-      0x7C2C0600,  //  0047  CALL	R11	3
-      0x5C281600,  //  0048  MOVE	R10	R11
-      0x4C2C0000,  //  0049  LDNIL	R11
-      0x202C140B,  //  004A  NE	R11	R10	R11
-      0x782E0002,  //  004B  JMPF	R11	#004F
-      0x002E260A,  //  004C  ADD	R11	K19	R10
-      0x002C1714,  //  004D  ADD	R11	R11	K20
-      0x70020000,  //  004E  JMP		#0050
-      0x582C0011,  //  004F  LDCONST	R11	K17
-      0x5C281600,  //  0050  MOVE	R10	R11
-      0x882C110A,  //  0051  GETMBR	R11	R8	K10
-      0x4C300000,  //  0052  LDNIL	R12
-      0x202C160C,  //  0053  NE	R11	R11	R12
-      0x782E0004,  //  0054  JMPF	R11	#005A
-      0x602C0018,  //  0055  GETGBL	R11	G24
-      0x58300015,  //  0056  LDCONST	R12	K21
-      0x8834110A,  //  0057  GETMBR	R13	R8	K10
-      0x7C2C0400,  //  0058  CALL	R11	2
-      0x70020000,  //  0059  JMP		#005B
-      0x582C0016,  //  005A  LDCONST	R11	K22
-      0x8830110B,  //  005B  GETMBR	R12	R8	K11
-      0x4C340000,  //  005C  LDNIL	R13
-      0x2030180D,  //  005D  NE	R12	R12	R13
-      0x78320004,  //  005E  JMPF	R12	#0064
-      0x60300018,  //  005F  GETGBL	R12	G24
-      0x58340017,  //  0060  LDCONST	R13	K23
-      0x8838110B,  //  0061  GETMBR	R14	R8	K11
-      0x7C300400,  //  0062  CALL	R12	2
-      0x70020000,  //  0063  JMP		#0065
-      0x58300018,  //  0064  LDCONST	R12	K24
-      0x8834110C,  //  0065  GETMBR	R13	R8	K12
-      0x4C380000,  //  0066  LDNIL	R14
-      0x20341A0E,  //  0067  NE	R13	R13	R14
-      0x78360004,  //  0068  JMPF	R13	#006E
-      0x60340018,  //  0069  GETGBL	R13	G24
-      0x58380015,  //  006A  LDCONST	R14	K21
-      0x883C110C,  //  006B  GETMBR	R15	R8	K12
-      0x7C340400,  //  006C  CALL	R13	2
-      0x70020000,  //  006D  JMP		#006F
-      0x58340016,  //  006E  LDCONST	R13	K22
-      0x4C380000,  //  006F  LDNIL	R14
-      0x20380C0E,  //  0070  NE	R14	R6	R14
-      0x783A0004,  //  0071  JMPF	R14	#0077
-      0x60380018,  //  0072  GETGBL	R14	G24
-      0x583C0019,  //  0073  LDCONST	R15	K25
-      0x5C400C00,  //  0074  MOVE	R16	R6
-      0x7C380400,  //  0075  CALL	R14	2
-      0x70020000,  //  0076  JMP		#0078
-      0x58380011,  //  0077  LDCONST	R14	K17
-      0xB83E3400,  //  0078  GETNGBL	R15	K26
-      0x60400018,  //  0079  GETGBL	R16	G24
-      0x5844001B,  //  007A  LDCONST	R17	K27
-      0x8848051C,  //  007B  GETMBR	R18	R2	K28
-      0x8848251D,  //  007C  GETMBR	R18	R18	K29
-      0x5C4C1600,  //  007D  MOVE	R19	R11
-      0x5C501800,  //  007E  MOVE	R20	R12
-      0x5C541A00,  //  007F  MOVE	R21	R13
-      0x5C581400,  //  0080  MOVE	R22	R10
-      0x5C5C1C00,  //  0081  MOVE	R23	R14
-      0x7C400E00,  //  0082  CALL	R16	7
-      0x58440010,  //  0083  LDCONST	R17	K16
-      0x7C3C0400,  //  0084  CALL	R15	2
-      0x7001FF9B,  //  0085  JMP		#0022
-      0x581C001E,  //  0086  LDCONST	R7	K30
-      0xAC1C0200,  //  0087  CATCH	R7	1	0
-      0xB0080000,  //  0088  RAISE	2	R0	R0
-      0x80040600,  //  0089  RET	1	R3
-      0x4C0C0000,  //  008A  LDNIL	R3
-      0x80040600,  //  008B  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expire_sendqueue),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_sendqueue_by_exchangeid
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(get_exchangeid),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(remove_sendqueue_by_exchangeid),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x58080000,  //  0004  LDCONST	R2	K0
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x140C0403,  //  0008  LT	R3	R2	R3
-      0x780E000C,  //  0009  JMPF	R3	#0017
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x940C0602,  //  000B  GETIDX	R3	R3	R2
-      0x8C0C0702,  //  000C  GETMET	R3	R3	K2
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x1C0C0601,  //  000E  EQ	R3	R3	R1
-      0x780E0004,  //  000F  JMPF	R3	#0015
-      0x880C0101,  //  0010  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
-      0x5C140400,  //  0012  MOVE	R5	R2
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x70020000,  //  0014  JMP		#0016
-      0x00080504,  //  0015  ADD	R2	R2	K4
-      0x7001FFED,  //  0016  JMP		#0005
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: path2raw
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_path2raw,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(attribute),
-    }),
-    be_str_weak(path2raw),
-    &be_const_str_solidified,
-    ( &(const binstruction[107]) {  /* code */
-      0x8C140300,  //  0000  GETMET	R5	R1	K0
-      0x541E0036,  //  0001  LDINT	R7	55
-      0x58200001,  //  0002  LDCONST	R8	K1
-      0x7C140600,  //  0003  CALL	R5	3
-      0x8C140300,  //  0004  GETMET	R5	R1	K0
-      0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200001,  //  0006  LDCONST	R8	K1
-      0x7C140600,  //  0007  CALL	R5	3
-      0x88140502,  //  0008  GETMBR	R5	R2	K2
-      0x541A00FE,  //  0009  LDINT	R6	255
-      0x18140A06,  //  000A  LE	R5	R5	R6
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x8C140300,  //  000C  GETMET	R5	R1	K0
-      0x541E2401,  //  000D  LDINT	R7	9218
-      0x5421FFFD,  //  000E  LDINT	R8	-2
-      0x7C140600,  //  000F  CALL	R5	3
-      0x8C140300,  //  0010  GETMET	R5	R1	K0
-      0x881C0502,  //  0011  GETMBR	R7	R2	K2
-      0x58200001,  //  0012  LDCONST	R8	K1
-      0x7C140600,  //  0013  CALL	R5	3
-      0x70020007,  //  0014  JMP		#001D
-      0x8C140300,  //  0015  GETMET	R5	R1	K0
-      0x541E2501,  //  0016  LDINT	R7	9474
-      0x5421FFFD,  //  0017  LDINT	R8	-2
-      0x7C140600,  //  0018  CALL	R5	3
-      0x8C140300,  //  0019  GETMET	R5	R1	K0
-      0x881C0502,  //  001A  GETMBR	R7	R2	K2
-      0x58200003,  //  001B  LDCONST	R8	K3
-      0x7C140600,  //  001C  CALL	R5	3
-      0x88140504,  //  001D  GETMBR	R5	R2	K4
-      0x541A00FE,  //  001E  LDINT	R6	255
-      0x18140A06,  //  001F  LE	R5	R5	R6
-      0x78160008,  //  0020  JMPF	R5	#002A
-      0x8C140300,  //  0021  GETMET	R5	R1	K0
-      0x541E2402,  //  0022  LDINT	R7	9219
-      0x5421FFFD,  //  0023  LDINT	R8	-2
-      0x7C140600,  //  0024  CALL	R5	3
-      0x8C140300,  //  0025  GETMET	R5	R1	K0
-      0x881C0504,  //  0026  GETMBR	R7	R2	K4
-      0x58200001,  //  0027  LDCONST	R8	K1
-      0x7C140600,  //  0028  CALL	R5	3
-      0x70020014,  //  0029  JMP		#003F
-      0x88140504,  //  002A  GETMBR	R5	R2	K4
-      0x541AFFFE,  //  002B  LDINT	R6	65535
-      0x18140A06,  //  002C  LE	R5	R5	R6
-      0x78160008,  //  002D  JMPF	R5	#0037
-      0x8C140300,  //  002E  GETMET	R5	R1	K0
-      0x541E2502,  //  002F  LDINT	R7	9475
-      0x5421FFFD,  //  0030  LDINT	R8	-2
-      0x7C140600,  //  0031  CALL	R5	3
-      0x8C140300,  //  0032  GETMET	R5	R1	K0
-      0x881C0504,  //  0033  GETMBR	R7	R2	K4
-      0x58200003,  //  0034  LDCONST	R8	K3
-      0x7C140600,  //  0035  CALL	R5	3
-      0x70020007,  //  0036  JMP		#003F
-      0x8C140300,  //  0037  GETMET	R5	R1	K0
-      0x541E2602,  //  0038  LDINT	R7	9731
-      0x5421FFFD,  //  0039  LDINT	R8	-2
-      0x7C140600,  //  003A  CALL	R5	3
-      0x8C140300,  //  003B  GETMET	R5	R1	K0
-      0x881C0504,  //  003C  GETMBR	R7	R2	K4
-      0x54220003,  //  003D  LDINT	R8	4
-      0x7C140600,  //  003E  CALL	R5	3
-      0x88140505,  //  003F  GETMBR	R5	R2	K5
-      0x541A00FE,  //  0040  LDINT	R6	255
-      0x18140A06,  //  0041  LE	R5	R5	R6
-      0x78160008,  //  0042  JMPF	R5	#004C
-      0x8C140300,  //  0043  GETMET	R5	R1	K0
-      0x541E2403,  //  0044  LDINT	R7	9220
-      0x5421FFFD,  //  0045  LDINT	R8	-2
-      0x7C140600,  //  0046  CALL	R5	3
-      0x8C140300,  //  0047  GETMET	R5	R1	K0
-      0x881C0505,  //  0048  GETMBR	R7	R2	K5
-      0x58200001,  //  0049  LDCONST	R8	K1
-      0x7C140600,  //  004A  CALL	R5	3
-      0x70020014,  //  004B  JMP		#0061
-      0x88140505,  //  004C  GETMBR	R5	R2	K5
-      0x541AFFFE,  //  004D  LDINT	R6	65535
-      0x18140A06,  //  004E  LE	R5	R5	R6
-      0x78160008,  //  004F  JMPF	R5	#0059
-      0x8C140300,  //  0050  GETMET	R5	R1	K0
-      0x541E2503,  //  0051  LDINT	R7	9476
-      0x5421FFFD,  //  0052  LDINT	R8	-2
-      0x7C140600,  //  0053  CALL	R5	3
-      0x8C140300,  //  0054  GETMET	R5	R1	K0
-      0x881C0505,  //  0055  GETMBR	R7	R2	K5
-      0x58200003,  //  0056  LDCONST	R8	K3
-      0x7C140600,  //  0057  CALL	R5	3
-      0x70020007,  //  0058  JMP		#0061
-      0x8C140300,  //  0059  GETMET	R5	R1	K0
-      0x541E2603,  //  005A  LDINT	R7	9732
-      0x5421FFFD,  //  005B  LDINT	R8	-2
-      0x7C140600,  //  005C  CALL	R5	3
-      0x8C140300,  //  005D  GETMET	R5	R1	K0
-      0x881C0505,  //  005E  GETMBR	R7	R2	K5
-      0x54220003,  //  005F  LDINT	R8	4
-      0x7C140600,  //  0060  CALL	R5	3
-      0x78120003,  //  0061  JMPF	R4	#0066
-      0x8C140300,  //  0062  GETMET	R5	R1	K0
-      0x541E3404,  //  0063  LDINT	R7	13317
-      0x5421FFFD,  //  0064  LDINT	R8	-2
-      0x7C140600,  //  0065  CALL	R5	3
-      0x8C140300,  //  0066  GETMET	R5	R1	K0
-      0x541E0017,  //  0067  LDINT	R7	24
-      0x58200001,  //  0068  LDCONST	R8	K1
-      0x7C140600,  //  0069  CALL	R5	3
-      0x80000000,  //  006A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_event_filters_min_no
-********************************************************************/
-extern const bclass be_class_Matter_IM;
-be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_IM, 
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_IM),
-    /* K1   */  be_nested_str_weak(int64),
-    /* K2   */  be_nested_str_weak(toint64),
-    /* K3   */  be_nested_str_weak(node),
-    /* K4   */  be_nested_str_weak(tobytes),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20node_id_X20filter_X20_X25s_X20doesn_X27t_X20match_X20_X25s),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_nested_str_weak(event_min),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(parse_event_filters_min_no),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x4C100000,  //  0002  LDNIL	R4
-      0x20100004,  //  0003  NE	R4	R0	R4
-      0x7812002B,  //  0004  JMPF	R4	#0031
-      0x60100010,  //  0005  GETGBL	R4	G16
-      0x5C140000,  //  0006  MOVE	R5	R0
-      0x7C100200,  //  0007  CALL	R4	1
-      0xA8020024,  //  0008  EXBLK	0	#002E
-      0x5C140800,  //  0009  MOVE	R5	R4
-      0x7C140000,  //  000A  CALL	R5	0
-      0xB81A0200,  //  000B  GETNGBL	R6	K1
-      0x8C180D02,  //  000C  GETMET	R6	R6	K2
-      0x88200B03,  //  000D  GETMBR	R8	R5	K3
-      0x7C180400,  //  000E  CALL	R6	2
-      0x781A0012,  //  000F  JMPF	R6	#0023
-      0x78060011,  //  0010  JMPF	R1	#0023
-      0x881C0B03,  //  0011  GETMBR	R7	R5	K3
-      0x8C1C0F04,  //  0012  GETMET	R7	R7	K4
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x201C0E01,  //  0014  NE	R7	R7	R1
-      0x781E000C,  //  0015  JMPF	R7	#0023
-      0xB81E0A00,  //  0016  GETNGBL	R7	K5
-      0x8C1C0F06,  //  0017  GETMET	R7	R7	K6
-      0x60240018,  //  0018  GETGBL	R9	G24
-      0x58280007,  //  0019  LDCONST	R10	K7
-      0x8C2C0D04,  //  001A  GETMET	R11	R6	K4
-      0x7C2C0200,  //  001B  CALL	R11	1
-      0x8C2C1708,  //  001C  GETMET	R11	R11	K8
-      0x7C2C0200,  //  001D  CALL	R11	1
-      0x8C300308,  //  001E  GETMET	R12	R1	K8
-      0x7C300200,  //  001F  CALL	R12	1
-      0x7C240600,  //  0020  CALL	R9	3
-      0x7C1C0400,  //  0021  CALL	R7	2
-      0x7001FFE5,  //  0022  JMP		#0009
-      0xB81E0200,  //  0023  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0024  GETMET	R7	R7	K2
-      0x88240B09,  //  0025  GETMBR	R9	R5	K9
-      0x7C1C0400,  //  0026  CALL	R7	2
-      0x4C200000,  //  0027  LDNIL	R8
-      0x1C200608,  //  0028  EQ	R8	R3	R8
-      0x74220001,  //  0029  JMPT	R8	#002C
-      0x14200607,  //  002A  LT	R8	R3	R7
-      0x78220000,  //  002B  JMPF	R8	#002D
-      0x5C0C0E00,  //  002C  MOVE	R3	R7
-      0x7001FFDA,  //  002D  JMP		#0009
-      0x5810000A,  //  002E  LDCONST	R4	K10
-      0xAC100200,  //  002F  CATCH	R4	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040600,  //  0031  RET	1	R3
+    ( &(const binstruction[124]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x1C0C0501,  //  0001  EQ	R3	R2	K1
+      0x780E000D,  //  0002  JMPF	R3	#0011
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x88140304,  //  0005  GETMBR	R5	R1	K4
+      0x88180305,  //  0006  GETMBR	R6	R1	K5
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x4C100000,  //  0008  LDNIL	R4
+      0x20100604,  //  0009  NE	R4	R3	R4
+      0x78120004,  //  000A  JMPF	R4	#0010
+      0x8C100106,  //  000B  GETMET	R4	R0	K6
+      0x5C180200,  //  000C  MOVE	R6	R1
+      0x5C1C0600,  //  000D  MOVE	R7	R3
+      0x7C100600,  //  000E  CALL	R4	3
+      0x80040800,  //  000F  RET	1	R4
+      0x7002000F,  //  0010  JMP		#0021
+      0x540E0007,  //  0011  LDINT	R3	8
+      0x1C0C0403,  //  0012  EQ	R3	R2	R3
+      0x780E000C,  //  0013  JMPF	R3	#0021
+      0x880C0107,  //  0014  GETMBR	R3	R0	K7
+      0x8C0C0703,  //  0015  GETMET	R3	R3	K3
+      0x88140304,  //  0016  GETMBR	R5	R1	K4
+      0x88180305,  //  0017  GETMBR	R6	R1	K5
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x4C100000,  //  0019  LDNIL	R4
+      0x20100604,  //  001A  NE	R4	R3	R4
+      0x78120004,  //  001B  JMPF	R4	#0021
+      0x8C100108,  //  001C  GETMET	R4	R0	K8
+      0x5C180200,  //  001D  MOVE	R6	R1
+      0x5C1C0600,  //  001E  MOVE	R7	R3
+      0x7C100600,  //  001F  CALL	R4	3
+      0x80040800,  //  0020  RET	1	R4
+      0xB80E1200,  //  0021  GETNGBL	R3	K9
+      0x880C070A,  //  0022  GETMBR	R3	R3	K10
+      0x8C0C070B,  //  0023  GETMET	R3	R3	K11
+      0x88140304,  //  0024  GETMBR	R5	R1	K4
+      0x88180305,  //  0025  GETMBR	R6	R1	K5
+      0x7C0C0600,  //  0026  CALL	R3	3
+      0x1C10050C,  //  0027  EQ	R4	R2	K12
+      0x78120005,  //  0028  JMPF	R4	#002F
+      0x8C10010D,  //  0029  GETMET	R4	R0	K13
+      0x5C180200,  //  002A  MOVE	R6	R1
+      0x5C1C0600,  //  002B  MOVE	R7	R3
+      0x7C100600,  //  002C  CALL	R4	3
+      0x80040800,  //  002D  RET	1	R4
+      0x7002004A,  //  002E  JMP		#007A
+      0x1C100501,  //  002F  EQ	R4	R2	K1
+      0x78120008,  //  0030  JMPF	R4	#003A
+      0x8C10010E,  //  0031  GETMET	R4	R0	K14
+      0x5C180200,  //  0032  MOVE	R6	R1
+      0x7C100400,  //  0033  CALL	R4	2
+      0x8C10010F,  //  0034  GETMET	R4	R0	K15
+      0x5C180200,  //  0035  MOVE	R6	R1
+      0x5C1C0600,  //  0036  MOVE	R7	R3
+      0x7C100600,  //  0037  CALL	R4	3
+      0x80040800,  //  0038  RET	1	R4
+      0x7002003F,  //  0039  JMP		#007A
+      0x1C100510,  //  003A  EQ	R4	R2	K16
+      0x78120008,  //  003B  JMPF	R4	#0045
+      0x8C10010E,  //  003C  GETMET	R4	R0	K14
+      0x5C180200,  //  003D  MOVE	R6	R1
+      0x7C100400,  //  003E  CALL	R4	2
+      0x8C100111,  //  003F  GETMET	R4	R0	K17
+      0x5C180200,  //  0040  MOVE	R6	R1
+      0x5C1C0600,  //  0041  MOVE	R7	R3
+      0x7C100600,  //  0042  CALL	R4	3
+      0x80040800,  //  0043  RET	1	R4
+      0x70020034,  //  0044  JMP		#007A
+      0x54120003,  //  0045  LDINT	R4	4
+      0x1C100404,  //  0046  EQ	R4	R2	R4
+      0x78120002,  //  0047  JMPF	R4	#004B
+      0x50100000,  //  0048  LDBOOL	R4	0	0
+      0x80040800,  //  0049  RET	1	R4
+      0x7002002E,  //  004A  JMP		#007A
+      0x54120004,  //  004B  LDINT	R4	5
+      0x1C100404,  //  004C  EQ	R4	R2	R4
+      0x78120002,  //  004D  JMPF	R4	#0051
+      0x50100000,  //  004E  LDBOOL	R4	0	0
+      0x80040800,  //  004F  RET	1	R4
+      0x70020028,  //  0050  JMP		#007A
+      0x54120005,  //  0051  LDINT	R4	6
+      0x1C100404,  //  0052  EQ	R4	R2	R4
+      0x78120008,  //  0053  JMPF	R4	#005D
+      0x8C10010E,  //  0054  GETMET	R4	R0	K14
+      0x5C180200,  //  0055  MOVE	R6	R1
+      0x7C100400,  //  0056  CALL	R4	2
+      0x8C100112,  //  0057  GETMET	R4	R0	K18
+      0x5C180200,  //  0058  MOVE	R6	R1
+      0x5C1C0600,  //  0059  MOVE	R7	R3
+      0x7C100600,  //  005A  CALL	R4	3
+      0x80040800,  //  005B  RET	1	R4
+      0x7002001C,  //  005C  JMP		#007A
+      0x54120006,  //  005D  LDINT	R4	7
+      0x1C100404,  //  005E  EQ	R4	R2	R4
+      0x78120002,  //  005F  JMPF	R4	#0063
+      0x50100000,  //  0060  LDBOOL	R4	0	0
+      0x80040800,  //  0061  RET	1	R4
+      0x70020016,  //  0062  JMP		#007A
+      0x54120007,  //  0063  LDINT	R4	8
+      0x1C100404,  //  0064  EQ	R4	R2	R4
+      0x78120005,  //  0065  JMPF	R4	#006C
+      0x8C100113,  //  0066  GETMET	R4	R0	K19
+      0x5C180200,  //  0067  MOVE	R6	R1
+      0x5C1C0600,  //  0068  MOVE	R7	R3
+      0x7C100600,  //  0069  CALL	R4	3
+      0x80040800,  //  006A  RET	1	R4
+      0x7002000D,  //  006B  JMP		#007A
+      0x54120008,  //  006C  LDINT	R4	9
+      0x1C100404,  //  006D  EQ	R4	R2	R4
+      0x78120002,  //  006E  JMPF	R4	#0072
+      0x50100000,  //  006F  LDBOOL	R4	0	0
+      0x80040800,  //  0070  RET	1	R4
+      0x70020007,  //  0071  JMP		#007A
+      0x54120009,  //  0072  LDINT	R4	10
+      0x1C100404,  //  0073  EQ	R4	R2	R4
+      0x78120004,  //  0074  JMPF	R4	#007A
+      0x8C100114,  //  0075  GETMET	R4	R0	K20
+      0x5C180200,  //  0076  MOVE	R6	R1
+      0x5C1C0600,  //  0077  MOVE	R7	R3
+      0x7C100600,  //  0078  CALL	R4	3
+      0x80040800,  //  0079  RET	1	R4
+      0x50100000,  //  007A  LDBOOL	R4	0	0
+      0x80040800,  //  007B  RET	1	R4
     })
   )
 );
@@ -3550,45 +3510,44 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
 be_local_class(Matter_IM,
     6,
     NULL,
-    be_nested_map(37,
+    be_nested_map(36,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(process_read_request_pull, 32), be_const_closure(class_Matter_IM_process_read_request_pull_closure) },
-        { be_const_key_weak(process_incoming_ack, 7), be_const_closure(class_Matter_IM_process_incoming_ack_closure) },
-        { be_const_key_weak(process_invoke_request, -1), be_const_closure(class_Matter_IM_process_invoke_request_closure) },
-        { be_const_key_weak(subscribe_request, -1), be_const_closure(class_Matter_IM_subscribe_request_closure) },
-        { be_const_key_weak(path2raw, 21), be_const_closure(class_Matter_IM_path2raw_closure) },
-        { be_const_key_weak(subs_shop, 33), be_const_var(1) },
-        { be_const_key_weak(process_read_or_subscribe_request_pull, -1), be_const_closure(class_Matter_IM_process_read_or_subscribe_request_pull_closure) },
-        { be_const_key_weak(invoke_request_solo, 11), be_const_var(4) },
-        { be_const_key_weak(process_incoming, -1), be_const_closure(class_Matter_IM_process_incoming_closure) },
-        { be_const_key_weak(process_invoke_request_solo, -1), be_const_closure(class_Matter_IM_process_invoke_request_solo_closure) },
-        { be_const_key_weak(invokeresponse2raw, 34), be_const_closure(class_Matter_IM_invokeresponse2raw_closure) },
-        { be_const_key_weak(tlv_solo, -1), be_const_var(5) },
-        { be_const_key_weak(send_queue, -1), be_const_var(2) },
-        { be_const_key_weak(remove_sendqueue_by_exchangeid, 15), be_const_closure(class_Matter_IM_remove_sendqueue_by_exchangeid_closure) },
-        { be_const_key_weak(process_write_request, 26), be_const_closure(class_Matter_IM_process_write_request_closure) },
-        { be_const_key_weak(read_single_attribute_to_bytes, -1), be_const_closure(class_Matter_IM_read_single_attribute_to_bytes_closure) },
+        { be_const_key_weak(process_write_request, 7), be_const_closure(class_Matter_IM_process_write_request_closure) },
+        { be_const_key_weak(process_incoming, 33), be_const_closure(class_Matter_IM_process_incoming_closure) },
+        { be_const_key_weak(path2raw, 26), be_const_closure(class_Matter_IM_path2raw_closure) },
+        { be_const_key_weak(attributedata2raw, 12), be_const_closure(class_Matter_IM_attributedata2raw_closure) },
         { be_const_key_weak(send_subscribe_update, -1), be_const_closure(class_Matter_IM_send_subscribe_update_closure) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
-        { be_const_key_weak(send_subscribe_heartbeat, -1), be_const_closure(class_Matter_IM_send_subscribe_heartbeat_closure) },
-        { be_const_key_weak(every_50ms, 28), be_const_closure(class_Matter_IM_every_50ms_closure) },
-        { be_const_key_weak(process_write_response, 27), be_const_closure(class_Matter_IM_process_write_response_closure) },
-        { be_const_key_weak(process_read_or_subscribe_request_event_pull, -1), be_const_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull_closure) },
-        { be_const_key_weak(send_ack_now, -1), be_const_closure(class_Matter_IM_send_ack_now_closure) },
-        { be_const_key_weak(process_read_request_solo, 13), be_const_closure(class_Matter_IM_process_read_request_solo_closure) },
-        { be_const_key_weak(attributedata2raw, 4), be_const_closure(class_Matter_IM_attributedata2raw_closure) },
-        { be_const_key_weak(write_single_attribute_status_to_bytes, 30), be_const_closure(class_Matter_IM_write_single_attribute_status_to_bytes_closure) },
-        { be_const_key_weak(process_status_response, -1), be_const_closure(class_Matter_IM_process_status_response_closure) },
-        { be_const_key_weak(send_status, -1), be_const_closure(class_Matter_IM_send_status_closure) },
-        { be_const_key_weak(find_sendqueue_by_exchangeid, -1), be_const_closure(class_Matter_IM_find_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(process_read_request_pull, -1), be_const_closure(class_Matter_IM_process_read_request_pull_closure) },
+        { be_const_key_weak(process_read_or_subscribe_request_pull, -1), be_const_closure(class_Matter_IM_process_read_or_subscribe_request_pull_closure) },
         { be_const_key_weak(process_timed_request, -1), be_const_closure(class_Matter_IM_process_timed_request_closure) },
-        { be_const_key_weak(attributestatus2raw, 35), be_const_closure(class_Matter_IM_attributestatus2raw_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_IM_every_second_closure) },
-        { be_const_key_weak(init, 3), be_const_closure(class_Matter_IM_init_closure) },
-        { be_const_key_weak(send_enqueued, -1), be_const_closure(class_Matter_IM_send_enqueued_closure) },
+        { be_const_key_weak(every_50ms, -1), be_const_closure(class_Matter_IM_every_50ms_closure) },
+        { be_const_key_weak(process_invoke_request, 24), be_const_closure(class_Matter_IM_process_invoke_request_closure) },
+        { be_const_key_weak(read_single_attribute_to_bytes, -1), be_const_closure(class_Matter_IM_read_single_attribute_to_bytes_closure) },
+        { be_const_key_weak(process_read_or_subscribe_request_event_pull, 10), be_const_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull_closure) },
+        { be_const_key_weak(invoke_request_solo, -1), be_const_var(4) },
+        { be_const_key_weak(subscribe_request, -1), be_const_closure(class_Matter_IM_subscribe_request_closure) },
+        { be_const_key_weak(send_enqueued, 27), be_const_closure(class_Matter_IM_send_enqueued_closure) },
+        { be_const_key_weak(device, 28), be_const_var(0) },
         { be_const_key_weak(expire_sendqueue, -1), be_const_closure(class_Matter_IM_expire_sendqueue_closure) },
+        { be_const_key_weak(process_incoming_ack, -1), be_const_closure(class_Matter_IM_process_incoming_ack_closure) },
+        { be_const_key_weak(remove_sendqueue_by_exchangeid, -1), be_const_closure(class_Matter_IM_remove_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(write_single_attribute_status_to_bytes, -1), be_const_closure(class_Matter_IM_write_single_attribute_status_to_bytes_closure) },
+        { be_const_key_weak(attributestatus2raw, 22), be_const_closure(class_Matter_IM_attributestatus2raw_closure) },
+        { be_const_key_weak(every_second, 20), be_const_closure(class_Matter_IM_every_second_closure) },
+        { be_const_key_weak(tlv_solo, 30), be_const_var(5) },
+        { be_const_key_weak(send_subscribe_heartbeat, -1), be_const_closure(class_Matter_IM_send_subscribe_heartbeat_closure) },
+        { be_const_key_weak(find_sendqueue_by_exchangeid, -1), be_const_closure(class_Matter_IM_find_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(process_read_request_solo, -1), be_const_closure(class_Matter_IM_process_read_request_solo_closure) },
+        { be_const_key_weak(invokeresponse2raw, -1), be_const_closure(class_Matter_IM_invokeresponse2raw_closure) },
+        { be_const_key_weak(parse_event_filters_min_no, 32), be_const_static_closure(class_Matter_IM_parse_event_filters_min_no_closure) },
+        { be_const_key_weak(subs_shop, 31), be_const_var(1) },
+        { be_const_key_weak(process_status_response, -1), be_const_closure(class_Matter_IM_process_status_response_closure) },
+        { be_const_key_weak(process_invoke_request_solo, -1), be_const_closure(class_Matter_IM_process_invoke_request_solo_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_IM_init_closure) },
+        { be_const_key_weak(send_ack_now, -1), be_const_closure(class_Matter_IM_send_ack_now_closure) },
         { be_const_key_weak(read_request_solo, -1), be_const_var(3) },
-        { be_const_key_weak(parse_event_filters_min_no, -1), be_const_static_closure(class_Matter_IM_parse_event_filters_min_no_closure) },
+        { be_const_key_weak(send_status, -1), be_const_closure(class_Matter_IM_send_status_closure) },
+        { be_const_key_weak(send_queue, 1), be_const_var(2) },
     })),
     be_str_weak(Matter_IM)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
@@ -2627,98 +2627,20 @@ be_local_closure(class_Matter_ReadRequestMessage_from_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-extern const bclass be_class_Matter_ReadRequestMessage;
-be_local_closure(class_Matter_ReadRequestMessage_to_TLV,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_ReadRequestMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(to_TLV_array),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(attributes_requests),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(event_requests),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(event_filters),
-    /* K10  */  be_nested_str_weak(add_TLV),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(BOOL),
-    /* K13  */  be_nested_str_weak(fabric_filtered),
-    /* K14  */  be_nested_str_weak(data_version_filters),
-    /* K15  */  be_nested_str_weak(U1),
-    /* K16  */  be_nested_str_weak(InteractionModelRevision),
-    }),
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0103,  //  0004  GETMET	R3	R0	K3
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x58180004,  //  0006  LDCONST	R6	K4
-      0x881C0105,  //  0007  GETMBR	R7	R0	K5
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0103,  //  0009  GETMET	R3	R0	K3
-      0x5C140400,  //  000A  MOVE	R5	R2
-      0x58180006,  //  000B  LDCONST	R6	K6
-      0x881C0107,  //  000C  GETMBR	R7	R0	K7
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0103,  //  000E  GETMET	R3	R0	K3
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x58180008,  //  0010  LDCONST	R6	K8
-      0x881C0109,  //  0011  GETMBR	R7	R0	K9
-      0x7C0C0800,  //  0012  CALL	R3	4
-      0x8C0C050A,  //  0013  GETMET	R3	R2	K10
-      0x5814000B,  //  0014  LDCONST	R5	K11
-      0x8818030C,  //  0015  GETMBR	R6	R1	K12
-      0x881C010D,  //  0016  GETMBR	R7	R0	K13
-      0x7C0C0800,  //  0017  CALL	R3	4
-      0x8C0C0103,  //  0018  GETMET	R3	R0	K3
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x541A0003,  //  001A  LDINT	R6	4
-      0x881C010E,  //  001B  GETMBR	R7	R0	K14
-      0x7C0C0800,  //  001C  CALL	R3	4
-      0x8C0C050A,  //  001D  GETMET	R3	R2	K10
-      0x541600FE,  //  001E  LDINT	R5	255
-      0x8818030F,  //  001F  GETMBR	R6	R1	K15
-      0x881C0110,  //  0020  GETMBR	R7	R0	K16
-      0x7C0C0800,  //  0021  CALL	R3	4
-      0x80040400,  //  0022  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_ReadRequestMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_ReadRequestMessage,
     5,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(7,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(event_filters, -1), be_const_var(2) },
-        { be_const_key_weak(fabric_filtered, 3), be_const_var(3) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_ReadRequestMessage_to_TLV_closure) },
         { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_ReadRequestMessage_from_TLV_closure) },
+        { be_const_key_weak(event_filters, -1), be_const_var(2) },
+        { be_const_key_weak(fabric_filtered, -1), be_const_var(3) },
         { be_const_key_weak(data_version_filters, -1), be_const_var(4) },
+        { be_const_key_weak(event_requests, 3), be_const_var(1) },
         { be_const_key_weak(attributes_requests, -1), be_const_var(0) },
-        { be_const_key_weak(event_requests, 0), be_const_var(1) },
     })),
     be_str_weak(Matter_ReadRequestMessage)
 );
@@ -2908,79 +2830,6 @@ be_local_class(Matter_ReadRequestMessage_solo,
 extern const bclass be_class_Matter_ReportDataMessage;
 
 /********************************************************************
-** Solidified function: from_TLV
-********************************************************************/
-extern const bclass be_class_Matter_ReportDataMessage;
-be_local_closure(class_Matter_ReportDataMessage_from_TLV,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_ReportDataMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subscription_id),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(attribute_reports),
-    /* K4   */  be_nested_str_weak(from_TLV_array),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(AttributeReportIB),
-    /* K8   */  be_nested_str_weak(event_reports),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(EventReportIB),
-    /* K11  */  be_nested_str_weak(more_chunked_messages),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(suppress_response),
-    }),
-    be_str_weak(from_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080104,  //  0009  GETMET	R2	R0	K4
-      0x8C100301,  //  000A  GETMET	R4	R1	K1
-      0x58180005,  //  000B  LDCONST	R6	K5
-      0x7C100400,  //  000C  CALL	R4	2
-      0xB8160C00,  //  000D  GETNGBL	R5	K6
-      0x88140B07,  //  000E  GETMBR	R5	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x90020602,  //  0010  SETMBR	R0	K3	R2
-      0x8C080104,  //  0011  GETMET	R2	R0	K4
-      0x8C100301,  //  0012  GETMET	R4	R1	K1
-      0x58180009,  //  0013  LDCONST	R6	K9
-      0x7C100400,  //  0014  CALL	R4	2
-      0xB8160C00,  //  0015  GETNGBL	R5	K6
-      0x88140B0A,  //  0016  GETMBR	R5	R5	K10
-      0x7C080600,  //  0017  CALL	R2	3
-      0x90021002,  //  0018  SETMBR	R0	K8	R2
-      0x8C080301,  //  0019  GETMET	R2	R1	K1
-      0x5810000C,  //  001A  LDCONST	R4	K12
-      0x7C080400,  //  001B  CALL	R2	2
-      0x90021602,  //  001C  SETMBR	R0	K11	R2
-      0x8C080301,  //  001D  GETMET	R2	R1	K1
-      0x54120003,  //  001E  LDINT	R4	4
-      0x7C080400,  //  001F  CALL	R2	2
-      0x90021A02,  //  0020  SETMBR	R0	K13	R2
-      0x80040000,  //  0021  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
 extern const bclass be_class_Matter_ReportDataMessage;
@@ -3065,15 +2914,14 @@ extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_ReportDataMessage,
     5,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(7,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(attribute_reports, -1), be_const_var(1) },
-        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_ReportDataMessage_from_TLV_closure) },
+        { be_const_key_weak(suppress_response, -1), be_const_var(4) },
+        { be_const_key_weak(event_reports, 3), be_const_var(2) },
+        { be_const_key_weak(subscription_id, -1), be_const_var(0) },
         { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_ReportDataMessage_to_TLV_closure) },
         { be_const_key_weak(more_chunked_messages, -1), be_const_var(3) },
-        { be_const_key_weak(event_reports, -1), be_const_var(2) },
-        { be_const_key_weak(suppress_response, -1), be_const_var(4) },
-        { be_const_key_weak(subscription_id, 5), be_const_var(0) },
+        { be_const_key_weak(attribute_reports, -1), be_const_var(1) },
     })),
     be_str_weak(Matter_ReportDataMessage)
 );
@@ -3183,120 +3031,23 @@ be_local_closure(class_Matter_SubscribeRequestMessage_from_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-extern const bclass be_class_Matter_SubscribeRequestMessage;
-be_local_closure(class_Matter_SubscribeRequestMessage_to_TLV,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_SubscribeRequestMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(BOOL),
-    /* K6   */  be_nested_str_weak(keep_subscriptions),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(min_interval_floor),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(max_interval_ceiling),
-    /* K12  */  be_nested_str_weak(to_TLV_array),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(attributes_requests),
-    /* K15  */  be_nested_str_weak(event_requests),
-    /* K16  */  be_nested_str_weak(event_filters),
-    /* K17  */  be_nested_str_weak(fabric_filtered),
-    /* K18  */  be_nested_str_weak(data_version_filters),
-    /* K19  */  be_nested_str_weak(U1),
-    /* K20  */  be_nested_str_weak(InteractionModelRevision),
-    }),
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180308,  //  000B  GETMBR	R6	R1	K8
-      0x881C0109,  //  000C  GETMBR	R7	R0	K9
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0503,  //  000E  GETMET	R3	R2	K3
-      0x5814000A,  //  000F  LDCONST	R5	K10
-      0x88180308,  //  0010  GETMBR	R6	R1	K8
-      0x881C010B,  //  0011  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0012  CALL	R3	4
-      0x8C0C010C,  //  0013  GETMET	R3	R0	K12
-      0x5C140400,  //  0014  MOVE	R5	R2
-      0x5818000D,  //  0015  LDCONST	R6	K13
-      0x881C010E,  //  0016  GETMBR	R7	R0	K14
-      0x7C0C0800,  //  0017  CALL	R3	4
-      0x8C0C010C,  //  0018  GETMET	R3	R0	K12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x541A0003,  //  001A  LDINT	R6	4
-      0x881C010F,  //  001B  GETMBR	R7	R0	K15
-      0x7C0C0800,  //  001C  CALL	R3	4
-      0x8C0C010C,  //  001D  GETMET	R3	R0	K12
-      0x5C140400,  //  001E  MOVE	R5	R2
-      0x541A0004,  //  001F  LDINT	R6	5
-      0x881C0110,  //  0020  GETMBR	R7	R0	K16
-      0x7C0C0800,  //  0021  CALL	R3	4
-      0x8C0C0503,  //  0022  GETMET	R3	R2	K3
-      0x54160006,  //  0023  LDINT	R5	7
-      0x88180305,  //  0024  GETMBR	R6	R1	K5
-      0x881C0111,  //  0025  GETMBR	R7	R0	K17
-      0x7C0C0800,  //  0026  CALL	R3	4
-      0x8C0C010C,  //  0027  GETMET	R3	R0	K12
-      0x5C140400,  //  0028  MOVE	R5	R2
-      0x541A0007,  //  0029  LDINT	R6	8
-      0x881C0112,  //  002A  GETMBR	R7	R0	K18
-      0x7C0C0800,  //  002B  CALL	R3	4
-      0x8C0C0503,  //  002C  GETMET	R3	R2	K3
-      0x541600FE,  //  002D  LDINT	R5	255
-      0x88180313,  //  002E  GETMBR	R6	R1	K19
-      0x881C0114,  //  002F  GETMBR	R7	R0	K20
-      0x7C0C0800,  //  0030  CALL	R3	4
-      0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_SubscribeRequestMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_SubscribeRequestMessage,
     8,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(10,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_SubscribeRequestMessage_to_TLV_closure) },
-        { be_const_key_weak(attributes_requests, 7), be_const_var(3) },
-        { be_const_key_weak(fabric_filtered, 6), be_const_var(6) },
+        { be_const_key_weak(attributes_requests, -1), be_const_var(3) },
+        { be_const_key_weak(event_requests, -1), be_const_var(4) },
         { be_const_key_weak(min_interval_floor, -1), be_const_var(1) },
+        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_SubscribeRequestMessage_from_TLV_closure) },
+        { be_const_key_weak(event_filters, -1), be_const_var(5) },
+        { be_const_key_weak(fabric_filtered, 0), be_const_var(6) },
+        { be_const_key_weak(keep_subscriptions, 3), be_const_var(0) },
         { be_const_key_weak(data_version_filters, -1), be_const_var(7) },
         { be_const_key_weak(max_interval_ceiling, -1), be_const_var(2) },
-        { be_const_key_weak(event_requests, 3), be_const_var(4) },
-        { be_const_key_weak(event_filters, -1), be_const_var(5) },
-        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_SubscribeRequestMessage_from_TLV_closure) },
-        { be_const_key_weak(keep_subscriptions, 0), be_const_var(0) },
     })),
     be_str_weak(Matter_SubscribeRequestMessage)
 );
@@ -3361,138 +3112,22 @@ be_local_closure(class_Matter_SubscribeResponseMessage_to_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: from_TLV
-********************************************************************/
-extern const bclass be_class_Matter_SubscribeResponseMessage;
-be_local_closure(class_Matter_SubscribeResponseMessage_from_TLV,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_SubscribeResponseMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subscription_id),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(max_interval),
-    /* K4   */  be_const_int(2),
-    }),
-    be_str_weak(from_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080301,  //  0009  GETMET	R2	R1	K1
-      0x58100004,  //  000A  LDCONST	R4	K4
-      0x7C080400,  //  000B  CALL	R2	2
-      0x90020602,  //  000C  SETMBR	R0	K3	R2
-      0x80040000,  //  000D  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_SubscribeResponseMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_SubscribeResponseMessage,
     2,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(4,
+    be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(subscription_id, 2), be_const_var(0) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_SubscribeResponseMessage_to_TLV_closure) },
-        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_SubscribeResponseMessage_from_TLV_closure) },
         { be_const_key_weak(max_interval, -1), be_const_var(1) },
+        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_SubscribeResponseMessage_to_TLV_closure) },
+        { be_const_key_weak(subscription_id, -1), be_const_var(0) },
     })),
     be_str_weak(Matter_SubscribeResponseMessage)
 );
 
 extern const bclass be_class_Matter_WriteRequestMessage;
-
-/********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-extern const bclass be_class_Matter_WriteRequestMessage;
-be_local_closure(class_Matter_WriteRequestMessage_to_TLV,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_WriteRequestMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(BOOL),
-    /* K6   */  be_nested_str_weak(suppress_response),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(timed_request),
-    /* K9   */  be_nested_str_weak(to_TLV_array),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(write_requests),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(more_chunked_messages),
-    /* K14  */  be_nested_str_weak(U1),
-    /* K15  */  be_nested_str_weak(InteractionModelRevision),
-    }),
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180305,  //  000B  GETMBR	R6	R1	K5
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0109,  //  000E  GETMET	R3	R0	K9
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x5818000A,  //  0010  LDCONST	R6	K10
-      0x881C010B,  //  0011  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0012  CALL	R3	4
-      0x8C0C0503,  //  0013  GETMET	R3	R2	K3
-      0x5814000C,  //  0014  LDCONST	R5	K12
-      0x88180305,  //  0015  GETMBR	R6	R1	K5
-      0x881C010D,  //  0016  GETMBR	R7	R0	K13
-      0x7C0C0800,  //  0017  CALL	R3	4
-      0x8C0C0503,  //  0018  GETMET	R3	R2	K3
-      0x541600FE,  //  0019  LDINT	R5	255
-      0x8818030E,  //  001A  GETMBR	R6	R1	K14
-      0x881C010F,  //  001B  GETMBR	R7	R0	K15
-      0x7C0C0800,  //  001C  CALL	R3	4
-      0x80040400,  //  001D  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified function: from_TLV
@@ -3564,64 +3199,18 @@ extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_WriteRequestMessage,
     4,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(6,
+    be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(suppress_response, 5), be_const_var(0) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_WriteRequestMessage_to_TLV_closure) },
-        { be_const_key_weak(timed_request, -1), be_const_var(1) },
         { be_const_key_weak(write_requests, -1), be_const_var(2) },
-        { be_const_key_weak(more_chunked_messages, -1), be_const_var(3) },
+        { be_const_key_weak(suppress_response, 2), be_const_var(0) },
+        { be_const_key_weak(timed_request, -1), be_const_var(1) },
         { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_WriteRequestMessage_from_TLV_closure) },
+        { be_const_key_weak(more_chunked_messages, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_WriteRequestMessage)
 );
 
 extern const bclass be_class_Matter_WriteResponseMessage;
-
-/********************************************************************
-** Solidified function: from_TLV
-********************************************************************/
-extern const bclass be_class_Matter_WriteResponseMessage;
-be_local_closure(class_Matter_WriteResponseMessage_from_TLV,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_WriteResponseMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(write_requests),
-    /* K1   */  be_nested_str_weak(from_TLV_array),
-    /* K2   */  be_nested_str_weak(findsubval),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(AttributeStatusIB),
-    }),
-    be_str_weak(from_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x8C080101,  //  0005  GETMET	R2	R0	K1
-      0x8C100302,  //  0006  GETMET	R4	R1	K2
-      0x58180003,  //  0007  LDCONST	R6	K3
-      0x7C100400,  //  0008  CALL	R4	2
-      0xB8160800,  //  0009  GETNGBL	R5	K4
-      0x88140B05,  //  000A  GETMBR	R5	R5	K5
-      0x7C080600,  //  000B  CALL	R2	3
-      0x90020002,  //  000C  SETMBR	R0	K0	R2
-      0x80040000,  //  000D  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified function: to_TLV
@@ -3679,11 +3268,10 @@ extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_WriteResponseMessage,
     1,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(3,
+    be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(from_TLV, 2), be_const_closure(class_Matter_WriteResponseMessage_from_TLV_closure) },
         { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_WriteResponseMessage_to_TLV_closure) },
-        { be_const_key_weak(write_responses, -1), be_const_var(0) },
+        { be_const_key_weak(write_responses, 0), be_const_var(0) },
     })),
     be_str_weak(Matter_WriteResponseMessage)
 );
@@ -3729,66 +3317,16 @@ be_local_closure(class_Matter_TimedRequestMessage_from_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-extern const bclass be_class_Matter_TimedRequestMessage;
-be_local_closure(class_Matter_TimedRequestMessage_to_TLV,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_TimedRequestMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U2),
-    /* K6   */  be_nested_str_weak(timeout),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(InteractionModelRevision),
-    }),
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x541600FE,  //  000A  LDINT	R5	255
-      0x88180307,  //  000B  GETMBR	R6	R1	K7
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x80040400,  //  000E  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_TimedRequestMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_TimedRequestMessage,
     1,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(3,
+    be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(timeout, 1), be_const_var(0) },
         { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_TimedRequestMessage_from_TLV_closure) },
-        { be_const_key_weak(timeout, 2), be_const_var(0) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_TimedRequestMessage_to_TLV_closure) },
     })),
     be_str_weak(Matter_TimedRequestMessage)
 );
@@ -3853,83 +3391,18 @@ be_local_closure(class_Matter_InvokeRequestMessage_from_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-extern const bclass be_class_Matter_InvokeRequestMessage;
-be_local_closure(class_Matter_InvokeRequestMessage_to_TLV,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_InvokeRequestMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(BOOL),
-    /* K6   */  be_nested_str_weak(suppress_response),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(timed_request),
-    /* K9   */  be_nested_str_weak(to_TLV_array),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(invoke_requests),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_nested_str_weak(InteractionModelRevision),
-    }),
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180305,  //  000B  GETMBR	R6	R1	K5
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0109,  //  000E  GETMET	R3	R0	K9
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x5818000A,  //  0010  LDCONST	R6	K10
-      0x881C010B,  //  0011  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0012  CALL	R3	4
-      0x8C0C0503,  //  0013  GETMET	R3	R2	K3
-      0x541600FE,  //  0014  LDINT	R5	255
-      0x8818030C,  //  0015  GETMBR	R6	R1	K12
-      0x881C010D,  //  0016  GETMBR	R7	R0	K13
-      0x7C0C0800,  //  0017  CALL	R3	4
-      0x80040400,  //  0018  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_InvokeRequestMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_InvokeRequestMessage,
     3,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(5,
+    be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(invoke_requests, -1), be_const_var(2) },
-        { be_const_key_weak(suppress_response, 2), be_const_var(0) },
+        { be_const_key_weak(suppress_response, 1), be_const_var(0) },
+        { be_const_key_weak(from_TLV, 3), be_const_closure(class_Matter_InvokeRequestMessage_from_TLV_closure) },
         { be_const_key_weak(timed_request, -1), be_const_var(1) },
-        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_InvokeRequestMessage_from_TLV_closure) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_InvokeRequestMessage_to_TLV_closure) },
+        { be_const_key_weak(invoke_requests, -1), be_const_var(2) },
     })),
     be_str_weak(Matter_InvokeRequestMessage)
 );
@@ -4264,69 +3737,17 @@ be_local_closure(class_Matter_InvokeResponseMessage_to_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: from_TLV
-********************************************************************/
-extern const bclass be_class_Matter_InvokeResponseMessage;
-be_local_closure(class_Matter_InvokeResponseMessage_from_TLV,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_InvokeResponseMessage, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(suppress_response),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(invoke_responses),
-    /* K4   */  be_nested_str_weak(from_TLV_array),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(InvokeResponseIB),
-    }),
-    be_str_weak(from_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080104,  //  0009  GETMET	R2	R0	K4
-      0x8C100301,  //  000A  GETMET	R4	R1	K1
-      0x58180005,  //  000B  LDCONST	R6	K5
-      0x7C100400,  //  000C  CALL	R4	2
-      0xB8160C00,  //  000D  GETNGBL	R5	K6
-      0x88140B07,  //  000E  GETMBR	R5	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x90020602,  //  0010  SETMBR	R0	K3	R2
-      0x80040000,  //  0011  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_InvokeResponseMessage
 ********************************************************************/
 extern const bclass be_class_Matter_IM_Message_base;
 be_local_class(Matter_InvokeResponseMessage,
     2,
     &be_class_Matter_IM_Message_base,
-    be_nested_map(4,
+    be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(suppress_response, 3), be_const_var(0) },
+        { be_const_key_weak(suppress_response, -1), be_const_var(0) },
         { be_const_key_weak(to_TLV, -1), be_const_closure(class_Matter_InvokeResponseMessage_to_TLV_closure) },
         { be_const_key_weak(invoke_responses, -1), be_const_var(1) },
-        { be_const_key_weak(from_TLV, -1), be_const_closure(class_Matter_InvokeResponseMessage_from_TLV_closure) },
     })),
     be_str_weak(Matter_InvokeResponseMessage)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -2428,7 +2428,7 @@ be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_stop_basic_commissioning,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2453,32 +2453,26 @@ be_local_closure(class_Matter_Device_stop_basic_commissioning,   /* name */
     }),
     be_str_weak(stop_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x78060004,  //  0002  JMPF	R1	#0008
-      0xB8060200,  //  0003  GETNGBL	R1	K1
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0x580C0003,  //  0005  LDCONST	R3	K3
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x4C040000,  //  0008  LDNIL	R1
+    ( &(const binstruction[19]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x8C080100,  //  0001  GETMET	R2	R0	K0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0xB80A0200,  //  0004  GETNGBL	R2	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x58100003,  //  0006  LDCONST	R4	K3
+      0x58140004,  //  0007  LDCONST	R5	K4
+      0x7C080600,  //  0008  CALL	R2	3
       0x90020A01,  //  0009  SETMBR	R0	K5	R1
-      0x8C040106,  //  000A  GETMET	R1	R0	K6
-      0x7C040200,  //  000B  CALL	R1	1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90020E01,  //  000D  SETMBR	R0	K7	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0x4C040000,  //  0010  LDNIL	R1
-      0x90021201,  //  0011  SETMBR	R0	K9	R1
-      0x4C040000,  //  0012  LDNIL	R1
-      0x90021401,  //  0013  SETMBR	R0	K10	R1
-      0x4C040000,  //  0014  LDNIL	R1
-      0x90021601,  //  0015  SETMBR	R0	K11	R1
-      0x4C040000,  //  0016  LDNIL	R1
-      0x90021801,  //  0017  SETMBR	R0	K12	R1
-      0x80000000,  //  0018  RET	0
+      0x8C080106,  //  000A  GETMET	R2	R0	K6
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020E01,  //  000C  SETMBR	R0	K7	R1
+      0x90021001,  //  000D  SETMBR	R0	K8	R1
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x90021401,  //  000F  SETMBR	R0	K10	R1
+      0x90021601,  //  0010  SETMBR	R0	K11	R1
+      0x90021801,  //  0011  SETMBR	R0	K12	R1
+      0x80000000,  //  0012  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter, comment code that is not used as a Matter device but only by controller type. Code is kept commented just in case we need them later.

No functional change.

Flash code reduction: 2800 bytes

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
