### PR TITLE
I2S: prevent crash with unconfigured audio

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -179,6 +179,10 @@ void (* const I2SAudio_Command[])(void) PROGMEM = {
 \*********************************************************************************************/
 
 void CmndI2SConfig(void) {
+  if(!audio_i2s.Settings){
+    ResponseCmndChar_P(PSTR("no valid settings"));
+    return;
+  }
   tI2SSettings * cfg = audio_i2s.Settings;
 
   // if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }


### PR DESCRIPTION
## Description:

When the i2s driver is running and no valid i2s pin setting was applied (or any other condition prevents the successful audio configuration at boot time), the command `i2sconfig` would lead to a crash.

So we check for valid audio settings before proceeding.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
