### PR TITLE
Berry internal: remove class from closure to simplify code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - Berry fix `bytes` setters and getters with negative offsets
 
 ### Removed
-
+- Berry internal: remove class from closure to simplify code
 
 ## [14.1.0.3] 20240722
 ### Added

--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -544,22 +544,6 @@ BERRY_API bbool be_classof(bvm *vm, int index)
         binstance *ins = var_toobj(v);
         var_setclass(top, be_instance_class(ins));
         return btrue;
-    } else if (var_isclosure(v)) {
-        bclosure *cl = var_toobj(v);
-        bproto *pr = cl->proto;
-        if (pr != NULL) {
-            bclass *cla;
-            if (pr->nproto > 0) {
-                cla = (bclass*) pr->ptab[pr->nproto];
-            } else {
-                cla = (bclass*) pr->ptab;
-            }
-            if (cla && var_basetype(cla) == BE_CLASS) {
-                bvalue *top = be_incrtop(vm);
-                var_setclass(top, cla);
-                return btrue;
-            }
-        }
     }
     return bfalse;
 }

--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -524,8 +524,8 @@ static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int ver
 {
     int size = (int)load_long(fp); /* proto count */
     if (size) {
-        bproto **p = be_malloc(vm, sizeof(bproto *) * (size + 1));
-        memset(p, 0, sizeof(bproto *) * (size + 1));
+        bproto **p = be_malloc(vm, sizeof(bproto *) * size);
+        memset(p, 0, sizeof(bproto *) * size);
         proto->ptab = p;
         proto->nproto = size;
         while (size--) {

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -311,7 +311,7 @@ static void setupvals(bfuncinfo *finfo)
 }
 
 /* Function is complete, finalize bproto */
-static void end_func(bparser *parser, bclass *c)
+static void end_func(bparser *parser)
 {
     bvm *vm = parser->vm;
     bfuncinfo *finfo = parser->finfo;
@@ -324,14 +324,8 @@ static void end_func(bparser *parser, bclass *c)
     proto->codesize = finfo->pc;
     proto->ktab = be_vector_release(vm, &finfo->kvec);
     proto->nconst = be_vector_count(&finfo->kvec);
-    /* special case here */
     proto->nproto = be_vector_count(&finfo->pvec);
-    if (proto->nproto == 0) {
-        proto->ptab = (void*) c;
-    } else {
-        be_vector_push_c(vm, &finfo->pvec, (void*) &c);
-        proto->ptab = be_vector_release(vm, &finfo->pvec);
-    }
+    proto->ptab = be_vector_release(vm, &finfo->pvec);
 #if BE_USE_MEM_ALIGNED
     proto->code = be_move_to_aligned(vm, proto->code, proto->codesize * sizeof(binstruction));     /* move `code` to 4-bytes aligned memory region */
     proto->ktab = be_move_to_aligned(vm, proto->ktab, proto->nconst * sizeof(bvalue));     /* move `ktab` to 4-bytes aligned memory region */
@@ -644,7 +638,7 @@ static bproto* funcbody(bparser *parser, bstring *name, bclass *c, int type)
         finfo.proto->varg |= BE_VA_STATICMETHOD;
     }
     stmtlist(parser); /* parse statement without final `end` */
-    end_func(parser, c); /* close function context */
+    end_func(parser); /* close function context */
     match_token(parser, KeyEnd); /* skip 'end' */
     return finfo.proto; /* return fully constructed `bproto` */
 }
@@ -700,7 +694,7 @@ static void lambda_expr(bparser *parser, bexpdesc *e)
     expr(parser, &e1);
     check_var(parser, &e1);
     be_code_ret(parser->finfo, &e1);
-    end_func(parser, NULL);
+    end_func(parser);
     init_exp(e, ETPROTO, be_code_proto(parser->finfo, finfo.proto));
     be_stackpop(parser->vm, 1);
 }
@@ -1827,7 +1821,7 @@ static void mainfunc(bparser *parser, bclosure *cl)
     cl->proto = finfo.proto;
     be_remove(parser->vm, -3);  /* pop proto from stack */
     stmtlist(parser);
-    end_func(parser, NULL);
+    end_func(parser);
     match_token(parser, TokenEOS); /* skip EOS */
 }
 

--- a/lib/libesp32/berry/tests/class.be
+++ b/lib/libesp32/berry/tests/class.be
@@ -58,18 +58,3 @@ assert(type(c4.c) == 'class')
 c5 = c4.c()
 assert(type(c5) == 'instance')
 assert(classname(c5) == 'map')
-
-#- classof now gets back the class of Berry methods -#
-class A
-    def f() end
-    static def g() end
-end
-class B : A
-    def h() end
-end
-assert(classof(A.f) == A)
-assert(classof(A.g) == A)
-assert(classof(B.h) == B)
-#- returns nil if native function of not in class -#
-assert(classof(int) == nil)
-assert(classof(def () end) == nil)

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Animate_core;
 /********************************************************************
 ** Solidified function: clear
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_clear,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Animate_core_clear,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(stop),
@@ -43,7 +42,6 @@ be_local_closure(class_Animate_core_clear,   /* name */
 /********************************************************************
 ** Solidified function: set_strip_bri
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_set_strip_bri,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -52,7 +50,7 @@ be_local_closure(class_Animate_core_set_strip_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(strip),
@@ -86,7 +84,6 @@ be_local_closure(class_Animate_core_set_strip_bri,   /* name */
 /********************************************************************
 ** Solidified function: remove_painter
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_remove_painter,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -95,7 +92,7 @@ be_local_closure(class_Animate_core_remove_painter,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(painters),
@@ -128,7 +125,6 @@ be_local_closure(class_Animate_core_remove_painter,   /* name */
 /********************************************************************
 ** Solidified function: stop
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_stop,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -137,7 +133,7 @@ be_local_closure(class_Animate_core_stop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(running),
@@ -180,7 +176,6 @@ be_local_closure(class_Animate_core_stop,   /* name */
 /********************************************************************
 ** Solidified function: get_bri
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_get_bri,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -189,7 +184,7 @@ be_local_closure(class_Animate_core_get_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(bri),
@@ -208,7 +203,6 @@ be_local_closure(class_Animate_core_get_bri,   /* name */
 /********************************************************************
 ** Solidified function: set_bri
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_set_bri,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -217,7 +211,7 @@ be_local_closure(class_Animate_core_set_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(bri),
@@ -239,7 +233,6 @@ be_local_closure(class_Animate_core_set_bri,   /* name */
 /********************************************************************
 ** Solidified function: add_painter
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_add_painter,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -248,7 +241,7 @@ be_local_closure(class_Animate_core_add_painter,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(painters),
@@ -279,7 +272,6 @@ be_local_closure(class_Animate_core_add_painter,   /* name */
 /********************************************************************
 ** Solidified function: fast_loop
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_fast_loop,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -288,7 +280,7 @@ be_local_closure(class_Animate_core_fast_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(running),
@@ -416,7 +408,6 @@ be_local_closure(class_Animate_core_fast_loop,   /* name */
 /********************************************************************
 ** Solidified function: remove_animator
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_remove_animator,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -425,7 +416,7 @@ be_local_closure(class_Animate_core_remove_animator,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(animators),
@@ -458,7 +449,6 @@ be_local_closure(class_Animate_core_remove_animator,   /* name */
 /********************************************************************
 ** Solidified function: animate
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_animate,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -467,7 +457,7 @@ be_local_closure(class_Animate_core_animate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(animate),
@@ -483,7 +473,6 @@ be_local_closure(class_Animate_core_animate,   /* name */
 /********************************************************************
 ** Solidified function: set_current
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_set_current,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -492,7 +481,7 @@ be_local_closure(class_Animate_core_set_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -513,7 +502,6 @@ be_local_closure(class_Animate_core_set_current,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -522,7 +510,7 @@ be_local_closure(class_Animate_core_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -532,7 +520,7 @@ be_local_closure(class_Animate_core_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(fast_loop),
@@ -546,7 +534,6 @@ be_local_closure(class_Animate_core_init,   /* name */
           0x80000000,  //  0003  RET	0
         })
       ),
-    &be_class_Animate_core, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
@@ -615,7 +602,6 @@ be_local_closure(class_Animate_core_init,   /* name */
 /********************************************************************
 ** Solidified function: set_cb
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_set_cb,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -624,7 +610,7 @@ be_local_closure(class_Animate_core_set_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(obj),
@@ -645,7 +631,6 @@ be_local_closure(class_Animate_core_set_cb,   /* name */
 /********************************************************************
 ** Solidified function: set_back_color
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_set_back_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -654,7 +639,7 @@ be_local_closure(class_Animate_core_set_back_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(back_color),
@@ -673,7 +658,6 @@ be_local_closure(class_Animate_core_set_back_color,   /* name */
 /********************************************************************
 ** Solidified function: add_background_animator
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_add_background_animator,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -682,7 +666,7 @@ be_local_closure(class_Animate_core_add_background_animator,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_cb),
@@ -709,7 +693,6 @@ be_local_closure(class_Animate_core_add_background_animator,   /* name */
 /********************************************************************
 ** Solidified function: add_animator
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_add_animator,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -718,7 +701,7 @@ be_local_closure(class_Animate_core_add_animator,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(animators),
@@ -749,7 +732,6 @@ be_local_closure(class_Animate_core_add_animator,   /* name */
 /********************************************************************
 ** Solidified function: remove
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_remove,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -758,7 +740,7 @@ be_local_closure(class_Animate_core_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(clear),
@@ -785,7 +767,6 @@ be_local_closure(class_Animate_core_remove,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Animate_core;
 be_local_closure(class_Animate_core_start,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -794,7 +775,7 @@ be_local_closure(class_Animate_core_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_core, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(running),

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_2_animate_effects.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_2_animate_effects.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Animate_painter;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_painter;
 be_local_closure(class_Animate_painter_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Animate_painter_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_painter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -46,7 +45,6 @@ be_local_closure(class_Animate_painter_init,   /* name */
 /********************************************************************
 ** Solidified function: paint
 ********************************************************************/
-extern const bclass be_class_Animate_painter;
 be_local_closure(class_Animate_painter_paint,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -55,7 +53,7 @@ be_local_closure(class_Animate_painter_paint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_painter, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(paint),
@@ -87,7 +85,6 @@ extern const bclass be_class_Animate_pulse;
 /********************************************************************
 ** Solidified function: set_pulse_size
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_set_pulse_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -96,7 +93,7 @@ be_local_closure(class_Animate_pulse_set_pulse_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(pulse_size),
@@ -115,7 +112,6 @@ be_local_closure(class_Animate_pulse_set_pulse_size,   /* name */
 /********************************************************************
 ** Solidified function: set_slew_size
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_set_slew_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -124,7 +120,7 @@ be_local_closure(class_Animate_pulse_set_slew_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(slew_size),
@@ -143,7 +139,6 @@ be_local_closure(class_Animate_pulse_set_slew_size,   /* name */
 /********************************************************************
 ** Solidified function: set_back_color
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_set_back_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -152,7 +147,7 @@ be_local_closure(class_Animate_pulse_set_back_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(back_color),
@@ -171,7 +166,6 @@ be_local_closure(class_Animate_pulse_set_back_color,   /* name */
 /********************************************************************
 ** Solidified function: set_pos
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_set_pos,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -180,7 +174,7 @@ be_local_closure(class_Animate_pulse_set_pos,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(pos),
@@ -199,7 +193,6 @@ be_local_closure(class_Animate_pulse_set_pos,   /* name */
 /********************************************************************
 ** Solidified function: set_color
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_set_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -208,7 +201,7 @@ be_local_closure(class_Animate_pulse_set_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(color),
@@ -227,7 +220,6 @@ be_local_closure(class_Animate_pulse_set_color,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -236,7 +228,7 @@ be_local_closure(class_Animate_pulse_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -291,7 +283,6 @@ be_local_closure(class_Animate_pulse_init,   /* name */
 /********************************************************************
 ** Solidified function: paint
 ********************************************************************/
-extern const bclass be_class_Animate_pulse;
 be_local_closure(class_Animate_pulse_paint,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -300,7 +291,7 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_pulse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(back_color),

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_9_module.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_9_module.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Animate_animator;
 /********************************************************************
 ** Solidified function: is_running
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_is_running,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Animate_animator_is_running,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(running),
@@ -39,7 +38,6 @@ be_local_closure(class_Animate_animator_is_running,   /* name */
 /********************************************************************
 ** Solidified function: beat
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_beat,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -48,7 +46,7 @@ be_local_closure(class_Animate_animator_beat,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(beat),
@@ -64,7 +62,6 @@ be_local_closure(class_Animate_animator_beat,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -73,7 +70,7 @@ be_local_closure(class_Animate_animator_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -101,7 +98,6 @@ be_local_closure(class_Animate_animator_init,   /* name */
 /********************************************************************
 ** Solidified function: stop
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_stop,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -110,7 +106,7 @@ be_local_closure(class_Animate_animator_stop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(origin),
@@ -133,7 +129,6 @@ be_local_closure(class_Animate_animator_stop,   /* name */
 /********************************************************************
 ** Solidified function: set_duration_ms
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_set_duration_ms,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -142,7 +137,7 @@ be_local_closure(class_Animate_animator_set_duration_ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(duration_ms),
@@ -161,7 +156,6 @@ be_local_closure(class_Animate_animator_set_duration_ms,   /* name */
 /********************************************************************
 ** Solidified function: set_cb
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_set_cb,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -170,7 +164,7 @@ be_local_closure(class_Animate_animator_set_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(obj),
@@ -191,7 +185,6 @@ be_local_closure(class_Animate_animator_set_cb,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Animate_animator;
 be_local_closure(class_Animate_animator_start,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -200,7 +193,7 @@ be_local_closure(class_Animate_animator_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_animator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(duration_ms),
@@ -263,7 +256,6 @@ extern const bclass be_class_Animate_palette;
 /********************************************************************
 ** Solidified function: ptr_to_palette
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_ptr_to_palette,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -272,7 +264,7 @@ be_local_closure(class_Animate_palette_ptr_to_palette,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Animate_palette),
@@ -337,7 +329,6 @@ be_local_closure(class_Animate_palette_ptr_to_palette,   /* name */
 /********************************************************************
 ** Solidified function: animate
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_animate,   /* name */
   be_nested_proto(
     26,                          /* nstack */
@@ -346,7 +337,7 @@ be_local_closure(class_Animate_palette_animate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(duration_ms),
@@ -576,7 +567,6 @@ be_local_closure(class_Animate_palette_animate,   /* name */
 /********************************************************************
 ** Solidified function: set_palette
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_set_palette,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -585,7 +575,7 @@ be_local_closure(class_Animate_palette_set_palette,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(ptr),
@@ -647,7 +637,6 @@ be_local_closure(class_Animate_palette_set_palette,   /* name */
 /********************************************************************
 ** Solidified function: to_css_gradient
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -656,7 +645,7 @@ be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_const_class(be_class_Animate_palette),
@@ -728,7 +717,6 @@ be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
 /********************************************************************
 ** Solidified function: set_bri
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_set_bri,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -737,7 +725,7 @@ be_local_closure(class_Animate_palette_set_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(bri),
@@ -759,7 +747,6 @@ be_local_closure(class_Animate_palette_set_bri,   /* name */
 /********************************************************************
 ** Solidified function: parse_palette
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_parse_palette,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -768,7 +755,7 @@ be_local_closure(class_Animate_palette_parse_palette,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(slots),
@@ -863,7 +850,6 @@ be_local_closure(class_Animate_palette_parse_palette,   /* name */
 /********************************************************************
 ** Solidified function: set_range
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_set_range,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -872,7 +858,7 @@ be_local_closure(class_Animate_palette_set_range,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(value_error),
@@ -905,7 +891,6 @@ be_local_closure(class_Animate_palette_set_range,   /* name */
 /********************************************************************
 ** Solidified function: set_value
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_set_value,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -914,7 +899,7 @@ be_local_closure(class_Animate_palette_set_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(range_min),
@@ -1039,7 +1024,6 @@ be_local_closure(class_Animate_palette_set_value,   /* name */
 /********************************************************************
 ** Solidified function: set_duration
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_set_duration,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1048,7 +1032,7 @@ be_local_closure(class_Animate_palette_set_duration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1085,7 +1069,6 @@ be_local_closure(class_Animate_palette_set_duration,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_palette;
 be_local_closure(class_Animate_palette_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1094,7 +1077,7 @@ be_local_closure(class_Animate_palette_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_palette, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1169,7 +1152,6 @@ extern const bclass be_class_Animate_oscillator;
 /********************************************************************
 ** Solidified function: set_duty_cycle
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_set_duty_cycle,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1178,7 +1160,7 @@ be_local_closure(class_Animate_oscillator_set_duty_cycle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1205,7 +1187,6 @@ be_local_closure(class_Animate_oscillator_set_duty_cycle,   /* name */
 /********************************************************************
 ** Solidified function: set_a
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_set_a,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1214,7 +1195,7 @@ be_local_closure(class_Animate_oscillator_set_a,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(a),
@@ -1233,7 +1214,6 @@ be_local_closure(class_Animate_oscillator_set_a,   /* name */
 /********************************************************************
 ** Solidified function: set_b
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_set_b,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1242,7 +1222,7 @@ be_local_closure(class_Animate_oscillator_set_b,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(b),
@@ -1261,7 +1241,6 @@ be_local_closure(class_Animate_oscillator_set_b,   /* name */
 /********************************************************************
 ** Solidified function: set_form
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_set_form,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1270,7 +1249,7 @@ be_local_closure(class_Animate_oscillator_set_form,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(1),
@@ -1294,7 +1273,6 @@ be_local_closure(class_Animate_oscillator_set_form,   /* name */
 /********************************************************************
 ** Solidified function: set_phase
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_set_phase,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1303,7 +1281,7 @@ be_local_closure(class_Animate_oscillator_set_phase,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1330,7 +1308,6 @@ be_local_closure(class_Animate_oscillator_set_phase,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1339,7 +1316,7 @@ be_local_closure(class_Animate_oscillator_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1383,7 +1360,6 @@ be_local_closure(class_Animate_oscillator_init,   /* name */
 /********************************************************************
 ** Solidified function: animate
 ********************************************************************/
-extern const bclass be_class_Animate_oscillator;
 be_local_closure(class_Animate_oscillator_animate,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -1392,7 +1368,7 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Animate_oscillator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(duration_ms),

--- a/lib/libesp32/berry_animate/src/solidify/solidified_leds_frame_be_methods.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_leds_frame_be_methods.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Leds_frame_be;
 /********************************************************************
 ** Solidified function: setitem
 ********************************************************************/
-extern const bclass be_class_Leds_frame_be;
 be_local_closure(class_Leds_frame_be_setitem,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Leds_frame_be_setitem,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_frame_be, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(set),
@@ -42,7 +41,6 @@ be_local_closure(class_Leds_frame_be_setitem,   /* name */
 /********************************************************************
 ** Solidified function: set_pixel
 ********************************************************************/
-extern const bclass be_class_Leds_frame_be;
 be_local_closure(class_Leds_frame_be_set_pixel,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -51,7 +49,7 @@ be_local_closure(class_Leds_frame_be_set_pixel,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_frame_be, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -95,7 +93,6 @@ be_local_closure(class_Leds_frame_be_set_pixel,   /* name */
 /********************************************************************
 ** Solidified function: item
 ********************************************************************/
-extern const bclass be_class_Leds_frame_be;
 be_local_closure(class_Leds_frame_be_item,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -104,7 +101,7 @@ be_local_closure(class_Leds_frame_be_item,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_frame_be, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(get),
@@ -127,7 +124,6 @@ be_local_closure(class_Leds_frame_be_item,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Leds_frame_be;
 be_local_closure(class_Leds_frame_be_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -136,7 +132,7 @@ be_local_closure(class_Leds_frame_be_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_frame_be, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(0),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_0_Inspect.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_0_Inspect.h
@@ -15,7 +15,7 @@ be_local_closure(module_matter_sort,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(1),
@@ -71,7 +71,7 @@ be_local_closure(module_matter_jitter,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -116,7 +116,7 @@ be_local_closure(module_matter_inspect,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -255,7 +255,7 @@ be_local_closure(module_matter_consolidate_clusters,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(CLUSTERS),
@@ -385,7 +385,7 @@ be_local_closure(module_matter_UC_LIST,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(UPDATE_COMMANDS),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Base38.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Base38.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Base38;
 /********************************************************************
 ** Solidified function: encode
 ********************************************************************/
-extern const bclass be_class_Matter_Base38;
 be_local_closure(class_Matter_Base38_encode,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Base38_encode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         6,                          /* nstack */
         2,                          /* argc */
@@ -26,7 +25,7 @@ be_local_closure(class_Matter_Base38_encode,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str_weak(0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_X2D_X2E),
@@ -53,7 +52,6 @@ be_local_closure(class_Matter_Base38_encode,   /* name */
           0x80040800,  //  000D  RET	1	R4
         })
       ),
-    &be_class_Matter_Base38, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Commisioning_Context;
 /********************************************************************
 ** Solidified function: parse_StatusReport
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -63,7 +62,6 @@ be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name
 /********************************************************************
 ** Solidified function: find_fabric_by_destination_id
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -72,7 +70,7 @@ be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -178,7 +176,6 @@ be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_every_second,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -187,7 +184,7 @@ be_local_closure(class_Matter_Commisioning_Context_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(every_second),
@@ -203,7 +200,6 @@ be_local_closure(class_Matter_Commisioning_Context_every_second,   /* name */
 /********************************************************************
 ** Solidified function: add_session
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_add_session,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -212,7 +208,7 @@ be_local_closure(class_Matter_Commisioning_Context_add_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -254,7 +250,6 @@ be_local_closure(class_Matter_Commisioning_Context_add_session,   /* name */
 /********************************************************************
 ** Solidified function: parse_PBKDFParamRequest
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -263,7 +258,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[47]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -439,7 +434,6 @@ be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /*
 /********************************************************************
 ** Solidified function: send_status_report
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_send_status_report,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -448,7 +442,7 @@ be_local_closure(class_Matter_Commisioning_Context_send_status_report,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(build_response),
@@ -496,7 +490,6 @@ be_local_closure(class_Matter_Commisioning_Context_send_status_report,   /* name
 /********************************************************************
 ** Solidified function: parse_Pake1
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
   be_nested_proto(
     20,                          /* nstack */
@@ -505,7 +498,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[51]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -684,7 +677,6 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -693,7 +685,7 @@ be_local_closure(class_Matter_Commisioning_Context_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -717,7 +709,6 @@ be_local_closure(class_Matter_Commisioning_Context_init,   /* name */
 /********************************************************************
 ** Solidified function: parse_Pake3
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -726,7 +717,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -874,7 +865,6 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
 /********************************************************************
 ** Solidified function: parse_Sigma3
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
   be_nested_proto(
     36,                          /* nstack */
@@ -883,7 +873,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[66]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -1245,7 +1235,6 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
 /********************************************************************
 ** Solidified function: process_incoming
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1254,7 +1243,7 @@ be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -1371,7 +1360,6 @@ be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name *
 /********************************************************************
 ** Solidified function: parse_Sigma1
 ********************************************************************/
-extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
   be_nested_proto(
     37,                          /* nstack */
@@ -1380,7 +1368,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Commisioning_Context, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[108]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_PBKDFParamRequest;
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_PBKDFParamRequest;
 be_local_closure(class_Matter_PBKDFParamRequest_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_PBKDFParamRequest_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PBKDFParamRequest, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -112,7 +111,6 @@ extern const bclass be_class_Matter_PBKDFParamResponse;
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_PBKDFParamResponse;
 be_local_closure(class_Matter_PBKDFParamResponse_tlv2raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -121,7 +119,7 @@ be_local_closure(class_Matter_PBKDFParamResponse_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PBKDFParamResponse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -235,7 +233,6 @@ extern const bclass be_class_Matter_Pake1;
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_Pake1;
 be_local_closure(class_Matter_Pake1_parse,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -244,7 +241,7 @@ be_local_closure(class_Matter_Pake1_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Pake1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -298,7 +295,6 @@ extern const bclass be_class_Matter_Pake2;
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_Pake2;
 be_local_closure(class_Matter_Pake2_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -307,7 +303,7 @@ be_local_closure(class_Matter_Pake2_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Pake2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -368,7 +364,6 @@ extern const bclass be_class_Matter_Pake3;
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_Pake3;
 be_local_closure(class_Matter_Pake3_parse,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -377,7 +372,7 @@ be_local_closure(class_Matter_Pake3_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Pake3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -431,7 +426,6 @@ extern const bclass be_class_Matter_Sigma1;
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_Sigma1;
 be_local_closure(class_Matter_Sigma1_parse,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -440,7 +434,7 @@ be_local_closure(class_Matter_Sigma1_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Sigma1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -552,7 +546,6 @@ extern const bclass be_class_Matter_Sigma2;
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_Sigma2;
 be_local_closure(class_Matter_Sigma2_tlv2raw,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -561,7 +554,7 @@ be_local_closure(class_Matter_Sigma2_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Sigma2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -665,7 +658,6 @@ extern const bclass be_class_Matter_Sigma2Resume;
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_Sigma2Resume;
 be_local_closure(class_Matter_Sigma2Resume_tlv2raw,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -674,7 +666,7 @@ be_local_closure(class_Matter_Sigma2Resume_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Sigma2Resume, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -771,7 +763,6 @@ extern const bclass be_class_Matter_Sigma3;
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_Sigma3;
 be_local_closure(class_Matter_Sigma3_parse,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -780,7 +771,7 @@ be_local_closure(class_Matter_Sigma3_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Sigma3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Control_Message;
 /********************************************************************
 ** Solidified function: parse_MsgCounterSyncRsp
 ********************************************************************/
-extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Control_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -57,7 +56,6 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name
 /********************************************************************
 ** Solidified function: parse_MsgCounterSyncReq
 ********************************************************************/
-extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -66,7 +64,7 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Control_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -105,7 +103,6 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -114,7 +111,7 @@ be_local_closure(class_Matter_Control_Message_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Control_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -138,7 +135,6 @@ be_local_closure(class_Matter_Control_Message_init,   /* name */
 /********************************************************************
 ** Solidified function: process_incoming_control_message
 ********************************************************************/
-extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_process_incoming_control_message,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -147,7 +143,7 @@ be_local_closure(class_Matter_Control_Message_process_incoming_control_message, 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Control_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_EventHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_EventHandler.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_EventHandler;
 /********************************************************************
 ** Solidified function: dump
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_dump,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_EventHandler_dump,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -120,7 +119,6 @@ be_local_closure(class_Matter_EventHandler_dump,   /* name */
 /********************************************************************
 ** Solidified function: get_last_event_no
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_get_last_event_no,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -129,7 +127,7 @@ be_local_closure(class_Matter_EventHandler_get_last_event_no,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(counter_event_no),
@@ -148,7 +146,6 @@ be_local_closure(class_Matter_EventHandler_get_last_event_no,   /* name */
 /********************************************************************
 ** Solidified function: get_next_event_no
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_get_next_event_no,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -157,7 +154,7 @@ be_local_closure(class_Matter_EventHandler_get_next_event_no,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(counter_event_no),
@@ -191,7 +188,6 @@ be_local_closure(class_Matter_EventHandler_get_next_event_no,   /* name */
 /********************************************************************
 ** Solidified function: load_event_no_persisted
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_load_event_no_persisted,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -200,7 +196,7 @@ be_local_closure(class_Matter_EventHandler_load_event_no_persisted,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(persist),
@@ -255,7 +251,6 @@ be_local_closure(class_Matter_EventHandler_load_event_no_persisted,   /* name */
 /********************************************************************
 ** Solidified function: queue_event
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_queue_event,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -264,7 +259,7 @@ be_local_closure(class_Matter_EventHandler_queue_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(priority),
@@ -345,7 +340,6 @@ be_local_closure(class_Matter_EventHandler_queue_event,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -354,7 +348,7 @@ be_local_closure(class_Matter_EventHandler_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(compact),
@@ -374,7 +368,6 @@ be_local_closure(class_Matter_EventHandler_every_second,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -383,7 +376,7 @@ be_local_closure(class_Matter_EventHandler_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -417,7 +410,6 @@ be_local_closure(class_Matter_EventHandler_init,   /* name */
 /********************************************************************
 ** Solidified function: find_min_no
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -426,7 +418,7 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         7,                          /* nstack */
         3,                          /* argc */
@@ -434,7 +426,7 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_const_int(1),
@@ -471,7 +463,6 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
           0x80040000,  //  0018  RET	1	R0
         })
       ),
-    &be_class_Matter_EventHandler, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
@@ -521,7 +512,6 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
 /********************************************************************
 ** Solidified function: publish_event
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
   be_nested_proto(
     23,                          /* nstack */
@@ -530,7 +520,7 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -689,7 +679,6 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
 /********************************************************************
 ** Solidified function: compact
 ********************************************************************/
-extern const bclass be_class_Matter_EventHandler;
 be_local_closure(class_Matter_EventHandler_compact,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -698,7 +687,7 @@ be_local_closure(class_Matter_EventHandler_compact,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         4,                          /* nstack */
         1,                          /* argc */
@@ -706,7 +695,7 @@ be_local_closure(class_Matter_EventHandler_compact,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_const_int(0),
@@ -730,7 +719,6 @@ be_local_closure(class_Matter_EventHandler_compact,   /* name */
           0x80000000,  //  000B  RET	0
         })
       ),
-    &be_class_Matter_EventHandler, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
@@ -794,7 +782,6 @@ extern const bclass be_class_Matter_EventQueued;
 /********************************************************************
 ** Solidified function: to_raw_bytes
 ********************************************************************/
-extern const bclass be_class_Matter_EventQueued;
 be_local_closure(class_Matter_EventQueued_to_raw_bytes,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -803,7 +790,7 @@ be_local_closure(class_Matter_EventQueued_to_raw_bytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventQueued, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(raw_tlv),
@@ -854,7 +841,6 @@ be_local_closure(class_Matter_EventQueued_to_raw_bytes,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_EventQueued;
 be_local_closure(class_Matter_EventQueued_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -863,7 +849,7 @@ be_local_closure(class_Matter_EventQueued_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventQueued, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_no),
@@ -932,7 +918,6 @@ be_local_closure(class_Matter_EventQueued_init,   /* name */
 /********************************************************************
 ** Solidified function: compact
 ********************************************************************/
-extern const bclass be_class_Matter_EventQueued;
 be_local_closure(class_Matter_EventQueued_compact,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -941,7 +926,7 @@ be_local_closure(class_Matter_EventQueued_compact,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventQueued, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(raw_tlv),
@@ -961,7 +946,6 @@ be_local_closure(class_Matter_EventQueued_compact,   /* name */
 /********************************************************************
 ** Solidified function: eventpath2raw
 ********************************************************************/
-extern const bclass be_class_Matter_EventQueued;
 be_local_closure(class_Matter_EventQueued_eventpath2raw,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -970,7 +954,7 @@ be_local_closure(class_Matter_EventQueued_eventpath2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventQueued, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),
@@ -1080,7 +1064,6 @@ be_local_closure(class_Matter_EventQueued_eventpath2raw,   /* name */
 /********************************************************************
 ** Solidified function: eventreport2raw
 ********************************************************************/
-extern const bclass be_class_Matter_EventQueued;
 be_local_closure(class_Matter_EventQueued_eventreport2raw,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -1089,7 +1072,7 @@ be_local_closure(class_Matter_EventQueued_eventreport2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventQueued, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Expirable;
 /********************************************************************
 ** Solidified function: before_remove
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_before_remove,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Expirable_before_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(before_remove),
@@ -34,7 +33,6 @@ be_local_closure(class_Matter_Expirable_before_remove,   /* name */
 /********************************************************************
 ** Solidified function: set_no_expiration
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_set_no_expiration,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -43,7 +41,7 @@ be_local_closure(class_Matter_Expirable_set_no_expiration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_expiration),
@@ -63,7 +61,6 @@ be_local_closure(class_Matter_Expirable_set_no_expiration,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -72,7 +69,7 @@ be_local_closure(class_Matter_Expirable_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_persist),
@@ -92,7 +89,6 @@ be_local_closure(class_Matter_Expirable_init,   /* name */
 /********************************************************************
 ** Solidified function: set_expire_time
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_set_expire_time,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -101,7 +97,7 @@ be_local_closure(class_Matter_Expirable_set_expire_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_expiration),
@@ -123,7 +119,6 @@ be_local_closure(class_Matter_Expirable_set_expire_time,   /* name */
 /********************************************************************
 ** Solidified function: has_expired
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_has_expired,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -132,7 +127,7 @@ be_local_closure(class_Matter_Expirable_has_expired,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -167,7 +162,6 @@ be_local_closure(class_Matter_Expirable_has_expired,   /* name */
 /********************************************************************
 ** Solidified function: set_parent_list
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_set_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -176,7 +170,7 @@ be_local_closure(class_Matter_Expirable_set_parent_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_list),
@@ -195,7 +189,6 @@ be_local_closure(class_Matter_Expirable_set_parent_list,   /* name */
 /********************************************************************
 ** Solidified function: hydrate_post
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_hydrate_post,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -204,7 +197,7 @@ be_local_closure(class_Matter_Expirable_hydrate_post,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(hydrate_post),
@@ -220,7 +213,6 @@ be_local_closure(class_Matter_Expirable_hydrate_post,   /* name */
 /********************************************************************
 ** Solidified function: set_expire_in_seconds
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_set_expire_in_seconds,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -229,7 +221,7 @@ be_local_closure(class_Matter_Expirable_set_expire_in_seconds,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -263,7 +255,6 @@ be_local_closure(class_Matter_Expirable_set_expire_in_seconds,   /* name */
 /********************************************************************
 ** Solidified function: get_parent_list
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_get_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -272,7 +263,7 @@ be_local_closure(class_Matter_Expirable_get_parent_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_list),
@@ -291,7 +282,6 @@ be_local_closure(class_Matter_Expirable_get_parent_list,   /* name */
 /********************************************************************
 ** Solidified function: does_persist
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_does_persist,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -300,7 +290,7 @@ be_local_closure(class_Matter_Expirable_does_persist,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_persist),
@@ -319,7 +309,6 @@ be_local_closure(class_Matter_Expirable_does_persist,   /* name */
 /********************************************************************
 ** Solidified function: set_persist
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_set_persist,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -328,7 +317,7 @@ be_local_closure(class_Matter_Expirable_set_persist,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_persist),
@@ -350,7 +339,6 @@ be_local_closure(class_Matter_Expirable_set_persist,   /* name */
 /********************************************************************
 ** Solidified function: persist_pre
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_persist_pre,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -359,7 +347,7 @@ be_local_closure(class_Matter_Expirable_persist_pre,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(persist_pre),
@@ -375,7 +363,6 @@ be_local_closure(class_Matter_Expirable_persist_pre,   /* name */
 /********************************************************************
 ** Solidified function: persist_post
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable;
 be_local_closure(class_Matter_Expirable_persist_post,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -384,7 +371,7 @@ be_local_closure(class_Matter_Expirable_persist_post,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(persist_post),
@@ -430,7 +417,6 @@ extern const bclass be_class_Matter_Expirable_list;
 /********************************************************************
 ** Solidified function: count_persistables
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_count_persistables,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -439,7 +425,7 @@ be_local_closure(class_Matter_Expirable_list_count_persistables,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -472,7 +458,6 @@ be_local_closure(class_Matter_Expirable_list_count_persistables,   /* name */
 /********************************************************************
 ** Solidified function: remove
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -481,7 +466,7 @@ be_local_closure(class_Matter_Expirable_list_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -521,7 +506,6 @@ be_local_closure(class_Matter_Expirable_list_remove,   /* name */
 /********************************************************************
 ** Solidified function: push
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_push,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -530,7 +514,7 @@ be_local_closure(class_Matter_Expirable_list_push,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -569,7 +553,6 @@ be_local_closure(class_Matter_Expirable_list_push,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -578,7 +561,7 @@ be_local_closure(class_Matter_Expirable_list_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
@@ -598,7 +581,6 @@ be_local_closure(class_Matter_Expirable_list_every_second,   /* name */
 /********************************************************************
 ** Solidified function: remove_expired
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_remove_expired,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -607,7 +589,7 @@ be_local_closure(class_Matter_Expirable_list_remove_expired,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -650,7 +632,6 @@ be_local_closure(class_Matter_Expirable_list_remove_expired,   /* name */
 /********************************************************************
 ** Solidified function: persistables
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -659,7 +640,7 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -669,7 +650,7 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
           be_local_const_upval(1, 1),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(_persist),
@@ -688,7 +669,6 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
           0x80000000,  //  0008  RET	0
         })
       ),
-    &be_class_Matter_Expirable_list, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
@@ -711,7 +691,6 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
 /********************************************************************
 ** Solidified function: setitem
 ********************************************************************/
-extern const bclass be_class_Matter_Expirable_list;
 be_local_closure(class_Matter_Expirable_list_setitem,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -720,7 +699,7 @@ be_local_closure(class_Matter_Expirable_list_setitem,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Expirable_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Fabric;
 /********************************************************************
 ** Solidified function: get_icac
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_icac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Fabric_get_icac,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(icac),
@@ -37,7 +36,6 @@ be_local_closure(class_Matter_Fabric_get_icac,   /* name */
 /********************************************************************
 ** Solidified function: before_remove
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_before_remove,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -46,7 +44,7 @@ be_local_closure(class_Matter_Fabric_before_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -84,7 +82,6 @@ be_local_closure(class_Matter_Fabric_before_remove,   /* name */
 /********************************************************************
 ** Solidified function: get_pk
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_pk,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -93,7 +90,7 @@ be_local_closure(class_Matter_Fabric_get_pk,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(no_private_key),
@@ -112,7 +109,6 @@ be_local_closure(class_Matter_Fabric_get_pk,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_compressed
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -121,7 +117,7 @@ be_local_closure(class_Matter_Fabric_get_fabric_compressed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_compressed),
@@ -140,7 +136,6 @@ be_local_closure(class_Matter_Fabric_get_fabric_compressed,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_id
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_fabric_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -149,7 +144,7 @@ be_local_closure(class_Matter_Fabric_get_fabric_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_id),
@@ -168,7 +163,6 @@ be_local_closure(class_Matter_Fabric_get_fabric_id,   /* name */
 /********************************************************************
 ** Solidified function: set_admin_subject_vendor
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_admin_subject_vendor,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -177,7 +171,7 @@ be_local_closure(class_Matter_Fabric_set_admin_subject_vendor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(admin_subject),
@@ -198,7 +192,6 @@ be_local_closure(class_Matter_Fabric_set_admin_subject_vendor,   /* name */
 /********************************************************************
 ** Solidified function: get_admin_vendor
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -207,7 +200,7 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(admin_vendor),
@@ -226,7 +219,6 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor,   /* name */
 /********************************************************************
 ** Solidified function: get_noc
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_noc,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -235,7 +227,7 @@ be_local_closure(class_Matter_Fabric_get_noc,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(noc),
@@ -254,7 +246,6 @@ be_local_closure(class_Matter_Fabric_get_noc,   /* name */
 /********************************************************************
 ** Solidified function: fromjson
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_fromjson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -263,7 +254,7 @@ be_local_closure(class_Matter_Fabric_fromjson,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Fabric),
@@ -373,7 +364,6 @@ be_local_closure(class_Matter_Fabric_fromjson,   /* name */
 /********************************************************************
 ** Solidified function: set_ca
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -382,7 +372,7 @@ be_local_closure(class_Matter_Fabric_set_ca,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(root_ca_certificate),
@@ -401,7 +391,6 @@ be_local_closure(class_Matter_Fabric_set_ca,   /* name */
 /********************************************************************
 ** Solidified function: tojson
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_tojson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -410,7 +399,7 @@ be_local_closure(class_Matter_Fabric_tojson,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -572,7 +561,6 @@ be_local_closure(class_Matter_Fabric_tojson,   /* name */
 /********************************************************************
 ** Solidified function: hydrate_post
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_hydrate_post,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -581,7 +569,7 @@ be_local_closure(class_Matter_Fabric_hydrate_post,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
@@ -620,7 +608,6 @@ be_local_closure(class_Matter_Fabric_hydrate_post,   /* name */
 /********************************************************************
 ** Solidified function: set_ipk_epoch_key
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -629,7 +616,7 @@ be_local_closure(class_Matter_Fabric_set_ipk_epoch_key,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(ipk_epoch_key),
@@ -648,7 +635,6 @@ be_local_closure(class_Matter_Fabric_set_ipk_epoch_key,   /* name */
 /********************************************************************
 ** Solidified function: set_fabric_device
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_fabric_device,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -657,7 +643,7 @@ be_local_closure(class_Matter_Fabric_set_fabric_device,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_id),
@@ -690,7 +676,6 @@ be_local_closure(class_Matter_Fabric_set_fabric_device,   /* name */
 /********************************************************************
 ** Solidified function: get_device_id
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_device_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -699,7 +684,7 @@ be_local_closure(class_Matter_Fabric_get_device_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(device_id),
@@ -718,7 +703,6 @@ be_local_closure(class_Matter_Fabric_get_device_id,   /* name */
 /********************************************************************
 ** Solidified function: get_admin_subject
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_admin_subject,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -727,7 +711,7 @@ be_local_closure(class_Matter_Fabric_get_admin_subject,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(admin_subject),
@@ -746,7 +730,6 @@ be_local_closure(class_Matter_Fabric_get_admin_subject,   /* name */
 /********************************************************************
 ** Solidified function: is_marked_for_deletion
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_is_marked_for_deletion,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -755,7 +738,7 @@ be_local_closure(class_Matter_Fabric_is_marked_for_deletion,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(deleted),
@@ -776,7 +759,6 @@ be_local_closure(class_Matter_Fabric_is_marked_for_deletion,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_id_as_int64
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_fabric_id_as_int64,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -785,7 +767,7 @@ be_local_closure(class_Matter_Fabric_get_fabric_id_as_int64,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(int64),
@@ -809,7 +791,6 @@ be_local_closure(class_Matter_Fabric_get_fabric_id_as_int64,   /* name */
 /********************************************************************
 ** Solidified function: get_ca
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -818,7 +799,7 @@ be_local_closure(class_Matter_Fabric_get_ca,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(root_ca_certificate),
@@ -837,7 +818,6 @@ be_local_closure(class_Matter_Fabric_get_ca,   /* name */
 /********************************************************************
 ** Solidified function: get_oldest_session
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_oldest_session,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -846,7 +826,7 @@ be_local_closure(class_Matter_Fabric_get_oldest_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_old_recent_session),
@@ -867,7 +847,6 @@ be_local_closure(class_Matter_Fabric_get_oldest_session,   /* name */
 /********************************************************************
 ** Solidified function: fabric_completed
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_fabric_completed,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -876,7 +855,7 @@ be_local_closure(class_Matter_Fabric_fabric_completed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_no_expiration),
@@ -909,7 +888,6 @@ be_local_closure(class_Matter_Fabric_fabric_completed,   /* name */
 /********************************************************************
 ** Solidified function: counter_group_data_snd_next
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -918,7 +896,7 @@ be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
@@ -972,7 +950,6 @@ be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
 /********************************************************************
 ** Solidified function: set_noc_icac
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_noc_icac,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -981,7 +958,7 @@ be_local_closure(class_Matter_Fabric_set_noc_icac,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(noc),
@@ -1002,7 +979,6 @@ be_local_closure(class_Matter_Fabric_set_noc_icac,   /* name */
 /********************************************************************
 ** Solidified function: set_pk
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_pk,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1011,7 +987,7 @@ be_local_closure(class_Matter_Fabric_set_pk,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(no_private_key),
@@ -1030,7 +1006,6 @@ be_local_closure(class_Matter_Fabric_set_pk,   /* name */
 /********************************************************************
 ** Solidified function: get_newest_session
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_newest_session,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1039,7 +1014,7 @@ be_local_closure(class_Matter_Fabric_get_newest_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_old_recent_session),
@@ -1060,7 +1035,6 @@ be_local_closure(class_Matter_Fabric_get_newest_session,   /* name */
 /********************************************************************
 ** Solidified function: log_new_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1069,7 +1043,7 @@ be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -1110,7 +1084,6 @@ be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
 /********************************************************************
 ** Solidified function: get_ca_pub
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_ca_pub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1119,7 +1092,7 @@ be_local_closure(class_Matter_Fabric_get_ca_pub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(root_ca_certificate),
@@ -1152,7 +1125,6 @@ be_local_closure(class_Matter_Fabric_get_ca_pub,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_index
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1161,7 +1133,7 @@ be_local_closure(class_Matter_Fabric_get_fabric_index,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_index),
@@ -1180,7 +1152,6 @@ be_local_closure(class_Matter_Fabric_get_fabric_index,   /* name */
 /********************************************************************
 ** Solidified function: writejson
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_writejson,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -1189,7 +1160,7 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[26]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -1356,7 +1327,6 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
 /********************************************************************
 ** Solidified function: counter_group_ctrl_snd_next
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1365,7 +1335,7 @@ be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
@@ -1419,7 +1389,6 @@ be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
 /********************************************************************
 ** Solidified function: fabric_candidate
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_fabric_candidate,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1428,7 +1397,7 @@ be_local_closure(class_Matter_Fabric_fabric_candidate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_expire_in_seconds),
@@ -1458,7 +1427,6 @@ be_local_closure(class_Matter_Fabric_fabric_candidate,   /* name */
 /********************************************************************
 ** Solidified function: assign_fabric_index
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_assign_fabric_index,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1467,7 +1435,7 @@ be_local_closure(class_Matter_Fabric_assign_fabric_index,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_fabric_index),
@@ -1498,7 +1466,6 @@ be_local_closure(class_Matter_Fabric_assign_fabric_index,   /* name */
 /********************************************************************
 ** Solidified function: get_old_recent_session
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_old_recent_session,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1507,7 +1474,7 @@ be_local_closure(class_Matter_Fabric_get_old_recent_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_sessions),
@@ -1557,7 +1524,6 @@ be_local_closure(class_Matter_Fabric_get_old_recent_session,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1566,7 +1532,7 @@ be_local_closure(class_Matter_Fabric_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -1631,7 +1597,6 @@ be_local_closure(class_Matter_Fabric_init,   /* name */
 /********************************************************************
 ** Solidified function: get_ipk_epoch_key
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1640,7 +1605,7 @@ be_local_closure(class_Matter_Fabric_get_ipk_epoch_key,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(ipk_epoch_key),
@@ -1659,7 +1624,6 @@ be_local_closure(class_Matter_Fabric_get_ipk_epoch_key,   /* name */
 /********************************************************************
 ** Solidified function: add_session
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_add_session,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1668,7 +1632,7 @@ be_local_closure(class_Matter_Fabric_add_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(_sessions),
@@ -1724,7 +1688,6 @@ be_local_closure(class_Matter_Fabric_add_session,   /* name */
 /********************************************************************
 ** Solidified function: set_fabric_index
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_set_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1733,7 +1696,7 @@ be_local_closure(class_Matter_Fabric_set_fabric_index,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_index),
@@ -1752,7 +1715,6 @@ be_local_closure(class_Matter_Fabric_set_fabric_index,   /* name */
 /********************************************************************
 ** Solidified function: get_device_id_as_int64
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_device_id_as_int64,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1761,7 +1723,7 @@ be_local_closure(class_Matter_Fabric_get_device_id_as_int64,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(int64),
@@ -1785,7 +1747,6 @@ be_local_closure(class_Matter_Fabric_get_device_id_as_int64,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_label
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_fabric_label,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1794,7 +1755,7 @@ be_local_closure(class_Matter_Fabric_get_fabric_label,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(fabric_label),
@@ -1813,7 +1774,6 @@ be_local_closure(class_Matter_Fabric_get_fabric_label,   /* name */
 /********************************************************************
 ** Solidified function: get_ipk_group_key
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_ipk_group_key,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1822,7 +1782,7 @@ be_local_closure(class_Matter_Fabric_get_ipk_group_key,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(ipk_epoch_key),
@@ -1870,7 +1830,6 @@ be_local_closure(class_Matter_Fabric_get_ipk_group_key,   /* name */
 /********************************************************************
 ** Solidified function: mark_for_deletion
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_mark_for_deletion,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1879,7 +1838,7 @@ be_local_closure(class_Matter_Fabric_mark_for_deletion,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(deleted),
@@ -1903,7 +1862,6 @@ be_local_closure(class_Matter_Fabric_mark_for_deletion,   /* name */
 /********************************************************************
 ** Solidified function: get_admin_vendor_name
 ********************************************************************/
-extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_get_admin_vendor_name,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1912,7 +1870,7 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Fabric, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(admin_vendor),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_HTTP_async;
 /********************************************************************
 ** Solidified function: parse_http_payload
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_parse_http_payload,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_HTTP_async_parse_http_payload,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(is_chunked),
@@ -132,7 +131,6 @@ be_local_closure(class_Matter_HTTP_async_parse_http_payload,   /* name */
 /********************************************************************
 ** Solidified function: event_http_finished
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_finished,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -141,7 +139,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_finished,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_http_finished),
@@ -157,7 +155,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_finished,   /* name */
 /********************************************************************
 ** Solidified function: event_http_header
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_header,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -166,7 +163,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_header,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -206,7 +203,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_header,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -215,7 +211,7 @@ be_local_closure(class_Matter_HTTP_async_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -278,7 +274,6 @@ be_local_closure(class_Matter_HTTP_async_init,   /* name */
 /********************************************************************
 ** Solidified function: event_http_failed
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_failed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -287,7 +282,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_failed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_http_failed),
@@ -303,7 +298,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_failed,   /* name */
 /********************************************************************
 ** Solidified function: parse_http_response
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_parse_http_response,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -312,7 +306,7 @@ be_local_closure(class_Matter_HTTP_async_parse_http_response,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(phase),
@@ -353,7 +347,6 @@ be_local_closure(class_Matter_HTTP_async_parse_http_response,   /* name */
 /********************************************************************
 ** Solidified function: event_refused
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_refused,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -362,7 +355,7 @@ be_local_closure(class_Matter_HTTP_async_event_refused,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(http_status),
@@ -385,7 +378,6 @@ be_local_closure(class_Matter_HTTP_async_event_refused,   /* name */
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -394,7 +386,7 @@ be_local_closure(class_Matter_HTTP_async_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -439,7 +431,6 @@ be_local_closure(class_Matter_HTTP_async_reset,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_begin,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -448,7 +439,7 @@ be_local_closure(class_Matter_HTTP_async_begin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(begin),
@@ -473,7 +464,6 @@ be_local_closure(class_Matter_HTTP_async_begin,   /* name */
 /********************************************************************
 ** Solidified function: event_established
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_established,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -482,7 +472,7 @@ be_local_closure(class_Matter_HTTP_async_event_established,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(send_http),
@@ -502,7 +492,6 @@ be_local_closure(class_Matter_HTTP_async_event_established,   /* name */
 /********************************************************************
 ** Solidified function: parse_http_headers
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_parse_http_headers,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -511,7 +500,7 @@ be_local_closure(class_Matter_HTTP_async_parse_http_headers,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -591,7 +580,6 @@ be_local_closure(class_Matter_HTTP_async_parse_http_headers,   /* name */
 /********************************************************************
 ** Solidified function: event_available
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_available,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -600,7 +588,7 @@ be_local_closure(class_Matter_HTTP_async_event_available,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(receive),
@@ -620,7 +608,6 @@ be_local_closure(class_Matter_HTTP_async_event_available,   /* name */
 /********************************************************************
 ** Solidified function: event_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -629,7 +616,7 @@ be_local_closure(class_Matter_HTTP_async_event_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(http_status),
@@ -652,7 +639,6 @@ be_local_closure(class_Matter_HTTP_async_event_timeout,   /* name */
 /********************************************************************
 ** Solidified function: compile_re
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_compile_re,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -661,7 +647,7 @@ be_local_closure(class_Matter_HTTP_async_compile_re,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(re),
@@ -716,7 +702,6 @@ be_local_closure(class_Matter_HTTP_async_compile_re,   /* name */
 /********************************************************************
 ** Solidified function: event_closed
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_closed,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -725,7 +710,7 @@ be_local_closure(class_Matter_HTTP_async_event_closed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(http_status),
@@ -752,7 +737,6 @@ be_local_closure(class_Matter_HTTP_async_event_closed,   /* name */
 /********************************************************************
 ** Solidified function: begin_sync
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_begin_sync,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -761,7 +745,7 @@ be_local_closure(class_Matter_HTTP_async_begin_sync,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(timeout),
@@ -820,7 +804,6 @@ be_local_closure(class_Matter_HTTP_async_begin_sync,   /* name */
 /********************************************************************
 ** Solidified function: send_http
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_send_http,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -829,7 +812,7 @@ be_local_closure(class_Matter_HTTP_async_send_http,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -914,7 +897,6 @@ be_local_closure(class_Matter_HTTP_async_send_http,   /* name */
 /********************************************************************
 ** Solidified function: event_http_headers_end
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_headers_end,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -923,7 +905,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_headers_end,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(response_offset),
@@ -953,7 +935,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_headers_end,   /* name */
 /********************************************************************
 ** Solidified function: event_http_status_code
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_status_code,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -962,7 +943,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_status_code,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(status_code),
@@ -981,7 +962,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_status_code,   /* name */
 /********************************************************************
 ** Solidified function: parse_http_status_line
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_parse_http_status_line,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -990,7 +970,7 @@ be_local_closure(class_Matter_HTTP_async_parse_http_status_line,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -1046,7 +1026,6 @@ be_local_closure(class_Matter_HTTP_async_parse_http_status_line,   /* name */
 /********************************************************************
 ** Solidified function: event_http_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_event_http_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -1055,7 +1034,7 @@ be_local_closure(class_Matter_HTTP_async_event_http_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_http_timeout),
@@ -1071,7 +1050,6 @@ be_local_closure(class_Matter_HTTP_async_event_http_timeout,   /* name */
 /********************************************************************
 ** Solidified function: receive
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_async;
 be_local_closure(class_Matter_HTTP_async_receive,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1080,7 +1058,7 @@ be_local_closure(class_Matter_HTTP_async_receive,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_HTTP_remote;
 /********************************************************************
 ** Solidified function: add_schedule
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_add_schedule,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_HTTP_remote_add_schedule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_update_time_map),
@@ -65,7 +64,6 @@ be_local_closure(class_Matter_HTTP_remote_add_schedule,   /* name */
 /********************************************************************
 ** Solidified function: dispatch_cb
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_dispatch_cb,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -74,7 +72,7 @@ be_local_closure(class_Matter_HTTP_remote_dispatch_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -122,7 +120,6 @@ be_local_closure(class_Matter_HTTP_remote_dispatch_cb,   /* name */
 /********************************************************************
 ** Solidified function: get_info
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_get_info,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -131,7 +128,7 @@ be_local_closure(class_Matter_HTTP_remote_get_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(info),
@@ -150,7 +147,6 @@ be_local_closure(class_Matter_HTTP_remote_get_info,   /* name */
 /********************************************************************
 ** Solidified function: parse_status_http
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -159,7 +155,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -343,7 +339,6 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
 /********************************************************************
 ** Solidified function: set_info
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_set_info,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -352,7 +347,7 @@ be_local_closure(class_Matter_HTTP_remote_set_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(info),
@@ -371,7 +366,6 @@ be_local_closure(class_Matter_HTTP_remote_set_info,   /* name */
 /********************************************************************
 ** Solidified function: device_is_alive
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_device_is_alive,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -380,7 +374,7 @@ be_local_closure(class_Matter_HTTP_remote_device_is_alive,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(reachable),
@@ -411,7 +405,6 @@ be_local_closure(class_Matter_HTTP_remote_device_is_alive,   /* name */
 /********************************************************************
 ** Solidified function: event_http_finished
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -420,7 +413,7 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),
@@ -494,7 +487,6 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
 /********************************************************************
 ** Solidified function: probe_async
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -503,7 +495,7 @@ be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -569,7 +561,6 @@ be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
 /********************************************************************
 ** Solidified function: info_changed
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_info_changed,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -578,7 +569,7 @@ be_local_closure(class_Matter_HTTP_remote_info_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -600,7 +591,6 @@ be_local_closure(class_Matter_HTTP_remote_info_changed,   /* name */
 /********************************************************************
 ** Solidified function: web_last_seen
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_web_last_seen,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -609,7 +599,7 @@ be_local_closure(class_Matter_HTTP_remote_web_last_seen,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -648,7 +638,6 @@ be_local_closure(class_Matter_HTTP_remote_web_last_seen,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_init,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -657,7 +646,7 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 4]) {
+    ( &(const struct bproto*[ 3]) {
       be_nested_proto(
         10,                          /* nstack */
         3,                          /* argc */
@@ -667,7 +656,7 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(parse_status_response_and_call_method),
@@ -697,7 +686,7 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(parse_status_response_and_call_method),
@@ -727,7 +716,7 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(parse_status_response_and_call_method),
@@ -748,7 +737,6 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
           0x80040600,  //  0009  RET	1	R3
         })
       ),
-    &be_class_Matter_HTTP_remote, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
@@ -823,7 +811,6 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
 /********************************************************************
 ** Solidified function: change_schedule
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_change_schedule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -832,7 +819,7 @@ be_local_closure(class_Matter_HTTP_remote_change_schedule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_update_time_map),
@@ -867,7 +854,6 @@ be_local_closure(class_Matter_HTTP_remote_change_schedule,   /* name */
 /********************************************************************
 ** Solidified function: parse_status_response_and_call_method
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -876,7 +862,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -960,7 +946,6 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
 /********************************************************************
 ** Solidified function: call_sync
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -969,7 +954,7 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -1079,7 +1064,6 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
 /********************************************************************
 ** Solidified function: scheduler
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_scheduler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1088,7 +1072,7 @@ be_local_closure(class_Matter_HTTP_remote_scheduler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_next_timestamp_map),
@@ -1180,7 +1164,6 @@ be_local_closure(class_Matter_HTTP_remote_scheduler,   /* name */
 /********************************************************************
 ** Solidified function: event_http_failed
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_event_http_failed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1189,7 +1172,7 @@ be_local_closure(class_Matter_HTTP_remote_event_http_failed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),
@@ -1225,7 +1208,6 @@ be_local_closure(class_Matter_HTTP_remote_event_http_failed,   /* name */
 /********************************************************************
 ** Solidified function: add_async_cb
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_add_async_cb,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1234,7 +1216,7 @@ be_local_closure(class_Matter_HTTP_remote_add_async_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(async_cb_map),
@@ -1254,7 +1236,6 @@ be_local_closure(class_Matter_HTTP_remote_add_async_cb,   /* name */
 /********************************************************************
 ** Solidified function: event_http_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_event_http_timeout,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1263,7 +1244,7 @@ be_local_closure(class_Matter_HTTP_remote_event_http_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_HTTP_remote, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_IM;
 /********************************************************************
 ** Solidified function: process_write_request
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_write_request,   /* name */
   be_nested_proto(
     21,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[41]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -220,7 +219,6 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
 /********************************************************************
 ** Solidified function: path2raw
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_path2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -229,7 +227,7 @@ be_local_closure(class_Matter_IM_path2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),
@@ -358,7 +356,6 @@ be_local_closure(class_Matter_IM_path2raw,   /* name */
 /********************************************************************
 ** Solidified function: attributedata2raw
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -367,7 +364,7 @@ be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),
@@ -413,7 +410,6 @@ be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
 /********************************************************************
 ** Solidified function: send_subscribe_update
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -422,7 +418,7 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -526,7 +522,6 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
 /********************************************************************
 ** Solidified function: process_read_request_pull
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_read_request_pull,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -535,7 +530,7 @@ be_local_closure(class_Matter_IM_process_read_request_pull,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -584,7 +579,6 @@ be_local_closure(class_Matter_IM_process_read_request_pull,   /* name */
 /********************************************************************
 ** Solidified function: process_read_or_subscribe_request_pull
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -593,7 +587,7 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[25]) {     /* constants */
     /* K0   */  be_nested_str_weak(attributes_requests),
@@ -749,7 +743,6 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* na
 /********************************************************************
 ** Solidified function: process_timed_request
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_timed_request,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -758,7 +751,7 @@ be_local_closure(class_Matter_IM_process_timed_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -807,7 +800,6 @@ be_local_closure(class_Matter_IM_process_timed_request,   /* name */
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -816,7 +808,7 @@ be_local_closure(class_Matter_IM_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(subs_shop),
@@ -838,7 +830,6 @@ be_local_closure(class_Matter_IM_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: process_invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -847,7 +838,7 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[41]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1126,7 +1117,6 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: process_read_or_subscribe_request_event_pull
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,   /* name */
   be_nested_proto(
     24,                          /* nstack */
@@ -1135,7 +1125,7 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,  
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_requests),
@@ -1322,7 +1312,6 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,  
 /********************************************************************
 ** Solidified function: send_enqueued
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_enqueued,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1331,7 +1320,7 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1381,7 +1370,6 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
 /********************************************************************
 ** Solidified function: subscribe_request
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -1390,7 +1378,7 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[35]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1537,7 +1525,6 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
 /********************************************************************
 ** Solidified function: send_ack_now
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_ack_now,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1546,7 +1533,7 @@ be_local_closure(class_Matter_IM_send_ack_now,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -1576,7 +1563,6 @@ be_local_closure(class_Matter_IM_send_ack_now,   /* name */
 /********************************************************************
 ** Solidified function: expire_sendqueue
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1585,7 +1571,7 @@ be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1633,7 +1619,6 @@ be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
 /********************************************************************
 ** Solidified function: process_incoming_ack
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1642,7 +1627,7 @@ be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
@@ -1678,7 +1663,6 @@ be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
 /********************************************************************
 ** Solidified function: remove_sendqueue_by_exchangeid
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1687,7 +1671,7 @@ be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1732,7 +1716,6 @@ be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
 /********************************************************************
 ** Solidified function: write_single_attribute_status_to_bytes
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -1741,7 +1724,7 @@ be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[25]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1868,7 +1851,6 @@ be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* na
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1877,7 +1859,7 @@ be_local_closure(class_Matter_IM_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -1928,7 +1910,6 @@ be_local_closure(class_Matter_IM_init,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1937,7 +1918,7 @@ be_local_closure(class_Matter_IM_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(expire_sendqueue),
@@ -1957,7 +1938,6 @@ be_local_closure(class_Matter_IM_every_second,   /* name */
 /********************************************************************
 ** Solidified function: process_invoke_request_solo
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -1966,7 +1946,7 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[38]) {     /* constants */
     /* K0   */  be_nested_str_weak(msg),
@@ -2208,7 +2188,6 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
 /********************************************************************
 ** Solidified function: send_subscribe_heartbeat
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2217,7 +2196,7 @@ be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -2277,7 +2256,6 @@ be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
 /********************************************************************
 ** Solidified function: find_sendqueue_by_exchangeid
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2286,7 +2264,7 @@ be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -2328,7 +2306,6 @@ be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
 /********************************************************************
 ** Solidified function: process_read_request_solo
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -2337,7 +2314,7 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[52]) {     /* constants */
     /* K0   */  be_nested_str_weak(status),
@@ -2647,7 +2624,6 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
 /********************************************************************
 ** Solidified function: parse_event_filters_min_no
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -2656,7 +2632,7 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_IM),
@@ -2733,7 +2709,6 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
 /********************************************************************
 ** Solidified function: invokeresponse2raw
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -2742,7 +2717,7 @@ be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),
@@ -2917,7 +2892,6 @@ be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
 /********************************************************************
 ** Solidified function: process_status_response
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_status_response,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2926,7 +2900,7 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(findsubval),
@@ -3000,7 +2974,6 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
 /********************************************************************
 ** Solidified function: attributestatus2raw
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -3009,7 +2982,7 @@ be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(add),
@@ -3078,7 +3051,6 @@ be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
 /********************************************************************
 ** Solidified function: read_single_attribute_to_bytes
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
   be_nested_proto(
     21,                          /* nstack */
@@ -3087,7 +3059,7 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -3299,7 +3271,6 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
 /********************************************************************
 ** Solidified function: send_status
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_status,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -3308,7 +3279,7 @@ be_local_closure(class_Matter_IM_send_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(send_queue),
@@ -3337,7 +3308,6 @@ be_local_closure(class_Matter_IM_send_status,   /* name */
 /********************************************************************
 ** Solidified function: process_incoming
 ********************************************************************/
-extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_incoming,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3346,7 +3316,7 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(opcode),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_IM_base;
 /********************************************************************
 ** Solidified function: to_TLV_array
 ********************************************************************/
-extern const bclass be_class_Matter_IM_base;
 be_local_closure(class_Matter_IM_base_to_TLV_array,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_IM_base_to_TLV_array,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_base, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(add_array),
@@ -60,7 +59,6 @@ be_local_closure(class_Matter_IM_base_to_TLV_array,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_IM_base;
 be_local_closure(class_Matter_IM_base_tostring,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -69,7 +67,7 @@ be_local_closure(class_Matter_IM_base_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_base, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_X3C),
@@ -102,7 +100,6 @@ be_local_closure(class_Matter_IM_base_tostring,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV_array
 ********************************************************************/
-extern const bclass be_class_Matter_IM_base;
 be_local_closure(class_Matter_IM_base_from_TLV_array,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -111,7 +108,7 @@ be_local_closure(class_Matter_IM_base_from_TLV_array,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_base, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(push),
@@ -172,7 +169,6 @@ extern const bclass be_class_Matter_IM_Message_base;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message_base;
 be_local_closure(class_Matter_IM_Message_base_init,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -181,7 +177,7 @@ be_local_closure(class_Matter_IM_Message_base_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message_base, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(InteractionModelRevision),
@@ -218,7 +214,6 @@ extern const bclass be_class_Matter_AttributePathIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributePathIB;
 be_local_closure(class_Matter_AttributePathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -227,7 +222,7 @@ be_local_closure(class_Matter_AttributePathIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributePathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -296,7 +291,6 @@ be_local_closure(class_Matter_AttributePathIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_AttributePathIB;
 be_local_closure(class_Matter_AttributePathIB_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -305,7 +299,7 @@ be_local_closure(class_Matter_AttributePathIB_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributePathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -396,7 +390,6 @@ be_local_closure(class_Matter_AttributePathIB_tostring,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributePathIB;
 be_local_closure(class_Matter_AttributePathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -405,7 +398,7 @@ be_local_closure(class_Matter_AttributePathIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributePathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_compression),
@@ -486,7 +479,6 @@ extern const bclass be_class_Matter_ClusterPathIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_ClusterPathIB;
 be_local_closure(class_Matter_ClusterPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -495,7 +487,7 @@ be_local_closure(class_Matter_ClusterPathIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_ClusterPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(node),
@@ -536,7 +528,6 @@ be_local_closure(class_Matter_ClusterPathIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_ClusterPathIB;
 be_local_closure(class_Matter_ClusterPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -545,7 +536,7 @@ be_local_closure(class_Matter_ClusterPathIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_ClusterPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -614,7 +605,6 @@ extern const bclass be_class_Matter_DataVersionFilterIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_DataVersionFilterIB;
 be_local_closure(class_Matter_DataVersionFilterIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -623,7 +613,7 @@ be_local_closure(class_Matter_DataVersionFilterIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_DataVersionFilterIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(path),
@@ -667,7 +657,6 @@ be_local_closure(class_Matter_DataVersionFilterIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_DataVersionFilterIB;
 be_local_closure(class_Matter_DataVersionFilterIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -676,7 +665,7 @@ be_local_closure(class_Matter_DataVersionFilterIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_DataVersionFilterIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -735,7 +724,6 @@ extern const bclass be_class_Matter_AttributeDataIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeDataIB;
 be_local_closure(class_Matter_AttributeDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -744,7 +732,7 @@ be_local_closure(class_Matter_AttributeDataIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(data_version),
@@ -794,7 +782,6 @@ be_local_closure(class_Matter_AttributeDataIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeDataIB;
 be_local_closure(class_Matter_AttributeDataIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -803,7 +790,7 @@ be_local_closure(class_Matter_AttributeDataIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -869,7 +856,6 @@ extern const bclass be_class_Matter_AttributeReportIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeReportIB;
 be_local_closure(class_Matter_AttributeReportIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -878,7 +864,7 @@ be_local_closure(class_Matter_AttributeReportIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeReportIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -915,7 +901,6 @@ be_local_closure(class_Matter_AttributeReportIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeReportIB;
 be_local_closure(class_Matter_AttributeReportIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -924,7 +909,7 @@ be_local_closure(class_Matter_AttributeReportIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeReportIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_status),
@@ -992,7 +977,6 @@ extern const bclass be_class_Matter_EventFilterIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventFilterIB;
 be_local_closure(class_Matter_EventFilterIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1001,7 +985,7 @@ be_local_closure(class_Matter_EventFilterIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventFilterIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(node),
@@ -1036,7 +1020,6 @@ be_local_closure(class_Matter_EventFilterIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventFilterIB;
 be_local_closure(class_Matter_EventFilterIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1045,7 +1028,7 @@ be_local_closure(class_Matter_EventFilterIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventFilterIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1104,7 +1087,6 @@ extern const bclass be_class_Matter_EventPathIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventPathIB;
 be_local_closure(class_Matter_EventPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1113,7 +1095,7 @@ be_local_closure(class_Matter_EventPathIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(node),
@@ -1165,7 +1147,6 @@ be_local_closure(class_Matter_EventPathIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventPathIB;
 be_local_closure(class_Matter_EventPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1174,7 +1155,7 @@ be_local_closure(class_Matter_EventPathIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1263,7 +1244,6 @@ extern const bclass be_class_Matter_EventDataIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventDataIB;
 be_local_closure(class_Matter_EventDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1272,7 +1252,7 @@ be_local_closure(class_Matter_EventDataIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(path),
@@ -1348,7 +1328,6 @@ be_local_closure(class_Matter_EventDataIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventDataIB;
 be_local_closure(class_Matter_EventDataIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1357,7 +1336,7 @@ be_local_closure(class_Matter_EventDataIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1470,7 +1449,6 @@ extern const bclass be_class_Matter_EventReportIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventReportIB;
 be_local_closure(class_Matter_EventReportIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1479,7 +1457,7 @@ be_local_closure(class_Matter_EventReportIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventReportIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1516,7 +1494,6 @@ be_local_closure(class_Matter_EventReportIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventReportIB;
 be_local_closure(class_Matter_EventReportIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1525,7 +1502,7 @@ be_local_closure(class_Matter_EventReportIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventReportIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_status),
@@ -1593,7 +1570,6 @@ extern const bclass be_class_Matter_CommandPathIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandPathIB;
 be_local_closure(class_Matter_CommandPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1602,7 +1578,7 @@ be_local_closure(class_Matter_CommandPathIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -1643,7 +1619,6 @@ be_local_closure(class_Matter_CommandPathIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandPathIB;
 be_local_closure(class_Matter_CommandPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1652,7 +1627,7 @@ be_local_closure(class_Matter_CommandPathIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandPathIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1720,7 +1695,6 @@ extern const bclass be_class_Matter_CommandDataIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandDataIB;
 be_local_closure(class_Matter_CommandDataIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1729,7 +1703,7 @@ be_local_closure(class_Matter_CommandDataIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1766,7 +1740,6 @@ be_local_closure(class_Matter_CommandDataIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandDataIB;
 be_local_closure(class_Matter_CommandDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1775,7 +1748,7 @@ be_local_closure(class_Matter_CommandDataIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandDataIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(command_path),
@@ -1837,7 +1810,6 @@ extern const bclass be_class_Matter_InvokeResponseIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeResponseIB;
 be_local_closure(class_Matter_InvokeResponseIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1846,7 +1818,7 @@ be_local_closure(class_Matter_InvokeResponseIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeResponseIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(command),
@@ -1895,7 +1867,6 @@ be_local_closure(class_Matter_InvokeResponseIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeResponseIB;
 be_local_closure(class_Matter_InvokeResponseIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1904,7 +1875,7 @@ be_local_closure(class_Matter_InvokeResponseIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeResponseIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1960,7 +1931,6 @@ extern const bclass be_class_Matter_CommandStatusIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandStatusIB;
 be_local_closure(class_Matter_CommandStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1969,7 +1939,7 @@ be_local_closure(class_Matter_CommandStatusIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2006,7 +1976,6 @@ be_local_closure(class_Matter_CommandStatusIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_CommandStatusIB;
 be_local_closure(class_Matter_CommandStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2015,7 +1984,7 @@ be_local_closure(class_Matter_CommandStatusIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_CommandStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(command_path),
@@ -2083,7 +2052,6 @@ extern const bclass be_class_Matter_EventStatusIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventStatusIB;
 be_local_closure(class_Matter_EventStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2092,7 +2060,7 @@ be_local_closure(class_Matter_EventStatusIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(path),
@@ -2141,7 +2109,6 @@ be_local_closure(class_Matter_EventStatusIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_EventStatusIB;
 be_local_closure(class_Matter_EventStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2150,7 +2117,7 @@ be_local_closure(class_Matter_EventStatusIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2206,7 +2173,6 @@ extern const bclass be_class_Matter_AttributeStatusIB;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeStatusIB;
 be_local_closure(class_Matter_AttributeStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2215,7 +2181,7 @@ be_local_closure(class_Matter_AttributeStatusIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(path),
@@ -2264,7 +2230,6 @@ be_local_closure(class_Matter_AttributeStatusIB_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_AttributeStatusIB;
 be_local_closure(class_Matter_AttributeStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2273,7 +2238,7 @@ be_local_closure(class_Matter_AttributeStatusIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_AttributeStatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2329,7 +2294,6 @@ extern const bclass be_class_Matter_StatusIB;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_StatusIB;
 be_local_closure(class_Matter_StatusIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2338,7 +2302,7 @@ be_local_closure(class_Matter_StatusIB_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_StatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2378,7 +2342,6 @@ be_local_closure(class_Matter_StatusIB_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_StatusIB;
 be_local_closure(class_Matter_StatusIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2387,7 +2350,7 @@ be_local_closure(class_Matter_StatusIB_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_StatusIB, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(status),
@@ -2441,7 +2404,6 @@ extern const bclass be_class_Matter_StatusResponseMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_StatusResponseMessage;
 be_local_closure(class_Matter_StatusResponseMessage_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2450,7 +2412,7 @@ be_local_closure(class_Matter_StatusResponseMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_StatusResponseMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(status),
@@ -2479,7 +2441,6 @@ be_local_closure(class_Matter_StatusResponseMessage_from_TLV,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_StatusResponseMessage;
 be_local_closure(class_Matter_StatusResponseMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2488,7 +2449,7 @@ be_local_closure(class_Matter_StatusResponseMessage_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_StatusResponseMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2546,7 +2507,6 @@ extern const bclass be_class_Matter_ReadRequestMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_ReadRequestMessage;
 be_local_closure(class_Matter_ReadRequestMessage_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2555,7 +2515,7 @@ be_local_closure(class_Matter_ReadRequestMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_ReadRequestMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(attributes_requests),
@@ -2650,7 +2610,6 @@ extern const bclass be_class_Matter_ReadRequestMessage_solo;
 /********************************************************************
 ** Solidified function: from_raw
 ********************************************************************/
-extern const bclass be_class_Matter_ReadRequestMessage_solo;
 be_local_closure(class_Matter_ReadRequestMessage_solo_from_raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -2659,7 +2618,7 @@ be_local_closure(class_Matter_ReadRequestMessage_solo_from_raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_ReadRequestMessage_solo, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -2832,7 +2791,6 @@ extern const bclass be_class_Matter_ReportDataMessage;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_ReportDataMessage;
 be_local_closure(class_Matter_ReportDataMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2841,7 +2799,7 @@ be_local_closure(class_Matter_ReportDataMessage_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_ReportDataMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2931,7 +2889,6 @@ extern const bclass be_class_Matter_SubscribeRequestMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_SubscribeRequestMessage;
 be_local_closure(class_Matter_SubscribeRequestMessage_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2940,7 +2897,7 @@ be_local_closure(class_Matter_SubscribeRequestMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_SubscribeRequestMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(keep_subscriptions),
@@ -3057,7 +3014,6 @@ extern const bclass be_class_Matter_SubscribeResponseMessage;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_SubscribeResponseMessage;
 be_local_closure(class_Matter_SubscribeResponseMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3066,7 +3022,7 @@ be_local_closure(class_Matter_SubscribeResponseMessage_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_SubscribeResponseMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -3132,7 +3088,6 @@ extern const bclass be_class_Matter_WriteRequestMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_WriteRequestMessage;
 be_local_closure(class_Matter_WriteRequestMessage_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3141,7 +3096,7 @@ be_local_closure(class_Matter_WriteRequestMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_WriteRequestMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(suppress_response),
@@ -3215,7 +3170,6 @@ extern const bclass be_class_Matter_WriteResponseMessage;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_WriteResponseMessage;
 be_local_closure(class_Matter_WriteResponseMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3224,7 +3178,7 @@ be_local_closure(class_Matter_WriteResponseMessage_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_WriteResponseMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -3281,7 +3235,6 @@ extern const bclass be_class_Matter_TimedRequestMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_TimedRequestMessage;
 be_local_closure(class_Matter_TimedRequestMessage_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3290,7 +3243,7 @@ be_local_closure(class_Matter_TimedRequestMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TimedRequestMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(timeout),
@@ -3336,7 +3289,6 @@ extern const bclass be_class_Matter_InvokeRequestMessage;
 /********************************************************************
 ** Solidified function: from_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeRequestMessage;
 be_local_closure(class_Matter_InvokeRequestMessage_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3345,7 +3297,7 @@ be_local_closure(class_Matter_InvokeRequestMessage_from_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeRequestMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(suppress_response),
@@ -3412,7 +3364,6 @@ extern const bclass be_class_Matter_InvokeRequestMessage_solo;
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeRequestMessage_solo;
 be_local_closure(class_Matter_InvokeRequestMessage_solo_reset,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -3421,7 +3372,7 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeRequestMessage_solo, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -3451,7 +3402,6 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_reset,   /* name */
 /********************************************************************
 ** Solidified function: from_raw
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeRequestMessage_solo;
 be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -3460,7 +3410,7 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeRequestMessage_solo, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -3682,7 +3632,6 @@ extern const bclass be_class_Matter_InvokeResponseMessage;
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_InvokeResponseMessage;
 be_local_closure(class_Matter_InvokeResponseMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3691,7 +3640,7 @@ be_local_closure(class_Matter_InvokeResponseMessage_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_InvokeResponseMessage, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_IM_Message;
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_reset,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_IM_Message_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(resp),
@@ -72,7 +71,6 @@ be_local_closure(class_Matter_IM_Message_reset,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -81,7 +79,7 @@ be_local_closure(class_Matter_IM_Message_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -104,7 +102,6 @@ be_local_closure(class_Matter_IM_Message_init,   /* name */
 /********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_send_im,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -113,7 +110,7 @@ be_local_closure(class_Matter_IM_Message_send_im,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(resp),
@@ -182,7 +179,6 @@ be_local_closure(class_Matter_IM_Message_send_im,   /* name */
 /********************************************************************
 ** Solidified function: status_error_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_status_error_received,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -191,7 +187,7 @@ be_local_closure(class_Matter_IM_Message_status_error_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(status_error_received),
@@ -207,7 +203,6 @@ be_local_closure(class_Matter_IM_Message_status_error_received,   /* name */
 /********************************************************************
 ** Solidified function: get_exchangeid
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_get_exchangeid,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -216,7 +211,7 @@ be_local_closure(class_Matter_IM_Message_get_exchangeid,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(resp),
@@ -237,7 +232,6 @@ be_local_closure(class_Matter_IM_Message_get_exchangeid,   /* name */
 /********************************************************************
 ** Solidified function: ack_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_ack_received,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -246,7 +240,7 @@ be_local_closure(class_Matter_IM_Message_ack_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(finishing),
@@ -281,7 +275,6 @@ be_local_closure(class_Matter_IM_Message_ack_received,   /* name */
 /********************************************************************
 ** Solidified function: reached_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_reached_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -290,7 +283,7 @@ be_local_closure(class_Matter_IM_Message_reached_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(reached_timeout),
@@ -306,7 +299,6 @@ be_local_closure(class_Matter_IM_Message_reached_timeout,   /* name */
 /********************************************************************
 ** Solidified function: status_ok_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_status_ok_received,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -315,7 +307,7 @@ be_local_closure(class_Matter_IM_Message_status_ok_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Message, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(expiration),
@@ -389,7 +381,6 @@ extern const bclass be_class_Matter_IM_Status;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Status;
 be_local_closure(class_Matter_IM_Status_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -398,7 +389,7 @@ be_local_closure(class_Matter_IM_Status_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Status, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -450,7 +441,6 @@ extern const bclass be_class_Matter_IM_InvokeResponse;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_InvokeResponse;
 be_local_closure(class_Matter_IM_InvokeResponse_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -459,7 +449,7 @@ be_local_closure(class_Matter_IM_InvokeResponse_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_InvokeResponse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -503,7 +493,6 @@ extern const bclass be_class_Matter_IM_WriteResponse;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_WriteResponse;
 be_local_closure(class_Matter_IM_WriteResponse_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -512,7 +501,7 @@ be_local_closure(class_Matter_IM_WriteResponse_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_WriteResponse, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -556,7 +545,6 @@ extern const bclass be_class_Matter_IM_ReportData_Pull;
 /********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
 be_local_closure(class_Matter_IM_ReportData_Pull_send_im,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -565,7 +553,7 @@ be_local_closure(class_Matter_IM_ReportData_Pull_send_im,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[47]) {     /* constants */
     /* K0   */  be_nested_str_weak(resp),
@@ -989,7 +977,6 @@ be_local_closure(class_Matter_IM_ReportData_Pull_send_im,   /* name */
 /********************************************************************
 ** Solidified function: status_ok_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
 be_local_closure(class_Matter_IM_ReportData_Pull_status_ok_received,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -998,7 +985,7 @@ be_local_closure(class_Matter_IM_ReportData_Pull_status_ok_received,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(status_ok_received),
@@ -1035,7 +1022,6 @@ be_local_closure(class_Matter_IM_ReportData_Pull_status_ok_received,   /* name *
 /********************************************************************
 ** Solidified function: set_subscription_id
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
 be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1044,7 +1030,7 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(subscription_id),
@@ -1063,7 +1049,6 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name 
 /********************************************************************
 ** Solidified function: set_suppress_response
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
 be_local_closure(class_Matter_IM_ReportData_Pull_set_suppress_response,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1072,7 +1057,7 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_suppress_response,   /* nam
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(suppress_response),
@@ -1091,7 +1076,6 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_suppress_response,   /* nam
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportData_Pull;
 be_local_closure(class_Matter_IM_ReportData_Pull_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1100,7 +1084,7 @@ be_local_closure(class_Matter_IM_ReportData_Pull_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportData_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1156,7 +1140,6 @@ extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 /********************************************************************
 ** Solidified function: ack_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_ack_received,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1165,7 +1148,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_ack_received,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(ack_received),
@@ -1206,7 +1189,6 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_ack_received,   /* na
 /********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_send_im,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1215,7 +1197,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_send_im,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(ready),
@@ -1331,7 +1313,6 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_send_im,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_init,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1340,7 +1321,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1393,7 +1374,6 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_init,   /* name */
 /********************************************************************
 ** Solidified function: status_error_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_error_received,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1402,7 +1382,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_error_received
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(sub),
@@ -1424,7 +1404,6 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_error_received
 /********************************************************************
 ** Solidified function: reached_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_reached_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1433,7 +1412,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_reached_timeout,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(sub),
@@ -1455,7 +1434,6 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_reached_timeout,   /*
 /********************************************************************
 ** Solidified function: status_ok_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_ok_received,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1464,7 +1442,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_ok_received,  
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_ReportDataSubscribed_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(report_data_phase),
@@ -1529,7 +1507,6 @@ extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 /********************************************************************
 ** Solidified function: status_error_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_error_received,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1538,7 +1515,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_error_received,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(sub),
@@ -1561,7 +1538,6 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_error_received,   /*
 /********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_send_im,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1570,7 +1546,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_send_im,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(send_im),
@@ -1597,7 +1573,6 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_send_im,   /* name */
 /********************************************************************
 ** Solidified function: ack_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1606,7 +1581,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(ack_received),
@@ -1631,7 +1606,6 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
 /********************************************************************
 ** Solidified function: reached_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_reached_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1640,7 +1614,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_reached_timeout,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(sub),
@@ -1662,7 +1636,6 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_reached_timeout,   /* name 
 /********************************************************************
 ** Solidified function: status_ok_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_ok_received,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1671,7 +1644,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_ok_received,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(status_ok_received),
@@ -1688,7 +1661,6 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_ok_received,   /* na
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 be_local_closure(class_Matter_IM_SubscribedHeartbeat_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1697,7 +1669,7 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribedHeartbeat, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1769,7 +1741,6 @@ extern const bclass be_class_Matter_IM_SubscribeResponse_Pull;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribeResponse_Pull;
 be_local_closure(class_Matter_IM_SubscribeResponse_Pull_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1778,7 +1749,7 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribeResponse_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1814,7 +1785,6 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_init,   /* name */
 /********************************************************************
 ** Solidified function: status_ok_received
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribeResponse_Pull;
 be_local_closure(class_Matter_IM_SubscribeResponse_Pull_status_ok_received,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1823,7 +1793,7 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_status_ok_received,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribeResponse_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -1877,7 +1847,6 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_status_ok_received,   /*
 /********************************************************************
 ** Solidified function: send_im
 ********************************************************************/
-extern const bclass be_class_Matter_IM_SubscribeResponse_Pull;
 be_local_closure(class_Matter_IM_SubscribeResponse_Pull_send_im,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1886,7 +1855,7 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_send_im,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_SubscribeResponse_Pull, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(report_data_phase),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_IM_Subscription;
 /********************************************************************
 ** Solidified function: event_published
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_event_published,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_IM_Subscription_event_published,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(update_event_no),
@@ -65,7 +64,6 @@ be_local_closure(class_Matter_IM_Subscription_event_published,   /* name */
 /********************************************************************
 ** Solidified function: attribute_updated_ctx
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_attribute_updated_ctx,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -74,7 +72,7 @@ be_local_closure(class_Matter_IM_Subscription_attribute_updated_ctx,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -135,7 +133,6 @@ be_local_closure(class_Matter_IM_Subscription_attribute_updated_ctx,   /* name *
 /********************************************************************
 ** Solidified function: clear_before_arm
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_clear_before_arm,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -144,7 +141,7 @@ be_local_closure(class_Matter_IM_Subscription_clear_before_arm,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(updates),
@@ -172,7 +169,6 @@ be_local_closure(class_Matter_IM_Subscription_clear_before_arm,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_init,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -181,7 +177,7 @@ be_local_closure(class_Matter_IM_Subscription_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(subs_shop),
@@ -293,7 +289,6 @@ be_local_closure(class_Matter_IM_Subscription_init,   /* name */
 /********************************************************************
 ** Solidified function: _add_attribute_unique_path
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription__add_attribute_unique_path,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -302,7 +297,7 @@ be_local_closure(class_Matter_IM_Subscription__add_attribute_unique_path,   /* n
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -353,7 +348,6 @@ be_local_closure(class_Matter_IM_Subscription__add_attribute_unique_path,   /* n
 /********************************************************************
 ** Solidified function: update_event_generator_array
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_update_event_generator_array,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -362,7 +356,7 @@ be_local_closure(class_Matter_IM_Subscription_update_event_generator_array,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_generators),
@@ -430,7 +424,6 @@ be_local_closure(class_Matter_IM_Subscription_update_event_generator_array,   /*
 /********************************************************************
 ** Solidified function: re_arm
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -439,7 +432,7 @@ be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(wait_status),
@@ -500,7 +493,6 @@ be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
 /********************************************************************
 ** Solidified function: set_event_generator_or_arr
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_set_event_generator_or_arr,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -509,7 +501,7 @@ be_local_closure(class_Matter_IM_Subscription_set_event_generator_or_arr,   /* n
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_generators),
@@ -545,7 +537,6 @@ be_local_closure(class_Matter_IM_Subscription_set_event_generator_or_arr,   /* n
 /********************************************************************
 ** Solidified function: remove_self
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_remove_self,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -554,7 +545,7 @@ be_local_closure(class_Matter_IM_Subscription_remove_self,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -626,7 +617,6 @@ extern const bclass be_class_Matter_IM_Subscription_Shop;
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_every_50ms,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -635,7 +625,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -724,7 +714,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -733,7 +722,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(im),
@@ -756,7 +745,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_init,   /* name */
 /********************************************************************
 ** Solidified function: attribute_updated_ctx
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -765,7 +753,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* n
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -800,7 +788,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* n
 /********************************************************************
 ** Solidified function: remove_sub
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_remove_sub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -809,7 +796,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_sub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -847,7 +834,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_sub,   /* name */
 /********************************************************************
 ** Solidified function: new_subscription
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_new_subscription,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -856,7 +842,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_new_subscription,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -916,7 +902,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_new_subscription,   /* name *
 /********************************************************************
 ** Solidified function: event_published
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_event_published,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -925,7 +910,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_event_published,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -959,7 +944,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_event_published,   /* name */
 /********************************************************************
 ** Solidified function: remove_by_session
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_session,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -968,7 +952,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_session,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1008,7 +992,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_session,   /* name 
 /********************************************************************
 ** Solidified function: remove_by_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1017,7 +1000,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_fabric,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_sessions),
@@ -1050,7 +1033,6 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_fabric,   /* name *
 /********************************************************************
 ** Solidified function: get_by_id
 ********************************************************************/
-extern const bclass be_class_Matter_IM_Subscription_Shop;
 be_local_closure(class_Matter_IM_Subscription_Shop_get_by_id,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1059,7 +1041,7 @@ be_local_closure(class_Matter_IM_Subscription_Shop_get_by_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_IM_Subscription_Shop, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Frame;
 /********************************************************************
 ** Solidified function: get_node_id
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_get_node_id,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Frame_get_node_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
@@ -44,7 +43,6 @@ be_local_closure(class_Matter_Frame_get_node_id,   /* name */
 /********************************************************************
 ** Solidified function: encrypt
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_encrypt,   /* name */
   be_nested_proto(
     23,                          /* nstack */
@@ -53,7 +51,7 @@ be_local_closure(class_Matter_Frame_encrypt,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -150,7 +148,6 @@ be_local_closure(class_Matter_Frame_encrypt,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -159,7 +156,7 @@ be_local_closure(class_Matter_Frame_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(message_handler),
@@ -184,7 +181,6 @@ be_local_closure(class_Matter_Frame_init,   /* name */
 /********************************************************************
 ** Solidified function: encode_frame
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_encode_frame,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -193,7 +189,7 @@ be_local_closure(class_Matter_Frame_encode_frame,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -399,7 +395,6 @@ be_local_closure(class_Matter_Frame_encode_frame,   /* name */
 /********************************************************************
 ** Solidified function: decode_header
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_decode_header,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -408,7 +403,7 @@ be_local_closure(class_Matter_Frame_decode_header,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -566,7 +561,6 @@ be_local_closure(class_Matter_Frame_decode_header,   /* name */
 /********************************************************************
 ** Solidified function: debug
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_debug,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -575,7 +569,7 @@ be_local_closure(class_Matter_Frame_debug,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -606,7 +600,6 @@ be_local_closure(class_Matter_Frame_debug,   /* name */
 /********************************************************************
 ** Solidified function: build_response
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_build_response,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -615,7 +608,7 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(message_handler),
@@ -750,7 +743,6 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
 /********************************************************************
 ** Solidified function: decrypt
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_decrypt,   /* name */
   be_nested_proto(
     23,                          /* nstack */
@@ -759,7 +751,7 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -919,7 +911,6 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
 /********************************************************************
 ** Solidified function: build_standalone_ack
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_build_standalone_ack,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -928,7 +919,7 @@ be_local_closure(class_Matter_Frame_build_standalone_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(message_handler),
@@ -1010,7 +1001,6 @@ be_local_closure(class_Matter_Frame_build_standalone_ack,   /* name */
 /********************************************************************
 ** Solidified function: initiate_response
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_initiate_response,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1019,7 +1009,7 @@ be_local_closure(class_Matter_Frame_initiate_response,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Frame),
@@ -1104,7 +1094,6 @@ be_local_closure(class_Matter_Frame_initiate_response,   /* name */
 /********************************************************************
 ** Solidified function: decode_payload
 ********************************************************************/
-extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_decode_payload,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1113,7 +1102,7 @@ be_local_closure(class_Matter_Frame_decode_payload,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(payload_idx),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_MessageHandler;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_MessageHandler_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -64,7 +63,6 @@ be_local_closure(class_Matter_MessageHandler_init,   /* name */
 /********************************************************************
 ** Solidified function: send_encrypted_ack
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -73,7 +71,7 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(x_flag_r),
@@ -136,7 +134,6 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
 /********************************************************************
 ** Solidified function: msg_received
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -145,7 +142,7 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[65]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -560,7 +557,6 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
 /********************************************************************
 ** Solidified function: send_response_frame
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_send_response_frame,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -569,7 +565,7 @@ be_local_closure(class_Matter_MessageHandler_send_response_frame,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -592,7 +588,6 @@ be_local_closure(class_Matter_MessageHandler_send_response_frame,   /* name */
 /********************************************************************
 ** Solidified function: send_simple_ack
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -601,7 +596,7 @@ be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(x_flag_r),
@@ -663,7 +658,6 @@ be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -672,7 +666,7 @@ be_local_closure(class_Matter_MessageHandler_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(im),
@@ -694,7 +688,6 @@ be_local_closure(class_Matter_MessageHandler_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -703,7 +696,7 @@ be_local_closure(class_Matter_MessageHandler_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_MessageHandler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(commissioning),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Module.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Module.h
@@ -15,7 +15,7 @@ be_local_closure(module_matter_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -53,7 +53,7 @@ be_local_closure(module_matter_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Path;
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_Path;
 be_local_closure(class_Matter_Path_reset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Path_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Path, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -52,7 +51,6 @@ be_local_closure(class_Matter_Path_reset,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Path;
 be_local_closure(class_Matter_Path_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -61,7 +59,7 @@ be_local_closure(class_Matter_Path_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Path, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -84,7 +82,6 @@ be_local_closure(class_Matter_Path_init,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_Path;
 be_local_closure(class_Matter_Path_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -93,7 +90,7 @@ be_local_closure(class_Matter_Path_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Path, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -201,7 +198,6 @@ be_local_closure(class_Matter_Path_tostring,   /* name */
 /********************************************************************
 ** Solidified function: copy
 ********************************************************************/
-extern const bclass be_class_Matter_Path;
 be_local_closure(class_Matter_Path_copy,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -210,7 +206,7 @@ be_local_closure(class_Matter_Path_copy,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Path, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_EventGenerator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_EventGenerator.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_EventGenerator;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_EventGenerator_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -37,7 +36,6 @@ be_local_closure(class_Matter_EventGenerator_init,   /* name */
 /********************************************************************
 ** Solidified function: get_pi
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_get_pi,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -46,7 +44,7 @@ be_local_closure(class_Matter_EventGenerator_get_pi,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_pi),
@@ -63,7 +61,6 @@ be_local_closure(class_Matter_EventGenerator_get_pi,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_start,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -72,7 +69,7 @@ be_local_closure(class_Matter_EventGenerator_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -105,7 +102,6 @@ be_local_closure(class_Matter_EventGenerator_start,   /* name */
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -114,7 +110,7 @@ be_local_closure(class_Matter_EventGenerator_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(event_no),
@@ -137,7 +133,6 @@ be_local_closure(class_Matter_EventGenerator_reset,   /* name */
 /********************************************************************
 ** Solidified function: is_finished
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_is_finished,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -146,7 +141,7 @@ be_local_closure(class_Matter_EventGenerator_is_finished,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(finished),
@@ -165,7 +160,6 @@ be_local_closure(class_Matter_EventGenerator_is_finished,   /* name */
 /********************************************************************
 ** Solidified function: event_is_match
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_event_is_match,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -174,7 +168,7 @@ be_local_closure(class_Matter_EventGenerator_event_is_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(path_in_endpoint),
@@ -234,7 +228,6 @@ be_local_closure(class_Matter_EventGenerator_event_is_match,   /* name */
 /********************************************************************
 ** Solidified function: next_event
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_next_event,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -243,7 +236,7 @@ be_local_closure(class_Matter_EventGenerator_next_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(finished),
@@ -293,7 +286,6 @@ be_local_closure(class_Matter_EventGenerator_next_event,   /* name */
 /********************************************************************
 ** Solidified function: restart_from
 ********************************************************************/
-extern const bclass be_class_Matter_EventGenerator;
 be_local_closure(class_Matter_EventGenerator_restart_from,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -302,7 +294,7 @@ be_local_closure(class_Matter_EventGenerator_restart_from,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_EventGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(finished),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_PathGenerator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_PathGenerator.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_PathGenerator;
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_reset,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_PathGenerator_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(path_concrete),
@@ -50,7 +49,6 @@ be_local_closure(class_Matter_PathGenerator_reset,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -59,7 +57,7 @@ be_local_closure(class_Matter_PathGenerator_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -78,7 +76,6 @@ be_local_closure(class_Matter_PathGenerator_init,   /* name */
 /********************************************************************
 ** Solidified function: is_direct
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_is_direct,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -87,7 +84,7 @@ be_local_closure(class_Matter_PathGenerator_is_direct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(path_in_endpoint),
@@ -121,7 +118,6 @@ be_local_closure(class_Matter_PathGenerator_is_direct,   /* name */
 /********************************************************************
 ** Solidified function: is_finished
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_is_finished,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -130,7 +126,7 @@ be_local_closure(class_Matter_PathGenerator_is_finished,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(pi),
@@ -151,7 +147,6 @@ be_local_closure(class_Matter_PathGenerator_is_finished,   /* name */
 /********************************************************************
 ** Solidified function: next_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_next_attribute,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -160,7 +155,7 @@ be_local_closure(class_Matter_PathGenerator_next_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(pi),
@@ -292,7 +287,6 @@ be_local_closure(class_Matter_PathGenerator_next_attribute,   /* name */
 /********************************************************************
 ** Solidified function: _next_cluster
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator__next_cluster,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -301,7 +295,7 @@ be_local_closure(class_Matter_PathGenerator__next_cluster,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(cluster),
@@ -367,7 +361,6 @@ be_local_closure(class_Matter_PathGenerator__next_cluster,   /* name */
 /********************************************************************
 ** Solidified function: _default_status_error
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator__default_status_error,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -376,7 +369,7 @@ be_local_closure(class_Matter_PathGenerator__default_status_error,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(is_direct),
@@ -424,7 +417,6 @@ be_local_closure(class_Matter_PathGenerator__default_status_error,   /* name */
 /********************************************************************
 ** Solidified function: _next_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator__next_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -433,7 +425,7 @@ be_local_closure(class_Matter_PathGenerator__next_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute),
@@ -501,7 +493,6 @@ be_local_closure(class_Matter_PathGenerator__next_attribute,   /* name */
 /********************************************************************
 ** Solidified function: _next_endpoint
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator__next_endpoint,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -510,7 +501,7 @@ be_local_closure(class_Matter_PathGenerator__next_endpoint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(pi),
@@ -590,7 +581,6 @@ be_local_closure(class_Matter_PathGenerator__next_endpoint,   /* name */
 /********************************************************************
 ** Solidified function: get_pi
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_get_pi,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -599,7 +589,7 @@ be_local_closure(class_Matter_PathGenerator_get_pi,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(pi),
@@ -628,7 +618,6 @@ be_local_closure(class_Matter_PathGenerator_get_pi,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Matter_PathGenerator;
 be_local_closure(class_Matter_PathGenerator_start,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -637,7 +626,7 @@ be_local_closure(class_Matter_PathGenerator_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_PathGenerator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(path_concrete),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin;
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(tick),
@@ -40,7 +39,6 @@ be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: state_json
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_state_json,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -49,7 +47,7 @@ be_local_closure(class_Matter_Plugin_state_json,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -98,7 +96,6 @@ be_local_closure(class_Matter_Plugin_state_json,   /* name */
 /********************************************************************
 ** Solidified function: ack_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_ack_request,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -107,7 +104,7 @@ be_local_closure(class_Matter_Plugin_ack_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(msg),
@@ -141,7 +138,6 @@ be_local_closure(class_Matter_Plugin_ack_request,   /* name */
 /********************************************************************
 ** Solidified function: write_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -150,7 +146,7 @@ be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(write_attribute),
@@ -167,7 +163,6 @@ be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -176,7 +171,7 @@ be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(invoke_request),
@@ -193,7 +188,6 @@ be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: append_state_json
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -202,7 +196,7 @@ be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -220,7 +214,6 @@ be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
 /********************************************************************
 ** Solidified function: every_250ms
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -229,7 +222,7 @@ be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(update_next),
@@ -283,7 +276,6 @@ be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
 /********************************************************************
 ** Solidified function: publish_event
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_publish_event,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -292,7 +284,7 @@ be_local_closure(class_Matter_Plugin_publish_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -325,7 +317,6 @@ be_local_closure(class_Matter_Plugin_publish_event,   /* name */
 /********************************************************************
 ** Solidified function: set_name
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_set_name,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -334,7 +325,7 @@ be_local_closure(class_Matter_Plugin_set_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(node_label),
@@ -369,7 +360,7 @@ be_local_closure(class_Matter_Plugin__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),
@@ -388,7 +379,6 @@ be_local_closure(class_Matter_Plugin__X3Clambda_X3E,   /* name */
 /********************************************************************
 ** Solidified function: ui_string_to_conf
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -397,7 +387,7 @@ be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Plugin),
@@ -426,7 +416,6 @@ be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
 /********************************************************************
 ** Solidified function: timed_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_timed_request,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -435,7 +424,7 @@ be_local_closure(class_Matter_Plugin_timed_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(timed_request),
@@ -452,7 +441,6 @@ be_local_closure(class_Matter_Plugin_timed_request,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -461,7 +449,7 @@ be_local_closure(class_Matter_Plugin_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -500,7 +488,6 @@ be_local_closure(class_Matter_Plugin_init,   /* name */
 /********************************************************************
 ** Solidified function: is_local_device
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -509,7 +496,7 @@ be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -531,7 +518,6 @@ be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
 /********************************************************************
 ** Solidified function: consolidate_update_commands
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -540,7 +526,7 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(UPDATE_COMMANDS),
@@ -559,7 +545,6 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow_lazy
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -568,7 +553,7 @@ be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tick),
@@ -598,7 +583,6 @@ be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
 /********************************************************************
 ** Solidified function: get_cluster_list_sorted
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -607,7 +591,7 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -631,7 +615,6 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
 /********************************************************************
 ** Solidified function: ui_conf_to_string
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -640,7 +623,7 @@ be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Plugin),
@@ -672,7 +655,6 @@ be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
 /********************************************************************
 ** Solidified function: attribute_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -681,7 +663,7 @@ be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -708,7 +690,6 @@ be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -717,7 +698,7 @@ be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(update_virtual),
@@ -733,7 +714,6 @@ be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: _parse_update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -742,7 +722,7 @@ be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -778,7 +758,6 @@ be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -787,7 +766,7 @@ be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(parse_configuration),
@@ -803,7 +782,6 @@ be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
 /********************************************************************
 ** Solidified function: get_name
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_get_name,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -812,7 +790,7 @@ be_local_closure(class_Matter_Plugin_get_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(node_label),
@@ -831,7 +809,6 @@ be_local_closure(class_Matter_Plugin_get_name,   /* name */
 /********************************************************************
 ** Solidified function: get_endpoint
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_get_endpoint,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -840,7 +817,7 @@ be_local_closure(class_Matter_Plugin_get_endpoint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -859,7 +836,6 @@ be_local_closure(class_Matter_Plugin_get_endpoint,   /* name */
 /********************************************************************
 ** Solidified function: contains_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -868,7 +844,7 @@ be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(clusters),
@@ -910,7 +886,6 @@ be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
 /********************************************************************
 ** Solidified function: subscribe_event
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -919,7 +894,7 @@ be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(subscribe_event),
@@ -936,7 +911,6 @@ be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
 /********************************************************************
 ** Solidified function: read_event
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_read_event,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -945,7 +919,7 @@ be_local_closure(class_Matter_Plugin_read_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(read_event),
@@ -962,7 +936,6 @@ be_local_closure(class_Matter_Plugin_read_event,   /* name */
 /********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -971,7 +944,7 @@ be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(parse_sensors),
@@ -987,7 +960,6 @@ be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
 /********************************************************************
 ** Solidified function: get_attribute_list
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_get_attribute_list,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -996,7 +968,7 @@ be_local_closure(class_Matter_Plugin_get_attribute_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(clusters),
@@ -1021,7 +993,6 @@ be_local_closure(class_Matter_Plugin_get_attribute_list,   /* name */
 /********************************************************************
 ** Solidified function: publish_command
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_publish_command,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -1030,7 +1001,7 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -1101,7 +1072,6 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
 /********************************************************************
 ** Solidified function: get_clusters
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1110,7 +1080,7 @@ be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(CLUSTERS),
@@ -1129,7 +1099,6 @@ be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
 /********************************************************************
 ** Solidified function: contains_cluster
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1138,7 +1107,7 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(clusters),
@@ -1161,7 +1130,6 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -1170,7 +1138,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1369,7 +1337,6 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: subscribe_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin;
 be_local_closure(class_Matter_Plugin_subscribe_attribute,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1378,7 +1345,7 @@ be_local_closure(class_Matter_Plugin_subscribe_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(subscribe_attribute),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Aggregator;
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Aggregator;
 be_local_closure(class_Matter_Plugin_Aggregator_read_attribute,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Aggregator_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Aggregator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -125,7 +124,6 @@ be_local_closure(class_Matter_Plugin_Aggregator_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Aggregator;
 be_local_closure(class_Matter_Plugin_Aggregator_invoke_request,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -134,7 +132,7 @@ be_local_closure(class_Matter_Plugin_Aggregator_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Aggregator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
@@ -9,7 +9,6 @@ extern const bclass be_class_GetOptionReader;
 /********************************************************************
 ** Solidified function: getoption
 ********************************************************************/
-extern const bclass be_class_GetOptionReader;
 be_local_closure(class_GetOptionReader_getoption,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_GetOptionReader_getoption,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_GetOptionReader, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(flag),
@@ -108,7 +107,6 @@ be_local_closure(class_GetOptionReader_getoption,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_GetOptionReader;
 be_local_closure(class_GetOptionReader_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -117,7 +115,7 @@ be_local_closure(class_GetOptionReader_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_GetOptionReader, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(value_error),
@@ -224,7 +222,6 @@ extern const bclass be_class_Matter_Plugin_Device;
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_parse_status,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -233,7 +230,7 @@ be_local_closure(class_Matter_Plugin_Device_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(parse_status),
@@ -249,7 +246,6 @@ be_local_closure(class_Matter_Plugin_Device_parse_status,   /* name */
 /********************************************************************
 ** Solidified function: register_cmd_cb
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -258,7 +254,7 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         8,                          /* nstack */
         3,                          /* argc */
@@ -268,7 +264,7 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(parse_http_response),
@@ -285,7 +281,6 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
           0x80040600,  //  0006  RET	1	R3
         })
       ),
-    &be_class_Matter_Plugin_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
@@ -314,7 +309,6 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -323,7 +317,7 @@ be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -354,7 +348,6 @@ be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
 /********************************************************************
 ** Solidified function: every_250ms
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -363,7 +356,7 @@ be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -395,7 +388,6 @@ be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
 /********************************************************************
 ** Solidified function: web_value_onoff
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -404,7 +396,7 @@ be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_X3Cb_X3EOn_X3C_X2Fb_X3E),
@@ -433,7 +425,6 @@ be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -442,7 +433,7 @@ be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -520,7 +511,6 @@ be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -529,7 +519,7 @@ be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -572,7 +562,6 @@ be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: call_remote_sync
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -581,7 +570,7 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -655,7 +644,6 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
 /********************************************************************
 ** Solidified function: parse_http_response
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -664,7 +652,7 @@ be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -700,7 +688,6 @@ be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -709,7 +696,7 @@ be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -746,7 +733,6 @@ be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -755,7 +741,7 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1059,7 +1045,6 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1068,7 +1053,7 @@ be_local_closure(class_Matter_Plugin_Device_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1115,7 +1100,6 @@ be_local_closure(class_Matter_Plugin_Device_init,   /* name */
 /********************************************************************
 ** Solidified function: append_state_json
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1124,7 +1108,7 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         12,                          /* nstack */
         2,                          /* argc */
@@ -1135,7 +1119,7 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
           be_local_const_upval(1, 3),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 6]) {     /* constants */
         /* K0   */  be_nested_str_weak(introspect),
@@ -1181,7 +1165,6 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
           0x80000000,  //  001E  RET	0
         })
       ),
-    &be_class_Matter_Plugin_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[42]) {     /* constants */
@@ -1335,7 +1318,6 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
 /********************************************************************
 ** Solidified function: _parse_sensor_entry
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1344,7 +1326,7 @@ be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Root;
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Root;
 be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
   be_nested_proto(
     25,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[96]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -1056,7 +1055,6 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: write_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Root;
 be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1065,7 +1063,7 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1194,7 +1192,6 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Root;
 be_local_closure(class_Matter_Plugin_Root_init,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -1203,7 +1200,7 @@ be_local_closure(class_Matter_Plugin_Root_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1276,7 +1273,6 @@ be_local_closure(class_Matter_Plugin_Root_init,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Root;
 be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
   be_nested_proto(
     31,                          /* nstack */
@@ -1285,7 +1281,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         3,                          /* nstack */
         0,                          /* argc */
@@ -1296,7 +1292,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
           be_local_const_upval(1, 10),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(device),
@@ -1313,7 +1309,6 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
           0x80000000,  //  0005  RET	0
         })
       ),
-    &be_class_Matter_Plugin_Root, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[102]) {     /* constants */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Fan.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Fan.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Fan;
 /********************************************************************
 ** Solidified function: set_fan_mode
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_set_fan_mode,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -90,7 +89,6 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_mode,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_update_virtual,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -99,7 +97,7 @@ be_local_closure(class_Matter_Plugin_Fan_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -165,7 +163,6 @@ be_local_closure(class_Matter_Plugin_Fan_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: set_fan_speed_pct
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_set_fan_speed_pct,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -174,7 +171,7 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_speed_pct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -241,7 +238,6 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_speed_pct,   /* name */
 /********************************************************************
 ** Solidified function: write_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_write_attribute,   /* name */
   be_nested_proto(
     21,                          /* nstack */
@@ -250,7 +246,7 @@ be_local_closure(class_Matter_Plugin_Fan_write_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -364,7 +360,6 @@ be_local_closure(class_Matter_Plugin_Fan_write_attribute,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -373,7 +368,7 @@ be_local_closure(class_Matter_Plugin_Fan_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -404,7 +399,6 @@ be_local_closure(class_Matter_Plugin_Fan_init,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Fan;
 be_local_closure(class_Matter_Plugin_Fan_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -413,7 +407,7 @@ be_local_closure(class_Matter_Plugin_Fan_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Fan, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Light0;
 /********************************************************************
 ** Solidified function: set_onoff
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -109,7 +108,6 @@ be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -118,7 +116,7 @@ be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -152,7 +150,6 @@ be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -161,7 +158,7 @@ be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_onoff),
@@ -193,7 +190,6 @@ be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -202,7 +198,7 @@ be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_relay_index),
@@ -239,7 +235,6 @@ be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -248,7 +243,7 @@ be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -286,7 +281,6 @@ be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -295,7 +289,7 @@ be_local_closure(class_Matter_Plugin_Light0_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -346,7 +340,6 @@ be_local_closure(class_Matter_Plugin_Light0_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -355,7 +348,7 @@ be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -409,7 +402,7 @@ be_local_closure(class_Matter_Plugin_Light0__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),
@@ -428,7 +421,6 @@ be_local_closure(class_Matter_Plugin_Light0__X3Clambda_X3E,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_update_shadow,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -437,7 +429,7 @@ be_local_closure(class_Matter_Plugin_Light0_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),
@@ -496,7 +488,6 @@ be_local_closure(class_Matter_Plugin_Light0_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_invoke_request,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -505,7 +496,7 @@ be_local_closure(class_Matter_Plugin_Light0_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -585,7 +576,6 @@ be_local_closure(class_Matter_Plugin_Light0_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light0;
 be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -594,7 +584,7 @@ be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light0, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_relay_index),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor;
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(contains),
@@ -79,7 +78,6 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -88,7 +86,7 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
@@ -132,7 +130,6 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_pre_value,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -141,7 +138,7 @@ be_local_closure(class_Matter_Plugin_Sensor_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(pre_value),
@@ -157,7 +154,6 @@ be_local_closure(class_Matter_Plugin_Sensor_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -166,7 +162,7 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),
@@ -223,7 +219,6 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_value_changed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -232,7 +227,7 @@ be_local_closure(class_Matter_Plugin_Sensor_value_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(value_changed),
@@ -248,7 +243,6 @@ be_local_closure(class_Matter_Plugin_Sensor_value_changed,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -257,7 +251,7 @@ be_local_closure(class_Matter_Plugin_Sensor_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -288,7 +282,6 @@ be_local_closure(class_Matter_Plugin_Sensor_init,   /* name */
 /********************************************************************
 ** Solidified function: filter_name_html
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -297,7 +290,7 @@ be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
@@ -334,7 +327,6 @@ be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -343,7 +335,7 @@ be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -386,7 +378,6 @@ be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -395,7 +386,7 @@ be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         9,                          /* nstack */
         2,                          /* argc */
@@ -26,7 +25,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_nested_str_weak(webserver),
@@ -50,7 +49,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
           0x80000000,  //  000B  RET	0
         })
       ),
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
@@ -114,7 +112,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -123,7 +120,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_status,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -148,7 +145,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_status,   /* name 
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -157,7 +153,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_update_virtual,   /* nam
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_air_quality),
@@ -249,7 +245,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_update_virtual,   /* nam
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -258,7 +253,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -292,7 +287,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_init,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -301,7 +295,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         6,                          /* nstack */
         2,                          /* argc */
@@ -313,7 +307,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
           be_local_const_upval(1, 4),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 9]) {     /* constants */
         /* K0   */  be_const_int(0),
@@ -405,7 +399,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
           0x80040400,  //  0049  RET	1	R2
         })
       ),
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
@@ -530,7 +523,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_configuration,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -539,7 +531,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_configuration,   /
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(prefix),
@@ -565,7 +557,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_configuration,   /
 /********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_sensors,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -574,7 +565,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_sensors,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -674,7 +665,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_sensors,   /* name
 /********************************************************************
 ** Solidified function: _parse_sensor_entry
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 be_local_closure(class_Matter_Plugin_Sensor_Air_Quality__parse_sensor_entry,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -683,7 +673,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality__parse_sensor_entry,   /
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Air_Quality, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Boolean.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Boolean.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_configuration,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Boolean, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_switch_index),
@@ -51,7 +50,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_configuration,   /* na
 /********************************************************************
 ** Solidified function: value_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 be_local_closure(class_Matter_Plugin_Sensor_Boolean_value_updated,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -60,7 +58,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_value_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Boolean, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(value_updated),
@@ -84,7 +82,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),
@@ -103,7 +101,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean__X3Clambda_X3E,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 be_local_closure(class_Matter_Plugin_Sensor_Boolean_update_shadow,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -112,7 +109,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Boolean, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(update_shadow),
@@ -182,7 +179,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 be_local_closure(class_Matter_Plugin_Sensor_Boolean_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -191,7 +187,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Boolean, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -220,7 +216,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_init,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -229,7 +224,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Boolean, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_GenericSwitch_Btn.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_GenericSwitch_Btn.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_read_attribute,   
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_GenericSwitch_Btn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -103,7 +102,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn__X3Clambda_X3E,   
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),
@@ -122,7 +121,6 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn__X3Clambda_X3E,   
 /********************************************************************
 ** Solidified function: set_position
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_set_position,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -131,7 +129,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_set_position,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_GenericSwitch_Btn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_position),
@@ -159,7 +157,6 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_set_position,   /*
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -168,7 +165,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_parse_configuratio
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_GenericSwitch_Btn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_switch_index),
@@ -201,7 +198,6 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_parse_configuratio
 /********************************************************************
 ** Solidified function: append_state_json
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_append_state_json,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -210,7 +206,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_append_state_json,
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_GenericSwitch_Btn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_X2C_X22Switch_X22_X3A_X25s),
@@ -235,7 +231,6 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_append_state_json,
 /********************************************************************
 ** Solidified function: button_handler
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_button_handler,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -244,7 +239,7 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_button_handler,   
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_GenericSwitch_Btn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_const_int(0),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Shutter;
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_parse_configuration,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_shutter_index),
@@ -51,7 +50,6 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_configuration,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -60,7 +58,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(light),
@@ -215,7 +213,6 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -224,7 +221,7 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -396,7 +393,7 @@ be_local_closure(class_Matter_Plugin_Shutter__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),
@@ -415,7 +412,6 @@ be_local_closure(class_Matter_Plugin_Shutter__X3Clambda_X3E,   /* name */
 /********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_parse_sensors,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -424,7 +420,7 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_sensors,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(Shutter),
@@ -505,7 +501,6 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_sensors,   /* name */
 /********************************************************************
 ** Solidified function: update_inverted
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_update_inverted,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -514,7 +509,7 @@ be_local_closure(class_Matter_Plugin_Shutter_update_inverted,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_shutter_inverted),
@@ -578,7 +573,6 @@ be_local_closure(class_Matter_Plugin_Shutter_update_inverted,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Shutter;
 be_local_closure(class_Matter_Plugin_Shutter_update_shadow,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -587,7 +581,7 @@ be_local_closure(class_Matter_Plugin_Shutter_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Shutter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Light1;
 /********************************************************************
 ** Solidified function: set_bri
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -142,7 +141,6 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
 /********************************************************************
 ** Solidified function: web_value_dimmer
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -151,7 +149,7 @@ be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -194,7 +192,6 @@ be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -203,7 +200,7 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(light),
@@ -359,7 +356,6 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -368,7 +364,7 @@ be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -455,7 +451,6 @@ be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -464,7 +459,7 @@ be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -545,7 +540,6 @@ be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -554,7 +548,7 @@ be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -598,7 +592,6 @@ be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -607,7 +600,7 @@ be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_bri),
@@ -636,7 +629,6 @@ be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_web_values,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -645,7 +637,7 @@ be_local_closure(class_Matter_Plugin_Light1_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -682,7 +674,6 @@ be_local_closure(class_Matter_Plugin_Light1_web_values,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -691,7 +682,7 @@ be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_status),
@@ -750,7 +741,6 @@ be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light1;
 be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -759,7 +749,7 @@ be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light1, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Contact.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 be_local_closure(class_Matter_Plugin_Sensor_Contact_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Contact, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_bool_value),
@@ -55,7 +54,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 be_local_closure(class_Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -64,7 +62,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Contact, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -112,7 +110,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -121,7 +118,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Contact, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -157,7 +154,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -166,7 +162,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values_prefix,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Contact, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -212,7 +208,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values_prefix,   /* name
 /********************************************************************
 ** Solidified function: value_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 be_local_closure(class_Matter_Plugin_Sensor_Contact_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -221,7 +216,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_value_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Contact, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 be_local_closure(class_Matter_Plugin_Sensor_Flow_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_value_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Flow, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -41,7 +40,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_value_changed,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 be_local_closure(class_Matter_Plugin_Sensor_Flow_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Flow, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -119,7 +117,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 be_local_closure(class_Matter_Plugin_Sensor_Flow_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -128,7 +125,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Flow, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(pre_value),
@@ -153,7 +150,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 be_local_closure(class_Matter_Plugin_Sensor_Flow_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -162,7 +158,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Flow, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 be_local_closure(class_Matter_Plugin_Sensor_Humidity_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_value_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Humidity, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -41,7 +40,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_value_changed,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 be_local_closure(class_Matter_Plugin_Sensor_Humidity_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_read_attribute,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Humidity, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -119,7 +117,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_read_attribute,   /* name *
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 be_local_closure(class_Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -128,7 +125,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Humidity, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(pre_value),
@@ -153,7 +150,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 be_local_closure(class_Matter_Plugin_Sensor_Humidity_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -162,7 +158,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Humidity, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 be_local_closure(class_Matter_Plugin_Sensor_Illuminance_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_value_changed,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Illuminance, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -41,7 +40,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_value_changed,   /* name
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 be_local_closure(class_Matter_Plugin_Sensor_Illuminance_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_read_attribute,   /* nam
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Illuminance, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -119,7 +117,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_read_attribute,   /* nam
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 be_local_closure(class_Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -128,7 +125,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Illuminance, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(math),
@@ -165,7 +162,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 be_local_closure(class_Matter_Plugin_Sensor_Illuminance_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -174,7 +170,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Illuminance, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Occupancy.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 be_local_closure(class_Matter_Plugin_Sensor_Occupancy_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_update_virtual,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Occupancy, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_bool_value),
@@ -55,7 +54,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_update_virtual,   /* name 
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 be_local_closure(class_Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -64,7 +62,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Occupancy, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -132,7 +130,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name 
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -141,7 +138,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Occupancy, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -177,7 +174,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -186,7 +182,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values_prefix,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Occupancy, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -232,7 +228,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values_prefix,   /* na
 /********************************************************************
 ** Solidified function: value_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 be_local_closure(class_Matter_Plugin_Sensor_Occupancy_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -241,7 +236,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_value_updated,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Occupancy, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_OnOff.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
 be_local_closure(class_Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_OnOff, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -69,7 +68,6 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: append_state_json
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
 be_local_closure(class_Matter_Plugin_Sensor_OnOff_append_state_json,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -78,7 +76,7 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_append_state_json,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_OnOff, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_X2C_X22OnOff_X22_X3A_X25s),
@@ -103,7 +101,6 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_append_state_json,   /* name *
 /********************************************************************
 ** Solidified function: value_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
 be_local_closure(class_Matter_Plugin_Sensor_OnOff_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -112,7 +109,7 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_value_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_OnOff, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 be_local_closure(class_Matter_Plugin_Sensor_Pressure_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_value_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Pressure, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -41,7 +40,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_value_changed,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 be_local_closure(class_Matter_Plugin_Sensor_Pressure_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_read_attribute,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Pressure, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -119,7 +117,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_read_attribute,   /* name *
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 be_local_closure(class_Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -128,7 +125,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Pressure, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(pre_value),
@@ -152,7 +149,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 be_local_closure(class_Matter_Plugin_Sensor_Pressure_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -161,7 +157,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Pressure, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Rain.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Rain.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 be_local_closure(class_Matter_Plugin_Sensor_Rain_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Rain, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_bool_value),
@@ -55,7 +54,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 be_local_closure(class_Matter_Plugin_Sensor_Rain_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -64,7 +62,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Rain, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -112,7 +110,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -121,7 +118,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Rain, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -157,7 +154,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -166,7 +162,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values_prefix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Rain, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -212,7 +208,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values_prefix,   /* name */
 /********************************************************************
 ** Solidified function: value_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 be_local_closure(class_Matter_Plugin_Sensor_Rain_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -221,7 +216,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_value_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Rain, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 /********************************************************************
 ** Solidified function: value_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 be_local_closure(class_Matter_Plugin_Sensor_Temp_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_value_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Temp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -41,7 +40,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_value_changed,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 be_local_closure(class_Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Temp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -117,7 +115,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: pre_value
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 be_local_closure(class_Matter_Plugin_Sensor_Temp_pre_value,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -126,7 +123,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_pre_value,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Temp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
@@ -191,7 +188,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_pre_value,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 be_local_closure(class_Matter_Plugin_Sensor_Temp_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -200,7 +196,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Temp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Waterleak.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Waterleak.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Sensor_Waterleak;
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Waterleak;
 be_local_closure(class_Matter_Plugin_Sensor_Waterleak_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_update_virtual,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Waterleak, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_bool_value),
@@ -51,13 +50,66 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_update_virtual,   /* name 
 );
 /*******************************************************************/
 
-// Borrowed method 'read_attribute' from class 'class_Matter_Plugin_Sensor_Rain'
-extern bclosure *class_Matter_Plugin_Sensor_Rain_read_attribute;
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Sensor_Waterleak_read_attribute,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(set),
+    /* K6   */  be_nested_str_weak(BOOL),
+    /* K7   */  be_nested_str_weak(shadow_bool_value),
+    /* K8   */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140502,  //  0002  GETMBR	R5	R2	K2
+      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0x541E0044,  //  0004  LDINT	R7	69
+      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
+      0x781E0006,  //  0006  JMPF	R7	#000E
+      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x781E0004,  //  0008  JMPF	R7	#000E
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x601C0003,  //  000E  GETGBL	R7	G3
+      0x5C200000,  //  000F  MOVE	R8	R0
+      0x7C1C0200,  //  0010  CALL	R7	1
+      0x8C1C0F08,  //  0011  GETMET	R7	R7	K8
+      0x5C240200,  //  0012  MOVE	R9	R1
+      0x5C280400,  //  0013  MOVE	R10	R2
+      0x5C2C0600,  //  0014  MOVE	R11	R3
+      0x7C1C0800,  //  0015  CALL	R7	4
+      0x80040E00,  //  0016  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Waterleak;
 be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -66,7 +118,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Waterleak, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -102,7 +154,6 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values,   /* name */
 /********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Sensor_Waterleak;
 be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -111,7 +162,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values_prefix,   /* na
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Sensor_Waterleak, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -153,8 +204,37 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values_prefix,   /* na
 );
 /*******************************************************************/
 
-// Borrowed method 'value_updated' from class 'class_Matter_Plugin_Sensor_Rain'
-extern bclosure *class_Matter_Plugin_Sensor_Rain_value_updated;
+
+/********************************************************************
+** Solidified function: value_updated
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Sensor_Waterleak_value_updated,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attribute_updated),
+    /* K1   */  be_const_int(0),
+    }),
+    be_str_weak(value_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0044,  //  0001  LDINT	R3	69
+      0x58100001,  //  0002  LDCONST	R4	K1
+      0x7C040600,  //  0003  CALL	R1	3
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified class: Matter_Plugin_Sensor_Waterleak
@@ -167,7 +247,7 @@ be_local_class(Matter_Plugin_Sensor_Waterleak,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(update_virtual, 6), be_const_closure(class_Matter_Plugin_Sensor_Waterleak_update_virtual_closure) },
         { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Waterleak) },
-        { be_const_key_weak(read_attribute, 5), be_const_closure(class_Matter_Plugin_Sensor_Rain_read_attribute_closure) },
+        { be_const_key_weak(read_attribute, 5), be_const_closure(class_Matter_Plugin_Sensor_Waterleak_read_attribute_closure) },
         { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(1,
     ( (struct bvalue*) &(const bvalue[]) {
@@ -264,7 +344,7 @@ be_local_class(Matter_Plugin_Sensor_Waterleak,
         { be_const_key_int(67, -1), be_const_int(1) },
     }))    ) } )) },
         { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Sensor_Waterleak_web_values_prefix_closure) },
-        { be_const_key_weak(value_updated, -1), be_const_closure(class_Matter_Plugin_Sensor_Rain_value_updated_closure) },
+        { be_const_key_weak(value_updated, -1), be_const_closure(class_Matter_Plugin_Sensor_Waterleak_value_updated_closure) },
         { be_const_key_weak(TYPE, 3), be_nested_str_weak(waterleak) },
     })),
     be_str_weak(Matter_Plugin_Sensor_Waterleak)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_ShutterTilt;
 /********************************************************************
 ** Solidified function: update_tilt_min_max
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_ShutterTilt;
 be_local_closure(class_Matter_Plugin_ShutterTilt_update_tilt_min_max,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_update_tilt_min_max,   /* name 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_ShutterTilt, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -80,7 +79,6 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_update_tilt_min_max,   /* name 
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_ShutterTilt;
 be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -89,7 +87,7 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_ShutterTilt, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -238,7 +236,6 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_ShutterTilt;
 be_local_closure(class_Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -247,7 +244,7 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_ShutterTilt, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(Shutter),
@@ -303,7 +300,6 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_ShutterTilt;
 be_local_closure(class_Matter_Plugin_ShutterTilt_invoke_request,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -312,7 +308,7 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_ShutterTilt, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(light),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Light2;
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -56,7 +55,6 @@ be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -65,7 +63,7 @@ be_local_closure(class_Matter_Plugin_Light2_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -167,7 +165,6 @@ be_local_closure(class_Matter_Plugin_Light2_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -176,7 +173,7 @@ be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),
@@ -244,7 +241,6 @@ be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: set_ct
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -253,7 +249,7 @@ be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(ct_min),
@@ -328,7 +324,6 @@ be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -337,7 +332,7 @@ be_local_closure(class_Matter_Plugin_Light2_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_status),
@@ -395,7 +390,6 @@ be_local_closure(class_Matter_Plugin_Light2_parse_status,   /* name */
 /********************************************************************
 ** Solidified function: web_value_ct
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -404,7 +398,7 @@ be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -445,7 +439,6 @@ be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -454,7 +447,7 @@ be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -494,7 +487,6 @@ be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -503,7 +495,7 @@ be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -550,7 +542,6 @@ be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -559,7 +550,7 @@ be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -656,7 +647,6 @@ be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: update_ct_minmax
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light2;
 be_local_closure(class_Matter_Plugin_Light2_update_ct_minmax,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -665,7 +655,7 @@ be_local_closure(class_Matter_Plugin_Light2_update_ct_minmax,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light2, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Light3;
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -174,7 +173,6 @@ be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -183,7 +181,7 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -309,7 +307,6 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
 /********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -318,7 +315,7 @@ be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(VIRTUAL),
@@ -425,7 +422,6 @@ be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
 /********************************************************************
 ** Solidified function: update_virtual
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -434,7 +430,7 @@ be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(find),
@@ -482,7 +478,6 @@ be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
 /********************************************************************
 ** Solidified function: set_hue_sat
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -491,7 +486,7 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -680,7 +675,6 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -689,7 +683,7 @@ be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -720,7 +714,6 @@ be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -729,7 +722,7 @@ be_local_closure(class_Matter_Plugin_Light3_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -769,7 +762,6 @@ be_local_closure(class_Matter_Plugin_Light3_web_values,   /* name */
 /********************************************************************
 ** Solidified function: parse_status
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -778,7 +770,7 @@ be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_status),
@@ -877,7 +869,6 @@ be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
 /********************************************************************
 ** Solidified function: web_value_RGB
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Light3;
 be_local_closure(class_Matter_Plugin_Light3_web_value_RGB,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -886,7 +877,7 @@ be_local_closure(class_Matter_Plugin_Light3_web_value_RGB,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Light3, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(shadow_hue),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light1.h
@@ -17,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Bridge_Light1__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light2.h
@@ -17,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Bridge_Light2__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_Light3.h
@@ -17,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Bridge_Light3__X3Clambda_X3E,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(_X3Clambda_X3E),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_8_Bridge_OnOff.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Plugin_Bridge_OnOff;
 /********************************************************************
 ** Solidified function: web_values
 ********************************************************************/
-extern const bclass be_class_Matter_Plugin_Bridge_OnOff;
 be_local_closure(class_Matter_Plugin_Bridge_OnOff_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Plugin_Bridge_OnOff_web_values,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Plugin_Bridge_OnOff, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Profiler;
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_start,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Profiler_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Profiler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),
@@ -68,7 +67,6 @@ be_local_closure(class_Matter_Profiler_start,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -77,7 +75,7 @@ be_local_closure(class_Matter_Profiler_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Profiler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),
@@ -134,7 +132,6 @@ be_local_closure(class_Matter_Profiler_init,   /* name */
 /********************************************************************
 ** Solidified function: set_active
 ********************************************************************/
-extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_set_active,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -143,7 +140,7 @@ be_local_closure(class_Matter_Profiler_set_active,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Profiler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),
@@ -165,7 +162,6 @@ be_local_closure(class_Matter_Profiler_set_active,   /* name */
 /********************************************************************
 ** Solidified function: log
 ********************************************************************/
-extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_log,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -174,7 +170,7 @@ be_local_closure(class_Matter_Profiler_log,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Profiler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),
@@ -228,7 +224,6 @@ be_local_closure(class_Matter_Profiler_log,   /* name */
 /********************************************************************
 ** Solidified function: dump
 ********************************************************************/
-extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_dump,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -237,7 +232,7 @@ be_local_closure(class_Matter_Profiler_dump,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Profiler, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Session;
 /********************************************************************
 ** Solidified function: get_device_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_device_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Session_get_device_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -43,7 +42,6 @@ be_local_closure(class_Matter_Session_get_device_id,   /* name */
 /********************************************************************
 ** Solidified function: before_remove
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_before_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -52,7 +50,7 @@ be_local_closure(class_Matter_Session_before_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -80,7 +78,6 @@ be_local_closure(class_Matter_Session_before_remove,   /* name */
 /********************************************************************
 ** Solidified function: set_mode_CASE
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_mode_CASE,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -89,7 +86,7 @@ be_local_closure(class_Matter_Session_set_mode_CASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_mode),
@@ -111,7 +108,6 @@ be_local_closure(class_Matter_Session_set_mode_CASE,   /* name */
 /********************************************************************
 ** Solidified function: is_CASE
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_is_CASE,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -120,7 +116,7 @@ be_local_closure(class_Matter_Session_is_CASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(mode),
@@ -142,7 +138,6 @@ be_local_closure(class_Matter_Session_is_CASE,   /* name */
 /********************************************************************
 ** Solidified function: persist_to_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_persist_to_fabric,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -151,7 +146,7 @@ be_local_closure(class_Matter_Session_persist_to_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -174,7 +169,6 @@ be_local_closure(class_Matter_Session_persist_to_fabric,   /* name */
 /********************************************************************
 ** Solidified function: get_noc
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_noc,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -183,7 +177,7 @@ be_local_closure(class_Matter_Session_get_noc,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -204,7 +198,6 @@ be_local_closure(class_Matter_Session_get_noc,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -213,7 +206,7 @@ be_local_closure(class_Matter_Session_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -293,7 +286,6 @@ be_local_closure(class_Matter_Session_init,   /* name */
 /********************************************************************
 ** Solidified function: get_admin_vendor
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -302,7 +294,7 @@ be_local_closure(class_Matter_Session_get_admin_vendor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -327,7 +319,6 @@ be_local_closure(class_Matter_Session_get_admin_vendor,   /* name */
 /********************************************************************
 ** Solidified function: get_i2r
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_i2r,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -336,7 +327,7 @@ be_local_closure(class_Matter_Session_get_i2r,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(i2rkey),
@@ -355,7 +346,6 @@ be_local_closure(class_Matter_Session_get_i2r,   /* name */
 /********************************************************************
 ** Solidified function: counter_rcv_validate
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_counter_rcv_validate,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -364,7 +354,7 @@ be_local_closure(class_Matter_Session_counter_rcv_validate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_rcv_impl),
@@ -395,7 +385,6 @@ be_local_closure(class_Matter_Session_counter_rcv_validate,   /* name */
 /********************************************************************
 ** Solidified function: get_ca
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -404,7 +393,7 @@ be_local_closure(class_Matter_Session_get_ca,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -425,7 +414,6 @@ be_local_closure(class_Matter_Session_get_ca,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_index
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -434,7 +422,7 @@ be_local_closure(class_Matter_Session_get_fabric_index,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -459,7 +447,6 @@ be_local_closure(class_Matter_Session_get_fabric_index,   /* name */
 /********************************************************************
 ** Solidified function: get_r2i
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_r2i,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -468,7 +455,7 @@ be_local_closure(class_Matter_Session_get_r2i,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(r2ikey),
@@ -487,7 +474,6 @@ be_local_closure(class_Matter_Session_get_r2i,   /* name */
 /********************************************************************
 ** Solidified function: counter_snd_next
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_counter_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -496,7 +482,7 @@ be_local_closure(class_Matter_Session_counter_snd_next,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_snd_impl),
@@ -540,7 +526,6 @@ be_local_closure(class_Matter_Session_counter_snd_next,   /* name */
 /********************************************************************
 ** Solidified function: get_temp_ca_pub
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_temp_ca_pub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -549,7 +534,7 @@ be_local_closure(class_Matter_Session_get_temp_ca_pub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
@@ -582,7 +567,6 @@ be_local_closure(class_Matter_Session_get_temp_ca_pub,   /* name */
 /********************************************************************
 ** Solidified function: get_temp_ca
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_temp_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -591,7 +575,7 @@ be_local_closure(class_Matter_Session_get_temp_ca,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
@@ -610,7 +594,6 @@ be_local_closure(class_Matter_Session_get_temp_ca,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_fabric_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -619,7 +602,7 @@ be_local_closure(class_Matter_Session_get_fabric_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -640,7 +623,6 @@ be_local_closure(class_Matter_Session_get_fabric_id,   /* name */
 /********************************************************************
 ** Solidified function: set_mode_PASE
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_mode_PASE,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -649,7 +631,7 @@ be_local_closure(class_Matter_Session_set_mode_PASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_mode),
@@ -671,7 +653,6 @@ be_local_closure(class_Matter_Session_set_mode_PASE,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_label
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_fabric_label,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -680,7 +661,7 @@ be_local_closure(class_Matter_Session_get_fabric_label,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -705,7 +686,6 @@ be_local_closure(class_Matter_Session_get_fabric_label,   /* name */
 /********************************************************************
 ** Solidified function: update
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_update,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -714,7 +694,7 @@ be_local_closure(class_Matter_Session_update,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(last_used),
@@ -738,7 +718,6 @@ be_local_closure(class_Matter_Session_update,   /* name */
 /********************************************************************
 ** Solidified function: get_icac
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_icac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -747,7 +726,7 @@ be_local_closure(class_Matter_Session_get_icac,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -768,7 +747,6 @@ be_local_closure(class_Matter_Session_get_icac,   /* name */
 /********************************************************************
 ** Solidified function: is_PASE
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_is_PASE,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -777,7 +755,7 @@ be_local_closure(class_Matter_Session_is_PASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(mode),
@@ -799,7 +777,6 @@ be_local_closure(class_Matter_Session_is_PASE,   /* name */
 /********************************************************************
 ** Solidified function: set_fabric_label
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_fabric_label,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -808,7 +785,7 @@ be_local_closure(class_Matter_Session_set_fabric_label,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -835,7 +812,6 @@ be_local_closure(class_Matter_Session_set_fabric_label,   /* name */
 /********************************************************************
 ** Solidified function: get_node_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_node_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -844,7 +820,7 @@ be_local_closure(class_Matter_Session_get_node_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -869,7 +845,6 @@ be_local_closure(class_Matter_Session_get_node_id,   /* name */
 /********************************************************************
 ** Solidified function: get_ca_pub
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_ca_pub,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -878,7 +853,7 @@ be_local_closure(class_Matter_Session_get_ca_pub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -900,7 +875,6 @@ be_local_closure(class_Matter_Session_get_ca_pub,   /* name */
 /********************************************************************
 ** Solidified function: get_pk
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_pk,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -909,7 +883,7 @@ be_local_closure(class_Matter_Session_get_pk,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -947,7 +921,6 @@ be_local_closure(class_Matter_Session_get_pk,   /* name */
 /********************************************************************
 ** Solidified function: tojson
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_tojson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -956,7 +929,7 @@ be_local_closure(class_Matter_Session_tojson,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -1089,7 +1062,6 @@ be_local_closure(class_Matter_Session_tojson,   /* name */
 /********************************************************************
 ** Solidified function: close
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_close,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1098,7 +1070,7 @@ be_local_closure(class_Matter_Session_close,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(local_session_id),
@@ -1196,7 +1168,6 @@ be_local_closure(class_Matter_Session_close,   /* name */
 /********************************************************************
 ** Solidified function: get_ac
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_ac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1205,7 +1176,7 @@ be_local_closure(class_Matter_Session_get_ac,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(attestation_challenge),
@@ -1224,7 +1195,6 @@ be_local_closure(class_Matter_Session_get_ac,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_fabric,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1233,7 +1203,7 @@ be_local_closure(class_Matter_Session_get_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -1252,7 +1222,6 @@ be_local_closure(class_Matter_Session_get_fabric,   /* name */
 /********************************************************************
 ** Solidified function: get_i2r_privacy
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_i2r_privacy,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1261,7 +1230,7 @@ be_local_closure(class_Matter_Session_get_i2r_privacy,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(_i2r_privacy),
@@ -1306,7 +1275,6 @@ be_local_closure(class_Matter_Session_get_i2r_privacy,   /* name */
 /********************************************************************
 ** Solidified function: fromjson
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_fromjson,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -1315,7 +1283,7 @@ be_local_closure(class_Matter_Session_fromjson,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Session),
@@ -1423,7 +1391,6 @@ be_local_closure(class_Matter_Session_fromjson,   /* name */
 /********************************************************************
 ** Solidified function: save
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_save,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1432,7 +1399,7 @@ be_local_closure(class_Matter_Session_save,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_store),
@@ -1454,7 +1421,6 @@ be_local_closure(class_Matter_Session_save,   /* name */
 /********************************************************************
 ** Solidified function: hydrate_post
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_hydrate_post,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1463,7 +1429,7 @@ be_local_closure(class_Matter_Session_hydrate_post,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_snd_impl),
@@ -1502,7 +1468,6 @@ be_local_closure(class_Matter_Session_hydrate_post,   /* name */
 /********************************************************************
 ** Solidified function: get_admin_subject
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_admin_subject,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1511,7 +1476,7 @@ be_local_closure(class_Matter_Session_get_admin_subject,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -1536,7 +1501,6 @@ be_local_closure(class_Matter_Session_get_admin_subject,   /* name */
 /********************************************************************
 ** Solidified function: get_ipk_epoch_key
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1545,7 +1509,7 @@ be_local_closure(class_Matter_Session_get_ipk_epoch_key,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -1566,7 +1530,6 @@ be_local_closure(class_Matter_Session_get_ipk_epoch_key,   /* name */
 /********************************************************************
 ** Solidified function: get_fabric_compressed
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1575,7 +1538,7 @@ be_local_closure(class_Matter_Session_get_fabric_compressed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
@@ -1600,7 +1563,6 @@ be_local_closure(class_Matter_Session_get_fabric_compressed,   /* name */
 /********************************************************************
 ** Solidified function: get_mode
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1609,7 +1571,7 @@ be_local_closure(class_Matter_Session_get_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(mode),
@@ -1628,7 +1590,6 @@ be_local_closure(class_Matter_Session_get_mode,   /* name */
 /********************************************************************
 ** Solidified function: set_temp_ca
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_temp_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1637,7 +1598,7 @@ be_local_closure(class_Matter_Session_set_temp_ca,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
@@ -1656,7 +1617,6 @@ be_local_closure(class_Matter_Session_set_temp_ca,   /* name */
 /********************************************************************
 ** Solidified function: set_mode
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1665,7 +1625,7 @@ be_local_closure(class_Matter_Session_set_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(mode),
@@ -1684,7 +1644,6 @@ be_local_closure(class_Matter_Session_set_mode,   /* name */
 /********************************************************************
 ** Solidified function: set_keys
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_set_keys,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1693,7 +1652,7 @@ be_local_closure(class_Matter_Session_set_keys,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(i2rkey),
@@ -1721,7 +1680,6 @@ be_local_closure(class_Matter_Session_set_keys,   /* name */
 /********************************************************************
 ** Solidified function: gen_CSR
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_gen_CSR,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -1730,7 +1688,7 @@ be_local_closure(class_Matter_Session_gen_CSR,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_pk),
@@ -1831,7 +1789,6 @@ be_local_closure(class_Matter_Session_gen_CSR,   /* name */
 /********************************************************************
 ** Solidified function: get_ipk_group_key
 ********************************************************************/
-extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_get_ipk_group_key,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1840,7 +1797,7 @@ be_local_closure(class_Matter_Session_get_ipk_group_key,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Session_Store;
 /********************************************************************
 ** Solidified function: remove_session
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_remove_session,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Session_Store_remove_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -55,7 +54,6 @@ be_local_closure(class_Matter_Session_Store_remove_session,   /* name */
 /********************************************************************
 ** Solidified function: gen_local_session_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_gen_local_session_id,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -64,7 +62,7 @@ be_local_closure(class_Matter_Session_Store_gen_local_session_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -105,7 +103,6 @@ be_local_closure(class_Matter_Session_Store_gen_local_session_id,   /* name */
 /********************************************************************
 ** Solidified function: load_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -114,7 +111,7 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -272,7 +269,6 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
 /********************************************************************
 ** Solidified function: find_children_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -281,7 +277,7 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         7,                          /* nstack */
         1,                          /* argc */
@@ -293,7 +289,7 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
           be_local_const_upval(1, 3),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 6]) {     /* constants */
         /* K0   */  be_nested_str_weak(active_fabrics),
@@ -338,7 +334,6 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
           0x80000000,  //  001D  RET	0
         })
       ),
-    &be_class_Matter_Session_Store, 
     }),
     0,                          /* has constants */
     NULL,                       /* no const */
@@ -369,7 +364,6 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
 /********************************************************************
 ** Solidified function: sessions_active
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_sessions_active,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -378,7 +372,7 @@ be_local_closure(class_Matter_Session_Store_sessions_active,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -422,7 +416,6 @@ be_local_closure(class_Matter_Session_Store_sessions_active,   /* name */
 /********************************************************************
 ** Solidified function: find_fabric_by_index
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_find_fabric_by_index,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -431,7 +424,7 @@ be_local_closure(class_Matter_Session_Store_find_fabric_by_index,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(active_fabrics),
@@ -469,7 +462,6 @@ be_local_closure(class_Matter_Session_Store_find_fabric_by_index,   /* name */
 /********************************************************************
 ** Solidified function: active_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -478,7 +470,7 @@ be_local_closure(class_Matter_Session_Store_active_fabrics,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
@@ -503,7 +495,6 @@ be_local_closure(class_Matter_Session_Store_active_fabrics,   /* name */
 /********************************************************************
 ** Solidified function: create_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_create_fabric,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -512,7 +503,7 @@ be_local_closure(class_Matter_Session_Store_create_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -535,7 +526,6 @@ be_local_closure(class_Matter_Session_Store_create_fabric,   /* name */
 /********************************************************************
 ** Solidified function: count_active_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_count_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -544,7 +534,7 @@ be_local_closure(class_Matter_Session_Store_count_active_fabrics,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
@@ -577,7 +567,6 @@ be_local_closure(class_Matter_Session_Store_count_active_fabrics,   /* name */
 /********************************************************************
 ** Solidified function: find_session_by_resumption_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -586,7 +575,7 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -647,7 +636,6 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
 /********************************************************************
 ** Solidified function: add_session
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_add_session,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -656,7 +644,7 @@ be_local_closure(class_Matter_Session_Store_add_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_expire_in_seconds),
@@ -686,7 +674,6 @@ be_local_closure(class_Matter_Session_Store_add_session,   /* name */
 /********************************************************************
 ** Solidified function: find_session_source_id_unsecure
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_find_session_source_id_unsecure,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -695,7 +682,7 @@ be_local_closure(class_Matter_Session_Store_find_session_source_id_unsecure,   /
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
@@ -744,7 +731,6 @@ be_local_closure(class_Matter_Session_Store_find_session_source_id_unsecure,   /
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -753,7 +739,7 @@ be_local_closure(class_Matter_Session_Store_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
@@ -773,7 +759,6 @@ be_local_closure(class_Matter_Session_Store_every_second,   /* name */
 /********************************************************************
 ** Solidified function: get_session_by_local_session_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_get_session_by_local_session_id,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -782,7 +767,7 @@ be_local_closure(class_Matter_Session_Store_get_session_by_local_session_id,   /
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -825,7 +810,6 @@ be_local_closure(class_Matter_Session_Store_get_session_by_local_session_id,   /
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -834,7 +818,7 @@ be_local_closure(class_Matter_Session_Store_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -865,7 +849,6 @@ be_local_closure(class_Matter_Session_Store_init,   /* name */
 /********************************************************************
 ** Solidified function: remove_expired
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_remove_expired,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -874,7 +857,7 @@ be_local_closure(class_Matter_Session_Store_remove_expired,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -900,7 +883,6 @@ be_local_closure(class_Matter_Session_Store_remove_expired,   /* name */
 /********************************************************************
 ** Solidified function: remove_redundant_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_remove_redundant_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -909,7 +891,7 @@ be_local_closure(class_Matter_Session_Store_remove_redundant_fabric,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -957,7 +939,6 @@ be_local_closure(class_Matter_Session_Store_remove_redundant_fabric,   /* name *
 /********************************************************************
 ** Solidified function: add_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_add_fabric,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -966,7 +947,7 @@ be_local_closure(class_Matter_Session_Store_add_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -1012,7 +993,6 @@ be_local_closure(class_Matter_Session_Store_add_fabric,   /* name */
 /********************************************************************
 ** Solidified function: get_session_by_source_node_id
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_get_session_by_source_node_id,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1021,7 +1001,7 @@ be_local_closure(class_Matter_Session_Store_get_session_by_source_node_id,   /* 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -1064,7 +1044,6 @@ be_local_closure(class_Matter_Session_Store_get_session_by_source_node_id,   /* 
 /********************************************************************
 ** Solidified function: next_fabric_idx
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_next_fabric_idx,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1073,7 +1052,7 @@ be_local_closure(class_Matter_Session_Store_next_fabric_idx,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
@@ -1120,7 +1099,6 @@ be_local_closure(class_Matter_Session_Store_next_fabric_idx,   /* name */
 /********************************************************************
 ** Solidified function: save_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1129,7 +1107,7 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -1271,7 +1249,6 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
 /********************************************************************
 ** Solidified function: create_session
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_create_session,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1280,7 +1257,7 @@ be_local_closure(class_Matter_Session_Store_create_session,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
@@ -1323,7 +1300,6 @@ be_local_closure(class_Matter_Session_Store_create_session,   /* name */
 /********************************************************************
 ** Solidified function: remove_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_remove_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1332,7 +1308,7 @@ be_local_closure(class_Matter_Session_Store_remove_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Session_Store, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_TCP_async;
 /********************************************************************
 ** Solidified function: read
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_read,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_TCP_async_read,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -45,7 +44,6 @@ be_local_closure(class_Matter_TCP_async_read,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_begin,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -54,7 +52,7 @@ be_local_closure(class_Matter_TCP_async_begin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -155,7 +153,6 @@ be_local_closure(class_Matter_TCP_async_begin,   /* name */
 /********************************************************************
 ** Solidified function: readbytes
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_readbytes,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -164,7 +161,7 @@ be_local_closure(class_Matter_TCP_async_readbytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -191,7 +188,6 @@ be_local_closure(class_Matter_TCP_async_readbytes,   /* name */
 /********************************************************************
 ** Solidified function: event_closed
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_closed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -200,7 +196,7 @@ be_local_closure(class_Matter_TCP_async_event_closed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_closed),
@@ -216,7 +212,6 @@ be_local_closure(class_Matter_TCP_async_event_closed,   /* name */
 /********************************************************************
 ** Solidified function: available
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_available,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -225,7 +220,7 @@ be_local_closure(class_Matter_TCP_async_available,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -252,7 +247,6 @@ be_local_closure(class_Matter_TCP_async_available,   /* name */
 /********************************************************************
 ** Solidified function: event_listening
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_listening,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -261,7 +255,7 @@ be_local_closure(class_Matter_TCP_async_event_listening,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_listening),
@@ -277,7 +271,6 @@ be_local_closure(class_Matter_TCP_async_event_listening,   /* name */
 /********************************************************************
 ** Solidified function: get_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_get_timeout,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -286,7 +279,7 @@ be_local_closure(class_Matter_TCP_async_get_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(timeout),
@@ -305,7 +298,6 @@ be_local_closure(class_Matter_TCP_async_get_timeout,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -314,7 +306,7 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -324,7 +316,7 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(loop),
@@ -338,7 +330,6 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
           0x80040000,  //  0003  RET	1	R0
         })
       ),
-    &be_class_Matter_TCP_async, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
@@ -387,7 +378,6 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -396,7 +386,7 @@ be_local_closure(class_Matter_TCP_async_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(loop),
@@ -416,7 +406,6 @@ be_local_closure(class_Matter_TCP_async_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: event_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -425,7 +414,7 @@ be_local_closure(class_Matter_TCP_async_event_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_timeout),
@@ -441,7 +430,6 @@ be_local_closure(class_Matter_TCP_async_event_timeout,   /* name */
 /********************************************************************
 ** Solidified function: event_available
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_available,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -450,7 +438,7 @@ be_local_closure(class_Matter_TCP_async_event_available,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_available),
@@ -466,7 +454,6 @@ be_local_closure(class_Matter_TCP_async_event_available,   /* name */
 /********************************************************************
 ** Solidified function: write
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_write,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -475,7 +462,7 @@ be_local_closure(class_Matter_TCP_async_write,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -503,7 +490,6 @@ be_local_closure(class_Matter_TCP_async_write,   /* name */
 /********************************************************************
 ** Solidified function: event_established
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_established,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -512,7 +498,7 @@ be_local_closure(class_Matter_TCP_async_event_established,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_established),
@@ -528,7 +514,6 @@ be_local_closure(class_Matter_TCP_async_event_established,   /* name */
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -537,7 +522,7 @@ be_local_closure(class_Matter_TCP_async_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp),
@@ -562,7 +547,6 @@ be_local_closure(class_Matter_TCP_async_reset,   /* name */
 /********************************************************************
 ** Solidified function: loop
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_loop,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -571,7 +555,7 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -694,7 +678,6 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
 /********************************************************************
 ** Solidified function: listening
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_listening,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -703,7 +686,7 @@ be_local_closure(class_Matter_TCP_async_listening,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp_connected),
@@ -730,7 +713,6 @@ be_local_closure(class_Matter_TCP_async_listening,   /* name */
 /********************************************************************
 ** Solidified function: set_timeout
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_set_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -739,7 +721,7 @@ be_local_closure(class_Matter_TCP_async_set_timeout,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(TIMEOUT),
@@ -763,7 +745,6 @@ be_local_closure(class_Matter_TCP_async_set_timeout,   /* name */
 /********************************************************************
 ** Solidified function: event_dnsfailed
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_dnsfailed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -772,7 +753,7 @@ be_local_closure(class_Matter_TCP_async_event_dnsfailed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_dnsfailed),
@@ -788,7 +769,6 @@ be_local_closure(class_Matter_TCP_async_event_dnsfailed,   /* name */
 /********************************************************************
 ** Solidified function: close
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_close,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -797,7 +777,7 @@ be_local_closure(class_Matter_TCP_async_close,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(tcp),
@@ -844,7 +824,6 @@ be_local_closure(class_Matter_TCP_async_close,   /* name */
 /********************************************************************
 ** Solidified function: event_refused
 ********************************************************************/
-extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_event_refused,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -853,7 +832,7 @@ be_local_closure(class_Matter_TCP_async_event_refused,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TCP_async, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(event_refused),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_TLV_item;
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_TLV_item_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(parent),
@@ -52,7 +51,6 @@ be_local_closure(class_Matter_TLV_item_reset,   /* name */
 /********************************************************************
 ** Solidified function: set_or_nil
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_or_nil,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -61,7 +59,7 @@ be_local_closure(class_Matter_TLV_item_set_or_nil,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -96,7 +94,6 @@ be_local_closure(class_Matter_TLV_item_set_or_nil,   /* name */
 /********************************************************************
 ** Solidified function: encode_len
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -105,7 +102,7 @@ be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[32]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -411,7 +408,6 @@ be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
 /********************************************************************
 ** Solidified function: set
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -420,7 +416,7 @@ be_local_closure(class_Matter_TLV_item_set,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
@@ -451,7 +447,6 @@ be_local_closure(class_Matter_TLV_item_set,   /* name */
 /********************************************************************
 ** Solidified function: to_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_to_TLV,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -460,7 +455,7 @@ be_local_closure(class_Matter_TLV_item_to_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(to_TLV),
@@ -476,7 +471,6 @@ be_local_closure(class_Matter_TLV_item_to_TLV,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_tostring,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -485,7 +479,7 @@ be_local_closure(class_Matter_TLV_item_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[34]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -702,7 +696,6 @@ be_local_closure(class_Matter_TLV_item_tostring,   /* name */
 /********************************************************************
 ** Solidified function: to_str_val
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_to_str_val,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -711,7 +704,7 @@ be_local_closure(class_Matter_TLV_item_to_str_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -841,7 +834,6 @@ be_local_closure(class_Matter_TLV_item_to_str_val,   /* name */
 /********************************************************************
 ** Solidified function: set_fulltag
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_fulltag,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -850,7 +842,7 @@ be_local_closure(class_Matter_TLV_item_set_fulltag,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_vendor),
@@ -885,7 +877,6 @@ be_local_closure(class_Matter_TLV_item_set_fulltag,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_parse,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -894,7 +885,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(typ),
@@ -1035,7 +1026,6 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
 /********************************************************************
 ** Solidified function: set_commonprofile
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_commonprofile,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1044,7 +1034,7 @@ be_local_closure(class_Matter_TLV_item_set_commonprofile,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_fulltag),
@@ -1067,7 +1057,6 @@ be_local_closure(class_Matter_TLV_item_set_commonprofile,   /* name */
 /********************************************************************
 ** Solidified function: _encode_tag
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item__encode_tag,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1076,7 +1065,7 @@ be_local_closure(class_Matter_TLV_item__encode_tag,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_number),
@@ -1234,7 +1223,6 @@ be_local_closure(class_Matter_TLV_item__encode_tag,   /* name */
 /********************************************************************
 ** Solidified function: sort
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_sort,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1243,7 +1231,7 @@ be_local_closure(class_Matter_TLV_item_sort,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_TLV_item),
@@ -1297,7 +1285,6 @@ be_local_closure(class_Matter_TLV_item_sort,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1306,7 +1293,7 @@ be_local_closure(class_Matter_TLV_item_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(parent),
@@ -1325,7 +1312,6 @@ be_local_closure(class_Matter_TLV_item_init,   /* name */
 /********************************************************************
 ** Solidified function: _cmp_gt
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1334,7 +1320,7 @@ be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_vendor),
@@ -1428,7 +1414,6 @@ be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1437,7 +1422,7 @@ be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -1901,7 +1886,6 @@ be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
 /********************************************************************
 ** Solidified function: _encode_tag_len
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1910,7 +1894,7 @@ be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_number),
@@ -1988,7 +1972,6 @@ be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
 /********************************************************************
 ** Solidified function: set_contextspecific
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_contextspecific,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1997,7 +1980,7 @@ be_local_closure(class_Matter_TLV_item_set_contextspecific,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_fulltag),
@@ -2022,7 +2005,6 @@ be_local_closure(class_Matter_TLV_item_set_contextspecific,   /* name */
 /********************************************************************
 ** Solidified function: set_parent
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_parent,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -2031,7 +2013,7 @@ be_local_closure(class_Matter_TLV_item_set_parent,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(parent),
@@ -2050,7 +2032,6 @@ be_local_closure(class_Matter_TLV_item_set_parent,   /* name */
 /********************************************************************
 ** Solidified function: create_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_create_TLV,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2059,7 +2040,7 @@ be_local_closure(class_Matter_TLV_item_create_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_TLV_item),
@@ -2091,7 +2072,6 @@ be_local_closure(class_Matter_TLV_item_create_TLV,   /* name */
 /********************************************************************
 ** Solidified function: set_anonymoustag
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_item;
 be_local_closure(class_Matter_TLV_item_set_anonymoustag,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2100,7 +2080,7 @@ be_local_closure(class_Matter_TLV_item_set_anonymoustag,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_item, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_fulltag),
@@ -2166,7 +2146,6 @@ extern const bclass be_class_Matter_TLV_list;
 /********************************************************************
 ** Solidified function: findsubval
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_findsubval,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2175,7 +2154,7 @@ be_local_closure(class_Matter_TLV_list_findsubval,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(findsub),
@@ -2202,7 +2181,6 @@ be_local_closure(class_Matter_TLV_list_findsubval,   /* name */
 /********************************************************************
 ** Solidified function: tlv2raw
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2211,7 +2189,7 @@ be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(_encode_tag),
@@ -2282,7 +2260,6 @@ be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
 /********************************************************************
 ** Solidified function: to_str_val
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_to_str_val,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2291,7 +2268,7 @@ be_local_closure(class_Matter_TLV_list_to_str_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(tostring),
@@ -2312,7 +2289,6 @@ be_local_closure(class_Matter_TLV_list_to_str_val,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2321,7 +2297,7 @@ be_local_closure(class_Matter_TLV_list_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tostring_inner),
@@ -2347,7 +2323,6 @@ be_local_closure(class_Matter_TLV_list_tostring,   /* name */
 /********************************************************************
 ** Solidified function: size
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_size,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2356,7 +2331,7 @@ be_local_closure(class_Matter_TLV_list_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -2377,7 +2352,6 @@ be_local_closure(class_Matter_TLV_list_size,   /* name */
 /********************************************************************
 ** Solidified function: setitem
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_setitem,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2386,7 +2360,7 @@ be_local_closure(class_Matter_TLV_list_setitem,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -2406,7 +2380,6 @@ be_local_closure(class_Matter_TLV_list_setitem,   /* name */
 /********************************************************************
 ** Solidified function: add_struct
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_add_struct,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2415,7 +2388,7 @@ be_local_closure(class_Matter_TLV_list_add_struct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -2446,7 +2419,6 @@ be_local_closure(class_Matter_TLV_list_add_struct,   /* name */
 /********************************************************************
 ** Solidified function: add_list
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_add_list,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2455,7 +2427,7 @@ be_local_closure(class_Matter_TLV_list_add_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -2486,7 +2458,6 @@ be_local_closure(class_Matter_TLV_list_add_list,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_parse,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2495,7 +2466,7 @@ be_local_closure(class_Matter_TLV_list_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -2538,7 +2509,6 @@ be_local_closure(class_Matter_TLV_list_parse,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2547,7 +2517,7 @@ be_local_closure(class_Matter_TLV_list_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -2581,7 +2551,6 @@ be_local_closure(class_Matter_TLV_list_init,   /* name */
 /********************************************************************
 ** Solidified function: item
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_item,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2590,7 +2559,7 @@ be_local_closure(class_Matter_TLV_list_item,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -2610,7 +2579,6 @@ be_local_closure(class_Matter_TLV_list_item,   /* name */
 /********************************************************************
 ** Solidified function: getsubval
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_getsubval,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2619,7 +2587,7 @@ be_local_closure(class_Matter_TLV_list_getsubval,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(getsub),
@@ -2642,7 +2610,6 @@ be_local_closure(class_Matter_TLV_list_getsubval,   /* name */
 /********************************************************************
 ** Solidified function: getsub
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_getsub,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2651,7 +2618,7 @@ be_local_closure(class_Matter_TLV_list_getsub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(findsub),
@@ -2678,7 +2645,6 @@ be_local_closure(class_Matter_TLV_list_getsub,   /* name */
 /********************************************************************
 ** Solidified function: add_obj
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_add_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2687,7 +2653,7 @@ be_local_closure(class_Matter_TLV_list_add_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -2728,7 +2694,6 @@ be_local_closure(class_Matter_TLV_list_add_obj,   /* name */
 /********************************************************************
 ** Solidified function: add_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_add_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2737,7 +2702,7 @@ be_local_closure(class_Matter_TLV_list_add_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -2781,7 +2746,6 @@ be_local_closure(class_Matter_TLV_list_add_TLV,   /* name */
 /********************************************************************
 ** Solidified function: add_array
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_add_array,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2790,7 +2754,7 @@ be_local_closure(class_Matter_TLV_list_add_array,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -2821,7 +2785,6 @@ be_local_closure(class_Matter_TLV_list_add_array,   /* name */
 /********************************************************************
 ** Solidified function: findsub
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_findsub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2830,7 +2793,7 @@ be_local_closure(class_Matter_TLV_list_findsub,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -2865,7 +2828,6 @@ be_local_closure(class_Matter_TLV_list_findsub,   /* name */
 /********************************************************************
 ** Solidified function: tostring_inner
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_tostring_inner,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2874,7 +2836,7 @@ be_local_closure(class_Matter_TLV_list_tostring_inner,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -2993,7 +2955,6 @@ be_local_closure(class_Matter_TLV_list_tostring_inner,   /* name */
 /********************************************************************
 ** Solidified function: push
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_push,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3002,7 +2963,7 @@ be_local_closure(class_Matter_TLV_list_push,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
@@ -3025,7 +2986,6 @@ be_local_closure(class_Matter_TLV_list_push,   /* name */
 /********************************************************************
 ** Solidified function: findsubtyp
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_findsubtyp,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3034,7 +2994,7 @@ be_local_closure(class_Matter_TLV_list_findsubtyp,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(findsub),
@@ -3062,7 +3022,6 @@ be_local_closure(class_Matter_TLV_list_findsubtyp,   /* name */
 /********************************************************************
 ** Solidified function: encode_len
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_list;
 be_local_closure(class_Matter_TLV_list_encode_len,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3071,7 +3030,7 @@ be_local_closure(class_Matter_TLV_list_encode_len,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_encode_tag_len),
@@ -3146,7 +3105,6 @@ extern const bclass be_class_Matter_TLV_struct;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_struct;
 be_local_closure(class_Matter_TLV_struct_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3155,7 +3113,7 @@ be_local_closure(class_Matter_TLV_struct_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_struct, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tostring_inner),
@@ -3181,7 +3139,6 @@ be_local_closure(class_Matter_TLV_struct_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_struct;
 be_local_closure(class_Matter_TLV_struct_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3190,7 +3147,7 @@ be_local_closure(class_Matter_TLV_struct_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_struct, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -3243,7 +3200,6 @@ extern const bclass be_class_Matter_TLV_array;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_array;
 be_local_closure(class_Matter_TLV_array_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3252,7 +3208,7 @@ be_local_closure(class_Matter_TLV_array_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(tostring_inner),
@@ -3278,7 +3234,6 @@ be_local_closure(class_Matter_TLV_array_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_array;
 be_local_closure(class_Matter_TLV_array_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3287,7 +3242,7 @@ be_local_closure(class_Matter_TLV_array_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -3321,7 +3276,6 @@ be_local_closure(class_Matter_TLV_array_init,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_TLV_array;
 be_local_closure(class_Matter_TLV_array_parse,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3330,7 +3284,7 @@ be_local_closure(class_Matter_TLV_array_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV_array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
@@ -3405,7 +3359,6 @@ extern const bclass be_class_Matter_TLV;
 /********************************************************************
 ** Solidified function: create_TLV
 ********************************************************************/
-extern const bclass be_class_Matter_TLV;
 be_local_closure(class_Matter_TLV_create_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3414,7 +3367,7 @@ be_local_closure(class_Matter_TLV_create_TLV,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_TLV),
@@ -3440,7 +3393,6 @@ be_local_closure(class_Matter_TLV_create_TLV,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Matter_TLV;
 be_local_closure(class_Matter_TLV_parse,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -3449,7 +3401,7 @@ be_local_closure(class_Matter_TLV_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_TLV, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_TLV),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_UDPPacket_sent;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_UDPPacket_sent;
 be_local_closure(class_Matter_UDPPacket_sent_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_UDPPacket_sent_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPPacket_sent, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(raw),
@@ -116,7 +115,6 @@ extern const bclass be_class_Matter_UDPServer;
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -125,7 +123,7 @@ be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(loop),
@@ -145,7 +143,6 @@ be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: send_UDP
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -154,7 +151,7 @@ be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -190,7 +187,6 @@ be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
 /********************************************************************
 ** Solidified function: received_ack
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -199,7 +195,7 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(ack_message_counter),
@@ -266,7 +262,6 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_start,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -275,7 +270,7 @@ be_local_closure(class_Matter_UDPServer_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(listening),
@@ -324,7 +319,6 @@ be_local_closure(class_Matter_UDPServer_start,   /* name */
 /********************************************************************
 ** Solidified function: send
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_send,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -333,7 +327,7 @@ be_local_closure(class_Matter_UDPServer_send,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(udp_socket),
@@ -407,7 +401,6 @@ be_local_closure(class_Matter_UDPServer_send,   /* name */
 /********************************************************************
 ** Solidified function: stop
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_stop,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -416,7 +409,7 @@ be_local_closure(class_Matter_UDPServer_stop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(listening),
@@ -450,7 +443,6 @@ be_local_closure(class_Matter_UDPServer_stop,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -459,7 +451,7 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -469,7 +461,7 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(loop),
@@ -483,7 +475,6 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
           0x80000000,  //  0003  RET	0
         })
       ),
-    &be_class_Matter_UDPServer, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
@@ -527,7 +518,6 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
 /********************************************************************
 ** Solidified function: _resend_packets
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -536,7 +526,7 @@ be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -630,7 +620,6 @@ be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
 /********************************************************************
 ** Solidified function: _backoff_time
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -639,7 +628,7 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         4,                          /* nstack */
         2,                          /* argc */
@@ -647,7 +636,7 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_const_int(1),
@@ -665,7 +654,6 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
           0x80040400,  //  0006  RET	1	R2
         })
       ),
-    &be_class_Matter_UDPServer, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
@@ -719,7 +707,6 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
 /********************************************************************
 ** Solidified function: loop
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_loop,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -728,7 +715,7 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -822,7 +809,6 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_every_second,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -831,7 +817,7 @@ be_local_closure(class_Matter_UDPServer_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UDPServer, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(every_second),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_UI;
 /********************************************************************
 ** Solidified function: equal_map
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_equal_map,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_UI_equal_map,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_UI),
@@ -91,7 +90,6 @@ be_local_closure(class_Matter_UI_equal_map,   /* name */
 /********************************************************************
 ** Solidified function: page_part_mgr_adv
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -100,7 +98,7 @@ be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -149,7 +147,6 @@ be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
 /********************************************************************
 ** Solidified function: page_part_mgr
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_page_part_mgr,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -158,7 +155,7 @@ be_local_closure(class_Matter_UI_page_part_mgr,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -218,7 +215,6 @@ be_local_closure(class_Matter_UI_page_part_mgr,   /* name */
 /********************************************************************
 ** Solidified function: plugin_name
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_plugin_name,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -227,7 +223,7 @@ be_local_closure(class_Matter_UI_plugin_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -254,7 +250,6 @@ be_local_closure(class_Matter_UI_plugin_name,   /* name */
 /********************************************************************
 ** Solidified function: matter_enabled
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_matter_enabled,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -263,7 +258,7 @@ be_local_closure(class_Matter_UI_matter_enabled,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -291,7 +286,6 @@ be_local_closure(class_Matter_UI_matter_enabled,   /* name */
 /********************************************************************
 ** Solidified function: generate_config_from_status
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_generate_config_from_status,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -300,7 +294,7 @@ be_local_closure(class_Matter_UI_generate_config_from_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -429,7 +423,6 @@ be_local_closure(class_Matter_UI_generate_config_from_status,   /* name */
 /********************************************************************
 ** Solidified function: web_sensor
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_web_sensor,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -438,7 +431,7 @@ be_local_closure(class_Matter_UI_web_sensor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -520,7 +513,6 @@ be_local_closure(class_Matter_UI_web_sensor,   /* name */
 /********************************************************************
 ** Solidified function: page_part_mgr_add
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_page_part_mgr_add,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -529,7 +521,7 @@ be_local_closure(class_Matter_UI_page_part_mgr_add,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -583,7 +575,6 @@ be_local_closure(class_Matter_UI_page_part_mgr_add,   /* name */
 /********************************************************************
 ** Solidified function: show_plugins_configuration
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_plugins_configuration,   /* name */
   be_nested_proto(
     29,                          /* nstack */
@@ -592,7 +583,7 @@ be_local_closure(class_Matter_UI_show_plugins_configuration,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[63]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1032,7 +1023,6 @@ be_local_closure(class_Matter_UI_show_plugins_configuration,   /* name */
 /********************************************************************
 ** Solidified function: show_commissioning_info
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_commissioning_info,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1041,7 +1031,7 @@ be_local_closure(class_Matter_UI_show_commissioning_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1132,7 +1122,6 @@ be_local_closure(class_Matter_UI_show_commissioning_info,   /* name */
 /********************************************************************
 ** Solidified function: show_remote_autoconf
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
   be_nested_proto(
     27,                          /* nstack */
@@ -1141,7 +1130,7 @@ be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[46]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1432,7 +1421,6 @@ be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
 /********************************************************************
 ** Solidified function: show_fabric_info
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -1441,7 +1429,7 @@ be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1585,7 +1573,6 @@ be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
 /********************************************************************
 ** Solidified function: web_get_arg
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_web_get_arg,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1594,7 +1581,7 @@ be_local_closure(class_Matter_UI_web_get_arg,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1634,7 +1621,6 @@ be_local_closure(class_Matter_UI_web_get_arg,   /* name */
 /********************************************************************
 ** Solidified function: plugin_option
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_plugin_option,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -1643,7 +1629,7 @@ be_local_closure(class_Matter_UI_plugin_option,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1732,7 +1718,6 @@ be_local_closure(class_Matter_UI_plugin_option,   /* name */
 /********************************************************************
 ** Solidified function: web_add_config_button
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_web_add_config_button,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1741,7 +1726,7 @@ be_local_closure(class_Matter_UI_web_add_config_button,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -1775,7 +1760,6 @@ be_local_closure(class_Matter_UI_web_add_config_button,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1784,7 +1768,7 @@ be_local_closure(class_Matter_UI_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -1809,7 +1793,6 @@ be_local_closure(class_Matter_UI_init,   /* name */
 /********************************************************************
 ** Solidified function: show_bridge_status
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -1818,7 +1801,7 @@ be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
@@ -1979,7 +1962,6 @@ be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
 /********************************************************************
 ** Solidified function: web_add_handler
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_web_add_handler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1988,7 +1970,7 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 5]) {
+    ( &(const struct bproto*[ 4]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -1998,7 +1980,7 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(page_part_mgr),
@@ -2021,7 +2003,7 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(page_part_ctl),
@@ -2044,7 +2026,7 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(page_part_mgr_adv),
@@ -2067,7 +2049,7 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(page_part_mgr_add),
@@ -2081,7 +2063,6 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
           0x80040000,  //  0003  RET	1	R0
         })
       ),
-    &be_class_Matter_UI, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
@@ -2128,7 +2109,6 @@ be_local_closure(class_Matter_UI_web_add_handler,   /* name */
 /********************************************************************
 ** Solidified function: show_passcode_form
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2137,7 +2117,7 @@ be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -2208,7 +2188,6 @@ be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
 /********************************************************************
 ** Solidified function: page_part_ctl
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
   be_nested_proto(
     23,                          /* nstack */
@@ -2217,7 +2196,7 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[101]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -2993,7 +2972,6 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
 /********************************************************************
 ** Solidified function: show_qrcode
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_qrcode,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -3002,7 +2980,7 @@ be_local_closure(class_Matter_UI_show_qrcode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -3160,7 +3138,6 @@ be_local_closure(class_Matter_UI_show_qrcode,   /* name */
 /********************************************************************
 ** Solidified function: show_enable
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_enable,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -3169,7 +3146,7 @@ be_local_closure(class_Matter_UI_show_enable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
@@ -3257,7 +3234,6 @@ be_local_closure(class_Matter_UI_show_enable,   /* name */
 /********************************************************************
 ** Solidified function: show_plugins_hints_js
 ********************************************************************/
-extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -3266,7 +3242,7 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_UI, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Matter_Device;
 /********************************************************************
 ** Solidified function: start_commissioning_complete
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_fabric),
@@ -67,7 +66,6 @@ be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
 /********************************************************************
 ** Solidified function: k2l_num
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_k2l_num,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -76,7 +74,7 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
@@ -150,7 +148,6 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
 /********************************************************************
 ** Solidified function: remove_fabric
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_remove_fabric,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -159,7 +156,7 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(log),
@@ -222,7 +219,6 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
 /********************************************************************
 ** Solidified function: _mdns_announce_hostname
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__mdns_announce_hostname,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -231,7 +227,7 @@ be_local_closure(class_Matter_Device__mdns_announce_hostname,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
@@ -418,7 +414,6 @@ be_local_closure(class_Matter_Device__mdns_announce_hostname,   /* name */
 /********************************************************************
 ** Solidified function: save_before_restart
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_save_before_restart,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -427,7 +422,7 @@ be_local_closure(class_Matter_Device_save_before_restart,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(stop_basic_commissioning),
@@ -450,7 +445,6 @@ be_local_closure(class_Matter_Device_save_before_restart,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_every_second,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -459,7 +453,7 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -503,7 +497,6 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
 /********************************************************************
 ** Solidified function: stop
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_stop,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -512,7 +505,7 @@ be_local_closure(class_Matter_Device_stop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -542,7 +535,6 @@ be_local_closure(class_Matter_Device_stop,   /* name */
 /********************************************************************
 ** Solidified function: every_250ms
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_every_250ms,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -551,7 +543,7 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(read_sensors_scheduler),
@@ -587,7 +579,6 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
 /********************************************************************
 ** Solidified function: msg_received
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_msg_received,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -596,7 +587,7 @@ be_local_closure(class_Matter_Device_msg_received,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(message_handler),
@@ -621,7 +612,6 @@ be_local_closure(class_Matter_Device_msg_received,   /* name */
 /********************************************************************
 ** Solidified function: add_read_sensors_schedule
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -630,7 +620,7 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_sensor_time),
@@ -664,7 +654,6 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
 /********************************************************************
 ** Solidified function: attribute_updated
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_attribute_updated,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -673,7 +662,7 @@ be_local_closure(class_Matter_Device_attribute_updated,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
@@ -716,7 +705,6 @@ be_local_closure(class_Matter_Device_attribute_updated,   /* name */
 /********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_invoke_request,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -725,7 +713,7 @@ be_local_closure(class_Matter_Device_invoke_request,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -773,7 +761,6 @@ be_local_closure(class_Matter_Device_invoke_request,   /* name */
 /********************************************************************
 ** Solidified function: autoconf_device
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_autoconf_device,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -782,7 +769,7 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -852,7 +839,6 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
 /********************************************************************
 ** Solidified function: get_plugin_class_displayname
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -861,7 +847,7 @@ be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_classes),
@@ -890,7 +876,6 @@ be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
 /********************************************************************
 ** Solidified function: every_50ms
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -899,7 +884,7 @@ be_local_closure(class_Matter_Device_every_50ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tick),
@@ -926,7 +911,6 @@ be_local_closure(class_Matter_Device_every_50ms,   /* name */
 /********************************************************************
 ** Solidified function: button_handler
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_button_handler,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -935,7 +919,7 @@ be_local_closure(class_Matter_Device_button_handler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -982,7 +966,6 @@ be_local_closure(class_Matter_Device_button_handler,   /* name */
 /********************************************************************
 ** Solidified function: register_commands
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_register_commands,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -991,7 +974,7 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 4]) {
+    ( &(const struct bproto*[ 3]) {
       be_nested_proto(
         10,                          /* nstack */
         4,                          /* argc */
@@ -1001,7 +984,7 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(MtrJoin),
@@ -1028,7 +1011,7 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(MtrUpdate),
@@ -1055,7 +1038,7 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(MtrInfo),
@@ -1073,7 +1056,6 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
           0x80040800,  //  0007  RET	1	R4
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
@@ -1112,7 +1094,6 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
 /********************************************************************
 ** Solidified function: compute_qrcode_content
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_compute_qrcode_content,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1121,7 +1102,7 @@ be_local_closure(class_Matter_Device_compute_qrcode_content,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(resize),
@@ -1189,7 +1170,6 @@ be_local_closure(class_Matter_Device_compute_qrcode_content,   /* name */
 /********************************************************************
 ** Solidified function: resolve_attribute_read_solo
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1198,7 +1178,7 @@ be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -1272,7 +1252,6 @@ be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
 /********************************************************************
 ** Solidified function: update_remotes_info
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1281,7 +1260,7 @@ be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(http_remotes),
@@ -1336,7 +1315,6 @@ be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
 /********************************************************************
 ** Solidified function: button_multi_pressed
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1345,7 +1323,7 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(button_handler),
@@ -1378,7 +1356,6 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
 /********************************************************************
 ** Solidified function: sort_distinct
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_sort_distinct,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1387,7 +1364,7 @@ be_local_closure(class_Matter_Device_sort_distinct,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
@@ -1461,7 +1438,6 @@ be_local_closure(class_Matter_Device_sort_distinct,   /* name */
 /********************************************************************
 ** Solidified function: mdns_remove_PASE
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_remove_PASE,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1470,7 +1446,7 @@ be_local_closure(class_Matter_Device_mdns_remove_PASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
@@ -1582,7 +1558,6 @@ be_local_closure(class_Matter_Device_mdns_remove_PASE,   /* name */
 /********************************************************************
 ** Solidified function: get_plugin_remote_info
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1591,7 +1566,7 @@ be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_config_remotes),
@@ -1616,7 +1591,6 @@ be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
 /********************************************************************
 ** Solidified function: start_root_basic_commissioning
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -1625,7 +1599,7 @@ be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name *
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
@@ -1738,7 +1712,6 @@ be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name *
 /********************************************************************
 ** Solidified function: event_fabrics_saved
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1747,7 +1720,7 @@ be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -1780,7 +1753,6 @@ be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
 /********************************************************************
 ** Solidified function: start_mdns_announce_hostnames
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1789,7 +1761,7 @@ be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         4,                          /* nstack */
         0,                          /* argc */
@@ -1799,7 +1771,7 @@ be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
         /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
@@ -1832,7 +1804,7 @@ be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
         /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
@@ -1856,7 +1828,6 @@ be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
           0x80000000,  //  0009  RET	0
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
@@ -1914,7 +1885,6 @@ be_local_closure(class_Matter_Device_start_mdns_announce_hostnames,   /* name */
 /********************************************************************
 ** Solidified function: mdns_announce_PASE
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1923,7 +1893,7 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[40]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
@@ -2201,7 +2171,6 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
 /********************************************************************
 ** Solidified function: autoconf_sensors_list
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_autoconf_sensors_list,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2210,7 +2179,7 @@ be_local_closure(class_Matter_Device_autoconf_sensors_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(k2l),
@@ -2363,7 +2332,6 @@ be_local_closure(class_Matter_Device_autoconf_sensors_list,   /* name */
 /********************************************************************
 ** Solidified function: process_attribute_expansion
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -2372,7 +2340,7 @@ be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
@@ -2425,7 +2393,6 @@ be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
 /********************************************************************
 ** Solidified function: stop_basic_commissioning
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_stop_basic_commissioning,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2434,7 +2401,7 @@ be_local_closure(class_Matter_Device_stop_basic_commissioning,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(is_root_commissioning_open),
@@ -2482,7 +2449,6 @@ be_local_closure(class_Matter_Device_stop_basic_commissioning,   /* name */
 /********************************************************************
 ** Solidified function: clean_remotes
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_clean_remotes,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2491,7 +2457,7 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -2604,7 +2570,6 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2613,7 +2578,7 @@ be_local_closure(class_Matter_Device_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         4,                          /* nstack */
         0,                          /* argc */
@@ -2623,7 +2588,7 @@ be_local_closure(class_Matter_Device_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
         /* K0   */  be_nested_str_weak(start),
@@ -2655,7 +2620,7 @@ be_local_closure(class_Matter_Device_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
         /* K0   */  be_nested_str_weak(start),
@@ -2678,7 +2643,6 @@ be_local_closure(class_Matter_Device_init,   /* name */
           0x80000000,  //  0008  RET	0
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[38]) {     /* constants */
@@ -2835,7 +2799,6 @@ be_local_closure(class_Matter_Device_init,   /* name */
 /********************************************************************
 ** Solidified function: mdns_remove_op_discovery
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_remove_op_discovery,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -2844,7 +2807,7 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
@@ -2960,7 +2923,6 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery,   /* name */
 /********************************************************************
 ** Solidified function: _start_udp
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__start_udp,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2969,7 +2931,7 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         8,                          /* nstack */
         3,                          /* argc */
@@ -2979,7 +2941,7 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(msg_received),
@@ -2996,7 +2958,6 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
           0x80040600,  //  0006  RET	1	R3
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
@@ -3048,7 +3009,6 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
 /********************************************************************
 ** Solidified function: adjust_next_ep
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3057,7 +3017,7 @@ be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_config),
@@ -3099,7 +3059,6 @@ be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
 /********************************************************************
 ** Solidified function: _trigger_read_sensors
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3108,7 +3067,7 @@ be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -3185,7 +3144,6 @@ be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
 /********************************************************************
 ** Solidified function: _instantiate_plugins_from_config
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__instantiate_plugins_from_config,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -3194,7 +3152,7 @@ be_local_closure(class_Matter_Device__instantiate_plugins_from_config,   /* name
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(k2l_num),
@@ -3387,7 +3345,6 @@ be_local_closure(class_Matter_Device__instantiate_plugins_from_config,   /* name
 /********************************************************************
 ** Solidified function: mdns_announce_op_discovery
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -3396,7 +3353,7 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
@@ -3554,7 +3511,6 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
 /********************************************************************
 ** Solidified function: start_commissioning_complete_deferred
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_commissioning_complete_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -3563,7 +3519,7 @@ be_local_closure(class_Matter_Device_start_commissioning_complete_deferred,   /*
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         3,                          /* nstack */
         0,                          /* argc */
@@ -3574,7 +3530,7 @@ be_local_closure(class_Matter_Device_start_commissioning_complete_deferred,   /*
           be_local_const_upval(1, 1),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(start_commissioning_complete),
@@ -3589,7 +3545,6 @@ be_local_closure(class_Matter_Device_start_commissioning_complete_deferred,   /*
           0x80040000,  //  0004  RET	1	R0
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
@@ -3616,7 +3571,6 @@ be_local_closure(class_Matter_Device_start_commissioning_complete_deferred,   /*
 /********************************************************************
 ** Solidified function: read_sensors_scheduler
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -3625,7 +3579,7 @@ be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_sensor_time),
@@ -3669,7 +3623,6 @@ be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
 /********************************************************************
 ** Solidified function: bridge_remove_endpoint
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -3678,7 +3631,7 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -3767,7 +3720,6 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
 /********************************************************************
 ** Solidified function: bridge_add_endpoint
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -3776,7 +3728,7 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_classes),
@@ -3880,7 +3832,6 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
 /********************************************************************
 ** Solidified function: is_root_commissioning_open
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_is_root_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -3889,7 +3840,7 @@ be_local_closure(class_Matter_Device_is_root_commissioning_open,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(commissioning_open),
@@ -3918,7 +3869,6 @@ be_local_closure(class_Matter_Device_is_root_commissioning_open,   /* name */
 /********************************************************************
 ** Solidified function: start_operational_discovery
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_operational_discovery,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3927,7 +3877,7 @@ be_local_closure(class_Matter_Device_start_operational_discovery,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -3955,7 +3905,6 @@ be_local_closure(class_Matter_Device_start_operational_discovery,   /* name */
 /********************************************************************
 ** Solidified function: MtrInfo
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_MtrInfo,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -3964,7 +3913,7 @@ be_local_closure(class_Matter_Device_MtrInfo,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
@@ -4029,7 +3978,6 @@ be_local_closure(class_Matter_Device_MtrInfo,   /* name */
 /********************************************************************
 ** Solidified function: signal_endpoints_changed
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4038,7 +3986,7 @@ be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
@@ -4073,7 +4021,6 @@ be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
 /********************************************************************
 ** Solidified function: MtrUpdate
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -4082,7 +4029,7 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[25]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -4249,7 +4196,6 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
 /********************************************************************
 ** Solidified function: start_operational_discovery_deferred
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_operational_discovery_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -4258,7 +4204,7 @@ be_local_closure(class_Matter_Device_start_operational_discovery_deferred,   /* 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         3,                          /* nstack */
         0,                          /* argc */
@@ -4269,7 +4215,7 @@ be_local_closure(class_Matter_Device_start_operational_discovery_deferred,   /* 
           be_local_const_upval(1, 1),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(start_operational_discovery),
@@ -4284,7 +4230,6 @@ be_local_closure(class_Matter_Device_start_operational_discovery_deferred,   /* 
           0x80040000,  //  0004  RET	1	R0
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
@@ -4311,7 +4256,6 @@ be_local_closure(class_Matter_Device_start_operational_discovery_deferred,   /* 
 /********************************************************************
 ** Solidified function: save_param
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_save_param,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -4320,7 +4264,7 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -4450,7 +4394,6 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
 /********************************************************************
 ** Solidified function: load_param
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_load_param,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -4459,7 +4402,7 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[36]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -4644,7 +4587,6 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
 /********************************************************************
 ** Solidified function: compute_manual_pairing_code
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_compute_manual_pairing_code,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -4653,7 +4595,7 @@ be_local_closure(class_Matter_Device_compute_manual_pairing_code,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(root_discriminator),
@@ -4705,7 +4647,6 @@ be_local_closure(class_Matter_Device_compute_manual_pairing_code,   /* name */
 /********************************************************************
 ** Solidified function: msg_send
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_msg_send,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4714,7 +4655,7 @@ be_local_closure(class_Matter_Device_msg_send,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(udp_server),
@@ -4737,7 +4678,6 @@ be_local_closure(class_Matter_Device_msg_send,   /* name */
 /********************************************************************
 ** Solidified function: button_pressed
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_button_pressed,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -4746,7 +4686,7 @@ be_local_closure(class_Matter_Device_button_pressed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(button_handler),
@@ -4793,7 +4733,6 @@ be_local_closure(class_Matter_Device_button_pressed,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -4802,7 +4741,7 @@ be_local_closure(class_Matter_Device_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(started),
@@ -4836,7 +4775,6 @@ be_local_closure(class_Matter_Device_start,   /* name */
 /********************************************************************
 ** Solidified function: register_http_remote
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_register_http_remote,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -4845,7 +4783,7 @@ be_local_closure(class_Matter_Device_register_http_remote,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(http_remotes),
@@ -4911,7 +4849,6 @@ be_local_closure(class_Matter_Device_register_http_remote,   /* name */
 /********************************************************************
 ** Solidified function: check_config_ep
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_check_config_ep,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -4920,7 +4857,7 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_config),
@@ -5027,7 +4964,6 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
 /********************************************************************
 ** Solidified function: mdns_remove_op_discovery_all_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -5036,7 +4972,7 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* 
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -5080,7 +5016,6 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* 
 /********************************************************************
 ** Solidified function: mdns_announce_op_discovery_all_fabrics
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -5089,7 +5024,7 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery_all_fabrics,   /
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -5133,7 +5068,6 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery_all_fabrics,   /
 /********************************************************************
 ** Solidified function: generate_random_passcode
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_generate_random_passcode,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -5142,7 +5076,7 @@ be_local_closure(class_Matter_Device_generate_random_passcode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -5201,7 +5135,6 @@ be_local_closure(class_Matter_Device_generate_random_passcode,   /* name */
 /********************************************************************
 ** Solidified function: is_commissioning_open
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -5210,7 +5143,7 @@ be_local_closure(class_Matter_Device_is_commissioning_open,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(commissioning_open),
@@ -5231,7 +5164,6 @@ be_local_closure(class_Matter_Device_is_commissioning_open,   /* name */
 /********************************************************************
 ** Solidified function: find_plugin_by_endpoint
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -5240,7 +5172,7 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -5277,7 +5209,6 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
 /********************************************************************
 ** Solidified function: conf_to_log
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_conf_to_log,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -5286,7 +5217,7 @@ be_local_closure(class_Matter_Device_conf_to_log,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
@@ -5332,7 +5263,6 @@ be_local_closure(class_Matter_Device_conf_to_log,   /* name */
 /********************************************************************
 ** Solidified function: received_ack
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_received_ack,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5341,7 +5271,7 @@ be_local_closure(class_Matter_Device_received_ack,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(udp_server),
@@ -5364,7 +5294,6 @@ be_local_closure(class_Matter_Device_received_ack,   /* name */
 /********************************************************************
 ** Solidified function: MtrInfo_one
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -5373,7 +5302,7 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(find_plugin_by_endpoint),
@@ -5415,7 +5344,6 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
 /********************************************************************
 ** Solidified function: get_plugin_class_arg
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5424,7 +5352,7 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_classes),
@@ -5453,7 +5381,6 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
 /********************************************************************
 ** Solidified function: k2l
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_k2l,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -5462,7 +5389,7 @@ be_local_closure(class_Matter_Device_k2l,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
@@ -5534,7 +5461,6 @@ be_local_closure(class_Matter_Device_k2l,   /* name */
 /********************************************************************
 ** Solidified function: start_basic_commissioning
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -5543,7 +5469,7 @@ be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         4,                          /* nstack */
         0,                          /* argc */
@@ -5553,7 +5479,7 @@ be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str_weak(mdns_announce_PASE),
@@ -5584,7 +5510,7 @@ be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str_weak(mdns_announce_PASE),
@@ -5606,7 +5532,6 @@ be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
           0x80000000,  //  0008  RET	0
         })
       ),
-    &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
@@ -5679,7 +5604,6 @@ be_local_closure(class_Matter_Device_start_basic_commissioning,   /* name */
 /********************************************************************
 ** Solidified function: _init_basic_commissioning
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__init_basic_commissioning,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -5688,7 +5612,7 @@ be_local_closure(class_Matter_Device__init_basic_commissioning,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
@@ -5716,7 +5640,6 @@ be_local_closure(class_Matter_Device__init_basic_commissioning,   /* name */
 /********************************************************************
 ** Solidified function: find_plugin_by_friendly_name
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -5725,7 +5648,7 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -5780,7 +5703,6 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
 /********************************************************************
 ** Solidified function: autoconf_device_map
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -5789,7 +5711,7 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[38]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -6105,7 +6027,6 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
 /********************************************************************
 ** Solidified function: get_active_endpoints
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -6114,7 +6035,7 @@ be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins),
@@ -6164,7 +6085,6 @@ be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
 /********************************************************************
 ** Solidified function: MtrJoin
 ********************************************************************/
-extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_MtrJoin,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -6173,7 +6093,7 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Matter_Device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(start_root_basic_commissioning),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_Wire.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_Wire.h
@@ -7,7 +7,6 @@
 /********************************************************************
 ** Solidified function: read_bytes
 ********************************************************************/
-extern const bclass be_class_Wire;
 be_local_closure(class_Wire_read_bytes,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -16,7 +15,7 @@ be_local_closure(class_Wire_read_bytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Wire, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(_begin_transmission),
@@ -62,7 +61,6 @@ be_local_closure(class_Wire_read_bytes,   /* name */
 /********************************************************************
 ** Solidified function: write_bytes
 ********************************************************************/
-extern const bclass be_class_Wire;
 be_local_closure(class_Wire_write_bytes,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -71,7 +69,7 @@ be_local_closure(class_Wire_write_bytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Wire, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_begin_transmission),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_autoconf_module.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_autoconf_module.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Autoconf;
 /********************************************************************
 ** Solidified function: page_autoconf_ctl
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_page_autoconf_ctl,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Autoconf_page_autoconf_ctl,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[39]) {     /* constants */
     /* K0   */  be_nested_str(webserver),
@@ -189,7 +188,6 @@ be_local_closure(class_Autoconf_page_autoconf_ctl,   /* name */
 /********************************************************************
 ** Solidified function: autoexec
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_autoexec,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -198,7 +196,7 @@ be_local_closure(class_Autoconf_autoexec,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str(_archive),
@@ -391,7 +389,6 @@ be_local_closure(class_Autoconf_autoexec,   /* name */
 /********************************************************************
 ** Solidified function: run_bat
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_run_bat,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -400,7 +397,7 @@ be_local_closure(class_Autoconf_run_bat,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str(r),
@@ -495,7 +492,6 @@ be_local_closure(class_Autoconf_run_bat,   /* name */
 /********************************************************************
 ** Solidified function: page_autoconf_mgr
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_page_autoconf_mgr,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -504,7 +500,7 @@ be_local_closure(class_Autoconf_page_autoconf_mgr,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[38]) {     /* constants */
     /* K0   */  be_nested_str(webserver),
@@ -682,7 +678,6 @@ be_local_closure(class_Autoconf_page_autoconf_mgr,   /* name */
 /********************************************************************
 ** Solidified function: get_current_module_name
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_get_current_module_name,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -691,7 +686,7 @@ be_local_closure(class_Autoconf_get_current_module_name,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_archive),
@@ -714,7 +709,6 @@ be_local_closure(class_Autoconf_get_current_module_name,   /* name */
 /********************************************************************
 ** Solidified function: delete_all_configs
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_delete_all_configs,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -723,7 +717,7 @@ be_local_closure(class_Autoconf_delete_all_configs,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -773,7 +767,6 @@ be_local_closure(class_Autoconf_delete_all_configs,   /* name */
 /********************************************************************
 ** Solidified function: set_first_time
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_set_first_time,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -782,7 +775,7 @@ be_local_closure(class_Autoconf_set_first_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_X2F_X2Eautoconf),
@@ -808,7 +801,6 @@ be_local_closure(class_Autoconf_set_first_time,   /* name */
 /********************************************************************
 ** Solidified function: load_templates
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_load_templates,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -817,7 +809,7 @@ be_local_closure(class_Autoconf_load_templates,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -937,7 +929,6 @@ be_local_closure(class_Autoconf_load_templates,   /* name */
 /********************************************************************
 ** Solidified function: web_add_config_button
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_web_add_config_button,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -946,7 +937,7 @@ be_local_closure(class_Autoconf_web_add_config_button,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(webserver),
@@ -970,7 +961,6 @@ be_local_closure(class_Autoconf_web_add_config_button,   /* name */
 /********************************************************************
 ** Solidified function: is_first_time
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_is_first_time,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -979,7 +969,7 @@ be_local_closure(class_Autoconf_is_first_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -1006,7 +996,6 @@ be_local_closure(class_Autoconf_is_first_time,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_init,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1015,7 +1004,7 @@ be_local_closure(class_Autoconf_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -1101,7 +1090,6 @@ be_local_closure(class_Autoconf_init,   /* name */
 /********************************************************************
 ** Solidified function: preinit
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_preinit,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1110,7 +1098,7 @@ be_local_closure(class_Autoconf_preinit,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(_archive),
@@ -1162,7 +1150,6 @@ be_local_closure(class_Autoconf_preinit,   /* name */
 /********************************************************************
 ** Solidified function: reset
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_reset,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1171,7 +1158,7 @@ be_local_closure(class_Autoconf_reset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -1234,7 +1221,6 @@ be_local_closure(class_Autoconf_reset,   /* name */
 /********************************************************************
 ** Solidified function: web_add_handler
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_web_add_handler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1243,7 +1229,7 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -1253,7 +1239,7 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str(page_autoconf_mgr),
@@ -1276,7 +1262,7 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str(page_autoconf_ctl),
@@ -1290,7 +1276,6 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
           0x80040000,  //  0003  RET	1	R0
         })
       ),
-    &be_class_Autoconf, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
@@ -1325,7 +1310,6 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
 /********************************************************************
 ** Solidified function: clear_first_time
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_clear_first_time,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1334,7 +1318,7 @@ be_local_closure(class_Autoconf_clear_first_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -1358,7 +1342,6 @@ be_local_closure(class_Autoconf_clear_first_time,   /* name */
 /********************************************************************
 ** Solidified function: get_current_module_path
 ********************************************************************/
-extern const bclass be_class_Autoconf;
 be_local_closure(class_Autoconf_get_current_module_path,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1367,7 +1350,7 @@ be_local_closure(class_Autoconf_get_current_module_path,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Autoconf, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(_archive),
@@ -1424,7 +1407,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_const_class(be_class_Autoconf),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_pbkdf2_hmac_sha256.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_pbkdf2_hmac_sha256.h
@@ -15,7 +15,7 @@ be_local_closure(_f,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         6,                          /* nstack */
         2,                          /* argc */
@@ -23,7 +23,7 @@ be_local_closure(_f,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_nested_str_weak(size),
@@ -54,7 +54,6 @@ be_local_closure(_f,   /* name */
           0x80000000,  //  0012  RET	0
         })
       ),
-    NULL, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
@@ -126,7 +125,7 @@ be_local_closure(PBKDF2_HMAC_SHA256,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
@@ -9,7 +9,6 @@ extern const bclass be_class_SPAKE2P_Matter;
 /********************************************************************
 ** Solidified function: compute_pB
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_compute_pB,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_SPAKE2P_Matter_compute_pB,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -69,7 +68,6 @@ extern const bclass be_class_SPAKE_Hasher;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_SPAKE_Hasher;
 be_local_closure(class_SPAKE_Hasher_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -78,7 +76,7 @@ be_local_closure(class_SPAKE_Hasher_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE_Hasher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -102,7 +100,6 @@ be_local_closure(class_SPAKE_Hasher_init,   /* name */
 /********************************************************************
 ** Solidified function: add_item
 ********************************************************************/
-extern const bclass be_class_SPAKE_Hasher;
 be_local_closure(class_SPAKE_Hasher_add_item,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -111,7 +108,7 @@ be_local_closure(class_SPAKE_Hasher_add_item,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE_Hasher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(size),
@@ -153,7 +150,6 @@ be_local_closure(class_SPAKE_Hasher_add_item,   /* name */
 /********************************************************************
 ** Solidified function: out
 ********************************************************************/
-extern const bclass be_class_SPAKE_Hasher;
 be_local_closure(class_SPAKE_Hasher_out,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -162,7 +158,7 @@ be_local_closure(class_SPAKE_Hasher_out,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE_Hasher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(hash),
@@ -200,7 +196,6 @@ be_local_class(SPAKE_Hasher,
 /********************************************************************
 ** Solidified function: compute_TT_hash
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_compute_TT_hash,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -209,7 +204,7 @@ be_local_closure(class_SPAKE2P_Matter_compute_TT_hash,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_const_class(be_class_SPAKE_Hasher),
@@ -369,7 +364,6 @@ be_local_closure(class_SPAKE2P_Matter_compute_TT_hash,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -378,7 +372,7 @@ be_local_closure(class_SPAKE2P_Matter_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(M),
@@ -418,7 +412,6 @@ be_local_closure(class_SPAKE2P_Matter_init,   /* name */
 /********************************************************************
 ** Solidified function: compute_pA
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_compute_pA,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -427,7 +420,7 @@ be_local_closure(class_SPAKE2P_Matter_compute_pA,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -476,7 +469,6 @@ be_local_closure(class_SPAKE2P_Matter_compute_pA,   /* name */
 /********************************************************************
 ** Solidified function: set_context
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_set_context,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -485,7 +477,7 @@ be_local_closure(class_SPAKE2P_Matter_set_context,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(Context),
@@ -520,7 +512,6 @@ be_local_closure(class_SPAKE2P_Matter_set_context,   /* name */
 /********************************************************************
 ** Solidified function: compute_ZV_verifier
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_compute_ZV_verifier,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -529,7 +520,7 @@ be_local_closure(class_SPAKE2P_Matter_compute_ZV_verifier,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
@@ -584,7 +575,6 @@ be_local_closure(class_SPAKE2P_Matter_compute_ZV_verifier,   /* name */
 /********************************************************************
 ** Solidified function: compute_ZV_prover
 ********************************************************************/
-extern const bclass be_class_SPAKE2P_Matter;
 be_local_closure(class_SPAKE2P_Matter_compute_ZV_prover,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -593,7 +583,7 @@ be_local_closure(class_SPAKE2P_Matter_compute_ZV_prover,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_SPAKE2P_Matter, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_driver_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_driver_class.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Driver;
 /********************************************************************
 ** Solidified function: add_cmd
 ********************************************************************/
-extern const bclass be_class_Driver;
 be_local_closure(class_Driver_add_cmd,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Driver_add_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         10,                          /* nstack */
         4,                          /* argc */
@@ -29,7 +28,7 @@ be_local_closure(class_Driver_add_cmd,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str__X3Clambda_X3E,
@@ -45,7 +44,6 @@ be_local_closure(class_Driver_add_cmd,   /* name */
           0x80040800,  //  0007  RET	1	R4
         })
       ),
-    &be_class_Driver, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_dyn.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_dyn.h
@@ -9,7 +9,6 @@ extern const bclass be_class_dyn;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_dyn;
 be_local_closure(class_dyn_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_dyn_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_dyn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_attr),
@@ -40,7 +39,6 @@ be_local_closure(class_dyn_tostring,   /* name */
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_dyn;
 be_local_closure(class_dyn_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -49,7 +47,7 @@ be_local_closure(class_dyn_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_dyn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_attr),
@@ -80,7 +78,6 @@ be_local_closure(class_dyn_member,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_dyn;
 be_local_closure(class_dyn_setmember,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -89,7 +86,7 @@ be_local_closure(class_dyn_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_dyn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(_attr),
@@ -109,7 +106,6 @@ be_local_closure(class_dyn_setmember,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_dyn;
 be_local_closure(class_dyn_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -118,7 +114,7 @@ be_local_closure(class_dyn_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_dyn, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(_attr),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_energy.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_energy.h
@@ -15,7 +15,7 @@ be_local_closure(module_energy_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(global),
@@ -45,7 +45,7 @@ be_local_closure(module_energy__deref,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(global),
@@ -103,7 +103,7 @@ be_local_closure(module_energy_read,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(energy),
@@ -143,7 +143,7 @@ be_local_closure(module_energy_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(energy),
@@ -181,7 +181,7 @@ be_local_closure(module_energy_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(energy),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
@@ -9,7 +9,6 @@ extern const bclass be_class_hue_bridge_monad;
 /********************************************************************
 ** Solidified function: full_status
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_full_status,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_hue_bridge_monad_full_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(hue_ntv),
@@ -59,7 +58,6 @@ be_local_closure(class_hue_bridge_monad_full_status,   /* name */
 /********************************************************************
 ** Solidified function: hue_status
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_hue_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -68,7 +66,7 @@ be_local_closure(class_hue_bridge_monad_hue_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(hue_ntv),
@@ -102,7 +100,6 @@ be_local_closure(class_hue_bridge_monad_hue_status,   /* name */
 /********************************************************************
 ** Solidified function: add_light
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_add_light,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -111,7 +108,7 @@ be_local_closure(class_hue_bridge_monad_add_light,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str(int),
@@ -184,7 +181,6 @@ be_local_closure(class_hue_bridge_monad_add_light,   /* name */
 /********************************************************************
 ** Solidified function: remove_light
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_remove_light,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -193,7 +189,7 @@ be_local_closure(class_hue_bridge_monad_remove_light,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(lights),
@@ -216,7 +212,6 @@ be_local_closure(class_hue_bridge_monad_remove_light,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -225,7 +220,7 @@ be_local_closure(class_hue_bridge_monad_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(lights),
@@ -246,7 +241,6 @@ be_local_closure(class_hue_bridge_monad_init,   /* name */
 /********************************************************************
 ** Solidified function: discover
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_discover,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -255,7 +249,7 @@ be_local_closure(class_hue_bridge_monad_discover,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(hue_ntv),
@@ -322,7 +316,6 @@ be_local_closure(class_hue_bridge_monad_discover,   /* name */
 /********************************************************************
 ** Solidified function: light_to_id
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_light_to_id,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -331,7 +324,7 @@ be_local_closure(class_hue_bridge_monad_light_to_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(lights),
@@ -371,7 +364,6 @@ be_local_closure(class_hue_bridge_monad_light_to_id,   /* name */
 /********************************************************************
 ** Solidified function: cmd
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_cmd,   /* name */
   be_nested_proto(
     18,                          /* nstack */
@@ -380,7 +372,7 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -594,7 +586,6 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
 /********************************************************************
 ** Solidified function: groups
 ********************************************************************/
-extern const bclass be_class_hue_bridge_monad;
 be_local_closure(class_hue_bridge_monad_groups,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -603,7 +594,7 @@ be_local_closure(class_hue_bridge_monad_groups,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_hue_bridge_monad, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(lights),
@@ -688,7 +679,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_const_class(be_class_hue_bridge_monad),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
@@ -9,7 +9,6 @@ extern const bclass be_class_AXP192;
 /********************************************************************
 ** Solidified function: set_dcdc_enable
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_dcdc_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_AXP192_set_dcdc_enable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(1),
@@ -61,7 +60,6 @@ be_local_closure(class_AXP192_set_dcdc_enable,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_power
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_bat_power,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -70,11 +68,11 @@ be_local_closure(class_AXP192_get_bat_power,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
+    /* K1   */  be_const_real_hex(0x3A102DE1),
     }),
     &be_const_str_get_bat_power,
     &be_const_str_solidified,
@@ -93,7 +91,6 @@ be_local_closure(class_AXP192_get_bat_power,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_voltage
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_bat_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -102,7 +99,7 @@ be_local_closure(class_AXP192_get_bat_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -125,7 +122,6 @@ be_local_closure(class_AXP192_get_bat_voltage,   /* name */
 /********************************************************************
 ** Solidified function: get_vbus_current
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_vbus_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -134,7 +130,7 @@ be_local_closure(class_AXP192_get_vbus_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -157,7 +153,6 @@ be_local_closure(class_AXP192_get_vbus_current,   /* name */
 /********************************************************************
 ** Solidified function: get_warning_level
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_warning_level,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -166,7 +161,7 @@ be_local_closure(class_AXP192_get_warning_level,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -189,7 +184,6 @@ be_local_closure(class_AXP192_get_warning_level,   /* name */
 /********************************************************************
 ** Solidified function: set_ldo_enable
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_ldo_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -198,7 +192,7 @@ be_local_closure(class_AXP192_set_ldo_enable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -232,7 +226,6 @@ be_local_closure(class_AXP192_set_ldo_enable,   /* name */
 /********************************************************************
 ** Solidified function: get_input_power_status
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_input_power_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -241,7 +234,7 @@ be_local_closure(class_AXP192_get_input_power_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -269,7 +262,6 @@ be_local_closure(class_AXP192_get_input_power_status,   /* name */
 /********************************************************************
 ** Solidified function: get_aps_voltage
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_aps_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -278,7 +270,7 @@ be_local_closure(class_AXP192_get_aps_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -301,7 +293,6 @@ be_local_closure(class_AXP192_get_aps_voltage,   /* name */
 /********************************************************************
 ** Solidified function: set_exten
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_exten,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -310,7 +301,7 @@ be_local_closure(class_AXP192_set_exten,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(write_bit),
@@ -333,7 +324,6 @@ be_local_closure(class_AXP192_set_exten,   /* name */
 /********************************************************************
 ** Solidified function: battery_present
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_battery_present,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -342,7 +332,7 @@ be_local_closure(class_AXP192_battery_present,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -377,7 +367,6 @@ be_local_closure(class_AXP192_battery_present,   /* name */
 /********************************************************************
 ** Solidified function: get_vbus_voltage
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_vbus_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -386,7 +375,7 @@ be_local_closure(class_AXP192_get_vbus_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -409,7 +398,6 @@ be_local_closure(class_AXP192_get_vbus_voltage,   /* name */
 /********************************************************************
 ** Solidified function: write_gpio
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_write_gpio,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -418,7 +406,7 @@ be_local_closure(class_AXP192_write_gpio,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -459,7 +447,6 @@ be_local_closure(class_AXP192_write_gpio,   /* name */
 /********************************************************************
 ** Solidified function: set_ldo_voltage
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -468,7 +455,7 @@ be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -527,7 +514,6 @@ be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
 /********************************************************************
 ** Solidified function: json_append
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_json_append,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -536,7 +522,7 @@ be_local_closure(class_AXP192_json_append,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -582,7 +568,6 @@ be_local_closure(class_AXP192_json_append,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -591,7 +576,7 @@ be_local_closure(class_AXP192_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(I2C_Driver),
@@ -619,7 +604,6 @@ be_local_closure(class_AXP192_init,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_current
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_bat_current,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -628,7 +612,7 @@ be_local_closure(class_AXP192_get_bat_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read13),
@@ -655,7 +639,6 @@ be_local_closure(class_AXP192_get_bat_current,   /* name */
 /********************************************************************
 ** Solidified function: web_sensor
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_web_sensor,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -664,7 +647,7 @@ be_local_closure(class_AXP192_web_sensor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -717,7 +700,6 @@ be_local_closure(class_AXP192_web_sensor,   /* name */
 /********************************************************************
 ** Solidified function: set_chg_current
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_chg_current,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -726,7 +708,7 @@ be_local_closure(class_AXP192_set_chg_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(write8),
@@ -756,7 +738,6 @@ be_local_closure(class_AXP192_set_chg_current,   /* name */
 /********************************************************************
 ** Solidified function: get_temp
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_temp,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -765,7 +746,7 @@ be_local_closure(class_AXP192_get_temp,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -790,7 +771,6 @@ be_local_closure(class_AXP192_get_temp,   /* name */
 /********************************************************************
 ** Solidified function: set_dc_voltage
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_set_dc_voltage,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -799,7 +779,7 @@ be_local_closure(class_AXP192_set_dc_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(1),
@@ -869,7 +849,6 @@ be_local_closure(class_AXP192_set_dc_voltage,   /* name */
 /********************************************************************
 ** Solidified function: power_off
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_power_off,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -878,7 +857,7 @@ be_local_closure(class_AXP192_power_off,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(write_bit),
@@ -902,7 +881,6 @@ be_local_closure(class_AXP192_power_off,   /* name */
 /********************************************************************
 ** Solidified function: get_battery_chargin_status
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -911,7 +889,7 @@ be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -938,7 +916,6 @@ be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_charge_current
 ********************************************************************/
-extern const bclass be_class_AXP192;
 be_local_closure(class_AXP192_get_bat_charge_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -947,7 +924,7 @@ be_local_closure(class_AXP192_get_bat_charge_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP192, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read13),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
@@ -9,7 +9,6 @@ extern const bclass be_class_AXP202;
 /********************************************************************
 ** Solidified function: set_shutdown_time
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_shutdown_time,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_AXP202_set_shutdown_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -64,7 +63,6 @@ be_local_closure(class_AXP202_set_shutdown_time,   /* name */
 /********************************************************************
 ** Solidified function: get_vbus_current
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_vbus_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -73,7 +71,7 @@ be_local_closure(class_AXP202_get_vbus_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -96,7 +94,6 @@ be_local_closure(class_AXP202_get_vbus_current,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_voltage
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_bat_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -105,7 +102,7 @@ be_local_closure(class_AXP202_get_bat_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -128,7 +125,6 @@ be_local_closure(class_AXP202_get_bat_voltage,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_current
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_bat_current,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -137,7 +133,7 @@ be_local_closure(class_AXP202_get_bat_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read13),
@@ -164,7 +160,6 @@ be_local_closure(class_AXP202_get_bat_current,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_power
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_bat_power,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -173,11 +168,11 @@ be_local_closure(class_AXP202_get_bat_power,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
+    /* K1   */  be_const_real_hex(0x3A102DE1),
     }),
     &be_const_str_get_bat_power,
     &be_const_str_solidified,
@@ -196,7 +191,6 @@ be_local_closure(class_AXP202_get_bat_power,   /* name */
 /********************************************************************
 ** Solidified function: get_aps_voltage
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_aps_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -205,7 +199,7 @@ be_local_closure(class_AXP202_get_aps_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -228,7 +222,6 @@ be_local_closure(class_AXP202_get_aps_voltage,   /* name */
 /********************************************************************
 ** Solidified function: get_vbus_voltage
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -237,7 +230,7 @@ be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -260,7 +253,6 @@ be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
 /********************************************************************
 ** Solidified function: set_ldo_enable
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_ldo_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -269,7 +261,7 @@ be_local_closure(class_AXP202_set_ldo_enable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -311,7 +303,6 @@ be_local_closure(class_AXP202_set_ldo_enable,   /* name */
 /********************************************************************
 ** Solidified function: battery_present
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_battery_present,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -320,7 +311,7 @@ be_local_closure(class_AXP202_battery_present,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -355,7 +346,6 @@ be_local_closure(class_AXP202_battery_present,   /* name */
 /********************************************************************
 ** Solidified function: set_chg_current_ma
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_chg_current_ma,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -364,7 +354,7 @@ be_local_closure(class_AXP202_set_chg_current_ma,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(write8),
@@ -398,7 +388,6 @@ be_local_closure(class_AXP202_set_chg_current_ma,   /* name */
 /********************************************************************
 ** Solidified function: set_dcdc_enable
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_dcdc_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -407,7 +396,7 @@ be_local_closure(class_AXP202_set_dcdc_enable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -442,7 +431,6 @@ be_local_closure(class_AXP202_set_dcdc_enable,   /* name */
 /********************************************************************
 ** Solidified function: set_chg_led_mode
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -451,7 +439,7 @@ be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(read8),
@@ -487,7 +475,6 @@ be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -496,7 +483,7 @@ be_local_closure(class_AXP202_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(I2C_Driver),
@@ -524,7 +511,6 @@ be_local_closure(class_AXP202_init,   /* name */
 /********************************************************************
 ** Solidified function: set_exten
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_exten,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -533,7 +519,7 @@ be_local_closure(class_AXP202_set_exten,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(write_bit),
@@ -557,7 +543,6 @@ be_local_closure(class_AXP202_set_exten,   /* name */
 /********************************************************************
 ** Solidified function: get_battery_chargin_status
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_battery_chargin_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -566,7 +551,7 @@ be_local_closure(class_AXP202_get_battery_chargin_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -593,7 +578,6 @@ be_local_closure(class_AXP202_get_battery_chargin_status,   /* name */
 /********************************************************************
 ** Solidified function: set_dc_voltage
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_dc_voltage,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -602,7 +586,7 @@ be_local_closure(class_AXP202_set_dc_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -667,7 +651,6 @@ be_local_closure(class_AXP202_set_dc_voltage,   /* name */
 /********************************************************************
 ** Solidified function: get_bat_charge_current
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -676,7 +659,7 @@ be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read13),
@@ -699,7 +682,6 @@ be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
 /********************************************************************
 ** Solidified function: get_temp
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_temp,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -708,7 +690,7 @@ be_local_closure(class_AXP202_get_temp,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(read12),
@@ -733,7 +715,6 @@ be_local_closure(class_AXP202_get_temp,   /* name */
 /********************************************************************
 ** Solidified function: set_ldo_voltage
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -742,7 +723,7 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -820,7 +801,6 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
 /********************************************************************
 ** Solidified function: set_limiting_off
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_set_limiting_off,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -829,7 +809,7 @@ be_local_closure(class_AXP202_set_limiting_off,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(write8),
@@ -856,7 +836,6 @@ be_local_closure(class_AXP202_set_limiting_off,   /* name */
 /********************************************************************
 ** Solidified function: get_input_power_status
 ********************************************************************/
-extern const bclass be_class_AXP202;
 be_local_closure(class_AXP202_get_input_power_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -865,7 +844,7 @@ be_local_closure(class_AXP202_get_input_power_status,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_AXP202, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(wire),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_driver.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_driver.h
@@ -9,7 +9,6 @@ extern const bclass be_class_I2C_Driver;
 /********************************************************************
 ** Solidified function: write_bit
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_write_bit,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_I2C_Driver_write_bit,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -64,7 +63,6 @@ be_local_closure(class_I2C_Driver_write_bit,   /* name */
 /********************************************************************
 ** Solidified function: read32
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read32,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -73,7 +71,7 @@ be_local_closure(class_I2C_Driver_read32,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -116,7 +114,6 @@ be_local_closure(class_I2C_Driver_read32,   /* name */
 /********************************************************************
 ** Solidified function: read13
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read13,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -125,7 +122,7 @@ be_local_closure(class_I2C_Driver_read13,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -159,7 +156,6 @@ be_local_closure(class_I2C_Driver_read13,   /* name */
 /********************************************************************
 ** Solidified function: read24
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read24,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -168,7 +164,7 @@ be_local_closure(class_I2C_Driver_read24,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -207,7 +203,6 @@ be_local_closure(class_I2C_Driver_read24,   /* name */
 /********************************************************************
 ** Solidified function: read14
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read14,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -216,7 +211,7 @@ be_local_closure(class_I2C_Driver_read14,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -250,7 +245,6 @@ be_local_closure(class_I2C_Driver_read14,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -259,7 +253,7 @@ be_local_closure(class_I2C_Driver_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(tasmota),
@@ -329,7 +323,6 @@ be_local_closure(class_I2C_Driver_init,   /* name */
 /********************************************************************
 ** Solidified function: write8
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_write8,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -338,7 +331,7 @@ be_local_closure(class_I2C_Driver_write8,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -366,7 +359,6 @@ be_local_closure(class_I2C_Driver_write8,   /* name */
 /********************************************************************
 ** Solidified function: read8
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read8,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -375,7 +367,7 @@ be_local_closure(class_I2C_Driver_read8,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -402,7 +394,6 @@ be_local_closure(class_I2C_Driver_read8,   /* name */
 /********************************************************************
 ** Solidified function: read12
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read12,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -411,7 +402,7 @@ be_local_closure(class_I2C_Driver_read12,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -445,7 +436,6 @@ be_local_closure(class_I2C_Driver_read12,   /* name */
 /********************************************************************
 ** Solidified function: read16
 ********************************************************************/
-extern const bclass be_class_I2C_Driver;
 be_local_closure(class_I2C_Driver_read16,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -454,7 +444,7 @@ be_local_closure(class_I2C_Driver_read16,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_I2C_Driver, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(wire),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_ft3663.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_ft3663.h
@@ -9,7 +9,6 @@ extern const bclass be_class_FT3663;
 /********************************************************************
 ** Solidified function: every_100ms
 ********************************************************************/
-extern const bclass be_class_FT3663;
 be_local_closure(class_FT3663_every_100ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_FT3663_every_100ms,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_FT3663, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(wire),
@@ -41,7 +40,6 @@ be_local_closure(class_FT3663_every_100ms,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_FT3663;
 be_local_closure(class_FT3663_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_FT3663_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_FT3663, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(init),
@@ -128,7 +126,6 @@ be_local_closure(class_FT3663_init,   /* name */
 /********************************************************************
 ** Solidified function: ts_loop
 ********************************************************************/
-extern const bclass be_class_FT3663;
 be_local_closure(class_FT3663_ts_loop,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -137,7 +134,7 @@ be_local_closure(class_FT3663_ts_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_FT3663, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str(wire),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -11,7 +11,6 @@ extern const bclass be_class_Leds_segment;
 /********************************************************************
 ** Solidified function: pixel_offset
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_pixel_offset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -20,7 +19,7 @@ be_local_closure(class_Leds_segment_pixel_offset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(offset),
@@ -39,7 +38,6 @@ be_local_closure(class_Leds_segment_pixel_offset,   /* name */
 /********************************************************************
 ** Solidified function: clear_to
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -48,7 +46,7 @@ be_local_closure(class_Leds_segment_clear_to,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -86,7 +84,6 @@ be_local_closure(class_Leds_segment_clear_to,   /* name */
 /********************************************************************
 ** Solidified function: pixel_count
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_pixel_count,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -95,7 +92,7 @@ be_local_closure(class_Leds_segment_pixel_count,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(leds),
@@ -114,7 +111,6 @@ be_local_closure(class_Leds_segment_pixel_count,   /* name */
 /********************************************************************
 ** Solidified function: pixels_buffer
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -123,7 +119,7 @@ be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     &be_const_str_pixels_buffer,
@@ -140,7 +136,6 @@ be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
 /********************************************************************
 ** Solidified function: dirty
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -149,7 +144,7 @@ be_local_closure(class_Leds_segment_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -171,7 +166,6 @@ be_local_closure(class_Leds_segment_dirty,   /* name */
 /********************************************************************
 ** Solidified function: can_show
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_can_show,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -180,7 +174,7 @@ be_local_closure(class_Leds_segment_can_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -202,7 +196,6 @@ be_local_closure(class_Leds_segment_can_show,   /* name */
 /********************************************************************
 ** Solidified function: set_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -211,7 +204,7 @@ be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -243,7 +236,6 @@ be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: is_dirty
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_is_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -252,7 +244,7 @@ be_local_closure(class_Leds_segment_is_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -274,7 +266,6 @@ be_local_closure(class_Leds_segment_is_dirty,   /* name */
 /********************************************************************
 ** Solidified function: clear
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -283,7 +274,7 @@ be_local_closure(class_Leds_segment_clear,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(clear_to),
@@ -308,7 +299,6 @@ be_local_closure(class_Leds_segment_clear,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_begin,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -317,7 +307,7 @@ be_local_closure(class_Leds_segment_begin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     &be_const_str_begin,
@@ -333,7 +323,6 @@ be_local_closure(class_Leds_segment_begin,   /* name */
 /********************************************************************
 ** Solidified function: get_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -342,7 +331,7 @@ be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -367,7 +356,6 @@ be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: pixel_size
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_pixel_size,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -376,7 +364,7 @@ be_local_closure(class_Leds_segment_pixel_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -398,7 +386,6 @@ be_local_closure(class_Leds_segment_pixel_size,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -407,7 +394,7 @@ be_local_closure(class_Leds_segment_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -436,7 +423,6 @@ be_local_closure(class_Leds_segment_init,   /* name */
 /********************************************************************
 ** Solidified function: show
 ********************************************************************/
-extern const bclass be_class_Leds_segment;
 be_local_closure(class_Leds_segment_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -445,7 +431,7 @@ be_local_closure(class_Leds_segment_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_segment, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(offset),
@@ -511,7 +497,6 @@ be_local_class(Leds_segment,
 /********************************************************************
 ** Solidified function: create_segment
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_create_segment,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -520,7 +505,7 @@ be_local_closure(class_Leds_create_segment,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(leds),
@@ -564,7 +549,6 @@ be_local_closure(class_Leds_create_segment,   /* name */
 /********************************************************************
 ** Solidified function: set_bri
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_set_bri,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -573,7 +557,7 @@ be_local_closure(class_Leds_set_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -600,7 +584,6 @@ be_local_closure(class_Leds_set_bri,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_begin,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -609,7 +592,7 @@ be_local_closure(class_Leds_begin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -631,7 +614,6 @@ be_local_closure(class_Leds_begin,   /* name */
 /********************************************************************
 ** Solidified function: clear
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -640,7 +622,7 @@ be_local_closure(class_Leds_clear,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(clear_to),
@@ -665,7 +647,6 @@ be_local_closure(class_Leds_clear,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_init,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -674,7 +655,7 @@ be_local_closure(class_Leds_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str(gpio),
@@ -748,7 +729,6 @@ be_local_closure(class_Leds_init,   /* name */
 /********************************************************************
 ** Solidified function: to_gamma
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_to_gamma,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -757,7 +737,7 @@ be_local_closure(class_Leds_to_gamma,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -786,7 +766,6 @@ be_local_closure(class_Leds_to_gamma,   /* name */
 /********************************************************************
 ** Solidified function: show
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -795,7 +774,7 @@ be_local_closure(class_Leds_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -817,7 +796,6 @@ be_local_closure(class_Leds_show,   /* name */
 /********************************************************************
 ** Solidified function: pixel_count
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_pixel_count,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -826,7 +804,7 @@ be_local_closure(class_Leds_pixel_count,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -847,7 +825,6 @@ be_local_closure(class_Leds_pixel_count,   /* name */
 /********************************************************************
 ** Solidified function: get_bri
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_get_bri,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -856,7 +833,7 @@ be_local_closure(class_Leds_get_bri,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -875,7 +852,6 @@ be_local_closure(class_Leds_get_bri,   /* name */
 /********************************************************************
 ** Solidified function: set_gamma
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_set_gamma,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -884,7 +860,7 @@ be_local_closure(class_Leds_set_gamma,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(gamma),
@@ -906,7 +882,6 @@ be_local_closure(class_Leds_set_gamma,   /* name */
 /********************************************************************
 ** Solidified function: get_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_get_pixel_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -915,7 +890,7 @@ be_local_closure(class_Leds_get_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -937,7 +912,6 @@ be_local_closure(class_Leds_get_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: dirty
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -946,7 +920,7 @@ be_local_closure(class_Leds_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -967,7 +941,6 @@ be_local_closure(class_Leds_dirty,   /* name */
 /********************************************************************
 ** Solidified function: matrix
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_matrix,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -976,7 +949,7 @@ be_local_closure(class_Leds_matrix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Leds),
@@ -1008,7 +981,6 @@ be_local_closure(class_Leds_matrix,   /* name */
 /********************************************************************
 ** Solidified function: pixel_offset
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_pixel_offset,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -1017,7 +989,7 @@ be_local_closure(class_Leds_pixel_offset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1035,7 +1007,6 @@ be_local_closure(class_Leds_pixel_offset,   /* name */
 /********************************************************************
 ** Solidified function: clear_to
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1044,7 +1015,7 @@ be_local_closure(class_Leds_clear_to,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -1075,7 +1046,6 @@ be_local_closure(class_Leds_clear_to,   /* name */
 /********************************************************************
 ** Solidified function: set_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_set_pixel_color,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1084,7 +1054,7 @@ be_local_closure(class_Leds_set_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(bri),
@@ -1116,7 +1086,6 @@ be_local_closure(class_Leds_set_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: pixel_size
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_pixel_size,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1125,7 +1094,7 @@ be_local_closure(class_Leds_pixel_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -1148,7 +1117,6 @@ extern const bclass be_class_Leds_matrix;
 /********************************************************************
 ** Solidified function: clear_to
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1157,7 +1125,7 @@ be_local_closure(class_Leds_matrix_clear_to,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1199,7 +1167,6 @@ be_local_closure(class_Leds_matrix_clear_to,   /* name */
 /********************************************************************
 ** Solidified function: show
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_show,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1208,7 +1175,7 @@ be_local_closure(class_Leds_matrix_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(offset),
@@ -1256,7 +1223,6 @@ be_local_closure(class_Leds_matrix_show,   /* name */
 /********************************************************************
 ** Solidified function: pixel_size
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_pixel_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1265,7 +1231,7 @@ be_local_closure(class_Leds_matrix_pixel_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(pix_size),
@@ -1284,7 +1250,6 @@ be_local_closure(class_Leds_matrix_pixel_size,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1293,7 +1258,7 @@ be_local_closure(class_Leds_matrix_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1333,7 +1298,6 @@ be_local_closure(class_Leds_matrix_init,   /* name */
 /********************************************************************
 ** Solidified function: set_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_set_pixel_color,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1342,7 +1306,7 @@ be_local_closure(class_Leds_matrix_set_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1375,7 +1339,6 @@ be_local_closure(class_Leds_matrix_set_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: pixels_buffer
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_pixels_buffer,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1384,7 +1347,7 @@ be_local_closure(class_Leds_matrix_pixels_buffer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1406,7 +1369,6 @@ be_local_closure(class_Leds_matrix_pixels_buffer,   /* name */
 /********************************************************************
 ** Solidified function: dirty
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1415,7 +1377,7 @@ be_local_closure(class_Leds_matrix_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1437,7 +1399,6 @@ be_local_closure(class_Leds_matrix_dirty,   /* name */
 /********************************************************************
 ** Solidified function: set_matrix_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_set_matrix_pixel_color,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1446,7 +1407,7 @@ be_local_closure(class_Leds_matrix_set_matrix_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1504,7 +1465,6 @@ be_local_closure(class_Leds_matrix_set_matrix_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: is_dirty
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_is_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1513,7 +1473,7 @@ be_local_closure(class_Leds_matrix_is_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1535,7 +1495,6 @@ be_local_closure(class_Leds_matrix_is_dirty,   /* name */
 /********************************************************************
 ** Solidified function: set_alternate
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_set_alternate,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1544,7 +1503,7 @@ be_local_closure(class_Leds_matrix_set_alternate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(alternate),
@@ -1563,7 +1522,6 @@ be_local_closure(class_Leds_matrix_set_alternate,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_begin,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -1572,7 +1530,7 @@ be_local_closure(class_Leds_matrix_begin,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     &be_const_str_begin,
@@ -1588,7 +1546,6 @@ be_local_closure(class_Leds_matrix_begin,   /* name */
 /********************************************************************
 ** Solidified function: pixel_count
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_pixel_count,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1597,7 +1554,7 @@ be_local_closure(class_Leds_matrix_pixel_count,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(w),
@@ -1619,7 +1576,6 @@ be_local_closure(class_Leds_matrix_pixel_count,   /* name */
 /********************************************************************
 ** Solidified function: get_alternate
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_get_alternate,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1628,7 +1584,7 @@ be_local_closure(class_Leds_matrix_get_alternate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(alternate),
@@ -1647,7 +1603,6 @@ be_local_closure(class_Leds_matrix_get_alternate,   /* name */
 /********************************************************************
 ** Solidified function: pixel_offset
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_pixel_offset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1656,7 +1611,7 @@ be_local_closure(class_Leds_matrix_pixel_offset,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(offset),
@@ -1675,7 +1630,6 @@ be_local_closure(class_Leds_matrix_pixel_offset,   /* name */
 /********************************************************************
 ** Solidified function: can_show
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_can_show,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1684,7 +1638,7 @@ be_local_closure(class_Leds_matrix_can_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1706,7 +1660,6 @@ be_local_closure(class_Leds_matrix_can_show,   /* name */
 /********************************************************************
 ** Solidified function: set_bytes
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_set_bytes,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -1715,7 +1668,7 @@ be_local_closure(class_Leds_matrix_set_bytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(h),
@@ -1753,7 +1706,6 @@ be_local_closure(class_Leds_matrix_set_bytes,   /* name */
 /********************************************************************
 ** Solidified function: get_pixel_color
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_get_pixel_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1762,7 +1714,7 @@ be_local_closure(class_Leds_matrix_get_pixel_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(strip),
@@ -1787,7 +1739,6 @@ be_local_closure(class_Leds_matrix_get_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: clear
 ********************************************************************/
-extern const bclass be_class_Leds_matrix;
 be_local_closure(class_Leds_matrix_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1796,7 +1747,7 @@ be_local_closure(class_Leds_matrix_clear,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds_matrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(clear_to),
@@ -1858,7 +1809,6 @@ be_local_class(Leds_matrix,
 /********************************************************************
 ** Solidified function: create_matrix
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_create_matrix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1867,7 +1817,7 @@ be_local_closure(class_Leds_create_matrix,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1925,7 +1875,6 @@ be_local_closure(class_Leds_create_matrix,   /* name */
 /********************************************************************
 ** Solidified function: get_gamma
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_get_gamma,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1934,7 +1883,7 @@ be_local_closure(class_Leds_get_gamma,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(gamma),
@@ -1953,7 +1902,6 @@ be_local_closure(class_Leds_get_gamma,   /* name */
 /********************************************************************
 ** Solidified function: is_dirty
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_is_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1962,7 +1910,7 @@ be_local_closure(class_Leds_is_dirty,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -1983,7 +1931,6 @@ be_local_closure(class_Leds_is_dirty,   /* name */
 /********************************************************************
 ** Solidified function: can_show
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_can_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1992,7 +1939,7 @@ be_local_closure(class_Leds_can_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -2014,7 +1961,6 @@ be_local_closure(class_Leds_can_show,   /* name */
 /********************************************************************
 ** Solidified function: assign_rmt
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_assign_rmt,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -2023,7 +1969,7 @@ be_local_closure(class_Leds_assign_rmt,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_const_class(be_class_Leds),
@@ -2128,7 +2074,6 @@ be_local_closure(class_Leds_assign_rmt,   /* name */
 /********************************************************************
 ** Solidified function: ctor
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_ctor,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -2137,7 +2082,7 @@ be_local_closure(class_Leds_ctor,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
@@ -2183,7 +2128,6 @@ be_local_closure(class_Leds_ctor,   /* name */
 /********************************************************************
 ** Solidified function: pixels_buffer
 ********************************************************************/
-extern const bclass be_class_Leds;
 be_local_closure(class_Leds_pixels_buffer,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2192,7 +2136,7 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Leds, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(call_native),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota.h
@@ -15,7 +15,7 @@ be_local_closure(module_lv_tasmota_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[36]) {     /* constants */
     /* K0   */  be_nested_str_weak(lv),
@@ -127,7 +127,6 @@ extern const bclass be_class_splash_runner;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_splash_runner;
 be_local_closure(class_splash_runner_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -136,7 +135,7 @@ be_local_closure(class_splash_runner_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_splash_runner, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -159,7 +158,6 @@ be_local_closure(class_splash_runner_init,   /* name */
 /********************************************************************
 ** Solidified function: display
 ********************************************************************/
-extern const bclass be_class_splash_runner;
 be_local_closure(class_splash_runner_display,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -168,7 +166,7 @@ be_local_closure(class_splash_runner_display,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_splash_runner, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(display),
@@ -227,7 +225,7 @@ be_local_closure(module_lv_tasmota_splash_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(display),
@@ -269,7 +267,7 @@ be_local_closure(module_lv_tasmota_splash_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(lv),
@@ -305,7 +303,7 @@ be_local_closure(module_lv_tasmota_splash,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[43]) {     /* constants */
     /* K0   */  be_nested_str_weak(display),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota_widgets.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota_widgets.h
@@ -9,7 +9,6 @@ extern const bclass be_class_lv_clock;
 /********************************************************************
 ** Solidified function: set_time
 ********************************************************************/
-extern const bclass be_class_lv_clock;
 be_local_closure(class_lv_clock_set_time,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_lv_clock_set_time,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_clock, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(hour),
@@ -68,7 +67,6 @@ be_local_closure(class_lv_clock_set_time,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_lv_clock;
 be_local_closure(class_lv_clock_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -77,7 +75,7 @@ be_local_closure(class_lv_clock_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_clock, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -119,7 +117,6 @@ be_local_closure(class_lv_clock_every_second,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_clock;
 be_local_closure(class_lv_clock_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -128,7 +125,7 @@ be_local_closure(class_lv_clock_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -138,7 +135,7 @@ be_local_closure(class_lv_clock_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(before_del),
@@ -152,7 +149,6 @@ be_local_closure(class_lv_clock_init,   /* name */
           0x80040000,  //  0003  RET	1	R0
         })
       ),
-    &be_class_lv_clock, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
@@ -218,7 +214,6 @@ be_local_closure(class_lv_clock_init,   /* name */
 /********************************************************************
 ** Solidified function: before_del
 ********************************************************************/
-extern const bclass be_class_lv_clock;
 be_local_closure(class_lv_clock_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -227,7 +222,7 @@ be_local_closure(class_lv_clock_before_del,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_clock, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -272,7 +267,6 @@ extern const bclass be_class_lv_clock_icon;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_clock_icon;
 be_local_closure(class_lv_clock_icon_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -281,7 +275,7 @@ be_local_closure(class_lv_clock_icon_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_clock_icon, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -389,7 +383,6 @@ extern const bclass be_class_lv_signal_arcs;
 /********************************************************************
 ** Solidified function: widget_event
 ********************************************************************/
-extern const bclass be_class_lv_signal_arcs;
 be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
   be_nested_proto(
     28,                          /* nstack */
@@ -398,7 +391,7 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         1,                          /* argc */
@@ -406,7 +399,7 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_const_int(1),
@@ -422,7 +415,6 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
           0x80000000,  //  0005  RET	0
         })
       ),
-    &be_class_lv_signal_arcs, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[35]) {     /* constants */
@@ -635,7 +627,6 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
 /********************************************************************
 ** Solidified function: get_percentage
 ********************************************************************/
-extern const bclass be_class_lv_signal_arcs;
 be_local_closure(class_lv_signal_arcs_get_percentage,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -644,7 +635,7 @@ be_local_closure(class_lv_signal_arcs_get_percentage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(percentage),
@@ -663,7 +654,6 @@ be_local_closure(class_lv_signal_arcs_get_percentage,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_signal_arcs;
 be_local_closure(class_lv_signal_arcs_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -672,7 +662,7 @@ be_local_closure(class_lv_signal_arcs_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -736,7 +726,6 @@ be_local_closure(class_lv_signal_arcs_init,   /* name */
 /********************************************************************
 ** Solidified function: set_percentage
 ********************************************************************/
-extern const bclass be_class_lv_signal_arcs;
 be_local_closure(class_lv_signal_arcs_set_percentage,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -745,7 +734,7 @@ be_local_closure(class_lv_signal_arcs_set_percentage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(percentage),
@@ -804,7 +793,6 @@ extern const bclass be_class_lv_wifi_arcs;
 /********************************************************************
 ** Solidified function: before_del
 ********************************************************************/
-extern const bclass be_class_lv_wifi_arcs;
 be_local_closure(class_lv_wifi_arcs_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -813,7 +801,7 @@ be_local_closure(class_lv_wifi_arcs_before_del,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -836,7 +824,6 @@ be_local_closure(class_lv_wifi_arcs_before_del,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_wifi_arcs;
 be_local_closure(class_lv_wifi_arcs_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -845,7 +832,7 @@ be_local_closure(class_lv_wifi_arcs_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -880,7 +867,6 @@ be_local_closure(class_lv_wifi_arcs_init,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_lv_wifi_arcs;
 be_local_closure(class_lv_wifi_arcs_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -889,7 +875,7 @@ be_local_closure(class_lv_wifi_arcs_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_arcs, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -953,7 +939,6 @@ extern const bclass be_class_lv_wifi_arcs_icon;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_wifi_arcs_icon;
 be_local_closure(class_lv_wifi_arcs_icon_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -962,7 +947,7 @@ be_local_closure(class_lv_wifi_arcs_icon_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_arcs_icon, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1079,7 +1064,6 @@ extern const bclass be_class_lv_signal_bars;
 /********************************************************************
 ** Solidified function: set_percentage
 ********************************************************************/
-extern const bclass be_class_lv_signal_bars;
 be_local_closure(class_lv_signal_bars_set_percentage,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1088,7 +1072,7 @@ be_local_closure(class_lv_signal_bars_set_percentage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(percentage),
@@ -1125,7 +1109,6 @@ be_local_closure(class_lv_signal_bars_set_percentage,   /* name */
 /********************************************************************
 ** Solidified function: get_percentage
 ********************************************************************/
-extern const bclass be_class_lv_signal_bars;
 be_local_closure(class_lv_signal_bars_get_percentage,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1134,7 +1117,7 @@ be_local_closure(class_lv_signal_bars_get_percentage,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(percentage),
@@ -1153,7 +1136,6 @@ be_local_closure(class_lv_signal_bars_get_percentage,   /* name */
 /********************************************************************
 ** Solidified function: widget_event
 ********************************************************************/
-extern const bclass be_class_lv_signal_bars;
 be_local_closure(class_lv_signal_bars_widget_event,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -1162,7 +1144,7 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         1,                          /* argc */
@@ -1170,7 +1152,7 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_const_int(1),
@@ -1186,7 +1168,6 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
           0x80000000,  //  0005  RET	0
         })
       ),
-    &be_class_lv_signal_bars, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[33]) {     /* constants */
@@ -1341,7 +1322,6 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_signal_bars;
 be_local_closure(class_lv_signal_bars_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1350,7 +1330,7 @@ be_local_closure(class_lv_signal_bars_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_signal_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1431,7 +1411,6 @@ extern const bclass be_class_lv_wifi_bars;
 /********************************************************************
 ** Solidified function: before_del
 ********************************************************************/
-extern const bclass be_class_lv_wifi_bars;
 be_local_closure(class_lv_wifi_bars_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1440,7 +1419,7 @@ be_local_closure(class_lv_wifi_bars_before_del,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -1463,7 +1442,6 @@ be_local_closure(class_lv_wifi_bars_before_del,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_wifi_bars;
 be_local_closure(class_lv_wifi_bars_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1472,7 +1450,7 @@ be_local_closure(class_lv_wifi_bars_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -1507,7 +1485,6 @@ be_local_closure(class_lv_wifi_bars_init,   /* name */
 /********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
-extern const bclass be_class_lv_wifi_bars;
 be_local_closure(class_lv_wifi_bars_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1516,7 +1493,7 @@ be_local_closure(class_lv_wifi_bars_every_second,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_bars, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
@@ -1580,7 +1557,6 @@ extern const bclass be_class_lv_wifi_bars_icon;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_wifi_bars_icon;
 be_local_closure(class_lv_wifi_bars_icon_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1589,7 +1565,7 @@ be_local_closure(class_lv_wifi_bars_icon_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_wifi_bars_icon, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_mqtt.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_mqtt.h
@@ -9,7 +9,6 @@ extern const bclass be_class_MQTT;
 /********************************************************************
 ** Solidified function: mqtt_data
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_mqtt_data,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_MQTT_mqtt_data,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_MQTT, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(topics),
@@ -69,7 +68,6 @@ be_local_closure(class_MQTT_mqtt_data,   /* name */
 /********************************************************************
 ** Solidified function: lazy_init
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_lazy_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -78,7 +76,7 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         2,                          /* nstack */
         0,                          /* argc */
@@ -88,7 +86,7 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str(mqtt_connect),
@@ -102,7 +100,6 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
           0x80040000,  //  0003  RET	1	R0
         })
       ),
-    &be_class_MQTT, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
@@ -142,7 +139,6 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
 /********************************************************************
 ** Solidified function: unsubscribe
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_unsubscribe,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -151,7 +147,7 @@ be_local_closure(class_MQTT_unsubscribe,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_MQTT, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(topics),
@@ -214,7 +210,6 @@ be_local_closure(class_MQTT_unsubscribe,   /* name */
 /********************************************************************
 ** Solidified function: mqtt_connect
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_mqtt_connect,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -223,7 +218,7 @@ be_local_closure(class_MQTT_mqtt_connect,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_MQTT, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(tasmota),
@@ -270,7 +265,6 @@ extern const bclass be_class_mqtt_listener;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_mqtt_listener;
 be_local_closure(class_mqtt_listener_tostring,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -279,7 +273,7 @@ be_local_closure(class_mqtt_listener_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_mqtt_listener, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X27_X25s_X27_X29_X3E),
@@ -305,7 +299,6 @@ be_local_closure(class_mqtt_listener_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_mqtt_listener;
 be_local_closure(class_mqtt_listener_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -314,7 +307,7 @@ be_local_closure(class_mqtt_listener_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_mqtt_listener, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -345,7 +338,6 @@ be_local_closure(class_mqtt_listener_init,   /* name */
 /********************************************************************
 ** Solidified function: mqtt_data
 ********************************************************************/
-extern const bclass be_class_mqtt_listener;
 be_local_closure(class_mqtt_listener_mqtt_data,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -354,7 +346,7 @@ be_local_closure(class_mqtt_listener_mqtt_data,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_mqtt_listener, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -450,7 +442,6 @@ be_local_class(mqtt_listener,
 /********************************************************************
 ** Solidified function: mqtt_listener_class
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_mqtt_listener_class,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -459,7 +450,7 @@ be_local_closure(class_MQTT_mqtt_listener_class,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_MQTT, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_const_class(be_class_mqtt_listener),
@@ -480,7 +471,6 @@ be_local_closure(class_MQTT_mqtt_listener_class,   /* name */
 /********************************************************************
 ** Solidified function: subscribe
 ********************************************************************/
-extern const bclass be_class_MQTT;
 be_local_closure(class_MQTT_subscribe,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -489,7 +479,7 @@ be_local_closure(class_MQTT_subscribe,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_MQTT, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str(lazy_init),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Partition_otadata;
 /********************************************************************
 ** Solidified function: save
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_save,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Partition_otadata_save,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -98,7 +97,6 @@ be_local_closure(class_Partition_otadata_save,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_tostring,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -107,7 +105,7 @@ be_local_closure(class_Partition_otadata_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(_X3Cinstance_X3A_X20Partition_otadata_X28ota_active_X3A_X25s_X2C_X20ota_seq_X3D_X5B_X25d_X2C_X25d_X5D_X2C_X20ota_max_X3D_X25d_X29_X3E),
@@ -147,7 +145,6 @@ be_local_closure(class_Partition_otadata_tostring,   /* name */
 /********************************************************************
 ** Solidified function: _validate
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata__validate,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -156,7 +153,7 @@ be_local_closure(class_Partition_otadata__validate,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(active_otadata),
@@ -214,7 +211,6 @@ be_local_closure(class_Partition_otadata__validate,   /* name */
 /********************************************************************
 ** Solidified function: set_ota_max
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_set_ota_max,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -223,7 +219,7 @@ be_local_closure(class_Partition_otadata_set_ota_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(maxota),
@@ -242,7 +238,6 @@ be_local_closure(class_Partition_otadata_set_ota_max,   /* name */
 /********************************************************************
 ** Solidified function: load
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_load,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -251,7 +246,7 @@ be_local_closure(class_Partition_otadata_load,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -324,7 +319,6 @@ be_local_closure(class_Partition_otadata_load,   /* name */
 /********************************************************************
 ** Solidified function: crc32_ota_seq
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_crc32_ota_seq,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -333,7 +327,7 @@ be_local_closure(class_Partition_otadata_crc32_ota_seq,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Partition_otadata),
@@ -365,7 +359,6 @@ be_local_closure(class_Partition_otadata_crc32_ota_seq,   /* name */
 /********************************************************************
 ** Solidified function: set_active
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_set_active,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -374,7 +367,7 @@ be_local_closure(class_Partition_otadata_set_active,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -437,7 +430,6 @@ be_local_closure(class_Partition_otadata_set_active,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Partition_otadata;
 be_local_closure(class_Partition_otadata_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -446,7 +438,7 @@ be_local_closure(class_Partition_otadata_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_otadata, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(maxota),
@@ -515,7 +507,6 @@ extern const bclass be_class_Partition;
 /********************************************************************
 ** Solidified function: save
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_save,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -524,7 +515,7 @@ be_local_closure(class_Partition_save,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -561,7 +552,6 @@ be_local_closure(class_Partition_save,   /* name */
 /********************************************************************
 ** Solidified function: load
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_load,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -570,7 +560,7 @@ be_local_closure(class_Partition_load,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -596,7 +586,6 @@ be_local_closure(class_Partition_load,   /* name */
 /********************************************************************
 ** Solidified function: get_active
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_active,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -605,7 +594,7 @@ be_local_closure(class_Partition_get_active,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(otadata),
@@ -626,7 +615,6 @@ be_local_closure(class_Partition_get_active,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -635,7 +623,7 @@ be_local_closure(class_Partition_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -665,7 +653,6 @@ be_local_closure(class_Partition_init,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -674,7 +661,7 @@ be_local_closure(class_Partition_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -758,7 +745,6 @@ be_local_closure(class_Partition_parse,   /* name */
 /********************************************************************
 ** Solidified function: get_max_flash_size_k
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_max_flash_size_k,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -767,7 +753,7 @@ be_local_closure(class_Partition_get_max_flash_size_k,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(tasmota),
@@ -809,7 +795,6 @@ be_local_closure(class_Partition_get_max_flash_size_k,   /* name */
 /********************************************************************
 ** Solidified function: resize_max_flash_size_k
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_resize_max_flash_size_k,   /* name */
   be_nested_proto(
     16,                          /* nstack */
@@ -818,7 +803,7 @@ be_local_closure(class_Partition_resize_max_flash_size_k,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str(tasmota),
@@ -944,7 +929,6 @@ be_local_closure(class_Partition_resize_max_flash_size_k,   /* name */
 /********************************************************************
 ** Solidified function: get_flash_definition_sector
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_flash_definition_sector,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -953,7 +937,7 @@ be_local_closure(class_Partition_get_flash_definition_sector,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_class(be_class_Partition),
@@ -1002,7 +986,6 @@ be_local_closure(class_Partition_get_flash_definition_sector,   /* name */
 /********************************************************************
 ** Solidified function: resize_fs_to_max
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_resize_fs_to_max,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1011,7 +994,7 @@ be_local_closure(class_Partition_resize_fs_to_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str(get_unallocated_k),
@@ -1093,7 +1076,6 @@ be_local_closure(class_Partition_resize_fs_to_max,   /* name */
 /********************************************************************
 ** Solidified function: switch_factory
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_switch_factory,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1102,7 +1084,7 @@ be_local_closure(class_Partition_switch_factory,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -1125,7 +1107,6 @@ be_local_closure(class_Partition_switch_factory,   /* name */
 /********************************************************************
 ** Solidified function: load_otadata
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_load_otadata,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1134,7 +1115,7 @@ be_local_closure(class_Partition_load_otadata,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(ota_max),
@@ -1191,7 +1172,6 @@ be_local_closure(class_Partition_load_otadata,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1200,7 +1180,7 @@ be_local_closure(class_Partition_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(_X3Cinstance_X3A_X20Partition_X28_X5B_X0A),
@@ -1248,7 +1228,6 @@ be_local_closure(class_Partition_tostring,   /* name */
 /********************************************************************
 ** Solidified function: has_factory
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_has_factory,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1257,7 +1236,7 @@ be_local_closure(class_Partition_has_factory,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(get_factory_slot),
@@ -1279,7 +1258,6 @@ be_local_closure(class_Partition_has_factory,   /* name */
 /********************************************************************
 ** Solidified function: tobytes
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_tobytes,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1288,7 +1266,7 @@ be_local_closure(class_Partition_tobytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -1348,7 +1326,6 @@ be_local_closure(class_Partition_tobytes,   /* name */
 /********************************************************************
 ** Solidified function: ota_max
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_ota_max,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1357,7 +1334,7 @@ be_local_closure(class_Partition_ota_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -1410,7 +1387,6 @@ be_local_closure(class_Partition_ota_max,   /* name */
 /********************************************************************
 ** Solidified function: invalidate_spiffs
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_invalidate_spiffs,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -1419,7 +1395,7 @@ be_local_closure(class_Partition_invalidate_spiffs,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -1465,7 +1441,6 @@ be_local_closure(class_Partition_invalidate_spiffs,   /* name */
 /********************************************************************
 ** Solidified function: get_factory_slot
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_factory_slot,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1474,7 +1449,7 @@ be_local_closure(class_Partition_get_factory_slot,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -1509,7 +1484,6 @@ be_local_closure(class_Partition_get_factory_slot,   /* name */
 /********************************************************************
 ** Solidified function: set_active
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_set_active,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1518,7 +1492,7 @@ be_local_closure(class_Partition_set_active,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1558,7 +1532,6 @@ be_local_closure(class_Partition_set_active,   /* name */
 /********************************************************************
 ** Solidified function: get_unallocated_k
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_unallocated_k,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1567,7 +1540,7 @@ be_local_closure(class_Partition_get_unallocated_k,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -1607,7 +1580,6 @@ be_local_closure(class_Partition_get_unallocated_k,   /* name */
 /********************************************************************
 ** Solidified function: get_ota_slot
 ********************************************************************/
-extern const bclass be_class_Partition;
 be_local_closure(class_Partition_get_ota_slot,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1616,7 +1588,7 @@ be_local_closure(class_Partition_get_ota_slot,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(slots),
@@ -1691,7 +1663,6 @@ extern const bclass be_class_Partition_info;
 /********************************************************************
 ** Solidified function: is_factory
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_is_factory,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1700,7 +1671,7 @@ be_local_closure(class_Partition_info_is_factory,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(type),
@@ -1728,7 +1699,6 @@ be_local_closure(class_Partition_info_is_factory,   /* name */
 /********************************************************************
 ** Solidified function: type_to_string
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_type_to_string,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1737,7 +1707,7 @@ be_local_closure(class_Partition_info_type_to_string,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(type),
@@ -1773,7 +1743,6 @@ be_local_closure(class_Partition_info_type_to_string,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1782,7 +1751,7 @@ be_local_closure(class_Partition_info_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str(type),
@@ -1874,7 +1843,6 @@ be_local_closure(class_Partition_info_init,   /* name */
 /********************************************************************
 ** Solidified function: subtype_to_string
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_subtype_to_string,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1883,7 +1851,7 @@ be_local_closure(class_Partition_info_subtype_to_string,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str(type),
@@ -2005,7 +1973,6 @@ be_local_closure(class_Partition_info_subtype_to_string,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_tostring,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -2014,7 +1981,7 @@ be_local_closure(class_Partition_info_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(type_to_string),
@@ -2068,7 +2035,6 @@ be_local_closure(class_Partition_info_tostring,   /* name */
 /********************************************************************
 ** Solidified function: is_ota
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_is_ota,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2077,7 +2043,7 @@ be_local_closure(class_Partition_info_is_ota,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(subtype),
@@ -2110,7 +2076,6 @@ be_local_closure(class_Partition_info_is_ota,   /* name */
 /********************************************************************
 ** Solidified function: tobytes
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_tobytes,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2119,7 +2084,7 @@ be_local_closure(class_Partition_info_tobytes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(AA50),
@@ -2186,7 +2151,6 @@ be_local_closure(class_Partition_info_tobytes,   /* name */
 /********************************************************************
 ** Solidified function: remove_trailing_zeroes
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_remove_trailing_zeroes,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2195,7 +2159,7 @@ be_local_closure(class_Partition_info_remove_trailing_zeroes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_Partition_info),
@@ -2239,7 +2203,6 @@ be_local_closure(class_Partition_info_remove_trailing_zeroes,   /* name */
 /********************************************************************
 ** Solidified function: is_spiffs
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_is_spiffs,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2248,7 +2211,7 @@ be_local_closure(class_Partition_info_is_spiffs,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(type),
@@ -2277,7 +2240,6 @@ be_local_closure(class_Partition_info_is_spiffs,   /* name */
 /********************************************************************
 ** Solidified function: get_image_size
 ********************************************************************/
-extern const bclass be_class_Partition_info;
 be_local_closure(class_Partition_info_get_image_size,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -2286,7 +2248,7 @@ be_local_closure(class_Partition_info_get_image_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Partition_info, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str(flash),
@@ -2437,7 +2399,7 @@ be_local_closure(init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(global),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
@@ -15,7 +15,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(Persist),
@@ -37,7 +37,6 @@ extern const bclass be_class_Persist;
 /********************************************************************
 ** Solidified function: json_fdump_map
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_json_fdump_map,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -46,7 +45,7 @@ be_local_closure(class_Persist_json_fdump_map,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -113,7 +112,6 @@ be_local_closure(class_Persist_json_fdump_map,   /* name */
 /********************************************************************
 ** Solidified function: json_fdump_any
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_json_fdump_any,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -122,7 +120,7 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -170,7 +168,6 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -179,7 +176,7 @@ be_local_closure(class_Persist_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -206,7 +203,6 @@ be_local_closure(class_Persist_init,   /* name */
 /********************************************************************
 ** Solidified function: save
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_save,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -215,7 +211,7 @@ be_local_closure(class_Persist_save,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(_dirty),
@@ -288,7 +284,6 @@ be_local_closure(class_Persist_save,   /* name */
 /********************************************************************
 ** Solidified function: zero
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_zero,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -297,7 +292,7 @@ be_local_closure(class_Persist_zero,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -321,7 +316,6 @@ be_local_closure(class_Persist_zero,   /* name */
 /********************************************************************
 ** Solidified function: find
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_find,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -330,7 +324,7 @@ be_local_closure(class_Persist_find,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -354,7 +348,6 @@ be_local_closure(class_Persist_find,   /* name */
 /********************************************************************
 ** Solidified function: has
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_has,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -363,7 +356,7 @@ be_local_closure(class_Persist_has,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -386,7 +379,6 @@ be_local_closure(class_Persist_has,   /* name */
 /********************************************************************
 ** Solidified function: json_fdump_list
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_json_fdump_list,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -395,7 +387,7 @@ be_local_closure(class_Persist_json_fdump_list,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -444,7 +436,6 @@ be_local_closure(class_Persist_json_fdump_list,   /* name */
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -453,7 +444,7 @@ be_local_closure(class_Persist_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -476,7 +467,6 @@ be_local_closure(class_Persist_member,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_setmember,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -485,7 +475,7 @@ be_local_closure(class_Persist_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -508,7 +498,6 @@ be_local_closure(class_Persist_setmember,   /* name */
 /********************************************************************
 ** Solidified function: contains
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_contains,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -517,7 +506,7 @@ be_local_closure(class_Persist_contains,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_p),
@@ -540,7 +529,6 @@ be_local_closure(class_Persist_contains,   /* name */
 /********************************************************************
 ** Solidified function: json_fdump
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_json_fdump,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -549,7 +537,7 @@ be_local_closure(class_Persist_json_fdump,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -583,7 +571,6 @@ be_local_closure(class_Persist_json_fdump,   /* name */
 /********************************************************************
 ** Solidified function: load
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_load,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -592,7 +579,7 @@ be_local_closure(class_Persist_load,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(json),
@@ -669,7 +656,6 @@ be_local_closure(class_Persist_load,   /* name */
 /********************************************************************
 ** Solidified function: remove
 ********************************************************************/
-extern const bclass be_class_Persist;
 be_local_closure(class_Persist_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -678,7 +664,7 @@ be_local_closure(class_Persist_remove,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Persist, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_p),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_python_compat.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_python_compat.h
@@ -15,7 +15,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(global),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Rule_Matcher_Key;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Key;
 be_local_closure(class_Rule_Matcher_Key_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Rule_Matcher_Key_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Key, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_X3CMatcher_X20key_X3D_X27),
@@ -43,7 +42,6 @@ be_local_closure(class_Rule_Matcher_Key_tostring,   /* name */
 /********************************************************************
 ** Solidified function: find_key_i
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Key;
 be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -52,7 +50,7 @@ be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Key, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_class(be_class_Rule_Matcher_Key),
@@ -104,7 +102,6 @@ be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Key;
 be_local_closure(class_Rule_Matcher_Key_match,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -113,7 +110,7 @@ be_local_closure(class_Rule_Matcher_Key_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Key, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(find_key_i),
@@ -154,7 +151,6 @@ be_local_closure(class_Rule_Matcher_Key_match,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Key;
 be_local_closure(class_Rule_Matcher_Key_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -163,7 +159,7 @@ be_local_closure(class_Rule_Matcher_Key_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Key, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(name),
@@ -201,7 +197,6 @@ extern const bclass be_class_Rule_Matcher_Wildcard;
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Wildcard;
 be_local_closure(class_Rule_Matcher_Wildcard_match,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -210,7 +205,7 @@ be_local_closure(class_Rule_Matcher_Wildcard_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Wildcard, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -251,7 +246,6 @@ be_local_closure(class_Rule_Matcher_Wildcard_match,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Wildcard;
 be_local_closure(class_Rule_Matcher_Wildcard_tostring,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -260,7 +254,7 @@ be_local_closure(class_Rule_Matcher_Wildcard_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Wildcard, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(_X3CMatcher_X20any_X3E),
@@ -294,7 +288,6 @@ extern const bclass be_class_Rule_Matcher_Operator;
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Operator;
 be_local_closure(class_Rule_Matcher_Operator_match,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -303,7 +296,7 @@ be_local_closure(class_Rule_Matcher_Operator_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Operator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(int),
@@ -344,7 +337,6 @@ be_local_closure(class_Rule_Matcher_Operator_match,   /* name */
 /********************************************************************
 ** Solidified function: op_parse
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Operator;
 be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -353,7 +345,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[14]) {
+    ( &(const struct bproto*[13]) {
       be_nested_proto(
         7,                          /* nstack */
         2,                          /* argc */
@@ -361,7 +353,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -389,7 +381,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -417,7 +409,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 3]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -445,7 +437,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -472,7 +464,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -499,7 +491,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str(tasmota),
@@ -526,7 +518,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_eq,
@@ -546,7 +538,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_neq,
@@ -566,7 +558,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_gt,
@@ -586,7 +578,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_gte,
@@ -606,7 +598,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_lt,
@@ -626,7 +618,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         0,                          /* has constants */
         NULL,                       /* no const */
         &be_const_str_op_lte,
@@ -646,7 +638,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_const_int(0),
@@ -662,7 +654,6 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
           0x80040400,  //  0005  RET	1	R2
         })
       ),
-    &be_class_Rule_Matcher_Operator, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[23]) {     /* constants */
@@ -799,7 +790,6 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Operator;
 be_local_closure(class_Rule_Matcher_Operator_tostring,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -808,7 +798,7 @@ be_local_closure(class_Rule_Matcher_Operator_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Operator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(op_value),
@@ -857,7 +847,6 @@ be_local_closure(class_Rule_Matcher_Operator_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Operator;
 be_local_closure(class_Rule_Matcher_Operator_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -866,7 +855,7 @@ be_local_closure(class_Rule_Matcher_Operator_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Operator, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(op_parse),
@@ -909,7 +898,6 @@ extern const bclass be_class_Rule_Matcher_Array;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Array;
 be_local_closure(class_Rule_Matcher_Array_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -918,7 +906,7 @@ be_local_closure(class_Rule_Matcher_Array_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(index),
@@ -937,7 +925,6 @@ be_local_closure(class_Rule_Matcher_Array_init,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Array;
 be_local_closure(class_Rule_Matcher_Array_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -946,7 +933,7 @@ be_local_closure(class_Rule_Matcher_Array_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_X3CMatcher_X20_X5B),
@@ -971,7 +958,6 @@ be_local_closure(class_Rule_Matcher_Array_tostring,   /* name */
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_Array;
 be_local_closure(class_Rule_Matcher_Array_match,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -980,7 +966,7 @@ be_local_closure(class_Rule_Matcher_Array_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_Array, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(index),
@@ -1045,7 +1031,6 @@ extern const bclass be_class_Rule_Matcher_AND_List;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_AND_List;
 be_local_closure(class_Rule_Matcher_AND_List_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1054,7 +1039,7 @@ be_local_closure(class_Rule_Matcher_AND_List_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_AND_List, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(and_list),
@@ -1073,7 +1058,6 @@ be_local_closure(class_Rule_Matcher_AND_List_init,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_AND_List;
 be_local_closure(class_Rule_Matcher_AND_List_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1082,7 +1066,7 @@ be_local_closure(class_Rule_Matcher_AND_List_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_AND_List, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_X3CMatcher_AND_List_X20),
@@ -1107,7 +1091,6 @@ be_local_closure(class_Rule_Matcher_AND_List_tostring,   /* name */
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher_AND_List;
 be_local_closure(class_Rule_Matcher_AND_List_match,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -1116,7 +1099,7 @@ be_local_closure(class_Rule_Matcher_AND_List_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher_AND_List, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -1179,7 +1162,6 @@ extern const bclass be_class_Rule_Matcher;
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher;
 be_local_closure(class_Rule_Matcher_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1188,7 +1170,7 @@ be_local_closure(class_Rule_Matcher_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str(matchers),
@@ -1209,7 +1191,6 @@ be_local_closure(class_Rule_Matcher_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher;
 be_local_closure(class_Rule_Matcher_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1218,7 +1199,7 @@ be_local_closure(class_Rule_Matcher_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(rule),
@@ -1241,7 +1222,6 @@ be_local_closure(class_Rule_Matcher_init,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher;
 be_local_closure(class_Rule_Matcher_parse,   /* name */
   be_nested_proto(
     20,                          /* nstack */
@@ -1250,7 +1230,7 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[26]) {     /* constants */
     /* K0   */  be_const_class(be_class_Rule_Matcher),
@@ -1439,7 +1419,6 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
 /********************************************************************
 ** Solidified function: match
 ********************************************************************/
-extern const bclass be_class_Rule_Matcher;
 be_local_closure(class_Rule_Matcher_match,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1448,7 +1427,7 @@ be_local_closure(class_Rule_Matcher_match,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Rule_Matcher, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(matchers),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Tapp;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Tapp;
 be_local_closure(class_Tapp_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Tapp_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tapp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(tasmota),
@@ -41,7 +40,6 @@ be_local_closure(class_Tapp_init,   /* name */
 /********************************************************************
 ** Solidified function: autoexec
 ********************************************************************/
-extern const bclass be_class_Tapp;
 be_local_closure(class_Tapp_autoexec,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_Tapp_autoexec,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tapp, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str(path),
@@ -136,7 +134,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_const_class(be_class_Tapp),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Tasmota;
 /********************************************************************
 ** Solidified function: cmd
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_cmd,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Tasmota_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(cmd_res),
@@ -68,7 +67,6 @@ be_local_closure(class_Tasmota_cmd,   /* name */
 /********************************************************************
 ** Solidified function: check_not_method
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_check_not_method,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -77,7 +75,7 @@ be_local_closure(class_Tasmota_check_not_method,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(introspect),
@@ -114,7 +112,6 @@ be_local_closure(class_Tasmota_check_not_method,   /* name */
 /********************************************************************
 ** Solidified function: remove_driver
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_driver,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -123,7 +120,7 @@ be_local_closure(class_Tasmota_remove_driver,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_drivers),
@@ -156,7 +153,6 @@ be_local_closure(class_Tasmota_remove_driver,   /* name */
 /********************************************************************
 ** Solidified function: event
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_event,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -165,7 +161,7 @@ be_local_closure(class_Tasmota_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[25]) {     /* constants */
     /* K0   */  be_nested_str(introspect),
@@ -314,7 +310,6 @@ be_local_closure(class_Tasmota_event,   /* name */
 /********************************************************************
 ** Solidified function: exec_cmd
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_exec_cmd,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -323,7 +318,7 @@ be_local_closure(class_Tasmota_exec_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(_ccmd),
@@ -371,7 +366,6 @@ be_local_closure(class_Tasmota_exec_cmd,   /* name */
 /********************************************************************
 ** Solidified function: set_light
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_set_light,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -380,7 +374,7 @@ be_local_closure(class_Tasmota_set_light,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
@@ -417,7 +411,6 @@ be_local_closure(class_Tasmota_set_light,   /* name */
 /********************************************************************
 ** Solidified function: run_cron
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_run_cron,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -426,7 +419,7 @@ be_local_closure(class_Tasmota_run_cron,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(_crons),
@@ -486,7 +479,6 @@ be_local_closure(class_Tasmota_run_cron,   /* name */
 /********************************************************************
 ** Solidified function: set_timer
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_set_timer,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -495,7 +487,7 @@ be_local_closure(class_Tasmota_set_timer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(check_not_method),
@@ -537,7 +529,6 @@ be_local_closure(class_Tasmota_set_timer,   /* name */
 /********************************************************************
 ** Solidified function: add_driver
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_add_driver,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -546,7 +537,7 @@ be_local_closure(class_Tasmota_add_driver,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(instance),
@@ -593,7 +584,6 @@ be_local_closure(class_Tasmota_add_driver,   /* name */
 /********************************************************************
 ** Solidified function: next_cron
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_next_cron,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -602,7 +592,7 @@ be_local_closure(class_Tasmota_next_cron,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(_crons),
@@ -641,7 +631,6 @@ be_local_closure(class_Tasmota_next_cron,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -650,7 +639,7 @@ be_local_closure(class_Tasmota_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         10,                          /* nstack */
         4,                          /* argc */
@@ -660,7 +649,7 @@ be_local_closure(class_Tasmota_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str(urlfetch_cmd),
@@ -678,7 +667,6 @@ be_local_closure(class_Tasmota_init,   /* name */
           0x80000000,  //  0007  RET	0
         })
       ),
-    &be_class_Tasmota, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
@@ -747,7 +735,6 @@ be_local_closure(class_Tasmota_init,   /* name */
 /********************************************************************
 ** Solidified function: add_rule
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_add_rule,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -756,7 +743,7 @@ be_local_closure(class_Tasmota_add_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(check_not_method),
@@ -810,7 +797,6 @@ be_local_closure(class_Tasmota_add_rule,   /* name */
 /********************************************************************
 ** Solidified function: try_rule
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_try_rule,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -819,7 +805,7 @@ be_local_closure(class_Tasmota_try_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(match),
@@ -855,7 +841,6 @@ be_local_closure(class_Tasmota_try_rule,   /* name */
 /********************************************************************
 ** Solidified function: find_op
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_find_op,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -864,7 +849,7 @@ be_local_closure(class_Tasmota_find_op,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(_find_op),
@@ -915,7 +900,6 @@ be_local_closure(class_Tasmota_find_op,   /* name */
 /********************************************************************
 ** Solidified function: remove_cmd
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_cmd,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -924,7 +908,7 @@ be_local_closure(class_Tasmota_remove_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(_ccmd),
@@ -949,7 +933,6 @@ be_local_closure(class_Tasmota_remove_cmd,   /* name */
 /********************************************************************
 ** Solidified function: gc
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_gc,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -958,7 +941,7 @@ be_local_closure(class_Tasmota_gc,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(gc),
@@ -983,7 +966,6 @@ be_local_closure(class_Tasmota_gc,   /* name */
 /********************************************************************
 ** Solidified function: find_list_i
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_find_list_i,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -992,7 +974,7 @@ be_local_closure(class_Tasmota_find_list_i,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -1032,7 +1014,6 @@ be_local_closure(class_Tasmota_find_list_i,   /* name */
 /********************************************************************
 ** Solidified function: remove_fast_loop
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1041,7 +1022,7 @@ be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_fl),
@@ -1075,7 +1056,6 @@ be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
 /********************************************************************
 ** Solidified function: exec_rules
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_exec_rules,   /* name */
   be_nested_proto(
     14,                          /* nstack */
@@ -1084,7 +1064,7 @@ be_local_closure(class_Tasmota_exec_rules,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(cmd_res),
@@ -1162,7 +1142,6 @@ be_local_closure(class_Tasmota_exec_rules,   /* name */
 /********************************************************************
 ** Solidified function: run_deferred
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_run_deferred,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1171,7 +1150,7 @@ be_local_closure(class_Tasmota_run_deferred,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(_timers),
@@ -1220,7 +1199,6 @@ be_local_closure(class_Tasmota_run_deferred,   /* name */
 /********************************************************************
 ** Solidified function: compile
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_compile,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1229,7 +1207,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -1343,7 +1321,6 @@ be_local_closure(class_Tasmota_compile,   /* name */
 /********************************************************************
 ** Solidified function: remove_timer
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_timer,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1352,7 +1329,7 @@ be_local_closure(class_Tasmota_remove_timer,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(_timers),
@@ -1392,7 +1369,6 @@ be_local_closure(class_Tasmota_remove_timer,   /* name */
 /********************************************************************
 ** Solidified function: remove_rule
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1401,7 +1377,7 @@ be_local_closure(class_Tasmota_remove_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(_rules),
@@ -1451,7 +1427,6 @@ be_local_closure(class_Tasmota_remove_rule,   /* name */
 /********************************************************************
 ** Solidified function: exec_tele
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_exec_tele,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -1460,7 +1435,7 @@ be_local_closure(class_Tasmota_exec_tele,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str(_rules),
@@ -1529,7 +1504,6 @@ be_local_closure(class_Tasmota_exec_tele,   /* name */
 /********************************************************************
 ** Solidified function: add_cmd
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_add_cmd,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1538,7 +1512,7 @@ be_local_closure(class_Tasmota_add_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(check_not_method),
@@ -1579,7 +1553,6 @@ be_local_closure(class_Tasmota_add_cmd,   /* name */
 /********************************************************************
 ** Solidified function: wire_scan
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_wire_scan,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1588,7 +1561,7 @@ be_local_closure(class_Tasmota_wire_scan,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(i2c_enabled),
@@ -1642,7 +1615,6 @@ be_local_closure(class_Tasmota_wire_scan,   /* name */
 /********************************************************************
 ** Solidified function: find_key_i
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_find_key_i,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1651,7 +1623,7 @@ be_local_closure(class_Tasmota_find_key_i,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -1702,7 +1674,6 @@ be_local_closure(class_Tasmota_find_key_i,   /* name */
 /********************************************************************
 ** Solidified function: urlfetch
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_urlfetch,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1711,7 +1682,7 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str(string),
@@ -1792,7 +1763,6 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
 /********************************************************************
 ** Solidified function: fast_loop
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_fast_loop,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1801,7 +1771,7 @@ be_local_closure(class_Tasmota_fast_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(_fl),
@@ -1835,7 +1805,6 @@ be_local_closure(class_Tasmota_fast_loop,   /* name */
 /********************************************************************
 ** Solidified function: gen_cb
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_gen_cb,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1844,7 +1813,7 @@ be_local_closure(class_Tasmota_gen_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(cb),
@@ -1867,7 +1836,6 @@ be_local_closure(class_Tasmota_gen_cb,   /* name */
 /********************************************************************
 ** Solidified function: time_str
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_time_str,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1876,7 +1844,7 @@ be_local_closure(class_Tasmota_time_str,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(time_dump),
@@ -1913,7 +1881,6 @@ be_local_closure(class_Tasmota_time_str,   /* name */
 /********************************************************************
 ** Solidified function: add_fast_loop
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_add_fast_loop,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1922,7 +1889,7 @@ be_local_closure(class_Tasmota_add_fast_loop,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(check_not_method),
@@ -1970,7 +1937,6 @@ be_local_closure(class_Tasmota_add_fast_loop,   /* name */
 /********************************************************************
 ** Solidified function: get_light
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_get_light,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1979,7 +1945,7 @@ be_local_closure(class_Tasmota_get_light,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
@@ -2014,7 +1980,6 @@ be_local_closure(class_Tasmota_get_light,   /* name */
 /********************************************************************
 ** Solidified function: add_cron
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_add_cron,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -2023,7 +1988,7 @@ be_local_closure(class_Tasmota_add_cron,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(check_not_method),
@@ -2072,7 +2037,6 @@ be_local_closure(class_Tasmota_add_cron,   /* name */
 /********************************************************************
 ** Solidified function: hs2rgb
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_hs2rgb,   /* name */
   be_nested_proto(
     17,                          /* nstack */
@@ -2081,7 +2045,7 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -2171,7 +2135,6 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
 /********************************************************************
 ** Solidified function: remove_cron
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_remove_cron,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2180,7 +2143,7 @@ be_local_closure(class_Tasmota_remove_cron,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(_crons),
@@ -2220,7 +2183,6 @@ be_local_closure(class_Tasmota_remove_cron,   /* name */
 /********************************************************************
 ** Solidified function: load
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_load,   /* name */
   be_nested_proto(
     26,                          /* nstack */
@@ -2229,7 +2191,7 @@ be_local_closure(class_Tasmota_load,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 7]) {
+    ( &(const struct bproto*[ 6]) {
       be_nested_proto(
         6,                          /* nstack */
         1,                          /* argc */
@@ -2237,7 +2199,7 @@ be_local_closure(class_Tasmota_load,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str(sys),
@@ -2270,7 +2232,7 @@ be_local_closure(class_Tasmota_load,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str(sys),
@@ -2303,7 +2265,7 @@ be_local_closure(class_Tasmota_load,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 8]) {     /* constants */
         /* K0   */  be_nested_str(r),
@@ -2370,7 +2332,7 @@ be_local_closure(class_Tasmota_load,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str(path),
@@ -2403,7 +2365,7 @@ be_local_closure(class_Tasmota_load,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str(file),
@@ -2446,7 +2408,7 @@ be_local_closure(class_Tasmota_load,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str(BRY_X3A_X20failed_X20to_X20run_X20compiled_X20code_X20_X28_X25s_X20_X2D_X20_X25s_X29),
@@ -2489,7 +2451,6 @@ be_local_closure(class_Tasmota_load,   /* name */
           0x80040200,  //  001D  RET	1	R1
         })
       ),
-    &be_class_Tasmota, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[20]) {     /* constants */
@@ -2690,7 +2651,6 @@ be_local_closure(class_Tasmota_load,   /* name */
 /********************************************************************
 ** Solidified function: urlfetch_cmd
 ********************************************************************/
-extern const bclass be_class_Tasmota;
 be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -2699,7 +2659,7 @@ be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Tasmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(string),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_trigger_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_trigger_class.h
@@ -9,7 +9,6 @@ extern const bclass be_class_Trigger;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_Trigger;
 be_local_closure(class_Trigger_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_Trigger_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Trigger, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(trig),
@@ -43,7 +42,6 @@ be_local_closure(class_Trigger_init,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_Trigger;
 be_local_closure(class_Trigger_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -52,7 +50,7 @@ be_local_closure(class_Trigger_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Trigger, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
@@ -90,7 +88,6 @@ be_local_closure(class_Trigger_tostring,   /* name */
 /********************************************************************
 ** Solidified function: time_reached
 ********************************************************************/
-extern const bclass be_class_Trigger;
 be_local_closure(class_Trigger_time_reached,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -99,7 +96,7 @@ be_local_closure(class_Trigger_time_reached,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Trigger, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(o),
@@ -131,7 +128,6 @@ be_local_closure(class_Trigger_time_reached,   /* name */
 /********************************************************************
 ** Solidified function: next
 ********************************************************************/
-extern const bclass be_class_Trigger;
 be_local_closure(class_Trigger_next,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -140,7 +136,7 @@ be_local_closure(class_Trigger_next,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_Trigger, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(o),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_uuid.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_uuid.h
@@ -15,7 +15,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str(math),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee.h
@@ -7,7 +7,6 @@
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_zb_device;
 be_local_closure(class_zb_device_tostring,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -16,7 +15,7 @@ be_local_closure(class_zb_device_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zb_device, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zb_coord.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zb_coord.h
@@ -9,7 +9,6 @@ extern const bclass be_class_zb_coord;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_zb_coord;
 be_local_closure(class_zb_coord_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_zb_coord_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zb_coord, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -41,7 +40,6 @@ be_local_closure(class_zb_coord_init,   /* name */
 /********************************************************************
 ** Solidified function: add_handler
 ********************************************************************/
-extern const bclass be_class_zb_coord;
 be_local_closure(class_zb_coord_add_handler,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -50,7 +48,7 @@ be_local_closure(class_zb_coord_add_handler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zb_coord, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(instance),
@@ -97,7 +95,6 @@ be_local_closure(class_zb_coord_add_handler,   /* name */
 /********************************************************************
 ** Solidified function: dispatch
 ********************************************************************/
-extern const bclass be_class_zb_coord;
 be_local_closure(class_zb_coord_dispatch,   /* name */
   be_nested_proto(
     19,                          /* nstack */
@@ -106,7 +103,7 @@ be_local_closure(class_zb_coord_dispatch,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zb_coord, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(_handlers),
@@ -206,7 +203,6 @@ be_local_closure(class_zb_coord_dispatch,   /* name */
 /********************************************************************
 ** Solidified function: remove_handler
 ********************************************************************/
-extern const bclass be_class_zb_coord;
 be_local_closure(class_zb_coord_remove_handler,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -215,7 +211,7 @@ be_local_closure(class_zb_coord_remove_handler,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zb_coord, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_handlers),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
@@ -9,7 +9,6 @@ extern const bclass be_class_zcl_attribute;
 /********************************************************************
 ** Solidified function: tomap
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_tomap,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_zcl_attribute_tomap,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(tomap),
@@ -59,7 +58,6 @@ be_local_closure(class_zcl_attribute_tomap,   /* name */
 /********************************************************************
 ** Solidified function: key_tostring
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_key_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -68,7 +66,7 @@ be_local_closure(class_zcl_attribute_key_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(_X3Cundefined_X3E),
@@ -166,7 +164,6 @@ be_local_closure(class_zcl_attribute_key_tostring,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -175,7 +172,7 @@ be_local_closure(class_zcl_attribute_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(cluster),
@@ -273,7 +270,6 @@ be_local_closure(class_zcl_attribute_setmember,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_tostring,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -282,7 +278,7 @@ be_local_closure(class_zcl_attribute_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -361,7 +357,6 @@ be_local_closure(class_zcl_attribute_tostring,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -370,7 +365,7 @@ be_local_closure(class_zcl_attribute_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -400,7 +395,6 @@ be_local_closure(class_zcl_attribute_init,   /* name */
 /********************************************************************
 ** Solidified function: deinit
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_deinit,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -409,7 +403,7 @@ be_local_closure(class_zcl_attribute_deinit,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(ismapped),
@@ -433,7 +427,6 @@ be_local_closure(class_zcl_attribute_deinit,   /* name */
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_zcl_attribute;
 be_local_closure(class_zcl_attribute_member,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -442,7 +435,7 @@ be_local_closure(class_zcl_attribute_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(cluster),
@@ -572,7 +565,6 @@ extern const bclass be_class_zcl_attribute_list;
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_zcl_attribute_list;
 be_local_closure(class_zcl_attribute_list_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -581,7 +573,7 @@ be_local_closure(class_zcl_attribute_list_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(groupaddr),
@@ -645,7 +637,6 @@ be_local_closure(class_zcl_attribute_list_member,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_zcl_attribute_list;
 be_local_closure(class_zcl_attribute_list_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -654,7 +645,7 @@ be_local_closure(class_zcl_attribute_list_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(groupaddr),
@@ -715,7 +706,6 @@ be_local_closure(class_zcl_attribute_list_setmember,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_zcl_attribute_list;
 be_local_closure(class_zcl_attribute_list_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -724,7 +714,7 @@ be_local_closure(class_zcl_attribute_list_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -754,7 +744,6 @@ be_local_closure(class_zcl_attribute_list_init,   /* name */
 /********************************************************************
 ** Solidified function: deinit
 ********************************************************************/
-extern const bclass be_class_zcl_attribute_list;
 be_local_closure(class_zcl_attribute_list_deinit,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -763,7 +752,7 @@ be_local_closure(class_zcl_attribute_list_deinit,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(ismapped),
@@ -787,7 +776,6 @@ be_local_closure(class_zcl_attribute_list_deinit,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_zcl_attribute_list;
 be_local_closure(class_zcl_attribute_list_tostring,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -796,7 +784,7 @@ be_local_closure(class_zcl_attribute_list_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_attribute_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_frame.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_frame.h
@@ -9,7 +9,6 @@ extern const bclass be_class_zcl_frame;
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_zcl_frame;
 be_local_closure(class_zcl_frame_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_zcl_frame_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(payload),
@@ -53,7 +52,6 @@ be_local_closure(class_zcl_frame_member,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_zcl_frame;
 be_local_closure(class_zcl_frame_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -62,7 +60,7 @@ be_local_closure(class_zcl_frame_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(payload),
@@ -99,7 +97,6 @@ be_local_closure(class_zcl_frame_setmember,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_zcl_frame;
 be_local_closure(class_zcl_frame_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -108,7 +105,7 @@ be_local_closure(class_zcl_frame_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -136,7 +133,6 @@ be_local_closure(class_zcl_frame_init,   /* name */
 /********************************************************************
 ** Solidified function: tomap
 ********************************************************************/
-extern const bclass be_class_zcl_frame;
 be_local_closure(class_zcl_frame_tomap,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -145,7 +141,7 @@ be_local_closure(class_zcl_frame_tomap,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tomap),
@@ -179,7 +175,6 @@ be_local_closure(class_zcl_frame_tomap,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-extern const bclass be_class_zcl_frame;
 be_local_closure(class_zcl_frame_tostring,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -188,7 +183,7 @@ be_local_closure(class_zcl_frame_tostring,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_zcl_frame, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(tomap),

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lv.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lv.h
@@ -15,7 +15,7 @@ be_local_closure(lv_module_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(lv),

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
@@ -9,7 +9,6 @@ extern const bclass be_class_lv_str_arr;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_str_arr;
 be_local_closure(class_lv_str_arr_init,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_lv_str_arr_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_str_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(l),
@@ -88,7 +87,6 @@ extern const bclass be_class_lv_int_arr;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_int_arr;
 be_local_closure(class_lv_int_arr_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -97,7 +95,7 @@ be_local_closure(class_lv_int_arr_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_int_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(instance),
@@ -179,7 +177,6 @@ be_local_closure(class_lv_int_arr_init,   /* name */
 /********************************************************************
 ** Solidified function: item
 ********************************************************************/
-extern const bclass be_class_lv_int_arr;
 be_local_closure(class_lv_int_arr_item,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -188,7 +185,7 @@ be_local_closure(class_lv_int_arr_item,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_int_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get),
@@ -211,7 +208,6 @@ be_local_closure(class_lv_int_arr_item,   /* name */
 /********************************************************************
 ** Solidified function: setitem
 ********************************************************************/
-extern const bclass be_class_lv_int_arr;
 be_local_closure(class_lv_int_arr_setitem,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -220,7 +216,7 @@ be_local_closure(class_lv_int_arr_setitem,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_int_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set),
@@ -262,7 +258,6 @@ extern const bclass be_class_lv_point_arr;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_point_arr;
 be_local_closure(class_lv_point_arr_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -271,7 +266,7 @@ be_local_closure(class_lv_point_arr_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_point_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(instance),
@@ -372,7 +367,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -421,7 +416,6 @@ extern const bclass be_class_lv_style_prop_arr;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_style_prop_arr;
 be_local_closure(class_lv_style_prop_arr_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -430,7 +424,7 @@ be_local_closure(class_lv_style_prop_arr_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_style_prop_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(instance),
@@ -506,7 +500,6 @@ extern const bclass be_class_lv_coord_arr;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lv_coord_arr;
 be_local_closure(class_lv_coord_arr_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -515,7 +508,7 @@ be_local_closure(class_lv_coord_arr_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_coord_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(instance),
@@ -597,7 +590,6 @@ be_local_closure(class_lv_coord_arr_init,   /* name */
 /********************************************************************
 ** Solidified function: item
 ********************************************************************/
-extern const bclass be_class_lv_coord_arr;
 be_local_closure(class_lv_coord_arr_item,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -606,7 +598,7 @@ be_local_closure(class_lv_coord_arr_item,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_coord_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get),
@@ -629,7 +621,6 @@ be_local_closure(class_lv_coord_arr_item,   /* name */
 /********************************************************************
 ** Solidified function: setitem
 ********************************************************************/
-extern const bclass be_class_lv_coord_arr;
 be_local_closure(class_lv_coord_arr_setitem,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -638,7 +629,7 @@ be_local_closure(class_lv_coord_arr_setitem,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lv_coord_arr, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set),

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_glob.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_glob.h
@@ -9,7 +9,6 @@ extern const bclass be_class_LVGL_glob;
 /********************************************************************
 ** Solidified function: get_event_cb
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         5,                          /* nstack */
         1,                          /* argc */
@@ -29,7 +28,7 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
           be_local_const_upval(1, 4),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(lvgl_event_dispatch),
@@ -45,7 +44,6 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
           0x80040200,  //  0005  RET	1	R1
         })
       ),
-    &be_class_LVGL_glob, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
@@ -99,7 +97,6 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
 /********************************************************************
 ** Solidified function: add_cb_event_closure
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_add_cb_event_closure,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -108,7 +105,7 @@ be_local_closure(class_LVGL_glob_add_cb_event_closure,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(cb_event_closure),
@@ -173,7 +170,6 @@ be_local_closure(class_LVGL_glob_add_cb_event_closure,   /* name */
 /********************************************************************
 ** Solidified function: make_cb
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_make_cb,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -182,7 +178,7 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         4,                          /* nstack */
         1,                          /* argc */
@@ -192,7 +188,7 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(remove_cb),
@@ -216,7 +212,7 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(lvgl_timer_dispatch),
@@ -231,7 +227,6 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
           0x80040200,  //  0004  RET	1	R1
         })
       ),
-    &be_class_LVGL_glob, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
@@ -335,7 +330,6 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
 /********************************************************************
 ** Solidified function: lvgl_timer_dispatch
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_lvgl_timer_dispatch,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -344,7 +338,7 @@ be_local_closure(class_LVGL_glob_lvgl_timer_dispatch,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -393,7 +387,6 @@ be_local_closure(class_LVGL_glob_lvgl_timer_dispatch,   /* name */
 /********************************************************************
 ** Solidified function: lvgl_event_dispatch
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_lvgl_event_dispatch,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -402,7 +395,7 @@ be_local_closure(class_LVGL_glob_lvgl_event_dispatch,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -470,7 +463,6 @@ be_local_closure(class_LVGL_glob_lvgl_event_dispatch,   /* name */
 /********************************************************************
 ** Solidified function: deregister_obj
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_deregister_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -479,7 +471,7 @@ be_local_closure(class_LVGL_glob_deregister_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(cb_obj),
@@ -515,7 +507,6 @@ be_local_closure(class_LVGL_glob_deregister_obj,   /* name */
 /********************************************************************
 ** Solidified function: register_obj
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_register_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -524,7 +515,7 @@ be_local_closure(class_LVGL_glob_register_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(cb_obj),
@@ -564,7 +555,6 @@ be_local_closure(class_LVGL_glob_register_obj,   /* name */
 /********************************************************************
 ** Solidified function: widget_event_impl
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_widget_event_impl,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -573,7 +563,7 @@ be_local_closure(class_LVGL_glob_widget_event_impl,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -650,7 +640,6 @@ be_local_closure(class_LVGL_glob_widget_event_impl,   /* name */
 /********************************************************************
 ** Solidified function: widget_dtor_impl
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_widget_dtor_impl,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -659,7 +648,7 @@ be_local_closure(class_LVGL_glob_widget_dtor_impl,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -704,7 +693,6 @@ be_local_closure(class_LVGL_glob_widget_dtor_impl,   /* name */
 /********************************************************************
 ** Solidified function: widget_ctor_impl
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_widget_ctor_impl,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -713,7 +701,7 @@ be_local_closure(class_LVGL_glob_widget_ctor_impl,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -775,7 +763,7 @@ be_local_closure(class_LVGL_glob__anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(LVG_X3A_X20call_X20to_X20unsupported_X20callback),
@@ -796,7 +784,6 @@ be_local_closure(class_LVGL_glob__anonymous_,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -805,7 +792,7 @@ be_local_closure(class_LVGL_glob_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         8,                          /* nstack */
         3,                          /* argc */
@@ -815,7 +802,7 @@ be_local_closure(class_LVGL_glob_init,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(make_cb),
@@ -832,7 +819,6 @@ be_local_closure(class_LVGL_glob_init,   /* name */
           0x80040600,  //  0006  RET	1	R3
         })
       ),
-    &be_class_LVGL_glob, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
@@ -859,7 +845,6 @@ be_local_closure(class_LVGL_glob_init,   /* name */
 /********************************************************************
 ** Solidified function: get_object_from_ptr
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_get_object_from_ptr,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -868,7 +853,7 @@ be_local_closure(class_LVGL_glob_get_object_from_ptr,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(cb_obj),
@@ -896,7 +881,6 @@ be_local_closure(class_LVGL_glob_get_object_from_ptr,   /* name */
 /********************************************************************
 ** Solidified function: create_custom_widget
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_create_custom_widget,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -905,7 +889,7 @@ be_local_closure(class_LVGL_glob_create_custom_widget,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -1034,7 +1018,6 @@ be_local_closure(class_LVGL_glob_create_custom_widget,   /* name */
 /********************************************************************
 ** Solidified function: widget_cb
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_widget_cb,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1043,7 +1026,7 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 4]) {
+    ( &(const struct bproto*[ 3]) {
       be_nested_proto(
         6,                          /* nstack */
         2,                          /* argc */
@@ -1053,7 +1036,7 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(widget_ctor_impl),
@@ -1078,7 +1061,7 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(widget_dtor_impl),
@@ -1103,7 +1086,7 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(widget_event_impl),
@@ -1119,7 +1102,6 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
           0x80040400,  //  0005  RET	1	R2
         })
       ),
-    &be_class_LVGL_glob, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[15]) {     /* constants */
@@ -1205,7 +1187,6 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
 /********************************************************************
 ** Solidified function: remove_cb
 ********************************************************************/
-extern const bclass be_class_LVGL_glob;
 be_local_closure(class_LVGL_glob_remove_cb,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1214,7 +1195,7 @@ be_local_closure(class_LVGL_glob_remove_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_LVGL_glob, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -9,7 +9,6 @@ extern const bclass be_class_lvh_root;
 /********************************************************************
 ** Solidified function: get_text
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -18,7 +17,7 @@ be_local_closure(class_lvh_root_get_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_text),
@@ -35,7 +34,6 @@ be_local_closure(class_lvh_root_get_text,   /* name */
 /********************************************************************
 ** Solidified function: get_text_rule_formula
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_text_rule_formula,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -44,7 +42,7 @@ be_local_closure(class_lvh_root_get_text_rule_formula,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule_formula),
@@ -63,7 +61,6 @@ be_local_closure(class_lvh_root_get_text_rule_formula,   /* name */
 /********************************************************************
 ** Solidified function: set_text_rule_formula
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_text_rule_formula,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -72,7 +69,7 @@ be_local_closure(class_lvh_root_set_text_rule_formula,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule_formula),
@@ -122,7 +119,6 @@ be_local_closure(class_lvh_root_set_text_rule_formula,   /* name */
 /********************************************************************
 ** Solidified function: get_text_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_text_rule,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -131,7 +127,7 @@ be_local_closure(class_lvh_root_get_text_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule),
@@ -150,7 +146,6 @@ be_local_closure(class_lvh_root_get_text_rule,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -159,7 +154,7 @@ be_local_closure(class_lvh_root_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(set_text),
@@ -175,7 +170,6 @@ be_local_closure(class_lvh_root_set_text,   /* name */
 /********************************************************************
 ** Solidified function: val_rule_matched
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_val_rule_matched,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -184,7 +178,7 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val_rule_function),
@@ -239,7 +233,6 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
 /********************************************************************
 ** Solidified function: parse_font
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_parse_font,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -248,7 +241,7 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(int),
@@ -430,7 +423,6 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
 /********************************************************************
 ** Solidified function: get_val_rule_formula
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_val_rule_formula,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -439,7 +431,7 @@ be_local_closure(class_lvh_root_get_val_rule_formula,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val_rule_formula),
@@ -458,7 +450,6 @@ be_local_closure(class_lvh_root_get_val_rule_formula,   /* name */
 /********************************************************************
 ** Solidified function: post_config
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_post_config,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -467,7 +458,7 @@ be_local_closure(class_lvh_root_post_config,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -493,7 +484,6 @@ be_local_closure(class_lvh_root_post_config,   /* name */
 /********************************************************************
 ** Solidified function: text_rule_matched
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_text_rule_matched,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -502,7 +492,7 @@ be_local_closure(class_lvh_root_text_rule_matched,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(int),
@@ -572,7 +562,6 @@ be_local_closure(class_lvh_root_text_rule_matched,   /* name */
 /********************************************************************
 ** Solidified function: get_meta
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_meta,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -581,7 +570,7 @@ be_local_closure(class_lvh_root_get_meta,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_meta),
@@ -600,7 +589,6 @@ be_local_closure(class_lvh_root_get_meta,   /* name */
 /********************************************************************
 ** Solidified function: set_value_str
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_value_str,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -609,7 +597,7 @@ be_local_closure(class_lvh_root_set_value_str,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_text),
@@ -630,7 +618,6 @@ be_local_closure(class_lvh_root_set_value_str,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -639,7 +626,7 @@ be_local_closure(class_lvh_root_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_page),
@@ -677,7 +664,6 @@ be_local_closure(class_lvh_root_init,   /* name */
 /********************************************************************
 ** Solidified function: get_delete
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_delete,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -686,7 +672,7 @@ be_local_closure(class_lvh_root_get_delete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(delete),
@@ -706,7 +692,6 @@ be_local_closure(class_lvh_root_get_delete,   /* name */
 /********************************************************************
 ** Solidified function: remove_trailing_zeroes
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_remove_trailing_zeroes,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -715,7 +700,7 @@ be_local_closure(class_lvh_root_remove_trailing_zeroes,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_lvh_root),
@@ -759,7 +744,6 @@ be_local_closure(class_lvh_root_remove_trailing_zeroes,   /* name */
 /********************************************************************
 ** Solidified function: set_val_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_val_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -768,7 +752,7 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         4,                          /* nstack */
         1,                          /* argc */
@@ -778,7 +762,7 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(val_rule_matched),
@@ -793,7 +777,6 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
           0x80040200,  //  0004  RET	1	R1
         })
       ),
-    &be_class_lvh_root, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
@@ -828,7 +811,6 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
 /********************************************************************
 ** Solidified function: get_val_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_val_rule,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -837,7 +819,7 @@ be_local_closure(class_lvh_root_get_val_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val_rule),
@@ -856,7 +838,6 @@ be_local_closure(class_lvh_root_get_val_rule,   /* name */
 /********************************************************************
 ** Solidified function: digits_to_style
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_digits_to_style,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -865,7 +846,7 @@ be_local_closure(class_lvh_root_digits_to_style,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -930,7 +911,6 @@ be_local_closure(class_lvh_root_digits_to_style,   /* name */
 /********************************************************************
 ** Solidified function: set_text_rule_format
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_text_rule_format,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -939,7 +919,7 @@ be_local_closure(class_lvh_root_set_text_rule_format,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule_format),
@@ -961,7 +941,6 @@ be_local_closure(class_lvh_root_set_text_rule_format,   /* name */
 /********************************************************************
 ** Solidified function: remove_val_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_remove_val_rule,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -970,7 +949,7 @@ be_local_closure(class_lvh_root_remove_val_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val_rule),
@@ -999,7 +978,6 @@ be_local_closure(class_lvh_root_remove_val_rule,   /* name */
 /********************************************************************
 ** Solidified function: delete
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_delete,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -1008,7 +986,7 @@ be_local_closure(class_lvh_root_delete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(delete),
@@ -1024,7 +1002,6 @@ be_local_closure(class_lvh_root_delete,   /* name */
 /********************************************************************
 ** Solidified function: get_obj
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_obj,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1033,7 +1010,7 @@ be_local_closure(class_lvh_root_get_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -1052,7 +1029,6 @@ be_local_closure(class_lvh_root_get_obj,   /* name */
 /********************************************************************
 ** Solidified function: is_color_attribute
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_is_color_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1061,7 +1037,7 @@ be_local_closure(class_lvh_root_is_color_attribute,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -1088,7 +1064,6 @@ be_local_closure(class_lvh_root_is_color_attribute,   /* name */
 /********************************************************************
 ** Solidified function: set_meta
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_meta,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1097,7 +1072,7 @@ be_local_closure(class_lvh_root_set_meta,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_meta),
@@ -1116,7 +1091,6 @@ be_local_closure(class_lvh_root_set_meta,   /* name */
 /********************************************************************
 ** Solidified function: set_delete
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_delete,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1125,7 +1099,7 @@ be_local_closure(class_lvh_root_set_delete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(type_error),
@@ -1145,7 +1119,6 @@ be_local_closure(class_lvh_root_set_delete,   /* name */
 /********************************************************************
 ** Solidified function: get_value_str
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_value_str,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1154,7 +1127,7 @@ be_local_closure(class_lvh_root_get_value_str,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_text),
@@ -1174,7 +1147,6 @@ be_local_closure(class_lvh_root_get_value_str,   /* name */
 /********************************************************************
 ** Solidified function: parse_color
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_parse_color,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -1183,7 +1155,7 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         10,                          /* nstack */
         1,                          /* argc */
@@ -1191,7 +1163,7 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
         0,                          /* has upvals */
         NULL,                       /* no upvals */
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[14]) {     /* constants */
         /* K0   */  be_nested_str_weak(string),
@@ -1281,7 +1253,6 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
           0x80040400,  //  0042  RET	1	R2
         })
       ),
-    &be_class_lvh_root, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
@@ -1348,7 +1319,6 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
 /********************************************************************
 ** Solidified function: get_text_rule_format
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_get_text_rule_format,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -1357,7 +1327,7 @@ be_local_closure(class_lvh_root_get_text_rule_format,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule_format),
@@ -1376,7 +1346,6 @@ be_local_closure(class_lvh_root_get_text_rule_format,   /* name */
 /********************************************************************
 ** Solidified function: remove_text_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_remove_text_rule,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1385,7 +1354,7 @@ be_local_closure(class_lvh_root_remove_text_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_text_rule),
@@ -1414,7 +1383,6 @@ be_local_closure(class_lvh_root_remove_text_rule,   /* name */
 /********************************************************************
 ** Solidified function: set_val_rule_formula
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_val_rule_formula,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -1423,7 +1391,7 @@ be_local_closure(class_lvh_root_set_val_rule_formula,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_root, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val_rule_formula),
@@ -1473,7 +1441,6 @@ be_local_closure(class_lvh_root_set_val_rule_formula,   /* name */
 /********************************************************************
 ** Solidified function: set_text_rule
 ********************************************************************/
-extern const bclass be_class_lvh_root;
 be_local_closure(class_lvh_root_set_text_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1482,7 +1449,7 @@ be_local_closure(class_lvh_root_set_text_rule,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         4,                          /* nstack */
         1,                          /* argc */
@@ -1492,7 +1459,7 @@ be_local_closure(class_lvh_root_set_text_rule,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(text_rule_matched),
@@ -1507,7 +1474,6 @@ be_local_closure(class_lvh_root_set_text_rule,   /* name */
           0x80040200,  //  0004  RET	1	R1
         })
       ),
-    &be_class_lvh_root, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
@@ -1648,7 +1614,6 @@ extern const bclass be_class_lvh_obj;
 /********************************************************************
 ** Solidified function: set_pad_bottom2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_pad_bottom2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1657,7 +1622,7 @@ be_local_closure(class_lvh_obj_set_pad_bottom2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -1693,7 +1658,6 @@ be_local_closure(class_lvh_obj_set_pad_bottom2,   /* name */
 /********************************************************************
 ** Solidified function: set_toggle
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_toggle,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1702,7 +1666,7 @@ be_local_closure(class_lvh_obj_set_toggle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -1759,7 +1723,6 @@ be_local_closure(class_lvh_obj_set_toggle,   /* name */
 /********************************************************************
 ** Solidified function: set_pad_left2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1768,7 +1731,7 @@ be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -1804,7 +1767,6 @@ be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
 /********************************************************************
 ** Solidified function: get_pad_top
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_pad_top,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1813,7 +1775,7 @@ be_local_closure(class_lvh_obj_get_pad_top,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -1847,7 +1809,6 @@ be_local_closure(class_lvh_obj_get_pad_top,   /* name */
 /********************************************************************
 ** Solidified function: get_line_width
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_line_width,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -1856,7 +1817,7 @@ be_local_closure(class_lvh_obj_get_line_width,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -1879,7 +1840,6 @@ be_local_closure(class_lvh_obj_get_line_width,   /* name */
 /********************************************************************
 ** Solidified function: get_adjustable
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_adjustable,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -1888,7 +1848,7 @@ be_local_closure(class_lvh_obj_get_adjustable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -1914,7 +1874,6 @@ be_local_closure(class_lvh_obj_get_adjustable,   /* name */
 /********************************************************************
 ** Solidified function: get_text
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_text,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -1923,7 +1882,7 @@ be_local_closure(class_lvh_obj_get_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -1951,7 +1910,6 @@ be_local_closure(class_lvh_obj_get_text,   /* name */
 /********************************************************************
 ** Solidified function: set_line_width
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_line_width,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -1960,7 +1918,7 @@ be_local_closure(class_lvh_obj_set_line_width,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -1986,7 +1944,6 @@ be_local_closure(class_lvh_obj_set_line_width,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -1995,7 +1952,7 @@ be_local_closure(class_lvh_obj_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(check_label),
@@ -2023,7 +1980,6 @@ be_local_closure(class_lvh_obj_set_text,   /* name */
 /********************************************************************
 ** Solidified function: set_align
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_align,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -2032,7 +1988,7 @@ be_local_closure(class_lvh_obj_set_align,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -2093,7 +2049,6 @@ be_local_closure(class_lvh_obj_set_align,   /* name */
 /********************************************************************
 ** Solidified function: get_value_color
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_value_color,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2102,7 +2057,7 @@ be_local_closure(class_lvh_obj_get_value_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_value_color),
@@ -2122,7 +2077,6 @@ be_local_closure(class_lvh_obj_get_value_color,   /* name */
 /********************************************************************
 ** Solidified function: get_pad_right
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_pad_right,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2131,7 +2085,7 @@ be_local_closure(class_lvh_obj_get_pad_right,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -2165,7 +2119,6 @@ be_local_closure(class_lvh_obj_get_pad_right,   /* name */
 /********************************************************************
 ** Solidified function: get_text_color
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_text_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2174,7 +2127,7 @@ be_local_closure(class_lvh_obj_get_text_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -2197,7 +2150,6 @@ be_local_closure(class_lvh_obj_get_text_color,   /* name */
 /********************************************************************
 ** Solidified function: get_action
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_action,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2206,7 +2158,7 @@ be_local_closure(class_lvh_obj_get_action,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_action),
@@ -2230,7 +2182,6 @@ be_local_closure(class_lvh_obj_get_action,   /* name */
 /********************************************************************
 ** Solidified function: get_value_ofs_y
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_value_ofs_y,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2239,7 +2190,7 @@ be_local_closure(class_lvh_obj_get_value_ofs_y,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -2261,7 +2212,6 @@ be_local_closure(class_lvh_obj_get_value_ofs_y,   /* name */
 /********************************************************************
 ** Solidified function: set_pad_all2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_pad_all2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2270,7 +2220,7 @@ be_local_closure(class_lvh_obj_set_pad_all2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -2306,7 +2256,6 @@ be_local_closure(class_lvh_obj_set_pad_all2,   /* name */
 /********************************************************************
 ** Solidified function: check_label
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_check_label,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -2315,7 +2264,7 @@ be_local_closure(class_lvh_obj_check_label,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -2366,7 +2315,6 @@ be_local_closure(class_lvh_obj_check_label,   /* name */
 /********************************************************************
 ** Solidified function: set_value_color
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_value_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2375,7 +2323,7 @@ be_local_closure(class_lvh_obj_set_value_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_text_color),
@@ -2396,7 +2344,6 @@ be_local_closure(class_lvh_obj_set_value_color,   /* name */
 /********************************************************************
 ** Solidified function: get_flex_in_new_track
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_flex_in_new_track,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2405,7 +2352,7 @@ be_local_closure(class_lvh_obj_get_flex_in_new_track,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -2431,7 +2378,6 @@ be_local_closure(class_lvh_obj_get_flex_in_new_track,   /* name */
 /********************************************************************
 ** Solidified function: delete
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_delete,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2440,7 +2386,7 @@ be_local_closure(class_lvh_obj_delete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_val_rule),
@@ -2487,7 +2433,6 @@ be_local_closure(class_lvh_obj_delete,   /* name */
 /********************************************************************
 ** Solidified function: get_value_ofs_x
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_value_ofs_x,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2496,7 +2441,7 @@ be_local_closure(class_lvh_obj_get_value_ofs_x,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -2518,7 +2463,6 @@ be_local_closure(class_lvh_obj_get_value_ofs_x,   /* name */
 /********************************************************************
 ** Solidified function: set_pad_top2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_pad_top2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -2527,7 +2471,7 @@ be_local_closure(class_lvh_obj_set_pad_top2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -2563,7 +2507,6 @@ be_local_closure(class_lvh_obj_set_pad_top2,   /* name */
 /********************************************************************
 ** Solidified function: set_click
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_click,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2572,7 +2515,7 @@ be_local_closure(class_lvh_obj_set_click,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_enabled),
@@ -2593,7 +2536,6 @@ be_local_closure(class_lvh_obj_set_click,   /* name */
 /********************************************************************
 ** Solidified function: set_adjustable
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_adjustable,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -2602,7 +2544,7 @@ be_local_closure(class_lvh_obj_set_adjustable,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -2636,7 +2578,6 @@ be_local_closure(class_lvh_obj_set_adjustable,   /* name */
 /********************************************************************
 ** Solidified function: event_cb
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_event_cb,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -2645,7 +2586,7 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         4,                          /* nstack */
         0,                          /* argc */
@@ -2657,7 +2598,7 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
           be_local_const_upval(1, 3),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(do_action),
@@ -2682,7 +2623,7 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
           be_local_const_upval(1, 7),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(tasmota),
@@ -2698,7 +2639,6 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
           0x80040000,  //  0004  RET	1	R0
         })
       ),
-    &be_class_lvh_obj, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[22]) {     /* constants */
@@ -2809,7 +2749,6 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -2818,7 +2757,7 @@ be_local_closure(class_lvh_obj_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
@@ -2846,7 +2785,6 @@ be_local_closure(class_lvh_obj_init,   /* name */
 /********************************************************************
 ** Solidified function: get_enabled
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_enabled,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2855,7 +2793,7 @@ be_local_closure(class_lvh_obj_get_enabled,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -2884,7 +2822,6 @@ be_local_closure(class_lvh_obj_get_enabled,   /* name */
 /********************************************************************
 ** Solidified function: get_click
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_click,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2893,7 +2830,7 @@ be_local_closure(class_lvh_obj_get_click,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_enabled),
@@ -2913,7 +2850,6 @@ be_local_closure(class_lvh_obj_get_click,   /* name */
 /********************************************************************
 ** Solidified function: get_label_mode
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_label_mode,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -2922,7 +2858,7 @@ be_local_closure(class_lvh_obj_get_label_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -2949,7 +2885,6 @@ be_local_closure(class_lvh_obj_get_label_mode,   /* name */
 /********************************************************************
 ** Solidified function: get_toggle
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_toggle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2958,7 +2893,7 @@ be_local_closure(class_lvh_obj_get_toggle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -2984,7 +2919,6 @@ be_local_closure(class_lvh_obj_get_toggle,   /* name */
 /********************************************************************
 ** Solidified function: get_hidden
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_hidden,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -2993,7 +2927,7 @@ be_local_closure(class_lvh_obj_get_hidden,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -3019,7 +2953,6 @@ be_local_closure(class_lvh_obj_get_hidden,   /* name */
 /********************************************************************
 ** Solidified function: set_value_font
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_value_font,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3028,7 +2961,7 @@ be_local_closure(class_lvh_obj_set_value_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_text_font),
@@ -3049,7 +2982,6 @@ be_local_closure(class_lvh_obj_set_value_font,   /* name */
 /********************************************************************
 ** Solidified function: get_value_font
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_value_font,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -3058,7 +2990,7 @@ be_local_closure(class_lvh_obj_get_value_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_text_font),
@@ -3078,7 +3010,6 @@ be_local_closure(class_lvh_obj_get_value_font,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_val,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3087,7 +3018,7 @@ be_local_closure(class_lvh_obj_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -3120,7 +3051,6 @@ be_local_closure(class_lvh_obj_set_val,   /* name */
 /********************************************************************
 ** Solidified function: set_text_color
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_text_color,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -3129,7 +3059,7 @@ be_local_closure(class_lvh_obj_set_text_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -3156,7 +3086,6 @@ be_local_closure(class_lvh_obj_set_text_color,   /* name */
 /********************************************************************
 ** Solidified function: set_action
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_action,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -3165,7 +3094,7 @@ be_local_closure(class_lvh_obj_set_action,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_action),
@@ -3187,7 +3116,6 @@ be_local_closure(class_lvh_obj_set_action,   /* name */
 /********************************************************************
 ** Solidified function: get_radius2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_radius2,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3196,7 +3124,7 @@ be_local_closure(class_lvh_obj_get_radius2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -3230,7 +3158,6 @@ be_local_closure(class_lvh_obj_get_radius2,   /* name */
 /********************************************************************
 ** Solidified function: set_pad_right2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_pad_right2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -3239,7 +3166,7 @@ be_local_closure(class_lvh_obj_set_pad_right2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -3275,7 +3202,6 @@ be_local_closure(class_lvh_obj_set_pad_right2,   /* name */
 /********************************************************************
 ** Solidified function: set_label_mode
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_label_mode,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -3284,7 +3210,7 @@ be_local_closure(class_lvh_obj_set_label_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(expand),
@@ -3361,7 +3287,6 @@ be_local_closure(class_lvh_obj_set_label_mode,   /* name */
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_setmember,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -3370,7 +3295,7 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -3577,7 +3502,6 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
 /********************************************************************
 ** Solidified function: set_enabled
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_enabled,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3586,7 +3510,7 @@ be_local_closure(class_lvh_obj_set_enabled,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -3620,7 +3544,6 @@ be_local_closure(class_lvh_obj_set_enabled,   /* name */
 /********************************************************************
 ** Solidified function: get_align
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_align,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3629,7 +3552,7 @@ be_local_closure(class_lvh_obj_get_align,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -3688,7 +3611,6 @@ be_local_closure(class_lvh_obj_get_align,   /* name */
 /********************************************************************
 ** Solidified function: get_pad_left
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_pad_left,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3697,7 +3619,7 @@ be_local_closure(class_lvh_obj_get_pad_left,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -3731,7 +3653,6 @@ be_local_closure(class_lvh_obj_get_pad_left,   /* name */
 /********************************************************************
 ** Solidified function: set_value_ofs_x
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_value_ofs_x,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -3740,7 +3661,7 @@ be_local_closure(class_lvh_obj_set_value_ofs_x,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(check_label),
@@ -3768,7 +3689,6 @@ be_local_closure(class_lvh_obj_set_value_ofs_x,   /* name */
 /********************************************************************
 ** Solidified function: set_flex_in_new_track
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_flex_in_new_track,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -3777,7 +3697,7 @@ be_local_closure(class_lvh_obj_set_flex_in_new_track,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -3811,7 +3731,6 @@ be_local_closure(class_lvh_obj_set_flex_in_new_track,   /* name */
 /********************************************************************
 ** Solidified function: member
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_member,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -3820,7 +3739,7 @@ be_local_closure(class_lvh_obj_member,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -3979,7 +3898,6 @@ be_local_closure(class_lvh_obj_member,   /* name */
 /********************************************************************
 ** Solidified function: get_text_font
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_text_font,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -3988,7 +3906,7 @@ be_local_closure(class_lvh_obj_get_text_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_text_font),
@@ -4004,7 +3922,6 @@ be_local_closure(class_lvh_obj_get_text_font,   /* name */
 /********************************************************************
 ** Solidified function: set_value_ofs_y
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_value_ofs_y,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -4013,7 +3930,7 @@ be_local_closure(class_lvh_obj_set_value_ofs_y,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(check_label),
@@ -4041,7 +3958,6 @@ be_local_closure(class_lvh_obj_set_value_ofs_y,   /* name */
 /********************************************************************
 ** Solidified function: set_radius2
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_radius2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4050,7 +3966,7 @@ be_local_closure(class_lvh_obj_set_radius2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -4086,7 +4002,6 @@ be_local_closure(class_lvh_obj_set_radius2,   /* name */
 /********************************************************************
 ** Solidified function: set_hidden
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_hidden,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4095,7 +4010,7 @@ be_local_closure(class_lvh_obj_set_hidden,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4129,7 +4044,6 @@ be_local_closure(class_lvh_obj_set_hidden,   /* name */
 /********************************************************************
 ** Solidified function: register_event_cb
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_register_event_cb,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -4138,7 +4052,7 @@ be_local_closure(class_lvh_obj_register_event_cb,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_page),
@@ -4179,7 +4093,6 @@ be_local_closure(class_lvh_obj_register_event_cb,   /* name */
 /********************************************************************
 ** Solidified function: set_text_font
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_set_text_font,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4188,7 +4101,7 @@ be_local_closure(class_lvh_obj_set_text_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_font),
@@ -4220,7 +4133,6 @@ be_local_closure(class_lvh_obj_set_text_font,   /* name */
 /********************************************************************
 ** Solidified function: get_pad_bottom
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4229,7 +4141,7 @@ be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
@@ -4263,7 +4175,6 @@ be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
 /********************************************************************
 ** Solidified function: get_pad_all
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_pad_all,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -4272,7 +4183,7 @@ be_local_closure(class_lvh_obj_get_pad_all,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_pad_all),
@@ -4288,7 +4199,6 @@ be_local_closure(class_lvh_obj_get_pad_all,   /* name */
 /********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4297,7 +4207,7 @@ be_local_closure(class_lvh_obj_get_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4319,7 +4229,6 @@ be_local_closure(class_lvh_obj_get_val,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_obj;
 be_local_closure(class_lvh_obj_post_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4328,7 +4237,7 @@ be_local_closure(class_lvh_obj_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_obj, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(register_event_cb),
@@ -4434,7 +4343,6 @@ extern const bclass be_class_lvh_fixed;
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_fixed;
 be_local_closure(class_lvh_fixed_post_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -4443,7 +4351,7 @@ be_local_closure(class_lvh_fixed_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_fixed, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(post_init),
@@ -4523,7 +4431,6 @@ extern const bclass be_class_lvh_flex;
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_flex;
 be_local_closure(class_lvh_flex_post_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4532,7 +4439,7 @@ be_local_closure(class_lvh_flex_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_flex, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(post_init),
@@ -4580,7 +4487,6 @@ extern const bclass be_class_lvh_label;
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_label;
 be_local_closure(class_lvh_label_post_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4589,7 +4495,7 @@ be_local_closure(class_lvh_label_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_label, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_label),
@@ -4633,7 +4539,6 @@ extern const bclass be_class_lvh_arc;
 /********************************************************************
 ** Solidified function: get_type
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_get_type,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4642,7 +4547,7 @@ be_local_closure(class_lvh_arc_get_type,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4664,7 +4569,6 @@ be_local_closure(class_lvh_arc_get_type,   /* name */
 /********************************************************************
 ** Solidified function: refresh_label_to_angle
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_refresh_label_to_angle,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4673,7 +4577,7 @@ be_local_closure(class_lvh_arc_refresh_label_to_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_label_angle),
@@ -4707,7 +4611,6 @@ be_local_closure(class_lvh_arc_refresh_label_to_angle,   /* name */
 /********************************************************************
 ** Solidified function: set_min
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4716,7 +4619,7 @@ be_local_closure(class_lvh_arc_set_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4747,7 +4650,6 @@ be_local_closure(class_lvh_arc_set_min,   /* name */
 /********************************************************************
 ** Solidified function: get_line_width1
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_get_line_width1,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -4756,7 +4658,7 @@ be_local_closure(class_lvh_arc_get_line_width1,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4786,7 +4688,6 @@ be_local_closure(class_lvh_arc_get_line_width1,   /* name */
 /********************************************************************
 ** Solidified function: set_type
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_type,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -4795,7 +4696,7 @@ be_local_closure(class_lvh_arc_set_type,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -4843,7 +4744,6 @@ be_local_closure(class_lvh_arc_set_type,   /* name */
 /********************************************************************
 ** Solidified function: set_line_width1
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_line_width1,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4852,7 +4752,7 @@ be_local_closure(class_lvh_arc_set_line_width1,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4885,7 +4785,6 @@ be_local_closure(class_lvh_arc_set_line_width1,   /* name */
 /********************************************************************
 ** Solidified function: get_min
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4894,7 +4793,7 @@ be_local_closure(class_lvh_arc_get_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4916,7 +4815,6 @@ be_local_closure(class_lvh_arc_get_min,   /* name */
 /********************************************************************
 ** Solidified function: set_line_width
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_line_width,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -4925,7 +4823,7 @@ be_local_closure(class_lvh_arc_set_line_width,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4951,7 +4849,6 @@ be_local_closure(class_lvh_arc_set_line_width,   /* name */
 /********************************************************************
 ** Solidified function: get_max
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -4960,7 +4857,7 @@ be_local_closure(class_lvh_arc_get_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -4982,7 +4879,6 @@ be_local_closure(class_lvh_arc_get_max,   /* name */
 /********************************************************************
 ** Solidified function: set_label_to_angle
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_label_to_angle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -4991,7 +4887,7 @@ be_local_closure(class_lvh_arc_set_label_to_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_label_angle),
@@ -5016,7 +4912,6 @@ be_local_closure(class_lvh_arc_set_label_to_angle,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5025,7 +4920,7 @@ be_local_closure(class_lvh_arc_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_val),
@@ -5052,7 +4947,6 @@ be_local_closure(class_lvh_arc_set_val,   /* name */
 /********************************************************************
 ** Solidified function: post_config
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_post_config,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -5061,7 +4955,7 @@ be_local_closure(class_lvh_arc_post_config,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(post_config),
@@ -5087,7 +4981,6 @@ be_local_closure(class_lvh_arc_post_config,   /* name */
 /********************************************************************
 ** Solidified function: get_line_width
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_get_line_width,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5096,7 +4989,7 @@ be_local_closure(class_lvh_arc_get_line_width,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5119,7 +5012,6 @@ be_local_closure(class_lvh_arc_get_line_width,   /* name */
 /********************************************************************
 ** Solidified function: set_max
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -5128,7 +5020,7 @@ be_local_closure(class_lvh_arc_set_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5159,7 +5051,6 @@ be_local_closure(class_lvh_arc_set_max,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_arc;
 be_local_closure(class_lvh_arc_set_text,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5168,7 +5059,7 @@ be_local_closure(class_lvh_arc_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_arc, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_text),
@@ -5228,7 +5119,6 @@ extern const bclass be_class_lvh_switch;
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_switch;
 be_local_closure(class_lvh_switch_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5237,7 +5127,7 @@ be_local_closure(class_lvh_switch_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_switch, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -5260,7 +5150,6 @@ be_local_closure(class_lvh_switch_set_val,   /* name */
 /********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
-extern const bclass be_class_lvh_switch;
 be_local_closure(class_lvh_switch_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -5269,7 +5158,7 @@ be_local_closure(class_lvh_switch_get_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_switch, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_toggle),
@@ -5308,7 +5197,6 @@ extern const bclass be_class_lvh_spinner;
 /********************************************************************
 ** Solidified function: set_angle
 ********************************************************************/
-extern const bclass be_class_lvh_spinner;
 be_local_closure(class_lvh_spinner_set_angle,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -5317,7 +5205,7 @@ be_local_closure(class_lvh_spinner_set_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spinner, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(set_angle),
@@ -5333,7 +5221,6 @@ be_local_closure(class_lvh_spinner_set_angle,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lvh_spinner;
 be_local_closure(class_lvh_spinner_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -5342,7 +5229,7 @@ be_local_closure(class_lvh_spinner_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spinner, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(_page),
@@ -5389,7 +5276,6 @@ be_local_closure(class_lvh_spinner_init,   /* name */
 /********************************************************************
 ** Solidified function: get_speed
 ********************************************************************/
-extern const bclass be_class_lvh_spinner;
 be_local_closure(class_lvh_spinner_get_speed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5398,7 +5284,7 @@ be_local_closure(class_lvh_spinner_get_speed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spinner, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_speed),
@@ -5414,7 +5300,6 @@ be_local_closure(class_lvh_spinner_get_speed,   /* name */
 /********************************************************************
 ** Solidified function: get_angle
 ********************************************************************/
-extern const bclass be_class_lvh_spinner;
 be_local_closure(class_lvh_spinner_get_angle,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5423,7 +5308,7 @@ be_local_closure(class_lvh_spinner_get_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spinner, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_angle),
@@ -5439,7 +5324,6 @@ be_local_closure(class_lvh_spinner_get_angle,   /* name */
 /********************************************************************
 ** Solidified function: set_speed
 ********************************************************************/
-extern const bclass be_class_lvh_spinner;
 be_local_closure(class_lvh_spinner_set_speed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -5448,7 +5332,7 @@ be_local_closure(class_lvh_spinner_set_speed,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spinner, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(set_speed),
@@ -5487,7 +5371,6 @@ extern const bclass be_class_lvh_img;
 /********************************************************************
 ** Solidified function: set_src
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_set_src,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5496,7 +5379,7 @@ be_local_closure(class_lvh_img_set_src,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota_logo),
@@ -5527,7 +5410,6 @@ be_local_closure(class_lvh_img_set_src,   /* name */
 /********************************************************************
 ** Solidified function: get_auto_size
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_get_auto_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5536,7 +5418,7 @@ be_local_closure(class_lvh_img_get_auto_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_auto_size),
@@ -5552,7 +5434,6 @@ be_local_closure(class_lvh_img_get_auto_size,   /* name */
 /********************************************************************
 ** Solidified function: set_auto_size
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_set_auto_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5561,7 +5442,7 @@ be_local_closure(class_lvh_img_set_auto_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5588,7 +5469,6 @@ be_local_closure(class_lvh_img_set_auto_size,   /* name */
 /********************************************************************
 ** Solidified function: set_angle
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_set_angle,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5597,7 +5477,7 @@ be_local_closure(class_lvh_img_set_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5624,7 +5504,6 @@ be_local_closure(class_lvh_img_set_angle,   /* name */
 /********************************************************************
 ** Solidified function: get_angle
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_get_angle,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -5633,7 +5512,7 @@ be_local_closure(class_lvh_img_get_angle,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5655,7 +5534,6 @@ be_local_closure(class_lvh_img_get_angle,   /* name */
 /********************************************************************
 ** Solidified function: set_raw
 ********************************************************************/
-extern const bclass be_class_lvh_img;
 be_local_closure(class_lvh_img_set_raw,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -5664,7 +5542,7 @@ be_local_closure(class_lvh_img_set_raw,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_img, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_raw),
@@ -5742,7 +5620,6 @@ extern const bclass be_class_lvh_qrcode;
 /********************************************************************
 ** Solidified function: get_qr_dark_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_qr_dark_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5751,7 +5628,7 @@ be_local_closure(class_lvh_qrcode_get_qr_dark_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_qr_dark_color),
@@ -5767,7 +5644,6 @@ be_local_closure(class_lvh_qrcode_get_qr_dark_color,   /* name */
 /********************************************************************
 ** Solidified function: set_qr_text
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_qr_text,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -5776,7 +5652,7 @@ be_local_closure(class_lvh_qrcode_set_qr_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(qr_text),
@@ -5801,7 +5677,6 @@ be_local_closure(class_lvh_qrcode_set_qr_text,   /* name */
 /********************************************************************
 ** Solidified function: set_light_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_light_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -5810,7 +5685,7 @@ be_local_closure(class_lvh_qrcode_set_light_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5839,7 +5714,6 @@ be_local_closure(class_lvh_qrcode_set_light_color,   /* name */
 /********************************************************************
 ** Solidified function: get_dark_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_dark_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5848,7 +5722,7 @@ be_local_closure(class_lvh_qrcode_get_dark_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_dark_color),
@@ -5864,7 +5738,6 @@ be_local_closure(class_lvh_qrcode_get_dark_color,   /* name */
 /********************************************************************
 ** Solidified function: set_qr_light_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_qr_light_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -5873,7 +5746,7 @@ be_local_closure(class_lvh_qrcode_set_qr_light_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5902,7 +5775,6 @@ be_local_closure(class_lvh_qrcode_set_qr_light_color,   /* name */
 /********************************************************************
 ** Solidified function: get_qr_light_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_qr_light_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5911,7 +5783,7 @@ be_local_closure(class_lvh_qrcode_get_qr_light_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_qr_light_color),
@@ -5927,7 +5799,6 @@ be_local_closure(class_lvh_qrcode_get_qr_light_color,   /* name */
 /********************************************************************
 ** Solidified function: set_qr_size
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_qr_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5936,7 +5807,7 @@ be_local_closure(class_lvh_qrcode_set_qr_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -5962,7 +5833,6 @@ be_local_closure(class_lvh_qrcode_set_qr_size,   /* name */
 /********************************************************************
 ** Solidified function: get_light_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_light_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -5971,7 +5841,7 @@ be_local_closure(class_lvh_qrcode_get_light_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_light_color),
@@ -5987,7 +5857,6 @@ be_local_closure(class_lvh_qrcode_get_light_color,   /* name */
 /********************************************************************
 ** Solidified function: set_size
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -5996,7 +5865,7 @@ be_local_closure(class_lvh_qrcode_set_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6022,7 +5891,6 @@ be_local_closure(class_lvh_qrcode_set_size,   /* name */
 /********************************************************************
 ** Solidified function: set_qr_dark_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_qr_dark_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -6031,7 +5899,7 @@ be_local_closure(class_lvh_qrcode_set_qr_dark_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6060,7 +5928,6 @@ be_local_closure(class_lvh_qrcode_set_qr_dark_color,   /* name */
 /********************************************************************
 ** Solidified function: get_qr_text
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_qr_text,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -6069,7 +5936,7 @@ be_local_closure(class_lvh_qrcode_get_qr_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_qr_text),
@@ -6085,7 +5952,6 @@ be_local_closure(class_lvh_qrcode_get_qr_text,   /* name */
 /********************************************************************
 ** Solidified function: set_dark_color
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_set_dark_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -6094,7 +5960,7 @@ be_local_closure(class_lvh_qrcode_set_dark_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6123,7 +5989,6 @@ be_local_closure(class_lvh_qrcode_set_dark_color,   /* name */
 /********************************************************************
 ** Solidified function: get_size
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -6132,7 +5997,7 @@ be_local_closure(class_lvh_qrcode_get_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_size),
@@ -6148,7 +6013,6 @@ be_local_closure(class_lvh_qrcode_get_size,   /* name */
 /********************************************************************
 ** Solidified function: post_config
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_post_config,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6157,7 +6021,7 @@ be_local_closure(class_lvh_qrcode_post_config,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(post_config),
@@ -6183,7 +6047,6 @@ be_local_closure(class_lvh_qrcode_post_config,   /* name */
 /********************************************************************
 ** Solidified function: _update
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode__update,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -6192,7 +6055,7 @@ be_local_closure(class_lvh_qrcode__update,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(qr_text),
@@ -6223,7 +6086,6 @@ be_local_closure(class_lvh_qrcode__update,   /* name */
 /********************************************************************
 ** Solidified function: get_qr_size
 ********************************************************************/
-extern const bclass be_class_lvh_qrcode;
 be_local_closure(class_lvh_qrcode_get_qr_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -6232,7 +6094,7 @@ be_local_closure(class_lvh_qrcode_get_qr_size,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_qrcode, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_qr_size),
@@ -6281,7 +6143,6 @@ extern const bclass be_class_lvh_slider;
 /********************************************************************
 ** Solidified function: set_max
 ********************************************************************/
-extern const bclass be_class_lvh_slider;
 be_local_closure(class_lvh_slider_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -6290,7 +6151,7 @@ be_local_closure(class_lvh_slider_set_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_slider, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6318,7 +6179,6 @@ be_local_closure(class_lvh_slider_set_max,   /* name */
 /********************************************************************
 ** Solidified function: get_min
 ********************************************************************/
-extern const bclass be_class_lvh_slider;
 be_local_closure(class_lvh_slider_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6327,7 +6187,7 @@ be_local_closure(class_lvh_slider_get_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_slider, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6349,7 +6209,6 @@ be_local_closure(class_lvh_slider_get_min,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_slider;
 be_local_closure(class_lvh_slider_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -6358,7 +6217,7 @@ be_local_closure(class_lvh_slider_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_slider, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -6385,7 +6244,6 @@ be_local_closure(class_lvh_slider_set_val,   /* name */
 /********************************************************************
 ** Solidified function: get_max
 ********************************************************************/
-extern const bclass be_class_lvh_slider;
 be_local_closure(class_lvh_slider_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6394,7 +6252,7 @@ be_local_closure(class_lvh_slider_get_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_slider, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6416,7 +6274,6 @@ be_local_closure(class_lvh_slider_get_max,   /* name */
 /********************************************************************
 ** Solidified function: set_min
 ********************************************************************/
-extern const bclass be_class_lvh_slider;
 be_local_closure(class_lvh_slider_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -6425,7 +6282,7 @@ be_local_closure(class_lvh_slider_set_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_slider, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6474,7 +6331,6 @@ extern const bclass be_class_lvh_roller;
 /********************************************************************
 ** Solidified function: set_options
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_set_options,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -6483,7 +6339,7 @@ be_local_closure(class_lvh_roller_set_options,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6510,7 +6366,6 @@ be_local_closure(class_lvh_roller_set_options,   /* name */
 /********************************************************************
 ** Solidified function: get_text
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_get_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -6519,7 +6374,7 @@ be_local_closure(class_lvh_roller_get_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(resize),
@@ -6559,7 +6414,6 @@ be_local_closure(class_lvh_roller_get_text,   /* name */
 /********************************************************************
 ** Solidified function: get_options
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_get_options,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6568,7 +6422,7 @@ be_local_closure(class_lvh_roller_get_options,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6590,7 +6444,6 @@ be_local_closure(class_lvh_roller_get_options,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -6599,7 +6452,7 @@ be_local_closure(class_lvh_roller_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -6626,7 +6479,6 @@ be_local_closure(class_lvh_roller_set_val,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_set_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -6635,7 +6487,7 @@ be_local_closure(class_lvh_roller_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_error),
@@ -6655,7 +6507,6 @@ be_local_closure(class_lvh_roller_set_text,   /* name */
 /********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
-extern const bclass be_class_lvh_roller;
 be_local_closure(class_lvh_roller_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6664,7 +6515,7 @@ be_local_closure(class_lvh_roller_get_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_roller, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6708,7 +6559,6 @@ extern const bclass be_class_lvh_led;
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_led;
 be_local_closure(class_lvh_led_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -6717,7 +6567,7 @@ be_local_closure(class_lvh_led_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_led, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -6742,7 +6592,6 @@ be_local_closure(class_lvh_led_set_val,   /* name */
 /********************************************************************
 ** Solidified function: get_color
 ********************************************************************/
-extern const bclass be_class_lvh_led;
 be_local_closure(class_lvh_led_get_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
@@ -6751,7 +6600,7 @@ be_local_closure(class_lvh_led_get_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_led, 
+    NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
     be_str_weak(get_color),
@@ -6767,7 +6616,6 @@ be_local_closure(class_lvh_led_get_color,   /* name */
 /********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
-extern const bclass be_class_lvh_led;
 be_local_closure(class_lvh_led_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6776,7 +6624,7 @@ be_local_closure(class_lvh_led_get_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_led, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6798,7 +6646,6 @@ be_local_closure(class_lvh_led_get_val,   /* name */
 /********************************************************************
 ** Solidified function: set_color
 ********************************************************************/
-extern const bclass be_class_lvh_led;
 be_local_closure(class_lvh_led_set_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -6807,7 +6654,7 @@ be_local_closure(class_lvh_led_set_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_led, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_color),
@@ -6854,7 +6701,6 @@ extern const bclass be_class_lvh_dropdown;
 /********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -6863,7 +6709,7 @@ be_local_closure(class_lvh_dropdown_get_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6885,7 +6731,6 @@ be_local_closure(class_lvh_dropdown_get_val,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_set_text,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -6894,7 +6739,7 @@ be_local_closure(class_lvh_dropdown_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -6917,7 +6762,6 @@ be_local_closure(class_lvh_dropdown_set_text,   /* name */
 /********************************************************************
 ** Solidified function: set_direction
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_set_direction,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -6926,7 +6770,7 @@ be_local_closure(class_lvh_dropdown_set_direction,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -6996,7 +6840,6 @@ be_local_closure(class_lvh_dropdown_set_direction,   /* name */
 /********************************************************************
 ** Solidified function: get_direction
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_get_direction,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -7005,7 +6848,7 @@ be_local_closure(class_lvh_dropdown_get_direction,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7044,7 +6887,6 @@ be_local_closure(class_lvh_dropdown_get_direction,   /* name */
 /********************************************************************
 ** Solidified function: set_show_selected
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_set_show_selected,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -7053,7 +6895,7 @@ be_local_closure(class_lvh_dropdown_set_show_selected,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7077,7 +6919,6 @@ be_local_closure(class_lvh_dropdown_set_show_selected,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -7086,7 +6927,7 @@ be_local_closure(class_lvh_dropdown_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -7111,7 +6952,6 @@ be_local_closure(class_lvh_dropdown_set_val,   /* name */
 /********************************************************************
 ** Solidified function: get_text
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_get_text,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7120,7 +6960,7 @@ be_local_closure(class_lvh_dropdown_get_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7170,7 +7010,6 @@ be_local_closure(class_lvh_dropdown_get_text,   /* name */
 /********************************************************************
 ** Solidified function: get_show_selected
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown;
 be_local_closure(class_lvh_dropdown_get_show_selected,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -7179,7 +7018,7 @@ be_local_closure(class_lvh_dropdown_get_show_selected,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7236,7 +7075,6 @@ extern const bclass be_class_lvh_dropdown_list;
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_dropdown_list;
 be_local_closure(class_lvh_dropdown_list_post_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -7245,7 +7083,7 @@ be_local_closure(class_lvh_dropdown_list_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_dropdown_list, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7311,7 +7149,6 @@ extern const bclass be_class_lvh_bar;
 /********************************************************************
 ** Solidified function: get_max
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -7320,7 +7157,7 @@ be_local_closure(class_lvh_bar_get_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7342,7 +7179,6 @@ be_local_closure(class_lvh_bar_get_max,   /* name */
 /********************************************************************
 ** Solidified function: set_max
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7351,7 +7187,7 @@ be_local_closure(class_lvh_bar_set_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7380,7 +7216,6 @@ be_local_closure(class_lvh_bar_set_max,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_post_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7389,7 +7224,7 @@ be_local_closure(class_lvh_bar_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(post_init),
@@ -7440,7 +7275,6 @@ be_local_closure(class_lvh_bar_post_init,   /* name */
 /********************************************************************
 ** Solidified function: get_min
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -7449,7 +7283,7 @@ be_local_closure(class_lvh_bar_get_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7471,7 +7305,6 @@ be_local_closure(class_lvh_bar_get_min,   /* name */
 /********************************************************************
 ** Solidified function: set_min
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7480,7 +7313,7 @@ be_local_closure(class_lvh_bar_set_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7509,7 +7342,6 @@ be_local_closure(class_lvh_bar_set_min,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_bar;
 be_local_closure(class_lvh_bar_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -7518,7 +7350,7 @@ be_local_closure(class_lvh_bar_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_bar, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -7569,7 +7401,6 @@ extern const bclass be_class_lvh_line;
 /********************************************************************
 ** Solidified function: set_points
 ********************************************************************/
-extern const bclass be_class_lvh_line;
 be_local_closure(class_lvh_line_set_points,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -7578,7 +7409,7 @@ be_local_closure(class_lvh_line_set_points,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_line, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_const_int(2),
@@ -7687,7 +7518,6 @@ extern const bclass be_class_lvh_scale;
 /********************************************************************
 ** Solidified function: set_text_src
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_set_text_src,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -7696,7 +7526,7 @@ be_local_closure(class_lvh_scale_set_text_src,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -7756,7 +7586,6 @@ be_local_closure(class_lvh_scale_set_text_src,   /* name */
 /********************************************************************
 ** Solidified function: get_max
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -7765,7 +7594,7 @@ be_local_closure(class_lvh_scale_get_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7787,7 +7616,6 @@ be_local_closure(class_lvh_scale_get_max,   /* name */
 /********************************************************************
 ** Solidified function: set_min
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7796,7 +7624,7 @@ be_local_closure(class_lvh_scale_set_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7825,7 +7653,6 @@ be_local_closure(class_lvh_scale_set_min,   /* name */
 /********************************************************************
 ** Solidified function: get_text_src
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_get_text_src,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -7834,7 +7661,7 @@ be_local_closure(class_lvh_scale_get_text_src,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_options),
@@ -7853,7 +7680,6 @@ be_local_closure(class_lvh_scale_get_text_src,   /* name */
 /********************************************************************
 ** Solidified function: set_max
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -7862,7 +7688,7 @@ be_local_closure(class_lvh_scale_set_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7891,7 +7717,6 @@ be_local_closure(class_lvh_scale_set_max,   /* name */
 /********************************************************************
 ** Solidified function: get_min
 ********************************************************************/
-extern const bclass be_class_lvh_scale;
 be_local_closure(class_lvh_scale_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -7900,7 +7725,7 @@ be_local_closure(class_lvh_scale_get_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -7946,7 +7771,6 @@ extern const bclass be_class_lvh_scale_section;
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_setmember,   /* name */
   be_nested_proto(
     12,                          /* nstack */
@@ -7955,7 +7779,7 @@ be_local_closure(class_lvh_scale_section_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[26]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -8138,7 +7962,6 @@ be_local_closure(class_lvh_scale_section_setmember,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_post_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -8147,7 +7970,7 @@ be_local_closure(class_lvh_scale_section_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -8233,7 +8056,6 @@ be_local_closure(class_lvh_scale_section_post_init,   /* name */
 /********************************************************************
 ** Solidified function: set_min
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_set_min,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -8242,7 +8064,7 @@ be_local_closure(class_lvh_scale_section_set_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_max),
@@ -8272,7 +8094,6 @@ be_local_closure(class_lvh_scale_section_set_min,   /* name */
 /********************************************************************
 ** Solidified function: set_max
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_set_max,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -8281,7 +8102,7 @@ be_local_closure(class_lvh_scale_section_set_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_min),
@@ -8311,7 +8132,6 @@ be_local_closure(class_lvh_scale_section_set_max,   /* name */
 /********************************************************************
 ** Solidified function: set_range
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_set_range,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -8320,7 +8140,7 @@ be_local_closure(class_lvh_scale_section_set_range,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_min),
@@ -8348,7 +8168,6 @@ be_local_closure(class_lvh_scale_section_set_range,   /* name */
 /********************************************************************
 ** Solidified function: delete
 ********************************************************************/
-extern const bclass be_class_lvh_scale_section;
 be_local_closure(class_lvh_scale_section_delete,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -8357,7 +8176,7 @@ be_local_closure(class_lvh_scale_section_delete,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_section, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_style),
@@ -8420,7 +8239,6 @@ extern const bclass be_class_lvh_scale_line;
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_scale_line;
 be_local_closure(class_lvh_scale_line_set_val,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -8429,7 +8247,7 @@ be_local_closure(class_lvh_scale_line_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_line, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(set_val),
@@ -8495,7 +8313,6 @@ be_local_closure(class_lvh_scale_line_set_val,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_scale_line;
 be_local_closure(class_lvh_scale_line_post_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -8504,7 +8321,7 @@ be_local_closure(class_lvh_scale_line_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_line, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_parent_lvh),
@@ -8563,7 +8380,6 @@ be_local_closure(class_lvh_scale_line_post_init,   /* name */
 /********************************************************************
 ** Solidified function: get_needle_length
 ********************************************************************/
-extern const bclass be_class_lvh_scale_line;
 be_local_closure(class_lvh_scale_line_get_needle_length,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -8572,7 +8388,7 @@ be_local_closure(class_lvh_scale_line_get_needle_length,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_line, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_needle_length),
@@ -8591,7 +8407,6 @@ be_local_closure(class_lvh_scale_line_get_needle_length,   /* name */
 /********************************************************************
 ** Solidified function: set_needle_length
 ********************************************************************/
-extern const bclass be_class_lvh_scale_line;
 be_local_closure(class_lvh_scale_line_set_needle_length,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -8600,7 +8415,7 @@ be_local_closure(class_lvh_scale_line_set_needle_length,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_scale_line, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_needle_length),
@@ -8651,7 +8466,6 @@ extern const bclass be_class_lvh_spangroup;
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_spangroup;
 be_local_closure(class_lvh_spangroup_post_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -8660,7 +8474,7 @@ be_local_closure(class_lvh_spangroup_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spangroup, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -8696,7 +8510,6 @@ be_local_closure(class_lvh_spangroup_post_init,   /* name */
 /********************************************************************
 ** Solidified function: refr_mode
 ********************************************************************/
-extern const bclass be_class_lvh_spangroup;
 be_local_closure(class_lvh_spangroup_refr_mode,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -8705,7 +8518,7 @@ be_local_closure(class_lvh_spangroup_refr_mode,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_spangroup, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -8745,7 +8558,6 @@ extern const bclass be_class_lvh_span;
 /********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
-extern const bclass be_class_lvh_span;
 be_local_closure(class_lvh_span_setmember,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -8754,7 +8566,7 @@ be_local_closure(class_lvh_span_setmember,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_span, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -8883,7 +8695,6 @@ be_local_closure(class_lvh_span_setmember,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_span;
 be_local_closure(class_lvh_span_post_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
@@ -8892,7 +8703,7 @@ be_local_closure(class_lvh_span_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_span, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -8935,7 +8746,6 @@ be_local_closure(class_lvh_span_post_init,   /* name */
 /********************************************************************
 ** Solidified function: set_text_font
 ********************************************************************/
-extern const bclass be_class_lvh_span;
 be_local_closure(class_lvh_span_set_text_font,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -8944,7 +8754,7 @@ be_local_closure(class_lvh_span_set_text_font,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_span, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(parse_font),
@@ -8979,7 +8789,6 @@ be_local_closure(class_lvh_span_set_text_font,   /* name */
 /********************************************************************
 ** Solidified function: set_text
 ********************************************************************/
-extern const bclass be_class_lvh_span;
 be_local_closure(class_lvh_span_set_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -8988,7 +8797,7 @@ be_local_closure(class_lvh_span_set_text,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_span, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -9034,7 +8843,6 @@ extern const bclass be_class_lvh_chart;
 /********************************************************************
 ** Solidified function: get_y_min
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_get_y_min,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -9043,7 +8851,7 @@ be_local_closure(class_lvh_chart_get_y_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_y_min),
@@ -9062,7 +8870,6 @@ be_local_closure(class_lvh_chart_get_y_min,   /* name */
 /********************************************************************
 ** Solidified function: add_point
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_add_point,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9071,7 +8878,7 @@ be_local_closure(class_lvh_chart_add_point,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -9096,7 +8903,6 @@ be_local_closure(class_lvh_chart_add_point,   /* name */
 /********************************************************************
 ** Solidified function: set_val2
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_val2,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -9105,7 +8911,7 @@ be_local_closure(class_lvh_chart_set_val2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(add_point2),
@@ -9126,7 +8932,6 @@ be_local_closure(class_lvh_chart_set_val2,   /* name */
 /********************************************************************
 ** Solidified function: set_y_min
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_y_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -9135,7 +8940,7 @@ be_local_closure(class_lvh_chart_set_y_min,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_y_min),
@@ -9166,7 +8971,6 @@ be_local_closure(class_lvh_chart_set_y_min,   /* name */
 /********************************************************************
 ** Solidified function: add_point2
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_add_point2,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9175,7 +8979,7 @@ be_local_closure(class_lvh_chart_add_point2,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -9200,7 +9004,6 @@ be_local_closure(class_lvh_chart_add_point2,   /* name */
 /********************************************************************
 ** Solidified function: set_series1_color
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_series1_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9209,7 +9012,7 @@ be_local_closure(class_lvh_chart_set_series1_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -9234,7 +9037,6 @@ be_local_closure(class_lvh_chart_set_series1_color,   /* name */
 /********************************************************************
 ** Solidified function: set_series2_color
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_series2_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9243,7 +9045,7 @@ be_local_closure(class_lvh_chart_set_series2_color,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
@@ -9268,7 +9070,6 @@ be_local_closure(class_lvh_chart_set_series2_color,   /* name */
 /********************************************************************
 ** Solidified function: set_y_max
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_y_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -9277,7 +9078,7 @@ be_local_closure(class_lvh_chart_set_y_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_y_max),
@@ -9308,7 +9109,6 @@ be_local_closure(class_lvh_chart_set_y_max,   /* name */
 /********************************************************************
 ** Solidified function: post_init
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_post_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9317,7 +9117,7 @@ be_local_closure(class_lvh_chart_post_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(_y_min),
@@ -9382,7 +9182,6 @@ be_local_closure(class_lvh_chart_post_init,   /* name */
 /********************************************************************
 ** Solidified function: get_y_max
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_get_y_max,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -9391,7 +9190,7 @@ be_local_closure(class_lvh_chart_get_y_max,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_y_max),
@@ -9410,7 +9209,6 @@ be_local_closure(class_lvh_chart_get_y_max,   /* name */
 /********************************************************************
 ** Solidified function: set_val
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -9419,7 +9217,7 @@ be_local_closure(class_lvh_chart_set_val,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_val),
@@ -9442,7 +9240,6 @@ be_local_closure(class_lvh_chart_set_val,   /* name */
 /********************************************************************
 ** Solidified function: set_v_div_line_count
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_v_div_line_count,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9451,7 +9248,7 @@ be_local_closure(class_lvh_chart_set_v_div_line_count,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_v_div),
@@ -9478,7 +9275,6 @@ be_local_closure(class_lvh_chart_set_v_div_line_count,   /* name */
 /********************************************************************
 ** Solidified function: set_h_div_line_count
 ********************************************************************/
-extern const bclass be_class_lvh_chart;
 be_local_closure(class_lvh_chart_set_h_div_line_count,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -9487,7 +9283,7 @@ be_local_closure(class_lvh_chart_set_h_div_line_count,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_chart, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_h_div),
@@ -9549,7 +9345,6 @@ extern const bclass be_class_lvh_btnmatrix;
 /********************************************************************
 ** Solidified function: set_options
 ********************************************************************/
-extern const bclass be_class_lvh_btnmatrix;
 be_local_closure(class_lvh_btnmatrix_set_options,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -9558,7 +9353,7 @@ be_local_closure(class_lvh_btnmatrix_set_options,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_btnmatrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -9618,7 +9413,6 @@ be_local_closure(class_lvh_btnmatrix_set_options,   /* name */
 /********************************************************************
 ** Solidified function: get_options
 ********************************************************************/
-extern const bclass be_class_lvh_btnmatrix;
 be_local_closure(class_lvh_btnmatrix_get_options,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -9627,7 +9421,7 @@ be_local_closure(class_lvh_btnmatrix_get_options,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_btnmatrix, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_options),
@@ -9714,7 +9508,6 @@ extern const bclass be_class_lvh_page;
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
@@ -9723,7 +9516,7 @@ be_local_closure(class_lvh_page_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -9821,7 +9614,6 @@ be_local_closure(class_lvh_page_init,   /* name */
 /********************************************************************
 ** Solidified function: show
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_show,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -9830,7 +9622,7 @@ be_local_closure(class_lvh_page_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
         3,                          /* nstack */
         0,                          /* argc */
@@ -9840,7 +9632,7 @@ be_local_closure(class_lvh_page_show,   /* name */
           be_local_const_upval(1, 3),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(tasmota),
@@ -9865,7 +9657,7 @@ be_local_closure(class_lvh_page_show,   /* name */
           be_local_const_upval(1, 4),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 2]) {     /* constants */
         /* K0   */  be_nested_str_weak(tasmota),
@@ -9881,7 +9673,6 @@ be_local_closure(class_lvh_page_show,   /* name */
           0x80040000,  //  0004  RET	1	R0
         })
       ),
-    &be_class_lvh_page, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[18]) {     /* constants */
@@ -9982,7 +9773,6 @@ be_local_closure(class_lvh_page_show,   /* name */
 /********************************************************************
 ** Solidified function: id
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -9991,7 +9781,7 @@ be_local_closure(class_lvh_page_id,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_page_id),
@@ -10010,7 +9800,6 @@ be_local_closure(class_lvh_page_id,   /* name */
 /********************************************************************
 ** Solidified function: get_scr
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_get_scr,   /* name */
   be_nested_proto(
     2,                          /* nstack */
@@ -10019,7 +9808,7 @@ be_local_closure(class_lvh_page_get_scr,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_scr),
@@ -10038,7 +9827,6 @@ be_local_closure(class_lvh_page_get_scr,   /* name */
 /********************************************************************
 ** Solidified function: get_obj
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_get_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -10047,7 +9835,7 @@ be_local_closure(class_lvh_page_get_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_obj_id),
@@ -10070,7 +9858,6 @@ be_local_closure(class_lvh_page_get_obj,   /* name */
 /********************************************************************
 ** Solidified function: add_obj
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_add_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -10079,7 +9866,7 @@ be_local_closure(class_lvh_page_add_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_obj_id),
@@ -10112,7 +9899,6 @@ be_local_closure(class_lvh_page_add_obj,   /* name */
 /********************************************************************
 ** Solidified function: remove_obj
 ********************************************************************/
-extern const bclass be_class_lvh_page;
 be_local_closure(class_lvh_page_remove_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -10121,7 +9907,7 @@ be_local_closure(class_lvh_page_remove_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_lvh_page, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(_obj_id),
@@ -10201,7 +9987,6 @@ extern const bclass be_class_HASPmota;
 /********************************************************************
 ** Solidified function: _load
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota__load,   /* name */
   be_nested_proto(
     15,                          /* nstack */
@@ -10210,7 +9995,7 @@ be_local_closure(class_HASPmota__load,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[26]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
@@ -10337,7 +10122,6 @@ be_local_closure(class_HASPmota__load,   /* name */
 /********************************************************************
 ** Solidified function: page_show
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_page_show,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -10346,7 +10130,7 @@ be_local_closure(class_HASPmota_page_show,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(lvh_pages),
@@ -10441,7 +10225,6 @@ be_local_closure(class_HASPmota_page_show,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
@@ -10450,7 +10233,7 @@ be_local_closure(class_HASPmota_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(fix_lv_version),
@@ -10479,7 +10262,6 @@ be_local_closure(class_HASPmota_init,   /* name */
 /********************************************************************
 ** Solidified function: event_dispatch
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_event_dispatch,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -10488,7 +10270,7 @@ be_local_closure(class_HASPmota_event_dispatch,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
@@ -10549,7 +10331,6 @@ be_local_closure(class_HASPmota_event_dispatch,   /* name */
 /********************************************************************
 ** Solidified function: pages_list_sorted
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
   be_nested_proto(
     8,                          /* nstack */
@@ -10558,7 +10339,7 @@ be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),
@@ -10630,7 +10411,6 @@ be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
 /********************************************************************
 ** Solidified function: get_page_cur
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_get_page_cur,   /* name */
   be_nested_proto(
     3,                          /* nstack */
@@ -10639,7 +10419,7 @@ be_local_closure(class_HASPmota_get_page_cur,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(lvh_pages),
@@ -10661,7 +10441,6 @@ be_local_closure(class_HASPmota_get_page_cur,   /* name */
 /********************************************************************
 ** Solidified function: fix_lv_version
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_fix_lv_version,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -10670,7 +10449,7 @@ be_local_closure(class_HASPmota_fix_lv_version,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_HASPmota),
@@ -10707,7 +10486,6 @@ be_local_closure(class_HASPmota_fix_lv_version,   /* name */
 /********************************************************************
 ** Solidified function: do_action
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_do_action,   /* name */
   be_nested_proto(
     6,                          /* nstack */
@@ -10716,7 +10494,7 @@ be_local_closure(class_HASPmota_do_action,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(lv),
@@ -10745,7 +10523,6 @@ be_local_closure(class_HASPmota_do_action,   /* name */
 /********************************************************************
 ** Solidified function: parse
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -10754,7 +10531,7 @@ be_local_closure(class_HASPmota_parse,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
@@ -10800,7 +10577,6 @@ be_local_closure(class_HASPmota_parse,   /* name */
 /********************************************************************
 ** Solidified function: register_event
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_register_event,   /* name */
   be_nested_proto(
     13,                          /* nstack */
@@ -10809,7 +10585,7 @@ be_local_closure(class_HASPmota_register_event,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
         4,                          /* nstack */
         1,                          /* argc */
@@ -10819,7 +10595,7 @@ be_local_closure(class_HASPmota_register_event,   /* name */
           be_local_const_upval(1, 0),
         }),
         0,                          /* has sup protos */
-        NULL, 
+        NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(event_dispatch),
@@ -10834,7 +10610,6 @@ be_local_closure(class_HASPmota_register_event,   /* name */
           0x80040200,  //  0004  RET	1	R1
         })
       ),
-    &be_class_HASPmota, 
     }),
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
@@ -10878,7 +10653,6 @@ be_local_closure(class_HASPmota_register_event,   /* name */
 /********************************************************************
 ** Solidified function: page_dir_to
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_page_dir_to,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -10887,7 +10661,7 @@ be_local_closure(class_HASPmota_page_dir_to,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(pages_list_sorted),
@@ -10940,7 +10714,6 @@ be_local_closure(class_HASPmota_page_dir_to,   /* name */
 /********************************************************************
 ** Solidified function: parse_page
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_parse_page,   /* name */
   be_nested_proto(
     9,                          /* nstack */
@@ -10949,7 +10722,7 @@ be_local_closure(class_HASPmota_parse_page,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(has),
@@ -11033,7 +10806,6 @@ be_local_closure(class_HASPmota_parse_page,   /* name */
 /********************************************************************
 ** Solidified function: sort
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_sort,   /* name */
   be_nested_proto(
     7,                          /* nstack */
@@ -11042,7 +10814,7 @@ be_local_closure(class_HASPmota_sort,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_class(be_class_HASPmota),
@@ -11092,7 +10864,6 @@ be_local_closure(class_HASPmota_sort,   /* name */
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_start,   /* name */
   be_nested_proto(
     11,                          /* nstack */
@@ -11101,7 +10872,7 @@ be_local_closure(class_HASPmota_start,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[33]) {     /* constants */
     /* K0   */  be_nested_str_weak(path),
@@ -11255,7 +11026,6 @@ be_local_closure(class_HASPmota_start,   /* name */
 /********************************************************************
 ** Solidified function: parse_obj
 ********************************************************************/
-extern const bclass be_class_HASPmota;
 be_local_closure(class_HASPmota_parse_obj,   /* name */
   be_nested_proto(
     22,                          /* nstack */
@@ -11264,7 +11034,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    &be_class_HASPmota, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
@@ -11599,7 +11369,7 @@ be_local_closure(_anonymous_,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
-    NULL, 
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(HASPmota),


### PR DESCRIPTION
## Description:

Berry revert of #21490
This PR introduced complexity in storage that is finally not worth it, as I found a different way to mutualize code in Matter. The same effect could be implemented at Solidification time, without changing the solidified code.

No functional change.

Code reduced by 1.8KB

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
