### PR TITLE
Bugfix: multiple SHT4x sensors at the same bus, support for SHT40-CD1B

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -32,7 +32,7 @@ Index | Define              | Driver   | Device   | Address(es) | Bus2 | Descrip
   13  | USE_ADS1115         | xsns_12  | ADS1115  | 0x48 - 0x4B | Yes  | 4-channel 16-bit A/D converter
   14  | USE_INA219          | xsns_13  | INA219   | 0x40 - 0x41, 0x44 - 0x45 |      | Low voltage current sensor
   15  | USE_SHT3X           | xsns_14  | SHT3X    | 0x44 - 0x45 | Yes  | Temperature and Humidity sensor
-  15  | USE_SHT3X           | xsns_14  | SHT4X    | 0x44 - 0x45 | Yes  | Temperature and Humidity sensor
+  15  | USE_SHT3X           | xsns_14  | SHT4X    | 0x44 - 0x46 | Yes  | Temperature and Humidity sensor
   15  | USE_SHT3X           | xsns_14  | SHTCX    | 0x70        | Yes  | Temperature and Humidity sensor
   16  | USE_TSL2561         | xsns_16  | TSL2561  | 0x29, 0x39, 0x49 |      | Light intensity sensor
   17  | USE_MGS             | xsns_19  | Grove    | 0x04        |      | Multichannel gas sensor

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -149,13 +149,13 @@ void Sht3xShow(bool json) {
       t = ConvertTemp(t);
       h = ConvertHumidity(h);
       strlcpy(types, sht3x_sensors[idx].types, sizeof(types));
-      if (sht3x_count > 1) {
-        snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[idx].types, IndexSeparator(), sht3x_sensors[idx].address);  // "SHT3X-0xXX"  
+      if (sht3x_count > 0) {
+        snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), types, IndexSeparator(), sht3x_sensors[idx].address);  // "SHT3X-0xXX"  
 #ifdef ESP32
         if (TasmotaGlobal.i2c_enabled_2) {
           for (uint32_t i = 1; i < sht3x_count; i++) {
             if (sht3x_sensors[0].bus != sht3x_sensors[i].bus) {
-              snprintf_P(types, sizeof(types), PSTR("%s%c%02X%c%d"), sht3x_sensors[idx].types, IndexSeparator(), sht3x_sensors[idx].address, IndexSeparator(), sht3x_sensors[idx].bus + 1);
+              snprintf_P(types, sizeof(types), PSTR("%s%c%d"), types, IndexSeparator(), sht3x_sensors[idx].bus + 1); // "SHT3X-0xXX-X"  
               break;
             }
           }

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -121,7 +121,6 @@ void Sht3xDetect(void) {
   float h;
 
   for (uint32_t bus = 0; bus < 2; bus++) {
-    bus_count++;
     for (uint32_t k = 0; k < SHT3X_TYPES; k++) {
       for (uint32_t i = 0; i < SHT3X_ADDRESSES; i++) {
         if (!I2cSetDevice(sht3x_addresses[i], bus)) { continue; }

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -155,7 +155,7 @@ void Sht3xShow(bool json) {
       strlcpy(types, sht3x_sensors[i].types, sizeof(types));
       if (sht3x_count > 1) {
         if (two_buses) {
-          snprintf_P(types, sizeof(types), PSTR("%s%c%02Xc%d%"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), ssht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
+          snprintf_P(types, sizeof(types), PSTR("%s%c%02Xc%d%"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), sht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
         }
         else {
           snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-0xXX"  

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -40,7 +40,7 @@ const char kSht3xTypes[] PROGMEM = "SHT3X|SHTC3|SHT4X";
 uint8_t sht3x_addresses[] = { 0x44, 0x45, 0x46, 0x70 };
 
 uint8_t sht3x_count = 0;
-uint8_t bus_count = 0;
+bool two_buses = false;
 struct SHT3XSTRUCT {
   uint8_t type;        // Sensor type
   uint8_t address;     // I2C bus address
@@ -132,7 +132,7 @@ void Sht3xDetect(void) {
           GetTextIndexed(sht3x_sensors[sht3x_count].types, sizeof(sht3x_sensors[sht3x_count].types), sht3x_sensors[sht3x_count].type, kSht3xTypes);
           I2cSetActiveFound(sht3x_sensors[sht3x_count].address, sht3x_sensors[sht3x_count].types, sht3x_sensors[sht3x_count].bus);
           if (sht3x_count > 0 && sht3x_sensors[sht3x_count-1].bus != sht3x_sensors[sht3x_count].bus) {
-            bus_count = 2;
+            two_buses = true;
           }
           sht3x_count++;
           if (SHT3X_ADDRESSES == sht3x_count) {
@@ -155,7 +155,7 @@ void Sht3xShow(bool json) {
       h = ConvertHumidity(h);
       strlcpy(types, sht3x_sensors[i].types, sizeof(types));
       if (sht3x_count > 1) {
-        if (bus_count > 1) {
+        if (two_buses) {
           snprintf_P(types, sizeof(types), PSTR("%s%c%02Xc%d%"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), ssht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
         }
         else {

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -149,7 +149,7 @@ void Sht3xShow(bool json) {
       t = ConvertTemp(t);
       h = ConvertHumidity(h);
       strlcpy(types, sht3x_sensors[idx].types, sizeof(types));
-      if (sht3x_count > 0) {
+      if (sht3x_count > 1) {
         snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), types, IndexSeparator(), sht3x_sensors[idx].address);  // "SHT3X-0xXX"  
 #ifdef ESP32
         if (TasmotaGlobal.i2c_enabled_2) {

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -25,19 +25,19 @@
  * This driver supports the following sensors:
  * - SHT3x series: SHT30, SHT31, SHT35 (addresses: A: 0x44, B: 0x45)
  * - SHTC series:  SHTC1, SHTC3 (address: 0x70)
- * - SHT4x series: SHT40, SHT41, SHT45 (addresses: A: 0x44, B: 0x45)
+ * - SHT4x series: SHT40, SHT41, SHT45 (addresses: A: 0x44, B: 0x45, C: 0x46)
 \*********************************************************************************************/
 
 #define XSNS_14             14
 #define XI2C_15             15         // See I2CDEVICES.md
 
 #define SHT3X_TYPES         3          // SHT3X, SHTCX and SHT4X
-#define SHT3X_ADDRESSES     3          // 0x44, 0x45 and 0x70
+#define SHT3X_ADDRESSES     4          // 0x44, 0x45, 0x46 and 0x70
 
 enum SHT3X_Types { SHT3X_TYPE_SHT3X, SHT3X_TYPE_SHTCX, SHT3X_TYPE_SHT4X };
 const char kSht3xTypes[] PROGMEM = "SHT3X|SHTC3|SHT4X";
 
-uint8_t sht3x_addresses[] = { 0x44, 0x45, 0x70 };
+uint8_t sht3x_addresses[] = { 0x44, 0x45, 0x46, 0x70 };
 
 uint8_t sht3x_count = 0;
 struct SHT3XSTRUCT {

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -121,9 +121,9 @@ void Sht3xDetect(void) {
 
   for (uint32_t bus = 0; bus < 2; bus++) {
     for (uint32_t k = 0; k < SHT3X_TYPES; k++) {
-      sht3x_sensors[sht3x_count].type = k;
       for (uint32_t i = 0; i < SHT3X_ADDRESSES; i++) {
         if (!I2cSetDevice(sht3x_addresses[i], bus)) { continue; }
+        sht3x_sensors[sht3x_count].type = k;
         sht3x_sensors[sht3x_count].address = sht3x_addresses[i];
         sht3x_sensors[sht3x_count].bus = bus;
         if (Sht3xRead(sht3x_count, t, h)) {

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -131,6 +131,9 @@ void Sht3xDetect(void) {
         if (Sht3xRead(sht3x_count, t, h)) {
           GetTextIndexed(sht3x_sensors[sht3x_count].types, sizeof(sht3x_sensors[sht3x_count].types), sht3x_sensors[sht3x_count].type, kSht3xTypes);
           I2cSetActiveFound(sht3x_sensors[sht3x_count].address, sht3x_sensors[sht3x_count].types, sht3x_sensors[sht3x_count].bus);
+          if (sht3x_count > 0 && sht3x_sensors[sht3x_count-1].bus != sht3x_sensors[sht3x_count].bus) {
+            bus_count = 2;
+          }
           sht3x_count++;
           if (SHT3X_ADDRESSES == sht3x_count) {
             return;
@@ -153,7 +156,7 @@ void Sht3xShow(bool json) {
       strlcpy(types, sht3x_sensors[i].types, sizeof(types));
       if (sht3x_count > 1) {
         if (bus_count > 1) {
-          snprintf_P(types, sizeof(types), PSTR("%s%c%d%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].bus, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-X-0xXX"          
+          snprintf_P(types, sizeof(types), PSTR("%s%c%02Xc%d%"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), ssht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
         }
         else {
           snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-0xXX"  

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -40,6 +40,7 @@ const char kSht3xTypes[] PROGMEM = "SHT3X|SHTC3|SHT4X";
 uint8_t sht3x_addresses[] = { 0x44, 0x45, 0x46, 0x70 };
 
 uint8_t sht3x_count = 0;
+uint8_t bus_count = 0;
 struct SHT3XSTRUCT {
   uint8_t type;        // Sensor type
   uint8_t address;     // I2C bus address
@@ -120,6 +121,7 @@ void Sht3xDetect(void) {
   float h;
 
   for (uint32_t bus = 0; bus < 2; bus++) {
+    bus_count++;
     for (uint32_t k = 0; k < SHT3X_TYPES; k++) {
       for (uint32_t i = 0; i < SHT3X_ADDRESSES; i++) {
         if (!I2cSetDevice(sht3x_addresses[i], bus)) { continue; }
@@ -150,7 +152,12 @@ void Sht3xShow(bool json) {
       h = ConvertHumidity(h);
       strlcpy(types, sht3x_sensors[i].types, sizeof(types));
       if (sht3x_count > 1) {
-        snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-0xXX"
+        if (bus_count > 1) {
+          snprintf_P(types, sizeof(types), PSTR("%s%c%d%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].bus, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-X-0xXX"          
+        }
+        else {
+          snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-0xXX"  
+        }
       }
       TempHumDewShow(json, ((0 == TasmotaGlobal.tele_period) && (0 == i)), types, t, h);
     }

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -155,7 +155,7 @@ void Sht3xShow(bool json) {
       strlcpy(types, sht3x_sensors[i].types, sizeof(types));
       if (sht3x_count > 1) {
         if (two_buses) {
-          snprintf_P(types, sizeof(types), PSTR("%s%c%02Xc%d%"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), sht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
+          snprintf_P(types, sizeof(types), PSTR("%s%c%02X%c%d"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address, IndexSeparator(), sht3x_sensors[i].bus);  // "SHT3X-0xXX-X"  
         }
         else {
           snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), sht3x_sensors[i].types, IndexSeparator(), sht3x_sensors[i].address);  // "SHT3X-0xXX"  


### PR DESCRIPTION
## Description:

- Before this fix, multiple SHT4x sensors on the same bus were not detected because the 'type' variable was set in the outer for-loop. The bug was introduced in https://github.com/arendst/Tasmota/commit/7295bdb5490c723bae082455210df0643e72f7c5. Once a sensor was found, the 'type' variable was reset to 0, preventing the detection of any additional sensors with types greater than 0, such as SHTC3 and SHT4X. Since the SHTC3 has only a single address, this issue only affected SHT4X sensors.

BEFORE:
https://github.com/arendst/Tasmota/blob/5df51a9365c72e0fd0d50b096ec0e2b28f2c23fd/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino#L122-L132

AFTER:
https://github.com/arendst/Tasmota/blob/3cf3f997250ef7fadcedcc1d6a554533c03fe78a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino#L123-L136


- Sensors of type SHT40-CD1B with address 0x46 were also not detected before this fix. Refer to the first page of the [datasheet](https://sensirion.com/media/documents/1D662E57/661CD1C1/HT_DS_Datasheet_SHT4xI-Digital.pdf) for more details.
- Additionally, the bus number was not displayed, making it impossible to distinguish sensors on different buses. To make it less intrusive, the bus number will only be displayed if necessary.

BEFORE:
![image](https://github.com/arendst/Tasmota/assets/47479352/bfb7ce4c-3ca4-4bf5-a2ce-5945281911aa)
Please note: Only one SHT4x sensor is detected (0x44) although two are present at the same bus

AFTER:
![image](https://github.com/arendst/Tasmota/assets/47479352/247ed189-8430-4dfc-bdd6-e6b835ae52d8)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

I don't have an ESP8266 at hand. Could somebody like @arendst @stibus please check the functionality? 