### PR TITLE
fix resistive Touch xpt for 2 spi busses

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -1784,6 +1784,7 @@ bool ValidGPIO(uint32_t pin, uint32_t gpio) {
   return (GPIO_USER == ValidPin(pin, BGPIO(gpio)));  // Only allow GPIO_USER pins
 }
 
+
 bool ValidSpiPinUsed(uint32_t gpio) {
   // ESP8266: If SPI pin selected chk if it's not one of the three Hardware SPI pins (12..14)
   bool result = false;
@@ -1793,6 +1794,27 @@ bool ValidSpiPinUsed(uint32_t gpio) {
   }
   return result;
 }
+
+#ifdef ESP32
+SPIClass *Init_SPI_Bus(uint32 bus) {
+  SPIClass *spi;
+  if (1 == bus) {
+    if (TasmotaGlobal.spi_enabled) {
+      spi = &SPI;
+      spi->begin(Pin(GPIO_SPI_CLK, 0), Pin(GPIO_SPI_MISO, 0), Pin(GPIO_SPI_MOSI, 0), -1);
+      return spi;
+    }
+  }
+  if (2 == bus) {
+    if (TasmotaGlobal.spi_enabled2) {
+      spi = new SPIClass(HSPI);
+      spi->begin(Pin(GPIO_SPI_CLK, 1), Pin(GPIO_SPI_MISO, 1), Pin(GPIO_SPI_MOSI, 1), -1);
+      return spi;
+    }
+  }
+  return nullptr;
+}
+#endif // ESP32
 
 bool JsonTemplate(char* dataBuf)
 {

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -1796,6 +1796,7 @@ bool ValidSpiPinUsed(uint32_t gpio) {
 }
 
 #ifdef ESP32
+#ifndef FIRMWARE_SAFEBOOT
 SPIClass *Init_SPI_Bus(uint32 bus) {
   SPIClass *spi;
   if (1 == bus) {
@@ -1814,6 +1815,7 @@ SPIClass *Init_SPI_Bus(uint32 bus) {
   }
   return nullptr;
 }
+#endif // FIRMWARE_SAFEBOOT
 #endif // ESP32
 
 bool JsonTemplate(char* dataBuf)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #21810

also fixes cache rewrite of push colors for lvgl and rgb displays

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
