### PR TITLE
Update SHT3X driver to bring it into line with other sensors, e.g., HYT..., and avoid unnecessary I²C reads

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -1,7 +1,7 @@
 /*
   xsns_14_sht3x.ino - SHT3X, SHT4X and SHTCX temperature and humidity sensor support for Tasmota
 
-  Copyright (C) 2022  Theo Arends, Stefan Tibus
+  Copyright (C) 2024  Theo Arends, Stefan Tibus, Jan-David Förster
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -1,7 +1,7 @@
 /*
   xsns_14_sht3x.ino - SHT3X, SHT4X and SHTCX temperature and humidity sensor support for Tasmota
 
-  Copyright (C) 2024  Theo Arends, Stefan Tibus, Jan-David Förster
+  Copyright (C) 2022  Theo Arends, Stefan Tibus
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -41,6 +41,9 @@ uint8_t sht3x_addresses[] = { 0x44, 0x45, 0x46, 0x70 };
 
 uint8_t sht3x_count = 0;
 struct SHT3XSTRUCT {
+  float   humi = NAN;
+  float   temp = NAN;
+  uint8_t valid = 0;
   uint8_t type;        // Sensor type
   uint8_t address;     // I2C bus address
   uint8_t bus;
@@ -64,9 +67,8 @@ uint8_t Sht3xComputeCrc(uint8_t data[], uint8_t len) {
   return crc;
 }
 
-bool Sht3xRead(uint32_t sensor, float &t, float &h) {
-  t = NAN;
-  h = NAN;
+bool Sht3xRead(uint32_t sensor) {
+  if (sht3x_sensors[sensor].valid) { sht3x_sensors[sensor].valid--; }
 
   TwoWire& myWire = I2cGetWire(sht3x_sensors[sensor].bus);
   if (&myWire == nullptr) { return false; }   // No valid I2c bus
@@ -95,7 +97,7 @@ bool Sht3xRead(uint32_t sensor, float &t, float &h) {
   if (myWire.endTransmission() != 0) {        // Stop I2C transmission
     return false;
   }
-  delay(30);                                  // Timing verified with logic analyzer (10 is to short)
+  delay(30);                                  // Timing verified with logic analyzer (10 is too short)
   uint8_t data[6];
   myWire.requestFrom(i2c_address, (uint8_t)6); // Request 6 bytes of data
   for (uint32_t i = 0; i < 6; i++) {
@@ -104,21 +106,24 @@ bool Sht3xRead(uint32_t sensor, float &t, float &h) {
   if ((Sht3xComputeCrc(&data[0], 2) != data[2]) || (Sht3xComputeCrc(&data[3], 2) != data[5])) {
     return false;
   }
-  t = ((float)(((data[0] << 8) | data[1]) * 175) / 65535.0) - 45.0;
+  float t;
+  float h;
+  t = ((((data[0] << 8) | data[1]) * 175) / 65535.0) - 45.0;
   if (type == SHT3X_TYPE_SHT4X) {
-    h = ((float)(((data[3] << 8) | data[4]) * 125) / 65535.0) - 6.0;
+    h = ((((data[3] << 8) | data[4]) * 125) / 65535.0) - 6.0;
   } else {
-    h = ((float)(((data[3] << 8) | data[4]) * 100) / 65535.0);
+    h = (((data[3] << 8) | data[4]) * 100) / 65535.0;
   }
-  return (!isnan(t) && !isnan(h));
+  sht3x_sensors[sensor].temp = ConvertTemp(t);
+  sht3x_sensors[sensor].humi = ConvertHumidity(h);
+  if (isnan(sht3x_sensors[sensor].temp) || isnan(sht3x_sensors[sensor].humi)) { return false; }
+    sht3x_sensors[sensor].valid = SENSOR_MAX_MISS;
+  return true;
 }
 
 /********************************************************************************************/
 
 void Sht3xDetect(void) {
-  float t;
-  float h;
-
   for (uint32_t bus = 0; bus < 2; bus++) {
     for (uint32_t k = 0; k < SHT3X_TYPES; k++) {
       for (uint32_t i = 0; i < SHT3X_ADDRESSES; i++) {
@@ -126,7 +131,7 @@ void Sht3xDetect(void) {
         sht3x_sensors[sht3x_count].type = k;
         sht3x_sensors[sht3x_count].address = sht3x_addresses[i];
         sht3x_sensors[sht3x_count].bus = bus;
-        if (Sht3xRead(sht3x_count, t, h)) {
+        if (Sht3xRead(sht3x_count)) {
           GetTextIndexed(sht3x_sensors[sht3x_count].types, sizeof(sht3x_sensors[sht3x_count].types), sht3x_sensors[sht3x_count].type, kSht3xTypes);
           I2cSetActiveFound(sht3x_sensors[sht3x_count].address, sht3x_sensors[sht3x_count].types, sht3x_sensors[sht3x_count].bus);
           sht3x_count++;
@@ -139,15 +144,20 @@ void Sht3xDetect(void) {
   }
 }
 
+
+void Sht3xUpdate(void) {
+    for (uint32_t idx = 0; idx < sht3x_count; idx++) {
+      if (!Sht3xRead(idx)) {
+        AddLogMissed(sht3x_sensors[idx].types, sht3x_sensors[idx].valid);
+      }
+  }
+}
+
 void Sht3xShow(bool json) {
-  float t;
-  float h;
   char types[11];
 
   for (uint32_t idx = 0; idx < sht3x_count; idx++) {
-    if (Sht3xRead(idx, t, h)) {
-      t = ConvertTemp(t);
-      h = ConvertHumidity(h);
+    if (sht3x_sensors[idx].valid) {
       strlcpy(types, sht3x_sensors[idx].types, sizeof(types));
       if (sht3x_count > 1) {
         snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), types, IndexSeparator(), sht3x_sensors[idx].address);  // "SHT3X-0xXX"  
@@ -162,7 +172,7 @@ void Sht3xShow(bool json) {
         }
 #endif
       }
-      TempHumDewShow(json, ((0 == TasmotaGlobal.tele_period) && (0 == idx)), types, t, h);
+      TempHumDewShow(json, ((0 == TasmotaGlobal.tele_period) && (0 == idx)), types, sht3x_sensors[idx].temp, sht3x_sensors[idx].humi);
     }
   }
 }
@@ -181,6 +191,9 @@ bool Xsns14(uint32_t function) {
   }
   else if (sht3x_count) {
     switch (function) {
+      case FUNC_EVERY_SECOND:
+        Sht3xUpdate();
+        break;
       case FUNC_JSON_APPEND:
         Sht3xShow(1);
         break;


### PR DESCRIPTION
## Description:
Until now, each sensor was queried at undefined intervals (~800 ms in my case) and additionally within the scope of TELEPERIOD. I think it makes sense to align this with other drivers, such as with the HYT (xsns_97_hyt.ino) and avoid unnecessary reads. Below, I am showcasing the effect with just three I²C devices on the same bus.

BEFORE:
![three_dev_before](https://github.com/user-attachments/assets/0117d4c7-b6e3-4bc0-b787-c0d52b228711)

AFTER:
![three_dev_new](https://github.com/user-attachments/assets/7f62e933-e14e-44b4-bac8-35c2497f8661)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
