### PR TITLE
IR changed error message when GPIO is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 support for energy margin checks, like ``MaxPower2`` per phase (#21695)
 - ESP32 TM1621 number overflow from "9999" to "12E3" (#21131)
 - ESP32 platform update from 2024.06.11 to 2024.07.10 (#21745)
+- IR changed error message when GPIO is not configured
 
 ### Fixed
 - Berry `bytes.resize()` for large sizes (#21716)

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -542,6 +542,7 @@
 
 // Commands xdrv_05_irremote.ino
 #define D_CMND_IRSEND "IRSend"
+  #define D_JSON_IRSEND_NOT_CONFIGURED "IRsend GPIO not configured"
   #define D_JSON_INVALID_JSON "Invalid JSON"
   #define D_JSON_INVALID_HEXDATA "Invalid Hex data"
   #define D_JSON_INVALID_RAWDATA "Invalid RawData"


### PR DESCRIPTION
## Description:

Follow-up of Discord discussion. Now when `IRSend` GPIO is not configured, the error is:
```
RSL: RESULT = {"IRSend":"IRsend GPIO not configured"}
```

instead of

```
RSL: RESULT = {"Command":"Unknown"}
```

This helps troubleshooting and testing whether the firmware contains IR support.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
