### PR TITLE
Berry fix `bytes` setters and getters with negative offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Berry fix `light.get` for separate RGB/CT
+- Berry fix `bytes` setters and getters with negative offsets
 
 ### Removed
 


### PR DESCRIPTION
## Description:

Applying patch from upstream https://github.com/berry-lang/berry/pull/440

`bytes` methods: `get`, `getfloat`, `set`, `setfloat`, `setbytes`, `reverse` and `setitem` now accept a negative offset which counts for number of bytes starting from the end  towards the beginning.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
