### PR TITLE
Neopool relay state detection and reporting fixes

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -2137,16 +2137,16 @@ void NeoPoolShow(bool json)
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CL  "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_CL_RELAY_GPIO)-1)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CD "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CD "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)-1)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_HEATING_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_HEATING "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_HEATING_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_HEATING "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_HEATING_GPIO)-1)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_UV "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_UV "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)-1)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_FILTVALVE "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_FILTVALVE "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)-1)) & 1);
     }
     ResponseJsonEnd();
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -2137,16 +2137,16 @@ void NeoPoolShow(bool json)
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CL  "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> (NeoPoolGetData(MBF_PAR_CL_RELAY_GPIO)-1)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CD " \":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_CD "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_CD_RELAY_GPIO)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_HEATING_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_HEATING " \":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_HEATING_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_HEATING "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_HEATING_GPIO)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_UV " \":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_UV "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_UV_RELAY_GPIO)) & 1);
     }
     if (0 != NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_FILTVALVE " \":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)) & 1);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_RELAY_FILTVALVE "\":%d"), (NeoPoolGetData(MBF_RELAY_STATE) >> NeoPoolGetData(MBF_PAR_FILTVALVE_GPIO)) & 1);
     }
     ResponseJsonEnd();
 


### PR DESCRIPTION
## Description:

This fixes reporting some Neopool relay states to MQTT.
Relay state calculation was wrong, at least in my case heating relay state was not properly detected without this fix.
Also, fixed keys used in json for reporting values, there was redundant space (I understand for some people it can be breaking change, e.g some dashboards can stop working, if they are already using key that contains space).

previously (without this PR) it was like this:
```
"Relay":{"State":[0,1,0,0,0,0,1],"Aux":[0,0,0,1],"Acid":0,"Redox":0,"Chlorine":0,"Heating ":0}
```

now it is:
```
"Relay":{"State":[0,1,0,0,0,0,1],"Aux":[0,0,0,1],"Acid":0,"Redox":0,"Chlorine":0,"Heating":1}
```

(in my case AUX4 relay is used for heating)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
