### PR TITLE
Matter support for split lights (`SetOption68 1` and `SetOption37 128`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for Sonoff iFan04-H using template (#16402)
 - Matter improve internal `inspect`for superclasses
+- Matter support for split lights (`SetOption68 1` and `SetOption37 128`)
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
@@ -47,13 +47,15 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
   # var tick                                          # tick value when it was last updated
   # var node_label                                    # name of the endpoint, used only in bridge mode, "" if none
   var tasmota_relay_index                             # Relay number in Tasmota (1 based), may be nil for Lights 1/2/3 internal
+  var light_index                                   # index number when using `light.get()` and `light.set()`
   var shadow_onoff                                    # (bool) status of the light power on/off
 
   #############################################################
   # Constructor
   def init(device, endpoint, config)
-    super(self).init(device, endpoint, config)
     self.shadow_onoff = false
+    self.light_index = 0                              # default is 0 for light object
+    super(self).init(device, endpoint, config)
   end
 
   #############################################################
@@ -105,7 +107,7 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
         self.update_shadow()
       else
         import light
-        light.set({'power':pow})
+        light.set({'power':pow}, self.light_index)
         self.update_shadow()
       end
     end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light3.be
@@ -25,7 +25,9 @@ import matter
 
 class Matter_Plugin_Light3 : Matter_Plugin_Light1
   static var TYPE = "light3"                                # name of the plug-in in json
-  static var DISPLAY_NAME = "Light 3 RGB"                           # display name of the plug-in
+  static var DISPLAY_NAME = "Light 3 RGB"                    # display name of the plug-in
+  static var ARG  = ""                                      # no arg for native light
+  static var ARG_HINT = "_Not used_"                        # Hint for entering the Argument (inside 'placeholder')
   static var CLUSTERS  = matter.consolidate_clusters(_class, {
     # 0x001D: inherited                                     # Descriptor Cluster 9.5 p.453
     # 0x0003: inherited                                     # Identify 1.2 p.16
@@ -65,7 +67,7 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
     if !self.VIRTUAL && !self.BRIDGE
       import light
       super(self).update_shadow()
-      var light_status = light.get()
+      var light_status = light.get(self.light_index)
       if light_status != nil
         var hue = light_status.find('hue', nil)
         var sat = light_status.find('sat', nil)
@@ -122,11 +124,11 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
       var sat_255 = (sat_254 != nil) ? tasmota.scale_uint(sat_254, 0, 254, 0, 255) : nil
 
       if (hue_360 != nil) && (sat_255 != nil)
-        light.set({'hue': hue_360, 'sat': sat_255})
+        light.set({'hue': hue_360, 'sat': sat_255}, self.light_index)
       elif (hue_360 != nil)
-        light.set({'hue': hue_360})
+        light.set({'hue': hue_360}, self.light_index)
       else
-        light.set({'sat': sat_255})
+        light.set({'sat': sat_255}, self.light_index)
       end
       self.update_shadow()
     end
@@ -176,7 +178,6 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
   # returns a TLV object if successful, contains the response
   #   or an `int` to indicate a status
   def invoke_request(session, val, ctx)
-    import light
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var command = ctx.command

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light1.be
@@ -28,6 +28,7 @@ class Matter_Plugin_Bridge_Light1 : Matter_Plugin_Light1
   static var TYPE = "http_light1"                   # name of the plug-in in json
   # static var DISPLAY_NAME = "Light 1 Dimmer"      # display name of the plug-in
   static var ARG  = "relay"                         # additional argument name (or empty if none)
+  static var ARG_HINT = "Relay<x> number"
   static var ARG_TYPE = / x -> int(x)               # function to convert argument to the right type
   static var UPDATE_TIME = 3000                     # update every 3s
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light2.be
@@ -28,6 +28,7 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Light2
   static var TYPE = "http_light2"                   # name of the plug-in in json
   # static var DISPLAY_NAME = "Light 2 CT"      # display name of the plug-in
   static var ARG  = "relay"                         # additional argument name (or empty if none)
+  static var ARG_HINT = "Relay<x> number"
   static var ARG_TYPE = / x -> int(x)               # function to convert argument to the right type
   static var UPDATE_TIME = 3000                     # update every 3s
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_Light3.be
@@ -28,6 +28,7 @@ class Matter_Plugin_Bridge_Light3 : Matter_Plugin_Light3
   static var TYPE = "http_light3"                   # name of the plug-in in json
   # static var DISPLAY_NAME = "Light 3 RGB"         # display name of the plug-in
   static var ARG  = "relay"                         # additional argument name (or empty if none)
+  static var ARG_HINT = "Relay<x> number"
   static var ARG_TYPE = / x -> int(x)               # function to convert argument to the right type
   static var UPDATE_TIME = 3000                     # update every 3s
 end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
@@ -7,6 +7,283 @@
 extern const bclass be_class_Matter_Plugin_Light0;
 
 /********************************************************************
+** Solidified function: set_onoff
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light0;
+be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light0, 
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(BRIDGE),
+    /* K1   */  be_nested_str_weak(call_remote_sync),
+    /* K2   */  be_nested_str_weak(Power),
+    /* K3   */  be_nested_str_weak(tasmota_relay_index),
+    /* K4   */  be_nested_str_weak(1),
+    /* K5   */  be_nested_str_weak(0),
+    /* K6   */  be_nested_str_weak(parse_status),
+    /* K7   */  be_nested_str_weak(VIRTUAL),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K9   */  be_nested_str_weak(attribute_updated),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(set_power),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(update_shadow),
+    /* K15  */  be_nested_str_weak(light),
+    /* K16  */  be_nested_str_weak(set),
+    /* K17  */  be_nested_str_weak(power),
+    /* K18  */  be_nested_str_weak(light_index),
+    }),
+    be_str_weak(set_onoff),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0011,  //  0001  JMPF	R2	#0014
+      0x8C080101,  //  0002  GETMET	R2	R0	K1
+      0x60100008,  //  0003  GETGBL	R4	G8
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x7C100200,  //  0005  CALL	R4	1
+      0x00120404,  //  0006  ADD	R4	K2	R4
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x58140004,  //  0008  LDCONST	R5	K4
+      0x70020000,  //  0009  JMP		#000B
+      0x58140005,  //  000A  LDCONST	R5	K5
+      0x7C080600,  //  000B  CALL	R2	3
+      0x4C0C0000,  //  000C  LDNIL	R3
+      0x200C0403,  //  000D  NE	R3	R2	R3
+      0x780E0003,  //  000E  JMPF	R3	#0013
+      0x8C0C0106,  //  000F  GETMET	R3	R0	K6
+      0x5C140400,  //  0010  MOVE	R5	R2
+      0x541A000A,  //  0011  LDINT	R6	11
+      0x7C0C0600,  //  0012  CALL	R3	3
+      0x70020022,  //  0013  JMP		#0037
+      0x88080107,  //  0014  GETMBR	R2	R0	K7
+      0x780A0008,  //  0015  JMPF	R2	#001F
+      0x88080108,  //  0016  GETMBR	R2	R0	K8
+      0x20080202,  //  0017  NE	R2	R1	R2
+      0x780A0004,  //  0018  JMPF	R2	#001E
+      0x8C080109,  //  0019  GETMET	R2	R0	K9
+      0x54120005,  //  001A  LDINT	R4	6
+      0x5814000A,  //  001B  LDCONST	R5	K10
+      0x7C080600,  //  001C  CALL	R2	3
+      0x90021001,  //  001D  SETMBR	R0	K8	R1
+      0x70020017,  //  001E  JMP		#0037
+      0x88080103,  //  001F  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0020  LDNIL	R3
+      0x20080403,  //  0021  NE	R2	R2	R3
+      0x780A000A,  //  0022  JMPF	R2	#002E
+      0xB80A1600,  //  0023  GETNGBL	R2	K11
+      0x8C08050C,  //  0024  GETMET	R2	R2	K12
+      0x88100103,  //  0025  GETMBR	R4	R0	K3
+      0x0410090D,  //  0026  SUB	R4	R4	K13
+      0x60140017,  //  0027  GETGBL	R5	G23
+      0x5C180200,  //  0028  MOVE	R6	R1
+      0x7C140200,  //  0029  CALL	R5	1
+      0x7C080600,  //  002A  CALL	R2	3
+      0x8C08010E,  //  002B  GETMET	R2	R0	K14
+      0x7C080200,  //  002C  CALL	R2	1
+      0x70020008,  //  002D  JMP		#0037
+      0xA40A1E00,  //  002E  IMPORT	R2	K15
+      0x8C0C0510,  //  002F  GETMET	R3	R2	K16
+      0x60140013,  //  0030  GETGBL	R5	G19
+      0x7C140000,  //  0031  CALL	R5	0
+      0x98162201,  //  0032  SETIDX	R5	K17	R1
+      0x88180112,  //  0033  GETMBR	R6	R0	K18
+      0x7C0C0600,  //  0034  CALL	R3	3
+      0x8C0C010E,  //  0035  GETMET	R3	R0	K14
+      0x7C0C0200,  //  0036  CALL	R3	1
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_values
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light0;
+be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light0, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    }),
+    be_str_weak(web_values),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x7C100400,  //  0009  CALL	R4	2
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light0;
+be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light0, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shadow_onoff),
+    /* K1   */  be_nested_str_weak(light_index),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x50100000,  //  0000  LDBOOL	R4	0	0
+      0x90020004,  //  0001  SETMBR	R0	K0	R4
+      0x90020302,  //  0002  SETMBR	R0	K1	K2
+      0x60100003,  //  0003  GETGBL	R4	G3
+      0x5C140000,  //  0004  MOVE	R5	R0
+      0x7C100200,  //  0005  CALL	R4	1
+      0x8C100903,  //  0006  GETMET	R4	R4	K3
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x5C200600,  //  0009  MOVE	R8	R3
+      0x7C100800,  //  000A  CALL	R4	4
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_configuration
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light0;
+be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light0, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota_relay_index),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
+      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x4C180000,  //  0003  LDNIL	R6
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x7C080200,  //  0005  CALL	R2	1
+      0x90020002,  //  0006  SETMBR	R0	K0	R2
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x20080403,  //  0009  NE	R2	R2	R3
+      0x780A0003,  //  000A  JMPF	R2	#000F
+      0x88080100,  //  000B  GETMBR	R2	R0	K0
+      0x18080503,  //  000C  LE	R2	R2	K3
+      0x780A0000,  //  000D  JMPF	R2	#000F
+      0x90020104,  //  000E  SETMBR	R0	K0	K4
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_virtual
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light0;
+be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light0, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find),
+    /* K1   */  be_nested_str_weak(Power),
+    /* K2   */  be_nested_str_weak(set_onoff),
+    /* K3   */  be_nested_str_weak(update_virtual),
+    }),
+    be_str_weak(update_virtual),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x200C0403,  //  0004  NE	R3	R2	R3
+      0x780E0004,  //  0005  JMPF	R3	#000B
+      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
+      0x60140017,  //  0007  GETGBL	R5	G23
+      0x5C180400,  //  0008  MOVE	R6	R2
+      0x7C140200,  //  0009  CALL	R5	1
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x600C0003,  //  000B  GETGBL	R3	G3
+      0x5C100000,  //  000C  MOVE	R4	R0
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light0;
@@ -67,261 +344,81 @@ be_local_closure(class_Matter_Plugin_Light0_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_virtual
+** Solidified function: web_values_prefix
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
+be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
+    10,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light0, 
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Power),
-    /* K2   */  be_nested_str_weak(set_onoff),
-    /* K3   */  be_nested_str_weak(update_virtual),
-    }),
-    be_str_weak(update_virtual),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x200C0403,  //  0004  NE	R3	R2	R3
-      0x780E0004,  //  0005  JMPF	R3	#000B
-      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
-      0x60140017,  //  0007  GETGBL	R5	G23
-      0x5C180400,  //  0008  MOVE	R6	R2
-      0x7C140200,  //  0009  CALL	R5	1
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x600C0003,  //  000B  GETGBL	R3	G3
-      0x5C100000,  //  000C  MOVE	R4	R0
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_status
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_relay_index),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(POWER),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(ON),
-    /* K6   */  be_nested_str_weak(shadow_onoff),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_const_int(0),
-    }),
-    be_str_weak(parse_status),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x540E000A,  //  0000  LDINT	R3	11
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0020,  //  0002  JMPF	R3	#0024
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x1C100901,  //  0005  EQ	R4	R4	K1
-      0x78120009,  //  0006  JMPF	R4	#0011
-      0x8C100302,  //  0007  GETMET	R4	R1	K2
-      0x58180003,  //  0008  LDCONST	R6	K3
-      0x7C100400,  //  0009  CALL	R4	2
-      0x78120005,  //  000A  JMPF	R4	#0011
-      0x8C100304,  //  000B  GETMET	R4	R1	K4
-      0x58180003,  //  000C  LDCONST	R6	K3
-      0x7C100400,  //  000D  CALL	R4	2
-      0x1C100905,  //  000E  EQ	R4	R4	K5
-      0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x70020007,  //  0010  JMP		#0019
-      0x8C100304,  //  0011  GETMET	R4	R1	K4
-      0x60180008,  //  0012  GETGBL	R6	G8
-      0x881C0100,  //  0013  GETMBR	R7	R0	K0
-      0x7C180200,  //  0014  CALL	R6	1
-      0x001A0606,  //  0015  ADD	R6	K3	R6
-      0x7C100400,  //  0016  CALL	R4	2
-      0x1C100905,  //  0017  EQ	R4	R4	K5
-      0x5C0C0800,  //  0018  MOVE	R3	R4
-      0x88100106,  //  0019  GETMBR	R4	R0	K6
-      0x60140017,  //  001A  GETGBL	R5	G23
-      0x5C180600,  //  001B  MOVE	R6	R3
-      0x7C140200,  //  001C  CALL	R5	1
-      0x20100805,  //  001D  NE	R4	R4	R5
-      0x78120004,  //  001E  JMPF	R4	#0024
-      0x8C100107,  //  001F  GETMET	R4	R0	K7
-      0x541A0005,  //  0020  LDINT	R6	6
-      0x581C0008,  //  0021  LDCONST	R7	K8
-      0x7C100600,  //  0022  CALL	R4	3
-      0x90020C03,  //  0023  SETMBR	R0	K6	R3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_configuration
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_relay_index),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(parse_configuration),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
-      0x4C180000,  //  0003  LDNIL	R6
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x7C080200,  //  0005  CALL	R2	1
-      0x90020002,  //  0006  SETMBR	R0	K0	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x20080403,  //  0009  NE	R2	R2	R3
-      0x780A0003,  //  000A  JMPF	R2	#000F
-      0x88080100,  //  000B  GETMBR	R2	R0	K0
-      0x18080503,  //  000C  LE	R2	R2	K3
-      0x780A0000,  //  000D  JMPF	R2	#000F
-      0x90020104,  //  000E  SETMBR	R0	K0	K4
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_onoff
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(call_remote_sync),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(get_name),
     /* K2   */  be_nested_str_weak(Power),
     /* K3   */  be_nested_str_weak(tasmota_relay_index),
-    /* K4   */  be_nested_str_weak(1),
-    /* K5   */  be_nested_str_weak(0),
-    /* K6   */  be_nested_str_weak(parse_status),
-    /* K7   */  be_nested_str_weak(VIRTUAL),
-    /* K8   */  be_nested_str_weak(shadow_onoff),
-    /* K9   */  be_nested_str_weak(attribute_updated),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(set_power),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(update_shadow),
-    /* K15  */  be_nested_str_weak(light),
-    /* K16  */  be_nested_str_weak(set),
-    /* K17  */  be_nested_str_weak(power),
+    /* K4   */  be_nested_str_weak(content_send),
+    /* K5   */  be_nested_str_weak(PREFIX),
+    /* K6   */  be_nested_str_weak(html_escape),
+    /* K7   */  be_nested_str_weak(),
     }),
-    be_str_weak(set_onoff),
+    be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[55]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0011,  //  0001  JMPF	R2	#0014
-      0x8C080101,  //  0002  GETMET	R2	R0	K1
-      0x60100008,  //  0003  GETGBL	R4	G8
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x7C100200,  //  0005  CALL	R4	1
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x70020000,  //  0009  JMP		#000B
-      0x58140005,  //  000A  LDCONST	R5	K5
-      0x7C080600,  //  000B  CALL	R2	3
-      0x4C0C0000,  //  000C  LDNIL	R3
-      0x200C0403,  //  000D  NE	R3	R2	R3
-      0x780E0003,  //  000E  JMPF	R3	#0013
-      0x8C0C0106,  //  000F  GETMET	R3	R0	K6
-      0x5C140400,  //  0010  MOVE	R5	R2
-      0x541A000A,  //  0011  LDINT	R6	11
-      0x7C0C0600,  //  0012  CALL	R3	3
-      0x70020021,  //  0013  JMP		#0036
-      0x88080107,  //  0014  GETMBR	R2	R0	K7
-      0x780A0008,  //  0015  JMPF	R2	#001F
-      0x88080108,  //  0016  GETMBR	R2	R0	K8
-      0x20080202,  //  0017  NE	R2	R1	R2
-      0x780A0004,  //  0018  JMPF	R2	#001E
-      0x8C080109,  //  0019  GETMET	R2	R0	K9
-      0x54120005,  //  001A  LDINT	R4	6
-      0x5814000A,  //  001B  LDCONST	R5	K10
-      0x7C080600,  //  001C  CALL	R2	3
-      0x90021001,  //  001D  SETMBR	R0	K8	R1
-      0x70020016,  //  001E  JMP		#0036
-      0x88080103,  //  001F  GETMBR	R2	R0	K3
-      0x4C0C0000,  //  0020  LDNIL	R3
-      0x20080403,  //  0021  NE	R2	R2	R3
-      0x780A000A,  //  0022  JMPF	R2	#002E
-      0xB80A1600,  //  0023  GETNGBL	R2	K11
-      0x8C08050C,  //  0024  GETMET	R2	R2	K12
-      0x88100103,  //  0025  GETMBR	R4	R0	K3
-      0x0410090D,  //  0026  SUB	R4	R4	K13
-      0x60140017,  //  0027  GETGBL	R5	G23
-      0x5C180200,  //  0028  MOVE	R6	R1
-      0x7C140200,  //  0029  CALL	R5	1
-      0x7C080600,  //  002A  CALL	R2	3
-      0x8C08010E,  //  002B  GETMET	R2	R0	K14
-      0x7C080200,  //  002C  CALL	R2	1
-      0x70020007,  //  002D  JMP		#0036
-      0xA40A1E00,  //  002E  IMPORT	R2	K15
-      0x8C0C0510,  //  002F  GETMET	R3	R2	K16
-      0x60140013,  //  0030  GETGBL	R5	G19
-      0x7C140000,  //  0031  CALL	R5	0
-      0x98162201,  //  0032  SETIDX	R5	K17	R1
-      0x7C0C0400,  //  0033  CALL	R3	2
-      0x8C0C010E,  //  0034  GETMET	R3	R0	K14
-      0x7C0C0200,  //  0035  CALL	R3	1
-      0x80000000,  //  0036  RET	0
+    ( &(const binstruction[22]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x5C0C0400,  //  0003  MOVE	R3	R2
+      0x740E0004,  //  0004  JMPT	R3	#000A
+      0x600C0008,  //  0005  GETGBL	R3	G8
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x5C240400,  //  000F  MOVE	R9	R2
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x70020000,  //  0011  JMP		#0013
+      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x7C140400,  //  0013  CALL	R5	2
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Light0__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL, 
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040009,  //  0000  GETGBL	R1	G9
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -390,87 +487,6 @@ be_local_closure(class_Matter_Plugin_Light0_update_shadow,   /* name */
       0x8C040309,  //  001E  GETMET	R1	R1	K9
       0x7C040200,  //  001F  CALL	R1	1
       0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_values
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    }),
-    be_str_weak(web_values),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
-      0x7C180400,  //  0008  CALL	R6	2
-      0x7C100400,  //  0009  CALL	R4	2
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_onoff),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x5C200600,  //  0006  MOVE	R8	R3
-      0x7C100800,  //  0007  CALL	R4	4
-      0x50100000,  //  0008  LDBOOL	R4	0	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
-      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -567,81 +583,70 @@ be_local_closure(class_Matter_Plugin_Light0_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: <lambda>
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Light0__X3Clambda_X3E,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL, 
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(_X3Clambda_X3E),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60040009,  //  0000  GETGBL	R1	G9
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_values_prefix
+** Solidified function: parse_status
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light0;
-be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
+be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light0, 
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Power),
-    /* K3   */  be_nested_str_weak(tasmota_relay_index),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota_relay_index),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(POWER),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(ON),
+    /* K6   */  be_nested_str_weak(shadow_onoff),
+    /* K7   */  be_nested_str_weak(attribute_updated),
+    /* K8   */  be_const_int(0),
     }),
-    be_str_weak(web_values_prefix),
+    be_str_weak(parse_status),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x5C0C0400,  //  0003  MOVE	R3	R2
-      0x740E0004,  //  0004  JMPT	R3	#000A
-      0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0403,  //  0008  ADD	R3	K2	R3
-      0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
-      0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
-      0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
-      0x5C240400,  //  000F  MOVE	R9	R2
-      0x7C1C0400,  //  0010  CALL	R7	2
-      0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
-      0x7C140400,  //  0013  CALL	R5	2
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[37]) {  /* code */
+      0x540E000A,  //  0000  LDINT	R3	11
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0020,  //  0002  JMPF	R3	#0024
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x88100100,  //  0004  GETMBR	R4	R0	K0
+      0x1C100901,  //  0005  EQ	R4	R4	K1
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0x8C100302,  //  0007  GETMET	R4	R1	K2
+      0x58180003,  //  0008  LDCONST	R6	K3
+      0x7C100400,  //  0009  CALL	R4	2
+      0x78120005,  //  000A  JMPF	R4	#0011
+      0x8C100304,  //  000B  GETMET	R4	R1	K4
+      0x58180003,  //  000C  LDCONST	R6	K3
+      0x7C100400,  //  000D  CALL	R4	2
+      0x1C100905,  //  000E  EQ	R4	R4	K5
+      0x5C0C0800,  //  000F  MOVE	R3	R4
+      0x70020007,  //  0010  JMP		#0019
+      0x8C100304,  //  0011  GETMET	R4	R1	K4
+      0x60180008,  //  0012  GETGBL	R6	G8
+      0x881C0100,  //  0013  GETMBR	R7	R0	K0
+      0x7C180200,  //  0014  CALL	R6	1
+      0x001A0606,  //  0015  ADD	R6	K3	R6
+      0x7C100400,  //  0016  CALL	R4	2
+      0x1C100905,  //  0017  EQ	R4	R4	K5
+      0x5C0C0800,  //  0018  MOVE	R3	R4
+      0x88100106,  //  0019  GETMBR	R4	R0	K6
+      0x60140017,  //  001A  GETGBL	R5	G23
+      0x5C180600,  //  001B  MOVE	R6	R3
+      0x7C140200,  //  001C  CALL	R5	1
+      0x20100805,  //  001D  NE	R4	R4	R5
+      0x78120004,  //  001E  JMPF	R4	#0024
+      0x8C100107,  //  001F  GETMET	R4	R0	K7
+      0x541A0005,  //  0020  LDINT	R6	6
+      0x581C0008,  //  0021  LDCONST	R7	K8
+      0x7C100600,  //  0022  CALL	R4	3
+      0x90020C03,  //  0023  SETMBR	R0	K6	R3
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -653,22 +658,17 @@ be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Device;
 be_local_class(Matter_Plugin_Light0,
-    2,
+    3,
     &be_class_Matter_Plugin_Device,
-    be_nested_map(21,
+    be_nested_map(22,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light0_read_attribute_closure) },
-        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light0_update_virtual_closure) },
-        { be_const_key_weak(tasmota_relay_index, 1), be_const_var(0) },
-        { be_const_key_weak(parse_status, 5), be_const_closure(class_Matter_Plugin_Light0_parse_status_closure) },
-        { be_const_key_weak(parse_configuration, -1), be_const_closure(class_Matter_Plugin_Light0_parse_configuration_closure) },
-        { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_nested_str_weak(Power),
-    }))    ) } )) },
-        { be_const_key_weak(set_onoff, -1), be_const_closure(class_Matter_Plugin_Light0_set_onoff_closure) },
-        { be_const_key_weak(CLUSTERS, 19), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(parse_status, 8), be_const_closure(class_Matter_Plugin_Light0_parse_status_closure) },
+        { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(Relay_X3Cx_X3E_X20number) },
+        { be_const_key_weak(light_index, -1), be_const_var(1) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(250) },
+        { be_const_key_weak(set_onoff, 18), be_const_closure(class_Matter_Plugin_Light0_set_onoff_closure) },
+        { be_const_key_weak(tasmota_relay_index, -1), be_const_var(0) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(6, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -752,23 +752,29 @@ be_local_class(Matter_Plugin_Light0,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Light0_init_closure) },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(250) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak(light0) },
-        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light0_web_values_closure) },
-        { be_const_key_weak(DISPLAY_NAME, 8), be_nested_str_weak(Light_X200_X20On) },
-        { be_const_key_weak(shadow_onoff, -1), be_const_var(1) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Light0_invoke_request_closure) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak(relay) },
+        { be_const_key_weak(invoke_request, 10), be_const_closure(class_Matter_Plugin_Light0_invoke_request_closure) },
+        { be_const_key_weak(init, 5), be_const_closure(class_Matter_Plugin_Light0_init_closure) },
+        { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(1,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_nested_str_weak(Power),
+    }))    ) } )) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light0_read_attribute_closure) },
+        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light0_update_virtual_closure) },
+        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Light0_web_values_prefix_closure) },
+        { be_const_key_weak(shadow_onoff, 11), be_const_var(2) },
+        { be_const_key_weak(TYPE, 13), be_nested_str_weak(light0) },
         { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(class_Matter_Plugin_Light0__X3Clambda_X3E_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Light0_update_shadow_closure) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(256, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(Relay_X3Cx_X3E_X20number) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Light0_update_shadow_closure) },
-        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Light0_web_values_prefix_closure) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Light_X200_X20On) },
+        { be_const_key_weak(web_values, 3), be_const_closure(class_Matter_Plugin_Light0_web_values_closure) },
+        { be_const_key_weak(parse_configuration, 0), be_const_closure(class_Matter_Plugin_Light0_parse_configuration_closure) },
     })),
     be_str_weak(Matter_Plugin_Light0)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
@@ -7,59 +7,6 @@
 extern const bclass be_class_Matter_Plugin_Light1;
 
 /********************************************************************
-** Solidified function: update_virtual
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Power),
-    /* K2   */  be_nested_str_weak(Bri),
-    /* K3   */  be_nested_str_weak(set_bri),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
-    be_str_weak(update_virtual),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x58140002,  //  0004  LDCONST	R5	K2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x4C100000,  //  0006  LDNIL	R4
-      0x20100604,  //  0007  NE	R4	R3	R4
-      0x78120006,  //  0008  JMPF	R4	#0010
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
-      0x60180009,  //  000A  GETGBL	R6	G9
-      0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x7C180200,  //  000C  CALL	R6	1
-      0x5C1C0400,  //  000D  MOVE	R7	R2
-      0x7C100600,  //  000E  CALL	R4	3
-      0x80000800,  //  000F  RET	0
-      0x60100003,  //  0010  GETGBL	R4	G3
-      0x5C140000,  //  0011  MOVE	R5	R0
-      0x7C100200,  //  0012  CALL	R4	1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180200,  //  0014  MOVE	R6	R1
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: set_bri
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
@@ -73,7 +20,7 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light1, 
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(BRIDGE),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -88,12 +35,13 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
     /* K11  */  be_nested_str_weak(light),
     /* K12  */  be_nested_str_weak(set),
     /* K13  */  be_nested_str_weak(bri),
-    /* K14  */  be_nested_str_weak(power),
-    /* K15  */  be_nested_str_weak(update_shadow),
+    /* K14  */  be_nested_str_weak(light_index),
+    /* K15  */  be_nested_str_weak(power),
+    /* K16  */  be_nested_str_weak(update_shadow),
     }),
     be_str_weak(set_bri),
     &be_const_str_solidified,
-    ( &(const binstruction[89]) {  /* code */
+    ( &(const binstruction[91]) {  /* code */
       0x140C0300,  //  0000  LT	R3	R1	K0
       0x780E0000,  //  0001  JMPF	R3	#0003
       0x58040000,  //  0002  LDCONST	R1	K0
@@ -133,7 +81,7 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
       0x5C1C0800,  //  0024  MOVE	R7	R4
       0x5422000A,  //  0025  LDINT	R8	11
       0x7C140600,  //  0026  CALL	R5	3
-      0x7002002F,  //  0027  JMP		#0058
+      0x70020031,  //  0027  JMP		#005A
       0x880C0107,  //  0028  GETMBR	R3	R0	K7
       0x780E0013,  //  0029  JMPF	R3	#003E
       0x4C0C0000,  //  002A  LDNIL	R3
@@ -155,7 +103,7 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
       0x58180000,  //  003A  LDCONST	R6	K0
       0x7C0C0600,  //  003B  CALL	R3	3
       0x90021401,  //  003C  SETMBR	R0	K10	R1
-      0x70020019,  //  003D  JMP		#0058
+      0x7002001B,  //  003D  JMP		#005A
       0xA40E1600,  //  003E  IMPORT	R3	K11
       0xB8120400,  //  003F  GETNGBL	R4	K2
       0x8C100903,  //  0040  GETMET	R4	R4	K3
@@ -167,22 +115,24 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
       0x7C100C00,  //  0046  CALL	R4	6
       0x4C140000,  //  0047  LDNIL	R5
       0x1C140405,  //  0048  EQ	R5	R2	R5
-      0x78160005,  //  0049  JMPF	R5	#0050
+      0x78160006,  //  0049  JMPF	R5	#0051
       0x8C14070C,  //  004A  GETMET	R5	R3	K12
       0x601C0013,  //  004B  GETGBL	R7	G19
       0x7C1C0000,  //  004C  CALL	R7	0
       0x981E1A04,  //  004D  SETIDX	R7	K13	R4
-      0x7C140400,  //  004E  CALL	R5	2
-      0x70020005,  //  004F  JMP		#0056
-      0x8C14070C,  //  0050  GETMET	R5	R3	K12
-      0x601C0013,  //  0051  GETGBL	R7	G19
-      0x7C1C0000,  //  0052  CALL	R7	0
-      0x981E1A04,  //  0053  SETIDX	R7	K13	R4
-      0x981E1C02,  //  0054  SETIDX	R7	K14	R2
-      0x7C140400,  //  0055  CALL	R5	2
-      0x8C14010F,  //  0056  GETMET	R5	R0	K15
-      0x7C140200,  //  0057  CALL	R5	1
-      0x80000000,  //  0058  RET	0
+      0x8820010E,  //  004E  GETMBR	R8	R0	K14
+      0x7C140600,  //  004F  CALL	R5	3
+      0x70020006,  //  0050  JMP		#0058
+      0x8C14070C,  //  0051  GETMET	R5	R3	K12
+      0x601C0013,  //  0052  GETGBL	R7	G19
+      0x7C1C0000,  //  0053  CALL	R7	0
+      0x981E1A04,  //  0054  SETIDX	R7	K13	R4
+      0x981E1E02,  //  0055  SETIDX	R7	K15	R2
+      0x8820010E,  //  0056  GETMBR	R8	R0	K14
+      0x7C140600,  //  0057  CALL	R5	3
+      0x8C140110,  //  0058  GETMET	R5	R0	K16
+      0x7C140200,  //  0059  CALL	R5	1
+      0x80000000,  //  005A  RET	0
     })
   )
 );
@@ -190,50 +140,12 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: web_value_dimmer
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
+be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
   be_nested_proto(
     9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_bri),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x5C200600,  //  0006  MOVE	R8	R3
-      0x7C100800,  //  0007  CALL	R4	4
-      0x90020302,  //  0008  SETMBR	R0	K1	K2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -241,290 +153,38 @@ be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light1, 
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(power),
-    /* K6   */  be_nested_str_weak(shadow_onoff),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(bri),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(scale_uint),
-    /* K12  */  be_nested_str_weak(shadow_bri),
-    /* K13  */  be_nested_str_weak(update_shadow),
-    }),
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x7406002B,  //  0001  JMPT	R1	#002E
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x74060029,  //  0003  JMPT	R1	#002E
-      0xA4060400,  //  0004  IMPORT	R1	K2
-      0x8C080303,  //  0005  GETMET	R2	R1	K3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x200C0403,  //  0008  NE	R3	R2	R3
-      0x780E0023,  //  0009  JMPF	R3	#002E
-      0x8C0C0504,  //  000A  GETMET	R3	R2	K4
-      0x58140005,  //  000B  LDCONST	R5	K5
-      0x4C180000,  //  000C  LDNIL	R6
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x88100106,  //  000E  GETMBR	R4	R0	K6
-      0x20100604,  //  000F  NE	R4	R3	R4
-      0x78120004,  //  0010  JMPF	R4	#0016
-      0x8C100107,  //  0011  GETMET	R4	R0	K7
-      0x541A0005,  //  0012  LDINT	R6	6
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x7C100600,  //  0014  CALL	R4	3
-      0x90020C03,  //  0015  SETMBR	R0	K6	R3
-      0x8C100504,  //  0016  GETMET	R4	R2	K4
-      0x58180009,  //  0017  LDCONST	R6	K9
-      0x4C1C0000,  //  0018  LDNIL	R7
-      0x7C100600,  //  0019  CALL	R4	3
-      0x4C140000,  //  001A  LDNIL	R5
-      0x20140805,  //  001B  NE	R5	R4	R5
-      0x78160010,  //  001C  JMPF	R5	#002E
-      0xB8161400,  //  001D  GETNGBL	R5	K10
-      0x8C140B0B,  //  001E  GETMET	R5	R5	K11
-      0x5C1C0800,  //  001F  MOVE	R7	R4
-      0x58200008,  //  0020  LDCONST	R8	K8
-      0x542600FE,  //  0021  LDINT	R9	255
-      0x58280008,  //  0022  LDCONST	R10	K8
-      0x542E00FD,  //  0023  LDINT	R11	254
-      0x7C140C00,  //  0024  CALL	R5	6
-      0x5C100A00,  //  0025  MOVE	R4	R5
-      0x8814010C,  //  0026  GETMBR	R5	R0	K12
-      0x20140805,  //  0027  NE	R5	R4	R5
-      0x78160004,  //  0028  JMPF	R5	#002E
-      0x8C140107,  //  0029  GETMET	R5	R0	K7
-      0x541E0007,  //  002A  LDINT	R7	8
-      0x58200008,  //  002B  LDCONST	R8	K8
-      0x7C140600,  //  002C  CALL	R5	3
-      0x90021804,  //  002D  SETMBR	R0	K12	R4
-      0x60040003,  //  002E  GETGBL	R1	G3
-      0x5C080000,  //  002F  MOVE	R2	R0
-      0x7C040200,  //  0030  CALL	R1	1
-      0x8C04030D,  //  0031  GETMET	R1	R1	K13
-      0x7C040200,  //  0032  CALL	R1	1
-      0x80000000,  //  0033  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_configuration
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(tasmota_relay_index),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(shadow_bri),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(scale_uint),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(_X25i_X25_X25),
+    /* K6   */  be_nested_str_weak(_X26_X23128261_X3B_X20),
     }),
-    be_str_weak(parse_configuration),
+    be_str_weak(web_value_dimmer),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A000E,  //  0001  JMPF	R2	#0011
-      0x60080009,  //  0002  GETGBL	R2	G9
-      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x4C180000,  //  0005  LDNIL	R6
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x7C080200,  //  0007  CALL	R2	1
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x20080403,  //  000B  NE	R2	R2	R3
-      0x780A0003,  //  000C  JMPF	R2	#0011
-      0x88080101,  //  000D  GETMBR	R2	R0	K1
-      0x18080504,  //  000E  LE	R2	R2	K4
-      0x780A0000,  //  000F  JMPF	R2	#0011
-      0x90020305,  //  0010  SETMBR	R0	K1	K5
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_status
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_status),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(Dimmer),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(scale_uint),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_bri),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    }),
-    be_str_weak(parse_status),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x540E000A,  //  0007  LDINT	R3	11
-      0x1C0C0403,  //  0008  EQ	R3	R2	R3
-      0x780E0017,  //  0009  JMPF	R3	#0022
-      0x600C0009,  //  000A  GETGBL	R3	G9
-      0x8C100301,  //  000B  GETMET	R4	R1	K1
-      0x58180002,  //  000C  LDCONST	R6	K2
-      0x7C100400,  //  000D  CALL	R4	2
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x4C100000,  //  000F  LDNIL	R4
-      0x20100604,  //  0010  NE	R4	R3	R4
-      0x7812000F,  //  0011  JMPF	R4	#0022
-      0xB8120600,  //  0012  GETNGBL	R4	K3
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x581C0005,  //  0015  LDCONST	R7	K5
-      0x54220063,  //  0016  LDINT	R8	100
-      0x58240005,  //  0017  LDCONST	R9	K5
-      0x542A00FD,  //  0018  LDINT	R10	254
-      0x7C100C00,  //  0019  CALL	R4	6
-      0x88140106,  //  001A  GETMBR	R5	R0	K6
-      0x20140805,  //  001B  NE	R5	R4	R5
-      0x78160004,  //  001C  JMPF	R5	#0022
-      0x8C140107,  //  001D  GETMET	R5	R0	K7
-      0x541E0007,  //  001E  LDINT	R7	8
-      0x58200005,  //  001F  LDCONST	R8	K5
-      0x7C140600,  //  0020  CALL	R5	3
-      0x90020C04,  //  0021  SETMBR	R0	K6	R4
-      0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_bri),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[59]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
-      0x541E0007,  //  0004  LDINT	R7	8
-      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E002A,  //  0006  JMPF	R7	#0032
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
-      0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
-      0x88240907,  //  000C  GETMBR	R9	R4	K7
-      0x88280108,  //  000D  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  000E  CALL	R7	3
-      0x80040E00,  //  000F  RET	1	R7
-      0x70020020,  //  0010  JMP		#0032
-      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
-      0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240907,  //  0014  GETMBR	R9	R4	K7
-      0x58280005,  //  0015  LDCONST	R10	K5
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x80040E00,  //  0017  RET	1	R7
-      0x70020018,  //  0018  JMP		#0032
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
-      0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
-      0x542A00FD,  //  001D  LDINT	R10	254
-      0x7C1C0600,  //  001E  CALL	R7	3
-      0x80040E00,  //  001F  RET	1	R7
-      0x70020010,  //  0020  JMP		#0032
-      0x541E000E,  //  0021  LDINT	R7	15
-      0x1C1C0C07,  //  0022  EQ	R7	R6	R7
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0706,  //  0024  GETMET	R7	R3	K6
-      0x88240907,  //  0025  GETMBR	R9	R4	K7
-      0x58280005,  //  0026  LDCONST	R10	K5
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020007,  //  0029  JMP		#0032
-      0x541E0010,  //  002A  LDINT	R7	17
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0004,  //  002C  JMPF	R7	#0032
-      0x8C1C0706,  //  002D  GETMET	R7	R3	K6
-      0x88240907,  //  002E  GETMBR	R9	R4	K7
-      0x88280108,  //  002F  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x601C0003,  //  0032  GETGBL	R7	G3
-      0x5C200000,  //  0033  MOVE	R8	R0
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0F0B,  //  0035  GETMET	R7	R7	K11
-      0x5C240200,  //  0036  MOVE	R9	R1
-      0x5C280400,  //  0037  MOVE	R10	R2
-      0x5C2C0600,  //  0038  MOVE	R11	R3
-      0x7C1C0800,  //  0039  CALL	R7	4
-      0x80040E00,  //  003A  RET	1	R7
+    ( &(const binstruction[20]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A000C,  //  0004  JMPF	R2	#0012
+      0xB80A0400,  //  0005  GETNGBL	R2	K2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x58140004,  //  0008  LDCONST	R5	K4
+      0x541A00FD,  //  0009  LDINT	R6	254
+      0x581C0004,  //  000A  LDCONST	R7	K4
+      0x54220063,  //  000B  LDINT	R8	100
+      0x7C080C00,  //  000C  CALL	R2	6
+      0x600C0018,  //  000D  GETGBL	R3	G24
+      0x58100005,  //  000E  LDCONST	R4	K5
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x5C040600,  //  0011  MOVE	R1	R3
+      0x000A0C01,  //  0012  ADD	R2	K6	R1
+      0x80040400,  //  0013  RET	1	R2
     })
   )
 );
@@ -697,51 +357,276 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: web_value_dimmer
+** Solidified function: read_attribute
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
-be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
+be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
+    12,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light1, 
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(shadow_bri),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(_X25i_X25_X25),
-    /* K6   */  be_nested_str_weak(_X26_X23128261_X3B_X20),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(set),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(shadow_bri),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(read_attribute),
     }),
-    be_str_weak(web_value_dimmer),
+    be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x20080403,  //  0003  NE	R2	R2	R3
-      0x780A000C,  //  0004  JMPF	R2	#0012
-      0xB80A0400,  //  0005  GETNGBL	R2	K2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x88100101,  //  0007  GETMBR	R4	R0	K1
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x541A00FD,  //  0009  LDINT	R6	254
-      0x581C0004,  //  000A  LDCONST	R7	K4
-      0x54220063,  //  000B  LDINT	R8	100
-      0x7C080C00,  //  000C  CALL	R2	6
-      0x600C0018,  //  000D  GETGBL	R3	G24
-      0x58100005,  //  000E  LDCONST	R4	K5
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x5C040600,  //  0011  MOVE	R1	R3
-      0x000A0C01,  //  0012  ADD	R2	K6	R1
-      0x80040400,  //  0013  RET	1	R2
+    ( &(const binstruction[59]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140502,  //  0002  GETMBR	R5	R2	K2
+      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0x541E0007,  //  0004  LDINT	R7	8
+      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
+      0x781E002A,  //  0006  JMPF	R7	#0032
+      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x781E0005,  //  000A  JMPF	R7	#0011
+      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
+      0x88240907,  //  000C  GETMBR	R9	R4	K7
+      0x88280108,  //  000D  GETMBR	R10	R0	K8
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x70020020,  //  0010  JMP		#0032
+      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
+      0x88240907,  //  0014  GETMBR	R9	R4	K7
+      0x58280005,  //  0015  LDCONST	R10	K5
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x80040E00,  //  0017  RET	1	R7
+      0x70020018,  //  0018  JMP		#0032
+      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x781E0005,  //  001A  JMPF	R7	#0021
+      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
+      0x542A00FD,  //  001D  LDINT	R10	254
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x70020010,  //  0020  JMP		#0032
+      0x541E000E,  //  0021  LDINT	R7	15
+      0x1C1C0C07,  //  0022  EQ	R7	R6	R7
+      0x781E0005,  //  0023  JMPF	R7	#002A
+      0x8C1C0706,  //  0024  GETMET	R7	R3	K6
+      0x88240907,  //  0025  GETMBR	R9	R4	K7
+      0x58280005,  //  0026  LDCONST	R10	K5
+      0x7C1C0600,  //  0027  CALL	R7	3
+      0x80040E00,  //  0028  RET	1	R7
+      0x70020007,  //  0029  JMP		#0032
+      0x541E0010,  //  002A  LDINT	R7	17
+      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
+      0x781E0004,  //  002C  JMPF	R7	#0032
+      0x8C1C0706,  //  002D  GETMET	R7	R3	K6
+      0x88240907,  //  002E  GETMBR	R9	R4	K7
+      0x88280108,  //  002F  GETMBR	R10	R0	K8
+      0x7C1C0600,  //  0030  CALL	R7	3
+      0x80040E00,  //  0031  RET	1	R7
+      0x601C0003,  //  0032  GETGBL	R7	G3
+      0x5C200000,  //  0033  MOVE	R8	R0
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x8C1C0F0B,  //  0035  GETMET	R7	R7	K11
+      0x5C240200,  //  0036  MOVE	R9	R1
+      0x5C280400,  //  0037  MOVE	R10	R2
+      0x5C2C0600,  //  0038  MOVE	R11	R3
+      0x7C1C0800,  //  0039  CALL	R7	4
+      0x80040E00,  //  003A  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_configuration
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light1;
+be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light1, 
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(BRIDGE),
+    /* K1   */  be_nested_str_weak(tasmota_relay_index),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(ARG),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(TYPE),
+    /* K7   */  be_nested_str_weak(light1),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(get_option),
+    /* K10  */  be_nested_str_weak(light),
+    /* K11  */  be_nested_str_weak(get),
+    /* K12  */  be_nested_str_weak(light_index),
+    }),
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A000F,  //  0001  JMPF	R2	#0012
+      0x60080009,  //  0002  GETGBL	R2	G9
+      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x4C180000,  //  0005  LDNIL	R6
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x7C080200,  //  0007  CALL	R2	1
+      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x20080403,  //  000B  NE	R2	R2	R3
+      0x780A0003,  //  000C  JMPF	R2	#0011
+      0x88080101,  //  000D  GETMBR	R2	R0	K1
+      0x18080504,  //  000E  LE	R2	R2	K4
+      0x780A0000,  //  000F  JMPF	R2	#0011
+      0x90020305,  //  0010  SETMBR	R0	K1	K5
+      0x70020020,  //  0011  JMP		#0033
+      0x88080101,  //  0012  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0013  LDNIL	R3
+      0x1C080403,  //  0014  EQ	R2	R2	R3
+      0x780A001C,  //  0015  JMPF	R2	#0033
+      0x88080106,  //  0016  GETMBR	R2	R0	K6
+      0x1C080507,  //  0017  EQ	R2	R2	K7
+      0x780A0019,  //  0018  JMPF	R2	#0033
+      0x8C080302,  //  0019  GETMET	R2	R1	K2
+      0x88100103,  //  001A  GETMBR	R4	R0	K3
+      0x7C080400,  //  001B  CALL	R2	2
+      0x4C0C0000,  //  001C  LDNIL	R3
+      0x1C0C0403,  //  001D  EQ	R3	R2	R3
+      0x780E000E,  //  001E  JMPF	R3	#002E
+      0xB80E1000,  //  001F  GETNGBL	R3	K8
+      0x8C0C0709,  //  0020  GETMET	R3	R3	K9
+      0x54160043,  //  0021  LDINT	R5	68
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x1C0C0704,  //  0023  EQ	R3	R3	K4
+      0x780E0007,  //  0024  JMPF	R3	#002D
+      0xA40E1400,  //  0025  IMPORT	R3	K10
+      0x8C10070B,  //  0026  GETMET	R4	R3	K11
+      0x58180005,  //  0027  LDCONST	R6	K5
+      0x7C100400,  //  0028  CALL	R4	2
+      0x4C140000,  //  0029  LDNIL	R5
+      0x20100805,  //  002A  NE	R4	R4	R5
+      0x78120000,  //  002B  JMPF	R4	#002D
+      0x90021905,  //  002C  SETMBR	R0	K12	K5
+      0x70020004,  //  002D  JMP		#0033
+      0x600C0009,  //  002E  GETGBL	R3	G9
+      0x5C100400,  //  002F  MOVE	R4	R2
+      0x7C0C0200,  //  0030  CALL	R3	1
+      0x040C0705,  //  0031  SUB	R3	R3	K5
+      0x90021803,  //  0032  SETMBR	R0	K12	R3
+      0x80000000,  //  0033  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_virtual
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light1;
+be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light1, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find),
+    /* K1   */  be_nested_str_weak(Power),
+    /* K2   */  be_nested_str_weak(Bri),
+    /* K3   */  be_nested_str_weak(set_bri),
+    /* K4   */  be_nested_str_weak(update_virtual),
+    }),
+    be_str_weak(update_virtual),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x58140002,  //  0004  LDCONST	R5	K2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x4C100000,  //  0006  LDNIL	R4
+      0x20100604,  //  0007  NE	R4	R3	R4
+      0x78120006,  //  0008  JMPF	R4	#0010
+      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x60180009,  //  000A  GETGBL	R6	G9
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C180200,  //  000C  CALL	R6	1
+      0x5C1C0400,  //  000D  MOVE	R7	R2
+      0x7C100600,  //  000E  CALL	R4	3
+      0x80000800,  //  000F  RET	0
+      0x60100003,  //  0010  GETGBL	R4	G3
+      0x5C140000,  //  0011  MOVE	R5	R0
+      0x7C100200,  //  0012  CALL	R4	1
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180200,  //  0014  MOVE	R6	R1
+      0x7C100400,  //  0015  CALL	R4	2
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light1;
+be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light1, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shadow_bri),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020101,  //  0000  SETMBR	R0	K0	K1
+      0x60100003,  //  0001  GETGBL	R4	G3
+      0x5C140000,  //  0002  MOVE	R5	R0
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100902,  //  0004  GETMET	R4	R4	K2
+      0x5C180200,  //  0005  MOVE	R6	R1
+      0x5C1C0400,  //  0006  MOVE	R7	R2
+      0x5C200600,  //  0007  MOVE	R8	R3
+      0x7C100800,  //  0008  CALL	R4	4
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -795,34 +680,198 @@ be_local_closure(class_Matter_Plugin_Light1_web_values,   /* name */
 
 
 /********************************************************************
+** Solidified function: parse_status
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light1;
+be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light1, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parse_status),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(Dimmer),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(scale_uint),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(shadow_bri),
+    /* K7   */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(parse_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x540E000A,  //  0007  LDINT	R3	11
+      0x1C0C0403,  //  0008  EQ	R3	R2	R3
+      0x780E0017,  //  0009  JMPF	R3	#0022
+      0x600C0009,  //  000A  GETGBL	R3	G9
+      0x8C100301,  //  000B  GETMET	R4	R1	K1
+      0x58180002,  //  000C  LDCONST	R6	K2
+      0x7C100400,  //  000D  CALL	R4	2
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x4C100000,  //  000F  LDNIL	R4
+      0x20100604,  //  0010  NE	R4	R3	R4
+      0x7812000F,  //  0011  JMPF	R4	#0022
+      0xB8120600,  //  0012  GETNGBL	R4	K3
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x581C0005,  //  0015  LDCONST	R7	K5
+      0x54220063,  //  0016  LDINT	R8	100
+      0x58240005,  //  0017  LDCONST	R9	K5
+      0x542A00FD,  //  0018  LDINT	R10	254
+      0x7C100C00,  //  0019  CALL	R4	6
+      0x88140106,  //  001A  GETMBR	R5	R0	K6
+      0x20140805,  //  001B  NE	R5	R4	R5
+      0x78160004,  //  001C  JMPF	R5	#0022
+      0x8C140107,  //  001D  GETMET	R5	R0	K7
+      0x541E0007,  //  001E  LDINT	R7	8
+      0x58200005,  //  001F  LDCONST	R8	K5
+      0x7C140600,  //  0020  CALL	R5	3
+      0x90020C04,  //  0021  SETMBR	R0	K6	R4
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light1;
+be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light1, 
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(VIRTUAL),
+    /* K1   */  be_nested_str_weak(BRIDGE),
+    /* K2   */  be_nested_str_weak(light),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_nested_str_weak(light_index),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_nested_str_weak(power),
+    /* K7   */  be_nested_str_weak(shadow_onoff),
+    /* K8   */  be_nested_str_weak(attribute_updated),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(bri),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(scale_uint),
+    /* K13  */  be_nested_str_weak(shadow_bri),
+    /* K14  */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x7406002C,  //  0001  JMPT	R1	#002F
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x7406002A,  //  0003  JMPT	R1	#002F
+      0xA4060400,  //  0004  IMPORT	R1	K2
+      0x8C080303,  //  0005  GETMET	R2	R1	K3
+      0x88100104,  //  0006  GETMBR	R4	R0	K4
+      0x7C080400,  //  0007  CALL	R2	2
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x200C0403,  //  0009  NE	R3	R2	R3
+      0x780E0023,  //  000A  JMPF	R3	#002F
+      0x8C0C0505,  //  000B  GETMET	R3	R2	K5
+      0x58140006,  //  000C  LDCONST	R5	K6
+      0x4C180000,  //  000D  LDNIL	R6
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x88100107,  //  000F  GETMBR	R4	R0	K7
+      0x20100604,  //  0010  NE	R4	R3	R4
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x8C100108,  //  0012  GETMET	R4	R0	K8
+      0x541A0005,  //  0013  LDINT	R6	6
+      0x581C0009,  //  0014  LDCONST	R7	K9
+      0x7C100600,  //  0015  CALL	R4	3
+      0x90020E03,  //  0016  SETMBR	R0	K7	R3
+      0x8C100505,  //  0017  GETMET	R4	R2	K5
+      0x5818000A,  //  0018  LDCONST	R6	K10
+      0x4C1C0000,  //  0019  LDNIL	R7
+      0x7C100600,  //  001A  CALL	R4	3
+      0x4C140000,  //  001B  LDNIL	R5
+      0x20140805,  //  001C  NE	R5	R4	R5
+      0x78160010,  //  001D  JMPF	R5	#002F
+      0xB8161600,  //  001E  GETNGBL	R5	K11
+      0x8C140B0C,  //  001F  GETMET	R5	R5	K12
+      0x5C1C0800,  //  0020  MOVE	R7	R4
+      0x58200009,  //  0021  LDCONST	R8	K9
+      0x542600FE,  //  0022  LDINT	R9	255
+      0x58280009,  //  0023  LDCONST	R10	K9
+      0x542E00FD,  //  0024  LDINT	R11	254
+      0x7C140C00,  //  0025  CALL	R5	6
+      0x5C100A00,  //  0026  MOVE	R4	R5
+      0x8814010D,  //  0027  GETMBR	R5	R0	K13
+      0x20140805,  //  0028  NE	R5	R4	R5
+      0x78160004,  //  0029  JMPF	R5	#002F
+      0x8C140108,  //  002A  GETMET	R5	R0	K8
+      0x541E0007,  //  002B  LDINT	R7	8
+      0x58200009,  //  002C  LDCONST	R8	K9
+      0x7C140600,  //  002D  CALL	R5	3
+      0x90021A04,  //  002E  SETMBR	R0	K13	R4
+      0x60040003,  //  002F  GETGBL	R1	G3
+      0x5C080000,  //  0030  MOVE	R2	R0
+      0x7C040200,  //  0031  CALL	R1	1
+      0x8C04030E,  //  0032  GETMET	R1	R1	K14
+      0x7C040200,  //  0033  CALL	R1	1
+      0x80000000,  //  0034  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin_Light1
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light0;
 be_local_class(Matter_Plugin_Light1,
     1,
     &be_class_Matter_Plugin_Light0,
-    be_nested_map(16,
+    be_nested_map(18,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(update_virtual, 1), be_const_closure(class_Matter_Plugin_Light1_update_virtual_closure) },
-        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light1_web_values_closure) },
-        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Light1_parse_status_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Light1_init_closure) },
-        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Light_X201_X20Dimmer) },
-        { be_const_key_weak(update_shadow, 6), be_const_closure(class_Matter_Plugin_Light1_update_shadow_closure) },
-        { be_const_key_weak(shadow_bri, 15), be_const_var(0) },
+        { be_const_key_weak(ARG_HINT, 16), be_nested_str_weak(_X28opt_X29_X20Light_X20number) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(light1) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(257, -1), be_const_int(2) },
+    }))    ) } )) },
         { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(2,
     ( (struct bvalue*) &(const bvalue[]) {
         be_nested_str_weak(Power),
         be_nested_str_weak(Bri),
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, 2), be_const_closure(class_Matter_Plugin_Light1_invoke_request_closure) },
-        { be_const_key_weak(TYPES, 12), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(257, -1), be_const_int(2) },
-    }))    ) } )) },
-        { be_const_key_weak(CLUSTERS, 9), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(web_value_dimmer, 13), be_const_closure(class_Matter_Plugin_Light1_web_value_dimmer_closure) },
+        { be_const_key_weak(set_bri, 17), be_const_closure(class_Matter_Plugin_Light1_set_bri_closure) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light1_read_attribute_closure) },
+        { be_const_key_weak(parse_configuration, 10), be_const_closure(class_Matter_Plugin_Light1_parse_configuration_closure) },
+        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light1_update_virtual_closure) },
+        { be_const_key_weak(DISPLAY_NAME, 0), be_nested_str_weak(Light_X201_X20Dimmer) },
+        { be_const_key_weak(update_shadow, 12), be_const_closure(class_Matter_Plugin_Light1_update_shadow_closure) },
+        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Light1_parse_status_closure) },
+        { be_const_key_weak(shadow_bri, -1), be_const_var(0) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(29, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -921,11 +970,10 @@ be_local_class(Matter_Plugin_Light1,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(set_bri, 8), be_const_closure(class_Matter_Plugin_Light1_set_bri_closure) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light1_read_attribute_closure) },
-        { be_const_key_weak(TYPE, 4), be_nested_str_weak(light1) },
-        { be_const_key_weak(web_value_dimmer, -1), be_const_closure(class_Matter_Plugin_Light1_web_value_dimmer_closure) },
-        { be_const_key_weak(parse_configuration, -1), be_const_closure(class_Matter_Plugin_Light1_parse_configuration_closure) },
+        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light1_web_values_closure) },
+        { be_const_key_weak(init, 11), be_const_closure(class_Matter_Plugin_Light1_init_closure) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak(light) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Light1_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Light1)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
@@ -7,12 +7,12 @@
 extern const bclass be_class_Matter_Plugin_Light2;
 
 /********************************************************************
-** Solidified function: set_ct
+** Solidified function: update_virtual
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
+be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -20,174 +20,33 @@ be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light2, 
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ct_min),
-    /* K1   */  be_nested_str_weak(ct_max),
-    /* K2   */  be_nested_str_weak(BRIDGE),
-    /* K3   */  be_nested_str_weak(call_remote_sync),
-    /* K4   */  be_nested_str_weak(CT),
-    /* K5   */  be_nested_str_weak(parse_status),
-    /* K6   */  be_nested_str_weak(VIRTUAL),
-    /* K7   */  be_nested_str_weak(shadow_ct),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_nested_str_weak(light),
-    /* K10  */  be_nested_str_weak(set),
-    /* K11  */  be_nested_str_weak(ct),
-    /* K12  */  be_nested_str_weak(update_shadow),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find),
+    /* K1   */  be_nested_str_weak(CT),
+    /* K2   */  be_nested_str_weak(set_ct),
+    /* K3   */  be_nested_str_weak(update_virtual),
     }),
-    be_str_weak(set_ct),
+    be_str_weak(update_virtual),
     &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x14080202,  //  0001  LT	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x24080202,  //  0005  GT	R2	R1	R2
-      0x780A0000,  //  0006  JMPF	R2	#0008
-      0x88040101,  //  0007  GETMBR	R1	R0	K1
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
-      0x780A000D,  //  0009  JMPF	R2	#0018
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100004,  //  000B  LDCONST	R4	K4
-      0x60140008,  //  000C  GETGBL	R5	G8
-      0x5C180200,  //  000D  MOVE	R6	R1
-      0x7C140200,  //  000E  CALL	R5	1
-      0x7C080600,  //  000F  CALL	R2	3
-      0x4C0C0000,  //  0010  LDNIL	R3
-      0x200C0403,  //  0011  NE	R3	R2	R3
-      0x780E0003,  //  0012  JMPF	R3	#0017
-      0x8C0C0105,  //  0013  GETMET	R3	R0	K5
-      0x5C140400,  //  0014  MOVE	R5	R2
-      0x541A000A,  //  0015  LDINT	R6	11
-      0x7C0C0600,  //  0016  CALL	R3	3
-      0x70020012,  //  0017  JMP		#002B
-      0x88080106,  //  0018  GETMBR	R2	R0	K6
-      0x780A0008,  //  0019  JMPF	R2	#0023
-      0x88080107,  //  001A  GETMBR	R2	R0	K7
-      0x20080202,  //  001B  NE	R2	R1	R2
-      0x780A0004,  //  001C  JMPF	R2	#0022
-      0x8C080108,  //  001D  GETMET	R2	R0	K8
-      0x541202FF,  //  001E  LDINT	R4	768
-      0x54160006,  //  001F  LDINT	R5	7
-      0x7C080600,  //  0020  CALL	R2	3
-      0x90020E01,  //  0021  SETMBR	R0	K7	R1
-      0x70020007,  //  0022  JMP		#002B
-      0xA40A1200,  //  0023  IMPORT	R2	K9
-      0x8C0C050A,  //  0024  GETMET	R3	R2	K10
-      0x60140013,  //  0025  GETGBL	R5	G19
-      0x7C140000,  //  0026  CALL	R5	0
-      0x98161601,  //  0027  SETIDX	R5	K11	R1
-      0x7C0C0400,  //  0028  CALL	R3	2
-      0x8C0C010C,  //  0029  GETMET	R3	R0	K12
-      0x7C0C0200,  //  002A  CALL	R3	1
-      0x80000000,  //  002B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(findsubval),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(ct_min),
-    /* K8   */  be_nested_str_weak(ct_max),
-    /* K9   */  be_nested_str_weak(set_ct),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(ct_X3A),
-    /* K12  */  be_nested_str_weak(publish_command),
-    /* K13  */  be_nested_str_weak(CT),
-    /* K14  */  be_nested_str_weak(invoke_request),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x541E02FF,  //  0004  LDINT	R7	768
-      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0030,  //  0006  JMPF	R7	#0038
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x541E0009,  //  0009  LDINT	R7	10
-      0x1C1C0C07,  //  000A  EQ	R7	R6	R7
-      0x781E0019,  //  000B  JMPF	R7	#0026
-      0x8C1C0505,  //  000C  GETMET	R7	R2	K5
-      0x58240006,  //  000D  LDCONST	R9	K6
-      0x7C1C0400,  //  000E  CALL	R7	2
-      0x88200107,  //  000F  GETMBR	R8	R0	K7
-      0x14200E08,  //  0010  LT	R8	R7	R8
-      0x78220000,  //  0011  JMPF	R8	#0013
-      0x881C0107,  //  0012  GETMBR	R7	R0	K7
-      0x88200108,  //  0013  GETMBR	R8	R0	K8
-      0x24200E08,  //  0014  GT	R8	R7	R8
-      0x78220000,  //  0015  JMPF	R8	#0017
-      0x881C0108,  //  0016  GETMBR	R7	R0	K8
-      0x8C200109,  //  0017  GETMET	R8	R0	K9
-      0x5C280E00,  //  0018  MOVE	R10	R7
-      0x7C200400,  //  0019  CALL	R8	2
-      0x60200008,  //  001A  GETGBL	R8	G8
-      0x5C240E00,  //  001B  MOVE	R9	R7
-      0x7C200200,  //  001C  CALL	R8	1
-      0x00221608,  //  001D  ADD	R8	K11	R8
-      0x900E1408,  //  001E  SETMBR	R3	K10	R8
-      0x8C20010C,  //  001F  GETMET	R8	R0	K12
-      0x5828000D,  //  0020  LDCONST	R10	K13
-      0x5C2C0E00,  //  0021  MOVE	R11	R7
-      0x7C200600,  //  0022  CALL	R8	3
-      0x50200200,  //  0023  LDBOOL	R8	1	0
-      0x80041000,  //  0024  RET	1	R8
-      0x70020010,  //  0025  JMP		#0037
-      0x541E0046,  //  0026  LDINT	R7	71
-      0x1C1C0C07,  //  0027  EQ	R7	R6	R7
-      0x781E0002,  //  0028  JMPF	R7	#002C
-      0x501C0200,  //  0029  LDBOOL	R7	1	0
-      0x80040E00,  //  002A  RET	1	R7
-      0x7002000A,  //  002B  JMP		#0037
-      0x541E004A,  //  002C  LDINT	R7	75
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0002,  //  002E  JMPF	R7	#0032
-      0x501C0200,  //  002F  LDBOOL	R7	1	0
-      0x80040E00,  //  0030  RET	1	R7
-      0x70020004,  //  0031  JMP		#0037
-      0x541E004B,  //  0032  LDINT	R7	76
-      0x1C1C0C07,  //  0033  EQ	R7	R6	R7
-      0x781E0001,  //  0034  JMPF	R7	#0037
-      0x501C0200,  //  0035  LDBOOL	R7	1	0
-      0x80040E00,  //  0036  RET	1	R7
-      0x70020008,  //  0037  JMP		#0041
-      0x601C0003,  //  0038  GETGBL	R7	G3
-      0x5C200000,  //  0039  MOVE	R8	R0
-      0x7C1C0200,  //  003A  CALL	R7	1
-      0x8C1C0F0E,  //  003B  GETMET	R7	R7	K14
-      0x5C240200,  //  003C  MOVE	R9	R1
-      0x5C280400,  //  003D  MOVE	R10	R2
-      0x5C2C0600,  //  003E  MOVE	R11	R3
-      0x7C1C0800,  //  003F  CALL	R7	4
-      0x80040E00,  //  0040  RET	1	R7
-      0x80000000,  //  0041  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x8C0C0300,  //  0001  GETMET	R3	R1	K0
+      0x58140001,  //  0002  LDCONST	R5	K1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x7C080200,  //  0004  CALL	R2	1
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x200C0403,  //  0006  NE	R3	R2	R3
+      0x780E0002,  //  0007  JMPF	R3	#000B
+      0x8C0C0102,  //  0008  GETMET	R3	R0	K2
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x600C0003,  //  000B  GETGBL	R3	G3
+      0x5C100000,  //  000C  MOVE	R4	R0
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -306,12 +165,89 @@ be_local_closure(class_Matter_Plugin_Light2_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_virtual
+** Solidified function: update_shadow
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
+be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light2, 
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(VIRTUAL),
+    /* K1   */  be_nested_str_weak(BRIDGE),
+    /* K2   */  be_nested_str_weak(light),
+    /* K3   */  be_nested_str_weak(update_ct_minmax),
+    /* K4   */  be_nested_str_weak(update_shadow),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(light_index),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(ct),
+    /* K9   */  be_nested_str_weak(shadow_ct),
+    /* K10  */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x74060020,  //  0001  JMPT	R1	#0023
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x7406001E,  //  0003  JMPT	R1	#0023
+      0xA4060400,  //  0004  IMPORT	R1	K2
+      0x8C080103,  //  0005  GETMET	R2	R0	K3
+      0x7C080200,  //  0006  CALL	R2	1
+      0x60080003,  //  0007  GETGBL	R2	G3
+      0x5C0C0000,  //  0008  MOVE	R3	R0
+      0x7C080200,  //  0009  CALL	R2	1
+      0x8C080504,  //  000A  GETMET	R2	R2	K4
+      0x7C080200,  //  000B  CALL	R2	1
+      0x8C080305,  //  000C  GETMET	R2	R1	K5
+      0x88100106,  //  000D  GETMBR	R4	R0	K6
+      0x7C080400,  //  000E  CALL	R2	2
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x200C0403,  //  0010  NE	R3	R2	R3
+      0x780E000F,  //  0011  JMPF	R3	#0022
+      0x8C0C0507,  //  0012  GETMET	R3	R2	K7
+      0x58140008,  //  0013  LDCONST	R5	K8
+      0x4C180000,  //  0014  LDNIL	R6
+      0x7C0C0600,  //  0015  CALL	R3	3
+      0x4C100000,  //  0016  LDNIL	R4
+      0x1C100604,  //  0017  EQ	R4	R3	R4
+      0x78120000,  //  0018  JMPF	R4	#001A
+      0x880C0109,  //  0019  GETMBR	R3	R0	K9
+      0x88100109,  //  001A  GETMBR	R4	R0	K9
+      0x20100604,  //  001B  NE	R4	R3	R4
+      0x78120004,  //  001C  JMPF	R4	#0022
+      0x8C10010A,  //  001D  GETMET	R4	R0	K10
+      0x541A02FF,  //  001E  LDINT	R6	768
+      0x541E0006,  //  001F  LDINT	R7	7
+      0x7C100600,  //  0020  CALL	R4	3
+      0x90021203,  //  0021  SETMBR	R0	K9	R3
+      0x70020004,  //  0022  JMP		#0028
+      0x60040003,  //  0023  GETGBL	R1	G3
+      0x5C080000,  //  0024  MOVE	R2	R0
+      0x7C040200,  //  0025  CALL	R1	1
+      0x8C040304,  //  0026  GETMET	R1	R1	K4
+      0x7C040200,  //  0027  CALL	R1	1
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ct
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light2;
+be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -319,170 +255,70 @@ be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light2, 
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(CT),
-    /* K2   */  be_nested_str_weak(set_ct),
-    /* K3   */  be_nested_str_weak(update_virtual),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ct_min),
+    /* K1   */  be_nested_str_weak(ct_max),
+    /* K2   */  be_nested_str_weak(BRIDGE),
+    /* K3   */  be_nested_str_weak(call_remote_sync),
+    /* K4   */  be_nested_str_weak(CT),
+    /* K5   */  be_nested_str_weak(parse_status),
+    /* K6   */  be_nested_str_weak(VIRTUAL),
+    /* K7   */  be_nested_str_weak(shadow_ct),
+    /* K8   */  be_nested_str_weak(attribute_updated),
+    /* K9   */  be_nested_str_weak(light),
+    /* K10  */  be_nested_str_weak(set),
+    /* K11  */  be_nested_str_weak(ct),
+    /* K12  */  be_nested_str_weak(light_index),
+    /* K13  */  be_nested_str_weak(update_shadow),
     }),
-    be_str_weak(update_virtual),
+    be_str_weak(set_ct),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0300,  //  0001  GETMET	R3	R1	K0
-      0x58140001,  //  0002  LDCONST	R5	K1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x7C080200,  //  0004  CALL	R2	1
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x200C0403,  //  0006  NE	R3	R2	R3
-      0x780E0002,  //  0007  JMPF	R3	#000B
-      0x8C0C0102,  //  0008  GETMET	R3	R0	K2
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x600C0003,  //  000B  GETGBL	R3	G3
-      0x5C100000,  //  000C  MOVE	R4	R0
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_ct_minmax
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_update_ct_minmax,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(get_option),
-    /* K2   */  be_nested_str_weak(ct_min),
-    /* K3   */  be_nested_str_weak(ct_max),
-    }),
-    be_str_weak(update_ct_minmax),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x540E0051,  //  0002  LDINT	R3	82
-      0x7C040400,  //  0003  CALL	R1	2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x540A00C7,  //  0005  LDINT	R2	200
-      0x70020000,  //  0006  JMP		#0008
-      0x540A0098,  //  0007  LDINT	R2	153
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0x78060001,  //  0009  JMPF	R1	#000C
-      0x540A017B,  //  000A  LDINT	R2	380
-      0x70020000,  //  000B  JMP		#000D
-      0x540A01F3,  //  000C  LDINT	R2	500
-      0x90020602,  //  000D  SETMBR	R0	K3	R2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(shadow_ct),
-    /* K3   */  be_nested_str_weak(update_ct_minmax),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x5C200600,  //  0006  MOVE	R8	R3
-      0x7C100800,  //  0007  CALL	R4	4
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
-      0x74120001,  //  0009  JMPT	R4	#000C
-      0x54120144,  //  000A  LDINT	R4	325
-      0x90020404,  //  000B  SETMBR	R0	K2	R4
-      0x8C100103,  //  000C  GETMET	R4	R0	K3
-      0x7C100200,  //  000D  CALL	R4	1
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_values
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    /* K6   */  be_nested_str_weak(web_value_dimmer),
-    /* K7   */  be_nested_str_weak(web_value_ct),
-    }),
-    be_str_weak(web_values),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
-      0x7C180400,  //  0008  CALL	R6	2
-      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C200107,  //  000B  GETMET	R8	R0	K7
-      0x7C200200,  //  000C  CALL	R8	1
-      0x7C100800,  //  000D  CALL	R4	4
-      0x7C080400,  //  000E  CALL	R2	2
-      0x80000000,  //  000F  RET	0
+    ( &(const binstruction[45]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x14080202,  //  0001  LT	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x24080202,  //  0005  GT	R2	R1	R2
+      0x780A0000,  //  0006  JMPF	R2	#0008
+      0x88040101,  //  0007  GETMBR	R1	R0	K1
+      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x780A000D,  //  0009  JMPF	R2	#0018
+      0x8C080103,  //  000A  GETMET	R2	R0	K3
+      0x58100004,  //  000B  LDCONST	R4	K4
+      0x60140008,  //  000C  GETGBL	R5	G8
+      0x5C180200,  //  000D  MOVE	R6	R1
+      0x7C140200,  //  000E  CALL	R5	1
+      0x7C080600,  //  000F  CALL	R2	3
+      0x4C0C0000,  //  0010  LDNIL	R3
+      0x200C0403,  //  0011  NE	R3	R2	R3
+      0x780E0003,  //  0012  JMPF	R3	#0017
+      0x8C0C0105,  //  0013  GETMET	R3	R0	K5
+      0x5C140400,  //  0014  MOVE	R5	R2
+      0x541A000A,  //  0015  LDINT	R6	11
+      0x7C0C0600,  //  0016  CALL	R3	3
+      0x70020013,  //  0017  JMP		#002C
+      0x88080106,  //  0018  GETMBR	R2	R0	K6
+      0x780A0008,  //  0019  JMPF	R2	#0023
+      0x88080107,  //  001A  GETMBR	R2	R0	K7
+      0x20080202,  //  001B  NE	R2	R1	R2
+      0x780A0004,  //  001C  JMPF	R2	#0022
+      0x8C080108,  //  001D  GETMET	R2	R0	K8
+      0x541202FF,  //  001E  LDINT	R4	768
+      0x54160006,  //  001F  LDINT	R5	7
+      0x7C080600,  //  0020  CALL	R2	3
+      0x90020E01,  //  0021  SETMBR	R0	K7	R1
+      0x70020008,  //  0022  JMP		#002C
+      0xA40A1200,  //  0023  IMPORT	R2	K9
+      0x8C0C050A,  //  0024  GETMET	R3	R2	K10
+      0x60140013,  //  0025  GETGBL	R5	G19
+      0x7C140000,  //  0026  CALL	R5	0
+      0x98161601,  //  0027  SETIDX	R5	K11	R1
+      0x8818010C,  //  0028  GETMBR	R6	R0	K12
+      0x7C0C0600,  //  0029  CALL	R3	3
+      0x8C0C010D,  //  002A  GETMET	R3	R0	K13
+      0x7C0C0200,  //  002B  CALL	R3	1
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -607,12 +443,12 @@ be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_shadow
+** Solidified function: web_values
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light2;
-be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
+be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -620,61 +456,241 @@ be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light2, 
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(update_ct_minmax),
-    /* K4   */  be_nested_str_weak(update_shadow),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(ct),
-    /* K8   */  be_nested_str_weak(shadow_ct),
-    /* K9   */  be_nested_str_weak(attribute_updated),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    /* K6   */  be_nested_str_weak(web_value_dimmer),
+    /* K7   */  be_nested_str_weak(web_value_ct),
     }),
-    be_str_weak(update_shadow),
+    be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x7406001F,  //  0001  JMPT	R1	#0022
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x7406001D,  //  0003  JMPT	R1	#0022
-      0xA4060400,  //  0004  IMPORT	R1	K2
-      0x8C080103,  //  0005  GETMET	R2	R0	K3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x60080003,  //  0007  GETGBL	R2	G3
-      0x5C0C0000,  //  0008  MOVE	R3	R0
-      0x7C080200,  //  0009  CALL	R2	1
-      0x8C080504,  //  000A  GETMET	R2	R2	K4
-      0x7C080200,  //  000B  CALL	R2	1
-      0x8C080305,  //  000C  GETMET	R2	R1	K5
-      0x7C080200,  //  000D  CALL	R2	1
-      0x4C0C0000,  //  000E  LDNIL	R3
-      0x200C0403,  //  000F  NE	R3	R2	R3
-      0x780E000F,  //  0010  JMPF	R3	#0021
-      0x8C0C0506,  //  0011  GETMET	R3	R2	K6
-      0x58140007,  //  0012  LDCONST	R5	K7
-      0x4C180000,  //  0013  LDNIL	R6
-      0x7C0C0600,  //  0014  CALL	R3	3
-      0x4C100000,  //  0015  LDNIL	R4
-      0x1C100604,  //  0016  EQ	R4	R3	R4
-      0x78120000,  //  0017  JMPF	R4	#0019
-      0x880C0108,  //  0018  GETMBR	R3	R0	K8
-      0x88100108,  //  0019  GETMBR	R4	R0	K8
-      0x20100604,  //  001A  NE	R4	R3	R4
-      0x78120004,  //  001B  JMPF	R4	#0021
-      0x8C100109,  //  001C  GETMET	R4	R0	K9
-      0x541A02FF,  //  001D  LDINT	R6	768
-      0x541E0006,  //  001E  LDINT	R7	7
-      0x7C100600,  //  001F  CALL	R4	3
-      0x90021003,  //  0020  SETMBR	R0	K8	R3
-      0x70020004,  //  0021  JMP		#0027
-      0x60040003,  //  0022  GETGBL	R1	G3
-      0x5C080000,  //  0023  MOVE	R2	R0
-      0x7C040200,  //  0024  CALL	R1	1
-      0x8C040304,  //  0025  GETMET	R1	R1	K4
-      0x7C040200,  //  0026  CALL	R1	1
-      0x80000000,  //  0027  RET	0
+    ( &(const binstruction[16]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C200107,  //  000B  GETMET	R8	R0	K7
+      0x7C200200,  //  000C  CALL	R8	1
+      0x7C100800,  //  000D  CALL	R4	4
+      0x7C080400,  //  000E  CALL	R2	2
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light2;
+be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light2, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(BRIDGE),
+    /* K2   */  be_nested_str_weak(shadow_ct),
+    /* K3   */  be_nested_str_weak(light),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(light_index),
+    /* K7   */  be_nested_str_weak(update_ct_minmax),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x74120009,  //  0009  JMPT	R4	#0014
+      0x54120144,  //  000A  LDINT	R4	325
+      0x90020404,  //  000B  SETMBR	R0	K2	R4
+      0xA4120600,  //  000C  IMPORT	R4	K3
+      0x8C140904,  //  000D  GETMET	R5	R4	K4
+      0x581C0005,  //  000E  LDCONST	R7	K5
+      0x7C140400,  //  000F  CALL	R5	2
+      0x4C180000,  //  0010  LDNIL	R6
+      0x20140A06,  //  0011  NE	R5	R5	R6
+      0x78160000,  //  0012  JMPF	R5	#0014
+      0x90020D05,  //  0013  SETMBR	R0	K6	K5
+      0x8C100107,  //  0014  GETMET	R4	R0	K7
+      0x7C100200,  //  0015  CALL	R4	1
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light2;
+be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light2, 
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(command),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_nested_str_weak(findsubval),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(ct_min),
+    /* K8   */  be_nested_str_weak(ct_max),
+    /* K9   */  be_nested_str_weak(set_ct),
+    /* K10  */  be_nested_str_weak(log),
+    /* K11  */  be_nested_str_weak(ct_X3A),
+    /* K12  */  be_nested_str_weak(publish_command),
+    /* K13  */  be_nested_str_weak(CT),
+    /* K14  */  be_nested_str_weak(invoke_request),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[66]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140702,  //  0002  GETMBR	R5	R3	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x541E02FF,  //  0004  LDINT	R7	768
+      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
+      0x781E0030,  //  0006  JMPF	R7	#0038
+      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x541E0009,  //  0009  LDINT	R7	10
+      0x1C1C0C07,  //  000A  EQ	R7	R6	R7
+      0x781E0019,  //  000B  JMPF	R7	#0026
+      0x8C1C0505,  //  000C  GETMET	R7	R2	K5
+      0x58240006,  //  000D  LDCONST	R9	K6
+      0x7C1C0400,  //  000E  CALL	R7	2
+      0x88200107,  //  000F  GETMBR	R8	R0	K7
+      0x14200E08,  //  0010  LT	R8	R7	R8
+      0x78220000,  //  0011  JMPF	R8	#0013
+      0x881C0107,  //  0012  GETMBR	R7	R0	K7
+      0x88200108,  //  0013  GETMBR	R8	R0	K8
+      0x24200E08,  //  0014  GT	R8	R7	R8
+      0x78220000,  //  0015  JMPF	R8	#0017
+      0x881C0108,  //  0016  GETMBR	R7	R0	K8
+      0x8C200109,  //  0017  GETMET	R8	R0	K9
+      0x5C280E00,  //  0018  MOVE	R10	R7
+      0x7C200400,  //  0019  CALL	R8	2
+      0x60200008,  //  001A  GETGBL	R8	G8
+      0x5C240E00,  //  001B  MOVE	R9	R7
+      0x7C200200,  //  001C  CALL	R8	1
+      0x00221608,  //  001D  ADD	R8	K11	R8
+      0x900E1408,  //  001E  SETMBR	R3	K10	R8
+      0x8C20010C,  //  001F  GETMET	R8	R0	K12
+      0x5828000D,  //  0020  LDCONST	R10	K13
+      0x5C2C0E00,  //  0021  MOVE	R11	R7
+      0x7C200600,  //  0022  CALL	R8	3
+      0x50200200,  //  0023  LDBOOL	R8	1	0
+      0x80041000,  //  0024  RET	1	R8
+      0x70020010,  //  0025  JMP		#0037
+      0x541E0046,  //  0026  LDINT	R7	71
+      0x1C1C0C07,  //  0027  EQ	R7	R6	R7
+      0x781E0002,  //  0028  JMPF	R7	#002C
+      0x501C0200,  //  0029  LDBOOL	R7	1	0
+      0x80040E00,  //  002A  RET	1	R7
+      0x7002000A,  //  002B  JMP		#0037
+      0x541E004A,  //  002C  LDINT	R7	75
+      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
+      0x781E0002,  //  002E  JMPF	R7	#0032
+      0x501C0200,  //  002F  LDBOOL	R7	1	0
+      0x80040E00,  //  0030  RET	1	R7
+      0x70020004,  //  0031  JMP		#0037
+      0x541E004B,  //  0032  LDINT	R7	76
+      0x1C1C0C07,  //  0033  EQ	R7	R6	R7
+      0x781E0001,  //  0034  JMPF	R7	#0037
+      0x501C0200,  //  0035  LDBOOL	R7	1	0
+      0x80040E00,  //  0036  RET	1	R7
+      0x70020008,  //  0037  JMP		#0041
+      0x601C0003,  //  0038  GETGBL	R7	G3
+      0x5C200000,  //  0039  MOVE	R8	R0
+      0x7C1C0200,  //  003A  CALL	R7	1
+      0x8C1C0F0E,  //  003B  GETMET	R7	R7	K14
+      0x5C240200,  //  003C  MOVE	R9	R1
+      0x5C280400,  //  003D  MOVE	R10	R2
+      0x5C2C0600,  //  003E  MOVE	R11	R3
+      0x7C1C0800,  //  003F  CALL	R7	4
+      0x80040E00,  //  0040  RET	1	R7
+      0x80000000,  //  0041  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_ct_minmax
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light2;
+be_local_closure(class_Matter_Plugin_Light2_update_ct_minmax,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light2, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(get_option),
+    /* K2   */  be_nested_str_weak(ct_min),
+    /* K3   */  be_nested_str_weak(ct_max),
+    }),
+    be_str_weak(update_ct_minmax),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x540E0051,  //  0002  LDINT	R3	82
+      0x7C040400,  //  0003  CALL	R1	2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x540A00C7,  //  0005  LDINT	R2	200
+      0x70020000,  //  0006  JMP		#0008
+      0x540A0098,  //  0007  LDINT	R2	153
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x78060001,  //  0009  JMPF	R1	#000C
+      0x540A017B,  //  000A  LDINT	R2	380
+      0x70020000,  //  000B  JMP		#000D
+      0x540A01F3,  //  000C  LDINT	R2	500
+      0x90020602,  //  000D  SETMBR	R0	K3	R2
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -688,22 +704,26 @@ extern const bclass be_class_Matter_Plugin_Light1;
 be_local_class(Matter_Plugin_Light2,
     3,
     &be_class_Matter_Plugin_Light1,
-    be_nested_map(18,
+    be_nested_map(20,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Light2_update_shadow_closure) },
-        { be_const_key_weak(set_ct, 13), be_const_closure(class_Matter_Plugin_Light2_set_ct_closure) },
+        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light2_update_virtual_closure) },
+        { be_const_key_weak(DISPLAY_NAME, 6), be_nested_str_weak(Light_X202_X20CT) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light2_read_attribute_closure) },
+        { be_const_key_weak(ct_max, 18), be_const_var(2) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
+        { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(_Not_X20used_) },
+        { be_const_key_weak(shadow_ct, -1), be_const_var(0) },
+        { be_const_key_weak(set_ct, 16), be_const_closure(class_Matter_Plugin_Light2_set_ct_closure) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(light2) },
+        { be_const_key_weak(update_shadow, 8), be_const_closure(class_Matter_Plugin_Light2_update_shadow_closure) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(268, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(UPDATE_COMMANDS, 17), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_nested_str_weak(Power),
-        be_nested_str_weak(Bri),
-        be_nested_str_weak(CT),
-    }))    ) } )) },
+        { be_const_key_weak(web_value_ct, -1), be_const_closure(class_Matter_Plugin_Light2_web_value_ct_closure) },
+        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light2_web_values_closure) },
+        { be_const_key_weak(ct_min, -1), be_const_var(1) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -818,19 +838,17 @@ be_local_class(Matter_Plugin_Light2,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Light2_init_closure) },
         { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Light2_invoke_request_closure) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light2_read_attribute_closure) },
-        { be_const_key_weak(shadow_ct, 0), be_const_var(0) },
-        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light2_update_virtual_closure) },
-        { be_const_key_weak(DISPLAY_NAME, 16), be_nested_str_weak(Light_X202_X20CT) },
-        { be_const_key_weak(web_value_ct, 11), be_const_closure(class_Matter_Plugin_Light2_web_value_ct_closure) },
-        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Light2_parse_status_closure) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak(light2) },
-        { be_const_key_weak(ct_min, 12), be_const_var(1) },
-        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light2_web_values_closure) },
-        { be_const_key_weak(init, 10), be_const_closure(class_Matter_Plugin_Light2_init_closure) },
         { be_const_key_weak(update_ct_minmax, -1), be_const_closure(class_Matter_Plugin_Light2_update_ct_minmax_closure) },
-        { be_const_key_weak(ct_max, -1), be_const_var(2) },
+        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Light2_parse_status_closure) },
+        { be_const_key_weak(UPDATE_COMMANDS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_nested_str_weak(Power),
+        be_nested_str_weak(Bri),
+        be_nested_str_weak(CT),
+    }))    ) } )) },
     })),
     be_str_weak(Matter_Plugin_Light2)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
@@ -7,69 +7,12 @@
 extern const bclass be_class_Matter_Plugin_Light3;
 
 /********************************************************************
-** Solidified function: update_virtual
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Hue),
-    /* K2   */  be_nested_str_weak(Sat),
-    /* K3   */  be_nested_str_weak(set_hue_sat),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
-    be_str_weak(update_virtual),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0300,  //  0001  GETMET	R3	R1	K0
-      0x58140001,  //  0002  LDCONST	R5	K1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x7C080200,  //  0004  CALL	R2	1
-      0x600C0009,  //  0005  GETGBL	R3	G9
-      0x8C100300,  //  0006  GETMET	R4	R1	K0
-      0x58180002,  //  0007  LDCONST	R6	K2
-      0x7C100400,  //  0008  CALL	R4	2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x4C100000,  //  000A  LDNIL	R4
-      0x20100404,  //  000B  NE	R4	R2	R4
-      0x74120002,  //  000C  JMPT	R4	#0010
-      0x4C100000,  //  000D  LDNIL	R4
-      0x20100604,  //  000E  NE	R4	R3	R4
-      0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C100103,  //  0010  GETMET	R4	R0	K3
-      0x5C180400,  //  0011  MOVE	R6	R2
-      0x5C1C0600,  //  0012  MOVE	R7	R3
-      0x7C100600,  //  0013  CALL	R4	3
-      0x60100003,  //  0014  GETGBL	R4	G3
-      0x5C140000,  //  0015  MOVE	R5	R0
-      0x7C100200,  //  0016  CALL	R4	1
-      0x8C100904,  //  0017  GETMET	R4	R4	K4
-      0x5C180200,  //  0018  MOVE	R6	R1
-      0x7C100400,  //  0019  CALL	R4	2
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    15,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -77,694 +20,151 @@ be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Light3, 
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_nested_str_weak(set_hue_sat),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(hue_X3A),
-    /* K11  */  be_nested_str_weak(publish_command),
-    /* K12  */  be_nested_str_weak(Hue),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(sat_X3A),
-    /* K17  */  be_nested_str_weak(Sat),
-    /* K18  */  be_nested_str_weak(_X20sat_X3A),
-    /* K19  */  be_nested_str_weak(invoke_request),
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(command),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(findsubval),
+    /* K7   */  be_nested_str_weak(set_hue_sat),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(hue_X3A),
+    /* K10  */  be_nested_str_weak(publish_command),
+    /* K11  */  be_nested_str_weak(Hue),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(sat_X3A),
+    /* K16  */  be_nested_str_weak(Sat),
+    /* K17  */  be_nested_str_weak(_X20sat_X3A),
+    /* K18  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+    ( &(const binstruction[121]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
-      0x542202FF,  //  0005  LDINT	R8	768
-      0x1C200C08,  //  0006  EQ	R8	R6	R8
-      0x78220067,  //  0007  JMPF	R8	#0070
-      0x8C200105,  //  0008  GETMET	R8	R0	K5
-      0x7C200200,  //  0009  CALL	R8	1
-      0x1C200F06,  //  000A  EQ	R8	R7	K6
-      0x78220012,  //  000B  JMPF	R8	#001F
-      0x8C200507,  //  000C  GETMET	R8	R2	K7
-      0x58280006,  //  000D  LDCONST	R10	K6
-      0x7C200400,  //  000E  CALL	R8	2
-      0x8C240108,  //  000F  GETMET	R9	R0	K8
-      0x5C2C1000,  //  0010  MOVE	R11	R8
-      0x4C300000,  //  0011  LDNIL	R12
-      0x7C240600,  //  0012  CALL	R9	3
-      0x60240008,  //  0013  GETGBL	R9	G8
-      0x5C281000,  //  0014  MOVE	R10	R8
-      0x7C240200,  //  0015  CALL	R9	1
-      0x00261409,  //  0016  ADD	R9	K10	R9
-      0x900E1209,  //  0017  SETMBR	R3	K9	R9
-      0x8C24010B,  //  0018  GETMET	R9	R0	K11
-      0x582C000C,  //  0019  LDCONST	R11	K12
-      0x5C301000,  //  001A  MOVE	R12	R8
-      0x7C240600,  //  001B  CALL	R9	3
-      0x50240200,  //  001C  LDBOOL	R9	1	0
-      0x80041200,  //  001D  RET	1	R9
-      0x7002004F,  //  001E  JMP		#006F
-      0x1C200F0D,  //  001F  EQ	R8	R7	K13
-      0x78220002,  //  0020  JMPF	R8	#0024
-      0x50200200,  //  0021  LDBOOL	R8	1	0
-      0x80041000,  //  0022  RET	1	R8
-      0x7002004A,  //  0023  JMP		#006F
-      0x1C200F0E,  //  0024  EQ	R8	R7	K14
-      0x78220002,  //  0025  JMPF	R8	#0029
-      0x50200200,  //  0026  LDBOOL	R8	1	0
-      0x80041000,  //  0027  RET	1	R8
-      0x70020045,  //  0028  JMP		#006F
-      0x1C200F0F,  //  0029  EQ	R8	R7	K15
-      0x78220012,  //  002A  JMPF	R8	#003E
-      0x8C200507,  //  002B  GETMET	R8	R2	K7
-      0x58280006,  //  002C  LDCONST	R10	K6
-      0x7C200400,  //  002D  CALL	R8	2
-      0x8C240108,  //  002E  GETMET	R9	R0	K8
-      0x4C2C0000,  //  002F  LDNIL	R11
-      0x5C301000,  //  0030  MOVE	R12	R8
-      0x7C240600,  //  0031  CALL	R9	3
-      0x60240008,  //  0032  GETGBL	R9	G8
-      0x5C281000,  //  0033  MOVE	R10	R8
-      0x7C240200,  //  0034  CALL	R9	1
-      0x00262009,  //  0035  ADD	R9	K16	R9
-      0x900E1209,  //  0036  SETMBR	R3	K9	R9
-      0x8C24010B,  //  0037  GETMET	R9	R0	K11
-      0x582C0011,  //  0038  LDCONST	R11	K17
-      0x5C301000,  //  0039  MOVE	R12	R8
-      0x7C240600,  //  003A  CALL	R9	3
-      0x50240200,  //  003B  LDBOOL	R9	1	0
-      0x80041200,  //  003C  RET	1	R9
-      0x70020030,  //  003D  JMP		#006F
-      0x54220003,  //  003E  LDINT	R8	4
-      0x1C200E08,  //  003F  EQ	R8	R7	R8
-      0x78220002,  //  0040  JMPF	R8	#0044
-      0x50200200,  //  0041  LDBOOL	R8	1	0
-      0x80041000,  //  0042  RET	1	R8
-      0x7002002A,  //  0043  JMP		#006F
-      0x54220004,  //  0044  LDINT	R8	5
-      0x1C200E08,  //  0045  EQ	R8	R7	R8
-      0x78220002,  //  0046  JMPF	R8	#004A
-      0x50200200,  //  0047  LDBOOL	R8	1	0
-      0x80041000,  //  0048  RET	1	R8
-      0x70020024,  //  0049  JMP		#006F
-      0x54220005,  //  004A  LDINT	R8	6
-      0x1C200E08,  //  004B  EQ	R8	R7	R8
-      0x7822001C,  //  004C  JMPF	R8	#006A
-      0x8C200507,  //  004D  GETMET	R8	R2	K7
-      0x58280006,  //  004E  LDCONST	R10	K6
-      0x7C200400,  //  004F  CALL	R8	2
-      0x8C240507,  //  0050  GETMET	R9	R2	K7
-      0x582C000D,  //  0051  LDCONST	R11	K13
-      0x7C240400,  //  0052  CALL	R9	2
-      0x8C280108,  //  0053  GETMET	R10	R0	K8
+      0x541E02FF,  //  0004  LDINT	R7	768
+      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
+      0x781E0067,  //  0006  JMPF	R7	#006F
+      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x781E0012,  //  000A  JMPF	R7	#001E
+      0x8C1C0506,  //  000B  GETMET	R7	R2	K6
+      0x58240005,  //  000C  LDCONST	R9	K5
+      0x7C1C0400,  //  000D  CALL	R7	2
+      0x8C200107,  //  000E  GETMET	R8	R0	K7
+      0x5C280E00,  //  000F  MOVE	R10	R7
+      0x4C2C0000,  //  0010  LDNIL	R11
+      0x7C200600,  //  0011  CALL	R8	3
+      0x60200008,  //  0012  GETGBL	R8	G8
+      0x5C240E00,  //  0013  MOVE	R9	R7
+      0x7C200200,  //  0014  CALL	R8	1
+      0x00221208,  //  0015  ADD	R8	K9	R8
+      0x900E1008,  //  0016  SETMBR	R3	K8	R8
+      0x8C20010A,  //  0017  GETMET	R8	R0	K10
+      0x5828000B,  //  0018  LDCONST	R10	K11
+      0x5C2C0E00,  //  0019  MOVE	R11	R7
+      0x7C200600,  //  001A  CALL	R8	3
+      0x50200200,  //  001B  LDBOOL	R8	1	0
+      0x80041000,  //  001C  RET	1	R8
+      0x7002004F,  //  001D  JMP		#006E
+      0x1C1C0D0C,  //  001E  EQ	R7	R6	K12
+      0x781E0002,  //  001F  JMPF	R7	#0023
+      0x501C0200,  //  0020  LDBOOL	R7	1	0
+      0x80040E00,  //  0021  RET	1	R7
+      0x7002004A,  //  0022  JMP		#006E
+      0x1C1C0D0D,  //  0023  EQ	R7	R6	K13
+      0x781E0002,  //  0024  JMPF	R7	#0028
+      0x501C0200,  //  0025  LDBOOL	R7	1	0
+      0x80040E00,  //  0026  RET	1	R7
+      0x70020045,  //  0027  JMP		#006E
+      0x1C1C0D0E,  //  0028  EQ	R7	R6	K14
+      0x781E0012,  //  0029  JMPF	R7	#003D
+      0x8C1C0506,  //  002A  GETMET	R7	R2	K6
+      0x58240005,  //  002B  LDCONST	R9	K5
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x8C200107,  //  002D  GETMET	R8	R0	K7
+      0x4C280000,  //  002E  LDNIL	R10
+      0x5C2C0E00,  //  002F  MOVE	R11	R7
+      0x7C200600,  //  0030  CALL	R8	3
+      0x60200008,  //  0031  GETGBL	R8	G8
+      0x5C240E00,  //  0032  MOVE	R9	R7
+      0x7C200200,  //  0033  CALL	R8	1
+      0x00221E08,  //  0034  ADD	R8	K15	R8
+      0x900E1008,  //  0035  SETMBR	R3	K8	R8
+      0x8C20010A,  //  0036  GETMET	R8	R0	K10
+      0x58280010,  //  0037  LDCONST	R10	K16
+      0x5C2C0E00,  //  0038  MOVE	R11	R7
+      0x7C200600,  //  0039  CALL	R8	3
+      0x50200200,  //  003A  LDBOOL	R8	1	0
+      0x80041000,  //  003B  RET	1	R8
+      0x70020030,  //  003C  JMP		#006E
+      0x541E0003,  //  003D  LDINT	R7	4
+      0x1C1C0C07,  //  003E  EQ	R7	R6	R7
+      0x781E0002,  //  003F  JMPF	R7	#0043
+      0x501C0200,  //  0040  LDBOOL	R7	1	0
+      0x80040E00,  //  0041  RET	1	R7
+      0x7002002A,  //  0042  JMP		#006E
+      0x541E0004,  //  0043  LDINT	R7	5
+      0x1C1C0C07,  //  0044  EQ	R7	R6	R7
+      0x781E0002,  //  0045  JMPF	R7	#0049
+      0x501C0200,  //  0046  LDBOOL	R7	1	0
+      0x80040E00,  //  0047  RET	1	R7
+      0x70020024,  //  0048  JMP		#006E
+      0x541E0005,  //  0049  LDINT	R7	6
+      0x1C1C0C07,  //  004A  EQ	R7	R6	R7
+      0x781E001C,  //  004B  JMPF	R7	#0069
+      0x8C1C0506,  //  004C  GETMET	R7	R2	K6
+      0x58240005,  //  004D  LDCONST	R9	K5
+      0x7C1C0400,  //  004E  CALL	R7	2
+      0x8C200506,  //  004F  GETMET	R8	R2	K6
+      0x5828000C,  //  0050  LDCONST	R10	K12
+      0x7C200400,  //  0051  CALL	R8	2
+      0x8C240107,  //  0052  GETMET	R9	R0	K7
+      0x5C2C0E00,  //  0053  MOVE	R11	R7
       0x5C301000,  //  0054  MOVE	R12	R8
-      0x5C341200,  //  0055  MOVE	R13	R9
-      0x7C280600,  //  0056  CALL	R10	3
-      0x60280008,  //  0057  GETGBL	R10	G8
-      0x5C2C1000,  //  0058  MOVE	R11	R8
-      0x7C280200,  //  0059  CALL	R10	1
-      0x002A140A,  //  005A  ADD	R10	K10	R10
-      0x00281512,  //  005B  ADD	R10	R10	K18
-      0x602C0008,  //  005C  GETGBL	R11	G8
-      0x5C301200,  //  005D  MOVE	R12	R9
-      0x7C2C0200,  //  005E  CALL	R11	1
-      0x0028140B,  //  005F  ADD	R10	R10	R11
-      0x900E120A,  //  0060  SETMBR	R3	K9	R10
-      0x8C28010B,  //  0061  GETMET	R10	R0	K11
-      0x5830000C,  //  0062  LDCONST	R12	K12
-      0x5C341000,  //  0063  MOVE	R13	R8
-      0x58380011,  //  0064  LDCONST	R14	K17
-      0x5C3C1200,  //  0065  MOVE	R15	R9
-      0x7C280A00,  //  0066  CALL	R10	5
-      0x50280200,  //  0067  LDBOOL	R10	1	0
-      0x80041400,  //  0068  RET	1	R10
-      0x70020004,  //  0069  JMP		#006F
-      0x54220046,  //  006A  LDINT	R8	71
-      0x1C200E08,  //  006B  EQ	R8	R7	R8
-      0x78220001,  //  006C  JMPF	R8	#006F
-      0x50200200,  //  006D  LDBOOL	R8	1	0
-      0x80041000,  //  006E  RET	1	R8
-      0x70020008,  //  006F  JMP		#0079
-      0x60200003,  //  0070  GETGBL	R8	G3
-      0x5C240000,  //  0071  MOVE	R9	R0
-      0x7C200200,  //  0072  CALL	R8	1
-      0x8C201113,  //  0073  GETMET	R8	R8	K19
-      0x5C280200,  //  0074  MOVE	R10	R1
-      0x5C2C0400,  //  0075  MOVE	R11	R2
-      0x5C300600,  //  0076  MOVE	R12	R3
-      0x7C200800,  //  0077  CALL	R8	4
-      0x80041000,  //  0078  RET	1	R8
-      0x80000000,  //  0079  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_hue),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(shadow_sat),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x5C200600,  //  0006  MOVE	R8	R3
-      0x7C100800,  //  0007  CALL	R4	4
-      0x90020302,  //  0008  SETMBR	R0	K1	K2
-      0x90020702,  //  0009  SETMBR	R0	K3	K2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(update_shadow),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(hue),
-    /* K7   */  be_nested_str_weak(sat),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(scale_uint),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(shadow_hue),
-    /* K12  */  be_nested_str_weak(shadow_sat),
-    /* K13  */  be_nested_str_weak(attribute_updated),
-    /* K14  */  be_const_int(1),
-    }),
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[74]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x74060041,  //  0001  JMPT	R1	#0044
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x7406003F,  //  0003  JMPT	R1	#0044
-      0xA4060400,  //  0004  IMPORT	R1	K2
-      0x60080003,  //  0005  GETGBL	R2	G3
-      0x5C0C0000,  //  0006  MOVE	R3	R0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x7C080200,  //  0009  CALL	R2	1
-      0x8C080304,  //  000A  GETMET	R2	R1	K4
-      0x7C080200,  //  000B  CALL	R2	1
-      0x4C0C0000,  //  000C  LDNIL	R3
-      0x200C0403,  //  000D  NE	R3	R2	R3
-      0x780E0033,  //  000E  JMPF	R3	#0043
-      0x8C0C0505,  //  000F  GETMET	R3	R2	K5
-      0x58140006,  //  0010  LDCONST	R5	K6
-      0x4C180000,  //  0011  LDNIL	R6
-      0x7C0C0600,  //  0012  CALL	R3	3
-      0x8C100505,  //  0013  GETMET	R4	R2	K5
-      0x58180007,  //  0014  LDCONST	R6	K7
-      0x4C1C0000,  //  0015  LDNIL	R7
-      0x7C100600,  //  0016  CALL	R4	3
-      0x4C140000,  //  0017  LDNIL	R5
-      0x20140605,  //  0018  NE	R5	R3	R5
-      0x78160009,  //  0019  JMPF	R5	#0024
-      0xB8161000,  //  001A  GETNGBL	R5	K8
-      0x8C140B09,  //  001B  GETMET	R5	R5	K9
-      0x5C1C0600,  //  001C  MOVE	R7	R3
-      0x5820000A,  //  001D  LDCONST	R8	K10
-      0x54260167,  //  001E  LDINT	R9	360
-      0x5828000A,  //  001F  LDCONST	R10	K10
-      0x542E00FD,  //  0020  LDINT	R11	254
-      0x7C140C00,  //  0021  CALL	R5	6
-      0x5C0C0A00,  //  0022  MOVE	R3	R5
-      0x70020000,  //  0023  JMP		#0025
-      0x880C010B,  //  0024  GETMBR	R3	R0	K11
-      0x4C140000,  //  0025  LDNIL	R5
-      0x20140805,  //  0026  NE	R5	R4	R5
-      0x78160009,  //  0027  JMPF	R5	#0032
-      0xB8161000,  //  0028  GETNGBL	R5	K8
-      0x8C140B09,  //  0029  GETMET	R5	R5	K9
-      0x5C1C0800,  //  002A  MOVE	R7	R4
-      0x5820000A,  //  002B  LDCONST	R8	K10
-      0x542600FE,  //  002C  LDINT	R9	255
-      0x5828000A,  //  002D  LDCONST	R10	K10
-      0x542E00FD,  //  002E  LDINT	R11	254
-      0x7C140C00,  //  002F  CALL	R5	6
-      0x5C100A00,  //  0030  MOVE	R4	R5
-      0x70020000,  //  0031  JMP		#0033
-      0x8810010C,  //  0032  GETMBR	R4	R0	K12
-      0x8814010B,  //  0033  GETMBR	R5	R0	K11
-      0x20140605,  //  0034  NE	R5	R3	R5
-      0x78160004,  //  0035  JMPF	R5	#003B
-      0x8C14010D,  //  0036  GETMET	R5	R0	K13
-      0x541E02FF,  //  0037  LDINT	R7	768
-      0x5820000A,  //  0038  LDCONST	R8	K10
-      0x7C140600,  //  0039  CALL	R5	3
-      0x90021603,  //  003A  SETMBR	R0	K11	R3
-      0x8814010C,  //  003B  GETMBR	R5	R0	K12
-      0x20140805,  //  003C  NE	R5	R4	R5
-      0x78160004,  //  003D  JMPF	R5	#0043
-      0x8C14010D,  //  003E  GETMET	R5	R0	K13
-      0x541E02FF,  //  003F  LDINT	R7	768
-      0x5820000E,  //  0040  LDCONST	R8	K14
-      0x7C140600,  //  0041  CALL	R5	3
-      0x90021804,  //  0042  SETMBR	R0	K12	R4
-      0x70020004,  //  0043  JMP		#0049
-      0x60040003,  //  0044  GETGBL	R1	G3
-      0x5C080000,  //  0045  MOVE	R2	R0
-      0x7C040200,  //  0046  CALL	R1	1
-      0x8C040303,  //  0047  GETMET	R1	R1	K3
-      0x7C040200,  //  0048  CALL	R1	1
-      0x80000000,  //  0049  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_value_RGB
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_web_value_RGB,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_hue),
-    /* K1   */  be_nested_str_weak(shadow_sat),
-    /* K2   */  be_nested_str_weak(light_state),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(set_bri),
-    /* K5   */  be_nested_str_weak(set_huesat),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(scale_uint),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
-    /* K10  */  be_nested_str_weak(r),
-    /* K11  */  be_nested_str_weak(g),
-    /* K12  */  be_nested_str_weak(b),
-    /* K13  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
-    /* K14  */  be_nested_str_weak(),
-    }),
-    be_str_weak(web_value_RGB),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060027,  //  0003  JMPF	R1	#002C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x20040202,  //  0006  NE	R1	R1	R2
-      0x78060023,  //  0007  JMPF	R1	#002C
-      0xB8060400,  //  0008  GETNGBL	R1	K2
-      0x58080003,  //  0009  LDCONST	R2	K3
-      0x7C040200,  //  000A  CALL	R1	1
-      0x8C080304,  //  000B  GETMET	R2	R1	K4
-      0x541200FE,  //  000C  LDINT	R4	255
-      0x7C080400,  //  000D  CALL	R2	2
-      0x8C080305,  //  000E  GETMET	R2	R1	K5
-      0xB8120C00,  //  000F  GETNGBL	R4	K6
-      0x8C100907,  //  0010  GETMET	R4	R4	K7
-      0x88180100,  //  0011  GETMBR	R6	R0	K0
-      0x581C0008,  //  0012  LDCONST	R7	K8
-      0x542200FD,  //  0013  LDINT	R8	254
-      0x58240008,  //  0014  LDCONST	R9	K8
-      0x542A0167,  //  0015  LDINT	R10	360
-      0x7C100C00,  //  0016  CALL	R4	6
-      0xB8160C00,  //  0017  GETNGBL	R5	K6
-      0x8C140B07,  //  0018  GETMET	R5	R5	K7
-      0x881C0101,  //  0019  GETMBR	R7	R0	K1
-      0x58200008,  //  001A  LDCONST	R8	K8
-      0x542600FD,  //  001B  LDINT	R9	254
-      0x58280008,  //  001C  LDCONST	R10	K8
-      0x542E00FE,  //  001D  LDINT	R11	255
-      0x7C140C00,  //  001E  CALL	R5	6
-      0x7C080600,  //  001F  CALL	R2	3
-      0x60080018,  //  0020  GETGBL	R2	G24
-      0x580C0009,  //  0021  LDCONST	R3	K9
-      0x8810030A,  //  0022  GETMBR	R4	R1	K10
-      0x8814030B,  //  0023  GETMBR	R5	R1	K11
-      0x8818030C,  //  0024  GETMBR	R6	R1	K12
-      0x7C080800,  //  0025  CALL	R2	4
-      0x600C0018,  //  0026  GETGBL	R3	G24
-      0x5810000D,  //  0027  LDCONST	R4	K13
-      0x5C140400,  //  0028  MOVE	R5	R2
-      0x5C180400,  //  0029  MOVE	R6	R2
-      0x7C0C0600,  //  002A  CALL	R3	3
-      0x80040600,  //  002B  RET	1	R3
-      0x80061C00,  //  002C  RET	1	K14
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_hue_sat
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_nested_str_weak(call_remote_sync),
-    /* K5   */  be_nested_str_weak(HSBColor1),
-    /* K6   */  be_nested_str_weak(parse_status),
-    /* K7   */  be_nested_str_weak(HSBColor2),
-    /* K8   */  be_nested_str_weak(VIRTUAL),
-    /* K9   */  be_nested_str_weak(shadow_hue),
-    /* K10  */  be_nested_str_weak(attribute_updated),
-    /* K11  */  be_nested_str_weak(shadow_sat),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(light),
-    /* K14  */  be_nested_str_weak(set),
-    /* K15  */  be_nested_str_weak(hue),
-    /* K16  */  be_nested_str_weak(sat),
-    /* K17  */  be_nested_str_weak(update_shadow),
-    }),
-    be_str_weak(set_hue_sat),
-    &be_const_str_solidified,
-    ( &(const binstruction[151]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0203,  //  0001  NE	R3	R1	R3
-      0x780E0006,  //  0002  JMPF	R3	#000A
-      0x140C0300,  //  0003  LT	R3	R1	K0
-      0x780E0000,  //  0004  JMPF	R3	#0006
-      0x58040000,  //  0005  LDCONST	R1	K0
-      0x540E00FD,  //  0006  LDINT	R3	254
-      0x240C0203,  //  0007  GT	R3	R1	R3
-      0x780E0000,  //  0008  JMPF	R3	#000A
-      0x540600FD,  //  0009  LDINT	R1	254
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x200C0403,  //  000B  NE	R3	R2	R3
-      0x780E0006,  //  000C  JMPF	R3	#0014
-      0x140C0500,  //  000D  LT	R3	R2	K0
-      0x780E0000,  //  000E  JMPF	R3	#0010
-      0x58080000,  //  000F  LDCONST	R2	K0
-      0x540E00FD,  //  0010  LDINT	R3	254
-      0x240C0403,  //  0011  GT	R3	R2	R3
-      0x780E0000,  //  0012  JMPF	R3	#0014
-      0x540A00FD,  //  0013  LDINT	R2	254
-      0x880C0101,  //  0014  GETMBR	R3	R0	K1
-      0x780E002C,  //  0015  JMPF	R3	#0043
-      0x4C0C0000,  //  0016  LDNIL	R3
-      0x200C0203,  //  0017  NE	R3	R1	R3
-      0x780E0012,  //  0018  JMPF	R3	#002C
-      0xB80E0400,  //  0019  GETNGBL	R3	K2
-      0x8C0C0703,  //  001A  GETMET	R3	R3	K3
-      0x5C140200,  //  001B  MOVE	R5	R1
-      0x58180000,  //  001C  LDCONST	R6	K0
-      0x541E00FD,  //  001D  LDINT	R7	254
-      0x58200000,  //  001E  LDCONST	R8	K0
-      0x54260167,  //  001F  LDINT	R9	360
-      0x7C0C0C00,  //  0020  CALL	R3	6
-      0x8C100104,  //  0021  GETMET	R4	R0	K4
-      0x58180005,  //  0022  LDCONST	R6	K5
-      0x5C1C0600,  //  0023  MOVE	R7	R3
-      0x7C100600,  //  0024  CALL	R4	3
-      0x4C140000,  //  0025  LDNIL	R5
-      0x20140805,  //  0026  NE	R5	R4	R5
-      0x78160003,  //  0027  JMPF	R5	#002C
-      0x8C140106,  //  0028  GETMET	R5	R0	K6
-      0x5C1C0800,  //  0029  MOVE	R7	R4
-      0x5422000A,  //  002A  LDINT	R8	11
-      0x7C140600,  //  002B  CALL	R5	3
-      0x4C0C0000,  //  002C  LDNIL	R3
-      0x200C0403,  //  002D  NE	R3	R2	R3
-      0x780E0012,  //  002E  JMPF	R3	#0042
-      0xB80E0400,  //  002F  GETNGBL	R3	K2
-      0x8C0C0703,  //  0030  GETMET	R3	R3	K3
-      0x5C140400,  //  0031  MOVE	R5	R2
-      0x58180000,  //  0032  LDCONST	R6	K0
-      0x541E00FD,  //  0033  LDINT	R7	254
-      0x58200000,  //  0034  LDCONST	R8	K0
-      0x54260063,  //  0035  LDINT	R9	100
-      0x7C0C0C00,  //  0036  CALL	R3	6
-      0x8C100104,  //  0037  GETMET	R4	R0	K4
-      0x58180007,  //  0038  LDCONST	R6	K7
-      0x5C1C0600,  //  0039  MOVE	R7	R3
-      0x7C100600,  //  003A  CALL	R4	3
-      0x4C140000,  //  003B  LDNIL	R5
-      0x20140805,  //  003C  NE	R5	R4	R5
-      0x78160003,  //  003D  JMPF	R5	#0042
-      0x8C140106,  //  003E  GETMET	R5	R0	K6
-      0x5C1C0800,  //  003F  MOVE	R7	R4
-      0x5422000A,  //  0040  LDINT	R8	11
-      0x7C140600,  //  0041  CALL	R5	3
-      0x70020052,  //  0042  JMP		#0096
-      0x880C0108,  //  0043  GETMBR	R3	R0	K8
-      0x780E0016,  //  0044  JMPF	R3	#005C
-      0x4C0C0000,  //  0045  LDNIL	R3
-      0x200C0203,  //  0046  NE	R3	R1	R3
-      0x780E0007,  //  0047  JMPF	R3	#0050
-      0x880C0109,  //  0048  GETMBR	R3	R0	K9
-      0x200C0203,  //  0049  NE	R3	R1	R3
-      0x780E0004,  //  004A  JMPF	R3	#0050
-      0x8C0C010A,  //  004B  GETMET	R3	R0	K10
-      0x541602FF,  //  004C  LDINT	R5	768
-      0x58180000,  //  004D  LDCONST	R6	K0
-      0x7C0C0600,  //  004E  CALL	R3	3
-      0x90021201,  //  004F  SETMBR	R0	K9	R1
-      0x4C0C0000,  //  0050  LDNIL	R3
-      0x200C0403,  //  0051  NE	R3	R2	R3
-      0x780E0007,  //  0052  JMPF	R3	#005B
-      0x880C010B,  //  0053  GETMBR	R3	R0	K11
-      0x200C0403,  //  0054  NE	R3	R2	R3
-      0x780E0004,  //  0055  JMPF	R3	#005B
-      0x8C0C010A,  //  0056  GETMET	R3	R0	K10
-      0x541602FF,  //  0057  LDINT	R5	768
-      0x5818000C,  //  0058  LDCONST	R6	K12
-      0x7C0C0600,  //  0059  CALL	R3	3
-      0x90021602,  //  005A  SETMBR	R0	K11	R2
-      0x70020039,  //  005B  JMP		#0096
-      0x4C0C0000,  //  005C  LDNIL	R3
-      0x200C0203,  //  005D  NE	R3	R1	R3
-      0x780E0008,  //  005E  JMPF	R3	#0068
-      0xB80E0400,  //  005F  GETNGBL	R3	K2
-      0x8C0C0703,  //  0060  GETMET	R3	R3	K3
-      0x5C140200,  //  0061  MOVE	R5	R1
-      0x58180000,  //  0062  LDCONST	R6	K0
-      0x541E00FD,  //  0063  LDINT	R7	254
-      0x58200000,  //  0064  LDCONST	R8	K0
-      0x54260167,  //  0065  LDINT	R9	360
-      0x7C0C0C00,  //  0066  CALL	R3	6
-      0x70020000,  //  0067  JMP		#0069
-      0x4C0C0000,  //  0068  LDNIL	R3
-      0x4C100000,  //  0069  LDNIL	R4
-      0x20100404,  //  006A  NE	R4	R2	R4
-      0x78120008,  //  006B  JMPF	R4	#0075
-      0xB8120400,  //  006C  GETNGBL	R4	K2
-      0x8C100903,  //  006D  GETMET	R4	R4	K3
-      0x5C180400,  //  006E  MOVE	R6	R2
-      0x581C0000,  //  006F  LDCONST	R7	K0
-      0x542200FD,  //  0070  LDINT	R8	254
-      0x58240000,  //  0071  LDCONST	R9	K0
-      0x542A00FE,  //  0072  LDINT	R10	255
-      0x7C100C00,  //  0073  CALL	R4	6
-      0x70020000,  //  0074  JMP		#0076
-      0x4C100000,  //  0075  LDNIL	R4
-      0x4C140000,  //  0076  LDNIL	R5
-      0x20140605,  //  0077  NE	R5	R3	R5
-      0x7816000A,  //  0078  JMPF	R5	#0084
-      0x4C140000,  //  0079  LDNIL	R5
-      0x20140805,  //  007A  NE	R5	R4	R5
-      0x78160007,  //  007B  JMPF	R5	#0084
-      0xB8161A00,  //  007C  GETNGBL	R5	K13
-      0x8C140B0E,  //  007D  GETMET	R5	R5	K14
-      0x601C0013,  //  007E  GETGBL	R7	G19
-      0x7C1C0000,  //  007F  CALL	R7	0
-      0x981E1E03,  //  0080  SETIDX	R7	K15	R3
-      0x981E2004,  //  0081  SETIDX	R7	K16	R4
-      0x7C140400,  //  0082  CALL	R5	2
-      0x7002000F,  //  0083  JMP		#0094
-      0x4C140000,  //  0084  LDNIL	R5
-      0x20140605,  //  0085  NE	R5	R3	R5
-      0x78160006,  //  0086  JMPF	R5	#008E
-      0xB8161A00,  //  0087  GETNGBL	R5	K13
-      0x8C140B0E,  //  0088  GETMET	R5	R5	K14
-      0x601C0013,  //  0089  GETGBL	R7	G19
-      0x7C1C0000,  //  008A  CALL	R7	0
-      0x981E1E03,  //  008B  SETIDX	R7	K15	R3
-      0x7C140400,  //  008C  CALL	R5	2
-      0x70020005,  //  008D  JMP		#0094
-      0xB8161A00,  //  008E  GETNGBL	R5	K13
-      0x8C140B0E,  //  008F  GETMET	R5	R5	K14
-      0x601C0013,  //  0090  GETGBL	R7	G19
-      0x7C1C0000,  //  0091  CALL	R7	0
-      0x981E2004,  //  0092  SETIDX	R7	K16	R4
-      0x7C140400,  //  0093  CALL	R5	2
-      0x8C140111,  //  0094  GETMET	R5	R0	K17
-      0x7C140200,  //  0095  CALL	R5	1
-      0x80000000,  //  0096  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_status
-********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
-be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_status),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(HSBColor),
-    /* K3   */  be_nested_str_weak(string),
-    /* K4   */  be_nested_str_weak(split),
-    /* K5   */  be_nested_str_weak(_X2C),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(scale_uint),
-    /* K10  */  be_nested_str_weak(shadow_hue),
-    /* K11  */  be_nested_str_weak(shadow_sat),
-    /* K12  */  be_nested_str_weak(attribute_updated),
-    }),
-    be_str_weak(parse_status),
-    &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x540E000A,  //  0007  LDINT	R3	11
-      0x1C0C0403,  //  0008  EQ	R3	R2	R3
-      0x780E003A,  //  0009  JMPF	R3	#0045
-      0x8C0C0301,  //  000A  GETMET	R3	R1	K1
-      0x58140002,  //  000B  LDCONST	R5	K2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x780E0036,  //  000D  JMPF	R3	#0045
-      0xA4120600,  //  000E  IMPORT	R4	K3
-      0x8C140904,  //  000F  GETMET	R5	R4	K4
-      0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x58200005,  //  0011  LDCONST	R8	K5
-      0x7C140600,  //  0012  CALL	R5	3
-      0x60180009,  //  0013  GETGBL	R6	G9
-      0x941C0B06,  //  0014  GETIDX	R7	R5	K6
-      0x7C180200,  //  0015  CALL	R6	1
-      0x601C0009,  //  0016  GETGBL	R7	G9
-      0x94200B07,  //  0017  GETIDX	R8	R5	K7
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x4C200000,  //  0019  LDNIL	R8
-      0x20200C08,  //  001A  NE	R8	R6	R8
-      0x78220009,  //  001B  JMPF	R8	#0026
-      0xB8221000,  //  001C  GETNGBL	R8	K8
-      0x8C201109,  //  001D  GETMET	R8	R8	K9
-      0x5C280C00,  //  001E  MOVE	R10	R6
-      0x582C0006,  //  001F  LDCONST	R11	K6
-      0x54320167,  //  0020  LDINT	R12	360
-      0x58340006,  //  0021  LDCONST	R13	K6
-      0x543A00FD,  //  0022  LDINT	R14	254
-      0x7C200C00,  //  0023  CALL	R8	6
-      0x5C181000,  //  0024  MOVE	R6	R8
-      0x70020000,  //  0025  JMP		#0027
-      0x8818010A,  //  0026  GETMBR	R6	R0	K10
-      0x4C200000,  //  0027  LDNIL	R8
-      0x20200E08,  //  0028  NE	R8	R7	R8
-      0x78220009,  //  0029  JMPF	R8	#0034
-      0xB8221000,  //  002A  GETNGBL	R8	K8
-      0x8C201109,  //  002B  GETMET	R8	R8	K9
-      0x5C280E00,  //  002C  MOVE	R10	R7
-      0x582C0006,  //  002D  LDCONST	R11	K6
-      0x54320063,  //  002E  LDINT	R12	100
-      0x58340006,  //  002F  LDCONST	R13	K6
-      0x543A00FD,  //  0030  LDINT	R14	254
-      0x7C200C00,  //  0031  CALL	R8	6
-      0x5C1C1000,  //  0032  MOVE	R7	R8
-      0x70020000,  //  0033  JMP		#0035
-      0x881C010B,  //  0034  GETMBR	R7	R0	K11
-      0x8820010A,  //  0035  GETMBR	R8	R0	K10
-      0x20200C08,  //  0036  NE	R8	R6	R8
-      0x78220004,  //  0037  JMPF	R8	#003D
-      0x8C20010C,  //  0038  GETMET	R8	R0	K12
-      0x542A02FF,  //  0039  LDINT	R10	768
-      0x582C0006,  //  003A  LDCONST	R11	K6
-      0x7C200600,  //  003B  CALL	R8	3
-      0x90021406,  //  003C  SETMBR	R0	K10	R6
-      0x8820010B,  //  003D  GETMBR	R8	R0	K11
-      0x20200E08,  //  003E  NE	R8	R7	R8
-      0x78220004,  //  003F  JMPF	R8	#0045
-      0x8C20010C,  //  0040  GETMET	R8	R0	K12
-      0x542A02FF,  //  0041  LDINT	R10	768
-      0x582C0007,  //  0042  LDCONST	R11	K7
-      0x7C200600,  //  0043  CALL	R8	3
-      0x90021607,  //  0044  SETMBR	R0	K11	R7
-      0x80000000,  //  0045  RET	0
+      0x7C240600,  //  0055  CALL	R9	3
+      0x60240008,  //  0056  GETGBL	R9	G8
+      0x5C280E00,  //  0057  MOVE	R10	R7
+      0x7C240200,  //  0058  CALL	R9	1
+      0x00261209,  //  0059  ADD	R9	K9	R9
+      0x00241311,  //  005A  ADD	R9	R9	K17
+      0x60280008,  //  005B  GETGBL	R10	G8
+      0x5C2C1000,  //  005C  MOVE	R11	R8
+      0x7C280200,  //  005D  CALL	R10	1
+      0x0024120A,  //  005E  ADD	R9	R9	R10
+      0x900E1009,  //  005F  SETMBR	R3	K8	R9
+      0x8C24010A,  //  0060  GETMET	R9	R0	K10
+      0x582C000B,  //  0061  LDCONST	R11	K11
+      0x5C300E00,  //  0062  MOVE	R12	R7
+      0x58340010,  //  0063  LDCONST	R13	K16
+      0x5C381000,  //  0064  MOVE	R14	R8
+      0x7C240A00,  //  0065  CALL	R9	5
+      0x50240200,  //  0066  LDBOOL	R9	1	0
+      0x80041200,  //  0067  RET	1	R9
+      0x70020004,  //  0068  JMP		#006E
+      0x541E0046,  //  0069  LDINT	R7	71
+      0x1C1C0C07,  //  006A  EQ	R7	R6	R7
+      0x781E0001,  //  006B  JMPF	R7	#006E
+      0x501C0200,  //  006C  LDBOOL	R7	1	0
+      0x80040E00,  //  006D  RET	1	R7
+      0x70020008,  //  006E  JMP		#0078
+      0x601C0003,  //  006F  GETGBL	R7	G3
+      0x5C200000,  //  0070  MOVE	R8	R0
+      0x7C1C0200,  //  0071  CALL	R7	1
+      0x8C1C0F12,  //  0072  GETMET	R7	R7	K18
+      0x5C240200,  //  0073  MOVE	R9	R1
+      0x5C280400,  //  0074  MOVE	R10	R2
+      0x5C2C0600,  //  0075  MOVE	R11	R3
+      0x7C1C0800,  //  0076  CALL	R7	4
+      0x80040E00,  //  0077  RET	1	R7
+      0x80000000,  //  0078  RET	0
     })
   )
 );
@@ -907,6 +307,417 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
 
 
 /********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(VIRTUAL),
+    /* K1   */  be_nested_str_weak(BRIDGE),
+    /* K2   */  be_nested_str_weak(light),
+    /* K3   */  be_nested_str_weak(update_shadow),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(light_index),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(hue),
+    /* K8   */  be_nested_str_weak(sat),
+    /* K9   */  be_nested_str_weak(tasmota),
+    /* K10  */  be_nested_str_weak(scale_uint),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(shadow_hue),
+    /* K13  */  be_nested_str_weak(shadow_sat),
+    /* K14  */  be_nested_str_weak(attribute_updated),
+    /* K15  */  be_const_int(1),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[75]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x74060042,  //  0001  JMPT	R1	#0045
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x74060040,  //  0003  JMPT	R1	#0045
+      0xA4060400,  //  0004  IMPORT	R1	K2
+      0x60080003,  //  0005  GETGBL	R2	G3
+      0x5C0C0000,  //  0006  MOVE	R3	R0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x8C080503,  //  0008  GETMET	R2	R2	K3
+      0x7C080200,  //  0009  CALL	R2	1
+      0x8C080304,  //  000A  GETMET	R2	R1	K4
+      0x88100105,  //  000B  GETMBR	R4	R0	K5
+      0x7C080400,  //  000C  CALL	R2	2
+      0x4C0C0000,  //  000D  LDNIL	R3
+      0x200C0403,  //  000E  NE	R3	R2	R3
+      0x780E0033,  //  000F  JMPF	R3	#0044
+      0x8C0C0506,  //  0010  GETMET	R3	R2	K6
+      0x58140007,  //  0011  LDCONST	R5	K7
+      0x4C180000,  //  0012  LDNIL	R6
+      0x7C0C0600,  //  0013  CALL	R3	3
+      0x8C100506,  //  0014  GETMET	R4	R2	K6
+      0x58180008,  //  0015  LDCONST	R6	K8
+      0x4C1C0000,  //  0016  LDNIL	R7
+      0x7C100600,  //  0017  CALL	R4	3
+      0x4C140000,  //  0018  LDNIL	R5
+      0x20140605,  //  0019  NE	R5	R3	R5
+      0x78160009,  //  001A  JMPF	R5	#0025
+      0xB8161200,  //  001B  GETNGBL	R5	K9
+      0x8C140B0A,  //  001C  GETMET	R5	R5	K10
+      0x5C1C0600,  //  001D  MOVE	R7	R3
+      0x5820000B,  //  001E  LDCONST	R8	K11
+      0x54260167,  //  001F  LDINT	R9	360
+      0x5828000B,  //  0020  LDCONST	R10	K11
+      0x542E00FD,  //  0021  LDINT	R11	254
+      0x7C140C00,  //  0022  CALL	R5	6
+      0x5C0C0A00,  //  0023  MOVE	R3	R5
+      0x70020000,  //  0024  JMP		#0026
+      0x880C010C,  //  0025  GETMBR	R3	R0	K12
+      0x4C140000,  //  0026  LDNIL	R5
+      0x20140805,  //  0027  NE	R5	R4	R5
+      0x78160009,  //  0028  JMPF	R5	#0033
+      0xB8161200,  //  0029  GETNGBL	R5	K9
+      0x8C140B0A,  //  002A  GETMET	R5	R5	K10
+      0x5C1C0800,  //  002B  MOVE	R7	R4
+      0x5820000B,  //  002C  LDCONST	R8	K11
+      0x542600FE,  //  002D  LDINT	R9	255
+      0x5828000B,  //  002E  LDCONST	R10	K11
+      0x542E00FD,  //  002F  LDINT	R11	254
+      0x7C140C00,  //  0030  CALL	R5	6
+      0x5C100A00,  //  0031  MOVE	R4	R5
+      0x70020000,  //  0032  JMP		#0034
+      0x8810010D,  //  0033  GETMBR	R4	R0	K13
+      0x8814010C,  //  0034  GETMBR	R5	R0	K12
+      0x20140605,  //  0035  NE	R5	R3	R5
+      0x78160004,  //  0036  JMPF	R5	#003C
+      0x8C14010E,  //  0037  GETMET	R5	R0	K14
+      0x541E02FF,  //  0038  LDINT	R7	768
+      0x5820000B,  //  0039  LDCONST	R8	K11
+      0x7C140600,  //  003A  CALL	R5	3
+      0x90021803,  //  003B  SETMBR	R0	K12	R3
+      0x8814010D,  //  003C  GETMBR	R5	R0	K13
+      0x20140805,  //  003D  NE	R5	R4	R5
+      0x78160004,  //  003E  JMPF	R5	#0044
+      0x8C14010E,  //  003F  GETMET	R5	R0	K14
+      0x541E02FF,  //  0040  LDINT	R7	768
+      0x5820000F,  //  0041  LDCONST	R8	K15
+      0x7C140600,  //  0042  CALL	R5	3
+      0x90021A04,  //  0043  SETMBR	R0	K13	R4
+      0x70020004,  //  0044  JMP		#004A
+      0x60040003,  //  0045  GETGBL	R1	G3
+      0x5C080000,  //  0046  MOVE	R2	R0
+      0x7C040200,  //  0047  CALL	R1	1
+      0x8C040303,  //  0048  GETMET	R1	R1	K3
+      0x7C040200,  //  0049  CALL	R1	1
+      0x80000000,  //  004A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_virtual
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find),
+    /* K1   */  be_nested_str_weak(Hue),
+    /* K2   */  be_nested_str_weak(Sat),
+    /* K3   */  be_nested_str_weak(set_hue_sat),
+    /* K4   */  be_nested_str_weak(update_virtual),
+    }),
+    be_str_weak(update_virtual),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x8C0C0300,  //  0001  GETMET	R3	R1	K0
+      0x58140001,  //  0002  LDCONST	R5	K1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x7C080200,  //  0004  CALL	R2	1
+      0x600C0009,  //  0005  GETGBL	R3	G9
+      0x8C100300,  //  0006  GETMET	R4	R1	K0
+      0x58180002,  //  0007  LDCONST	R6	K2
+      0x7C100400,  //  0008  CALL	R4	2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x4C100000,  //  000A  LDNIL	R4
+      0x20100404,  //  000B  NE	R4	R2	R4
+      0x74120002,  //  000C  JMPT	R4	#0010
+      0x4C100000,  //  000D  LDNIL	R4
+      0x20100604,  //  000E  NE	R4	R3	R4
+      0x78120003,  //  000F  JMPF	R4	#0014
+      0x8C100103,  //  0010  GETMET	R4	R0	K3
+      0x5C180400,  //  0011  MOVE	R6	R2
+      0x5C1C0600,  //  0012  MOVE	R7	R3
+      0x7C100600,  //  0013  CALL	R4	3
+      0x60100003,  //  0014  GETGBL	R4	G3
+      0x5C140000,  //  0015  MOVE	R5	R0
+      0x7C100200,  //  0016  CALL	R4	1
+      0x8C100904,  //  0017  GETMET	R4	R4	K4
+      0x5C180200,  //  0018  MOVE	R6	R1
+      0x7C100400,  //  0019  CALL	R4	2
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_hue_sat
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(BRIDGE),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(scale_uint),
+    /* K4   */  be_nested_str_weak(call_remote_sync),
+    /* K5   */  be_nested_str_weak(HSBColor1),
+    /* K6   */  be_nested_str_weak(parse_status),
+    /* K7   */  be_nested_str_weak(HSBColor2),
+    /* K8   */  be_nested_str_weak(VIRTUAL),
+    /* K9   */  be_nested_str_weak(shadow_hue),
+    /* K10  */  be_nested_str_weak(attribute_updated),
+    /* K11  */  be_nested_str_weak(shadow_sat),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(light),
+    /* K14  */  be_nested_str_weak(set),
+    /* K15  */  be_nested_str_weak(hue),
+    /* K16  */  be_nested_str_weak(sat),
+    /* K17  */  be_nested_str_weak(light_index),
+    /* K18  */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(set_hue_sat),
+    &be_const_str_solidified,
+    ( &(const binstruction[154]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0203,  //  0001  NE	R3	R1	R3
+      0x780E0006,  //  0002  JMPF	R3	#000A
+      0x140C0300,  //  0003  LT	R3	R1	K0
+      0x780E0000,  //  0004  JMPF	R3	#0006
+      0x58040000,  //  0005  LDCONST	R1	K0
+      0x540E00FD,  //  0006  LDINT	R3	254
+      0x240C0203,  //  0007  GT	R3	R1	R3
+      0x780E0000,  //  0008  JMPF	R3	#000A
+      0x540600FD,  //  0009  LDINT	R1	254
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x200C0403,  //  000B  NE	R3	R2	R3
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x140C0500,  //  000D  LT	R3	R2	K0
+      0x780E0000,  //  000E  JMPF	R3	#0010
+      0x58080000,  //  000F  LDCONST	R2	K0
+      0x540E00FD,  //  0010  LDINT	R3	254
+      0x240C0403,  //  0011  GT	R3	R2	R3
+      0x780E0000,  //  0012  JMPF	R3	#0014
+      0x540A00FD,  //  0013  LDINT	R2	254
+      0x880C0101,  //  0014  GETMBR	R3	R0	K1
+      0x780E002C,  //  0015  JMPF	R3	#0043
+      0x4C0C0000,  //  0016  LDNIL	R3
+      0x200C0203,  //  0017  NE	R3	R1	R3
+      0x780E0012,  //  0018  JMPF	R3	#002C
+      0xB80E0400,  //  0019  GETNGBL	R3	K2
+      0x8C0C0703,  //  001A  GETMET	R3	R3	K3
+      0x5C140200,  //  001B  MOVE	R5	R1
+      0x58180000,  //  001C  LDCONST	R6	K0
+      0x541E00FD,  //  001D  LDINT	R7	254
+      0x58200000,  //  001E  LDCONST	R8	K0
+      0x54260167,  //  001F  LDINT	R9	360
+      0x7C0C0C00,  //  0020  CALL	R3	6
+      0x8C100104,  //  0021  GETMET	R4	R0	K4
+      0x58180005,  //  0022  LDCONST	R6	K5
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C100600,  //  0024  CALL	R4	3
+      0x4C140000,  //  0025  LDNIL	R5
+      0x20140805,  //  0026  NE	R5	R4	R5
+      0x78160003,  //  0027  JMPF	R5	#002C
+      0x8C140106,  //  0028  GETMET	R5	R0	K6
+      0x5C1C0800,  //  0029  MOVE	R7	R4
+      0x5422000A,  //  002A  LDINT	R8	11
+      0x7C140600,  //  002B  CALL	R5	3
+      0x4C0C0000,  //  002C  LDNIL	R3
+      0x200C0403,  //  002D  NE	R3	R2	R3
+      0x780E0012,  //  002E  JMPF	R3	#0042
+      0xB80E0400,  //  002F  GETNGBL	R3	K2
+      0x8C0C0703,  //  0030  GETMET	R3	R3	K3
+      0x5C140400,  //  0031  MOVE	R5	R2
+      0x58180000,  //  0032  LDCONST	R6	K0
+      0x541E00FD,  //  0033  LDINT	R7	254
+      0x58200000,  //  0034  LDCONST	R8	K0
+      0x54260063,  //  0035  LDINT	R9	100
+      0x7C0C0C00,  //  0036  CALL	R3	6
+      0x8C100104,  //  0037  GETMET	R4	R0	K4
+      0x58180007,  //  0038  LDCONST	R6	K7
+      0x5C1C0600,  //  0039  MOVE	R7	R3
+      0x7C100600,  //  003A  CALL	R4	3
+      0x4C140000,  //  003B  LDNIL	R5
+      0x20140805,  //  003C  NE	R5	R4	R5
+      0x78160003,  //  003D  JMPF	R5	#0042
+      0x8C140106,  //  003E  GETMET	R5	R0	K6
+      0x5C1C0800,  //  003F  MOVE	R7	R4
+      0x5422000A,  //  0040  LDINT	R8	11
+      0x7C140600,  //  0041  CALL	R5	3
+      0x70020055,  //  0042  JMP		#0099
+      0x880C0108,  //  0043  GETMBR	R3	R0	K8
+      0x780E0016,  //  0044  JMPF	R3	#005C
+      0x4C0C0000,  //  0045  LDNIL	R3
+      0x200C0203,  //  0046  NE	R3	R1	R3
+      0x780E0007,  //  0047  JMPF	R3	#0050
+      0x880C0109,  //  0048  GETMBR	R3	R0	K9
+      0x200C0203,  //  0049  NE	R3	R1	R3
+      0x780E0004,  //  004A  JMPF	R3	#0050
+      0x8C0C010A,  //  004B  GETMET	R3	R0	K10
+      0x541602FF,  //  004C  LDINT	R5	768
+      0x58180000,  //  004D  LDCONST	R6	K0
+      0x7C0C0600,  //  004E  CALL	R3	3
+      0x90021201,  //  004F  SETMBR	R0	K9	R1
+      0x4C0C0000,  //  0050  LDNIL	R3
+      0x200C0403,  //  0051  NE	R3	R2	R3
+      0x780E0007,  //  0052  JMPF	R3	#005B
+      0x880C010B,  //  0053  GETMBR	R3	R0	K11
+      0x200C0403,  //  0054  NE	R3	R2	R3
+      0x780E0004,  //  0055  JMPF	R3	#005B
+      0x8C0C010A,  //  0056  GETMET	R3	R0	K10
+      0x541602FF,  //  0057  LDINT	R5	768
+      0x5818000C,  //  0058  LDCONST	R6	K12
+      0x7C0C0600,  //  0059  CALL	R3	3
+      0x90021602,  //  005A  SETMBR	R0	K11	R2
+      0x7002003C,  //  005B  JMP		#0099
+      0x4C0C0000,  //  005C  LDNIL	R3
+      0x200C0203,  //  005D  NE	R3	R1	R3
+      0x780E0008,  //  005E  JMPF	R3	#0068
+      0xB80E0400,  //  005F  GETNGBL	R3	K2
+      0x8C0C0703,  //  0060  GETMET	R3	R3	K3
+      0x5C140200,  //  0061  MOVE	R5	R1
+      0x58180000,  //  0062  LDCONST	R6	K0
+      0x541E00FD,  //  0063  LDINT	R7	254
+      0x58200000,  //  0064  LDCONST	R8	K0
+      0x54260167,  //  0065  LDINT	R9	360
+      0x7C0C0C00,  //  0066  CALL	R3	6
+      0x70020000,  //  0067  JMP		#0069
+      0x4C0C0000,  //  0068  LDNIL	R3
+      0x4C100000,  //  0069  LDNIL	R4
+      0x20100404,  //  006A  NE	R4	R2	R4
+      0x78120008,  //  006B  JMPF	R4	#0075
+      0xB8120400,  //  006C  GETNGBL	R4	K2
+      0x8C100903,  //  006D  GETMET	R4	R4	K3
+      0x5C180400,  //  006E  MOVE	R6	R2
+      0x581C0000,  //  006F  LDCONST	R7	K0
+      0x542200FD,  //  0070  LDINT	R8	254
+      0x58240000,  //  0071  LDCONST	R9	K0
+      0x542A00FE,  //  0072  LDINT	R10	255
+      0x7C100C00,  //  0073  CALL	R4	6
+      0x70020000,  //  0074  JMP		#0076
+      0x4C100000,  //  0075  LDNIL	R4
+      0x4C140000,  //  0076  LDNIL	R5
+      0x20140605,  //  0077  NE	R5	R3	R5
+      0x7816000B,  //  0078  JMPF	R5	#0085
+      0x4C140000,  //  0079  LDNIL	R5
+      0x20140805,  //  007A  NE	R5	R4	R5
+      0x78160008,  //  007B  JMPF	R5	#0085
+      0xB8161A00,  //  007C  GETNGBL	R5	K13
+      0x8C140B0E,  //  007D  GETMET	R5	R5	K14
+      0x601C0013,  //  007E  GETGBL	R7	G19
+      0x7C1C0000,  //  007F  CALL	R7	0
+      0x981E1E03,  //  0080  SETIDX	R7	K15	R3
+      0x981E2004,  //  0081  SETIDX	R7	K16	R4
+      0x88200111,  //  0082  GETMBR	R8	R0	K17
+      0x7C140600,  //  0083  CALL	R5	3
+      0x70020011,  //  0084  JMP		#0097
+      0x4C140000,  //  0085  LDNIL	R5
+      0x20140605,  //  0086  NE	R5	R3	R5
+      0x78160007,  //  0087  JMPF	R5	#0090
+      0xB8161A00,  //  0088  GETNGBL	R5	K13
+      0x8C140B0E,  //  0089  GETMET	R5	R5	K14
+      0x601C0013,  //  008A  GETGBL	R7	G19
+      0x7C1C0000,  //  008B  CALL	R7	0
+      0x981E1E03,  //  008C  SETIDX	R7	K15	R3
+      0x88200111,  //  008D  GETMBR	R8	R0	K17
+      0x7C140600,  //  008E  CALL	R5	3
+      0x70020006,  //  008F  JMP		#0097
+      0xB8161A00,  //  0090  GETNGBL	R5	K13
+      0x8C140B0E,  //  0091  GETMET	R5	R5	K14
+      0x601C0013,  //  0092  GETGBL	R7	G19
+      0x7C1C0000,  //  0093  CALL	R7	0
+      0x981E2004,  //  0094  SETIDX	R7	K16	R4
+      0x88200111,  //  0095  GETMBR	R8	R0	K17
+      0x7C140600,  //  0096  CALL	R5	3
+      0x8C140112,  //  0097  GETMET	R5	R0	K18
+      0x7C140200,  //  0098  CALL	R5	1
+      0x80000000,  //  0099  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_hue),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(shadow_sat),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x90020302,  //  0008  SETMBR	R0	K1	K2
+      0x90020702,  //  0009  SETMBR	R0	K3	K2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light3;
@@ -956,26 +767,215 @@ be_local_closure(class_Matter_Plugin_Light3_web_values,   /* name */
 
 
 /********************************************************************
+** Solidified function: parse_status
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parse_status),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(HSBColor),
+    /* K3   */  be_nested_str_weak(string),
+    /* K4   */  be_nested_str_weak(split),
+    /* K5   */  be_nested_str_weak(_X2C),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(scale_uint),
+    /* K10  */  be_nested_str_weak(shadow_hue),
+    /* K11  */  be_nested_str_weak(shadow_sat),
+    /* K12  */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(parse_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[70]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x540E000A,  //  0007  LDINT	R3	11
+      0x1C0C0403,  //  0008  EQ	R3	R2	R3
+      0x780E003A,  //  0009  JMPF	R3	#0045
+      0x8C0C0301,  //  000A  GETMET	R3	R1	K1
+      0x58140002,  //  000B  LDCONST	R5	K2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x780E0036,  //  000D  JMPF	R3	#0045
+      0xA4120600,  //  000E  IMPORT	R4	K3
+      0x8C140904,  //  000F  GETMET	R5	R4	K4
+      0x5C1C0600,  //  0010  MOVE	R7	R3
+      0x58200005,  //  0011  LDCONST	R8	K5
+      0x7C140600,  //  0012  CALL	R5	3
+      0x60180009,  //  0013  GETGBL	R6	G9
+      0x941C0B06,  //  0014  GETIDX	R7	R5	K6
+      0x7C180200,  //  0015  CALL	R6	1
+      0x601C0009,  //  0016  GETGBL	R7	G9
+      0x94200B07,  //  0017  GETIDX	R8	R5	K7
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x4C200000,  //  0019  LDNIL	R8
+      0x20200C08,  //  001A  NE	R8	R6	R8
+      0x78220009,  //  001B  JMPF	R8	#0026
+      0xB8221000,  //  001C  GETNGBL	R8	K8
+      0x8C201109,  //  001D  GETMET	R8	R8	K9
+      0x5C280C00,  //  001E  MOVE	R10	R6
+      0x582C0006,  //  001F  LDCONST	R11	K6
+      0x54320167,  //  0020  LDINT	R12	360
+      0x58340006,  //  0021  LDCONST	R13	K6
+      0x543A00FD,  //  0022  LDINT	R14	254
+      0x7C200C00,  //  0023  CALL	R8	6
+      0x5C181000,  //  0024  MOVE	R6	R8
+      0x70020000,  //  0025  JMP		#0027
+      0x8818010A,  //  0026  GETMBR	R6	R0	K10
+      0x4C200000,  //  0027  LDNIL	R8
+      0x20200E08,  //  0028  NE	R8	R7	R8
+      0x78220009,  //  0029  JMPF	R8	#0034
+      0xB8221000,  //  002A  GETNGBL	R8	K8
+      0x8C201109,  //  002B  GETMET	R8	R8	K9
+      0x5C280E00,  //  002C  MOVE	R10	R7
+      0x582C0006,  //  002D  LDCONST	R11	K6
+      0x54320063,  //  002E  LDINT	R12	100
+      0x58340006,  //  002F  LDCONST	R13	K6
+      0x543A00FD,  //  0030  LDINT	R14	254
+      0x7C200C00,  //  0031  CALL	R8	6
+      0x5C1C1000,  //  0032  MOVE	R7	R8
+      0x70020000,  //  0033  JMP		#0035
+      0x881C010B,  //  0034  GETMBR	R7	R0	K11
+      0x8820010A,  //  0035  GETMBR	R8	R0	K10
+      0x20200C08,  //  0036  NE	R8	R6	R8
+      0x78220004,  //  0037  JMPF	R8	#003D
+      0x8C20010C,  //  0038  GETMET	R8	R0	K12
+      0x542A02FF,  //  0039  LDINT	R10	768
+      0x582C0006,  //  003A  LDCONST	R11	K6
+      0x7C200600,  //  003B  CALL	R8	3
+      0x90021406,  //  003C  SETMBR	R0	K10	R6
+      0x8820010B,  //  003D  GETMBR	R8	R0	K11
+      0x20200E08,  //  003E  NE	R8	R7	R8
+      0x78220004,  //  003F  JMPF	R8	#0045
+      0x8C20010C,  //  0040  GETMET	R8	R0	K12
+      0x542A02FF,  //  0041  LDINT	R10	768
+      0x582C0007,  //  0042  LDCONST	R11	K7
+      0x7C200600,  //  0043  CALL	R8	3
+      0x90021607,  //  0044  SETMBR	R0	K11	R7
+      0x80000000,  //  0045  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_value_RGB
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Light3;
+be_local_closure(class_Matter_Plugin_Light3_web_value_RGB,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    &be_class_Matter_Plugin_Light3, 
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shadow_hue),
+    /* K1   */  be_nested_str_weak(shadow_sat),
+    /* K2   */  be_nested_str_weak(light_state),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_bri),
+    /* K5   */  be_nested_str_weak(set_huesat),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(scale_uint),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
+    /* K10  */  be_nested_str_weak(r),
+    /* K11  */  be_nested_str_weak(g),
+    /* K12  */  be_nested_str_weak(b),
+    /* K13  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
+    /* K14  */  be_nested_str_weak(),
+    }),
+    be_str_weak(web_value_RGB),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060027,  //  0003  JMPF	R1	#002C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x20040202,  //  0006  NE	R1	R1	R2
+      0x78060023,  //  0007  JMPF	R1	#002C
+      0xB8060400,  //  0008  GETNGBL	R1	K2
+      0x58080003,  //  0009  LDCONST	R2	K3
+      0x7C040200,  //  000A  CALL	R1	1
+      0x8C080304,  //  000B  GETMET	R2	R1	K4
+      0x541200FE,  //  000C  LDINT	R4	255
+      0x7C080400,  //  000D  CALL	R2	2
+      0x8C080305,  //  000E  GETMET	R2	R1	K5
+      0xB8120C00,  //  000F  GETNGBL	R4	K6
+      0x8C100907,  //  0010  GETMET	R4	R4	K7
+      0x88180100,  //  0011  GETMBR	R6	R0	K0
+      0x581C0008,  //  0012  LDCONST	R7	K8
+      0x542200FD,  //  0013  LDINT	R8	254
+      0x58240008,  //  0014  LDCONST	R9	K8
+      0x542A0167,  //  0015  LDINT	R10	360
+      0x7C100C00,  //  0016  CALL	R4	6
+      0xB8160C00,  //  0017  GETNGBL	R5	K6
+      0x8C140B07,  //  0018  GETMET	R5	R5	K7
+      0x881C0101,  //  0019  GETMBR	R7	R0	K1
+      0x58200008,  //  001A  LDCONST	R8	K8
+      0x542600FD,  //  001B  LDINT	R9	254
+      0x58280008,  //  001C  LDCONST	R10	K8
+      0x542E00FE,  //  001D  LDINT	R11	255
+      0x7C140C00,  //  001E  CALL	R5	6
+      0x7C080600,  //  001F  CALL	R2	3
+      0x60080018,  //  0020  GETGBL	R2	G24
+      0x580C0009,  //  0021  LDCONST	R3	K9
+      0x8810030A,  //  0022  GETMBR	R4	R1	K10
+      0x8814030B,  //  0023  GETMBR	R5	R1	K11
+      0x8818030C,  //  0024  GETMBR	R6	R1	K12
+      0x7C080800,  //  0025  CALL	R2	4
+      0x600C0018,  //  0026  GETGBL	R3	G24
+      0x5810000D,  //  0027  LDCONST	R4	K13
+      0x5C140400,  //  0028  MOVE	R5	R2
+      0x5C180400,  //  0029  MOVE	R6	R2
+      0x7C0C0600,  //  002A  CALL	R3	3
+      0x80040600,  //  002B  RET	1	R3
+      0x80061C00,  //  002C  RET	1	K14
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin_Light3
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
 be_local_class(Matter_Plugin_Light3,
     2,
     &be_class_Matter_Plugin_Light1,
-    be_nested_map(16,
+    be_nested_map(18,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(update_virtual, 1), be_const_closure(class_Matter_Plugin_Light3_update_virtual_closure) },
-        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light3_web_values_closure) },
+        { be_const_key_weak(ARG_HINT, 17), be_nested_str_weak(_Not_X20used_) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(light3) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(269, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Light3_init_closure) },
-        { be_const_key_weak(shadow_hue, -1), be_const_var(0) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Light3_update_shadow_closure) },
-        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Light_X203_X20RGB) },
-        { be_const_key_weak(UPDATE_COMMANDS, 15), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(4,
     ( (struct bvalue*) &(const bvalue[]) {
         be_nested_str_weak(Power),
@@ -983,9 +983,16 @@ be_local_class(Matter_Plugin_Light3,
         be_nested_str_weak(Hue),
         be_nested_str_weak(Sat),
     }))    ) } )) },
-        { be_const_key_weak(read_attribute, 2), be_const_closure(class_Matter_Plugin_Light3_read_attribute_closure) },
-        { be_const_key_weak(set_hue_sat, -1), be_const_closure(class_Matter_Plugin_Light3_set_hue_sat_closure) },
-        { be_const_key_weak(CLUSTERS, 8), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(shadow_hue, 13), be_const_var(0) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Light3_invoke_request_closure) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Light3_read_attribute_closure) },
+        { be_const_key_weak(update_shadow, 11), be_const_closure(class_Matter_Plugin_Light3_update_shadow_closure) },
+        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Light3_update_virtual_closure) },
+        { be_const_key_weak(ARG, 0), be_nested_str_weak() },
+        { be_const_key_weak(shadow_sat, -1), be_const_var(1) },
+        { be_const_key_weak(web_value_RGB, -1), be_const_closure(class_Matter_Plugin_Light3_web_value_RGB_closure) },
+        { be_const_key_weak(parse_status, 16), be_const_closure(class_Matter_Plugin_Light3_parse_status_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(8, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -1101,11 +1108,10 @@ be_local_class(Matter_Plugin_Light3,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, 12), be_const_closure(class_Matter_Plugin_Light3_invoke_request_closure) },
-        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Light3_parse_status_closure) },
-        { be_const_key_weak(TYPE, 6), be_nested_str_weak(light3) },
-        { be_const_key_weak(shadow_sat, -1), be_const_var(1) },
-        { be_const_key_weak(web_value_RGB, -1), be_const_closure(class_Matter_Plugin_Light3_web_value_RGB_closure) },
+        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Light3_web_values_closure) },
+        { be_const_key_weak(set_hue_sat, 12), be_const_closure(class_Matter_Plugin_Light3_set_hue_sat_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Light3_init_closure) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Light_X203_X20RGB) },
     })),
     be_str_weak(Matter_Plugin_Light3)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light1.h
@@ -40,13 +40,14 @@ extern const bclass be_class_Matter_Plugin_Light1;
 be_local_class(Matter_Plugin_Bridge_Light1,
     0,
     &be_class_Matter_Plugin_Light1,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(TYPE, 3), be_nested_str_weak(http_light1) },
-        { be_const_key_weak(UPDATE_TIME, 2), be_const_int(3000) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(3000) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(http_light1) },
         { be_const_key_weak(BRIDGE, -1), be_const_bool(1) },
+        { be_const_key_weak(ARG_HINT, 5), be_nested_str_weak(Relay_X3Cx_X3E_X20number) },
+        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(class_Matter_Plugin_Bridge_Light1__X3Clambda_X3E_closure) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak(relay) },
-        { be_const_key_weak(ARG_TYPE, 0), be_const_static_closure(class_Matter_Plugin_Bridge_Light1__X3Clambda_X3E_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_Light1)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light2.h
@@ -40,13 +40,14 @@ extern const bclass be_class_Matter_Plugin_Light2;
 be_local_class(Matter_Plugin_Bridge_Light2,
     0,
     &be_class_Matter_Plugin_Light2,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(TYPE, 3), be_nested_str_weak(http_light2) },
-        { be_const_key_weak(UPDATE_TIME, 2), be_const_int(3000) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(3000) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(http_light2) },
         { be_const_key_weak(BRIDGE, -1), be_const_bool(1) },
+        { be_const_key_weak(ARG_HINT, 5), be_nested_str_weak(Relay_X3Cx_X3E_X20number) },
+        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(class_Matter_Plugin_Bridge_Light2__X3Clambda_X3E_closure) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak(relay) },
-        { be_const_key_weak(ARG_TYPE, 0), be_const_static_closure(class_Matter_Plugin_Bridge_Light2__X3Clambda_X3E_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_Light2)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light3.h
@@ -40,13 +40,14 @@ extern const bclass be_class_Matter_Plugin_Light3;
 be_local_class(Matter_Plugin_Bridge_Light3,
     0,
     &be_class_Matter_Plugin_Light3,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(TYPE, 3), be_nested_str_weak(http_light3) },
-        { be_const_key_weak(UPDATE_TIME, 2), be_const_int(3000) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(3000) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(http_light3) },
         { be_const_key_weak(BRIDGE, -1), be_const_bool(1) },
+        { be_const_key_weak(ARG_HINT, 5), be_nested_str_weak(Relay_X3Cx_X3E_X20number) },
+        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(class_Matter_Plugin_Bridge_Light3__X3Clambda_X3E_closure) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak(relay) },
-        { be_const_key_weak(ARG_TYPE, 0), be_const_static_closure(class_Matter_Plugin_Bridge_Light3__X3Clambda_X3E_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_Light3)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -5795,24 +5795,24 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(START_ENDPOINT),
-    /* K3   */  be_nested_str_weak(light),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(channels),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_const_int(0),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(light),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(channels),
+    /* K8   */  be_nested_str_weak(),
     /* K9   */  be_const_int(1),
     /* K10  */  be_nested_str_weak(type),
     /* K11  */  be_nested_str_weak(light1),
     /* K12  */  be_const_int(2),
     /* K13  */  be_nested_str_weak(light2),
-    /* K14  */  be_nested_str_weak(light3),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(cmd),
-    /* K17  */  be_nested_str_weak(Status_X2013),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
-    /* K20  */  be_const_int(3),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(light3),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(cmd),
+    /* K18  */  be_nested_str_weak(Status_X2013),
+    /* K19  */  be_nested_str_weak(log),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
     /* K21  */  be_nested_str_weak(contains),
     /* K22  */  be_nested_str_weak(StatusSHT),
     /* K23  */  be_nested_str_weak(SHT),
@@ -5833,203 +5833,269 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
     }),
     be_str_weak(autoconf_device_map),
     &be_const_str_solidified,
-    ( &(const binstruction[196]) {  /* code */
+    ( &(const binstruction[262]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x60080013,  //  0001  GETGBL	R2	G19
       0x7C080000,  //  0002  CALL	R2	0
       0xB80E0200,  //  0003  GETNGBL	R3	K1
       0x880C0702,  //  0004  GETMBR	R3	R3	K2
-      0x50100000,  //  0005  LDBOOL	R4	0	0
-      0xA4160600,  //  0006  IMPORT	R5	K3
-      0x8C180B04,  //  0007  GETMET	R6	R5	K4
-      0x7C180200,  //  0008  CALL	R6	1
-      0x4C1C0000,  //  0009  LDNIL	R7
-      0x201C0C07,  //  000A  NE	R7	R6	R7
-      0x781E0024,  //  000B  JMPF	R7	#0031
-      0x601C000C,  //  000C  GETGBL	R7	G12
-      0x8C200D05,  //  000D  GETMET	R8	R6	K5
-      0x58280006,  //  000E  LDCONST	R10	K6
-      0x582C0007,  //  000F  LDCONST	R11	K7
-      0x7C200600,  //  0010  CALL	R8	3
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x24200F08,  //  0012  GT	R8	R7	K8
-      0x7822001C,  //  0013  JMPF	R8	#0031
-      0x1C200F09,  //  0014  EQ	R8	R7	K9
-      0x78220007,  //  0015  JMPF	R8	#001E
-      0x60200008,  //  0016  GETGBL	R8	G8
-      0x5C240600,  //  0017  MOVE	R9	R3
-      0x7C200200,  //  0018  CALL	R8	1
-      0x60240013,  //  0019  GETGBL	R9	G19
-      0x7C240000,  //  001A  CALL	R9	0
-      0x9826150B,  //  001B  SETIDX	R9	K10	K11
-      0x98081009,  //  001C  SETIDX	R2	R8	R9
-      0x70020010,  //  001D  JMP		#002F
-      0x1C200F0C,  //  001E  EQ	R8	R7	K12
-      0x78220007,  //  001F  JMPF	R8	#0028
-      0x60200008,  //  0020  GETGBL	R8	G8
-      0x5C240600,  //  0021  MOVE	R9	R3
-      0x7C200200,  //  0022  CALL	R8	1
-      0x60240013,  //  0023  GETGBL	R9	G19
-      0x7C240000,  //  0024  CALL	R9	0
-      0x9826150D,  //  0025  SETIDX	R9	K10	K13
-      0x98081009,  //  0026  SETIDX	R2	R8	R9
-      0x70020006,  //  0027  JMP		#002F
-      0x60200008,  //  0028  GETGBL	R8	G8
-      0x5C240600,  //  0029  MOVE	R9	R3
-      0x7C200200,  //  002A  CALL	R8	1
-      0x60240013,  //  002B  GETGBL	R9	G19
-      0x7C240000,  //  002C  CALL	R9	0
-      0x9826150E,  //  002D  SETIDX	R9	K10	K14
-      0x98081009,  //  002E  SETIDX	R2	R8	R9
-      0x50100200,  //  002F  LDBOOL	R4	1	0
-      0x000C0709,  //  0030  ADD	R3	R3	K9
-      0xB81E1E00,  //  0031  GETNGBL	R7	K15
-      0x8C1C0F10,  //  0032  GETMET	R7	R7	K16
-      0x58240011,  //  0033  LDCONST	R9	K17
-      0x50280200,  //  0034  LDBOOL	R10	1	0
-      0x7C1C0600,  //  0035  CALL	R7	3
-      0x60200012,  //  0036  GETGBL	R8	G18
-      0x7C200000,  //  0037  CALL	R8	0
-      0xB8262400,  //  0038  GETNGBL	R9	K18
-      0x60280008,  //  0039  GETGBL	R10	G8
-      0x5C2C0E00,  //  003A  MOVE	R11	R7
-      0x7C280200,  //  003B  CALL	R10	1
-      0x002A260A,  //  003C  ADD	R10	K19	R10
-      0x582C0014,  //  003D  LDCONST	R11	K20
-      0x7C240400,  //  003E  CALL	R9	2
-      0x4C240000,  //  003F  LDNIL	R9
-      0x20240E09,  //  0040  NE	R9	R7	R9
-      0x7826004D,  //  0041  JMPF	R9	#0090
-      0x8C240F15,  //  0042  GETMET	R9	R7	K21
-      0x582C0016,  //  0043  LDCONST	R11	K22
-      0x7C240400,  //  0044  CALL	R9	2
-      0x78260049,  //  0045  JMPF	R9	#0090
-      0x941C0F16,  //  0046  GETIDX	R7	R7	K22
-      0x58240008,  //  0047  LDCONST	R9	K8
-      0x50280200,  //  0048  LDBOOL	R10	1	0
-      0x782A0045,  //  0049  JMPF	R10	#0090
-      0x60280008,  //  004A  GETGBL	R10	G8
-      0x5C2C1200,  //  004B  MOVE	R11	R9
-      0x7C280200,  //  004C  CALL	R10	1
-      0x002A2E0A,  //  004D  ADD	R10	K23	R10
-      0x8C2C0F15,  //  004E  GETMET	R11	R7	K21
-      0x5C341400,  //  004F  MOVE	R13	R10
-      0x7C2C0400,  //  0050  CALL	R11	2
-      0x742E0000,  //  0051  JMPT	R11	#0053
-      0x7002003C,  //  0052  JMP		#0090
-      0x942C0E0A,  //  0053  GETIDX	R11	R7	R10
-      0xB8322400,  //  0054  GETNGBL	R12	K18
-      0x60340018,  //  0055  GETGBL	R13	G24
-      0x58380018,  //  0056  LDCONST	R14	K24
-      0x5C3C1400,  //  0057  MOVE	R15	R10
-      0x60400008,  //  0058  GETGBL	R16	G8
-      0x5C441600,  //  0059  MOVE	R17	R11
-      0x7C400200,  //  005A  CALL	R16	1
-      0x7C340600,  //  005B  CALL	R13	3
-      0x58380014,  //  005C  LDCONST	R14	K20
-      0x7C300400,  //  005D  CALL	R12	2
-      0x8C301705,  //  005E  GETMET	R12	R11	K5
-      0x58380019,  //  005F  LDCONST	R14	K25
-      0x543DFFFE,  //  0060  LDINT	R15	-1
-      0x7C300600,  //  0061  CALL	R12	3
-      0x8C341705,  //  0062  GETMET	R13	R11	K5
-      0x583C001A,  //  0063  LDCONST	R15	K26
-      0x5441FFFE,  //  0064  LDINT	R16	-1
-      0x7C340600,  //  0065  CALL	R13	3
-      0x24381908,  //  0066  GT	R14	R12	K8
-      0x783A0002,  //  0067  JMPF	R14	#006B
-      0x8C38111B,  //  0068  GETMET	R14	R8	K27
-      0x04401909,  //  0069  SUB	R16	R12	K9
-      0x7C380400,  //  006A  CALL	R14	2
-      0x24381B08,  //  006B  GT	R14	R13	K8
-      0x783A0002,  //  006C  JMPF	R14	#0070
-      0x8C38111B,  //  006D  GETMET	R14	R8	K27
-      0x04401B09,  //  006E  SUB	R16	R13	K9
-      0x7C380400,  //  006F  CALL	R14	2
-      0xB83A2400,  //  0070  GETNGBL	R14	K18
-      0x603C0018,  //  0071  GETGBL	R15	G24
-      0x5840001C,  //  0072  LDCONST	R16	K28
-      0x5C441800,  //  0073  MOVE	R17	R12
-      0x5C481A00,  //  0074  MOVE	R18	R13
-      0x7C3C0600,  //  0075  CALL	R15	3
-      0x58400014,  //  0076  LDCONST	R16	K20
-      0x7C380400,  //  0077  CALL	R14	2
-      0x8C381705,  //  0078  GETMET	R14	R11	K5
-      0x5840001D,  //  0079  LDCONST	R16	K29
-      0x7C380400,  //  007A  CALL	R14	2
-      0x783A0002,  //  007B  JMPF	R14	#007F
-      0x943C1D0C,  //  007C  GETIDX	R15	R14	K12
-      0x243C1F08,  //  007D  GT	R15	R15	K8
-      0x743E0000,  //  007E  JMPT	R15	#0080
-      0x503C0001,  //  007F  LDBOOL	R15	0	1
-      0x503C0200,  //  0080  LDBOOL	R15	1	0
-      0x60400008,  //  0081  GETGBL	R16	G8
-      0x5C440600,  //  0082  MOVE	R17	R3
-      0x7C400200,  //  0083  CALL	R16	1
-      0x60440013,  //  0084  GETGBL	R17	G19
-      0x7C440000,  //  0085  CALL	R17	0
-      0x783E0001,  //  0086  JMPF	R15	#0089
-      0x5848001E,  //  0087  LDCONST	R18	K30
-      0x70020000,  //  0088  JMP		#008A
-      0x5848001F,  //  0089  LDCONST	R18	K31
-      0x98461412,  //  008A  SETIDX	R17	K10	R18
-      0x98463E09,  //  008B  SETIDX	R17	K31	R9
-      0x98082011,  //  008C  SETIDX	R2	R16	R17
-      0x000C0709,  //  008D  ADD	R3	R3	K9
-      0x00241309,  //  008E  ADD	R9	R9	K9
-      0x7001FFB7,  //  008F  JMP		#0048
-      0x6024000C,  //  0090  GETGBL	R9	G12
-      0xB82A1E00,  //  0091  GETNGBL	R10	K15
-      0x8C281520,  //  0092  GETMET	R10	R10	K32
-      0x7C280200,  //  0093  CALL	R10	1
-      0x7C240200,  //  0094  CALL	R9	1
-      0x58280008,  //  0095  LDCONST	R10	K8
-      0x78120000,  //  0096  JMPF	R4	#0098
-      0x04241309,  //  0097  SUB	R9	R9	K9
-      0x142C1409,  //  0098  LT	R11	R10	R9
-      0x782E0011,  //  0099  JMPF	R11	#00AC
-      0x8C2C1105,  //  009A  GETMET	R11	R8	K5
-      0x5C341400,  //  009B  MOVE	R13	R10
-      0x7C2C0400,  //  009C  CALL	R11	2
-      0x4C300000,  //  009D  LDNIL	R12
-      0x1C2C160C,  //  009E  EQ	R11	R11	R12
-      0x782E0009,  //  009F  JMPF	R11	#00AA
-      0x602C0008,  //  00A0  GETGBL	R11	G8
-      0x5C300600,  //  00A1  MOVE	R12	R3
-      0x7C2C0200,  //  00A2  CALL	R11	1
-      0x60300013,  //  00A3  GETGBL	R12	G19
-      0x7C300000,  //  00A4  CALL	R12	0
-      0x98321521,  //  00A5  SETIDX	R12	K10	K33
-      0x00341509,  //  00A6  ADD	R13	R10	K9
-      0x9832420D,  //  00A7  SETIDX	R12	K33	R13
-      0x9808160C,  //  00A8  SETIDX	R2	R11	R12
-      0x000C0709,  //  00A9  ADD	R3	R3	K9
-      0x00281509,  //  00AA  ADD	R10	R10	K9
-      0x7001FFEB,  //  00AB  JMP		#0098
-      0x8C2C0322,  //  00AC  GETMET	R11	R1	K34
-      0xB8361E00,  //  00AD  GETNGBL	R13	K15
-      0x8C341B23,  //  00AE  GETMET	R13	R13	K35
-      0x7C340200,  //  00AF  CALL	R13	1
-      0x7C2C0400,  //  00B0  CALL	R11	2
-      0x8C300124,  //  00B1  GETMET	R12	R0	K36
-      0x5C381600,  //  00B2  MOVE	R14	R11
-      0x7C300400,  //  00B3  CALL	R12	2
-      0x60340010,  //  00B4  GETGBL	R13	G16
-      0x5C381800,  //  00B5  MOVE	R14	R12
-      0x7C340200,  //  00B6  CALL	R13	1
-      0xA8020007,  //  00B7  EXBLK	0	#00C0
-      0x5C381A00,  //  00B8  MOVE	R14	R13
-      0x7C380000,  //  00B9  CALL	R14	0
-      0x603C0008,  //  00BA  GETGBL	R15	G8
-      0x5C400600,  //  00BB  MOVE	R16	R3
-      0x7C3C0200,  //  00BC  CALL	R15	1
-      0x98081E0E,  //  00BD  SETIDX	R2	R15	R14
-      0x000C0709,  //  00BE  ADD	R3	R3	K9
-      0x7001FFF7,  //  00BF  JMP		#00B8
-      0x58340025,  //  00C0  LDCONST	R13	K37
-      0xAC340200,  //  00C1  CATCH	R13	1	0
-      0xB0080000,  //  00C2  RAISE	2	R0	R0
-      0x80040400,  //  00C3  RET	1	R2
+      0x58100003,  //  0005  LDCONST	R4	K3
+      0xA4160800,  //  0006  IMPORT	R5	K4
+      0x8C180B05,  //  0007  GETMET	R6	R5	K5
+      0x58200003,  //  0008  LDCONST	R8	K3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x201C0C07,  //  000B  NE	R7	R6	R7
+      0x781E0066,  //  000C  JMPF	R7	#0074
+      0x601C000C,  //  000D  GETGBL	R7	G12
+      0x8C200D06,  //  000E  GETMET	R8	R6	K6
+      0x58280007,  //  000F  LDCONST	R10	K7
+      0x582C0008,  //  0010  LDCONST	R11	K8
+      0x7C200600,  //  0011  CALL	R8	3
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0x58100009,  //  0013  LDCONST	R4	K9
+      0x24200F03,  //  0014  GT	R8	R7	K3
+      0x7822005D,  //  0015  JMPF	R8	#0074
+      0x1C200F09,  //  0016  EQ	R8	R7	K9
+      0x7822001E,  //  0017  JMPF	R8	#0037
+      0x60200008,  //  0018  GETGBL	R8	G8
+      0x5C240600,  //  0019  MOVE	R9	R3
+      0x7C200200,  //  001A  CALL	R8	1
+      0x60240013,  //  001B  GETGBL	R9	G19
+      0x7C240000,  //  001C  CALL	R9	0
+      0x9826150B,  //  001D  SETIDX	R9	K10	K11
+      0x98081009,  //  001E  SETIDX	R2	R8	R9
+      0x000C0709,  //  001F  ADD	R3	R3	K9
+      0x58200009,  //  0020  LDCONST	R8	K9
+      0x4C240000,  //  0021  LDNIL	R9
+      0x8C280B05,  //  0022  GETMET	R10	R5	K5
+      0x5C301000,  //  0023  MOVE	R12	R8
+      0x7C280400,  //  0024  CALL	R10	2
+      0x5C241400,  //  0025  MOVE	R9	R10
+      0x4C2C0000,  //  0026  LDNIL	R11
+      0x2028140B,  //  0027  NE	R10	R10	R11
+      0x782A000C,  //  0028  JMPF	R10	#0036
+      0x60280008,  //  0029  GETGBL	R10	G8
+      0x5C2C0600,  //  002A  MOVE	R11	R3
+      0x7C280200,  //  002B  CALL	R10	1
+      0x602C0013,  //  002C  GETGBL	R11	G19
+      0x7C2C0000,  //  002D  CALL	R11	0
+      0x982E150B,  //  002E  SETIDX	R11	K10	K11
+      0x00301109,  //  002F  ADD	R12	R8	K9
+      0x982E080C,  //  0030  SETIDX	R11	K4	R12
+      0x9808140B,  //  0031  SETIDX	R2	R10	R11
+      0x000C0709,  //  0032  ADD	R3	R3	K9
+      0x00100909,  //  0033  ADD	R4	R4	K9
+      0x00201109,  //  0034  ADD	R8	R8	K9
+      0x7001FFEB,  //  0035  JMP		#0022
+      0x7002003C,  //  0036  JMP		#0074
+      0x1C200F0C,  //  0037  EQ	R8	R7	K12
+      0x78220008,  //  0038  JMPF	R8	#0042
+      0x60200008,  //  0039  GETGBL	R8	G8
+      0x5C240600,  //  003A  MOVE	R9	R3
+      0x7C200200,  //  003B  CALL	R8	1
+      0x60240013,  //  003C  GETGBL	R9	G19
+      0x7C240000,  //  003D  CALL	R9	0
+      0x9826150D,  //  003E  SETIDX	R9	K10	K13
+      0x98081009,  //  003F  SETIDX	R2	R8	R9
+      0x000C0709,  //  0040  ADD	R3	R3	K9
+      0x70020031,  //  0041  JMP		#0074
+      0x1C200F0E,  //  0042  EQ	R8	R7	K14
+      0x7822002B,  //  0043  JMPF	R8	#0070
+      0x60200008,  //  0044  GETGBL	R8	G8
+      0x5C240600,  //  0045  MOVE	R9	R3
+      0x7C200200,  //  0046  CALL	R8	1
+      0x60240013,  //  0047  GETGBL	R9	G19
+      0x7C240000,  //  0048  CALL	R9	0
+      0x9826150F,  //  0049  SETIDX	R9	K10	K15
+      0x98081009,  //  004A  SETIDX	R2	R8	R9
+      0x000C0709,  //  004B  ADD	R3	R3	K9
+      0x8C200B05,  //  004C  GETMET	R8	R5	K5
+      0x58280009,  //  004D  LDCONST	R10	K9
+      0x7C200400,  //  004E  CALL	R8	2
+      0x4C240000,  //  004F  LDNIL	R9
+      0x20241009,  //  0050  NE	R9	R8	R9
+      0x7826001C,  //  0051  JMPF	R9	#006F
+      0x6024000C,  //  0052  GETGBL	R9	G12
+      0x8C281106,  //  0053  GETMET	R10	R8	K6
+      0x58300007,  //  0054  LDCONST	R12	K7
+      0x58340008,  //  0055  LDCONST	R13	K8
+      0x7C280600,  //  0056  CALL	R10	3
+      0x7C240200,  //  0057  CALL	R9	1
+      0x1C281309,  //  0058  EQ	R10	R9	K9
+      0x782A0009,  //  0059  JMPF	R10	#0064
+      0x60280008,  //  005A  GETGBL	R10	G8
+      0x5C2C0600,  //  005B  MOVE	R11	R3
+      0x7C280200,  //  005C  CALL	R10	1
+      0x602C0013,  //  005D  GETGBL	R11	G19
+      0x7C2C0000,  //  005E  CALL	R11	0
+      0x982E150B,  //  005F  SETIDX	R11	K10	K11
+      0x9808140B,  //  0060  SETIDX	R2	R10	R11
+      0x000C0709,  //  0061  ADD	R3	R3	K9
+      0x00100909,  //  0062  ADD	R4	R4	K9
+      0x7002000A,  //  0063  JMP		#006F
+      0x1C28130C,  //  0064  EQ	R10	R9	K12
+      0x782A0008,  //  0065  JMPF	R10	#006F
+      0x60280008,  //  0066  GETGBL	R10	G8
+      0x5C2C0600,  //  0067  MOVE	R11	R3
+      0x7C280200,  //  0068  CALL	R10	1
+      0x602C0013,  //  0069  GETGBL	R11	G19
+      0x7C2C0000,  //  006A  CALL	R11	0
+      0x982E150D,  //  006B  SETIDX	R11	K10	K13
+      0x9808140B,  //  006C  SETIDX	R2	R10	R11
+      0x000C0709,  //  006D  ADD	R3	R3	K9
+      0x00100909,  //  006E  ADD	R4	R4	K9
+      0x70020003,  //  006F  JMP		#0074
+      0x54220003,  //  0070  LDINT	R8	4
+      0x1C200E08,  //  0071  EQ	R8	R7	R8
+      0x78220000,  //  0072  JMPF	R8	#0074
+      0x7001FFFF,  //  0073  JMP		#0074
+      0xB81E2000,  //  0074  GETNGBL	R7	K16
+      0x8C1C0F11,  //  0075  GETMET	R7	R7	K17
+      0x58240012,  //  0076  LDCONST	R9	K18
+      0x50280200,  //  0077  LDBOOL	R10	1	0
+      0x7C1C0600,  //  0078  CALL	R7	3
+      0x60200012,  //  0079  GETGBL	R8	G18
+      0x7C200000,  //  007A  CALL	R8	0
+      0xB8262600,  //  007B  GETNGBL	R9	K19
+      0x60280008,  //  007C  GETGBL	R10	G8
+      0x5C2C0E00,  //  007D  MOVE	R11	R7
+      0x7C280200,  //  007E  CALL	R10	1
+      0x002A280A,  //  007F  ADD	R10	K20	R10
+      0x582C000E,  //  0080  LDCONST	R11	K14
+      0x7C240400,  //  0081  CALL	R9	2
+      0x4C240000,  //  0082  LDNIL	R9
+      0x20240E09,  //  0083  NE	R9	R7	R9
+      0x7826004D,  //  0084  JMPF	R9	#00D3
+      0x8C240F15,  //  0085  GETMET	R9	R7	K21
+      0x582C0016,  //  0086  LDCONST	R11	K22
+      0x7C240400,  //  0087  CALL	R9	2
+      0x78260049,  //  0088  JMPF	R9	#00D3
+      0x941C0F16,  //  0089  GETIDX	R7	R7	K22
+      0x58240003,  //  008A  LDCONST	R9	K3
+      0x50280200,  //  008B  LDBOOL	R10	1	0
+      0x782A0045,  //  008C  JMPF	R10	#00D3
+      0x60280008,  //  008D  GETGBL	R10	G8
+      0x5C2C1200,  //  008E  MOVE	R11	R9
+      0x7C280200,  //  008F  CALL	R10	1
+      0x002A2E0A,  //  0090  ADD	R10	K23	R10
+      0x8C2C0F15,  //  0091  GETMET	R11	R7	K21
+      0x5C341400,  //  0092  MOVE	R13	R10
+      0x7C2C0400,  //  0093  CALL	R11	2
+      0x742E0000,  //  0094  JMPT	R11	#0096
+      0x7002003C,  //  0095  JMP		#00D3
+      0x942C0E0A,  //  0096  GETIDX	R11	R7	R10
+      0xB8322600,  //  0097  GETNGBL	R12	K19
+      0x60340018,  //  0098  GETGBL	R13	G24
+      0x58380018,  //  0099  LDCONST	R14	K24
+      0x5C3C1400,  //  009A  MOVE	R15	R10
+      0x60400008,  //  009B  GETGBL	R16	G8
+      0x5C441600,  //  009C  MOVE	R17	R11
+      0x7C400200,  //  009D  CALL	R16	1
+      0x7C340600,  //  009E  CALL	R13	3
+      0x5838000E,  //  009F  LDCONST	R14	K14
+      0x7C300400,  //  00A0  CALL	R12	2
+      0x8C301706,  //  00A1  GETMET	R12	R11	K6
+      0x58380019,  //  00A2  LDCONST	R14	K25
+      0x543DFFFE,  //  00A3  LDINT	R15	-1
+      0x7C300600,  //  00A4  CALL	R12	3
+      0x8C341706,  //  00A5  GETMET	R13	R11	K6
+      0x583C001A,  //  00A6  LDCONST	R15	K26
+      0x5441FFFE,  //  00A7  LDINT	R16	-1
+      0x7C340600,  //  00A8  CALL	R13	3
+      0x24381903,  //  00A9  GT	R14	R12	K3
+      0x783A0002,  //  00AA  JMPF	R14	#00AE
+      0x8C38111B,  //  00AB  GETMET	R14	R8	K27
+      0x04401909,  //  00AC  SUB	R16	R12	K9
+      0x7C380400,  //  00AD  CALL	R14	2
+      0x24381B03,  //  00AE  GT	R14	R13	K3
+      0x783A0002,  //  00AF  JMPF	R14	#00B3
+      0x8C38111B,  //  00B0  GETMET	R14	R8	K27
+      0x04401B09,  //  00B1  SUB	R16	R13	K9
+      0x7C380400,  //  00B2  CALL	R14	2
+      0xB83A2600,  //  00B3  GETNGBL	R14	K19
+      0x603C0018,  //  00B4  GETGBL	R15	G24
+      0x5840001C,  //  00B5  LDCONST	R16	K28
+      0x5C441800,  //  00B6  MOVE	R17	R12
+      0x5C481A00,  //  00B7  MOVE	R18	R13
+      0x7C3C0600,  //  00B8  CALL	R15	3
+      0x5840000E,  //  00B9  LDCONST	R16	K14
+      0x7C380400,  //  00BA  CALL	R14	2
+      0x8C381706,  //  00BB  GETMET	R14	R11	K6
+      0x5840001D,  //  00BC  LDCONST	R16	K29
+      0x7C380400,  //  00BD  CALL	R14	2
+      0x783A0002,  //  00BE  JMPF	R14	#00C2
+      0x943C1D0C,  //  00BF  GETIDX	R15	R14	K12
+      0x243C1F03,  //  00C0  GT	R15	R15	K3
+      0x743E0000,  //  00C1  JMPT	R15	#00C3
+      0x503C0001,  //  00C2  LDBOOL	R15	0	1
+      0x503C0200,  //  00C3  LDBOOL	R15	1	0
+      0x60400008,  //  00C4  GETGBL	R16	G8
+      0x5C440600,  //  00C5  MOVE	R17	R3
+      0x7C400200,  //  00C6  CALL	R16	1
+      0x60440013,  //  00C7  GETGBL	R17	G19
+      0x7C440000,  //  00C8  CALL	R17	0
+      0x783E0001,  //  00C9  JMPF	R15	#00CC
+      0x5848001E,  //  00CA  LDCONST	R18	K30
+      0x70020000,  //  00CB  JMP		#00CD
+      0x5848001F,  //  00CC  LDCONST	R18	K31
+      0x98461412,  //  00CD  SETIDX	R17	K10	R18
+      0x98463E09,  //  00CE  SETIDX	R17	K31	R9
+      0x98082011,  //  00CF  SETIDX	R2	R16	R17
+      0x000C0709,  //  00D0  ADD	R3	R3	K9
+      0x00241309,  //  00D1  ADD	R9	R9	K9
+      0x7001FFB7,  //  00D2  JMP		#008B
+      0x6024000C,  //  00D3  GETGBL	R9	G12
+      0xB82A2000,  //  00D4  GETNGBL	R10	K16
+      0x8C281520,  //  00D5  GETMET	R10	R10	K32
+      0x7C280200,  //  00D6  CALL	R10	1
+      0x7C240200,  //  00D7  CALL	R9	1
+      0x58280003,  //  00D8  LDCONST	R10	K3
+      0x04241204,  //  00D9  SUB	R9	R9	R4
+      0x142C1409,  //  00DA  LT	R11	R10	R9
+      0x782E0011,  //  00DB  JMPF	R11	#00EE
+      0x8C2C1106,  //  00DC  GETMET	R11	R8	K6
+      0x5C341400,  //  00DD  MOVE	R13	R10
+      0x7C2C0400,  //  00DE  CALL	R11	2
+      0x4C300000,  //  00DF  LDNIL	R12
+      0x1C2C160C,  //  00E0  EQ	R11	R11	R12
+      0x782E0009,  //  00E1  JMPF	R11	#00EC
+      0x602C0008,  //  00E2  GETGBL	R11	G8
+      0x5C300600,  //  00E3  MOVE	R12	R3
+      0x7C2C0200,  //  00E4  CALL	R11	1
+      0x60300013,  //  00E5  GETGBL	R12	G19
+      0x7C300000,  //  00E6  CALL	R12	0
+      0x98321521,  //  00E7  SETIDX	R12	K10	K33
+      0x00341509,  //  00E8  ADD	R13	R10	K9
+      0x9832420D,  //  00E9  SETIDX	R12	K33	R13
+      0x9808160C,  //  00EA  SETIDX	R2	R11	R12
+      0x000C0709,  //  00EB  ADD	R3	R3	K9
+      0x00281509,  //  00EC  ADD	R10	R10	K9
+      0x7001FFEB,  //  00ED  JMP		#00DA
+      0x8C2C0322,  //  00EE  GETMET	R11	R1	K34
+      0xB8362000,  //  00EF  GETNGBL	R13	K16
+      0x8C341B23,  //  00F0  GETMET	R13	R13	K35
+      0x7C340200,  //  00F1  CALL	R13	1
+      0x7C2C0400,  //  00F2  CALL	R11	2
+      0x8C300124,  //  00F3  GETMET	R12	R0	K36
+      0x5C381600,  //  00F4  MOVE	R14	R11
+      0x7C300400,  //  00F5  CALL	R12	2
+      0x60340010,  //  00F6  GETGBL	R13	G16
+      0x5C381800,  //  00F7  MOVE	R14	R12
+      0x7C340200,  //  00F8  CALL	R13	1
+      0xA8020007,  //  00F9  EXBLK	0	#0102
+      0x5C381A00,  //  00FA  MOVE	R14	R13
+      0x7C380000,  //  00FB  CALL	R14	0
+      0x603C0008,  //  00FC  GETGBL	R15	G8
+      0x5C400600,  //  00FD  MOVE	R16	R3
+      0x7C3C0200,  //  00FE  CALL	R15	1
+      0x98081E0E,  //  00FF  SETIDX	R2	R15	R14
+      0x000C0709,  //  0100  ADD	R3	R3	K9
+      0x7001FFF7,  //  0101  JMP		#00FA
+      0x58340025,  //  0102  LDCONST	R13	K37
+      0xAC340200,  //  0103  CATCH	R13	1	0
+      0xB0080000,  //  0104  RAISE	2	R0	R0
+      0x80040400,  //  0105  RET	1	R2
     })
   )
 );

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_light.ino
@@ -105,7 +105,7 @@ extern "C" {
           }
         }
       } else { // Light.pwm_multi_channels
-        if ((light_num >= 0) && (light_num < LST_MAX)) {
+        if ((light_num >= 0) && (light_num < LST_MAX) && (light_num < Light.subtype)) {
           data_present = true;
           be_map_insert_bool(vm, "power", Light.power & (1 << light_num));
           be_map_insert_int(vm, "bri", Light.current_color[light_num]);
@@ -221,56 +221,72 @@ extern "C" {
         }
       }
 
-      // ct
-      if (has_ct) {
-        light_controller.changeCTB(val_ct, light_state.getBriCT());
-      }
-
-      // hue
-      if (has_hue) {
-        uint8_t sat;
-        uint8_t bri;
-        light_state.getHSB(nullptr, &sat, &bri);
-        light_controller.changeHSB(val_hue, sat, bri);
-      }
-
-      // sat
-      if (has_sat) {
-        uint16_t hue;
-        uint8_t bri;
-        light_state.getHSB(&hue, nullptr, &bri);
-        light_controller.changeHSB(hue, val_sat, bri);
-      }
-
-      // rgb
-      if (has_rgb) {
-        SBuffer buf = SBuffer::SBufferFromHex(val_rgb_s, strlen(val_rgb_s));
-        uint8_t channels[LST_MAX] = {};
-        memcpy(channels, buf.buf(), buf.len() > LST_MAX ? LST_MAX : buf.len());
-        bool on = false;    // if all are zero, then only set power off
-        for (uint32_t i = 0; i < LST_MAX; i++) {
-          if (channels[i] != 0) { on = true; }
+      if (!Light.pwm_multi_channels) {
+        // ct
+        if (has_ct) {
+          light_controller.changeCTB(val_ct, light_state.getBriCT());
         }
-        if (on) {
-          light_controller.changeChannels(channels);
-        } else {
-          ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
-        }
-      }
 
-      // channels
-      if (has_channels) {
-        if (val_on) {
-          light_controller.changeChannels(channels);
-        } else {
-          ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
+        // hue
+        if (has_hue) {
+          uint8_t sat;
+          uint8_t bri;
+          light_state.getHSB(nullptr, &sat, &bri);
+          light_controller.changeHSB(val_hue, sat, bri);
         }
-      }
 
-      // bri is done after channels and rgb
-      // bri
-      if (has_bri) {
-        light_controller.changeBri(val_bri);
+        // sat
+        if (has_sat) {
+          uint16_t hue;
+          uint8_t bri;
+          light_state.getHSB(&hue, nullptr, &bri);
+          light_controller.changeHSB(hue, val_sat, bri);
+        }
+
+        // rgb
+        if (has_rgb) {
+          SBuffer buf = SBuffer::SBufferFromHex(val_rgb_s, strlen(val_rgb_s));
+          uint8_t channels[LST_MAX] = {};
+          memcpy(channels, buf.buf(), buf.len() > LST_MAX ? LST_MAX : buf.len());
+          bool on = false;    // if all are zero, then only set power off
+          for (uint32_t i = 0; i < LST_MAX; i++) {
+            if (channels[i] != 0) { on = true; }
+          }
+          if (on) {
+            light_controller.changeChannels(channels);
+          } else {
+            ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
+          }
+        }
+
+        // channels
+        if (has_channels) {
+          if (val_on) {
+            light_controller.changeChannels(channels);
+          } else {
+            ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
+          }
+        }
+
+        // bri is done after channels and rgb
+        // bri
+        if (has_bri) {
+          if (light_controller.isCTRGBLinked()) {
+            light_controller.changeBri(val_bri);
+          } else {
+            if (idx == 0) {
+              light_controller.changeBriRGB(val_bri);
+            } else {
+              light_controller.changeBriCT(val_bri);
+            }
+          }
+        }
+      } else {
+        // multi-channel (SetOption68 1)
+        // bri
+        if (has_bri) {
+          LightSetBri(Light.device + idx, val_bri);
+        }
       }
 
       push_getlight(vm, idx);


### PR DESCRIPTION
## Description:

Matter support for new split light modes:

### RGB and White Split

See [RGB and White Split](https://tasmota.github.io/docs/Lights/#rgb-and-white-split) enabled with `SetOption37 128`.

4 channels lights are split as 1 RGB and 1 Dimmer:
![image](https://github.com/user-attachments/assets/0d8ba0f8-425f-465c-8013-1575ea4c8e91)

5 channels light are split as 1 RGB and 1 CT:
![image](https://github.com/user-attachments/assets/daf3e8f5-69af-4e53-a29b-e058fe9c9da0)

### Independent PWM Channels

See [Independent PWM Channels](https://tasmota.github.io/docs/Lights/#independent-pwm-channels) enabled with `SetOption68 1`

All channels are defined as independant Light Dimmers:
![image](https://github.com/user-attachments/assets/e077fb97-a501-4932-8e5c-6bc7f1f4e057)

Note: the first Dimmer has no parameter and is mapped to the default (first) channel. Other channels need an additional `light` parameter to map to the appropriate channel (numbering starts with `1` which is also the default).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
