### PR TITLE
Berry consolidated constants for solidified classes reduces Flash size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- Berry consolidated constants for solidified classes reduces Flash size
 
 ### Fixed
 - Berry `light.get` for separate RGB/CT (#21818)

--- a/lib/libesp32/berry/src/be_gc.c
+++ b/lib/libesp32/berry/src/be_gc.c
@@ -320,7 +320,11 @@ static void free_proto(bvm *vm, bgcobject *obj)
     bproto *proto = cast_proto(obj);
     gc_try (proto != NULL) {
         be_free(vm, proto->upvals, proto->nupvals * sizeof(bupvaldesc));
-        be_free(vm, proto->ktab, proto->nconst * sizeof(bvalue));
+        if (!(proto->varg & BE_VA_SHARED_KTAB)) {       /* do not free shared ktab */
+                                                        /*caveat: the shared ktab is never GCed, in practice this is not a problem */
+                                                        /* since shared ktab are primarily meant for solidification hence not gc-able */
+            be_free(vm, proto->ktab, proto->nconst * sizeof(bvalue));
+        }
         be_free(vm, proto->ptab, proto->nproto * sizeof(bproto*));
         be_free(vm, proto->code, proto->codesize * sizeof(binstruction));
 #if BE_DEBUG_RUNTIME_INFO

--- a/lib/libesp32/berry/src/be_object.h
+++ b/lib/libesp32/berry/src/be_object.h
@@ -42,6 +42,7 @@
 #define BE_VA_VARARG            (1 << 0)    /* function has variable number of arguments */
 #define BE_VA_METHOD            (1 << 1)    /* function is a method (this is only a hint) */
 #define BE_VA_STATICMETHOD      (1 << 2)    /* the function is a static method and has the class as implicit '_class' variable */
+#define BE_VA_SHARED_KTAB       (1 << 3)    /* the funciton has a shared consolidated ktab */
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
 #define bcommon_header          \

--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -114,9 +114,9 @@ static void toidentifier(char *to, const char *p)
     *to = 0;      // final NULL
 }
 
-static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefixname, const char *key, void* fout);
+static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefix_name, const char *key, void* fout);
 
-static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *prefixname, void* fout)
+static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *prefix_name, void* fout)
 {
     // compact first
     be_map_compact(vm, map);
@@ -144,14 +144,14 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *p
             } else {
                 logfmt("        { be_const_key_weak(%s, %i), ", id_buf, key_next);
             }
-            m_solidify_bvalue(vm, str_literal, &node->value, prefixname, str(node->key.v.s), fout);
+            m_solidify_bvalue(vm, str_literal, &node->value, prefix_name, str(node->key.v.s), fout);
         } else if (node->key.type == BE_INT) {
 #if BE_INTGER_TYPE == 2
             logfmt("        { be_const_key_int(%lli, %i), ", node->key.v.i, key_next);
 #else
             logfmt("        { be_const_key_int(%i, %i), ", node->key.v.i, key_next);
 #endif
-            m_solidify_bvalue(vm, str_literal, &node->value, prefixname, NULL, fout);
+            m_solidify_bvalue(vm, str_literal, &node->value, prefix_name, NULL, fout);
         } else {
             char error[64];
             snprintf(error, sizeof(error), "Unsupported type in key: %i", node->key.type);
@@ -164,21 +164,21 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *p
 
 }
 
-static void m_solidify_list(bvm *vm, bbool str_literal, const blist * list, const char *prefixname, void* fout)
+static void m_solidify_list(bvm *vm, bbool str_literal, const blist * list, const char *prefix_name, void* fout)
 {
     logfmt("    be_nested_list(%i,\n", list->count);
 
     logfmt("    ( (struct bvalue*) &(const bvalue[]) {\n");
     for (int i = 0; i < list->count; i++) {
         logfmt("        ");
-        m_solidify_bvalue(vm, str_literal, &list->data[i], prefixname, "", fout);
+        m_solidify_bvalue(vm, str_literal, &list->data[i], prefix_name, "", fout);
         logfmt(",\n");
     }
     logfmt("    }))");        // TODO need terminal comma?
 }
 
 // pass key name in case of class, or NULL if none
-static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefixname, const char *key, void* fout)
+static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefix_name, const char *key, void* fout)
 {
     int type = var_primetype(value);
     switch (type) {
@@ -247,7 +247,7 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, 
             toidentifier(func_name_id, func_name);
             logfmt("be_const_%sclosure(%s%s%s_closure)",
                 var_isstatic(value) ? "static_" : "",
-                prefixname ? prefixname : "", prefixname ? "_" : "",
+                prefix_name ? prefix_name : "", prefix_name ? "_" : "",
                 func_name_id);
         }
         break;
@@ -255,12 +255,12 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, 
         logfmt("be_const_class(be_class_%s)", str(((bclass*) var_toobj(value))->name));
         break;
     case BE_COMPTR:
-        logfmt("be_const_comptr(&be_ntv_%s_%s)", prefixname ? prefixname : "unknown", key ? key : "unknown");
+        logfmt("be_const_comptr(&be_ntv_%s_%s)", prefix_name ? prefix_name : "unknown", key ? key : "unknown");
         break;
     case BE_NTVFUNC:
         logfmt("be_const_%sfunc(be_ntv_%s_%s)",
             var_isstatic(value) ? "static_" : "",
-            prefixname ? prefixname : "unknown", key ? key : "unknown");
+            prefix_name ? prefix_name : "unknown", key ? key : "unknown");
         break;
     case BE_INSTANCE:
     {
@@ -290,16 +290,16 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, 
             } else {
                 logfmt("        be_const_list( * ");
             }
-            m_solidify_bvalue(vm, str_literal, &ins->members[0], prefixname, key, fout);
+            m_solidify_bvalue(vm, str_literal, &ins->members[0], prefix_name, key, fout);
             logfmt("    ) } ))");
         }
     }
         break;
     case BE_MAP:
-        m_solidify_map(vm, str_literal, (bmap *) var_toobj(value), prefixname, fout);
+        m_solidify_map(vm, str_literal, (bmap *) var_toobj(value), prefix_name, fout);
         break;
     case BE_LIST:
-        m_solidify_list(vm, str_literal, (blist *) var_toobj(value), prefixname, fout);
+        m_solidify_list(vm, str_literal, (blist *) var_toobj(value), prefix_name, fout);
         break;
     default:
         {
@@ -316,7 +316,7 @@ static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cl, vo
 static void m_solidify_proto_inner_class(bvm *vm, bbool str_literal, const bproto *pr, void* fout)
 {
     // parse any class in constants to output it first
-    if (pr->nconst > 0) {
+    if ((pr->nconst > 0) && (!(pr->varg & BE_VA_SHARED_KTAB))) {        /* if shared ktab, this was done already earlier */
         for (int k = 0; k < pr->nconst; k++) {
             if (var_type(&pr->ktab[k]) == BE_CLASS) {
                 if ((k == 0) && (pr->varg & BE_VA_STATICMETHOD)) {
@@ -330,7 +330,7 @@ static void m_solidify_proto_inner_class(bvm *vm, bbool str_literal, const bprot
     }
 }
 
-static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const char * func_name, int indent, void* fout)
+static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const char * func_name, int indent, const char * prefix_name, void* fout)
 {
     logfmt("%*sbe_nested_proto(\n", indent, "");
     indent += 2;
@@ -357,7 +357,7 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%"PRId32, func_name, i);
-            m_solidify_proto(vm, str_literal, pr->ptab[i], sub_name, indent+2, fout);
+            m_solidify_proto(vm, str_literal, pr->ptab[i], sub_name, indent+2, prefix_name, fout);
             logfmt(",\n");
         }
         logfmt("%*s}),\n", indent, "");
@@ -367,13 +367,18 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const
 
     logfmt("%*s%d,                          /* has constants */\n", indent, "", (pr->nconst > 0) ? 1 : 0);
     if (pr->nconst > 0) {
-        logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
-        for (int k = 0; k < pr->nconst; k++) {
-            logfmt("%*s/* K%-3d */  ", indent, "", k);
-            m_solidify_bvalue(vm, str_literal, &pr->ktab[k], NULL, NULL, fout);
-            logfmt(",\n");
+        // we output the full table unless it's a shared ktab
+        if (pr->varg & BE_VA_SHARED_KTAB) {
+            logfmt("%*s&be_ktab_%s,     /* shared constants */\n", indent, "", prefix_name);
+        } else {
+            logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
+            for (int k = 0; k < pr->nconst; k++) {
+                logfmt("%*s/* K%-3d */  ", indent, "", k);
+                m_solidify_bvalue(vm, str_literal, &pr->ktab[k], NULL, NULL, fout);
+                logfmt(",\n");
+            }
+            logfmt("%*s}),\n", indent, "");
         }
-        logfmt("%*s}),\n", indent, "");
     } else {
         logfmt("%*sNULL,                       /* no const */\n", indent, "");
     }
@@ -413,7 +418,7 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const
 
 }
 
-static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, const char * prefixname, void* fout)
+static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, const char * prefix_name, void* fout)
 {   
     bproto *pr = clo->proto;
     const char * func_name = str(pr->name);
@@ -437,11 +442,11 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, 
         char func_name_id[id_len];
         toidentifier(func_name_id, func_name);
         logfmt("be_local_closure(%s%s%s,   /* name */\n",
-            prefixname ? prefixname : "", prefixname ? "_" : "",
+            prefix_name ? prefix_name : "", prefix_name ? "_" : "",
             func_name_id);
     }
 
-    m_solidify_proto(vm, str_literal, pr, func_name, indent, fout);
+    m_solidify_proto(vm, str_literal, pr, func_name, indent, prefix_name, fout);
     logfmt("\n");
 
     // closure
@@ -449,11 +454,17 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, 
     logfmt("/*******************************************************************/\n\n");
 }
 
+static void m_compact_class(bvm *vm, bbool str_literal, const bclass *cla, void* fout);
+
 static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cla, void* fout)
 {
     const char * classname = str(cla->name);
-    char prefixname[strlen(classname) + 10];
-    snprintf(prefixname, sizeof(prefixname), "class_%s", classname);
+
+    /* TODO try compacting for now */
+    m_compact_class(vm, str_literal, cla, fout);
+
+    char prefix_name[strlen(classname) + 10];
+    snprintf(prefix_name, sizeof(prefix_name), "class_%s", classname);
     /* pre-declare class to support '_class' implicit variable */
     logfmt("\nextern const bclass be_class_%s;\n", classname);
 
@@ -464,7 +475,7 @@ static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cla, v
         while ((node = be_map_next(cla->members, &iter)) != NULL) {
             if (var_isstr(&node->key) && var_isclosure(&node->value)) {
                 bclosure *f = var_toobj(&node->value);
-                m_solidify_closure(vm, str_literal, f, prefixname, fout);
+                m_solidify_closure(vm, str_literal, f, prefix_name, fout);
             }
         }
     }
@@ -488,7 +499,7 @@ static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cla, v
     }
 
     if (cla->members) {
-        m_solidify_map(vm, str_literal, cla->members, prefixname, fout);
+        m_solidify_map(vm, str_literal, cla->members, prefix_name, fout);
         logfmt(",\n");
     } else {
         logfmt("    NULL,\n");
@@ -514,8 +525,8 @@ static void m_solidify_module(bvm *vm, bbool str_literal, bmodule *ml, void* fou
 {
     const char * modulename = be_module_name(ml);
     if (!modulename) { modulename = ""; }
-    // char prefixname[strlen(modulename) + 10];
-    // snprintf(prefixname, sizeof(prefixname), "module_%s", modulename);
+    // char prefix_name[strlen(modulename) + 10];
+    // snprintf(prefix_name, sizeof(prefix_name), "module_%s", modulename);
 
     /* iterate on members to dump closures and classes */
     if (ml->table) {
@@ -571,12 +582,12 @@ static int m_dump(bvm *vm)
             }
             be_pop(vm, 1);
         }
-        const char *prefixname = NULL;  /* allow to specify an explicit prefix */
+        const char *prefix_name = NULL;  /* allow to specify an explicit prefix */
         if (top >= 4 && be_isstring(vm, 4)) {
-            prefixname = be_tostring(vm, 4);
+            prefix_name = be_tostring(vm, 4);
         }
         if (var_isclosure(v)) {
-            m_solidify_closure(vm, str_literal, var_toobj(v), prefixname, fout);
+            m_solidify_closure(vm, str_literal, var_toobj(v), prefix_name, fout);
         } else if (var_isclass(v)) {
             m_solidify_class(vm, str_literal, var_toobj(v), fout);
         } else if (var_ismodule(v)) {
@@ -588,9 +599,294 @@ static int m_dump(bvm *vm)
     be_return_nil(vm);
 }
 
+static void m_compact_class(bvm *vm, bbool str_literal, const bclass *cla, void* fout)
+{
+    const char * classname = str(cla->name);
+
+    /* reserve an array big enough for max size ktab (256) */
+    const int MAX_KTAB_SIZE = 256;
+    bvalue ktab[MAX_KTAB_SIZE];       /* size is 2048 byte for 32 bits, so fitting in ESP32, may need to be changed on smaller architectures */
+    int ktab_size = 0;
+
+    /* for statistics, keep the aggregate number of bvalues */
+    int ktab_total = 0;
+
+    /* iterate on members to dump closures */
+    if (cla->members) {
+        bmapnode *node;
+        bmapiter iter = be_map_iter();
+
+        /* first iteration to build the global ktab */
+        while ((node = be_map_next(cla->members, &iter)) != NULL) {
+            if (var_isstr(&node->key) && var_isclosure(&node->value)) {
+                bclosure *cl = var_toobj(&node->value);
+                bproto *pr = cl->proto;
+
+                if (pr->varg & BE_VA_SHARED_KTAB) { continue; }
+
+                // iterate on each bvalue in ktab
+                for (int i = 0; i < pr->nconst; i++) {
+                    // look if the bvalue pair is already in ktab
+                    int found = 0;
+                    for (int j = 0; j < ktab_size; j++) {
+                        // to avoid any size issue, we compare all bytes
+                        // berry_log_C("// p1=%p p2=%p sz=%i", &pr->ktab[i], &ktab[j], sizeof(bvalue));
+                        if ((pr->ktab[i].type == ktab[j].type) && (pr->ktab[i].v.i == ktab[j].v.i) && (pr->ktab[i].v.c == ktab[j].v.c)) {
+                        // if (memcmp(&pr->ktab[i], &ktab[j], sizeof(bvalue)) == 0) {
+                            found = 1;
+                            break;
+                        }
+                    }
+                    // if not already there, add it
+                    if (!found) {
+                        ktab[ktab_size++] = pr->ktab[i];
+                    }
+                    if (ktab_size >= MAX_KTAB_SIZE) {
+                        logfmt("// ktab too big for class '%s' - skipping\n", classname);
+                        return;
+                    }
+                }
+                ktab_total += pr->nconst;
+            }
+        }
+
+        if (ktab_size == ktab_total) {
+            return;         /* nothing to optimize, can happen for classes with zero or 1 method */
+        }
+        /* allocate a proper ktab */
+        bvalue *new_ktab = be_malloc(vm, sizeof(bvalue) * ktab_size);
+        memmove(new_ktab, ktab, sizeof(bvalue) * ktab_size);
+
+        /* second iteration to replace ktab and patch code */
+        iter = be_map_iter();
+        while ((node = be_map_next(cla->members, &iter)) != NULL) {
+            if (var_isstr(&node->key) && var_isclosure(&node->value)) {
+                bclosure *cl = var_toobj(&node->value);
+                bproto *pr = cl->proto;
+
+                if (pr->varg & BE_VA_SHARED_KTAB) { continue; }
+
+                uint8_t mapping_array[MAX_KTAB_SIZE];
+                // iterate in proto ktab to get the index in the global ktab
+                for (int i = 0; i < pr->nconst; i++) {
+                    for (int j = 0; j < ktab_size; j++) {
+                        // compare all bytes
+                        if ((pr->ktab[i].type == ktab[j].type) && (pr->ktab[i].v.i == ktab[j].v.i) && (pr->ktab[i].v.c == ktab[j].v.c)) {
+                        // if (memcmp(&pr->ktab[i], &ktab[j], sizeof(bvalue)) == 0) {
+                            mapping_array[i] = j;
+                            break;
+                        }
+                    }
+                }
+
+                // replace ktab
+                pr->ktab = new_ktab;
+                pr->nconst = ktab_size;
+                // flag as shared ktab
+                pr->varg |= BE_VA_SHARED_KTAB;
+                // parse code to replace any K<x> reference
+                for (int pc = 0; pc < pr->codesize; pc++) {
+                    uint32_t ins = pr->code[pc];
+                    bopcode op = IGET_OP(ins);
+
+           
+                    switch (op) {
+                    case OP_ADD: case OP_SUB: case OP_MUL: case OP_DIV:
+                    case OP_MOD: case OP_LT: case OP_LE: case OP_EQ:
+                    case OP_NE:  case OP_GT:  case OP_GE: case OP_CONNECT:
+                    case OP_GETMBR: case OP_SETMBR:  case OP_GETMET: case OP_SETMET:
+                    case OP_GETIDX: case OP_SETIDX: case OP_AND:
+                    case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
+                    case OP_RAISE:
+                        // B and C might contain 'K' constant
+                        if (isKB(ins)) {
+                            int kidx = IGET_RKB(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                        }
+                        if (isKC(ins)) {
+                            int kidx = IGET_RKC(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKC_MASK) | ISET_RKC(setK(mapping_array[kidx]));
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    case OP_MOVE: case OP_SETSUPER: case OP_NEG: case OP_FLIP: case OP_IMPORT:
+                    case OP_GETNGBL: case OP_SETNGBL:
+                        // Only B might contain 'K' constant
+                        if (isKB(ins)) {
+                            int kidx = IGET_RKB(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    case OP_CLASS:
+                    case OP_LDCONST:
+                        // Bx contains the K
+                        {
+                            int kidx = IGET_Bx(ins);
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IBx_MASK) | ISET_Bx(mapping_array[kidx]);
+                            pr->code[pc] = ins;
+                        }
+                        break;
+                    // case OP_GETGBL: case OP_SETGBL:
+                    //     logbuf("%s\tR%d\tG%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
+                    //     break;
+                    // case OP_MOVE: case OP_SETSUPER: case OP_NEG: case OP_FLIP: case OP_IMPORT:
+                    //     logbuf("%s\tR%d\t%c%d", opc2str(op), IGET_RA(ins),
+                    //             isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK);
+                    //     break;
+                    // case OP_JMP:
+                    //     logbuf("%s\t\t#%.4X", opc2str(op), IGET_sBx(ins) + pc + 1);
+                    //     break;
+                    // case OP_JMPT: case OP_JMPF:
+                    //     logbuf("%s\tR%d\t#%.4X", opc2str(op), IGET_RA(ins), IGET_sBx(ins) + pc + 1);
+                    //     break;
+                    // case OP_LDINT:
+                    //     logbuf("%s\tR%d\t%d", opc2str(op), IGET_RA(ins), IGET_sBx(ins));
+                    //     break;
+                    // case OP_LDBOOL:
+                    //     logbuf("%s\tR%d\t%d\t%d", opc2str(op),  IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
+                    //     break;
+                    case OP_RET:
+                        if (IGET_RA(ins)) {
+                            // Only B might contain 'K' constant
+                            if (isKB(ins)) {
+                                int kidx = IGET_RKB(ins) & KR_MASK;
+                                if (kidx >= ktab_size) {
+                                    be_raise(vm, "value_error", "invalid ktab index");
+                                }
+                                ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                            }
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    // case OP_GETUPV: case OP_SETUPV:
+                    //     logbuf("%s\tR%d\tU%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
+                    //     break;
+                    // case OP_LDCONST:
+                    //     logbuf("%s\tR%d\tK%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
+                    //     break;
+                    // case OP_CALL:
+                    //     logbuf("%s\tR%d\t%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins));
+                    //     break;
+                    // case OP_CLOSURE:
+                    //     logbuf("%s\tR%d\tP%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
+                    //     break;
+                    // case OP_CLASS:
+                    //     logbuf("%s\tK%d", opc2str(op), IGET_Bx(ins));
+                    //     break;
+                    // case OP_CLOSE: case OP_LDNIL:
+                    //     logbuf("%s\tR%d", opc2str(op), IGET_RA(ins));
+                    //     break;
+                    // case OP_RAISE:
+                    //     logbuf("%s\t%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),
+                    //             isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK,
+                    //             isKC(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
+                    //     break;
+                    // case OP_EXBLK:
+                    //     if (IGET_RA(ins)) {
+                    //         logbuf("%s\t%d\t%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
+                    //     } else {
+                    //         logbuf("%s\t%d\t#%.4X", opc2str(op), IGET_RA(ins), IGET_sBx(ins) + pc + 1);
+                    //     }
+                    //     break;
+                    // case OP_CATCH:
+                    //     logbuf("%s\tR%d\t%d\t%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
+                    //     break;
+                    default:
+                        break;
+                    }
+
+                }
+            }
+        }
+    }
+    // logfmt("extern const bclass be_class_%s;\n", classname);
+    // scan classes and generate extern statements for classes
+    for (int k = 0; k < ktab_size; k++) {
+        // if it's a class, print an extern statement
+        if (var_isclass(&ktab[k])) {
+            bclass *cl = var_toobj(&ktab[k]);
+            logfmt("extern const bclass be_class_%s;\n", str(cl->name));
+        }
+    }
+
+    // scan again to export all sub-classes
+    for (int k = 0; k < ktab_size; k++) {
+        // if it's a class, print an extern statement
+        if (var_isclass(&ktab[k])) {
+            bclass *cl = var_toobj(&ktab[k]);
+            if (cl != cla) {
+                m_solidify_subclass(vm, str_literal, cl, fout);
+            }
+        }
+    }
+
+    // output shared ktab
+    int indent = 0;
+    logfmt("// compact class '%s' ktab size: %d, total: %d (saved %i bytes)\n", classname, ktab_size, ktab_total, (ktab_total - ktab_size) * 8);
+    logfmt("static const bvalue be_ktab_class_%s[%i] = {\n", classname, ktab_size);
+    for (int k = 0; k < ktab_size; k++) {
+        logfmt("%*s/* K%-3d */  ", indent + 2, "", k);
+        m_solidify_bvalue(vm, str_literal, &ktab[k], NULL, NULL, fout);
+        logfmt(",\n");
+    }
+    logfmt("%*s};\n", indent, "");
+    logfmt("\n");
+}
+
+// takes a class or a module
+// scans all first level bproto
+// build a consolidated 'ktab' array
+// check that the array is not bigger than 256 (which is the max acceptable constants)
+// (for now) print the potential saving
+static int m_compact(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        bbool str_literal = bfalse;
+        if (top >= 2) {
+            str_literal = be_tobool(vm, 2);
+        }
+        void* fout = NULL;      /* output file */
+        if (top >= 3 && be_isinstance(vm, 3)) {
+            be_getmember(vm, 3, ".p");
+            if (be_iscomptr(vm, -1)) {
+                fout = be_tocomptr(vm, -1);
+            }
+            be_pop(vm, 1);
+        }
+        // const char *prefix_name = NULL;  /* allow to specify an explicit prefix */
+        // if (top >= 4 && be_isstring(vm, 4)) {
+        //     prefix_name = be_tostring(vm, 4);
+        // }
+        if (var_isclass(v)) {
+            m_compact_class(vm, str_literal, var_toobj(v), fout);
+        } else if (var_ismodule(v)) {
+            // TODO
+        } else {
+            be_raise(vm, "value_error", "unsupported type");
+        }
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(solidify) {
     be_native_module_function("dump", m_dump),
+    be_native_module_function("compact", m_compact),
 };
 
 be_define_native_module(solidify, NULL);
@@ -598,6 +894,7 @@ be_define_native_module(solidify, NULL);
 /* @const_object_info_begin
 module solidify (scope: global, depend: BE_USE_SOLIDIFY_MODULE) {
     dump, func(m_dump)
+    compact, func(m_compact)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_solidify.h"

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
@@ -3,6 +3,59 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Animate_core' ktab size: 49, total: 98 (saved 392 bytes)
+static const bvalue be_ktab_class_Animate_core[49] = {
+  /* K0   */  be_nested_str_weak(stop),
+  /* K1   */  be_nested_str_weak(strip),
+  /* K2   */  be_nested_str_weak(clear),
+  /* K3   */  be_nested_str_weak(set_bri),
+  /* K4   */  be_nested_str_weak(tasmota),
+  /* K5   */  be_nested_str_weak(scale_uint),
+  /* K6   */  be_nested_str_weak(bri),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(painters),
+  /* K9   */  be_nested_str_weak(remove),
+  /* K10  */  be_nested_str_weak(find),
+  /* K11  */  be_nested_str_weak(running),
+  /* K12  */  be_nested_str_weak(animators),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str_weak(remove_fast_loop),
+  /* K16  */  be_nested_str_weak(fast_loop_cb),
+  /* K17  */  be_nested_str_weak(set_strip_bri),
+  /* K18  */  be_nested_str_weak(push),
+  /* K19  */  be_nested_str_weak(time_reached),
+  /* K20  */  be_nested_str_weak(fast_loop_next),
+  /* K21  */  be_nested_str_weak(can_show),
+  /* K22  */  be_nested_str_weak(frame),
+  /* K23  */  be_nested_str_weak(fill_pixels),
+  /* K24  */  be_nested_str_weak(back_color),
+  /* K25  */  be_nested_str_weak(millis),
+  /* K26  */  be_nested_str_weak(FAST_LOOP_MIN),
+  /* K27  */  be_nested_str_weak(animate),
+  /* K28  */  be_nested_str_weak(layer),
+  /* K29  */  be_const_int(-16777216),
+  /* K30  */  be_nested_str_weak(paint),
+  /* K31  */  be_nested_str_weak(blend_pixels),
+  /* K32  */  be_nested_str_weak(obj),
+  /* K33  */  be_nested_str_weak(mth),
+  /* K34  */  be_nested_str_weak(paste_pixels),
+  /* K35  */  be_nested_str_weak(pixels_buffer),
+  /* K36  */  be_nested_str_weak(get_bri),
+  /* K37  */  be_nested_str_weak(get_gamma),
+  /* K38  */  be_nested_str_weak(dirty),
+  /* K39  */  be_nested_str_weak(show),
+  /* K40  */  be_nested_str_weak(global),
+  /* K41  */  be_nested_str_weak(_cur_anim),
+  /* K42  */  be_nested_str_weak(pixel_count),
+  /* K43  */  be_nested_str_weak(set_current),
+  /* K44  */  be_nested_str_weak(set_cb),
+  /* K45  */  be_nested_str_weak(set_back_color),
+  /* K46  */  be_nested_str_weak(add_animator),
+  /* K47  */  be_nested_str_weak(start),
+  /* K48  */  be_nested_str_weak(add_fast_loop),
+};
+
 
 extern const bclass be_class_Animate_core;
 
@@ -13,17 +66,13 @@ be_local_closure(class_Animate_core_clear,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop),
-    /* K1   */  be_nested_str_weak(strip),
-    /* K2   */  be_nested_str_weak(clear),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(clear),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
@@ -46,31 +95,24 @@ be_local_closure(class_Animate_core_set_strip_bri,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(strip),
-    /* K1   */  be_nested_str_weak(set_bri),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_nested_str_weak(bri),
-    /* K5   */  be_const_int(0),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(set_strip_bri),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
-      0x88140104,  //  0004  GETMBR	R5	R0	K4
-      0x58180005,  //  0005  LDCONST	R6	K5
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040303,  //  0001  GETMET	R1	R1	K3
+      0xB80E0800,  //  0002  GETNGBL	R3	K4
+      0x8C0C0705,  //  0003  GETMET	R3	R3	K5
+      0x88140106,  //  0004  GETMBR	R5	R0	K6
+      0x58180007,  //  0005  LDCONST	R6	K7
       0x541E0063,  //  0006  LDINT	R7	100
-      0x58200005,  //  0007  LDCONST	R8	K5
+      0x58200007,  //  0007  LDCONST	R8	K7
       0x542600FE,  //  0008  LDINT	R9	255
       0x7C0C0C00,  //  0009  CALL	R3	6
       0x7C040400,  //  000A  CALL	R1	2
@@ -88,32 +130,27 @@ be_local_closure(class_Animate_core_remove_painter,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(painters),
-    /* K1   */  be_nested_str_weak(remove),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(clear),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(remove_painter),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080108,  //  0000  GETMBR	R2	R0	K8
       0x4C0C0000,  //  0001  LDNIL	R3
       0x200C0203,  //  0002  NE	R3	R1	R3
       0x780E0005,  //  0003  JMPF	R3	#000A
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x8C140502,  //  0005  GETMET	R5	R2	K2
+      0x8C0C0509,  //  0004  GETMET	R3	R2	K9
+      0x8C14050A,  //  0005  GETMET	R5	R2	K10
       0x5C1C0200,  //  0006  MOVE	R7	R1
       0x7C140400,  //  0007  CALL	R5	2
       0x7C0C0400,  //  0008  CALL	R3	2
       0x70020001,  //  0009  JMP		#000C
-      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
       0x7C0C0200,  //  000B  CALL	R3	1
       0x80000000,  //  000C  RET	0
     })
@@ -129,42 +166,33 @@ be_local_closure(class_Animate_core_stop,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_nested_str_weak(animators),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(remove_fast_loop),
-    /* K7   */  be_nested_str_weak(fast_loop_cb),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(stop),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x58080002,  //  0003  LDCONST	R2	K2
+      0x90021601,  //  0001  SETMBR	R0	K11	R1
+      0x8804010C,  //  0002  GETMBR	R1	R0	K12
+      0x5808000D,  //  0003  LDCONST	R2	K13
       0x600C000C,  //  0004  GETGBL	R3	G12
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C0C0200,  //  0006  CALL	R3	1
       0x140C0403,  //  0007  LT	R3	R2	R3
       0x780E0004,  //  0008  JMPF	R3	#000E
       0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
+      0x8C0C0700,  //  000A  GETMET	R3	R3	K0
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x00080504,  //  000C  ADD	R2	R2	K4
+      0x0008050E,  //  000C  ADD	R2	R2	K14
       0x7001FFF5,  //  000D  JMP		#0004
-      0xB80E0A00,  //  000E  GETNGBL	R3	K5
-      0x8C0C0706,  //  000F  GETMET	R3	R3	K6
-      0x88140107,  //  0010  GETMBR	R5	R0	K7
+      0xB80E0800,  //  000E  GETNGBL	R3	K4
+      0x8C0C070F,  //  000F  GETMET	R3	R3	K15
+      0x88140110,  //  0010  GETMBR	R5	R0	K16
       0x7C0C0400,  //  0011  CALL	R3	2
       0x80000000,  //  0012  RET	0
     })
@@ -180,19 +208,17 @@ be_local_closure(class_Animate_core_get_bri,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(get_bri),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080106,  //  0000  GETMBR	R2	R0	K6
       0x80040400,  //  0001  RET	1	R2
     })
   )
@@ -207,21 +233,18 @@ be_local_closure(class_Animate_core_set_bri,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
-    /* K1   */  be_nested_str_weak(set_strip_bri),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(set_bri),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x90020C01,  //  0000  SETMBR	R0	K6	R1
+      0x8C080111,  //  0001  GETMET	R2	R0	K17
       0x7C080200,  //  0002  CALL	R2	1
       0x80000000,  //  0003  RET	0
     })
@@ -237,29 +260,25 @@ be_local_closure(class_Animate_core_add_painter,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(painters),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(add_painter),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080108,  //  0000  GETMBR	R2	R0	K8
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C080403,  //  0005  EQ	R2	R2	R3
       0x780A0003,  //  0006  JMPF	R2	#000B
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x88080108,  //  0007  GETMBR	R2	R0	K8
+      0x8C080512,  //  0008  GETMET	R2	R2	K18
       0x5C100200,  //  0009  MOVE	R4	R1
       0x7C080400,  //  000A  CALL	R2	2
       0x80000000,  //  000B  RET	0
@@ -276,67 +295,38 @@ be_local_closure(class_Animate_core_fast_loop,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(time_reached),
-    /* K3   */  be_nested_str_weak(fast_loop_next),
-    /* K4   */  be_nested_str_weak(strip),
-    /* K5   */  be_nested_str_weak(can_show),
-    /* K6   */  be_nested_str_weak(frame),
-    /* K7   */  be_nested_str_weak(fill_pixels),
-    /* K8   */  be_nested_str_weak(back_color),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(millis),
-    /* K11  */  be_nested_str_weak(FAST_LOOP_MIN),
-    /* K12  */  be_nested_str_weak(animators),
-    /* K13  */  be_nested_str_weak(animate),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(layer),
-    /* K16  */  be_nested_str_weak(painters),
-    /* K17  */  be_const_int(-16777216),
-    /* K18  */  be_nested_str_weak(paint),
-    /* K19  */  be_nested_str_weak(blend_pixels),
-    /* K20  */  be_nested_str_weak(obj),
-    /* K21  */  be_nested_str_weak(mth),
-    /* K22  */  be_nested_str_weak(paste_pixels),
-    /* K23  */  be_nested_str_weak(pixels_buffer),
-    /* K24  */  be_nested_str_weak(get_bri),
-    /* K25  */  be_nested_str_weak(get_gamma),
-    /* K26  */  be_nested_str_weak(dirty),
-    /* K27  */  be_nested_str_weak(show),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(fast_loop),
     &be_const_str_solidified,
     ( &(const binstruction[84]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010B,  //  0000  GETMBR	R1	R0	K11
       0x78060050,  //  0001  JMPF	R1	#0053
-      0xB8060200,  //  0002  GETNGBL	R1	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x880C0103,  //  0004  GETMBR	R3	R0	K3
+      0xB8060800,  //  0002  GETNGBL	R1	K4
+      0x8C040313,  //  0003  GETMET	R1	R1	K19
+      0x880C0114,  //  0004  GETMBR	R3	R0	K20
       0x7C040400,  //  0005  CALL	R1	2
       0x7806004B,  //  0006  JMPF	R1	#0053
-      0x88040104,  //  0007  GETMBR	R1	R0	K4
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x88040101,  //  0007  GETMBR	R1	R0	K1
+      0x8C040315,  //  0008  GETMET	R1	R1	K21
       0x7C040200,  //  0009  CALL	R1	1
       0x78060047,  //  000A  JMPF	R1	#0053
-      0x88040106,  //  000B  GETMBR	R1	R0	K6
-      0x8C040307,  //  000C  GETMET	R1	R1	K7
-      0x880C0108,  //  000D  GETMBR	R3	R0	K8
+      0x88040116,  //  000B  GETMBR	R1	R0	K22
+      0x8C040317,  //  000C  GETMET	R1	R1	K23
+      0x880C0118,  //  000D  GETMBR	R3	R0	K24
       0x7C040400,  //  000E  CALL	R1	2
-      0x58040009,  //  000F  LDCONST	R1	K9
-      0xB80A0200,  //  0010  GETNGBL	R2	K1
-      0x8C08050A,  //  0011  GETMET	R2	R2	K10
+      0x58040007,  //  000F  LDCONST	R1	K7
+      0xB80A0800,  //  0010  GETNGBL	R2	K4
+      0x8C080519,  //  0011  GETMET	R2	R2	K25
       0x7C080200,  //  0012  CALL	R2	1
-      0x880C010B,  //  0013  GETMBR	R3	R0	K11
+      0x880C011A,  //  0013  GETMBR	R3	R0	K26
       0x000C0403,  //  0014  ADD	R3	R2	R3
-      0x90020603,  //  0015  SETMBR	R0	K3	R3
+      0x90022803,  //  0015  SETMBR	R0	K20	R3
       0x600C000C,  //  0016  GETGBL	R3	G12
       0x8810010C,  //  0017  GETMBR	R4	R0	K12
       0x7C0C0200,  //  0018  CALL	R3	1
@@ -344,59 +334,59 @@ be_local_closure(class_Animate_core_fast_loop,   /* name */
       0x780E0006,  //  001A  JMPF	R3	#0022
       0x880C010C,  //  001B  GETMBR	R3	R0	K12
       0x940C0601,  //  001C  GETIDX	R3	R3	R1
-      0x8C0C070D,  //  001D  GETMET	R3	R3	K13
+      0x8C0C071B,  //  001D  GETMET	R3	R3	K27
       0x5C140400,  //  001E  MOVE	R5	R2
       0x7C0C0400,  //  001F  CALL	R3	2
       0x0004030E,  //  0020  ADD	R1	R1	K14
       0x7001FFF3,  //  0021  JMP		#0016
-      0x58040009,  //  0022  LDCONST	R1	K9
-      0x880C0106,  //  0023  GETMBR	R3	R0	K6
-      0x8810010F,  //  0024  GETMBR	R4	R0	K15
+      0x58040007,  //  0022  LDCONST	R1	K7
+      0x880C0116,  //  0023  GETMBR	R3	R0	K22
+      0x8810011C,  //  0024  GETMBR	R4	R0	K28
       0x6014000C,  //  0025  GETGBL	R5	G12
-      0x88180110,  //  0026  GETMBR	R6	R0	K16
+      0x88180108,  //  0026  GETMBR	R6	R0	K8
       0x7C140200,  //  0027  CALL	R5	1
       0x14140205,  //  0028  LT	R5	R1	R5
       0x7816000D,  //  0029  JMPF	R5	#0038
-      0x8C140907,  //  002A  GETMET	R5	R4	K7
-      0x581C0011,  //  002B  LDCONST	R7	K17
+      0x8C140917,  //  002A  GETMET	R5	R4	K23
+      0x581C001D,  //  002B  LDCONST	R7	K29
       0x7C140400,  //  002C  CALL	R5	2
-      0x88140110,  //  002D  GETMBR	R5	R0	K16
+      0x88140108,  //  002D  GETMBR	R5	R0	K8
       0x94140A01,  //  002E  GETIDX	R5	R5	R1
-      0x8C140B12,  //  002F  GETMET	R5	R5	K18
+      0x8C140B1E,  //  002F  GETMET	R5	R5	K30
       0x5C1C0800,  //  0030  MOVE	R7	R4
       0x7C140400,  //  0031  CALL	R5	2
       0x78160002,  //  0032  JMPF	R5	#0036
-      0x8C140713,  //  0033  GETMET	R5	R3	K19
+      0x8C14071F,  //  0033  GETMET	R5	R3	K31
       0x5C1C0800,  //  0034  MOVE	R7	R4
       0x7C140400,  //  0035  CALL	R5	2
       0x0004030E,  //  0036  ADD	R1	R1	K14
       0x7001FFEC,  //  0037  JMP		#0025
-      0x88140114,  //  0038  GETMBR	R5	R0	K20
-      0x88180115,  //  0039  GETMBR	R6	R0	K21
+      0x88140120,  //  0038  GETMBR	R5	R0	K32
+      0x88180121,  //  0039  GETMBR	R6	R0	K33
       0x78160003,  //  003A  JMPF	R5	#003F
       0x781A0002,  //  003B  JMPF	R6	#003F
       0x5C1C0C00,  //  003C  MOVE	R7	R6
       0x5C200A00,  //  003D  MOVE	R8	R5
       0x7C1C0200,  //  003E  CALL	R7	1
-      0x8C1C010D,  //  003F  GETMET	R7	R0	K13
+      0x8C1C011B,  //  003F  GETMET	R7	R0	K27
       0x7C1C0200,  //  0040  CALL	R7	1
-      0x881C0106,  //  0041  GETMBR	R7	R0	K6
-      0x8C1C0F16,  //  0042  GETMET	R7	R7	K22
-      0x88240104,  //  0043  GETMBR	R9	R0	K4
-      0x8C241317,  //  0044  GETMET	R9	R9	K23
+      0x881C0116,  //  0041  GETMBR	R7	R0	K22
+      0x8C1C0F22,  //  0042  GETMET	R7	R7	K34
+      0x88240101,  //  0043  GETMBR	R9	R0	K1
+      0x8C241323,  //  0044  GETMET	R9	R9	K35
       0x7C240200,  //  0045  CALL	R9	1
-      0x88280104,  //  0046  GETMBR	R10	R0	K4
-      0x8C281518,  //  0047  GETMET	R10	R10	K24
+      0x88280101,  //  0046  GETMBR	R10	R0	K1
+      0x8C281524,  //  0047  GETMET	R10	R10	K36
       0x7C280200,  //  0048  CALL	R10	1
-      0x882C0104,  //  0049  GETMBR	R11	R0	K4
-      0x8C2C1719,  //  004A  GETMET	R11	R11	K25
+      0x882C0101,  //  0049  GETMBR	R11	R0	K1
+      0x8C2C1725,  //  004A  GETMET	R11	R11	K37
       0x7C2C0200,  //  004B  CALL	R11	1
       0x7C1C0800,  //  004C  CALL	R7	4
-      0x881C0104,  //  004D  GETMBR	R7	R0	K4
-      0x8C1C0F1A,  //  004E  GETMET	R7	R7	K26
+      0x881C0101,  //  004D  GETMBR	R7	R0	K1
+      0x8C1C0F26,  //  004E  GETMET	R7	R7	K38
       0x7C1C0200,  //  004F  CALL	R7	1
-      0x881C0104,  //  0050  GETMBR	R7	R0	K4
-      0x8C1C0F1B,  //  0051  GETMET	R7	R7	K27
+      0x881C0101,  //  0050  GETMBR	R7	R0	K1
+      0x8C1C0F27,  //  0051  GETMET	R7	R7	K39
       0x7C1C0200,  //  0052  CALL	R7	1
       0x80000000,  //  0053  RET	0
     })
@@ -412,32 +402,27 @@ be_local_closure(class_Animate_core_remove_animator,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(remove),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(clear),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(remove_animator),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
       0x4C0C0000,  //  0001  LDNIL	R3
       0x200C0203,  //  0002  NE	R3	R1	R3
       0x780E0005,  //  0003  JMPF	R3	#000A
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x8C140502,  //  0005  GETMET	R5	R2	K2
+      0x8C0C0509,  //  0004  GETMET	R3	R2	K9
+      0x8C14050A,  //  0005  GETMET	R5	R2	K10
       0x5C1C0200,  //  0006  MOVE	R7	R1
       0x7C140400,  //  0007  CALL	R5	2
       0x7C0C0400,  //  0008  CALL	R3	2
       0x70020001,  //  0009  JMP		#000C
-      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
       0x7C0C0200,  //  000B  CALL	R3	1
       0x80000000,  //  000C  RET	0
     })
@@ -453,13 +438,13 @@ be_local_closure(class_Animate_core_animate,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(animate),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -477,21 +462,18 @@ be_local_closure(class_Animate_core_set_current,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_cur_anim),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(set_current),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x90060200,  //  0001  SETMBR	R1	K1	R0
+      0xB8065000,  //  0000  GETNGBL	R1	K40
+      0x90065200,  //  0001  SETMBR	R1	K41	R0
       0x80000000,  //  0002  RET	0
     })
   )
@@ -506,7 +488,7 @@ be_local_closure(class_Animate_core_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -536,60 +518,44 @@ be_local_closure(class_Animate_core_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animate),
-    /* K1   */  be_nested_str_weak(strip),
-    /* K2   */  be_nested_str_weak(bri),
-    /* K3   */  be_nested_str_weak(set_strip_bri),
-    /* K4   */  be_nested_str_weak(running),
-    /* K5   */  be_nested_str_weak(pixel_count),
-    /* K6   */  be_nested_str_weak(animators),
-    /* K7   */  be_nested_str_weak(painters),
-    /* K8   */  be_nested_str_weak(clear),
-    /* K9   */  be_nested_str_weak(frame),
-    /* K10  */  be_nested_str_weak(layer),
-    /* K11  */  be_nested_str_weak(fast_loop_cb),
-    /* K12  */  be_nested_str_weak(back_color),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(set_current),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA40E3600,  //  0000  IMPORT	R3	K27
       0x90020201,  //  0001  SETMBR	R0	K1	R1
       0x4C100000,  //  0002  LDNIL	R4
       0x1C100404,  //  0003  EQ	R4	R2	R4
       0x78120000,  //  0004  JMPF	R4	#0006
       0x540A0031,  //  0005  LDINT	R2	50
-      0x90020402,  //  0006  SETMBR	R0	K2	R2
-      0x8C100103,  //  0007  GETMET	R4	R0	K3
+      0x90020C02,  //  0006  SETMBR	R0	K6	R2
+      0x8C100111,  //  0007  GETMET	R4	R0	K17
       0x7C100200,  //  0008  CALL	R4	1
       0x50100000,  //  0009  LDBOOL	R4	0	0
-      0x90020804,  //  000A  SETMBR	R0	K4	R4
-      0x8C100305,  //  000B  GETMET	R4	R1	K5
+      0x90021604,  //  000A  SETMBR	R0	K11	R4
+      0x8C10032A,  //  000B  GETMET	R4	R1	K42
       0x7C100200,  //  000C  CALL	R4	1
-      0x90020A04,  //  000D  SETMBR	R0	K5	R4
+      0x90025404,  //  000D  SETMBR	R0	K42	R4
       0x60100012,  //  000E  GETGBL	R4	G18
       0x7C100000,  //  000F  CALL	R4	0
-      0x90020C04,  //  0010  SETMBR	R0	K6	R4
+      0x90021804,  //  0010  SETMBR	R0	K12	R4
       0x60100012,  //  0011  GETGBL	R4	G18
       0x7C100000,  //  0012  CALL	R4	0
-      0x90020E04,  //  0013  SETMBR	R0	K7	R4
-      0x8C100108,  //  0014  GETMET	R4	R0	K8
+      0x90021004,  //  0013  SETMBR	R0	K8	R4
+      0x8C100102,  //  0014  GETMET	R4	R0	K2
       0x7C100200,  //  0015  CALL	R4	1
-      0x8C100709,  //  0016  GETMET	R4	R3	K9
-      0x88180105,  //  0017  GETMBR	R6	R0	K5
+      0x8C100716,  //  0016  GETMET	R4	R3	K22
+      0x8818012A,  //  0017  GETMBR	R6	R0	K42
       0x7C100400,  //  0018  CALL	R4	2
-      0x90021204,  //  0019  SETMBR	R0	K9	R4
-      0x8C100709,  //  001A  GETMET	R4	R3	K9
-      0x88180105,  //  001B  GETMBR	R6	R0	K5
+      0x90022C04,  //  0019  SETMBR	R0	K22	R4
+      0x8C100716,  //  001A  GETMET	R4	R3	K22
+      0x8818012A,  //  001B  GETMBR	R6	R0	K42
       0x7C100400,  //  001C  CALL	R4	2
-      0x90021404,  //  001D  SETMBR	R0	K10	R4
+      0x90023804,  //  001D  SETMBR	R0	K28	R4
       0x84100000,  //  001E  CLOSURE	R4	P0
-      0x90021604,  //  001F  SETMBR	R0	K11	R4
-      0x9002190D,  //  0020  SETMBR	R0	K12	K13
-      0x8C10010E,  //  0021  GETMET	R4	R0	K14
+      0x90022004,  //  001F  SETMBR	R0	K16	R4
+      0x90023107,  //  0020  SETMBR	R0	K24	K7
+      0x8C10012B,  //  0021  GETMET	R4	R0	K43
       0x7C100200,  //  0022  CALL	R4	1
       0xA0000000,  //  0023  CLOSE	R0
       0x80000000,  //  0024  RET	0
@@ -606,21 +572,18 @@ be_local_closure(class_Animate_core_set_cb,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(obj),
-    /* K1   */  be_nested_str_weak(mth),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(set_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90024001,  //  0000  SETMBR	R0	K32	R1
+      0x90024202,  //  0001  SETMBR	R0	K33	R2
       0x80000000,  //  0002  RET	0
     })
   )
@@ -635,19 +598,17 @@ be_local_closure(class_Animate_core_set_back_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(back_color),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(set_back_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90023001,  //  0000  SETMBR	R0	K24	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -662,25 +623,21 @@ be_local_closure(class_Animate_core_add_background_animator,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_cb),
-    /* K1   */  be_nested_str_weak(set_back_color),
-    /* K2   */  be_nested_str_weak(add_animator),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(add_background_animator),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x8C08032C,  //  0000  GETMET	R2	R1	K44
       0x5C100000,  //  0001  MOVE	R4	R0
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x8814012D,  //  0002  GETMBR	R5	R0	K45
       0x7C080600,  //  0003  CALL	R2	3
-      0x8C080102,  //  0004  GETMET	R2	R0	K2
+      0x8C08012E,  //  0004  GETMET	R2	R0	K46
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
       0x80000000,  //  0007  RET	0
@@ -697,29 +654,25 @@ be_local_closure(class_Animate_core_add_animator,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(add_animator),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C080403,  //  0005  EQ	R2	R2	R3
       0x780A0003,  //  0006  JMPF	R2	#000B
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x8808010C,  //  0007  GETMBR	R2	R0	K12
+      0x8C080512,  //  0008  GETMET	R2	R2	K18
       0x5C100200,  //  0009  MOVE	R4	R1
       0x7C080400,  //  000A  CALL	R2	2
       0x80000000,  //  000B  RET	0
@@ -736,26 +689,21 @@ be_local_closure(class_Animate_core_remove,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clear),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_fast_loop),
-    /* K3   */  be_nested_str_weak(fast_loop_cb),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(remove),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040102,  //  0000  GETMET	R1	R0	K2
       0x7C040200,  //  0001  CALL	R1	1
-      0xB8060200,  //  0002  GETNGBL	R1	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x880C0103,  //  0004  GETMBR	R3	R0	K3
+      0xB8060800,  //  0002  GETNGBL	R1	K4
+      0x8C04030F,  //  0003  GETMET	R1	R1	K15
+      0x880C0110,  //  0004  GETMBR	R3	R0	K16
       0x7C040400,  //  0005  CALL	R1	2
       0x80000000,  //  0006  RET	0
     })
@@ -771,44 +719,34 @@ be_local_closure(class_Animate_core_start,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_nested_str_weak(animators),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fast_loop_next),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(add_fast_loop),
-    /* K8   */  be_nested_str_weak(fast_loop_cb),
-    }),
+    &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
       0x50040200,  //  0000  LDBOOL	R1	1	0
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x58080002,  //  0003  LDCONST	R2	K2
+      0x90021601,  //  0001  SETMBR	R0	K11	R1
+      0x8804010C,  //  0002  GETMBR	R1	R0	K12
+      0x5808000D,  //  0003  LDCONST	R2	K13
       0x600C000C,  //  0004  GETGBL	R3	G12
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C0C0200,  //  0006  CALL	R3	1
       0x140C0403,  //  0007  LT	R3	R2	R3
       0x780E0004,  //  0008  JMPF	R3	#000E
       0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
+      0x8C0C072F,  //  000A  GETMET	R3	R3	K47
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x00080504,  //  000C  ADD	R2	R2	K4
+      0x0008050E,  //  000C  ADD	R2	R2	K14
       0x7001FFF5,  //  000D  JMP		#0004
-      0x90020B02,  //  000E  SETMBR	R0	K5	K2
-      0xB80E0C00,  //  000F  GETNGBL	R3	K6
-      0x8C0C0707,  //  0010  GETMET	R3	R3	K7
-      0x88140108,  //  0011  GETMBR	R5	R0	K8
+      0x9002290D,  //  000E  SETMBR	R0	K20	K13
+      0xB80E0800,  //  000F  GETNGBL	R3	K4
+      0x8C0C0730,  //  0010  GETMET	R3	R3	K48
+      0x88140110,  //  0011  GETMBR	R5	R0	K16
       0x7C0C0400,  //  0012  CALL	R3	2
       0x80000000,  //  0013  RET	0
     })

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_2_animate_effects.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_2_animate_effects.h
@@ -79,6 +79,25 @@ be_local_class(Animate_painter,
     })),
     be_str_weak(Animate_painter)
 );
+// compact class 'Animate_pulse' ktab size: 15, total: 28 (saved 104 bytes)
+static const bvalue be_ktab_class_Animate_pulse[15] = {
+  /* K0   */  be_nested_str_weak(pulse_size),
+  /* K1   */  be_nested_str_weak(slew_size),
+  /* K2   */  be_nested_str_weak(back_color),
+  /* K3   */  be_nested_str_weak(pos),
+  /* K4   */  be_nested_str_weak(color),
+  /* K5   */  be_nested_str_weak(init),
+  /* K6   */  be_const_int(16777215),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_const_int(-16777216),
+  /* K10  */  be_nested_str_weak(fill_pixels),
+  /* K11  */  be_nested_str_weak(pixel_size),
+  /* K12  */  be_nested_str_weak(blend),
+  /* K13  */  be_nested_str_weak(tasmota),
+  /* K14  */  be_nested_str_weak(scale_int),
+};
+
 
 extern const bclass be_class_Animate_pulse;
 
@@ -89,15 +108,13 @@ be_local_closure(class_Animate_pulse_set_pulse_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pulse_size),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(set_pulse_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -116,19 +133,17 @@ be_local_closure(class_Animate_pulse_set_slew_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(slew_size),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(set_slew_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020201,  //  0000  SETMBR	R0	K1	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -143,19 +158,17 @@ be_local_closure(class_Animate_pulse_set_back_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(back_color),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(set_back_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020401,  //  0000  SETMBR	R0	K2	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -170,19 +183,17 @@ be_local_closure(class_Animate_pulse_set_pos,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pos),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(set_pos),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020601,  //  0000  SETMBR	R0	K3	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -197,19 +208,17 @@ be_local_closure(class_Animate_pulse_set_color,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(color),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(set_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020801,  //  0000  SETMBR	R0	K4	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -224,55 +233,44 @@ be_local_closure(class_Animate_pulse_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_const_int(16777215),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(color),
-    /* K5   */  be_nested_str_weak(back_color),
-    /* K6   */  be_const_int(-16777216),
-    /* K7   */  be_nested_str_weak(pulse_size),
-    /* K8   */  be_nested_str_weak(slew_size),
-    /* K9   */  be_nested_str_weak(pos),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100905,  //  0003  GETMET	R4	R4	K5
       0x7C100200,  //  0004  CALL	R4	1
       0x4C100000,  //  0005  LDNIL	R4
       0x1C100204,  //  0006  EQ	R4	R1	R4
       0x78120000,  //  0007  JMPF	R4	#0009
-      0x58040001,  //  0008  LDCONST	R1	K1
+      0x58040006,  //  0008  LDCONST	R1	K6
       0x4C100000,  //  0009  LDNIL	R4
       0x1C100404,  //  000A  EQ	R4	R2	R4
       0x78120000,  //  000B  JMPF	R4	#000D
-      0x58080002,  //  000C  LDCONST	R2	K2
+      0x58080007,  //  000C  LDCONST	R2	K7
       0x4C100000,  //  000D  LDNIL	R4
       0x1C100604,  //  000E  EQ	R4	R3	R4
       0x78120000,  //  000F  JMPF	R4	#0011
-      0x580C0003,  //  0010  LDCONST	R3	K3
+      0x580C0008,  //  0010  LDCONST	R3	K8
       0x90020801,  //  0011  SETMBR	R0	K4	R1
-      0x90020B06,  //  0012  SETMBR	R0	K5	K6
-      0x14100503,  //  0013  LT	R4	R2	K3
+      0x90020509,  //  0012  SETMBR	R0	K2	K9
+      0x14100508,  //  0013  LT	R4	R2	K8
       0x78120000,  //  0014  JMPF	R4	#0016
-      0x58080003,  //  0015  LDCONST	R2	K3
-      0x90020E02,  //  0016  SETMBR	R0	K7	R2
-      0x14100703,  //  0017  LT	R4	R3	K3
+      0x58080008,  //  0015  LDCONST	R2	K8
+      0x90020002,  //  0016  SETMBR	R0	K0	R2
+      0x14100708,  //  0017  LT	R4	R3	K8
       0x78120000,  //  0018  JMPF	R4	#001A
-      0x580C0003,  //  0019  LDCONST	R3	K3
-      0x90021003,  //  001A  SETMBR	R0	K8	R3
-      0x90021303,  //  001B  SETMBR	R0	K9	K3
+      0x580C0008,  //  0019  LDCONST	R3	K8
+      0x90020203,  //  001A  SETMBR	R0	K1	R3
+      0x90020708,  //  001B  SETMBR	R0	K3	K8
       0x80000000,  //  001C  RET	0
     })
   )
@@ -287,41 +285,27 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
   be_nested_proto(
     22,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(back_color),
-    /* K1   */  be_const_int(-16777216),
-    /* K2   */  be_nested_str_weak(fill_pixels),
-    /* K3   */  be_nested_str_weak(pos),
-    /* K4   */  be_nested_str_weak(slew_size),
-    /* K5   */  be_nested_str_weak(pulse_size),
-    /* K6   */  be_nested_str_weak(color),
-    /* K7   */  be_nested_str_weak(pixel_size),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(blend),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(scale_int),
-    }),
+    &be_ktab_class_Animate_pulse,     /* shared constants */
     be_str_weak(paint),
     &be_const_str_solidified,
     ( &(const binstruction[91]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x200C0501,  //  0001  NE	R3	R2	K1
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x200C0509,  //  0001  NE	R3	R2	K9
       0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
+      0x8C0C030A,  //  0003  GETMET	R3	R1	K10
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
       0x880C0103,  //  0006  GETMBR	R3	R0	K3
-      0x88100104,  //  0007  GETMBR	R4	R0	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
-      0x88180106,  //  0009  GETMBR	R6	R0	K6
-      0x881C0307,  //  000A  GETMBR	R7	R1	K7
+      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x88140100,  //  0008  GETMBR	R5	R0	K0
+      0x88180104,  //  0009  GETMBR	R6	R0	K4
+      0x881C030B,  //  000A  GETMBR	R7	R1	K11
       0x4C200000,  //  000B  LDNIL	R8
       0x4C240000,  //  000C  LDNIL	R9
       0x5C200600,  //  000D  MOVE	R8	R3
@@ -337,7 +321,7 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
       0x142C1409,  //  0017  LT	R11	R10	R9
       0x782E0002,  //  0018  JMPF	R11	#001C
       0x98041406,  //  0019  SETIDX	R1	R10	R6
-      0x00281509,  //  001A  ADD	R10	R10	K9
+      0x00281507,  //  001A  ADD	R10	R10	K7
       0x7001FFFA,  //  001B  JMP		#0017
       0x242C0908,  //  001C  GT	R11	R4	K8
       0x782E003A,  //  001D  JMPF	R11	#0059
@@ -353,21 +337,21 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
       0x5C281000,  //  0027  MOVE	R10	R8
       0x142C1409,  //  0028  LT	R11	R10	R9
       0x782E000F,  //  0029  JMPF	R11	#003A
-      0x8C2C030A,  //  002A  GETMET	R11	R1	K10
+      0x8C2C030C,  //  002A  GETMET	R11	R1	K12
       0x5C340400,  //  002B  MOVE	R13	R2
       0x5C380C00,  //  002C  MOVE	R14	R6
-      0xB83E1600,  //  002D  GETNGBL	R15	K11
-      0x8C3C1F0C,  //  002E  GETMET	R15	R15	K12
+      0xB83E1A00,  //  002D  GETNGBL	R15	K13
+      0x8C3C1F0E,  //  002E  GETMET	R15	R15	K14
       0x5C441400,  //  002F  MOVE	R17	R10
       0x04480604,  //  0030  SUB	R18	R3	R4
-      0x04482509,  //  0031  SUB	R18	R18	K9
+      0x04482507,  //  0031  SUB	R18	R18	K7
       0x5C4C0600,  //  0032  MOVE	R19	R3
       0x545200FE,  //  0033  LDINT	R20	255
       0x58540008,  //  0034  LDCONST	R21	K8
       0x7C3C0C00,  //  0035  CALL	R15	6
       0x7C2C0800,  //  0036  CALL	R11	4
       0x9804140B,  //  0037  SETIDX	R1	R10	R11
-      0x00281509,  //  0038  ADD	R10	R10	K9
+      0x00281507,  //  0038  ADD	R10	R10	K7
       0x7001FFED,  //  0039  JMP		#0028
       0x002C0605,  //  003A  ADD	R11	R3	R5
       0x5C201600,  //  003B  MOVE	R8	R11
@@ -383,14 +367,14 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
       0x5C281000,  //  0045  MOVE	R10	R8
       0x142C1409,  //  0046  LT	R11	R10	R9
       0x782E0010,  //  0047  JMPF	R11	#0059
-      0x8C2C030A,  //  0048  GETMET	R11	R1	K10
+      0x8C2C030C,  //  0048  GETMET	R11	R1	K12
       0x5C340400,  //  0049  MOVE	R13	R2
       0x5C380C00,  //  004A  MOVE	R14	R6
-      0xB83E1600,  //  004B  GETNGBL	R15	K11
-      0x8C3C1F0C,  //  004C  GETMET	R15	R15	K12
+      0xB83E1A00,  //  004B  GETNGBL	R15	K13
+      0x8C3C1F0E,  //  004C  GETMET	R15	R15	K14
       0x5C441400,  //  004D  MOVE	R17	R10
       0x00480605,  //  004E  ADD	R18	R3	R5
-      0x04482509,  //  004F  SUB	R18	R18	K9
+      0x04482507,  //  004F  SUB	R18	R18	K7
       0x004C0605,  //  0050  ADD	R19	R3	R5
       0x004C2604,  //  0051  ADD	R19	R19	R4
       0x58500008,  //  0052  LDCONST	R20	K8
@@ -398,7 +382,7 @@ be_local_closure(class_Animate_pulse_paint,   /* name */
       0x7C3C0C00,  //  0054  CALL	R15	6
       0x7C2C0800,  //  0055  CALL	R11	4
       0x9804140B,  //  0056  SETIDX	R1	R10	R11
-      0x00281509,  //  0057  ADD	R10	R10	K9
+      0x00281507,  //  0057  ADD	R10	R10	K7
       0x7001FFEC,  //  0058  JMP		#0046
       0x502C0200,  //  0059  LDBOOL	R11	1	0
       0x80041600,  //  005A  RET	1	R11

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_9_module.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_9_module.h
@@ -3,6 +3,20 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Animate_animator' ktab size: 10, total: 14 (saved 32 bytes)
+static const bvalue be_ktab_class_Animate_animator[10] = {
+  /* K0   */  be_nested_str_weak(running),
+  /* K1   */  be_nested_str_weak(global),
+  /* K2   */  be_nested_str_weak(_cur_anim),
+  /* K3   */  be_nested_str_weak(add_animator),
+  /* K4   */  be_nested_str_weak(origin),
+  /* K5   */  be_nested_str_weak(duration_ms),
+  /* K6   */  be_nested_str_weak(obj),
+  /* K7   */  be_nested_str_weak(mth),
+  /* K8   */  be_nested_str_weak(tasmota),
+  /* K9   */  be_nested_str_weak(millis),
+};
+
 
 extern const bclass be_class_Animate_animator;
 
@@ -13,15 +27,13 @@ be_local_closure(class_Animate_animator_is_running,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(is_running),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -42,13 +54,13 @@ be_local_closure(class_Animate_animator_beat,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(beat),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -66,26 +78,22 @@ be_local_closure(class_Animate_animator_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_cur_anim),
-    /* K2   */  be_nested_str_weak(add_animator),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040302,  //  0001  GETMBR	R1	R1	K2
       0x4C080000,  //  0002  LDNIL	R2
       0x20080202,  //  0003  NE	R2	R1	R2
       0x780A0002,  //  0004  JMPF	R2	#0008
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x8C080303,  //  0005  GETMET	R2	R1	K3
       0x5C100000,  //  0006  MOVE	R4	R0
       0x7C080400,  //  0007  CALL	R2	2
       0x80000000,  //  0008  RET	0
@@ -102,23 +110,20 @@ be_local_closure(class_Animate_animator_stop,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(origin),
-    /* K1   */  be_nested_str_weak(running),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(stop),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020801,  //  0001  SETMBR	R0	K4	R1
       0x50040000,  //  0002  LDBOOL	R1	0	0
-      0x90020201,  //  0003  SETMBR	R0	K1	R1
+      0x90020001,  //  0003  SETMBR	R0	K0	R1
       0x80000000,  //  0004  RET	0
     })
   )
@@ -133,19 +138,17 @@ be_local_closure(class_Animate_animator_set_duration_ms,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(duration_ms),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(set_duration_ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020A01,  //  0000  SETMBR	R0	K5	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -160,21 +163,18 @@ be_local_closure(class_Animate_animator_set_cb,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(obj),
-    /* K1   */  be_nested_str_weak(mth),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(set_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90020C01,  //  0000  SETMBR	R0	K6	R1
+      0x90020E02,  //  0001  SETMBR	R0	K7	R2
       0x80000000,  //  0002  RET	0
     })
   )
@@ -189,23 +189,17 @@ be_local_closure(class_Animate_animator_start,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(duration_ms),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(origin),
-    /* K4   */  be_nested_str_weak(running),
-    }),
+    &be_ktab_class_Animate_animator,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080105,  //  0000  GETMBR	R2	R0	K5
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x780A0000,  //  0003  JMPF	R2	#0005
@@ -213,13 +207,13 @@ be_local_closure(class_Animate_animator_start,   /* name */
       0x4C080000,  //  0005  LDNIL	R2
       0x1C080202,  //  0006  EQ	R2	R1	R2
       0x780A0003,  //  0007  JMPF	R2	#000C
-      0xB80A0200,  //  0008  GETNGBL	R2	K1
-      0x8C080502,  //  0009  GETMET	R2	R2	K2
+      0xB80A1000,  //  0008  GETNGBL	R2	K8
+      0x8C080509,  //  0009  GETMET	R2	R2	K9
       0x7C080200,  //  000A  CALL	R2	1
       0x5C040400,  //  000B  MOVE	R1	R2
-      0x90020601,  //  000C  SETMBR	R0	K3	R1
+      0x90020801,  //  000C  SETMBR	R0	K4	R1
       0x50080200,  //  000D  LDBOOL	R2	1	0
-      0x90020802,  //  000E  SETMBR	R0	K4	R2
+      0x90020002,  //  000E  SETMBR	R0	K0	R2
       0x80000000,  //  000F  RET	0
     })
   )
@@ -250,6 +244,56 @@ be_local_class(Animate_animator,
     })),
     be_str_weak(Animate_animator)
 );
+extern const bclass be_class_Animate_palette;
+// compact class 'Animate_palette' ktab size: 45, total: 87 (saved 336 bytes)
+static const bvalue be_ktab_class_Animate_palette[45] = {
+  /* K0   */  be_const_class(be_class_Animate_palette),
+  /* K1   */  be_nested_str_weak(ptr),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(duration_ms),
+  /* K5   */  be_nested_str_weak(tasmota),
+  /* K6   */  be_nested_str_weak(millis),
+  /* K7   */  be_nested_str_weak(origin),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(scale_uint),
+  /* K10  */  be_nested_str_weak(slots),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(slots_arr),
+  /* K13  */  be_nested_str_weak(palette),
+  /* K14  */  be_nested_str_weak(get),
+  /* K15  */  be_nested_str_weak(color),
+  /* K16  */  be_nested_str_weak(set_rgb),
+  /* K17  */  be_nested_str_weak(bri),
+  /* K18  */  be_nested_str_weak(set_bri),
+  /* K19  */  be_nested_str_weak(r),
+  /* K20  */  be_nested_str_weak(g),
+  /* K21  */  be_nested_str_weak(b),
+  /* K22  */  be_nested_str_weak(obj),
+  /* K23  */  be_nested_str_weak(mth),
+  /* K24  */  be_nested_str_weak(ptr_to_palette),
+  /* K25  */  be_nested_str_weak(set_duration),
+  /* K26  */  be_nested_str_weak(range_min),
+  /* K27  */  be_nested_str_weak(range_max),
+  /* K28  */  be_nested_str_weak(set_range),
+  /* K29  */  be_nested_str_weak(parse_palette),
+  /* K30  */  be_nested_str_weak(background_X3Alinear_X2Dgradient_X28to_X20right),
+  /* K31  */  be_nested_str_weak(_X2C_X23_X2502X_X2502X_X2502X_X20_X25_X2E1f_X25_X25),
+  /* K32  */  be_const_real_hex(0x41200000),
+  /* K33  */  be_nested_str_weak(_X29_X3B),
+  /* K34  */  be_nested_str_weak(resize),
+  /* K35  */  be_const_int(1),
+  /* K36  */  be_nested_str_weak(scale_int),
+  /* K37  */  be_nested_str_weak(value_error),
+  /* K38  */  be_nested_str_weak(min_X20must_X20be_X20lower_X20than_X20mex),
+  /* K39  */  be_nested_str_weak(duration_ms_X20must_X20be_X20positive),
+  /* K40  */  be_nested_str_weak(init),
+  /* K41  */  be_nested_str_weak(running),
+  /* K42  */  be_nested_str_weak(light_state),
+  /* K43  */  be_nested_str_weak(RGB),
+  /* K44  */  be_nested_str_weak(set_palette),
+};
+
 
 extern const bclass be_class_Animate_palette;
 
@@ -260,18 +304,13 @@ be_local_closure(class_Animate_palette_ptr_to_palette,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Animate_palette),
-    /* K1   */  be_nested_str_weak(ptr),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(ptr_to_palette),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
@@ -333,39 +372,17 @@ be_local_closure(class_Animate_palette_animate,   /* name */
   be_nested_proto(
     26,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(duration_ms),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(origin),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(scale_uint),
-    /* K6   */  be_nested_str_weak(slots),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(slots_arr),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(palette),
-    /* K11  */  be_nested_str_weak(get),
-    /* K12  */  be_nested_str_weak(color),
-    /* K13  */  be_nested_str_weak(set_rgb),
-    /* K14  */  be_nested_str_weak(bri),
-    /* K15  */  be_nested_str_weak(set_bri),
-    /* K16  */  be_nested_str_weak(r),
-    /* K17  */  be_nested_str_weak(g),
-    /* K18  */  be_nested_str_weak(b),
-    /* K19  */  be_nested_str_weak(obj),
-    /* K20  */  be_nested_str_weak(mth),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(animate),
     &be_const_str_solidified,
     ( &(const binstruction[193]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x780A0000,  //  0003  JMPF	R2	#0005
@@ -373,55 +390,55 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x4C080000,  //  0005  LDNIL	R2
       0x1C080202,  //  0006  EQ	R2	R1	R2
       0x780A0003,  //  0007  JMPF	R2	#000C
-      0xB80A0200,  //  0008  GETNGBL	R2	K1
-      0x8C080502,  //  0009  GETMET	R2	R2	K2
+      0xB80A0A00,  //  0008  GETNGBL	R2	K5
+      0x8C080506,  //  0009  GETMET	R2	R2	K6
       0x7C080200,  //  000A  CALL	R2	1
       0x5C040400,  //  000B  MOVE	R1	R2
-      0x88080103,  //  000C  GETMBR	R2	R0	K3
+      0x88080107,  //  000C  GETMBR	R2	R0	K7
       0x04080202,  //  000D  SUB	R2	R1	R2
-      0x140C0504,  //  000E  LT	R3	R2	K4
+      0x140C0508,  //  000E  LT	R3	R2	K8
       0x780E0001,  //  000F  JMPF	R3	#0012
-      0x58080004,  //  0010  LDCONST	R2	K4
-      0x88040103,  //  0011  GETMBR	R1	R0	K3
-      0x880C0100,  //  0012  GETMBR	R3	R0	K0
-      0xB8120200,  //  0013  GETNGBL	R4	K1
-      0x88100905,  //  0014  GETMBR	R4	R4	K5
+      0x58080008,  //  0010  LDCONST	R2	K8
+      0x88040107,  //  0011  GETMBR	R1	R0	K7
+      0x880C0104,  //  0012  GETMBR	R3	R0	K4
+      0xB8120A00,  //  0013  GETNGBL	R4	K5
+      0x88100909,  //  0014  GETMBR	R4	R4	K9
       0x28140403,  //  0015  GE	R5	R2	R3
       0x78160005,  //  0016  JMPF	R5	#001D
       0x0C180403,  //  0017  DIV	R6	R2	R3
       0x08180C03,  //  0018  MUL	R6	R6	R3
-      0x88140103,  //  0019  GETMBR	R5	R0	K3
+      0x88140107,  //  0019  GETMBR	R5	R0	K7
       0x00140A06,  //  001A  ADD	R5	R5	R6
-      0x90020605,  //  001B  SETMBR	R0	K3	R5
+      0x90020E05,  //  001B  SETMBR	R0	K7	R5
       0x10080403,  //  001C  MOD	R2	R2	R3
-      0x88140106,  //  001D  GETMBR	R5	R0	K6
-      0x04180B07,  //  001E  SUB	R6	R5	K7
-      0x241C0D04,  //  001F  GT	R7	R6	K4
+      0x8814010A,  //  001D  GETMBR	R5	R0	K10
+      0x04180B0B,  //  001E  SUB	R6	R5	K11
+      0x241C0D08,  //  001F  GT	R7	R6	K8
       0x781E0006,  //  0020  JMPF	R7	#0028
-      0x881C0108,  //  0021  GETMBR	R7	R0	K8
+      0x881C010C,  //  0021  GETMBR	R7	R0	K12
       0x941C0E06,  //  0022  GETIDX	R7	R7	R6
       0x281C0407,  //  0023  GE	R7	R2	R7
       0x781E0000,  //  0024  JMPF	R7	#0026
       0x70020001,  //  0025  JMP		#0028
-      0x04180D09,  //  0026  SUB	R6	R6	K9
+      0x04180D02,  //  0026  SUB	R6	R6	K2
       0x7001FFF6,  //  0027  JMP		#001F
-      0x881C010A,  //  0028  GETMBR	R7	R0	K10
-      0x8C1C0F0B,  //  0029  GETMET	R7	R7	K11
+      0x881C010D,  //  0028  GETMBR	R7	R0	K13
+      0x8C1C0F0E,  //  0029  GETMET	R7	R7	K14
       0x54260003,  //  002A  LDINT	R9	4
       0x08240C09,  //  002B  MUL	R9	R6	R9
       0x542A0003,  //  002C  LDINT	R10	4
       0x7C1C0600,  //  002D  CALL	R7	3
-      0x8820010A,  //  002E  GETMBR	R8	R0	K10
-      0x8C20110B,  //  002F  GETMET	R8	R8	K11
-      0x00280D09,  //  0030  ADD	R10	R6	K9
+      0x8820010D,  //  002E  GETMBR	R8	R0	K13
+      0x8C20110E,  //  002F  GETMET	R8	R8	K14
+      0x00280D02,  //  0030  ADD	R10	R6	K2
       0x542E0003,  //  0031  LDINT	R11	4
       0x0828140B,  //  0032  MUL	R10	R10	R11
       0x542E0003,  //  0033  LDINT	R11	4
       0x7C200600,  //  0034  CALL	R8	3
-      0x88240108,  //  0035  GETMBR	R9	R0	K8
+      0x8824010C,  //  0035  GETMBR	R9	R0	K12
       0x94241206,  //  0036  GETIDX	R9	R9	R6
-      0x00280D09,  //  0037  ADD	R10	R6	K9
-      0x882C0108,  //  0038  GETMBR	R11	R0	K8
+      0x00280D02,  //  0037  ADD	R10	R6	K2
+      0x882C010C,  //  0038  GETMBR	R11	R0	K12
       0x9428160A,  //  0039  GETIDX	R10	R11	R10
       0x5C300800,  //  003A  MOVE	R12	R4
       0x5C340400,  //  003B  MOVE	R13	R2
@@ -463,8 +480,8 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x544E00FE,  //  005F  LDINT	R19	255
       0x2C482413,  //  0060  AND	R18	R18	R19
       0x7C340A00,  //  0061  CALL	R13	5
-      0x8838010C,  //  0062  GETMBR	R14	R0	K12
-      0x8C3C1D0D,  //  0063  GETMET	R15	R14	K13
+      0x8838010F,  //  0062  GETMBR	R14	R0	K15
+      0x8C3C1D10,  //  0063  GETMET	R15	R14	K16
       0x54460007,  //  0064  LDINT	R17	8
       0x3C440E11,  //  0065  SHR	R17	R7	R17
       0x544A00FE,  //  0066  LDINT	R18	255
@@ -478,8 +495,8 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x545200FE,  //  006E  LDINT	R20	255
       0x2C4C2614,  //  006F  AND	R19	R19	R20
       0x7C3C0800,  //  0070  CALL	R15	4
-      0x883C1D0E,  //  0071  GETMBR	R15	R14	K14
-      0x8C401D0D,  //  0072  GETMET	R16	R14	K13
+      0x883C1D11,  //  0071  GETMBR	R15	R14	K17
+      0x8C401D10,  //  0072  GETMET	R16	R14	K16
       0x544A0007,  //  0073  LDINT	R18	8
       0x3C481012,  //  0074  SHR	R18	R8	R18
       0x544E00FE,  //  0075  LDINT	R19	255
@@ -493,7 +510,7 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x545600FE,  //  007D  LDINT	R21	255
       0x2C502815,  //  007E  AND	R20	R20	R21
       0x7C400800,  //  007F  CALL	R16	4
-      0x88401D0E,  //  0080  GETMBR	R16	R14	K14
+      0x88401D11,  //  0080  GETMBR	R16	R14	K17
       0x5C440800,  //  0081  MOVE	R17	R4
       0x5C480400,  //  0082  MOVE	R18	R2
       0x5C4C1200,  //  0083  MOVE	R19	R9
@@ -501,45 +518,45 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x5C541E00,  //  0085  MOVE	R21	R15
       0x5C582000,  //  0086  MOVE	R22	R16
       0x7C440A00,  //  0087  CALL	R17	5
-      0x8C481D0D,  //  0088  GETMET	R18	R14	K13
+      0x8C481D10,  //  0088  GETMET	R18	R14	K16
       0x5C501600,  //  0089  MOVE	R20	R11
       0x5C541800,  //  008A  MOVE	R21	R12
       0x5C581A00,  //  008B  MOVE	R22	R13
       0x7C480800,  //  008C  CALL	R18	4
-      0x8C481D0F,  //  008D  GETMET	R18	R14	K15
+      0x8C481D12,  //  008D  GETMET	R18	R14	K18
       0x5C502200,  //  008E  MOVE	R20	R17
       0x7C480400,  //  008F  CALL	R18	2
-      0x882C1D10,  //  0090  GETMBR	R11	R14	K16
-      0x88301D11,  //  0091  GETMBR	R12	R14	K17
-      0x88341D12,  //  0092  GETMBR	R13	R14	K18
-      0x8848010E,  //  0093  GETMBR	R18	R0	K14
+      0x882C1D13,  //  0090  GETMBR	R11	R14	K19
+      0x88301D14,  //  0091  GETMBR	R12	R14	K20
+      0x88341D15,  //  0092  GETMBR	R13	R14	K21
+      0x88480111,  //  0093  GETMBR	R18	R0	K17
       0x544E0063,  //  0094  LDINT	R19	100
       0x204C2413,  //  0095  NE	R19	R18	R19
       0x784E001A,  //  0096  JMPF	R19	#00B2
-      0xB84E0200,  //  0097  GETNGBL	R19	K1
-      0x8C4C2705,  //  0098  GETMET	R19	R19	K5
+      0xB84E0A00,  //  0097  GETNGBL	R19	K5
+      0x8C4C2709,  //  0098  GETMET	R19	R19	K9
       0x5C541600,  //  0099  MOVE	R21	R11
-      0x58580004,  //  009A  LDCONST	R22	K4
+      0x58580008,  //  009A  LDCONST	R22	K8
       0x545E0063,  //  009B  LDINT	R23	100
-      0x58600004,  //  009C  LDCONST	R24	K4
+      0x58600008,  //  009C  LDCONST	R24	K8
       0x5C642400,  //  009D  MOVE	R25	R18
       0x7C4C0C00,  //  009E  CALL	R19	6
       0x5C2C2600,  //  009F  MOVE	R11	R19
-      0xB84E0200,  //  00A0  GETNGBL	R19	K1
-      0x8C4C2705,  //  00A1  GETMET	R19	R19	K5
+      0xB84E0A00,  //  00A0  GETNGBL	R19	K5
+      0x8C4C2709,  //  00A1  GETMET	R19	R19	K9
       0x5C541800,  //  00A2  MOVE	R21	R12
-      0x58580004,  //  00A3  LDCONST	R22	K4
+      0x58580008,  //  00A3  LDCONST	R22	K8
       0x545E0063,  //  00A4  LDINT	R23	100
-      0x58600004,  //  00A5  LDCONST	R24	K4
+      0x58600008,  //  00A5  LDCONST	R24	K8
       0x5C642400,  //  00A6  MOVE	R25	R18
       0x7C4C0C00,  //  00A7  CALL	R19	6
       0x5C302600,  //  00A8  MOVE	R12	R19
-      0xB84E0200,  //  00A9  GETNGBL	R19	K1
-      0x8C4C2705,  //  00AA  GETMET	R19	R19	K5
+      0xB84E0A00,  //  00A9  GETNGBL	R19	K5
+      0x8C4C2709,  //  00AA  GETMET	R19	R19	K9
       0x5C541A00,  //  00AB  MOVE	R21	R13
-      0x58580004,  //  00AC  LDCONST	R22	K4
+      0x58580008,  //  00AC  LDCONST	R22	K8
       0x545E0063,  //  00AD  LDINT	R23	100
-      0x58600004,  //  00AE  LDCONST	R24	K4
+      0x58600008,  //  00AE  LDCONST	R24	K8
       0x5C642400,  //  00AF  MOVE	R25	R18
       0x7C4C0C00,  //  00B0  CALL	R19	6
       0x5C342600,  //  00B1  MOVE	R13	R19
@@ -549,8 +566,8 @@ be_local_closure(class_Animate_palette_animate,   /* name */
       0x38501814,  //  00B5  SHL	R20	R12	R20
       0x304C2614,  //  00B6  OR	R19	R19	R20
       0x304C260D,  //  00B7  OR	R19	R19	R13
-      0x88500113,  //  00B8  GETMBR	R20	R0	K19
-      0x88540114,  //  00B9  GETMBR	R21	R0	K20
+      0x88500116,  //  00B8  GETMBR	R20	R0	K22
+      0x88540117,  //  00B9  GETMBR	R21	R0	K23
       0x78520004,  //  00BA  JMPF	R20	#00C0
       0x78560003,  //  00BB  JMPF	R21	#00C0
       0x5C582A00,  //  00BC  MOVE	R22	R21
@@ -571,61 +588,51 @@ be_local_closure(class_Animate_palette_set_palette,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ptr),
-    /* K1   */  be_nested_str_weak(ptr_to_palette),
-    /* K2   */  be_nested_str_weak(palette),
-    /* K3   */  be_nested_str_weak(slots),
-    /* K4   */  be_nested_str_weak(duration_ms),
-    /* K5   */  be_nested_str_weak(set_duration),
-    /* K6   */  be_nested_str_weak(range_min),
-    /* K7   */  be_nested_str_weak(range_max),
-    /* K8   */  be_nested_str_weak(set_range),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(set_palette),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x1C080501,  //  0003  EQ	R2	R2	K1
       0x780A0003,  //  0004  JMPF	R2	#0009
-      0x8C080101,  //  0005  GETMET	R2	R0	K1
+      0x8C080118,  //  0005  GETMET	R2	R0	K24
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
       0x5C040400,  //  0008  MOVE	R1	R2
-      0x90020401,  //  0009  SETMBR	R0	K2	R1
+      0x90021A01,  //  0009  SETMBR	R0	K13	R1
       0x6008000C,  //  000A  GETGBL	R2	G12
       0x5C0C0200,  //  000B  MOVE	R3	R1
       0x7C080200,  //  000C  CALL	R2	1
       0x540E0003,  //  000D  LDINT	R3	4
       0x0C080403,  //  000E  DIV	R2	R2	R3
-      0x90020602,  //  000F  SETMBR	R0	K3	R2
+      0x90021402,  //  000F  SETMBR	R0	K10	R2
       0x88080104,  //  0010  GETMBR	R2	R0	K4
       0x4C0C0000,  //  0011  LDNIL	R3
       0x20080403,  //  0012  NE	R2	R2	R3
       0x780A0003,  //  0013  JMPF	R2	#0018
-      0x8C080105,  //  0014  GETMET	R2	R0	K5
+      0x8C080119,  //  0014  GETMET	R2	R0	K25
       0x88100104,  //  0015  GETMBR	R4	R0	K4
       0x7C080400,  //  0016  CALL	R2	2
       0x7002000B,  //  0017  JMP		#0024
-      0x88080106,  //  0018  GETMBR	R2	R0	K6
+      0x8808011A,  //  0018  GETMBR	R2	R0	K26
       0x4C0C0000,  //  0019  LDNIL	R3
       0x20080403,  //  001A  NE	R2	R2	R3
       0x780A0007,  //  001B  JMPF	R2	#0024
-      0x88080107,  //  001C  GETMBR	R2	R0	K7
+      0x8808011B,  //  001C  GETMBR	R2	R0	K27
       0x4C0C0000,  //  001D  LDNIL	R3
       0x20080403,  //  001E  NE	R2	R2	R3
       0x780A0003,  //  001F  JMPF	R2	#0024
-      0x8C080108,  //  0020  GETMET	R2	R0	K8
-      0x88100106,  //  0021  GETMBR	R4	R0	K6
-      0x88140107,  //  0022  GETMBR	R5	R0	K7
+      0x8C08011C,  //  0020  GETMET	R2	R0	K28
+      0x8810011A,  //  0021  GETMBR	R4	R0	K26
+      0x8814011B,  //  0022  GETMBR	R5	R0	K27
       0x7C080600,  //  0023  CALL	R2	3
       0x80000000,  //  0024  RET	0
     })
@@ -641,24 +648,13 @@ be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Animate_palette),
-    /* K1   */  be_nested_str_weak(parse_palette),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(background_X3Alinear_X2Dgradient_X28to_X20right),
-    /* K4   */  be_nested_str_weak(palette),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(_X2C_X23_X2502X_X2502X_X2502X_X20_X25_X2E1f_X25_X25),
-    /* K7   */  be_const_real_hex(0x41200000),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(_X29_X3B),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(to_css_gradient),
     &be_const_str_solidified,
     ( &(const binstruction[46]) {  /* code */
@@ -666,20 +662,20 @@ be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
       0x5C080200,  //  0001  MOVE	R2	R1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x58140002,  //  0005  LDCONST	R5	K2
+      0x8C0C051D,  //  0004  GETMET	R3	R2	K29
+      0x58140008,  //  0005  LDCONST	R5	K8
       0x541A03E7,  //  0006  LDINT	R6	1000
       0x7C0C0600,  //  0007  CALL	R3	3
-      0x58100003,  //  0008  LDCONST	R4	K3
-      0x58140002,  //  0009  LDCONST	R5	K2
+      0x5810001E,  //  0008  LDCONST	R4	K30
+      0x58140008,  //  0009  LDCONST	R5	K8
       0x6018000C,  //  000A  GETGBL	R6	G12
       0x5C1C0600,  //  000B  MOVE	R7	R3
       0x7C180200,  //  000C  CALL	R6	1
       0x14180A06,  //  000D  LT	R6	R5	R6
       0x781A001C,  //  000E  JMPF	R6	#002C
       0x94180605,  //  000F  GETIDX	R6	R3	R5
-      0x881C0504,  //  0010  GETMBR	R7	R2	K4
-      0x8C1C0F05,  //  0011  GETMET	R7	R7	K5
+      0x881C050D,  //  0010  GETMBR	R7	R2	K13
+      0x8C1C0F0E,  //  0011  GETMET	R7	R7	K14
       0x54260003,  //  0012  LDINT	R9	4
       0x08240A09,  //  0013  MUL	R9	R5	R9
       0x542A0003,  //  0014  LDINT	R10	4
@@ -697,16 +693,16 @@ be_local_closure(class_Animate_palette_to_css_gradient,   /* name */
       0x542E00FE,  //  0020  LDINT	R11	255
       0x2C28140B,  //  0021  AND	R10	R10	R11
       0x602C0018,  //  0022  GETGBL	R11	G24
-      0x58300006,  //  0023  LDCONST	R12	K6
+      0x5830001F,  //  0023  LDCONST	R12	K31
       0x5C341000,  //  0024  MOVE	R13	R8
       0x5C381200,  //  0025  MOVE	R14	R9
       0x5C3C1400,  //  0026  MOVE	R15	R10
-      0x0C400D07,  //  0027  DIV	R16	R6	K7
+      0x0C400D20,  //  0027  DIV	R16	R6	K32
       0x7C2C0A00,  //  0028  CALL	R11	5
       0x0010080B,  //  0029  ADD	R4	R4	R11
-      0x00140B08,  //  002A  ADD	R5	R5	K8
+      0x00140B02,  //  002A  ADD	R5	R5	K2
       0x7001FFDD,  //  002B  JMP		#000A
-      0x00100909,  //  002C  ADD	R4	R4	K9
+      0x00100921,  //  002C  ADD	R4	R4	K33
       0x80040800,  //  002D  RET	1	R4
     })
   )
@@ -721,22 +717,20 @@ be_local_closure(class_Animate_palette_set_bri,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(set_bri),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x90022202,  //  0003  SETMBR	R0	K17	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -751,94 +745,85 @@ be_local_closure(class_Animate_palette_parse_palette,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(slots),
-    /* K1   */  be_nested_str_weak(resize),
-    /* K2   */  be_nested_str_weak(palette),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(scale_int),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(parse_palette),
     &be_const_str_solidified,
     ( &(const binstruction[71]) {  /* code */
       0x600C0012,  //  0000  GETGBL	R3	G18
       0x7C0C0000,  //  0001  CALL	R3	0
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x8C140701,  //  0003  GETMET	R5	R3	K1
+      0x8810010A,  //  0002  GETMBR	R4	R0	K10
+      0x8C140722,  //  0003  GETMET	R5	R3	K34
       0x5C1C0800,  //  0004  MOVE	R7	R4
       0x7C140400,  //  0005  CALL	R5	2
-      0x88140102,  //  0006  GETMBR	R5	R0	K2
-      0x8C140B03,  //  0007  GETMET	R5	R5	K3
-      0x581C0004,  //  0008  LDCONST	R7	K4
-      0x58200005,  //  0009  LDCONST	R8	K5
+      0x8814010D,  //  0006  GETMBR	R5	R0	K13
+      0x8C140B0E,  //  0007  GETMET	R5	R5	K14
+      0x581C0008,  //  0008  LDCONST	R7	K8
+      0x58200023,  //  0009  LDCONST	R8	K35
       0x7C140600,  //  000A  CALL	R5	3
-      0x20140B04,  //  000B  NE	R5	R5	K4
+      0x20140B08,  //  000B  NE	R5	R5	K8
       0x78160024,  //  000C  JMPF	R5	#0032
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x58180004,  //  000E  LDCONST	R6	K4
-      0x041C0905,  //  000F  SUB	R7	R4	K5
+      0x58140008,  //  000D  LDCONST	R5	K8
+      0x58180008,  //  000E  LDCONST	R6	K8
+      0x041C0923,  //  000F  SUB	R7	R4	K35
       0x141C0C07,  //  0010  LT	R7	R6	R7
       0x781E0008,  //  0011  JMPF	R7	#001B
-      0x881C0102,  //  0012  GETMBR	R7	R0	K2
-      0x8C1C0F03,  //  0013  GETMET	R7	R7	K3
+      0x881C010D,  //  0012  GETMBR	R7	R0	K13
+      0x8C1C0F0E,  //  0013  GETMET	R7	R7	K14
       0x54260003,  //  0014  LDINT	R9	4
       0x08240C09,  //  0015  MUL	R9	R6	R9
-      0x58280005,  //  0016  LDCONST	R10	K5
+      0x58280023,  //  0016  LDCONST	R10	K35
       0x7C1C0600,  //  0017  CALL	R7	3
       0x00140A07,  //  0018  ADD	R5	R5	R7
-      0x00180D05,  //  0019  ADD	R6	R6	K5
+      0x00180D23,  //  0019  ADD	R6	R6	K35
       0x7001FFF3,  //  001A  JMP		#000F
-      0x581C0004,  //  001B  LDCONST	R7	K4
-      0x58180004,  //  001C  LDCONST	R6	K4
+      0x581C0008,  //  001B  LDCONST	R7	K8
+      0x58180008,  //  001C  LDCONST	R6	K8
       0x14200C04,  //  001D  LT	R8	R6	R4
       0x78220011,  //  001E  JMPF	R8	#0031
-      0xB8220C00,  //  001F  GETNGBL	R8	K6
-      0x8C201107,  //  0020  GETMET	R8	R8	K7
+      0xB8220A00,  //  001F  GETNGBL	R8	K5
+      0x8C201124,  //  0020  GETMET	R8	R8	K36
       0x5C280E00,  //  0021  MOVE	R10	R7
-      0x582C0004,  //  0022  LDCONST	R11	K4
+      0x582C0008,  //  0022  LDCONST	R11	K8
       0x5C300A00,  //  0023  MOVE	R12	R5
       0x5C340200,  //  0024  MOVE	R13	R1
       0x5C380400,  //  0025  MOVE	R14	R2
       0x7C200C00,  //  0026  CALL	R8	6
       0x980C0C08,  //  0027  SETIDX	R3	R6	R8
-      0x88200102,  //  0028  GETMBR	R8	R0	K2
-      0x8C201103,  //  0029  GETMET	R8	R8	K3
+      0x8820010D,  //  0028  GETMBR	R8	R0	K13
+      0x8C20110E,  //  0029  GETMET	R8	R8	K14
       0x542A0003,  //  002A  LDINT	R10	4
       0x08280C0A,  //  002B  MUL	R10	R6	R10
-      0x582C0005,  //  002C  LDCONST	R11	K5
+      0x582C0023,  //  002C  LDCONST	R11	K35
       0x7C200600,  //  002D  CALL	R8	3
       0x001C0E08,  //  002E  ADD	R7	R7	R8
-      0x00180D05,  //  002F  ADD	R6	R6	K5
+      0x00180D23,  //  002F  ADD	R6	R6	K35
       0x7001FFEB,  //  0030  JMP		#001D
       0x70020013,  //  0031  JMP		#0046
-      0x58140004,  //  0032  LDCONST	R5	K4
+      0x58140008,  //  0032  LDCONST	R5	K8
       0x14180A04,  //  0033  LT	R6	R5	R4
       0x781A0010,  //  0034  JMPF	R6	#0046
-      0x88180102,  //  0035  GETMBR	R6	R0	K2
-      0x8C180D03,  //  0036  GETMET	R6	R6	K3
+      0x8818010D,  //  0035  GETMBR	R6	R0	K13
+      0x8C180D0E,  //  0036  GETMET	R6	R6	K14
       0x54220003,  //  0037  LDINT	R8	4
       0x08200A08,  //  0038  MUL	R8	R5	R8
-      0x58240005,  //  0039  LDCONST	R9	K5
+      0x58240023,  //  0039  LDCONST	R9	K35
       0x7C180600,  //  003A  CALL	R6	3
-      0xB81E0C00,  //  003B  GETNGBL	R7	K6
-      0x8C1C0F07,  //  003C  GETMET	R7	R7	K7
+      0xB81E0A00,  //  003B  GETNGBL	R7	K5
+      0x8C1C0F24,  //  003C  GETMET	R7	R7	K36
       0x5C240C00,  //  003D  MOVE	R9	R6
-      0x58280004,  //  003E  LDCONST	R10	K4
+      0x58280008,  //  003E  LDCONST	R10	K8
       0x542E00FE,  //  003F  LDINT	R11	255
       0x5C300200,  //  0040  MOVE	R12	R1
       0x5C340400,  //  0041  MOVE	R13	R2
       0x7C1C0C00,  //  0042  CALL	R7	6
       0x980C0A07,  //  0043  SETIDX	R3	R5	R7
-      0x00140B05,  //  0044  ADD	R5	R5	K5
+      0x00140B23,  //  0044  ADD	R5	R5	K35
       0x7001FFEC,  //  0045  JMP		#0033
       0x80040600,  //  0046  RET	1	R3
     })
@@ -854,33 +839,26 @@ be_local_closure(class_Animate_palette_set_range,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(value_error),
-    /* K1   */  be_nested_str_weak(min_X20must_X20be_X20lower_X20than_X20mex),
-    /* K2   */  be_nested_str_weak(range_min),
-    /* K3   */  be_nested_str_weak(range_max),
-    /* K4   */  be_nested_str_weak(slots_arr),
-    /* K5   */  be_nested_str_weak(parse_palette),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(set_range),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x280C0202,  //  0000  GE	R3	R1	R2
       0x780E0000,  //  0001  JMPF	R3	#0003
-      0xB0060101,  //  0002  RAISE	1	K0	K1
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x90020602,  //  0004  SETMBR	R0	K3	R2
-      0x8C0C0105,  //  0005  GETMET	R3	R0	K5
+      0xB0064B26,  //  0002  RAISE	1	K37	K38
+      0x90023401,  //  0003  SETMBR	R0	K26	R1
+      0x90023602,  //  0004  SETMBR	R0	K27	R2
+      0x8C0C011D,  //  0005  GETMET	R3	R0	K29
       0x5C140200,  //  0006  MOVE	R5	R1
       0x5C180400,  //  0007  MOVE	R6	R2
       0x7C0C0600,  //  0008  CALL	R3	3
-      0x90020803,  //  0009  SETMBR	R0	K4	R3
+      0x90021803,  //  0009  SETMBR	R0	K12	R3
       0x80000000,  //  000A  RET	0
     })
   )
@@ -895,70 +873,56 @@ be_local_closure(class_Animate_palette_set_value,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(range_min),
-    /* K1   */  be_nested_str_weak(range_max),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_int),
-    /* K4   */  be_nested_str_weak(slots),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(slots_arr),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(palette),
-    /* K10  */  be_nested_str_weak(get),
-    /* K11  */  be_nested_str_weak(obj),
-    /* K12  */  be_nested_str_weak(mth),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(set_value),
     &be_const_str_solidified,
     ( &(const binstruction[96]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808011A,  //  0000  GETMBR	R2	R0	K26
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x740A0003,  //  0003  JMPT	R2	#0008
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8808011B,  //  0004  GETMBR	R2	R0	K27
       0x4C0C0000,  //  0005  LDNIL	R3
       0x1C080403,  //  0006  EQ	R2	R2	R3
       0x780A0001,  //  0007  JMPF	R2	#000A
       0x4C080000,  //  0008  LDNIL	R2
       0x80040400,  //  0009  RET	1	R2
-      0xB80A0400,  //  000A  GETNGBL	R2	K2
-      0x88080503,  //  000B  GETMBR	R2	R2	K3
-      0x880C0104,  //  000C  GETMBR	R3	R0	K4
-      0x04100705,  //  000D  SUB	R4	R3	K5
-      0x24140906,  //  000E  GT	R5	R4	K6
+      0xB80A0A00,  //  000A  GETNGBL	R2	K5
+      0x88080524,  //  000B  GETMBR	R2	R2	K36
+      0x880C010A,  //  000C  GETMBR	R3	R0	K10
+      0x0410070B,  //  000D  SUB	R4	R3	K11
+      0x24140903,  //  000E  GT	R5	R4	K3
       0x78160006,  //  000F  JMPF	R5	#0017
-      0x88140107,  //  0010  GETMBR	R5	R0	K7
+      0x8814010C,  //  0010  GETMBR	R5	R0	K12
       0x94140A04,  //  0011  GETIDX	R5	R5	R4
       0x28140205,  //  0012  GE	R5	R1	R5
       0x78160000,  //  0013  JMPF	R5	#0015
       0x70020001,  //  0014  JMP		#0017
-      0x04100908,  //  0015  SUB	R4	R4	K8
+      0x04100902,  //  0015  SUB	R4	R4	K2
       0x7001FFF6,  //  0016  JMP		#000E
-      0x88140109,  //  0017  GETMBR	R5	R0	K9
-      0x8C140B0A,  //  0018  GETMET	R5	R5	K10
+      0x8814010D,  //  0017  GETMBR	R5	R0	K13
+      0x8C140B0E,  //  0018  GETMET	R5	R5	K14
       0x541E0003,  //  0019  LDINT	R7	4
       0x081C0807,  //  001A  MUL	R7	R4	R7
       0x54220003,  //  001B  LDINT	R8	4
       0x7C140600,  //  001C  CALL	R5	3
-      0x88180109,  //  001D  GETMBR	R6	R0	K9
-      0x8C180D0A,  //  001E  GETMET	R6	R6	K10
-      0x00200908,  //  001F  ADD	R8	R4	K8
+      0x8818010D,  //  001D  GETMBR	R6	R0	K13
+      0x8C180D0E,  //  001E  GETMET	R6	R6	K14
+      0x00200902,  //  001F  ADD	R8	R4	K2
       0x54260003,  //  0020  LDINT	R9	4
       0x08201009,  //  0021  MUL	R8	R8	R9
       0x54260003,  //  0022  LDINT	R9	4
       0x7C180600,  //  0023  CALL	R6	3
-      0x881C0107,  //  0024  GETMBR	R7	R0	K7
+      0x881C010C,  //  0024  GETMBR	R7	R0	K12
       0x941C0E04,  //  0025  GETIDX	R7	R7	R4
-      0x00200908,  //  0026  ADD	R8	R4	K8
-      0x88240107,  //  0027  GETMBR	R9	R0	K7
+      0x00200902,  //  0026  ADD	R8	R4	K2
+      0x8824010C,  //  0027  GETMBR	R9	R0	K12
       0x94201208,  //  0028  GETIDX	R8	R9	R8
       0x5C280400,  //  0029  MOVE	R10	R2
       0x5C2C0200,  //  002A  MOVE	R11	R1
@@ -1006,8 +970,8 @@ be_local_closure(class_Animate_palette_set_value,   /* name */
       0x3834140D,  //  0054  SHL	R13	R10	R13
       0x3030180D,  //  0055  OR	R12	R12	R13
       0x3030180B,  //  0056  OR	R12	R12	R11
-      0x8834010B,  //  0057  GETMBR	R13	R0	K11
-      0x8838010C,  //  0058  GETMBR	R14	R0	K12
+      0x88340116,  //  0057  GETMBR	R13	R0	K22
+      0x88380117,  //  0058  GETMBR	R14	R0	K23
       0x78360004,  //  0059  JMPF	R13	#005F
       0x783A0003,  //  005A  JMPF	R14	#005F
       0x5C3C1C00,  //  005B  MOVE	R15	R14
@@ -1028,21 +992,13 @@ be_local_closure(class_Animate_palette_set_duration,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(duration_ms_X20must_X20be_X20positive),
-    /* K3   */  be_nested_str_weak(duration_ms),
-    /* K4   */  be_nested_str_weak(slots_arr),
-    /* K5   */  be_nested_str_weak(parse_palette),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(set_duration),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -1050,15 +1006,15 @@ be_local_closure(class_Animate_palette_set_duration,   /* name */
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
       0x80000400,  //  0003  RET	0
-      0x18080300,  //  0004  LE	R2	R1	K0
+      0x18080308,  //  0004  LE	R2	R1	K8
       0x780A0000,  //  0005  JMPF	R2	#0007
-      0xB0060302,  //  0006  RAISE	1	K1	K2
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x8C080105,  //  0008  GETMET	R2	R0	K5
-      0x58100000,  //  0009  LDCONST	R4	K0
-      0x04140306,  //  000A  SUB	R5	R1	K6
+      0xB0064B27,  //  0006  RAISE	1	K37	K39
+      0x90020801,  //  0007  SETMBR	R0	K4	R1
+      0x8C08011D,  //  0008  GETMET	R2	R0	K29
+      0x58100008,  //  0009  LDCONST	R4	K8
+      0x04140302,  //  000A  SUB	R5	R1	K2
       0x7C080600,  //  000B  CALL	R2	3
-      0x90020802,  //  000C  SETMBR	R0	K4	R2
+      0x90021802,  //  000C  SETMBR	R0	K12	R2
       0x80000000,  //  000D  RET	0
     })
   )
@@ -1073,41 +1029,32 @@ be_local_closure(class_Animate_palette_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(duration_ms),
-    /* K2   */  be_nested_str_weak(running),
-    /* K3   */  be_nested_str_weak(bri),
-    /* K4   */  be_nested_str_weak(color),
-    /* K5   */  be_nested_str_weak(light_state),
-    /* K6   */  be_nested_str_weak(RGB),
-    /* K7   */  be_nested_str_weak(set_palette),
-    }),
+    &be_ktab_class_Animate_palette,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x8C0C0728,  //  0003  GETMET	R3	R3	K40
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x90020802,  //  0005  SETMBR	R0	K4	R2
       0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x90020403,  //  0007  SETMBR	R0	K2	R3
+      0x90025203,  //  0007  SETMBR	R0	K41	R3
       0x540E0063,  //  0008  LDINT	R3	100
-      0x90020603,  //  0009  SETMBR	R0	K3	R3
-      0xB80E0A00,  //  000A  GETNGBL	R3	K5
-      0xB8120A00,  //  000B  GETNGBL	R4	K5
-      0x88100906,  //  000C  GETMBR	R4	R4	K6
+      0x90022203,  //  0009  SETMBR	R0	K17	R3
+      0xB80E5400,  //  000A  GETNGBL	R3	K42
+      0xB8125400,  //  000B  GETNGBL	R4	K42
+      0x8810092B,  //  000C  GETMBR	R4	R4	K43
       0x7C0C0200,  //  000D  CALL	R3	1
-      0x90020803,  //  000E  SETMBR	R0	K4	R3
-      0x8C0C0107,  //  000F  GETMET	R3	R0	K7
+      0x90021E03,  //  000E  SETMBR	R0	K15	R3
+      0x8C0C012C,  //  000F  GETMET	R3	R0	K44
       0x5C140200,  //  0010  MOVE	R5	R1
       0x7C0C0400,  //  0011  CALL	R3	2
       0x80000000,  //  0012  RET	0
@@ -1146,6 +1093,32 @@ be_local_class(Animate_palette,
     })),
     be_str_weak(Animate_palette)
 );
+// compact class 'Animate_oscillator' ktab size: 22, total: 38 (saved 128 bytes)
+static const bvalue be_ktab_class_Animate_oscillator[22] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(duty_cycle),
+  /* K2   */  be_nested_str_weak(a),
+  /* K3   */  be_nested_str_weak(b),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(form),
+  /* K6   */  be_nested_str_weak(phase),
+  /* K7   */  be_nested_str_weak(init),
+  /* K8   */  be_nested_str_weak(duration_ms),
+  /* K9   */  be_nested_str_weak(value),
+  /* K10  */  be_nested_str_weak(tasmota),
+  /* K11  */  be_nested_str_weak(millis),
+  /* K12  */  be_nested_str_weak(origin),
+  /* K13  */  be_nested_str_weak(scale_uint),
+  /* K14  */  be_nested_str_weak(beat),
+  /* K15  */  be_const_int(1),
+  /* K16  */  be_nested_str_weak(scale_int),
+  /* K17  */  be_const_int(2),
+  /* K18  */  be_const_int(3),
+  /* K19  */  be_nested_str_weak(sine_int),
+  /* K20  */  be_nested_str_weak(obj),
+  /* K21  */  be_nested_str_weak(mth),
+};
+
 
 extern const bclass be_class_Animate_oscillator;
 
@@ -1156,16 +1129,13 @@ be_local_closure(class_Animate_oscillator_set_duty_cycle,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(duty_cycle),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(set_duty_cycle),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -1191,19 +1161,17 @@ be_local_closure(class_Animate_oscillator_set_a,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(a),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(set_a),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020401,  //  0000  SETMBR	R0	K2	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1218,19 +1186,17 @@ be_local_closure(class_Animate_oscillator_set_b,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(b),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(set_b),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020601,  //  0000  SETMBR	R0	K3	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1245,24 +1211,21 @@ be_local_closure(class_Animate_oscillator_set_form,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_const_int(1),
-    /* K1   */  be_nested_str_weak(form),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(set_form),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
-      0x58040000,  //  0003  LDCONST	R1	K0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0x58040004,  //  0003  LDCONST	R1	K4
+      0x90020A01,  //  0004  SETMBR	R0	K5	R1
       0x80000000,  //  0005  RET	0
     })
   )
@@ -1277,16 +1240,13 @@ be_local_closure(class_Animate_oscillator_set_phase,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(phase),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(set_phase),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -1297,7 +1257,7 @@ be_local_closure(class_Animate_oscillator_set_phase,   /* name */
       0x24080202,  //  0004  GT	R2	R1	R2
       0x780A0000,  //  0005  JMPF	R2	#0007
       0x54060063,  //  0006  LDINT	R1	100
-      0x90020201,  //  0007  SETMBR	R0	K1	R1
+      0x90020C01,  //  0007  SETMBR	R0	K6	R1
       0x80000000,  //  0008  RET	0
     })
   )
@@ -1312,44 +1272,33 @@ be_local_closure(class_Animate_oscillator_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(phase),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(duty_cycle),
-    /* K4   */  be_nested_str_weak(a),
-    /* K5   */  be_nested_str_weak(b),
-    /* K6   */  be_nested_str_weak(duration_ms),
-    /* K7   */  be_nested_str_weak(value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(form),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x60140003,  //  0000  GETGBL	R5	G3
       0x5C180000,  //  0001  MOVE	R6	R0
       0x7C140200,  //  0002  CALL	R5	1
-      0x8C140B00,  //  0003  GETMET	R5	R5	K0
+      0x8C140B07,  //  0003  GETMET	R5	R5	K7
       0x7C140200,  //  0004  CALL	R5	1
-      0x90020302,  //  0005  SETMBR	R0	K1	K2
+      0x90020D00,  //  0005  SETMBR	R0	K6	K0
       0x54160031,  //  0006  LDINT	R5	50
-      0x90020605,  //  0007  SETMBR	R0	K3	R5
-      0x90020801,  //  0008  SETMBR	R0	K4	R1
-      0x90020A02,  //  0009  SETMBR	R0	K5	R2
-      0x90020C03,  //  000A  SETMBR	R0	K6	R3
-      0x90020E01,  //  000B  SETMBR	R0	K7	R1
+      0x90020205,  //  0007  SETMBR	R0	K1	R5
+      0x90020401,  //  0008  SETMBR	R0	K2	R1
+      0x90020602,  //  0009  SETMBR	R0	K3	R2
+      0x90021003,  //  000A  SETMBR	R0	K8	R3
+      0x90021201,  //  000B  SETMBR	R0	K9	R1
       0x4C140000,  //  000C  LDNIL	R5
       0x1C140805,  //  000D  EQ	R5	R4	R5
       0x78160000,  //  000E  JMPF	R5	#0010
-      0x58100008,  //  000F  LDCONST	R4	K8
-      0x90021204,  //  0010  SETMBR	R0	K9	R4
+      0x58100004,  //  000F  LDCONST	R4	K4
+      0x90020A04,  //  0010  SETMBR	R0	K5	R4
       0x80000000,  //  0011  RET	0
     })
   )
@@ -1364,38 +1313,17 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(duration_ms),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(origin),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(scale_uint),
-    /* K6   */  be_nested_str_weak(duty_cycle),
-    /* K7   */  be_nested_str_weak(beat),
-    /* K8   */  be_nested_str_weak(a),
-    /* K9   */  be_nested_str_weak(b),
-    /* K10  */  be_nested_str_weak(value),
-    /* K11  */  be_nested_str_weak(phase),
-    /* K12  */  be_nested_str_weak(form),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(scale_int),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(sine_int),
-    /* K18  */  be_nested_str_weak(obj),
-    /* K19  */  be_nested_str_weak(mth),
-    }),
+    &be_ktab_class_Animate_oscillator,     /* shared constants */
     be_str_weak(animate),
     &be_const_str_solidified,
     ( &(const binstruction[141]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080108,  //  0000  GETMBR	R2	R0	K8
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x780A0000,  //  0003  JMPF	R2	#0005
@@ -1403,24 +1331,24 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
       0x4C080000,  //  0005  LDNIL	R2
       0x1C080202,  //  0006  EQ	R2	R1	R2
       0x780A0003,  //  0007  JMPF	R2	#000C
-      0xB80A0200,  //  0008  GETNGBL	R2	K1
-      0x8C080502,  //  0009  GETMET	R2	R2	K2
+      0xB80A1400,  //  0008  GETNGBL	R2	K10
+      0x8C08050B,  //  0009  GETMET	R2	R2	K11
       0x7C080200,  //  000A  CALL	R2	1
       0x5C040400,  //  000B  MOVE	R1	R2
-      0x88080103,  //  000C  GETMBR	R2	R0	K3
+      0x8808010C,  //  000C  GETMBR	R2	R0	K12
       0x04080202,  //  000D  SUB	R2	R1	R2
-      0x140C0504,  //  000E  LT	R3	R2	K4
+      0x140C0500,  //  000E  LT	R3	R2	K0
       0x780E0001,  //  000F  JMPF	R3	#0012
-      0x58080004,  //  0010  LDCONST	R2	K4
-      0x88040103,  //  0011  GETMBR	R1	R0	K3
-      0x880C0100,  //  0012  GETMBR	R3	R0	K0
+      0x58080000,  //  0010  LDCONST	R2	K0
+      0x8804010C,  //  0011  GETMBR	R1	R0	K12
+      0x880C0108,  //  0012  GETMBR	R3	R0	K8
       0x4C100000,  //  0013  LDNIL	R4
-      0xB8160200,  //  0014  GETNGBL	R5	K1
-      0x8C140B05,  //  0015  GETMET	R5	R5	K5
-      0x881C0106,  //  0016  GETMBR	R7	R0	K6
-      0x58200004,  //  0017  LDCONST	R8	K4
+      0xB8161400,  //  0014  GETNGBL	R5	K10
+      0x8C140B0D,  //  0015  GETMET	R5	R5	K13
+      0x881C0101,  //  0016  GETMBR	R7	R0	K1
+      0x58200000,  //  0017  LDCONST	R8	K0
       0x54260063,  //  0018  LDINT	R9	100
-      0x58280004,  //  0019  LDCONST	R10	K4
+      0x58280000,  //  0019  LDCONST	R10	K0
       0x5C2C0600,  //  001A  MOVE	R11	R3
       0x7C140C00,  //  001B  CALL	R5	6
       0x5C100A00,  //  001C  MOVE	R4	R5
@@ -1428,71 +1356,71 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
       0x78160007,  //  001E  JMPF	R5	#0027
       0x0C180403,  //  001F  DIV	R6	R2	R3
       0x08180C03,  //  0020  MUL	R6	R6	R3
-      0x88140103,  //  0021  GETMBR	R5	R0	K3
+      0x8814010C,  //  0021  GETMBR	R5	R0	K12
       0x00140A06,  //  0022  ADD	R5	R5	R6
-      0x90020605,  //  0023  SETMBR	R0	K3	R5
+      0x90021805,  //  0023  SETMBR	R0	K12	R5
       0x10080403,  //  0024  MOD	R2	R2	R3
-      0x8C140107,  //  0025  GETMET	R5	R0	K7
+      0x8C14010E,  //  0025  GETMET	R5	R0	K14
       0x7C140200,  //  0026  CALL	R5	1
-      0x88140108,  //  0027  GETMBR	R5	R0	K8
-      0x88180109,  //  0028  GETMBR	R6	R0	K9
-      0x881C010A,  //  0029  GETMBR	R7	R0	K10
+      0x88140102,  //  0027  GETMBR	R5	R0	K2
+      0x88180103,  //  0028  GETMBR	R6	R0	K3
+      0x881C0109,  //  0029  GETMBR	R7	R0	K9
       0x5C200400,  //  002A  MOVE	R8	R2
-      0x8824010B,  //  002B  GETMBR	R9	R0	K11
-      0x24241304,  //  002C  GT	R9	R9	K4
+      0x88240106,  //  002B  GETMBR	R9	R0	K6
+      0x24241300,  //  002C  GT	R9	R9	K0
       0x7826000B,  //  002D  JMPF	R9	#003A
-      0xB8260200,  //  002E  GETNGBL	R9	K1
-      0x8C241305,  //  002F  GETMET	R9	R9	K5
-      0x882C010B,  //  0030  GETMBR	R11	R0	K11
-      0x58300004,  //  0031  LDCONST	R12	K4
+      0xB8261400,  //  002E  GETNGBL	R9	K10
+      0x8C24130D,  //  002F  GETMET	R9	R9	K13
+      0x882C0106,  //  0030  GETMBR	R11	R0	K6
+      0x58300000,  //  0031  LDCONST	R12	K0
       0x54360063,  //  0032  LDINT	R13	100
-      0x58380004,  //  0033  LDCONST	R14	K4
+      0x58380000,  //  0033  LDCONST	R14	K0
       0x5C3C0600,  //  0034  MOVE	R15	R3
       0x7C240C00,  //  0035  CALL	R9	6
       0x00201009,  //  0036  ADD	R8	R8	R9
       0x24241003,  //  0037  GT	R9	R8	R3
       0x78260000,  //  0038  JMPF	R9	#003A
       0x04201003,  //  0039  SUB	R8	R8	R3
-      0x8824010C,  //  003A  GETMBR	R9	R0	K12
-      0x1C24130D,  //  003B  EQ	R9	R9	K13
+      0x88240105,  //  003A  GETMBR	R9	R0	K5
+      0x1C24130F,  //  003B  EQ	R9	R9	K15
       0x78260009,  //  003C  JMPF	R9	#0047
-      0xB8260200,  //  003D  GETNGBL	R9	K1
-      0x8C24130E,  //  003E  GETMET	R9	R9	K14
+      0xB8261400,  //  003D  GETNGBL	R9	K10
+      0x8C241310,  //  003E  GETMET	R9	R9	K16
       0x5C2C1000,  //  003F  MOVE	R11	R8
-      0x58300004,  //  0040  LDCONST	R12	K4
-      0x0434070D,  //  0041  SUB	R13	R3	K13
+      0x58300000,  //  0040  LDCONST	R12	K0
+      0x0434070F,  //  0041  SUB	R13	R3	K15
       0x5C380A00,  //  0042  MOVE	R14	R5
       0x5C3C0C00,  //  0043  MOVE	R15	R6
       0x7C240C00,  //  0044  CALL	R9	6
       0x5C1C1200,  //  0045  MOVE	R7	R9
       0x7002003B,  //  0046  JMP		#0083
-      0x8824010C,  //  0047  GETMBR	R9	R0	K12
-      0x1C24130F,  //  0048  EQ	R9	R9	K15
+      0x88240105,  //  0047  GETMBR	R9	R0	K5
+      0x1C241311,  //  0048  EQ	R9	R9	K17
       0x78260015,  //  0049  JMPF	R9	#0060
       0x14241004,  //  004A  LT	R9	R8	R4
       0x78260009,  //  004B  JMPF	R9	#0056
-      0xB8260200,  //  004C  GETNGBL	R9	K1
-      0x8C24130E,  //  004D  GETMET	R9	R9	K14
+      0xB8261400,  //  004C  GETNGBL	R9	K10
+      0x8C241310,  //  004D  GETMET	R9	R9	K16
       0x5C2C1000,  //  004E  MOVE	R11	R8
-      0x58300004,  //  004F  LDCONST	R12	K4
-      0x0434090D,  //  0050  SUB	R13	R4	K13
+      0x58300000,  //  004F  LDCONST	R12	K0
+      0x0434090F,  //  0050  SUB	R13	R4	K15
       0x5C380A00,  //  0051  MOVE	R14	R5
       0x5C3C0C00,  //  0052  MOVE	R15	R6
       0x7C240C00,  //  0053  CALL	R9	6
       0x5C1C1200,  //  0054  MOVE	R7	R9
       0x70020008,  //  0055  JMP		#005F
-      0xB8260200,  //  0056  GETNGBL	R9	K1
-      0x8C24130E,  //  0057  GETMET	R9	R9	K14
+      0xB8261400,  //  0056  GETNGBL	R9	K10
+      0x8C241310,  //  0057  GETMET	R9	R9	K16
       0x5C2C1000,  //  0058  MOVE	R11	R8
       0x5C300800,  //  0059  MOVE	R12	R4
-      0x0434070D,  //  005A  SUB	R13	R3	K13
+      0x0434070F,  //  005A  SUB	R13	R3	K15
       0x5C380C00,  //  005B  MOVE	R14	R6
       0x5C3C0A00,  //  005C  MOVE	R15	R5
       0x7C240C00,  //  005D  CALL	R9	6
       0x5C1C1200,  //  005E  MOVE	R7	R9
       0x70020022,  //  005F  JMP		#0083
-      0x8824010C,  //  0060  GETMBR	R9	R0	K12
-      0x1C241310,  //  0061  EQ	R9	R9	K16
+      0x88240105,  //  0060  GETMBR	R9	R0	K5
+      0x1C241312,  //  0061  EQ	R9	R9	K18
       0x78260005,  //  0062  JMPF	R9	#0069
       0x14241004,  //  0063  LT	R9	R8	R4
       0x78260001,  //  0064  JMPF	R9	#0067
@@ -1500,25 +1428,25 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
       0x70020000,  //  0066  JMP		#0068
       0x5C1C0C00,  //  0067  MOVE	R7	R6
       0x70020019,  //  0068  JMP		#0083
-      0x8824010C,  //  0069  GETMBR	R9	R0	K12
+      0x88240105,  //  0069  GETMBR	R9	R0	K5
       0x542A0003,  //  006A  LDINT	R10	4
       0x1C24120A,  //  006B  EQ	R9	R9	R10
       0x78260015,  //  006C  JMPF	R9	#0083
-      0xB8260200,  //  006D  GETNGBL	R9	K1
-      0x8C24130E,  //  006E  GETMET	R9	R9	K14
+      0xB8261400,  //  006D  GETNGBL	R9	K10
+      0x8C241310,  //  006E  GETMET	R9	R9	K16
       0x5C2C1000,  //  006F  MOVE	R11	R8
-      0x58300004,  //  0070  LDCONST	R12	K4
-      0x0434070D,  //  0071  SUB	R13	R3	K13
-      0x58380004,  //  0072  LDCONST	R14	K4
+      0x58300000,  //  0070  LDCONST	R12	K0
+      0x0434070F,  //  0071  SUB	R13	R3	K15
+      0x58380000,  //  0072  LDCONST	R14	K0
       0x543E7FFE,  //  0073  LDINT	R15	32767
       0x7C240C00,  //  0074  CALL	R9	6
-      0xB82A0200,  //  0075  GETNGBL	R10	K1
-      0x8C281511,  //  0076  GETMET	R10	R10	K17
+      0xB82A1400,  //  0075  GETNGBL	R10	K10
+      0x8C281513,  //  0076  GETMET	R10	R10	K19
       0x54321FFF,  //  0077  LDINT	R12	8192
       0x0430120C,  //  0078  SUB	R12	R9	R12
       0x7C280400,  //  0079  CALL	R10	2
-      0xB82E0200,  //  007A  GETNGBL	R11	K1
-      0x8C2C170E,  //  007B  GETMET	R11	R11	K14
+      0xB82E1400,  //  007A  GETNGBL	R11	K10
+      0x8C2C1710,  //  007B  GETMET	R11	R11	K16
       0x5C341400,  //  007C  MOVE	R13	R10
       0x5439EFFF,  //  007D  LDINT	R14	-4096
       0x543E0FFF,  //  007E  LDINT	R15	4096
@@ -1526,9 +1454,9 @@ be_local_closure(class_Animate_oscillator_animate,   /* name */
       0x5C440C00,  //  0080  MOVE	R17	R6
       0x7C2C0C00,  //  0081  CALL	R11	6
       0x5C1C1600,  //  0082  MOVE	R7	R11
-      0x90021407,  //  0083  SETMBR	R0	K10	R7
-      0x88240112,  //  0084  GETMBR	R9	R0	K18
-      0x88280113,  //  0085  GETMBR	R10	R0	K19
+      0x90021207,  //  0083  SETMBR	R0	K9	R7
+      0x88240114,  //  0084  GETMBR	R9	R0	K20
+      0x88280115,  //  0085  GETMBR	R10	R0	K21
       0x78260004,  //  0086  JMPF	R9	#008C
       0x782A0003,  //  0087  JMPF	R10	#008C
       0x5C2C1400,  //  0088  MOVE	R11	R10

--- a/lib/libesp32/berry_animate/src/solidify/solidified_leds_frame_be_methods.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_leds_frame_be_methods.h
@@ -3,6 +3,16 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Leds_frame_be' ktab size: 6, total: 7 (saved 8 bytes)
+static const bvalue be_ktab_class_Leds_frame_be[6] = {
+  /* K0   */  be_nested_str(set),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str(setitem),
+  /* K3   */  be_nested_str(get),
+  /* K4   */  be_nested_str(pixel_size),
+  /* K5   */  be_nested_str(init),
+};
+
 
 extern const bclass be_class_Leds_frame_be;
 
@@ -13,15 +23,13 @@ be_local_closure(class_Leds_frame_be_setitem,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(set),
-    }),
+    &be_ktab_class_Leds_frame_be,     /* shared constants */
     &be_const_str_setitem,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -45,23 +53,20 @@ be_local_closure(class_Leds_frame_be_set_pixel,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(setitem),
-    }),
+    &be_ktab_class_Leds_frame_be,     /* shared constants */
     &be_const_str_set_pixel,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0x4C180000,  //  0000  LDNIL	R6
       0x1C180A06,  //  0001  EQ	R6	R5	R6
       0x781A0000,  //  0002  JMPF	R6	#0004
-      0x58140000,  //  0003  LDCONST	R5	K0
+      0x58140001,  //  0003  LDCONST	R5	K1
       0x541A00FE,  //  0004  LDINT	R6	255
       0x2C180A06,  //  0005  AND	R6	R5	R6
       0x541E0017,  //  0006  LDINT	R7	24
@@ -79,7 +84,7 @@ be_local_closure(class_Leds_frame_be_set_pixel,   /* name */
       0x541E00FE,  //  0012  LDINT	R7	255
       0x2C1C0807,  //  0013  AND	R7	R4	R7
       0x30180C07,  //  0014  OR	R6	R6	R7
-      0x8C1C0101,  //  0015  GETMET	R7	R0	K1
+      0x8C1C0102,  //  0015  GETMET	R7	R0	K2
       0x5C240200,  //  0016  MOVE	R9	R1
       0x5C280C00,  //  0017  MOVE	R10	R6
       0x7C1C0600,  //  0018  CALL	R7	3
@@ -97,19 +102,17 @@ be_local_closure(class_Leds_frame_be_item,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(get),
-    }),
+    &be_ktab_class_Leds_frame_be,     /* shared constants */
     &be_const_str_item,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080103,  //  0000  GETMET	R2	R0	K3
       0x54120003,  //  0001  LDINT	R4	4
       0x08100204,  //  0002  MUL	R4	R1	R4
       0x54160003,  //  0003  LDINT	R5	4
@@ -128,28 +131,24 @@ be_local_closure(class_Leds_frame_be_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(pixel_size),
-    /* K2   */  be_nested_str(init),
-    }),
+    &be_ktab_class_Leds_frame_be,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x14080300,  //  0000  LT	R2	R1	K0
+      0x14080301,  //  0000  LT	R2	R1	K1
       0x780A0000,  //  0001  JMPF	R2	#0003
       0x44040200,  //  0002  NEG	R1	R1
-      0x90020201,  //  0003  SETMBR	R0	K1	R1
+      0x90020801,  //  0003  SETMBR	R0	K4	R1
       0x60080003,  //  0004  GETGBL	R2	G3
       0x5C0C0000,  //  0005  MOVE	R3	R0
       0x7C080200,  //  0006  CALL	R2	1
-      0x8C080502,  //  0007  GETMET	R2	R2	K2
+      0x8C080505,  //  0007  GETMET	R2	R2	K5
       0x5411FFFB,  //  0008  LDINT	R4	-4
       0x08100204,  //  0009  MUL	R4	R1	R4
       0x7C080400,  //  000A  CALL	R2	2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -3,6 +3,200 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Commisioning_Context' ktab size: 190, total: 359 (saved 1352 bytes)
+static const bvalue be_ktab_class_Matter_Commisioning_Context[190] = {
+  /* K0   */  be_nested_str_weak(session),
+  /* K1   */  be_nested_str_weak(raw),
+  /* K2   */  be_nested_str_weak(app_payload_idx),
+  /* K3   */  be_const_int(2147483647),
+  /* K4   */  be_nested_str_weak(tohex),
+  /* K5   */  be_nested_str_weak(log),
+  /* K6   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20_X25s),
+  /* K7   */  be_nested_str_weak(0000000000000000),
+  /* K8   */  be_const_int(3),
+  /* K9   */  be_nested_str_weak(crypto),
+  /* K10  */  be_nested_str_weak(tasmota),
+  /* K11  */  be_nested_str_weak(loglevel),
+  /* K12  */  be_nested_str_weak(MTR_X3A_X20SEARCHING_X3A_X20destinationId_X3D),
+  /* K13  */  be_nested_str_weak(device),
+  /* K14  */  be_nested_str_weak(sessions),
+  /* K15  */  be_nested_str_weak(fabrics),
+  /* K16  */  be_nested_str_weak(noc),
+  /* K17  */  be_nested_str_weak(fabric_id),
+  /* K18  */  be_nested_str_weak(device_id),
+  /* K19  */  be_nested_str_weak(get_ca_pub),
+  /* K20  */  be_nested_str_weak(get_ipk_group_key),
+  /* K21  */  be_nested_str_weak(HMAC_SHA256),
+  /* K22  */  be_nested_str_weak(update),
+  /* K23  */  be_nested_str_weak(out),
+  /* K24  */  be_nested_str_weak(MTR_X3A_X20SIGMA1_X3A_X20candidateDestinationId_X3D),
+  /* K25  */  be_nested_str_weak(stop_iteration),
+  /* K26  */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
+  /* K27  */  be_nested_str_weak(create_session),
+  /* K28  */  be_nested_str_weak(set_keys),
+  /* K29  */  be_nested_str_weak(opcode),
+  /* K30  */  be_nested_str_weak(local_session_id),
+  /* K31  */  be_const_int(0),
+  /* K32  */  be_nested_str_weak(protocol_id),
+  /* K33  */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
+  /* K34  */  be_const_int(2),
+  /* K35  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+  /* K36  */  be_const_int(3),
+  /* K37  */  be_nested_str_weak(send_status_report),
+  /* K38  */  be_const_int(1),
+  /* K39  */  be_nested_str_weak(matter),
+  /* K40  */  be_nested_str_weak(PBKDFParamRequest),
+  /* K41  */  be_nested_str_weak(parse),
+  /* K42  */  be_nested_str_weak(set_mode_PASE),
+  /* K43  */  be_nested_str_weak(__Msg1),
+  /* K44  */  be_nested_str_weak(passcodeId),
+  /* K45  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
+  /* K46  */  be_nested_str_weak(__future_initiator_session_id),
+  /* K47  */  be_nested_str_weak(initiator_session_id),
+  /* K48  */  be_nested_str_weak(__future_local_session_id),
+  /* K49  */  be_nested_str_weak(gen_local_session_id),
+  /* K50  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+  /* K51  */  be_nested_str_weak(remote_ip),
+  /* K52  */  be_nested_str_weak(remote_port),
+  /* K53  */  be_nested_str_weak(PBKDFParamResponse),
+  /* K54  */  be_nested_str_weak(initiatorRandom),
+  /* K55  */  be_nested_str_weak(responderRandom),
+  /* K56  */  be_nested_str_weak(random),
+  /* K57  */  be_nested_str_weak(responderSessionId),
+  /* K58  */  be_nested_str_weak(pbkdf_parameters_salt),
+  /* K59  */  be_nested_str_weak(commissioning_salt),
+  /* K60  */  be_nested_str_weak(pbkdf_parameters_iterations),
+  /* K61  */  be_nested_str_weak(commissioning_iterations),
+  /* K62  */  be_nested_str_weak(tlv2raw),
+  /* K63  */  be_nested_str_weak(__Msg2),
+  /* K64  */  be_nested_str_weak(build_response),
+  /* K65  */  be_nested_str_weak(encode_frame),
+  /* K66  */  be_nested_str_weak(responder),
+  /* K67  */  be_nested_str_weak(send_response_frame),
+  /* K68  */  be_nested_str_weak(add),
+  /* K69  */  be_const_int(2),
+  /* K70  */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
+  /* K71  */  be_nested_str_weak(Pake1),
+  /* K72  */  be_nested_str_weak(pA),
+  /* K73  */  be_nested_str_weak(SPAKE2P_Matter),
+  /* K74  */  be_nested_str_weak(commissioning_w0),
+  /* K75  */  be_nested_str_weak(commissioning_L),
+  /* K76  */  be_nested_str_weak(compute_pB),
+  /* K77  */  be_nested_str_weak(compute_ZV_verifier),
+  /* K78  */  be_nested_str_weak(SHA256),
+  /* K79  */  be_nested_str_weak(fromstring),
+  /* K80  */  be_nested_str_weak(Matter_Context_Prefix),
+  /* K81  */  be_nested_str_weak(set_context),
+  /* K82  */  be_nested_str_weak(compute_TT_hash),
+  /* K83  */  be_nested_str_weak(Pake2),
+  /* K84  */  be_nested_str_weak(pB),
+  /* K85  */  be_nested_str_weak(cB),
+  /* K86  */  be_nested_str_weak(__spake_cA),
+  /* K87  */  be_nested_str_weak(cA),
+  /* K88  */  be_nested_str_weak(__spake_Ke),
+  /* K89  */  be_nested_str_weak(Ke),
+  /* K90  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K91  */  be_nested_str_weak(_ip),
+  /* K92  */  be_nested_str_weak(_port),
+  /* K93  */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake3_X20message),
+  /* K94  */  be_nested_str_weak(Pake3),
+  /* K95  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
+  /* K96  */  be_nested_str_weak(rtc_utc),
+  /* K97  */  be_nested_str_weak(HKDF_SHA256),
+  /* K98  */  be_nested_str_weak(derive),
+  /* K99  */  be_nested_str_weak(SEKeys_Info),
+  /* K100 */  be_nested_str_weak(add_session),
+  /* K101 */  be_const_int(3),
+  /* K102 */  be_const_int(1),
+  /* K103 */  be_const_int(2),
+  /* K104 */  be_nested_str_weak(Sigma3),
+  /* K105 */  be_nested_str_weak(S3K_Info),
+  /* K106 */  be_nested_str_weak(shared_secret),
+  /* K107 */  be_nested_str_weak(TBEData3Encrypted),
+  /* K108 */  be_const_int(2147483647),
+  /* K109 */  be_nested_str_weak(AES_CCM),
+  /* K110 */  be_nested_str_weak(TBEData3_Nonce),
+  /* K111 */  be_nested_str_weak(decrypt),
+  /* K112 */  be_nested_str_weak(tag),
+  /* K113 */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
+  /* K114 */  be_nested_str_weak(TLV),
+  /* K115 */  be_nested_str_weak(findsubval),
+  /* K116 */  be_nested_str_weak(findsub),
+  /* K117 */  be_nested_str_weak(int),
+  /* K118 */  be_nested_str_weak(peer_node_id),
+  /* K119 */  be_nested_str_weak(int64),
+  /* K120 */  be_nested_str_weak(fromu32),
+  /* K121 */  be_nested_str_weak(tobytes),
+  /* K122 */  be_nested_str_weak(Matter_TLV_struct),
+  /* K123 */  be_nested_str_weak(add_TLV),
+  /* K124 */  be_nested_str_weak(B1),
+  /* K125 */  be_nested_str_weak(__initiator_pub),
+  /* K126 */  be_nested_str_weak(__responder_pub),
+  /* K127 */  be_nested_str_weak(EC_P256),
+  /* K128 */  be_nested_str_weak(ecdsa_verify_sha256),
+  /* K129 */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
+  /* K130 */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X20Invalid_X20signature_X2C_X20trying_X20anyways),
+  /* K131 */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
+  /* K132 */  be_nested_str_weak(Msg3),
+  /* K133 */  be_nested_str_weak(close),
+  /* K134 */  be_nested_str_weak(_breadcrumb),
+  /* K135 */  be_nested_str_weak(counter_snd_next),
+  /* K136 */  be_nested_str_weak(set_persist),
+  /* K137 */  be_nested_str_weak(set_no_expiration),
+  /* K138 */  be_nested_str_weak(persist_to_fabric),
+  /* K139 */  be_nested_str_weak(save),
+  /* K140 */  be_nested_str_weak(is_commissioning_open),
+  /* K141 */  be_nested_str_weak(MTR_X3A_X20commissioning_X20not_X20open),
+  /* K142 */  be_nested_str_weak(parse_PBKDFParamRequest),
+  /* K143 */  be_nested_str_weak(parse_Pake1),
+  /* K144 */  be_nested_str_weak(parse_Pake3),
+  /* K145 */  be_nested_str_weak(parse_Sigma1),
+  /* K146 */  be_nested_str_weak(parse_Sigma3),
+  /* K147 */  be_nested_str_weak(parse_StatusReport),
+  /* K148 */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
+  /* K149 */  be_nested_str_weak(Sigma1),
+  /* K150 */  be_nested_str_weak(initiatorEphPubKey),
+  /* K151 */  be_nested_str_weak(resumptionID),
+  /* K152 */  be_nested_str_weak(initiatorResumeMIC),
+  /* K153 */  be_nested_str_weak(find_session_by_resumption_id),
+  /* K154 */  be_nested_str_weak(_fabric),
+  /* K155 */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20FAILED_X2C_X20session_X20not_X20found_X20resumption_id_X3D_X25s),
+  /* K156 */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption),
+  /* K157 */  be_nested_str_weak(Sigma1_Resume),
+  /* K158 */  be_nested_str_weak(NCASE_SigmaS1),
+  /* K159 */  be_nested_str_weak(_source_node_id),
+  /* K160 */  be_nested_str_weak(source_node_id),
+  /* K161 */  be_nested_str_weak(set_mode_CASE),
+  /* K162 */  be_nested_str_weak(resumption_id),
+  /* K163 */  be_nested_str_weak(Sigma2_Resume),
+  /* K164 */  be_nested_str_weak(NCASE_SigmaS2),
+  /* K165 */  be_nested_str_weak(Sigma2Resume),
+  /* K166 */  be_nested_str_weak(sigma2ResumeMIC),
+  /* K167 */  be_nested_str_weak(responderSessionID),
+  /* K168 */  be_nested_str_weak(SessionResumptionKeys),
+  /* K169 */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20SUCCEEDED),
+  /* K170 */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20FAILED_X2C_X20switching_X20to_X20CASE),
+  /* K171 */  be_nested_str_weak(find_fabric_by_destination_id),
+  /* K172 */  be_nested_str_weak(destinationId),
+  /* K173 */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
+  /* K174 */  be_nested_str_weak(__responder_priv),
+  /* K175 */  be_nested_str_weak(public_key),
+  /* K176 */  be_nested_str_weak(shared_key),
+  /* K177 */  be_nested_str_weak(B2),
+  /* K178 */  be_nested_str_weak(get_noc),
+  /* K179 */  be_nested_str_weak(get_icac),
+  /* K180 */  be_nested_str_weak(ecdsa_sign_sha256),
+  /* K181 */  be_nested_str_weak(get_pk),
+  /* K182 */  be_nested_str_weak(Msg1),
+  /* K183 */  be_nested_str_weak(S2K_Info),
+  /* K184 */  be_nested_str_weak(TBEData2_Nonce),
+  /* K185 */  be_nested_str_weak(encrypt),
+  /* K186 */  be_nested_str_weak(Sigma2),
+  /* K187 */  be_nested_str_weak(responderEphPubKey),
+  /* K188 */  be_nested_str_weak(encrypted2),
+  /* K189 */  be_nested_str_weak(MTR_X3A_X20New_X20Connection_X20_X28CASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+};
+
 
 extern const bclass be_class_Matter_Commisioning_Context;
 
@@ -13,23 +207,13 @@ be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(raw),
-    /* K2   */  be_nested_str_weak(app_payload_idx),
-    /* K3   */  be_const_int(2147483647),
-    /* K4   */  be_nested_str_weak(tohex),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20_X25s),
-    /* K7   */  be_nested_str_weak(0000000000000000),
-    /* K8   */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_StatusReport),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
@@ -66,95 +250,75 @@ be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id
   be_nested_proto(
     13,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(loglevel),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20SEARCHING_X3A_X20destinationId_X3D),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(device),
-    /* K7   */  be_nested_str_weak(sessions),
-    /* K8   */  be_nested_str_weak(fabrics),
-    /* K9   */  be_nested_str_weak(noc),
-    /* K10  */  be_nested_str_weak(fabric_id),
-    /* K11  */  be_nested_str_weak(device_id),
-    /* K12  */  be_nested_str_weak(get_ca_pub),
-    /* K13  */  be_nested_str_weak(get_ipk_group_key),
-    /* K14  */  be_nested_str_weak(HMAC_SHA256),
-    /* K15  */  be_nested_str_weak(update),
-    /* K16  */  be_nested_str_weak(out),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20SIGMA1_X3A_X20candidateDestinationId_X3D),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(find_fabric_by_destination_id),
     &be_const_str_solidified,
     ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0xA40E1200,  //  0000  IMPORT	R3	K9
+      0xB8121400,  //  0001  GETNGBL	R4	K10
+      0x8C10090B,  //  0002  GETMET	R4	R4	K11
       0x541A0003,  //  0003  LDINT	R6	4
       0x7C100400,  //  0004  CALL	R4	2
       0x78120005,  //  0005  JMPF	R4	#000C
-      0xB8120600,  //  0006  GETNGBL	R4	K3
-      0x8C140305,  //  0007  GETMET	R5	R1	K5
+      0xB8120A00,  //  0006  GETNGBL	R4	K5
+      0x8C140304,  //  0007  GETMET	R5	R1	K4
       0x7C140200,  //  0008  CALL	R5	1
-      0x00160805,  //  0009  ADD	R5	K4	R5
+      0x00161805,  //  0009  ADD	R5	K12	R5
       0x541A0003,  //  000A  LDINT	R6	4
       0x7C100400,  //  000B  CALL	R4	2
       0x60100010,  //  000C  GETGBL	R4	G16
-      0x88140106,  //  000D  GETMBR	R5	R0	K6
-      0x88140B07,  //  000E  GETMBR	R5	R5	K7
-      0x88140B08,  //  000F  GETMBR	R5	R5	K8
+      0x8814010D,  //  000D  GETMBR	R5	R0	K13
+      0x88140B0E,  //  000E  GETMBR	R5	R5	K14
+      0x88140B0F,  //  000F  GETMBR	R5	R5	K15
       0x7C100200,  //  0010  CALL	R4	1
       0xA802002F,  //  0011  EXBLK	0	#0042
       0x5C140800,  //  0012  MOVE	R5	R4
       0x7C140000,  //  0013  CALL	R5	0
-      0x88180B09,  //  0014  GETMBR	R6	R5	K9
+      0x88180B10,  //  0014  GETMBR	R6	R5	K16
       0x4C1C0000,  //  0015  LDNIL	R7
       0x1C180C07,  //  0016  EQ	R6	R6	R7
       0x741A0007,  //  0017  JMPT	R6	#0020
-      0x88180B0A,  //  0018  GETMBR	R6	R5	K10
+      0x88180B11,  //  0018  GETMBR	R6	R5	K17
       0x4C1C0000,  //  0019  LDNIL	R7
       0x1C180C07,  //  001A  EQ	R6	R6	R7
       0x741A0003,  //  001B  JMPT	R6	#0020
-      0x88180B0B,  //  001C  GETMBR	R6	R5	K11
+      0x88180B12,  //  001C  GETMBR	R6	R5	K18
       0x4C1C0000,  //  001D  LDNIL	R7
       0x1C180C07,  //  001E  EQ	R6	R6	R7
       0x781A0000,  //  001F  JMPF	R6	#0021
       0x7001FFF0,  //  0020  JMP		#0012
-      0x8C180B0C,  //  0021  GETMET	R6	R5	K12
+      0x8C180B13,  //  0021  GETMET	R6	R5	K19
       0x7C180200,  //  0022  CALL	R6	1
       0x00180406,  //  0023  ADD	R6	R2	R6
-      0x881C0B0A,  //  0024  GETMBR	R7	R5	K10
+      0x881C0B11,  //  0024  GETMBR	R7	R5	K17
       0x00180C07,  //  0025  ADD	R6	R6	R7
-      0x881C0B0B,  //  0026  GETMBR	R7	R5	K11
+      0x881C0B12,  //  0026  GETMBR	R7	R5	K18
       0x00180C07,  //  0027  ADD	R6	R6	R7
-      0x8C1C0B0D,  //  0028  GETMET	R7	R5	K13
+      0x8C1C0B14,  //  0028  GETMET	R7	R5	K20
       0x7C1C0200,  //  0029  CALL	R7	1
-      0x8C20070E,  //  002A  GETMET	R8	R3	K14
+      0x8C200715,  //  002A  GETMET	R8	R3	K21
       0x5C280E00,  //  002B  MOVE	R10	R7
       0x7C200400,  //  002C  CALL	R8	2
-      0x8C24110F,  //  002D  GETMET	R9	R8	K15
+      0x8C241116,  //  002D  GETMET	R9	R8	K22
       0x5C2C0C00,  //  002E  MOVE	R11	R6
       0x7C240400,  //  002F  CALL	R9	2
-      0x8C241110,  //  0030  GETMET	R9	R8	K16
+      0x8C241117,  //  0030  GETMET	R9	R8	K23
       0x7C240200,  //  0031  CALL	R9	1
-      0xB82A0200,  //  0032  GETNGBL	R10	K1
-      0x8C281502,  //  0033  GETMET	R10	R10	K2
+      0xB82A1400,  //  0032  GETNGBL	R10	K10
+      0x8C28150B,  //  0033  GETMET	R10	R10	K11
       0x54320003,  //  0034  LDINT	R12	4
       0x7C280400,  //  0035  CALL	R10	2
       0x782A0005,  //  0036  JMPF	R10	#003D
-      0xB82A0600,  //  0037  GETNGBL	R10	K3
-      0x8C2C1305,  //  0038  GETMET	R11	R9	K5
+      0xB82A0A00,  //  0037  GETNGBL	R10	K5
+      0x8C2C1304,  //  0038  GETMET	R11	R9	K4
       0x7C2C0200,  //  0039  CALL	R11	1
-      0x002E220B,  //  003A  ADD	R11	K17	R11
+      0x002E300B,  //  003A  ADD	R11	K24	R11
       0x54320003,  //  003B  LDINT	R12	4
       0x7C280400,  //  003C  CALL	R10	2
       0x1C281201,  //  003D  EQ	R10	R9	R1
@@ -162,7 +326,7 @@ be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id
       0xA8040001,  //  003F  EXBLK	1	1
       0x80040A00,  //  0040  RET	1	R5
       0x7001FFCF,  //  0041  JMP		#0012
-      0x58100012,  //  0042  LDCONST	R4	K18
+      0x58100019,  //  0042  LDCONST	R4	K25
       0xAC100200,  //  0043  CATCH	R4	1	0
       0xB0080000,  //  0044  RAISE	2	R0	R0
       0x4C100000,  //  0045  LDNIL	R4
@@ -180,13 +344,13 @@ be_local_closure(class_Matter_Commisioning_Context_every_second,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -204,38 +368,31 @@ be_local_closure(class_Matter_Commisioning_Context_add_session,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
-    /* K2   */  be_nested_str_weak(device),
-    /* K3   */  be_nested_str_weak(sessions),
-    /* K4   */  be_nested_str_weak(create_session),
-    /* K5   */  be_nested_str_weak(set_keys),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(add_session),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xB81A0000,  //  0000  GETNGBL	R6	K0
+      0xB81A0A00,  //  0000  GETNGBL	R6	K5
       0x601C0018,  //  0001  GETGBL	R7	G24
-      0x58200001,  //  0002  LDCONST	R8	K1
+      0x5820001A,  //  0002  LDCONST	R8	K26
       0x5C240200,  //  0003  MOVE	R9	R1
       0x5C280400,  //  0004  MOVE	R10	R2
       0x7C1C0600,  //  0005  CALL	R7	3
       0x54220003,  //  0006  LDINT	R8	4
       0x7C180400,  //  0007  CALL	R6	2
-      0x88180102,  //  0008  GETMBR	R6	R0	K2
-      0x88180D03,  //  0009  GETMBR	R6	R6	K3
-      0x8C180D04,  //  000A  GETMET	R6	R6	K4
+      0x8818010D,  //  0008  GETMBR	R6	R0	K13
+      0x88180D0E,  //  0009  GETMBR	R6	R6	K14
+      0x8C180D1B,  //  000A  GETMET	R6	R6	K27
       0x5C200200,  //  000B  MOVE	R8	R1
       0x5C240400,  //  000C  MOVE	R9	R2
       0x7C180600,  //  000D  CALL	R6	3
-      0x8C1C0D05,  //  000E  GETMET	R7	R6	K5
+      0x8C1C0D1C,  //  000E  GETMET	R7	R6	K28
       0x5C240600,  //  000F  MOVE	R9	R3
       0x5C280800,  //  0010  MOVE	R10	R4
       0x5C2C0A00,  //  0011  MOVE	R11	R5
@@ -254,173 +411,125 @@ be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /*
   be_nested_proto(
     12,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[47]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(send_status_report),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(matter),
-    /* K14  */  be_nested_str_weak(PBKDFParamRequest),
-    /* K15  */  be_nested_str_weak(parse),
-    /* K16  */  be_nested_str_weak(raw),
-    /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(set_mode_PASE),
-    /* K19  */  be_nested_str_weak(__Msg1),
-    /* K20  */  be_const_int(2147483647),
-    /* K21  */  be_nested_str_weak(passcodeId),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
-    /* K23  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K24  */  be_nested_str_weak(initiator_session_id),
-    /* K25  */  be_nested_str_weak(__future_local_session_id),
-    /* K26  */  be_nested_str_weak(device),
-    /* K27  */  be_nested_str_weak(sessions),
-    /* K28  */  be_nested_str_weak(gen_local_session_id),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K30  */  be_nested_str_weak(remote_ip),
-    /* K31  */  be_nested_str_weak(remote_port),
-    /* K32  */  be_nested_str_weak(PBKDFParamResponse),
-    /* K33  */  be_nested_str_weak(initiatorRandom),
-    /* K34  */  be_nested_str_weak(responderRandom),
-    /* K35  */  be_nested_str_weak(random),
-    /* K36  */  be_nested_str_weak(responderSessionId),
-    /* K37  */  be_nested_str_weak(pbkdf_parameters_salt),
-    /* K38  */  be_nested_str_weak(commissioning_salt),
-    /* K39  */  be_nested_str_weak(pbkdf_parameters_iterations),
-    /* K40  */  be_nested_str_weak(commissioning_iterations),
-    /* K41  */  be_nested_str_weak(tlv2raw),
-    /* K42  */  be_nested_str_weak(__Msg2),
-    /* K43  */  be_nested_str_weak(build_response),
-    /* K44  */  be_nested_str_weak(encode_frame),
-    /* K45  */  be_nested_str_weak(responder),
-    /* K46  */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_PBKDFParamRequest),
     &be_const_str_solidified,
     ( &(const binstruction[113]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x880C0300,  //  0001  GETMBR	R3	R1	K0
+      0x8810031D,  //  0002  GETMBR	R4	R1	K29
       0x5416001F,  //  0003  LDINT	R5	32
       0x20100805,  //  0004  NE	R4	R4	R5
       0x74120005,  //  0005  JMPT	R4	#000C
-      0x88100303,  //  0006  GETMBR	R4	R1	K3
-      0x20100904,  //  0007  NE	R4	R4	K4
+      0x8810031E,  //  0006  GETMBR	R4	R1	K30
+      0x2010091F,  //  0007  NE	R4	R4	K31
       0x74120002,  //  0008  JMPT	R4	#000C
-      0x88100305,  //  0009  GETMBR	R4	R1	K5
-      0x20100904,  //  000A  NE	R4	R4	K4
+      0x88100320,  //  0009  GETMBR	R4	R1	K32
+      0x2010091F,  //  000A  NE	R4	R4	K31
       0x78120010,  //  000B  JMPF	R4	#001D
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x58180008,  //  000E  LDCONST	R6	K8
+      0xB8120A00,  //  000C  GETNGBL	R4	K5
+      0x58140021,  //  000D  LDCONST	R5	K33
+      0x58180022,  //  000E  LDCONST	R6	K34
       0x7C100400,  //  000F  CALL	R4	2
-      0xB8120C00,  //  0010  GETNGBL	R4	K6
-      0x58140009,  //  0011  LDCONST	R5	K9
-      0x5818000A,  //  0012  LDCONST	R6	K10
+      0xB8120A00,  //  0010  GETNGBL	R4	K5
+      0x58140023,  //  0011  LDCONST	R5	K35
+      0x58180024,  //  0012  LDCONST	R6	K36
       0x7C100400,  //  0013  CALL	R4	2
-      0x8C10010B,  //  0014  GETMET	R4	R0	K11
+      0x8C100125,  //  0014  GETMET	R4	R0	K37
       0x5C180200,  //  0015  MOVE	R6	R1
-      0x581C000C,  //  0016  LDCONST	R7	K12
-      0x58200004,  //  0017  LDCONST	R8	K4
-      0x58240008,  //  0018  LDCONST	R9	K8
+      0x581C0026,  //  0016  LDCONST	R7	K38
+      0x5820001F,  //  0017  LDCONST	R8	K31
+      0x58240022,  //  0018  LDCONST	R9	K34
       0x50280000,  //  0019  LDBOOL	R10	0	0
       0x7C100C00,  //  001A  CALL	R4	6
       0x50100000,  //  001B  LDBOOL	R4	0	0
       0x80040800,  //  001C  RET	1	R4
-      0xB8121A00,  //  001D  GETNGBL	R4	K13
-      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0xB8124E00,  //  001D  GETNGBL	R4	K39
+      0x8C100928,  //  001E  GETMET	R4	R4	K40
       0x7C100200,  //  001F  CALL	R4	1
-      0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x88180310,  //  0021  GETMBR	R6	R1	K16
-      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x8C100929,  //  0020  GETMET	R4	R4	K41
+      0x88180301,  //  0021  GETMBR	R6	R1	K1
+      0x881C0302,  //  0022  GETMBR	R7	R1	K2
       0x7C100600,  //  0023  CALL	R4	3
-      0x88140301,  //  0024  GETMBR	R5	R1	K1
-      0x8C140B12,  //  0025  GETMET	R5	R5	K18
+      0x88140300,  //  0024  GETMBR	R5	R1	K0
+      0x8C140B2A,  //  0025  GETMET	R5	R5	K42
       0x7C140200,  //  0026  CALL	R5	1
-      0x88140311,  //  0027  GETMBR	R5	R1	K17
-      0x40140B14,  //  0028  CONNECT	R5	R5	K20
-      0x88180310,  //  0029  GETMBR	R6	R1	K16
+      0x88140302,  //  0027  GETMBR	R5	R1	K2
+      0x40140B03,  //  0028  CONNECT	R5	R5	K3
+      0x88180301,  //  0029  GETMBR	R6	R1	K1
       0x94140C05,  //  002A  GETIDX	R5	R6	R5
-      0x900E2605,  //  002B  SETMBR	R3	K19	R5
-      0x88140915,  //  002C  GETMBR	R5	R4	K21
-      0x20140B04,  //  002D  NE	R5	R5	K4
+      0x900E5605,  //  002B  SETMBR	R3	K43	R5
+      0x8814092C,  //  002C  GETMBR	R5	R4	K44
+      0x20140B1F,  //  002D  NE	R5	R5	K31
       0x78160010,  //  002E  JMPF	R5	#0040
-      0xB8160C00,  //  002F  GETNGBL	R5	K6
-      0x58180016,  //  0030  LDCONST	R6	K22
-      0x581C0008,  //  0031  LDCONST	R7	K8
+      0xB8160A00,  //  002F  GETNGBL	R5	K5
+      0x5818002D,  //  0030  LDCONST	R6	K45
+      0x581C0022,  //  0031  LDCONST	R7	K34
       0x7C140400,  //  0032  CALL	R5	2
-      0xB8160C00,  //  0033  GETNGBL	R5	K6
-      0x58180009,  //  0034  LDCONST	R6	K9
-      0x581C000A,  //  0035  LDCONST	R7	K10
+      0xB8160A00,  //  0033  GETNGBL	R5	K5
+      0x58180023,  //  0034  LDCONST	R6	K35
+      0x581C0024,  //  0035  LDCONST	R7	K36
       0x7C140400,  //  0036  CALL	R5	2
-      0x8C14010B,  //  0037  GETMET	R5	R0	K11
+      0x8C140125,  //  0037  GETMET	R5	R0	K37
       0x5C1C0200,  //  0038  MOVE	R7	R1
-      0x5820000C,  //  0039  LDCONST	R8	K12
-      0x58240004,  //  003A  LDCONST	R9	K4
-      0x58280008,  //  003B  LDCONST	R10	K8
+      0x58200026,  //  0039  LDCONST	R8	K38
+      0x5824001F,  //  003A  LDCONST	R9	K31
+      0x58280022,  //  003B  LDCONST	R10	K34
       0x502C0000,  //  003C  LDBOOL	R11	0	0
       0x7C140C00,  //  003D  CALL	R5	6
       0x50140000,  //  003E  LDBOOL	R5	0	0
       0x80040A00,  //  003F  RET	1	R5
-      0x88140918,  //  0040  GETMBR	R5	R4	K24
-      0x900E2E05,  //  0041  SETMBR	R3	K23	R5
-      0x8814011A,  //  0042  GETMBR	R5	R0	K26
-      0x88140B1B,  //  0043  GETMBR	R5	R5	K27
-      0x8C140B1C,  //  0044  GETMET	R5	R5	K28
+      0x8814092F,  //  0040  GETMBR	R5	R4	K47
+      0x900E5C05,  //  0041  SETMBR	R3	K46	R5
+      0x8814010D,  //  0042  GETMBR	R5	R0	K13
+      0x88140B0E,  //  0043  GETMBR	R5	R5	K14
+      0x8C140B31,  //  0044  GETMET	R5	R5	K49
       0x7C140200,  //  0045  CALL	R5	1
-      0x900E3205,  //  0046  SETMBR	R3	K25	R5
-      0xB8160C00,  //  0047  GETNGBL	R5	K6
+      0x900E6005,  //  0046  SETMBR	R3	K48	R5
+      0xB8160A00,  //  0047  GETNGBL	R5	K5
       0x60180018,  //  0048  GETGBL	R6	G24
-      0x581C001D,  //  0049  LDCONST	R7	K29
-      0x88200719,  //  004A  GETMBR	R8	R3	K25
-      0x8824031E,  //  004B  GETMBR	R9	R1	K30
-      0x8828031F,  //  004C  GETMBR	R10	R1	K31
+      0x581C0032,  //  0049  LDCONST	R7	K50
+      0x88200730,  //  004A  GETMBR	R8	R3	K48
+      0x88240333,  //  004B  GETMBR	R9	R1	K51
+      0x88280334,  //  004C  GETMBR	R10	R1	K52
       0x7C180800,  //  004D  CALL	R6	4
-      0x581C000A,  //  004E  LDCONST	R7	K10
+      0x581C0024,  //  004E  LDCONST	R7	K36
       0x7C140400,  //  004F  CALL	R5	2
-      0xB8161A00,  //  0050  GETNGBL	R5	K13
-      0x8C140B20,  //  0051  GETMET	R5	R5	K32
+      0xB8164E00,  //  0050  GETNGBL	R5	K39
+      0x8C140B35,  //  0051  GETMET	R5	R5	K53
       0x7C140200,  //  0052  CALL	R5	1
-      0x88180921,  //  0053  GETMBR	R6	R4	K33
-      0x90164206,  //  0054  SETMBR	R5	K33	R6
-      0x8C180523,  //  0055  GETMET	R6	R2	K35
+      0x88180936,  //  0053  GETMBR	R6	R4	K54
+      0x90166C06,  //  0054  SETMBR	R5	K54	R6
+      0x8C180538,  //  0055  GETMET	R6	R2	K56
       0x5422001F,  //  0056  LDINT	R8	32
       0x7C180400,  //  0057  CALL	R6	2
-      0x90164406,  //  0058  SETMBR	R5	K34	R6
-      0x88180719,  //  0059  GETMBR	R6	R3	K25
-      0x90164806,  //  005A  SETMBR	R5	K36	R6
-      0x8818011A,  //  005B  GETMBR	R6	R0	K26
-      0x88180D26,  //  005C  GETMBR	R6	R6	K38
-      0x90164A06,  //  005D  SETMBR	R5	K37	R6
-      0x8818011A,  //  005E  GETMBR	R6	R0	K26
-      0x88180D28,  //  005F  GETMBR	R6	R6	K40
-      0x90164E06,  //  0060  SETMBR	R5	K39	R6
-      0x8C180B29,  //  0061  GETMET	R6	R5	K41
+      0x90166E06,  //  0058  SETMBR	R5	K55	R6
+      0x88180730,  //  0059  GETMBR	R6	R3	K48
+      0x90167206,  //  005A  SETMBR	R5	K57	R6
+      0x8818010D,  //  005B  GETMBR	R6	R0	K13
+      0x88180D3B,  //  005C  GETMBR	R6	R6	K59
+      0x90167406,  //  005D  SETMBR	R5	K58	R6
+      0x8818010D,  //  005E  GETMBR	R6	R0	K13
+      0x88180D3D,  //  005F  GETMBR	R6	R6	K61
+      0x90167806,  //  0060  SETMBR	R5	K60	R6
+      0x8C180B3E,  //  0061  GETMET	R6	R5	K62
       0x7C180200,  //  0062  CALL	R6	1
-      0x900E5406,  //  0063  SETMBR	R3	K42	R6
-      0x8C1C032B,  //  0064  GETMET	R7	R1	K43
+      0x900E7E06,  //  0063  SETMBR	R3	K63	R6
+      0x8C1C0340,  //  0064  GETMET	R7	R1	K64
       0x54260020,  //  0065  LDINT	R9	33
       0x50280200,  //  0066  LDBOOL	R10	1	0
       0x7C1C0600,  //  0067  CALL	R7	3
-      0x8C200F2C,  //  0068  GETMET	R8	R7	K44
+      0x8C200F41,  //  0068  GETMET	R8	R7	K65
       0x5C280C00,  //  0069  MOVE	R10	R6
       0x7C200400,  //  006A  CALL	R8	2
-      0x8824012D,  //  006B  GETMBR	R9	R0	K45
-      0x8C24132E,  //  006C  GETMET	R9	R9	K46
+      0x88240142,  //  006B  GETMBR	R9	R0	K66
+      0x8C241343,  //  006C  GETMET	R9	R9	K67
       0x5C2C0E00,  //  006D  MOVE	R11	R7
       0x7C240400,  //  006E  CALL	R9	2
       0x50240200,  //  006F  LDBOOL	R9	1	0
@@ -438,46 +547,39 @@ be_local_closure(class_Matter_Commisioning_Context_send_status_report,   /* name
   be_nested_proto(
     12,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(build_response),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(encode_frame),
-    /* K4   */  be_nested_str_weak(responder),
-    /* K5   */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(send_status_report),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x8C180300,  //  0000  GETMET	R6	R1	K0
+      0x8C180340,  //  0000  GETMET	R6	R1	K64
       0x5422003F,  //  0001  LDINT	R8	64
       0x5C240A00,  //  0002  MOVE	R9	R5
       0x7C180600,  //  0003  CALL	R6	3
       0x601C0015,  //  0004  GETGBL	R7	G21
       0x7C1C0000,  //  0005  CALL	R7	0
-      0x8C200F01,  //  0006  GETMET	R8	R7	K1
+      0x8C200F44,  //  0006  GETMET	R8	R7	K68
       0x5C280400,  //  0007  MOVE	R10	R2
-      0x582C0002,  //  0008  LDCONST	R11	K2
+      0x582C0045,  //  0008  LDCONST	R11	K69
       0x7C200600,  //  0009  CALL	R8	3
-      0x8C200F01,  //  000A  GETMET	R8	R7	K1
+      0x8C200F44,  //  000A  GETMET	R8	R7	K68
       0x5C280600,  //  000B  MOVE	R10	R3
       0x542E0003,  //  000C  LDINT	R11	4
       0x7C200600,  //  000D  CALL	R8	3
-      0x8C200F01,  //  000E  GETMET	R8	R7	K1
+      0x8C200F44,  //  000E  GETMET	R8	R7	K68
       0x5C280800,  //  000F  MOVE	R10	R4
       0x542E0003,  //  0010  LDINT	R11	4
       0x7C200600,  //  0011  CALL	R8	3
-      0x8C200D03,  //  0012  GETMET	R8	R6	K3
+      0x8C200D41,  //  0012  GETMET	R8	R6	K65
       0x5C280E00,  //  0013  MOVE	R10	R7
       0x7C200400,  //  0014  CALL	R8	2
-      0x88240104,  //  0015  GETMBR	R9	R0	K4
-      0x8C241305,  //  0016  GETMET	R9	R9	K5
+      0x88240142,  //  0015  GETMBR	R9	R0	K66
+      0x8C241343,  //  0016  GETMET	R9	R9	K67
       0x5C2C0C00,  //  0017  MOVE	R11	R6
       0x7C240400,  //  0018  CALL	R9	2
       0x80000000,  //  0019  RET	0
@@ -494,176 +596,124 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
   be_nested_proto(
     20,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[51]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_nested_str_weak(send_status_report),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(matter),
-    /* K14  */  be_nested_str_weak(Pake1),
-    /* K15  */  be_nested_str_weak(parse),
-    /* K16  */  be_nested_str_weak(raw),
-    /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(pA),
-    /* K19  */  be_nested_str_weak(SPAKE2P_Matter),
-    /* K20  */  be_nested_str_weak(device),
-    /* K21  */  be_nested_str_weak(commissioning_w0),
-    /* K22  */  be_nested_str_weak(commissioning_L),
-    /* K23  */  be_nested_str_weak(random),
-    /* K24  */  be_nested_str_weak(compute_pB),
-    /* K25  */  be_nested_str_weak(compute_ZV_verifier),
-    /* K26  */  be_nested_str_weak(SHA256),
-    /* K27  */  be_nested_str_weak(update),
-    /* K28  */  be_nested_str_weak(fromstring),
-    /* K29  */  be_nested_str_weak(Matter_Context_Prefix),
-    /* K30  */  be_nested_str_weak(__Msg1),
-    /* K31  */  be_nested_str_weak(__Msg2),
-    /* K32  */  be_nested_str_weak(out),
-    /* K33  */  be_nested_str_weak(set_context),
-    /* K34  */  be_nested_str_weak(compute_TT_hash),
-    /* K35  */  be_nested_str_weak(Pake2),
-    /* K36  */  be_nested_str_weak(pB),
-    /* K37  */  be_nested_str_weak(cB),
-    /* K38  */  be_nested_str_weak(tlv2raw),
-    /* K39  */  be_nested_str_weak(__spake_cA),
-    /* K40  */  be_nested_str_weak(cA),
-    /* K41  */  be_nested_str_weak(__spake_Ke),
-    /* K42  */  be_nested_str_weak(Ke),
-    /* K43  */  be_nested_str_weak(build_response),
-    /* K44  */  be_nested_str_weak(encode_frame),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K46  */  be_nested_str_weak(__future_local_session_id),
-    /* K47  */  be_nested_str_weak(_ip),
-    /* K48  */  be_nested_str_weak(_port),
-    /* K49  */  be_nested_str_weak(responder),
-    /* K50  */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_Pake1),
     &be_const_str_solidified,
     ( &(const binstruction[112]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x880C0300,  //  0001  GETMBR	R3	R1	K0
+      0x8810031D,  //  0002  GETMBR	R4	R1	K29
       0x54160021,  //  0003  LDINT	R5	34
       0x20100805,  //  0004  NE	R4	R4	R5
       0x74120005,  //  0005  JMPT	R4	#000C
-      0x88100303,  //  0006  GETMBR	R4	R1	K3
-      0x20100904,  //  0007  NE	R4	R4	K4
+      0x8810031E,  //  0006  GETMBR	R4	R1	K30
+      0x2010091F,  //  0007  NE	R4	R4	K31
       0x74120002,  //  0008  JMPT	R4	#000C
-      0x88100305,  //  0009  GETMBR	R4	R1	K5
-      0x20100904,  //  000A  NE	R4	R4	K4
+      0x88100320,  //  0009  GETMBR	R4	R1	K32
+      0x2010091F,  //  000A  NE	R4	R4	K31
       0x78120010,  //  000B  JMPF	R4	#001D
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x58180008,  //  000E  LDCONST	R6	K8
+      0xB8120A00,  //  000C  GETNGBL	R4	K5
+      0x58140046,  //  000D  LDCONST	R5	K70
+      0x58180024,  //  000E  LDCONST	R6	K36
       0x7C100400,  //  000F  CALL	R4	2
-      0xB8120C00,  //  0010  GETNGBL	R4	K6
-      0x58140009,  //  0011  LDCONST	R5	K9
-      0x58180008,  //  0012  LDCONST	R6	K8
+      0xB8120A00,  //  0010  GETNGBL	R4	K5
+      0x58140023,  //  0011  LDCONST	R5	K35
+      0x58180024,  //  0012  LDCONST	R6	K36
       0x7C100400,  //  0013  CALL	R4	2
-      0x8C10010A,  //  0014  GETMET	R4	R0	K10
+      0x8C100125,  //  0014  GETMET	R4	R0	K37
       0x5C180200,  //  0015  MOVE	R6	R1
-      0x581C000B,  //  0016  LDCONST	R7	K11
-      0x58200004,  //  0017  LDCONST	R8	K4
-      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x581C0026,  //  0016  LDCONST	R7	K38
+      0x5820001F,  //  0017  LDCONST	R8	K31
+      0x58240045,  //  0018  LDCONST	R9	K69
       0x50280000,  //  0019  LDBOOL	R10	0	0
       0x7C100C00,  //  001A  CALL	R4	6
       0x50100000,  //  001B  LDBOOL	R4	0	0
       0x80040800,  //  001C  RET	1	R4
-      0xB8121A00,  //  001D  GETNGBL	R4	K13
-      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0xB8124E00,  //  001D  GETNGBL	R4	K39
+      0x8C100947,  //  001E  GETMET	R4	R4	K71
       0x7C100200,  //  001F  CALL	R4	1
-      0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x88180310,  //  0021  GETMBR	R6	R1	K16
-      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x8C100929,  //  0020  GETMET	R4	R4	K41
+      0x88180301,  //  0021  GETMBR	R6	R1	K1
+      0x881C0302,  //  0022  GETMBR	R7	R1	K2
       0x7C100600,  //  0023  CALL	R4	3
-      0x88140912,  //  0024  GETMBR	R5	R4	K18
-      0x8C180513,  //  0025  GETMET	R6	R2	K19
-      0x88200114,  //  0026  GETMBR	R8	R0	K20
-      0x88201115,  //  0027  GETMBR	R8	R8	K21
+      0x88140948,  //  0024  GETMBR	R5	R4	K72
+      0x8C180549,  //  0025  GETMET	R6	R2	K73
+      0x8820010D,  //  0026  GETMBR	R8	R0	K13
+      0x8820114A,  //  0027  GETMBR	R8	R8	K74
       0x4C240000,  //  0028  LDNIL	R9
-      0x88280114,  //  0029  GETMBR	R10	R0	K20
-      0x88281516,  //  002A  GETMBR	R10	R10	K22
+      0x8828010D,  //  0029  GETMBR	R10	R0	K13
+      0x8828154B,  //  002A  GETMBR	R10	R10	K75
       0x7C180800,  //  002B  CALL	R6	4
-      0x8C1C0517,  //  002C  GETMET	R7	R2	K23
+      0x8C1C0538,  //  002C  GETMET	R7	R2	K56
       0x5426001F,  //  002D  LDINT	R9	32
       0x7C1C0400,  //  002E  CALL	R7	2
-      0x8C200D18,  //  002F  GETMET	R8	R6	K24
+      0x8C200D4C,  //  002F  GETMET	R8	R6	K76
       0x5C280E00,  //  0030  MOVE	R10	R7
       0x7C200400,  //  0031  CALL	R8	2
-      0x8C200D19,  //  0032  GETMET	R8	R6	K25
+      0x8C200D4D,  //  0032  GETMET	R8	R6	K77
       0x5C280A00,  //  0033  MOVE	R10	R5
       0x7C200400,  //  0034  CALL	R8	2
-      0x8C20051A,  //  0035  GETMET	R8	R2	K26
+      0x8C20054E,  //  0035  GETMET	R8	R2	K78
       0x7C200200,  //  0036  CALL	R8	1
-      0x8C24111B,  //  0037  GETMET	R9	R8	K27
+      0x8C241116,  //  0037  GETMET	R9	R8	K22
       0x602C0015,  //  0038  GETGBL	R11	G21
       0x7C2C0000,  //  0039  CALL	R11	0
-      0x8C2C171C,  //  003A  GETMET	R11	R11	K28
-      0x8834011D,  //  003B  GETMBR	R13	R0	K29
+      0x8C2C174F,  //  003A  GETMET	R11	R11	K79
+      0x88340150,  //  003B  GETMBR	R13	R0	K80
       0x7C2C0400,  //  003C  CALL	R11	2
       0x7C240400,  //  003D  CALL	R9	2
-      0x8C24111B,  //  003E  GETMET	R9	R8	K27
-      0x882C071E,  //  003F  GETMBR	R11	R3	K30
+      0x8C241116,  //  003E  GETMET	R9	R8	K22
+      0x882C072B,  //  003F  GETMBR	R11	R3	K43
       0x7C240400,  //  0040  CALL	R9	2
-      0x8C24111B,  //  0041  GETMET	R9	R8	K27
-      0x882C071F,  //  0042  GETMBR	R11	R3	K31
+      0x8C241116,  //  0041  GETMET	R9	R8	K22
+      0x882C073F,  //  0042  GETMBR	R11	R3	K63
       0x7C240400,  //  0043  CALL	R9	2
-      0x8C241120,  //  0044  GETMET	R9	R8	K32
+      0x8C241117,  //  0044  GETMET	R9	R8	K23
       0x7C240200,  //  0045  CALL	R9	1
-      0x901A2405,  //  0046  SETMBR	R6	K18	R5
-      0x8C280D21,  //  0047  GETMET	R10	R6	K33
+      0x901A9005,  //  0046  SETMBR	R6	K72	R5
+      0x8C280D51,  //  0047  GETMET	R10	R6	K81
       0x5C301200,  //  0048  MOVE	R12	R9
       0x7C280400,  //  0049  CALL	R10	2
-      0x8C280D22,  //  004A  GETMET	R10	R6	K34
+      0x8C280D52,  //  004A  GETMET	R10	R6	K82
       0x50300200,  //  004B  LDBOOL	R12	1	0
       0x7C280400,  //  004C  CALL	R10	2
-      0xB82A1A00,  //  004D  GETNGBL	R10	K13
-      0x8C281523,  //  004E  GETMET	R10	R10	K35
+      0xB82A4E00,  //  004D  GETNGBL	R10	K39
+      0x8C281553,  //  004E  GETMET	R10	R10	K83
       0x7C280200,  //  004F  CALL	R10	1
-      0x882C0D24,  //  0050  GETMBR	R11	R6	K36
-      0x902A480B,  //  0051  SETMBR	R10	K36	R11
-      0x882C0D25,  //  0052  GETMBR	R11	R6	K37
-      0x902A4A0B,  //  0053  SETMBR	R10	K37	R11
-      0x8C2C1526,  //  0054  GETMET	R11	R10	K38
+      0x882C0D54,  //  0050  GETMBR	R11	R6	K84
+      0x902AA80B,  //  0051  SETMBR	R10	K84	R11
+      0x882C0D55,  //  0052  GETMBR	R11	R6	K85
+      0x902AAA0B,  //  0053  SETMBR	R10	K85	R11
+      0x8C2C153E,  //  0054  GETMET	R11	R10	K62
       0x7C2C0200,  //  0055  CALL	R11	1
-      0x88300D28,  //  0056  GETMBR	R12	R6	K40
-      0x900E4E0C,  //  0057  SETMBR	R3	K39	R12
-      0x88300D2A,  //  0058  GETMBR	R12	R6	K42
-      0x900E520C,  //  0059  SETMBR	R3	K41	R12
-      0x8C30032B,  //  005A  GETMET	R12	R1	K43
+      0x88300D57,  //  0056  GETMBR	R12	R6	K87
+      0x900EAC0C,  //  0057  SETMBR	R3	K86	R12
+      0x88300D59,  //  0058  GETMBR	R12	R6	K89
+      0x900EB00C,  //  0059  SETMBR	R3	K88	R12
+      0x8C300340,  //  005A  GETMET	R12	R1	K64
       0x543A0022,  //  005B  LDINT	R14	35
       0x503C0200,  //  005C  LDBOOL	R15	1	0
       0x7C300600,  //  005D  CALL	R12	3
-      0x8C34192C,  //  005E  GETMET	R13	R12	K44
+      0x8C341941,  //  005E  GETMET	R13	R12	K65
       0x5C3C1600,  //  005F  MOVE	R15	R11
       0x7C340400,  //  0060  CALL	R13	2
-      0xB83A0C00,  //  0061  GETNGBL	R14	K6
+      0xB83A0A00,  //  0061  GETNGBL	R14	K5
       0x603C0018,  //  0062  GETGBL	R15	G24
-      0x5840002D,  //  0063  LDCONST	R16	K45
-      0x8844072E,  //  0064  GETMBR	R17	R3	K46
-      0x8848072F,  //  0065  GETMBR	R18	R3	K47
-      0x884C0730,  //  0066  GETMBR	R19	R3	K48
+      0x5840005A,  //  0063  LDCONST	R16	K90
+      0x88440730,  //  0064  GETMBR	R17	R3	K48
+      0x8848075B,  //  0065  GETMBR	R18	R3	K91
+      0x884C075C,  //  0066  GETMBR	R19	R3	K92
       0x7C3C0800,  //  0067  CALL	R15	4
-      0x5840000C,  //  0068  LDCONST	R16	K12
+      0x58400045,  //  0068  LDCONST	R16	K69
       0x7C380400,  //  0069  CALL	R14	2
-      0x88380131,  //  006A  GETMBR	R14	R0	K49
-      0x8C381D32,  //  006B  GETMET	R14	R14	K50
+      0x88380142,  //  006A  GETMBR	R14	R0	K66
+      0x8C381D43,  //  006B  GETMET	R14	R14	K67
       0x5C401800,  //  006C  MOVE	R16	R12
       0x7C380400,  //  006D  CALL	R14	2
       0x50380200,  //  006E  LDBOOL	R14	1	0
@@ -681,24 +731,20 @@ be_local_closure(class_Matter_Commisioning_Context_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(responder),
-    /* K2   */  be_nested_str_weak(device),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x880C0302,  //  0002  GETMBR	R3	R1	K2
-      0x90020403,  //  0003  SETMBR	R0	K2	R3
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x90028401,  //  0001  SETMBR	R0	K66	R1
+      0x880C030D,  //  0002  GETMBR	R3	R1	K13
+      0x90021A03,  //  0003  SETMBR	R0	K13	R3
       0x80000000,  //  0004  RET	0
     })
   )
@@ -713,123 +759,91 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake3_X20message),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_nested_str_weak(send_status_report),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(matter),
-    /* K14  */  be_nested_str_weak(Pake3),
-    /* K15  */  be_nested_str_weak(parse),
-    /* K16  */  be_nested_str_weak(raw),
-    /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(cA),
-    /* K19  */  be_nested_str_weak(__spake_cA),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
-    /* K21  */  be_nested_str_weak(tasmota),
-    /* K22  */  be_nested_str_weak(rtc_utc),
-    /* K23  */  be_nested_str_weak(HKDF_SHA256),
-    /* K24  */  be_nested_str_weak(derive),
-    /* K25  */  be_nested_str_weak(__spake_Ke),
-    /* K26  */  be_nested_str_weak(fromstring),
-    /* K27  */  be_nested_str_weak(SEKeys_Info),
-    /* K28  */  be_nested_str_weak(add_session),
-    /* K29  */  be_nested_str_weak(__future_local_session_id),
-    /* K30  */  be_nested_str_weak(__future_initiator_session_id),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_Pake3),
     &be_const_str_solidified,
     ( &(const binstruction[101]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x880C0300,  //  0001  GETMBR	R3	R1	K0
+      0x8810031D,  //  0002  GETMBR	R4	R1	K29
       0x54160023,  //  0003  LDINT	R5	36
       0x20100805,  //  0004  NE	R4	R4	R5
       0x74120005,  //  0005  JMPT	R4	#000C
-      0x88100303,  //  0006  GETMBR	R4	R1	K3
-      0x20100904,  //  0007  NE	R4	R4	K4
+      0x8810031E,  //  0006  GETMBR	R4	R1	K30
+      0x2010091F,  //  0007  NE	R4	R4	K31
       0x74120002,  //  0008  JMPT	R4	#000C
-      0x88100305,  //  0009  GETMBR	R4	R1	K5
-      0x20100904,  //  000A  NE	R4	R4	K4
+      0x88100320,  //  0009  GETMBR	R4	R1	K32
+      0x2010091F,  //  000A  NE	R4	R4	K31
       0x78120010,  //  000B  JMPF	R4	#001D
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x58180008,  //  000E  LDCONST	R6	K8
+      0xB8120A00,  //  000C  GETNGBL	R4	K5
+      0x5814005D,  //  000D  LDCONST	R5	K93
+      0x58180024,  //  000E  LDCONST	R6	K36
       0x7C100400,  //  000F  CALL	R4	2
-      0xB8120C00,  //  0010  GETNGBL	R4	K6
-      0x58140009,  //  0011  LDCONST	R5	K9
-      0x58180008,  //  0012  LDCONST	R6	K8
+      0xB8120A00,  //  0010  GETNGBL	R4	K5
+      0x58140023,  //  0011  LDCONST	R5	K35
+      0x58180024,  //  0012  LDCONST	R6	K36
       0x7C100400,  //  0013  CALL	R4	2
-      0x8C10010A,  //  0014  GETMET	R4	R0	K10
+      0x8C100125,  //  0014  GETMET	R4	R0	K37
       0x5C180200,  //  0015  MOVE	R6	R1
-      0x581C000B,  //  0016  LDCONST	R7	K11
-      0x58200004,  //  0017  LDCONST	R8	K4
-      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x581C0026,  //  0016  LDCONST	R7	K38
+      0x5820001F,  //  0017  LDCONST	R8	K31
+      0x58240045,  //  0018  LDCONST	R9	K69
       0x50280000,  //  0019  LDBOOL	R10	0	0
       0x7C100C00,  //  001A  CALL	R4	6
       0x50100000,  //  001B  LDBOOL	R4	0	0
       0x80040800,  //  001C  RET	1	R4
-      0xB8121A00,  //  001D  GETNGBL	R4	K13
-      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0xB8124E00,  //  001D  GETNGBL	R4	K39
+      0x8C10095E,  //  001E  GETMET	R4	R4	K94
       0x7C100200,  //  001F  CALL	R4	1
-      0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x88180310,  //  0021  GETMBR	R6	R1	K16
-      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x8C100929,  //  0020  GETMET	R4	R4	K41
+      0x88180301,  //  0021  GETMBR	R6	R1	K1
+      0x881C0302,  //  0022  GETMBR	R7	R1	K2
       0x7C100600,  //  0023  CALL	R4	3
-      0x88140912,  //  0024  GETMBR	R5	R4	K18
-      0x88180713,  //  0025  GETMBR	R6	R3	K19
+      0x88140957,  //  0024  GETMBR	R5	R4	K87
+      0x88180756,  //  0025  GETMBR	R6	R3	K86
       0x20180A06,  //  0026  NE	R6	R5	R6
       0x781A0010,  //  0027  JMPF	R6	#0039
-      0xB81A0C00,  //  0028  GETNGBL	R6	K6
-      0x581C0014,  //  0029  LDCONST	R7	K20
-      0x58200008,  //  002A  LDCONST	R8	K8
+      0xB81A0A00,  //  0028  GETNGBL	R6	K5
+      0x581C005F,  //  0029  LDCONST	R7	K95
+      0x58200024,  //  002A  LDCONST	R8	K36
       0x7C180400,  //  002B  CALL	R6	2
-      0xB81A0C00,  //  002C  GETNGBL	R6	K6
-      0x581C0009,  //  002D  LDCONST	R7	K9
-      0x58200008,  //  002E  LDCONST	R8	K8
+      0xB81A0A00,  //  002C  GETNGBL	R6	K5
+      0x581C0023,  //  002D  LDCONST	R7	K35
+      0x58200024,  //  002E  LDCONST	R8	K36
       0x7C180400,  //  002F  CALL	R6	2
-      0x8C18010A,  //  0030  GETMET	R6	R0	K10
+      0x8C180125,  //  0030  GETMET	R6	R0	K37
       0x5C200200,  //  0031  MOVE	R8	R1
-      0x5824000B,  //  0032  LDCONST	R9	K11
-      0x58280004,  //  0033  LDCONST	R10	K4
-      0x582C000C,  //  0034  LDCONST	R11	K12
+      0x58240026,  //  0032  LDCONST	R9	K38
+      0x5828001F,  //  0033  LDCONST	R10	K31
+      0x582C0045,  //  0034  LDCONST	R11	K69
       0x50300000,  //  0035  LDBOOL	R12	0	0
       0x7C180C00,  //  0036  CALL	R6	6
       0x50180000,  //  0037  LDBOOL	R6	0	0
       0x80040C00,  //  0038  RET	1	R6
-      0xB81A2A00,  //  0039  GETNGBL	R6	K21
-      0x8C180D16,  //  003A  GETMET	R6	R6	K22
+      0xB81A1400,  //  0039  GETNGBL	R6	K10
+      0x8C180D60,  //  003A  GETMET	R6	R6	K96
       0x7C180200,  //  003B  CALL	R6	1
-      0x8C1C0517,  //  003C  GETMET	R7	R2	K23
+      0x8C1C0561,  //  003C  GETMET	R7	R2	K97
       0x7C1C0200,  //  003D  CALL	R7	1
-      0x8C1C0F18,  //  003E  GETMET	R7	R7	K24
-      0x88240719,  //  003F  GETMBR	R9	R3	K25
+      0x8C1C0F62,  //  003E  GETMET	R7	R7	K98
+      0x88240758,  //  003F  GETMBR	R9	R3	K88
       0x60280015,  //  0040  GETGBL	R10	G21
       0x7C280000,  //  0041  CALL	R10	0
       0x602C0015,  //  0042  GETGBL	R11	G21
       0x7C2C0000,  //  0043  CALL	R11	0
-      0x8C2C171A,  //  0044  GETMET	R11	R11	K26
-      0x8834011B,  //  0045  GETMBR	R13	R0	K27
+      0x8C2C174F,  //  0044  GETMET	R11	R11	K79
+      0x88340163,  //  0045  GETMBR	R13	R0	K99
       0x7C2C0400,  //  0046  CALL	R11	2
       0x5432002F,  //  0047  LDINT	R12	48
       0x7C1C0A00,  //  0048  CALL	R7	5
       0x5422000E,  //  0049  LDINT	R8	15
-      0x40220808,  //  004A  CONNECT	R8	K4	R8
+      0x40223E08,  //  004A  CONNECT	R8	K31	R8
       0x94200E08,  //  004B  GETIDX	R8	R7	R8
       0x5426000F,  //  004C  LDINT	R9	16
       0x542A001E,  //  004D  LDINT	R10	31
@@ -839,16 +853,16 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
       0x542E002E,  //  0051  LDINT	R11	47
       0x4028140B,  //  0052  CONNECT	R10	R10	R11
       0x94280E0A,  //  0053  GETIDX	R10	R7	R10
-      0x8C2C010A,  //  0054  GETMET	R11	R0	K10
+      0x8C2C0125,  //  0054  GETMET	R11	R0	K37
       0x5C340200,  //  0055  MOVE	R13	R1
-      0x58380004,  //  0056  LDCONST	R14	K4
-      0x583C0004,  //  0057  LDCONST	R15	K4
-      0x58400004,  //  0058  LDCONST	R16	K4
+      0x5838001F,  //  0056  LDCONST	R14	K31
+      0x583C001F,  //  0057  LDCONST	R15	K31
+      0x5840001F,  //  0058  LDCONST	R16	K31
       0x50440000,  //  0059  LDBOOL	R17	0	0
       0x7C2C0C00,  //  005A  CALL	R11	6
-      0x8C2C011C,  //  005B  GETMET	R11	R0	K28
-      0x8834071D,  //  005C  GETMBR	R13	R3	K29
-      0x8838071E,  //  005D  GETMBR	R14	R3	K30
+      0x8C2C0164,  //  005B  GETMET	R11	R0	K100
+      0x88340730,  //  005C  GETMBR	R13	R3	K48
+      0x8838072E,  //  005D  GETMBR	R14	R3	K46
       0x5C3C1000,  //  005E  MOVE	R15	R8
       0x5C401200,  //  005F  MOVE	R16	R9
       0x5C441400,  //  0060  MOVE	R17	R10
@@ -869,154 +883,87 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
   be_nested_proto(
     36,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[66]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(opcode),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(protocol_id),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(send_status_report),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(session),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(Sigma3),
-    /* K14  */  be_nested_str_weak(parse),
-    /* K15  */  be_nested_str_weak(raw),
-    /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(SHA256),
-    /* K18  */  be_nested_str_weak(update),
-    /* K19  */  be_nested_str_weak(__Msg1),
-    /* K20  */  be_nested_str_weak(__Msg2),
-    /* K21  */  be_nested_str_weak(out),
-    /* K22  */  be_nested_str_weak(fromstring),
-    /* K23  */  be_nested_str_weak(S3K_Info),
-    /* K24  */  be_nested_str_weak(HKDF_SHA256),
-    /* K25  */  be_nested_str_weak(derive),
-    /* K26  */  be_nested_str_weak(shared_secret),
-    /* K27  */  be_nested_str_weak(get_ipk_group_key),
-    /* K28  */  be_nested_str_weak(TBEData3Encrypted),
-    /* K29  */  be_const_int(2147483647),
-    /* K30  */  be_nested_str_weak(AES_CCM),
-    /* K31  */  be_nested_str_weak(TBEData3_Nonce),
-    /* K32  */  be_nested_str_weak(decrypt),
-    /* K33  */  be_nested_str_weak(tag),
-    /* K34  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
-    /* K35  */  be_nested_str_weak(TLV),
-    /* K36  */  be_nested_str_weak(findsubval),
-    /* K37  */  be_nested_str_weak(findsub),
-    /* K38  */  be_nested_str_weak(int),
-    /* K39  */  be_nested_str_weak(peer_node_id),
-    /* K40  */  be_nested_str_weak(int64),
-    /* K41  */  be_nested_str_weak(fromu32),
-    /* K42  */  be_nested_str_weak(tobytes),
-    /* K43  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K44  */  be_nested_str_weak(add_TLV),
-    /* K45  */  be_nested_str_weak(B1),
-    /* K46  */  be_nested_str_weak(__initiator_pub),
-    /* K47  */  be_nested_str_weak(__responder_pub),
-    /* K48  */  be_nested_str_weak(tlv2raw),
-    /* K49  */  be_nested_str_weak(EC_P256),
-    /* K50  */  be_nested_str_weak(ecdsa_verify_sha256),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
-    /* K52  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X20Invalid_X20signature_X2C_X20trying_X20anyways),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
-    /* K54  */  be_nested_str_weak(Msg3),
-    /* K55  */  be_nested_str_weak(SEKeys_Info),
-    /* K56  */  be_nested_str_weak(tasmota),
-    /* K57  */  be_nested_str_weak(rtc_utc),
-    /* K58  */  be_nested_str_weak(close),
-    /* K59  */  be_nested_str_weak(set_keys),
-    /* K60  */  be_nested_str_weak(_breadcrumb),
-    /* K61  */  be_nested_str_weak(counter_snd_next),
-    /* K62  */  be_nested_str_weak(set_persist),
-    /* K63  */  be_nested_str_weak(set_no_expiration),
-    /* K64  */  be_nested_str_weak(persist_to_fabric),
-    /* K65  */  be_nested_str_weak(save),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_Sigma3),
     &be_const_str_solidified,
     ( &(const binstruction[280]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x880C031D,  //  0001  GETMBR	R3	R1	K29
       0x54120031,  //  0002  LDINT	R4	50
       0x200C0604,  //  0003  NE	R3	R3	R4
       0x740E0005,  //  0004  JMPT	R3	#000B
-      0x880C0302,  //  0005  GETMBR	R3	R1	K2
-      0x200C0703,  //  0006  NE	R3	R3	K3
+      0x880C031E,  //  0005  GETMBR	R3	R1	K30
+      0x200C071F,  //  0006  NE	R3	R3	K31
       0x740E0002,  //  0007  JMPT	R3	#000B
-      0x880C0304,  //  0008  GETMBR	R3	R1	K4
-      0x200C0703,  //  0009  NE	R3	R3	K3
+      0x880C0320,  //  0008  GETMBR	R3	R1	K32
+      0x200C071F,  //  0009  NE	R3	R3	K31
       0x780E000C,  //  000A  JMPF	R3	#0018
       0xB80E0A00,  //  000B  GETNGBL	R3	K5
-      0x58100006,  //  000C  LDCONST	R4	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
+      0x58100023,  //  000C  LDCONST	R4	K35
+      0x58140065,  //  000D  LDCONST	R5	K101
       0x7C0C0400,  //  000E  CALL	R3	2
-      0x8C0C0108,  //  000F  GETMET	R3	R0	K8
+      0x8C0C0125,  //  000F  GETMET	R3	R0	K37
       0x5C140200,  //  0010  MOVE	R5	R1
-      0x58180009,  //  0011  LDCONST	R6	K9
-      0x581C0003,  //  0012  LDCONST	R7	K3
-      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x58180066,  //  0011  LDCONST	R6	K102
+      0x581C001F,  //  0012  LDCONST	R7	K31
+      0x58200067,  //  0013  LDCONST	R8	K103
       0x50240000,  //  0014  LDBOOL	R9	0	0
       0x7C0C0C00,  //  0015  CALL	R3	6
       0x500C0000,  //  0016  LDBOOL	R3	0	0
       0x80040600,  //  0017  RET	1	R3
-      0x880C030B,  //  0018  GETMBR	R3	R1	K11
-      0xB8121800,  //  0019  GETNGBL	R4	K12
-      0x8C10090D,  //  001A  GETMET	R4	R4	K13
+      0x880C0300,  //  0018  GETMBR	R3	R1	K0
+      0xB8124E00,  //  0019  GETNGBL	R4	K39
+      0x8C100968,  //  001A  GETMET	R4	R4	K104
       0x7C100200,  //  001B  CALL	R4	1
-      0x8C10090E,  //  001C  GETMET	R4	R4	K14
-      0x8818030F,  //  001D  GETMBR	R6	R1	K15
-      0x881C0310,  //  001E  GETMBR	R7	R1	K16
+      0x8C100929,  //  001C  GETMET	R4	R4	K41
+      0x88180301,  //  001D  GETMBR	R6	R1	K1
+      0x881C0302,  //  001E  GETMBR	R7	R1	K2
       0x7C100600,  //  001F  CALL	R4	3
-      0x8C140511,  //  0020  GETMET	R5	R2	K17
+      0x8C14054E,  //  0020  GETMET	R5	R2	K78
       0x7C140200,  //  0021  CALL	R5	1
-      0x8C140B12,  //  0022  GETMET	R5	R5	K18
-      0x881C0713,  //  0023  GETMBR	R7	R3	K19
+      0x8C140B16,  //  0022  GETMET	R5	R5	K22
+      0x881C072B,  //  0023  GETMBR	R7	R3	K43
       0x7C140400,  //  0024  CALL	R5	2
-      0x8C140B12,  //  0025  GETMET	R5	R5	K18
-      0x881C0714,  //  0026  GETMBR	R7	R3	K20
+      0x8C140B16,  //  0025  GETMET	R5	R5	K22
+      0x881C073F,  //  0026  GETMBR	R7	R3	K63
       0x7C140400,  //  0027  CALL	R5	2
-      0x8C140B15,  //  0028  GETMET	R5	R5	K21
+      0x8C140B17,  //  0028  GETMET	R5	R5	K23
       0x7C140200,  //  0029  CALL	R5	1
       0x60180015,  //  002A  GETGBL	R6	G21
       0x7C180000,  //  002B  CALL	R6	0
-      0x8C180D16,  //  002C  GETMET	R6	R6	K22
-      0x88200117,  //  002D  GETMBR	R8	R0	K23
+      0x8C180D4F,  //  002C  GETMET	R6	R6	K79
+      0x88200169,  //  002D  GETMBR	R8	R0	K105
       0x7C180400,  //  002E  CALL	R6	2
-      0x8C1C0518,  //  002F  GETMET	R7	R2	K24
+      0x8C1C0561,  //  002F  GETMET	R7	R2	K97
       0x7C1C0200,  //  0030  CALL	R7	1
-      0x8C1C0F19,  //  0031  GETMET	R7	R7	K25
-      0x8824071A,  //  0032  GETMBR	R9	R3	K26
-      0x8C28071B,  //  0033  GETMET	R10	R3	K27
+      0x8C1C0F62,  //  0031  GETMET	R7	R7	K98
+      0x8824076A,  //  0032  GETMBR	R9	R3	K106
+      0x8C280714,  //  0033  GETMET	R10	R3	K20
       0x7C280200,  //  0034  CALL	R10	1
       0x00281405,  //  0035  ADD	R10	R10	R5
       0x5C2C0C00,  //  0036  MOVE	R11	R6
       0x5432000F,  //  0037  LDINT	R12	16
       0x7C1C0A00,  //  0038  CALL	R7	5
       0x5421FFEE,  //  0039  LDINT	R8	-17
-      0x40220608,  //  003A  CONNECT	R8	K3	R8
-      0x8824091C,  //  003B  GETMBR	R9	R4	K28
+      0x40223E08,  //  003A  CONNECT	R8	K31	R8
+      0x8824096B,  //  003B  GETMBR	R9	R4	K107
       0x94201208,  //  003C  GETIDX	R8	R9	R8
       0x5429FFEF,  //  003D  LDINT	R10	-16
-      0x4028151D,  //  003E  CONNECT	R10	R10	K29
-      0x882C091C,  //  003F  GETMBR	R11	R4	K28
+      0x4028156C,  //  003E  CONNECT	R10	R10	K108
+      0x882C096B,  //  003F  GETMBR	R11	R4	K107
       0x9424160A,  //  0040  GETIDX	R9	R11	R10
-      0x8C30051E,  //  0041  GETMET	R12	R2	K30
+      0x8C30056D,  //  0041  GETMET	R12	R2	K109
       0x5C380E00,  //  0042  MOVE	R14	R7
       0x603C0015,  //  0043  GETGBL	R15	G21
       0x7C3C0000,  //  0044  CALL	R15	0
-      0x8C3C1F16,  //  0045  GETMET	R15	R15	K22
-      0x8844011F,  //  0046  GETMBR	R17	R0	K31
+      0x8C3C1F4F,  //  0045  GETMET	R15	R15	K79
+      0x8844016E,  //  0046  GETMBR	R17	R0	K110
       0x7C3C0400,  //  0047  CALL	R15	2
       0x60400015,  //  0048  GETGBL	R16	G21
       0x7C400000,  //  0049  CALL	R16	0
@@ -1026,112 +973,112 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x544A000F,  //  004D  LDINT	R18	16
       0x7C300C00,  //  004E  CALL	R12	6
       0x5C281800,  //  004F  MOVE	R10	R12
-      0x8C301520,  //  0050  GETMET	R12	R10	K32
+      0x8C30156F,  //  0050  GETMET	R12	R10	K111
       0x5C381000,  //  0051  MOVE	R14	R8
       0x7C300400,  //  0052  CALL	R12	2
       0x5C2C1800,  //  0053  MOVE	R11	R12
-      0x8C301521,  //  0054  GETMET	R12	R10	K33
+      0x8C301570,  //  0054  GETMET	R12	R10	K112
       0x7C300200,  //  0055  CALL	R12	1
       0x20341809,  //  0056  NE	R13	R12	R9
       0x78360010,  //  0057  JMPF	R13	#0069
       0xB8360A00,  //  0058  GETNGBL	R13	K5
-      0x58380022,  //  0059  LDCONST	R14	K34
-      0x583C0007,  //  005A  LDCONST	R15	K7
+      0x58380071,  //  0059  LDCONST	R14	K113
+      0x583C0065,  //  005A  LDCONST	R15	K101
       0x7C340400,  //  005B  CALL	R13	2
       0xB8360A00,  //  005C  GETNGBL	R13	K5
-      0x58380006,  //  005D  LDCONST	R14	K6
-      0x583C0007,  //  005E  LDCONST	R15	K7
+      0x58380023,  //  005D  LDCONST	R14	K35
+      0x583C0065,  //  005E  LDCONST	R15	K101
       0x7C340400,  //  005F  CALL	R13	2
-      0x8C340108,  //  0060  GETMET	R13	R0	K8
+      0x8C340125,  //  0060  GETMET	R13	R0	K37
       0x5C3C0200,  //  0061  MOVE	R15	R1
-      0x58400009,  //  0062  LDCONST	R16	K9
-      0x58440003,  //  0063  LDCONST	R17	K3
-      0x5848000A,  //  0064  LDCONST	R18	K10
+      0x58400066,  //  0062  LDCONST	R16	K102
+      0x5844001F,  //  0063  LDCONST	R17	K31
+      0x58480067,  //  0064  LDCONST	R18	K103
       0x504C0000,  //  0065  LDBOOL	R19	0	0
       0x7C340C00,  //  0066  CALL	R13	6
       0x50340000,  //  0067  LDBOOL	R13	0	0
       0x80041A00,  //  0068  RET	1	R13
-      0xB8361800,  //  0069  GETNGBL	R13	K12
-      0x88341B23,  //  006A  GETMBR	R13	R13	K35
-      0x8C341B0E,  //  006B  GETMET	R13	R13	K14
+      0xB8364E00,  //  0069  GETNGBL	R13	K39
+      0x88341B72,  //  006A  GETMBR	R13	R13	K114
+      0x8C341B29,  //  006B  GETMET	R13	R13	K41
       0x5C3C1600,  //  006C  MOVE	R15	R11
       0x7C340400,  //  006D  CALL	R13	2
-      0x8C381B24,  //  006E  GETMET	R14	R13	K36
-      0x58400009,  //  006F  LDCONST	R16	K9
+      0x8C381B73,  //  006E  GETMET	R14	R13	K115
+      0x58400066,  //  006F  LDCONST	R16	K102
       0x7C380400,  //  0070  CALL	R14	2
-      0x8C3C1B24,  //  0071  GETMET	R15	R13	K36
-      0x5844000A,  //  0072  LDCONST	R17	K10
+      0x8C3C1B73,  //  0071  GETMET	R15	R13	K115
+      0x58440067,  //  0072  LDCONST	R17	K103
       0x7C3C0400,  //  0073  CALL	R15	2
-      0x8C401B24,  //  0074  GETMET	R16	R13	K36
-      0x58480007,  //  0075  LDCONST	R18	K7
+      0x8C401B73,  //  0074  GETMET	R16	R13	K115
+      0x58480065,  //  0075  LDCONST	R18	K101
       0x7C400400,  //  0076  CALL	R16	2
-      0xB8461800,  //  0077  GETNGBL	R17	K12
-      0x88442323,  //  0078  GETMBR	R17	R17	K35
-      0x8C44230E,  //  0079  GETMET	R17	R17	K14
+      0xB8464E00,  //  0077  GETNGBL	R17	K39
+      0x88442372,  //  0078  GETMBR	R17	R17	K114
+      0x8C442329,  //  0079  GETMET	R17	R17	K41
       0x5C4C1C00,  //  007A  MOVE	R19	R14
       0x7C440400,  //  007B  CALL	R17	2
-      0x8C482324,  //  007C  GETMET	R18	R17	K36
+      0x8C482373,  //  007C  GETMET	R18	R17	K115
       0x54520008,  //  007D  LDINT	R20	9
       0x7C480400,  //  007E  CALL	R18	2
-      0x8C4C2325,  //  007F  GETMET	R19	R17	K37
+      0x8C4C2374,  //  007F  GETMET	R19	R17	K116
       0x54560005,  //  0080  LDINT	R21	6
       0x7C4C0400,  //  0081  CALL	R19	2
-      0x8C502724,  //  0082  GETMET	R20	R19	K36
+      0x8C502773,  //  0082  GETMET	R20	R19	K115
       0x545A0010,  //  0083  LDINT	R22	17
       0x7C500400,  //  0084  CALL	R20	2
       0x60540004,  //  0085  GETGBL	R21	G4
       0x5C582800,  //  0086  MOVE	R22	R20
       0x7C540200,  //  0087  CALL	R21	1
-      0x1C542B26,  //  0088  EQ	R21	R21	K38
+      0x1C542B75,  //  0088  EQ	R21	R21	K117
       0x78560007,  //  0089  JMPF	R21	#0092
-      0xB8565000,  //  008A  GETNGBL	R21	K40
-      0x8C542B29,  //  008B  GETMET	R21	R21	K41
+      0xB856EE00,  //  008A  GETNGBL	R21	K119
+      0x8C542B78,  //  008B  GETMET	R21	R21	K120
       0x5C5C2800,  //  008C  MOVE	R23	R20
       0x7C540400,  //  008D  CALL	R21	2
-      0x8C542B2A,  //  008E  GETMET	R21	R21	K42
+      0x8C542B79,  //  008E  GETMET	R21	R21	K121
       0x7C540200,  //  008F  CALL	R21	1
-      0x900E4E15,  //  0090  SETMBR	R3	K39	R21
+      0x900EEC15,  //  0090  SETMBR	R3	K118	R21
       0x70020002,  //  0091  JMP		#0095
-      0x8C54292A,  //  0092  GETMET	R21	R20	K42
+      0x8C542979,  //  0092  GETMET	R21	R20	K121
       0x7C540200,  //  0093  CALL	R21	1
-      0x900E4E15,  //  0094  SETMBR	R3	K39	R21
-      0xB8561800,  //  0095  GETNGBL	R21	K12
-      0x88542B23,  //  0096  GETMBR	R21	R21	K35
-      0x8C542B2B,  //  0097  GETMET	R21	R21	K43
+      0x900EEC15,  //  0094  SETMBR	R3	K118	R21
+      0xB8564E00,  //  0095  GETNGBL	R21	K39
+      0x88542B72,  //  0096  GETMBR	R21	R21	K114
+      0x8C542B7A,  //  0097  GETMET	R21	R21	K122
       0x7C540200,  //  0098  CALL	R21	1
-      0x8C582B2C,  //  0099  GETMET	R22	R21	K44
-      0x58600009,  //  009A  LDCONST	R24	K9
-      0xB8661800,  //  009B  GETNGBL	R25	K12
-      0x88643323,  //  009C  GETMBR	R25	R25	K35
-      0x8864332D,  //  009D  GETMBR	R25	R25	K45
+      0x8C582B7B,  //  0099  GETMET	R22	R21	K123
+      0x58600066,  //  009A  LDCONST	R24	K102
+      0xB8664E00,  //  009B  GETNGBL	R25	K39
+      0x88643372,  //  009C  GETMBR	R25	R25	K114
+      0x8864337C,  //  009D  GETMBR	R25	R25	K124
       0x5C681C00,  //  009E  MOVE	R26	R14
       0x7C580800,  //  009F  CALL	R22	4
-      0x8C582B2C,  //  00A0  GETMET	R22	R21	K44
-      0x5860000A,  //  00A1  LDCONST	R24	K10
-      0xB8661800,  //  00A2  GETNGBL	R25	K12
-      0x88643323,  //  00A3  GETMBR	R25	R25	K35
-      0x8864332D,  //  00A4  GETMBR	R25	R25	K45
+      0x8C582B7B,  //  00A0  GETMET	R22	R21	K123
+      0x58600067,  //  00A1  LDCONST	R24	K103
+      0xB8664E00,  //  00A2  GETNGBL	R25	K39
+      0x88643372,  //  00A3  GETMBR	R25	R25	K114
+      0x8864337C,  //  00A4  GETMBR	R25	R25	K124
       0x5C681E00,  //  00A5  MOVE	R26	R15
       0x7C580800,  //  00A6  CALL	R22	4
-      0x8C582B2C,  //  00A7  GETMET	R22	R21	K44
-      0x58600007,  //  00A8  LDCONST	R24	K7
-      0xB8661800,  //  00A9  GETNGBL	R25	K12
-      0x88643323,  //  00AA  GETMBR	R25	R25	K35
-      0x8864332D,  //  00AB  GETMBR	R25	R25	K45
-      0x8868072E,  //  00AC  GETMBR	R26	R3	K46
+      0x8C582B7B,  //  00A7  GETMET	R22	R21	K123
+      0x58600065,  //  00A8  LDCONST	R24	K101
+      0xB8664E00,  //  00A9  GETNGBL	R25	K39
+      0x88643372,  //  00AA  GETMBR	R25	R25	K114
+      0x8864337C,  //  00AB  GETMBR	R25	R25	K124
+      0x8868077D,  //  00AC  GETMBR	R26	R3	K125
       0x7C580800,  //  00AD  CALL	R22	4
-      0x8C582B2C,  //  00AE  GETMET	R22	R21	K44
+      0x8C582B7B,  //  00AE  GETMET	R22	R21	K123
       0x54620003,  //  00AF  LDINT	R24	4
-      0xB8661800,  //  00B0  GETNGBL	R25	K12
-      0x88643323,  //  00B1  GETMBR	R25	R25	K35
-      0x8864332D,  //  00B2  GETMBR	R25	R25	K45
-      0x8868072F,  //  00B3  GETMBR	R26	R3	K47
+      0xB8664E00,  //  00B0  GETNGBL	R25	K39
+      0x88643372,  //  00B1  GETMBR	R25	R25	K114
+      0x8864337C,  //  00B2  GETMBR	R25	R25	K124
+      0x8868077E,  //  00B3  GETMBR	R26	R3	K126
       0x7C580800,  //  00B4  CALL	R22	4
-      0x8C582B30,  //  00B5  GETMET	R22	R21	K48
+      0x8C582B3E,  //  00B5  GETMET	R22	R21	K62
       0x7C580200,  //  00B6  CALL	R22	1
-      0x8C5C0531,  //  00B7  GETMET	R23	R2	K49
+      0x8C5C057F,  //  00B7  GETMET	R23	R2	K127
       0x7C5C0200,  //  00B8  CALL	R23	1
-      0x8C5C2F32,  //  00B9  GETMET	R23	R23	K50
+      0x8C5C2F80,  //  00B9  GETMET	R23	R23	K128
       0x5C642400,  //  00BA  MOVE	R25	R18
       0x5C682C00,  //  00BB  MOVE	R26	R22
       0x5C6C2000,  //  00BC  MOVE	R27	R16
@@ -1139,52 +1086,52 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x5C602E00,  //  00BE  MOVE	R24	R23
       0x74620008,  //  00BF  JMPT	R24	#00C9
       0xB8620A00,  //  00C0  GETNGBL	R24	K5
-      0x58640033,  //  00C1  LDCONST	R25	K51
-      0x5868000A,  //  00C2  LDCONST	R26	K10
+      0x58640081,  //  00C1  LDCONST	R25	K129
+      0x58680067,  //  00C2  LDCONST	R26	K103
       0x7C600400,  //  00C3  CALL	R24	2
       0xB8620A00,  //  00C4  GETNGBL	R24	K5
-      0x58640034,  //  00C5  LDCONST	R25	K52
-      0x5868000A,  //  00C6  LDCONST	R26	K10
+      0x58640082,  //  00C5  LDCONST	R25	K130
+      0x58680067,  //  00C6  LDCONST	R26	K103
       0x7C600400,  //  00C7  CALL	R24	2
       0x70020003,  //  00C8  JMP		#00CD
       0xB8620A00,  //  00C9  GETNGBL	R24	K5
-      0x58640035,  //  00CA  LDCONST	R25	K53
-      0x58680007,  //  00CB  LDCONST	R26	K7
+      0x58640083,  //  00CA  LDCONST	R25	K131
+      0x58680065,  //  00CB  LDCONST	R26	K101
       0x7C600400,  //  00CC  CALL	R24	2
-      0x8C600511,  //  00CD  GETMET	R24	R2	K17
+      0x8C60054E,  //  00CD  GETMET	R24	R2	K78
       0x7C600200,  //  00CE  CALL	R24	1
-      0x8C603112,  //  00CF  GETMET	R24	R24	K18
-      0x88680713,  //  00D0  GETMBR	R26	R3	K19
+      0x8C603116,  //  00CF  GETMET	R24	R24	K22
+      0x8868072B,  //  00D0  GETMBR	R26	R3	K43
       0x7C600400,  //  00D1  CALL	R24	2
-      0x8C603112,  //  00D2  GETMET	R24	R24	K18
-      0x88680714,  //  00D3  GETMBR	R26	R3	K20
+      0x8C603116,  //  00D2  GETMET	R24	R24	K22
+      0x8868073F,  //  00D3  GETMBR	R26	R3	K63
       0x7C600400,  //  00D4  CALL	R24	2
-      0x8C603112,  //  00D5  GETMET	R24	R24	K18
-      0x88680936,  //  00D6  GETMBR	R26	R4	K54
+      0x8C603116,  //  00D5  GETMET	R24	R24	K22
+      0x88680984,  //  00D6  GETMBR	R26	R4	K132
       0x7C600400,  //  00D7  CALL	R24	2
-      0x8C603115,  //  00D8  GETMET	R24	R24	K21
+      0x8C603117,  //  00D8  GETMET	R24	R24	K23
       0x7C600200,  //  00D9  CALL	R24	1
       0x5C143000,  //  00DA  MOVE	R5	R24
       0x4C600000,  //  00DB  LDNIL	R24
-      0x900E2618,  //  00DC  SETMBR	R3	K19	R24
+      0x900E5618,  //  00DC  SETMBR	R3	K43	R24
       0x4C600000,  //  00DD  LDNIL	R24
-      0x900E2818,  //  00DE  SETMBR	R3	K20	R24
-      0x8C600518,  //  00DF  GETMET	R24	R2	K24
+      0x900E7E18,  //  00DE  SETMBR	R3	K63	R24
+      0x8C600561,  //  00DF  GETMET	R24	R2	K97
       0x7C600200,  //  00E0  CALL	R24	1
-      0x8C603119,  //  00E1  GETMET	R24	R24	K25
-      0x8868071A,  //  00E2  GETMBR	R26	R3	K26
-      0x8C6C071B,  //  00E3  GETMET	R27	R3	K27
+      0x8C603162,  //  00E1  GETMET	R24	R24	K98
+      0x8868076A,  //  00E2  GETMBR	R26	R3	K106
+      0x8C6C0714,  //  00E3  GETMET	R27	R3	K20
       0x7C6C0200,  //  00E4  CALL	R27	1
       0x006C3605,  //  00E5  ADD	R27	R27	R5
       0x60700015,  //  00E6  GETGBL	R28	G21
       0x7C700000,  //  00E7  CALL	R28	0
-      0x8C703916,  //  00E8  GETMET	R28	R28	K22
-      0x88780137,  //  00E9  GETMBR	R30	R0	K55
+      0x8C70394F,  //  00E8  GETMET	R28	R28	K79
+      0x88780163,  //  00E9  GETMBR	R30	R0	K99
       0x7C700400,  //  00EA  CALL	R28	2
       0x5476002F,  //  00EB  LDINT	R29	48
       0x7C600A00,  //  00EC  CALL	R24	5
       0x5466000E,  //  00ED  LDINT	R25	15
-      0x40660619,  //  00EE  CONNECT	R25	K3	R25
+      0x40663E19,  //  00EE  CONNECT	R25	K31	R25
       0x94643019,  //  00EF  GETIDX	R25	R24	R25
       0x546A000F,  //  00F0  LDINT	R26	16
       0x546E001E,  //  00F1  LDINT	R27	31
@@ -1194,35 +1141,35 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x5472002E,  //  00F5  LDINT	R28	47
       0x406C361C,  //  00F6  CONNECT	R27	R27	R28
       0x946C301B,  //  00F7  GETIDX	R27	R24	R27
-      0xB8727000,  //  00F8  GETNGBL	R28	K56
-      0x8C703939,  //  00F9  GETMET	R28	R28	K57
+      0xB8721400,  //  00F8  GETNGBL	R28	K10
+      0x8C703960,  //  00F9  GETMET	R28	R28	K96
       0x7C700200,  //  00FA  CALL	R28	1
-      0x8C740108,  //  00FB  GETMET	R29	R0	K8
+      0x8C740125,  //  00FB  GETMET	R29	R0	K37
       0x5C7C0200,  //  00FC  MOVE	R31	R1
-      0x58800003,  //  00FD  LDCONST	R32	K3
-      0x58840003,  //  00FE  LDCONST	R33	K3
-      0x58880003,  //  00FF  LDCONST	R34	K3
+      0x5880001F,  //  00FD  LDCONST	R32	K31
+      0x5884001F,  //  00FE  LDCONST	R33	K31
+      0x5888001F,  //  00FF  LDCONST	R34	K31
       0x508C0200,  //  0100  LDBOOL	R35	1	0
       0x7C740C00,  //  0101  CALL	R29	6
-      0x8C74073A,  //  0102  GETMET	R29	R3	K58
+      0x8C740785,  //  0102  GETMET	R29	R3	K133
       0x7C740200,  //  0103  CALL	R29	1
-      0x8C74073B,  //  0104  GETMET	R29	R3	K59
+      0x8C74071C,  //  0104  GETMET	R29	R3	K28
       0x5C7C3200,  //  0105  MOVE	R31	R25
       0x5C803400,  //  0106  MOVE	R32	R26
       0x5C843600,  //  0107  MOVE	R33	R27
       0x5C883800,  //  0108  MOVE	R34	R28
       0x7C740A00,  //  0109  CALL	R29	5
-      0x900E7903,  //  010A  SETMBR	R3	K60	K3
-      0x8C74073D,  //  010B  GETMET	R29	R3	K61
+      0x900F0D1F,  //  010A  SETMBR	R3	K134	K31
+      0x8C740787,  //  010B  GETMET	R29	R3	K135
       0x7C740200,  //  010C  CALL	R29	1
-      0x8C74073E,  //  010D  GETMET	R29	R3	K62
+      0x8C740788,  //  010D  GETMET	R29	R3	K136
       0x507C0200,  //  010E  LDBOOL	R31	1	0
       0x7C740400,  //  010F  CALL	R29	2
-      0x8C74073F,  //  0110  GETMET	R29	R3	K63
+      0x8C740789,  //  0110  GETMET	R29	R3	K137
       0x7C740200,  //  0111  CALL	R29	1
-      0x8C740740,  //  0112  GETMET	R29	R3	K64
+      0x8C74078A,  //  0112  GETMET	R29	R3	K138
       0x7C740200,  //  0113  CALL	R29	1
-      0x8C740741,  //  0114  GETMET	R29	R3	K65
+      0x8C74078B,  //  0114  GETMET	R29	R3	K139
       0x7C740200,  //  0115  CALL	R29	1
       0x50740200,  //  0116  LDBOOL	R29	1	0
       0x80043A00,  //  0117  RET	1	R29
@@ -1239,113 +1186,99 @@ be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name *
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(is_commissioning_open),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20commissioning_X20not_X20open),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(parse_PBKDFParamRequest),
-    /* K7   */  be_nested_str_weak(parse_Pake1),
-    /* K8   */  be_nested_str_weak(parse_Pake3),
-    /* K9   */  be_nested_str_weak(parse_Sigma1),
-    /* K10  */  be_nested_str_weak(parse_Sigma3),
-    /* K11  */  be_nested_str_weak(parse_StatusReport),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(process_incoming),
     &be_const_str_solidified,
     ( &(const binstruction[88]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010D,  //  0000  GETMBR	R2	R0	K13
+      0x8C08058C,  //  0001  GETMET	R2	R2	K140
       0x7C080200,  //  0002  CALL	R2	1
       0x740A000D,  //  0003  JMPT	R2	#0012
-      0x88080302,  //  0004  GETMBR	R2	R1	K2
+      0x8808031D,  //  0004  GETMBR	R2	R1	K29
       0x540E001F,  //  0005  LDINT	R3	32
       0x28080403,  //  0006  GE	R2	R2	R3
       0x780A0009,  //  0007  JMPF	R2	#0012
-      0x88080302,  //  0008  GETMBR	R2	R1	K2
+      0x8808031D,  //  0008  GETMBR	R2	R1	K29
       0x540E0023,  //  0009  LDINT	R3	36
       0x18080403,  //  000A  LE	R2	R2	R3
       0x780A0005,  //  000B  JMPF	R2	#0012
-      0xB80A0600,  //  000C  GETNGBL	R2	K3
-      0x580C0004,  //  000D  LDCONST	R3	K4
-      0x58100005,  //  000E  LDCONST	R4	K5
+      0xB80A0A00,  //  000C  GETNGBL	R2	K5
+      0x580C008D,  //  000D  LDCONST	R3	K141
+      0x58100022,  //  000E  LDCONST	R4	K34
       0x7C080400,  //  000F  CALL	R2	2
       0x50080000,  //  0010  LDBOOL	R2	0	0
       0x80040400,  //  0011  RET	1	R2
-      0x88080302,  //  0012  GETMBR	R2	R1	K2
+      0x8808031D,  //  0012  GETMBR	R2	R1	K29
       0x540E000F,  //  0013  LDINT	R3	16
       0x1C080403,  //  0014  EQ	R2	R2	R3
       0x780A0000,  //  0015  JMPF	R2	#0017
       0x7002003E,  //  0016  JMP		#0056
-      0x88080302,  //  0017  GETMBR	R2	R1	K2
+      0x8808031D,  //  0017  GETMBR	R2	R1	K29
       0x540E001F,  //  0018  LDINT	R3	32
       0x1C080403,  //  0019  EQ	R2	R2	R3
       0x780A0004,  //  001A  JMPF	R2	#0020
-      0x8C080106,  //  001B  GETMET	R2	R0	K6
+      0x8C08018E,  //  001B  GETMET	R2	R0	K142
       0x5C100200,  //  001C  MOVE	R4	R1
       0x7C080400,  //  001D  CALL	R2	2
       0x80040400,  //  001E  RET	1	R2
       0x70020035,  //  001F  JMP		#0056
-      0x88080302,  //  0020  GETMBR	R2	R1	K2
+      0x8808031D,  //  0020  GETMBR	R2	R1	K29
       0x540E0021,  //  0021  LDINT	R3	34
       0x1C080403,  //  0022  EQ	R2	R2	R3
       0x780A0004,  //  0023  JMPF	R2	#0029
-      0x8C080107,  //  0024  GETMET	R2	R0	K7
+      0x8C08018F,  //  0024  GETMET	R2	R0	K143
       0x5C100200,  //  0025  MOVE	R4	R1
       0x7C080400,  //  0026  CALL	R2	2
       0x80040400,  //  0027  RET	1	R2
       0x7002002C,  //  0028  JMP		#0056
-      0x88080302,  //  0029  GETMBR	R2	R1	K2
+      0x8808031D,  //  0029  GETMBR	R2	R1	K29
       0x540E0023,  //  002A  LDINT	R3	36
       0x1C080403,  //  002B  EQ	R2	R2	R3
       0x780A0004,  //  002C  JMPF	R2	#0032
-      0x8C080108,  //  002D  GETMET	R2	R0	K8
+      0x8C080190,  //  002D  GETMET	R2	R0	K144
       0x5C100200,  //  002E  MOVE	R4	R1
       0x7C080400,  //  002F  CALL	R2	2
       0x80040400,  //  0030  RET	1	R2
       0x70020023,  //  0031  JMP		#0056
-      0x88080302,  //  0032  GETMBR	R2	R1	K2
+      0x8808031D,  //  0032  GETMBR	R2	R1	K29
       0x540E002F,  //  0033  LDINT	R3	48
       0x1C080403,  //  0034  EQ	R2	R2	R3
       0x780A0004,  //  0035  JMPF	R2	#003B
-      0x8C080109,  //  0036  GETMET	R2	R0	K9
+      0x8C080191,  //  0036  GETMET	R2	R0	K145
       0x5C100200,  //  0037  MOVE	R4	R1
       0x7C080400,  //  0038  CALL	R2	2
       0x80040400,  //  0039  RET	1	R2
       0x7002001A,  //  003A  JMP		#0056
-      0x88080302,  //  003B  GETMBR	R2	R1	K2
+      0x8808031D,  //  003B  GETMBR	R2	R1	K29
       0x540E0031,  //  003C  LDINT	R3	50
       0x1C080403,  //  003D  EQ	R2	R2	R3
       0x780A0004,  //  003E  JMPF	R2	#0044
-      0x8C08010A,  //  003F  GETMET	R2	R0	K10
+      0x8C080192,  //  003F  GETMET	R2	R0	K146
       0x5C100200,  //  0040  MOVE	R4	R1
       0x7C080400,  //  0041  CALL	R2	2
       0x80040400,  //  0042  RET	1	R2
       0x70020011,  //  0043  JMP		#0056
-      0x88080302,  //  0044  GETMBR	R2	R1	K2
+      0x8808031D,  //  0044  GETMBR	R2	R1	K29
       0x540E003F,  //  0045  LDINT	R3	64
       0x1C080403,  //  0046  EQ	R2	R2	R3
       0x780A0004,  //  0047  JMPF	R2	#004D
-      0x8C08010B,  //  0048  GETMET	R2	R0	K11
+      0x8C080193,  //  0048  GETMET	R2	R0	K147
       0x5C100200,  //  0049  MOVE	R4	R1
       0x7C080400,  //  004A  CALL	R2	2
       0x80040400,  //  004B  RET	1	R2
       0x70020008,  //  004C  JMP		#0056
-      0xB80A0600,  //  004D  GETNGBL	R2	K3
+      0xB80A0A00,  //  004D  GETNGBL	R2	K5
       0x600C0018,  //  004E  GETGBL	R3	G24
-      0x5810000C,  //  004F  LDCONST	R4	K12
-      0x88140302,  //  0050  GETMBR	R5	R1	K2
+      0x58100094,  //  004F  LDCONST	R4	K148
+      0x8814031D,  //  0050  GETMBR	R5	R1	K29
       0x7C0C0400,  //  0051  CALL	R3	2
-      0x58100005,  //  0052  LDCONST	R4	K5
+      0x58100022,  //  0052  LDCONST	R4	K34
       0x7C080400,  //  0053  CALL	R2	2
       0x50080000,  //  0054  LDBOOL	R2	0	0
       0x80040400,  //  0055  RET	1	R2
@@ -1364,164 +1297,55 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
   be_nested_proto(
     37,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[108]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(send_status_report),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(Sigma1),
-    /* K14  */  be_nested_str_weak(parse),
-    /* K15  */  be_nested_str_weak(raw),
-    /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(__initiator_pub),
-    /* K18  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K19  */  be_nested_str_weak(resumptionID),
-    /* K20  */  be_nested_str_weak(initiatorResumeMIC),
-    /* K21  */  be_nested_str_weak(device),
-    /* K22  */  be_nested_str_weak(sessions),
-    /* K23  */  be_nested_str_weak(find_session_by_resumption_id),
-    /* K24  */  be_nested_str_weak(_fabric),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20FAILED_X2C_X20session_X20not_X20found_X20resumption_id_X3D_X25s),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption),
-    /* K27  */  be_nested_str_weak(initiatorRandom),
-    /* K28  */  be_nested_str_weak(fromstring),
-    /* K29  */  be_nested_str_weak(Sigma1_Resume),
-    /* K30  */  be_nested_str_weak(HKDF_SHA256),
-    /* K31  */  be_nested_str_weak(derive),
-    /* K32  */  be_nested_str_weak(shared_secret),
-    /* K33  */  be_nested_str_weak(NCASE_SigmaS1),
-    /* K34  */  be_const_int(2147483647),
-    /* K35  */  be_nested_str_weak(AES_CCM),
-    /* K36  */  be_nested_str_weak(decrypt),
-    /* K37  */  be_nested_str_weak(tag),
-    /* K38  */  be_nested_str_weak(_source_node_id),
-    /* K39  */  be_nested_str_weak(source_node_id),
-    /* K40  */  be_nested_str_weak(set_mode_CASE),
-    /* K41  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K42  */  be_nested_str_weak(initiator_session_id),
-    /* K43  */  be_nested_str_weak(__future_local_session_id),
-    /* K44  */  be_nested_str_weak(gen_local_session_id),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K46  */  be_nested_str_weak(remote_ip),
-    /* K47  */  be_nested_str_weak(remote_port),
-    /* K48  */  be_nested_str_weak(resumption_id),
-    /* K49  */  be_nested_str_weak(random),
-    /* K50  */  be_nested_str_weak(Sigma2_Resume),
-    /* K51  */  be_nested_str_weak(NCASE_SigmaS2),
-    /* K52  */  be_nested_str_weak(Sigma2Resume),
-    /* K53  */  be_nested_str_weak(sigma2ResumeMIC),
-    /* K54  */  be_nested_str_weak(responderSessionID),
-    /* K55  */  be_nested_str_weak(SessionResumptionKeys),
-    /* K56  */  be_nested_str_weak(tasmota),
-    /* K57  */  be_nested_str_weak(rtc_utc),
-    /* K58  */  be_nested_str_weak(tlv2raw),
-    /* K59  */  be_nested_str_weak(__Msg1),
-    /* K60  */  be_nested_str_weak(build_response),
-    /* K61  */  be_nested_str_weak(encode_frame),
-    /* K62  */  be_nested_str_weak(responder),
-    /* K63  */  be_nested_str_weak(send_response_frame),
-    /* K64  */  be_nested_str_weak(close),
-    /* K65  */  be_nested_str_weak(set_keys),
-    /* K66  */  be_nested_str_weak(peer_node_id),
-    /* K67  */  be_nested_str_weak(_breadcrumb),
-    /* K68  */  be_nested_str_weak(counter_snd_next),
-    /* K69  */  be_nested_str_weak(set_persist),
-    /* K70  */  be_nested_str_weak(set_no_expiration),
-    /* K71  */  be_nested_str_weak(persist_to_fabric),
-    /* K72  */  be_nested_str_weak(save),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20SUCCEEDED),
-    /* K74  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Sigma1_X20Resumption_X20FAILED_X2C_X20switching_X20to_X20CASE),
-    /* K75  */  be_nested_str_weak(find_fabric_by_destination_id),
-    /* K76  */  be_nested_str_weak(destinationId),
-    /* K77  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
-    /* K78  */  be_nested_str_weak(__responder_priv),
-    /* K79  */  be_nested_str_weak(__responder_pub),
-    /* K80  */  be_nested_str_weak(EC_P256),
-    /* K81  */  be_nested_str_weak(public_key),
-    /* K82  */  be_nested_str_weak(shared_key),
-    /* K83  */  be_nested_str_weak(TLV),
-    /* K84  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K85  */  be_nested_str_weak(add_TLV),
-    /* K86  */  be_nested_str_weak(B2),
-    /* K87  */  be_nested_str_weak(get_noc),
-    /* K88  */  be_nested_str_weak(get_icac),
-    /* K89  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K90  */  be_nested_str_weak(get_pk),
-    /* K91  */  be_nested_str_weak(Msg1),
-    /* K92  */  be_nested_str_weak(SHA256),
-    /* K93  */  be_nested_str_weak(update),
-    /* K94  */  be_nested_str_weak(out),
-    /* K95  */  be_nested_str_weak(S2K_Info),
-    /* K96  */  be_nested_str_weak(get_ipk_group_key),
-    /* K97  */  be_nested_str_weak(TBEData2_Nonce),
-    /* K98  */  be_nested_str_weak(encrypt),
-    /* K99  */  be_nested_str_weak(Sigma2),
-    /* K100 */  be_nested_str_weak(responderRandom),
-    /* K101 */  be_nested_str_weak(responderSessionId),
-    /* K102 */  be_nested_str_weak(responderEphPubKey),
-    /* K103 */  be_nested_str_weak(encrypted2),
-    /* K104 */  be_nested_str_weak(__Msg2),
-    /* K105 */  be_nested_str_weak(MTR_X3A_X20New_X20Connection_X20_X28CASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K106 */  be_nested_str_weak(_ip),
-    /* K107 */  be_nested_str_weak(_port),
-    }),
+    &be_ktab_class_Matter_Commisioning_Context,     /* shared constants */
     be_str_weak(parse_Sigma1),
     &be_const_str_solidified,
     ( &(const binstruction[497]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x880C0300,  //  0001  GETMBR	R3	R1	K0
+      0x8810031D,  //  0002  GETMBR	R4	R1	K29
       0x5416002F,  //  0003  LDINT	R5	48
       0x20100805,  //  0004  NE	R4	R4	R5
       0x74120005,  //  0005  JMPT	R4	#000C
-      0x88100303,  //  0006  GETMBR	R4	R1	K3
-      0x20100904,  //  0007  NE	R4	R4	K4
+      0x8810031E,  //  0006  GETMBR	R4	R1	K30
+      0x2010091F,  //  0007  NE	R4	R4	K31
       0x74120002,  //  0008  JMPT	R4	#000C
-      0x88100305,  //  0009  GETMBR	R4	R1	K5
-      0x20100904,  //  000A  NE	R4	R4	K4
+      0x88100320,  //  0009  GETMBR	R4	R1	K32
+      0x2010091F,  //  000A  NE	R4	R4	K31
       0x7812000C,  //  000B  JMPF	R4	#0019
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x58180008,  //  000E  LDCONST	R6	K8
+      0xB8120A00,  //  000C  GETNGBL	R4	K5
+      0x58140023,  //  000D  LDCONST	R5	K35
+      0x58180024,  //  000E  LDCONST	R6	K36
       0x7C100400,  //  000F  CALL	R4	2
-      0x8C100109,  //  0010  GETMET	R4	R0	K9
+      0x8C100125,  //  0010  GETMET	R4	R0	K37
       0x5C180200,  //  0011  MOVE	R6	R1
-      0x581C000A,  //  0012  LDCONST	R7	K10
-      0x58200004,  //  0013  LDCONST	R8	K4
-      0x5824000B,  //  0014  LDCONST	R9	K11
+      0x581C0026,  //  0012  LDCONST	R7	K38
+      0x5820001F,  //  0013  LDCONST	R8	K31
+      0x58240045,  //  0014  LDCONST	R9	K69
       0x50280000,  //  0015  LDBOOL	R10	0	0
       0x7C100C00,  //  0016  CALL	R4	6
       0x50100000,  //  0017  LDBOOL	R4	0	0
       0x80040800,  //  0018  RET	1	R4
-      0xB8121800,  //  0019  GETNGBL	R4	K12
-      0x8C10090D,  //  001A  GETMET	R4	R4	K13
+      0xB8124E00,  //  0019  GETNGBL	R4	K39
+      0x8C100995,  //  001A  GETMET	R4	R4	K149
       0x7C100200,  //  001B  CALL	R4	1
-      0x8C10090E,  //  001C  GETMET	R4	R4	K14
-      0x8818030F,  //  001D  GETMBR	R6	R1	K15
-      0x881C0310,  //  001E  GETMBR	R7	R1	K16
+      0x8C100929,  //  001C  GETMET	R4	R4	K41
+      0x88180301,  //  001D  GETMBR	R6	R1	K1
+      0x881C0302,  //  001E  GETMBR	R7	R1	K2
       0x7C100600,  //  001F  CALL	R4	3
-      0x88140912,  //  0020  GETMBR	R5	R4	K18
-      0x900E2205,  //  0021  SETMBR	R3	K17	R5
-      0x88140913,  //  0022  GETMBR	R5	R4	K19
+      0x88140996,  //  0020  GETMBR	R5	R4	K150
+      0x900EFA05,  //  0021  SETMBR	R3	K125	R5
+      0x88140997,  //  0022  GETMBR	R5	R4	K151
       0x4C180000,  //  0023  LDNIL	R6
       0x20140A06,  //  0024  NE	R5	R5	R6
       0x78160003,  //  0025  JMPF	R5	#002A
-      0x88140914,  //  0026  GETMBR	R5	R4	K20
+      0x88140998,  //  0026  GETMBR	R5	R4	K152
       0x4C180000,  //  0027  LDNIL	R6
       0x20140A06,  //  0028  NE	R5	R5	R6
       0x74160000,  //  0029  JMPT	R5	#002B
@@ -1529,62 +1353,62 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x50140200,  //  002B  LDBOOL	R5	1	0
       0x4C180000,  //  002C  LDNIL	R6
       0x78160014,  //  002D  JMPF	R5	#0043
-      0x881C0115,  //  002E  GETMBR	R7	R0	K21
-      0x881C0F16,  //  002F  GETMBR	R7	R7	K22
-      0x8C1C0F17,  //  0030  GETMET	R7	R7	K23
-      0x88240913,  //  0031  GETMBR	R9	R4	K19
+      0x881C010D,  //  002E  GETMBR	R7	R0	K13
+      0x881C0F0E,  //  002F  GETMBR	R7	R7	K14
+      0x8C1C0F99,  //  0030  GETMET	R7	R7	K153
+      0x88240997,  //  0031  GETMBR	R9	R4	K151
       0x7C1C0400,  //  0032  CALL	R7	2
       0x5C180E00,  //  0033  MOVE	R6	R7
       0x4C1C0000,  //  0034  LDNIL	R7
       0x1C1C0C07,  //  0035  EQ	R7	R6	R7
       0x741E0003,  //  0036  JMPT	R7	#003B
-      0x881C0D18,  //  0037  GETMBR	R7	R6	K24
+      0x881C0D9A,  //  0037  GETMBR	R7	R6	K154
       0x4C200000,  //  0038  LDNIL	R8
       0x1C1C0E08,  //  0039  EQ	R7	R7	R8
       0x781E0007,  //  003A  JMPF	R7	#0043
-      0xB81E0C00,  //  003B  GETNGBL	R7	K6
+      0xB81E0A00,  //  003B  GETNGBL	R7	K5
       0x60200018,  //  003C  GETGBL	R8	G24
-      0x58240019,  //  003D  LDCONST	R9	K25
-      0x88280913,  //  003E  GETMBR	R10	R4	K19
+      0x5824009B,  //  003D  LDCONST	R9	K155
+      0x88280997,  //  003E  GETMBR	R10	R4	K151
       0x7C200400,  //  003F  CALL	R8	2
-      0x58240008,  //  0040  LDCONST	R9	K8
+      0x58240024,  //  0040  LDCONST	R9	K36
       0x7C1C0400,  //  0041  CALL	R7	2
       0x50140000,  //  0042  LDBOOL	R5	0	0
       0x781600C3,  //  0043  JMPF	R5	#0108
-      0xB81E0C00,  //  0044  GETNGBL	R7	K6
-      0x5820001A,  //  0045  LDCONST	R8	K26
-      0x58240008,  //  0046  LDCONST	R9	K8
+      0xB81E0A00,  //  0044  GETNGBL	R7	K5
+      0x5820009C,  //  0045  LDCONST	R8	K156
+      0x58240024,  //  0046  LDCONST	R9	K36
       0x7C1C0400,  //  0047  CALL	R7	2
-      0x881C091B,  //  0048  GETMBR	R7	R4	K27
-      0x88200913,  //  0049  GETMBR	R8	R4	K19
+      0x881C0936,  //  0048  GETMBR	R7	R4	K54
+      0x88200997,  //  0049  GETMBR	R8	R4	K151
       0x001C0E08,  //  004A  ADD	R7	R7	R8
       0x60200015,  //  004B  GETGBL	R8	G21
       0x7C200000,  //  004C  CALL	R8	0
-      0x8C20111C,  //  004D  GETMET	R8	R8	K28
-      0x5828001D,  //  004E  LDCONST	R10	K29
+      0x8C20114F,  //  004D  GETMET	R8	R8	K79
+      0x5828009D,  //  004E  LDCONST	R10	K157
       0x7C200400,  //  004F  CALL	R8	2
-      0x8C24051E,  //  0050  GETMET	R9	R2	K30
+      0x8C240561,  //  0050  GETMET	R9	R2	K97
       0x7C240200,  //  0051  CALL	R9	1
-      0x8C24131F,  //  0052  GETMET	R9	R9	K31
-      0x882C0D20,  //  0053  GETMBR	R11	R6	K32
+      0x8C241362,  //  0052  GETMET	R9	R9	K98
+      0x882C0D6A,  //  0053  GETMBR	R11	R6	K106
       0x5C300E00,  //  0054  MOVE	R12	R7
       0x5C341000,  //  0055  MOVE	R13	R8
       0x543A000F,  //  0056  LDINT	R14	16
       0x7C240A00,  //  0057  CALL	R9	5
       0x60280015,  //  0058  GETGBL	R10	G21
       0x7C280000,  //  0059  CALL	R10	0
-      0x8C28151C,  //  005A  GETMET	R10	R10	K28
-      0x58300021,  //  005B  LDCONST	R12	K33
+      0x8C28154F,  //  005A  GETMET	R10	R10	K79
+      0x5830009E,  //  005B  LDCONST	R12	K158
       0x7C280400,  //  005C  CALL	R10	2
       0x542DFFEE,  //  005D  LDINT	R11	-17
-      0x402E080B,  //  005E  CONNECT	R11	K4	R11
-      0x88300914,  //  005F  GETMBR	R12	R4	K20
+      0x402E3E0B,  //  005E  CONNECT	R11	K31	R11
+      0x88300998,  //  005F  GETMBR	R12	R4	K152
       0x942C180B,  //  0060  GETIDX	R11	R12	R11
       0x5435FFEF,  //  0061  LDINT	R13	-16
-      0x40341B22,  //  0062  CONNECT	R13	R13	K34
-      0x88380914,  //  0063  GETMBR	R14	R4	K20
+      0x40341B03,  //  0062  CONNECT	R13	R13	K3
+      0x88380998,  //  0063  GETMBR	R14	R4	K152
       0x94301C0D,  //  0064  GETIDX	R12	R14	R13
-      0x8C3C0523,  //  0065  GETMET	R15	R2	K35
+      0x8C3C056D,  //  0065  GETMET	R15	R2	K109
       0x5C441200,  //  0066  MOVE	R17	R9
       0x5C481400,  //  0067  MOVE	R18	R10
       0x604C0015,  //  0068  GETGBL	R19	G21
@@ -1595,97 +1419,97 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x5456000F,  //  006D  LDINT	R21	16
       0x7C3C0C00,  //  006E  CALL	R15	6
       0x5C341E00,  //  006F  MOVE	R13	R15
-      0x8C3C1B24,  //  0070  GETMET	R15	R13	K36
+      0x8C3C1B6F,  //  0070  GETMET	R15	R13	K111
       0x5C441600,  //  0071  MOVE	R17	R11
       0x7C3C0400,  //  0072  CALL	R15	2
       0x5C381E00,  //  0073  MOVE	R14	R15
-      0x8C3C1B25,  //  0074  GETMET	R15	R13	K37
+      0x8C3C1B70,  //  0074  GETMET	R15	R13	K112
       0x7C3C0200,  //  0075  CALL	R15	1
       0x1C40180F,  //  0076  EQ	R16	R12	R15
       0x7842008A,  //  0077  JMPF	R16	#0103
-      0x88400D18,  //  0078  GETMBR	R16	R6	K24
-      0x900E3010,  //  0079  SETMBR	R3	K24	R16
-      0x88400327,  //  007A  GETMBR	R16	R1	K39
-      0x900E4C10,  //  007B  SETMBR	R3	K38	R16
-      0x8C400728,  //  007C  GETMET	R16	R3	K40
+      0x88400D9A,  //  0078  GETMBR	R16	R6	K154
+      0x900F3410,  //  0079  SETMBR	R3	K154	R16
+      0x884003A0,  //  007A  GETMBR	R16	R1	K160
+      0x900F3E10,  //  007B  SETMBR	R3	K159	R16
+      0x8C4007A1,  //  007C  GETMET	R16	R3	K161
       0x7C400200,  //  007D  CALL	R16	1
-      0x8840092A,  //  007E  GETMBR	R16	R4	K42
-      0x900E5210,  //  007F  SETMBR	R3	K41	R16
-      0x88400115,  //  0080  GETMBR	R16	R0	K21
-      0x88402116,  //  0081  GETMBR	R16	R16	K22
-      0x8C40212C,  //  0082  GETMET	R16	R16	K44
+      0x8840092F,  //  007E  GETMBR	R16	R4	K47
+      0x900E5C10,  //  007F  SETMBR	R3	K46	R16
+      0x8840010D,  //  0080  GETMBR	R16	R0	K13
+      0x8840210E,  //  0081  GETMBR	R16	R16	K14
+      0x8C402131,  //  0082  GETMET	R16	R16	K49
       0x7C400200,  //  0083  CALL	R16	1
-      0x900E5610,  //  0084  SETMBR	R3	K43	R16
-      0xB8420C00,  //  0085  GETNGBL	R16	K6
+      0x900E6010,  //  0084  SETMBR	R3	K48	R16
+      0xB8420A00,  //  0085  GETNGBL	R16	K5
       0x60440018,  //  0086  GETGBL	R17	G24
-      0x5848002D,  //  0087  LDCONST	R18	K45
-      0x884C072B,  //  0088  GETMBR	R19	R3	K43
-      0x8850032E,  //  0089  GETMBR	R20	R1	K46
-      0x8854032F,  //  008A  GETMBR	R21	R1	K47
+      0x58480032,  //  0087  LDCONST	R18	K50
+      0x884C0730,  //  0088  GETMBR	R19	R3	K48
+      0x88500333,  //  0089  GETMBR	R20	R1	K51
+      0x88540334,  //  008A  GETMBR	R21	R1	K52
       0x7C440800,  //  008B  CALL	R17	4
-      0x58480008,  //  008C  LDCONST	R18	K8
+      0x58480024,  //  008C  LDCONST	R18	K36
       0x7C400400,  //  008D  CALL	R16	2
-      0x88400D20,  //  008E  GETMBR	R16	R6	K32
-      0x900E4010,  //  008F  SETMBR	R3	K32	R16
-      0x8C400531,  //  0090  GETMET	R16	R2	K49
+      0x88400D6A,  //  008E  GETMBR	R16	R6	K106
+      0x900ED410,  //  008F  SETMBR	R3	K106	R16
+      0x8C400538,  //  0090  GETMET	R16	R2	K56
       0x544A000F,  //  0091  LDINT	R18	16
       0x7C400400,  //  0092  CALL	R16	2
-      0x900E6010,  //  0093  SETMBR	R3	K48	R16
+      0x900F4410,  //  0093  SETMBR	R3	K162	R16
       0x60400015,  //  0094  GETGBL	R16	G21
       0x7C400000,  //  0095  CALL	R16	0
-      0x8C40211C,  //  0096  GETMET	R16	R16	K28
-      0x58480032,  //  0097  LDCONST	R18	K50
+      0x8C40214F,  //  0096  GETMET	R16	R16	K79
+      0x584800A3,  //  0097  LDCONST	R18	K163
       0x7C400400,  //  0098  CALL	R16	2
-      0x8844091B,  //  0099  GETMBR	R17	R4	K27
-      0x88480730,  //  009A  GETMBR	R18	R3	K48
+      0x88440936,  //  0099  GETMBR	R17	R4	K54
+      0x884807A2,  //  009A  GETMBR	R18	R3	K162
       0x00442212,  //  009B  ADD	R17	R17	R18
-      0x8C48051E,  //  009C  GETMET	R18	R2	K30
+      0x8C480561,  //  009C  GETMET	R18	R2	K97
       0x7C480200,  //  009D  CALL	R18	1
-      0x8C48251F,  //  009E  GETMET	R18	R18	K31
-      0x88500720,  //  009F  GETMBR	R20	R3	K32
+      0x8C482562,  //  009E  GETMET	R18	R18	K98
+      0x8850076A,  //  009F  GETMBR	R20	R3	K106
       0x5C542200,  //  00A0  MOVE	R21	R17
       0x5C582000,  //  00A1  MOVE	R22	R16
       0x545E000F,  //  00A2  LDINT	R23	16
       0x7C480A00,  //  00A3  CALL	R18	5
-      0x8C4C0523,  //  00A4  GETMET	R19	R2	K35
+      0x8C4C056D,  //  00A4  GETMET	R19	R2	K109
       0x5C542400,  //  00A5  MOVE	R21	R18
       0x60580015,  //  00A6  GETGBL	R22	G21
       0x7C580000,  //  00A7  CALL	R22	0
-      0x8C582D1C,  //  00A8  GETMET	R22	R22	K28
-      0x58600033,  //  00A9  LDCONST	R24	K51
+      0x8C582D4F,  //  00A8  GETMET	R22	R22	K79
+      0x586000A4,  //  00A9  LDCONST	R24	K164
       0x7C580400,  //  00AA  CALL	R22	2
       0x605C0015,  //  00AB  GETGBL	R23	G21
       0x7C5C0000,  //  00AC  CALL	R23	0
-      0x58600004,  //  00AD  LDCONST	R24	K4
+      0x5860001F,  //  00AD  LDCONST	R24	K31
       0x5466000F,  //  00AE  LDINT	R25	16
       0x7C4C0C00,  //  00AF  CALL	R19	6
-      0x8C502725,  //  00B0  GETMET	R20	R19	K37
+      0x8C502770,  //  00B0  GETMET	R20	R19	K112
       0x7C500200,  //  00B1  CALL	R20	1
-      0xB8561800,  //  00B2  GETNGBL	R21	K12
-      0x8C542B34,  //  00B3  GETMET	R21	R21	K52
+      0xB8564E00,  //  00B2  GETNGBL	R21	K39
+      0x8C542BA5,  //  00B3  GETMET	R21	R21	K165
       0x7C540200,  //  00B4  CALL	R21	1
-      0x88580730,  //  00B5  GETMBR	R22	R3	K48
-      0x90562616,  //  00B6  SETMBR	R21	K19	R22
-      0x90566A14,  //  00B7  SETMBR	R21	K53	R20
-      0x8858072B,  //  00B8  GETMBR	R22	R3	K43
-      0x90566C16,  //  00B9  SETMBR	R21	K54	R22
-      0x8858091B,  //  00BA  GETMBR	R22	R4	K27
-      0x885C0D30,  //  00BB  GETMBR	R23	R6	K48
+      0x885807A2,  //  00B5  GETMBR	R22	R3	K162
+      0x90572E16,  //  00B6  SETMBR	R21	K151	R22
+      0x90574C14,  //  00B7  SETMBR	R21	K166	R20
+      0x88580730,  //  00B8  GETMBR	R22	R3	K48
+      0x90574E16,  //  00B9  SETMBR	R21	K167	R22
+      0x88580936,  //  00BA  GETMBR	R22	R4	K54
+      0x885C0DA2,  //  00BB  GETMBR	R23	R6	K162
       0x00582C17,  //  00BC  ADD	R22	R22	R23
-      0x8C5C051E,  //  00BD  GETMET	R23	R2	K30
+      0x8C5C0561,  //  00BD  GETMET	R23	R2	K97
       0x7C5C0200,  //  00BE  CALL	R23	1
-      0x8C5C2F1F,  //  00BF  GETMET	R23	R23	K31
-      0x88640720,  //  00C0  GETMBR	R25	R3	K32
+      0x8C5C2F62,  //  00BF  GETMET	R23	R23	K98
+      0x8864076A,  //  00C0  GETMBR	R25	R3	K106
       0x5C682C00,  //  00C1  MOVE	R26	R22
       0x606C0015,  //  00C2  GETGBL	R27	G21
       0x7C6C0000,  //  00C3  CALL	R27	0
-      0x8C6C371C,  //  00C4  GETMET	R27	R27	K28
-      0x58740037,  //  00C5  LDCONST	R29	K55
+      0x8C6C374F,  //  00C4  GETMET	R27	R27	K79
+      0x587400A8,  //  00C5  LDCONST	R29	K168
       0x7C6C0400,  //  00C6  CALL	R27	2
       0x5472002F,  //  00C7  LDINT	R28	48
       0x7C5C0A00,  //  00C8  CALL	R23	5
       0x5462000E,  //  00C9  LDINT	R24	15
-      0x40620818,  //  00CA  CONNECT	R24	K4	R24
+      0x40623E18,  //  00CA  CONNECT	R24	K31	R24
       0x94602E18,  //  00CB  GETIDX	R24	R23	R24
       0x5466000F,  //  00CC  LDINT	R25	16
       0x546A001E,  //  00CD  LDINT	R26	31
@@ -1695,241 +1519,241 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x546E002E,  //  00D1  LDINT	R27	47
       0x4068341B,  //  00D2  CONNECT	R26	R26	R27
       0x94682E1A,  //  00D3  GETIDX	R26	R23	R26
-      0xB86E7000,  //  00D4  GETNGBL	R27	K56
-      0x8C6C3739,  //  00D5  GETMET	R27	R27	K57
+      0xB86E1400,  //  00D4  GETNGBL	R27	K10
+      0x8C6C3760,  //  00D5  GETMET	R27	R27	K96
       0x7C6C0200,  //  00D6  CALL	R27	1
-      0x8C702B3A,  //  00D7  GETMET	R28	R21	K58
+      0x8C702B3E,  //  00D7  GETMET	R28	R21	K62
       0x7C700200,  //  00D8  CALL	R28	1
       0x4C740000,  //  00D9  LDNIL	R29
-      0x900E761D,  //  00DA  SETMBR	R3	K59	R29
-      0x8C74033C,  //  00DB  GETMET	R29	R1	K60
+      0x900E561D,  //  00DA  SETMBR	R3	K43	R29
+      0x8C740340,  //  00DB  GETMET	R29	R1	K64
       0x547E0032,  //  00DC  LDINT	R31	51
       0x50800200,  //  00DD  LDBOOL	R32	1	0
       0x7C740600,  //  00DE  CALL	R29	3
-      0x8C783B3D,  //  00DF  GETMET	R30	R29	K61
+      0x8C783B41,  //  00DF  GETMET	R30	R29	K65
       0x5C803800,  //  00E0  MOVE	R32	R28
       0x7C780400,  //  00E1  CALL	R30	2
-      0x887C013E,  //  00E2  GETMBR	R31	R0	K62
-      0x8C7C3F3F,  //  00E3  GETMET	R31	R31	K63
+      0x887C0142,  //  00E2  GETMBR	R31	R0	K66
+      0x8C7C3F43,  //  00E3  GETMET	R31	R31	K67
       0x5C843A00,  //  00E4  MOVE	R33	R29
       0x7C7C0400,  //  00E5  CALL	R31	2
-      0x8C7C0740,  //  00E6  GETMET	R31	R3	K64
+      0x8C7C0785,  //  00E6  GETMET	R31	R3	K133
       0x7C7C0200,  //  00E7  CALL	R31	1
-      0x8C7C0741,  //  00E8  GETMET	R31	R3	K65
+      0x8C7C071C,  //  00E8  GETMET	R31	R3	K28
       0x5C843000,  //  00E9  MOVE	R33	R24
       0x5C883200,  //  00EA  MOVE	R34	R25
       0x5C8C3400,  //  00EB  MOVE	R35	R26
       0x5C903600,  //  00EC  MOVE	R36	R27
       0x7C7C0A00,  //  00ED  CALL	R31	5
-      0x887C0D42,  //  00EE  GETMBR	R31	R6	K66
-      0x900E841F,  //  00EF  SETMBR	R3	K66	R31
-      0x900E8704,  //  00F0  SETMBR	R3	K67	K4
-      0x8C7C0744,  //  00F1  GETMET	R31	R3	K68
+      0x887C0D76,  //  00EE  GETMBR	R31	R6	K118
+      0x900EEC1F,  //  00EF  SETMBR	R3	K118	R31
+      0x900F0D1F,  //  00F0  SETMBR	R3	K134	K31
+      0x8C7C0787,  //  00F1  GETMET	R31	R3	K135
       0x7C7C0200,  //  00F2  CALL	R31	1
-      0x8C7C0745,  //  00F3  GETMET	R31	R3	K69
+      0x8C7C0788,  //  00F3  GETMET	R31	R3	K136
       0x50840200,  //  00F4  LDBOOL	R33	1	0
       0x7C7C0400,  //  00F5  CALL	R31	2
-      0x8C7C0746,  //  00F6  GETMET	R31	R3	K70
+      0x8C7C0789,  //  00F6  GETMET	R31	R3	K137
       0x7C7C0200,  //  00F7  CALL	R31	1
-      0x8C7C0747,  //  00F8  GETMET	R31	R3	K71
+      0x8C7C078A,  //  00F8  GETMET	R31	R3	K138
       0x7C7C0200,  //  00F9  CALL	R31	1
-      0x8C7C0748,  //  00FA  GETMET	R31	R3	K72
+      0x8C7C078B,  //  00FA  GETMET	R31	R3	K139
       0x7C7C0200,  //  00FB  CALL	R31	1
-      0xB87E0C00,  //  00FC  GETNGBL	R31	K6
-      0x58800049,  //  00FD  LDCONST	R32	K73
-      0x58840008,  //  00FE  LDCONST	R33	K8
+      0xB87E0A00,  //  00FC  GETNGBL	R31	K5
+      0x588000A9,  //  00FD  LDCONST	R32	K169
+      0x58840024,  //  00FE  LDCONST	R33	K36
       0x7C7C0400,  //  00FF  CALL	R31	2
       0x507C0200,  //  0100  LDBOOL	R31	1	0
       0x80043E00,  //  0101  RET	1	R31
       0x70020004,  //  0102  JMP		#0108
-      0xB8420C00,  //  0103  GETNGBL	R16	K6
-      0x5844004A,  //  0104  LDCONST	R17	K74
-      0x58480008,  //  0105  LDCONST	R18	K8
+      0xB8420A00,  //  0103  GETNGBL	R16	K5
+      0x584400AA,  //  0104  LDCONST	R17	K170
+      0x58480024,  //  0105  LDCONST	R18	K36
       0x7C400400,  //  0106  CALL	R16	2
       0x50140000,  //  0107  LDBOOL	R5	0	0
       0x5C1C0A00,  //  0108  MOVE	R7	R5
       0x741E00E4,  //  0109  JMPT	R7	#01EF
-      0x8C1C014B,  //  010A  GETMET	R7	R0	K75
-      0x8824094C,  //  010B  GETMBR	R9	R4	K76
-      0x8828091B,  //  010C  GETMBR	R10	R4	K27
+      0x8C1C01AB,  //  010A  GETMET	R7	R0	K171
+      0x882409AC,  //  010B  GETMBR	R9	R4	K172
+      0x88280936,  //  010C  GETMBR	R10	R4	K54
       0x7C1C0600,  //  010D  CALL	R7	3
-      0x900E3007,  //  010E  SETMBR	R3	K24	R7
+      0x900F3407,  //  010E  SETMBR	R3	K154	R7
       0x4C200000,  //  010F  LDNIL	R8
       0x1C200608,  //  0110  EQ	R8	R3	R8
       0x74220003,  //  0111  JMPT	R8	#0116
-      0x88200718,  //  0112  GETMBR	R8	R3	K24
+      0x8820079A,  //  0112  GETMBR	R8	R3	K154
       0x4C240000,  //  0113  LDNIL	R9
       0x1C201009,  //  0114  EQ	R8	R8	R9
       0x7822000C,  //  0115  JMPF	R8	#0123
-      0xB8220C00,  //  0116  GETNGBL	R8	K6
-      0x5824004D,  //  0117  LDCONST	R9	K77
-      0x58280008,  //  0118  LDCONST	R10	K8
+      0xB8220A00,  //  0116  GETNGBL	R8	K5
+      0x582400AD,  //  0117  LDCONST	R9	K173
+      0x58280024,  //  0118  LDCONST	R10	K36
       0x7C200400,  //  0119  CALL	R8	2
-      0x8C200109,  //  011A  GETMET	R8	R0	K9
+      0x8C200125,  //  011A  GETMET	R8	R0	K37
       0x5C280200,  //  011B  MOVE	R10	R1
-      0x582C000A,  //  011C  LDCONST	R11	K10
-      0x58300004,  //  011D  LDCONST	R12	K4
-      0x5834000A,  //  011E  LDCONST	R13	K10
+      0x582C0026,  //  011C  LDCONST	R11	K38
+      0x5830001F,  //  011D  LDCONST	R12	K31
+      0x58340026,  //  011E  LDCONST	R13	K38
       0x50380000,  //  011F  LDBOOL	R14	0	0
       0x7C200C00,  //  0120  CALL	R8	6
       0x50200000,  //  0121  LDBOOL	R8	0	0
       0x80041000,  //  0122  RET	1	R8
-      0x88200327,  //  0123  GETMBR	R8	R1	K39
-      0x900E4C08,  //  0124  SETMBR	R3	K38	R8
-      0x8C200728,  //  0125  GETMET	R8	R3	K40
+      0x882003A0,  //  0123  GETMBR	R8	R1	K160
+      0x900F3E08,  //  0124  SETMBR	R3	K159	R8
+      0x8C2007A1,  //  0125  GETMET	R8	R3	K161
       0x7C200200,  //  0126  CALL	R8	1
-      0x8820092A,  //  0127  GETMBR	R8	R4	K42
-      0x900E5208,  //  0128  SETMBR	R3	K41	R8
-      0x88200115,  //  0129  GETMBR	R8	R0	K21
-      0x88201116,  //  012A  GETMBR	R8	R8	K22
-      0x8C20112C,  //  012B  GETMET	R8	R8	K44
+      0x8820092F,  //  0127  GETMBR	R8	R4	K47
+      0x900E5C08,  //  0128  SETMBR	R3	K46	R8
+      0x8820010D,  //  0129  GETMBR	R8	R0	K13
+      0x8820110E,  //  012A  GETMBR	R8	R8	K14
+      0x8C201131,  //  012B  GETMET	R8	R8	K49
       0x7C200200,  //  012C  CALL	R8	1
-      0x900E5608,  //  012D  SETMBR	R3	K43	R8
-      0xB8220C00,  //  012E  GETNGBL	R8	K6
+      0x900E6008,  //  012D  SETMBR	R3	K48	R8
+      0xB8220A00,  //  012E  GETNGBL	R8	K5
       0x60240018,  //  012F  GETGBL	R9	G24
-      0x5828002D,  //  0130  LDCONST	R10	K45
-      0x882C072B,  //  0131  GETMBR	R11	R3	K43
-      0x8830032E,  //  0132  GETMBR	R12	R1	K46
-      0x8834032F,  //  0133  GETMBR	R13	R1	K47
+      0x58280032,  //  0130  LDCONST	R10	K50
+      0x882C0730,  //  0131  GETMBR	R11	R3	K48
+      0x88300333,  //  0132  GETMBR	R12	R1	K51
+      0x88340334,  //  0133  GETMBR	R13	R1	K52
       0x7C240800,  //  0134  CALL	R9	4
-      0x58280008,  //  0135  LDCONST	R10	K8
+      0x58280024,  //  0135  LDCONST	R10	K36
       0x7C200400,  //  0136  CALL	R8	2
-      0x8C200531,  //  0137  GETMET	R8	R2	K49
+      0x8C200538,  //  0137  GETMET	R8	R2	K56
       0x542A000F,  //  0138  LDINT	R10	16
       0x7C200400,  //  0139  CALL	R8	2
-      0x900E6008,  //  013A  SETMBR	R3	K48	R8
-      0x8C200531,  //  013B  GETMET	R8	R2	K49
+      0x900F4408,  //  013A  SETMBR	R3	K162	R8
+      0x8C200538,  //  013B  GETMET	R8	R2	K56
       0x542A001F,  //  013C  LDINT	R10	32
       0x7C200400,  //  013D  CALL	R8	2
-      0x900E9C08,  //  013E  SETMBR	R3	K78	R8
-      0x8C200550,  //  013F  GETMET	R8	R2	K80
+      0x900F5C08,  //  013E  SETMBR	R3	K174	R8
+      0x8C20057F,  //  013F  GETMET	R8	R2	K127
       0x7C200200,  //  0140  CALL	R8	1
-      0x8C201151,  //  0141  GETMET	R8	R8	K81
-      0x8828074E,  //  0142  GETMBR	R10	R3	K78
+      0x8C2011AF,  //  0141  GETMET	R8	R8	K175
+      0x882807AE,  //  0142  GETMBR	R10	R3	K174
       0x7C200400,  //  0143  CALL	R8	2
-      0x900E9E08,  //  0144  SETMBR	R3	K79	R8
-      0x8C200531,  //  0145  GETMET	R8	R2	K49
+      0x900EFC08,  //  0144  SETMBR	R3	K126	R8
+      0x8C200538,  //  0145  GETMET	R8	R2	K56
       0x542A001F,  //  0146  LDINT	R10	32
       0x7C200400,  //  0147  CALL	R8	2
-      0x8C240550,  //  0148  GETMET	R9	R2	K80
+      0x8C24057F,  //  0148  GETMET	R9	R2	K127
       0x7C240200,  //  0149  CALL	R9	1
-      0x8C241352,  //  014A  GETMET	R9	R9	K82
-      0x882C074E,  //  014B  GETMBR	R11	R3	K78
-      0x88300912,  //  014C  GETMBR	R12	R4	K18
+      0x8C2413B0,  //  014A  GETMET	R9	R9	K176
+      0x882C07AE,  //  014B  GETMBR	R11	R3	K174
+      0x88300996,  //  014C  GETMBR	R12	R4	K150
       0x7C240600,  //  014D  CALL	R9	3
-      0x900E4009,  //  014E  SETMBR	R3	K32	R9
-      0xB8261800,  //  014F  GETNGBL	R9	K12
-      0x88241353,  //  0150  GETMBR	R9	R9	K83
-      0x8C241354,  //  0151  GETMET	R9	R9	K84
+      0x900ED409,  //  014E  SETMBR	R3	K106	R9
+      0xB8264E00,  //  014F  GETNGBL	R9	K39
+      0x88241372,  //  0150  GETMBR	R9	R9	K114
+      0x8C24137A,  //  0151  GETMET	R9	R9	K122
       0x7C240200,  //  0152  CALL	R9	1
-      0x8C281355,  //  0153  GETMET	R10	R9	K85
-      0x5830000A,  //  0154  LDCONST	R12	K10
-      0xB8361800,  //  0155  GETNGBL	R13	K12
-      0x88341B53,  //  0156  GETMBR	R13	R13	K83
-      0x88341B56,  //  0157  GETMBR	R13	R13	K86
-      0x8C380F57,  //  0158  GETMET	R14	R7	K87
+      0x8C28137B,  //  0153  GETMET	R10	R9	K123
+      0x58300026,  //  0154  LDCONST	R12	K38
+      0xB8364E00,  //  0155  GETNGBL	R13	K39
+      0x88341B72,  //  0156  GETMBR	R13	R13	K114
+      0x88341BB1,  //  0157  GETMBR	R13	R13	K177
+      0x8C380FB2,  //  0158  GETMET	R14	R7	K178
       0x7C380200,  //  0159  CALL	R14	1
       0x7C280800,  //  015A  CALL	R10	4
-      0x8C281355,  //  015B  GETMET	R10	R9	K85
-      0x5830000B,  //  015C  LDCONST	R12	K11
-      0xB8361800,  //  015D  GETNGBL	R13	K12
-      0x88341B53,  //  015E  GETMBR	R13	R13	K83
-      0x88341B56,  //  015F  GETMBR	R13	R13	K86
-      0x8C380F58,  //  0160  GETMET	R14	R7	K88
+      0x8C28137B,  //  015B  GETMET	R10	R9	K123
+      0x58300045,  //  015C  LDCONST	R12	K69
+      0xB8364E00,  //  015D  GETNGBL	R13	K39
+      0x88341B72,  //  015E  GETMBR	R13	R13	K114
+      0x88341BB1,  //  015F  GETMBR	R13	R13	K177
+      0x8C380FB3,  //  0160  GETMET	R14	R7	K179
       0x7C380200,  //  0161  CALL	R14	1
       0x7C280800,  //  0162  CALL	R10	4
-      0x8C281355,  //  0163  GETMET	R10	R9	K85
-      0x58300008,  //  0164  LDCONST	R12	K8
-      0xB8361800,  //  0165  GETNGBL	R13	K12
-      0x88341B53,  //  0166  GETMBR	R13	R13	K83
-      0x88341B56,  //  0167  GETMBR	R13	R13	K86
-      0x8838074F,  //  0168  GETMBR	R14	R3	K79
+      0x8C28137B,  //  0163  GETMET	R10	R9	K123
+      0x58300024,  //  0164  LDCONST	R12	K36
+      0xB8364E00,  //  0165  GETNGBL	R13	K39
+      0x88341B72,  //  0166  GETMBR	R13	R13	K114
+      0x88341BB1,  //  0167  GETMBR	R13	R13	K177
+      0x8838077E,  //  0168  GETMBR	R14	R3	K126
       0x7C280800,  //  0169  CALL	R10	4
-      0x8C281355,  //  016A  GETMET	R10	R9	K85
+      0x8C28137B,  //  016A  GETMET	R10	R9	K123
       0x54320003,  //  016B  LDINT	R12	4
-      0xB8361800,  //  016C  GETNGBL	R13	K12
-      0x88341B53,  //  016D  GETMBR	R13	R13	K83
-      0x88341B56,  //  016E  GETMBR	R13	R13	K86
-      0x88380912,  //  016F  GETMBR	R14	R4	K18
+      0xB8364E00,  //  016C  GETNGBL	R13	K39
+      0x88341B72,  //  016D  GETMBR	R13	R13	K114
+      0x88341BB1,  //  016E  GETMBR	R13	R13	K177
+      0x88380996,  //  016F  GETMBR	R14	R4	K150
       0x7C280800,  //  0170  CALL	R10	4
-      0x8C280550,  //  0171  GETMET	R10	R2	K80
+      0x8C28057F,  //  0171  GETMET	R10	R2	K127
       0x7C280200,  //  0172  CALL	R10	1
-      0x8C281559,  //  0173  GETMET	R10	R10	K89
-      0x8C300F5A,  //  0174  GETMET	R12	R7	K90
+      0x8C2815B4,  //  0173  GETMET	R10	R10	K180
+      0x8C300FB5,  //  0174  GETMET	R12	R7	K181
       0x7C300200,  //  0175  CALL	R12	1
-      0x8C34133A,  //  0176  GETMET	R13	R9	K58
+      0x8C34133E,  //  0176  GETMET	R13	R9	K62
       0x7C340200,  //  0177  CALL	R13	1
       0x7C280600,  //  0178  CALL	R10	3
-      0xB82E1800,  //  0179  GETNGBL	R11	K12
-      0x882C1753,  //  017A  GETMBR	R11	R11	K83
-      0x8C2C1754,  //  017B  GETMET	R11	R11	K84
+      0xB82E4E00,  //  0179  GETNGBL	R11	K39
+      0x882C1772,  //  017A  GETMBR	R11	R11	K114
+      0x8C2C177A,  //  017B  GETMET	R11	R11	K122
       0x7C2C0200,  //  017C  CALL	R11	1
-      0x8C301755,  //  017D  GETMET	R12	R11	K85
-      0x5838000A,  //  017E  LDCONST	R14	K10
-      0xB83E1800,  //  017F  GETNGBL	R15	K12
-      0x883C1F53,  //  0180  GETMBR	R15	R15	K83
-      0x883C1F56,  //  0181  GETMBR	R15	R15	K86
-      0x8C400F57,  //  0182  GETMET	R16	R7	K87
+      0x8C30177B,  //  017D  GETMET	R12	R11	K123
+      0x58380026,  //  017E  LDCONST	R14	K38
+      0xB83E4E00,  //  017F  GETNGBL	R15	K39
+      0x883C1F72,  //  0180  GETMBR	R15	R15	K114
+      0x883C1FB1,  //  0181  GETMBR	R15	R15	K177
+      0x8C400FB2,  //  0182  GETMET	R16	R7	K178
       0x7C400200,  //  0183  CALL	R16	1
       0x7C300800,  //  0184  CALL	R12	4
-      0x8C301755,  //  0185  GETMET	R12	R11	K85
-      0x5838000B,  //  0186  LDCONST	R14	K11
-      0xB83E1800,  //  0187  GETNGBL	R15	K12
-      0x883C1F53,  //  0188  GETMBR	R15	R15	K83
-      0x883C1F56,  //  0189  GETMBR	R15	R15	K86
-      0x8C400F58,  //  018A  GETMET	R16	R7	K88
+      0x8C30177B,  //  0185  GETMET	R12	R11	K123
+      0x58380045,  //  0186  LDCONST	R14	K69
+      0xB83E4E00,  //  0187  GETNGBL	R15	K39
+      0x883C1F72,  //  0188  GETMBR	R15	R15	K114
+      0x883C1FB1,  //  0189  GETMBR	R15	R15	K177
+      0x8C400FB3,  //  018A  GETMET	R16	R7	K179
       0x7C400200,  //  018B  CALL	R16	1
       0x7C300800,  //  018C  CALL	R12	4
-      0x8C301755,  //  018D  GETMET	R12	R11	K85
-      0x58380008,  //  018E  LDCONST	R14	K8
-      0xB83E1800,  //  018F  GETNGBL	R15	K12
-      0x883C1F53,  //  0190  GETMBR	R15	R15	K83
-      0x883C1F56,  //  0191  GETMBR	R15	R15	K86
+      0x8C30177B,  //  018D  GETMET	R12	R11	K123
+      0x58380024,  //  018E  LDCONST	R14	K36
+      0xB83E4E00,  //  018F  GETNGBL	R15	K39
+      0x883C1F72,  //  0190  GETMBR	R15	R15	K114
+      0x883C1FB1,  //  0191  GETMBR	R15	R15	K177
       0x5C401400,  //  0192  MOVE	R16	R10
       0x7C300800,  //  0193  CALL	R12	4
-      0x8C301755,  //  0194  GETMET	R12	R11	K85
+      0x8C30177B,  //  0194  GETMET	R12	R11	K123
       0x543A0003,  //  0195  LDINT	R14	4
-      0xB83E1800,  //  0196  GETNGBL	R15	K12
-      0x883C1F53,  //  0197  GETMBR	R15	R15	K83
-      0x883C1F56,  //  0198  GETMBR	R15	R15	K86
-      0x88400730,  //  0199  GETMBR	R16	R3	K48
+      0xB83E4E00,  //  0196  GETNGBL	R15	K39
+      0x883C1F72,  //  0197  GETMBR	R15	R15	K114
+      0x883C1FB1,  //  0198  GETMBR	R15	R15	K177
+      0x884007A2,  //  0199  GETMBR	R16	R3	K162
       0x7C300800,  //  019A  CALL	R12	4
-      0x8830095B,  //  019B  GETMBR	R12	R4	K91
-      0x900E760C,  //  019C  SETMBR	R3	K59	R12
-      0x8C30055C,  //  019D  GETMET	R12	R2	K92
+      0x883009B6,  //  019B  GETMBR	R12	R4	K182
+      0x900E560C,  //  019C  SETMBR	R3	K43	R12
+      0x8C30054E,  //  019D  GETMET	R12	R2	K78
       0x7C300200,  //  019E  CALL	R12	1
-      0x8C30195D,  //  019F  GETMET	R12	R12	K93
-      0x8838073B,  //  01A0  GETMBR	R14	R3	K59
+      0x8C301916,  //  019F  GETMET	R12	R12	K22
+      0x8838072B,  //  01A0  GETMBR	R14	R3	K43
       0x7C300400,  //  01A1  CALL	R12	2
-      0x8C30195E,  //  01A2  GETMET	R12	R12	K94
+      0x8C301917,  //  01A2  GETMET	R12	R12	K23
       0x7C300200,  //  01A3  CALL	R12	1
       0x60340015,  //  01A4  GETGBL	R13	G21
       0x7C340000,  //  01A5  CALL	R13	0
-      0x8C341B1C,  //  01A6  GETMET	R13	R13	K28
-      0x883C015F,  //  01A7  GETMBR	R15	R0	K95
+      0x8C341B4F,  //  01A6  GETMET	R13	R13	K79
+      0x883C01B7,  //  01A7  GETMBR	R15	R0	K183
       0x7C340400,  //  01A8  CALL	R13	2
-      0x8C380F60,  //  01A9  GETMET	R14	R7	K96
+      0x8C380F14,  //  01A9  GETMET	R14	R7	K20
       0x7C380200,  //  01AA  CALL	R14	1
       0x00381C08,  //  01AB  ADD	R14	R14	R8
-      0x883C074F,  //  01AC  GETMBR	R15	R3	K79
+      0x883C077E,  //  01AC  GETMBR	R15	R3	K126
       0x00381C0F,  //  01AD  ADD	R14	R14	R15
       0x00381C0C,  //  01AE  ADD	R14	R14	R12
-      0x8C3C051E,  //  01AF  GETMET	R15	R2	K30
+      0x8C3C0561,  //  01AF  GETMET	R15	R2	K97
       0x7C3C0200,  //  01B0  CALL	R15	1
-      0x8C3C1F1F,  //  01B1  GETMET	R15	R15	K31
-      0x88440720,  //  01B2  GETMBR	R17	R3	K32
+      0x8C3C1F62,  //  01B1  GETMET	R15	R15	K98
+      0x8844076A,  //  01B2  GETMBR	R17	R3	K106
       0x5C481C00,  //  01B3  MOVE	R18	R14
       0x5C4C1A00,  //  01B4  MOVE	R19	R13
       0x5452000F,  //  01B5  LDINT	R20	16
       0x7C3C0A00,  //  01B6  CALL	R15	5
-      0x8C40173A,  //  01B7  GETMET	R16	R11	K58
+      0x8C40173E,  //  01B7  GETMET	R16	R11	K62
       0x7C400200,  //  01B8  CALL	R16	1
-      0x8C440523,  //  01B9  GETMET	R17	R2	K35
+      0x8C44056D,  //  01B9  GETMET	R17	R2	K109
       0x5C4C1E00,  //  01BA  MOVE	R19	R15
       0x60500015,  //  01BB  GETGBL	R20	G21
       0x7C500000,  //  01BC  CALL	R20	0
-      0x8C50291C,  //  01BD  GETMET	R20	R20	K28
-      0x88580161,  //  01BE  GETMBR	R22	R0	K97
+      0x8C50294F,  //  01BD  GETMET	R20	R20	K79
+      0x885801B8,  //  01BE  GETMBR	R22	R0	K184
       0x7C500400,  //  01BF  CALL	R20	2
       0x60540015,  //  01C0  GETGBL	R21	G21
       0x7C540000,  //  01C1  CALL	R21	0
@@ -1938,42 +1762,42 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x7C580200,  //  01C4  CALL	R22	1
       0x545E000F,  //  01C5  LDINT	R23	16
       0x7C440C00,  //  01C6  CALL	R17	6
-      0x8C482362,  //  01C7  GETMET	R18	R17	K98
+      0x8C4823B9,  //  01C7  GETMET	R18	R17	K185
       0x5C502000,  //  01C8  MOVE	R20	R16
       0x7C480400,  //  01C9  CALL	R18	2
-      0x8C4C2325,  //  01CA  GETMET	R19	R17	K37
+      0x8C4C2370,  //  01CA  GETMET	R19	R17	K112
       0x7C4C0200,  //  01CB  CALL	R19	1
       0x00482413,  //  01CC  ADD	R18	R18	R19
-      0xB84E1800,  //  01CD  GETNGBL	R19	K12
-      0x8C4C2763,  //  01CE  GETMET	R19	R19	K99
+      0xB84E4E00,  //  01CD  GETNGBL	R19	K39
+      0x8C4C27BA,  //  01CE  GETMET	R19	R19	K186
       0x7C4C0200,  //  01CF  CALL	R19	1
-      0x904EC808,  //  01D0  SETMBR	R19	K100	R8
-      0x8850072B,  //  01D1  GETMBR	R20	R3	K43
-      0x904ECA14,  //  01D2  SETMBR	R19	K101	R20
-      0x8850074F,  //  01D3  GETMBR	R20	R3	K79
-      0x904ECC14,  //  01D4  SETMBR	R19	K102	R20
-      0x904ECE12,  //  01D5  SETMBR	R19	K103	R18
-      0x8C50273A,  //  01D6  GETMET	R20	R19	K58
+      0x904E6E08,  //  01D0  SETMBR	R19	K55	R8
+      0x88500730,  //  01D1  GETMBR	R20	R3	K48
+      0x904E7214,  //  01D2  SETMBR	R19	K57	R20
+      0x8850077E,  //  01D3  GETMBR	R20	R3	K126
+      0x904F7614,  //  01D4  SETMBR	R19	K187	R20
+      0x904F7812,  //  01D5  SETMBR	R19	K188	R18
+      0x8C50273E,  //  01D6  GETMET	R20	R19	K62
       0x7C500200,  //  01D7  CALL	R20	1
-      0x900ED014,  //  01D8  SETMBR	R3	K104	R20
-      0x8C54033C,  //  01D9  GETMET	R21	R1	K60
+      0x900E7E14,  //  01D8  SETMBR	R3	K63	R20
+      0x8C540340,  //  01D9  GETMET	R21	R1	K64
       0x545E0030,  //  01DA  LDINT	R23	49
       0x50600200,  //  01DB  LDBOOL	R24	1	0
       0x7C540600,  //  01DC  CALL	R21	3
-      0x8C582B3D,  //  01DD  GETMET	R22	R21	K61
+      0x8C582B41,  //  01DD  GETMET	R22	R21	K65
       0x5C602800,  //  01DE  MOVE	R24	R20
       0x7C580400,  //  01DF  CALL	R22	2
-      0xB85E0C00,  //  01E0  GETNGBL	R23	K6
+      0xB85E0A00,  //  01E0  GETNGBL	R23	K5
       0x60600018,  //  01E1  GETGBL	R24	G24
-      0x58640069,  //  01E2  LDCONST	R25	K105
-      0x8868072B,  //  01E3  GETMBR	R26	R3	K43
-      0x886C076A,  //  01E4  GETMBR	R27	R3	K106
-      0x8870076B,  //  01E5  GETMBR	R28	R3	K107
+      0x586400BD,  //  01E2  LDCONST	R25	K189
+      0x88680730,  //  01E3  GETMBR	R26	R3	K48
+      0x886C075B,  //  01E4  GETMBR	R27	R3	K91
+      0x8870075C,  //  01E5  GETMBR	R28	R3	K92
       0x7C600800,  //  01E6  CALL	R24	4
-      0x5864000B,  //  01E7  LDCONST	R25	K11
+      0x58640045,  //  01E7  LDCONST	R25	K69
       0x7C5C0400,  //  01E8  CALL	R23	2
-      0x885C013E,  //  01E9  GETMBR	R23	R0	K62
-      0x8C5C2F3F,  //  01EA  GETMET	R23	R23	K63
+      0x885C0142,  //  01E9  GETMBR	R23	R0	K66
+      0x8C5C2F43,  //  01EA  GETMET	R23	R23	K67
       0x5C642A00,  //  01EB  MOVE	R25	R21
       0x7C5C0400,  //  01EC  CALL	R23	2
       0x505C0200,  //  01ED  LDBOOL	R23	1	0

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
@@ -3,6 +3,32 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Control_Message' ktab size: 22, total: 31 (saved 72 bytes)
+static const bvalue be_ktab_class_Matter_Control_Message[22] = {
+  /* K0   */  be_nested_str_weak(session),
+  /* K1   */  be_nested_str_weak(log),
+  /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
+  /* K3   */  be_nested_str_weak(raw),
+  /* K4   */  be_nested_str_weak(app_payload_idx),
+  /* K5   */  be_const_int(2147483647),
+  /* K6   */  be_nested_str_weak(tohex),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
+  /* K9   */  be_nested_str_weak(crypto),
+  /* K10  */  be_nested_str_weak(responder),
+  /* K11  */  be_nested_str_weak(device),
+  /* K12  */  be_nested_str_weak(MTR_X3A_X20received_X20control_X20message_X20),
+  /* K13  */  be_nested_str_weak(matter),
+  /* K14  */  be_nested_str_weak(inspect),
+  /* K15  */  be_const_int(3),
+  /* K16  */  be_nested_str_weak(opcode),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(parse_MsgCounterSyncReq),
+  /* K19  */  be_const_int(1),
+  /* K20  */  be_nested_str_weak(parse_MsgCounterSyncRsp),
+  /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
+};
+
 
 extern const bclass be_class_Matter_Control_Message;
 
@@ -13,22 +39,13 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K3   */  be_nested_str_weak(raw),
-    /* K4   */  be_nested_str_weak(app_payload_idx),
-    /* K5   */  be_const_int(2147483647),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_Control_Message,     /* shared constants */
     be_str_weak(parse_MsgCounterSyncRsp),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -60,29 +77,20 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K3   */  be_nested_str_weak(raw),
-    /* K4   */  be_nested_str_weak(app_payload_idx),
-    /* K5   */  be_const_int(2147483647),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_Control_Message,     /* shared constants */
     be_str_weak(parse_MsgCounterSyncReq),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
       0x60100018,  //  0002  GETGBL	R4	G24
-      0x58140002,  //  0003  LDCONST	R5	K2
+      0x58140008,  //  0003  LDCONST	R5	K8
       0x88180304,  //  0004  GETMBR	R6	R1	K4
       0x40180D05,  //  0005  CONNECT	R6	R6	K5
       0x881C0303,  //  0006  GETMBR	R7	R1	K3
@@ -107,24 +115,20 @@ be_local_closure(class_Matter_Control_Message_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(responder),
-    /* K2   */  be_nested_str_weak(device),
-    }),
+    &be_ktab_class_Matter_Control_Message,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x880C0302,  //  0002  GETMBR	R3	R1	K2
-      0x90020403,  //  0003  SETMBR	R0	K2	R3
+      0xA40A1200,  //  0000  IMPORT	R2	K9
+      0x90021401,  //  0001  SETMBR	R0	K10	R1
+      0x880C030B,  //  0002  GETMBR	R3	R1	K11
+      0x90021603,  //  0003  SETMBR	R0	K11	R3
       0x80000000,  //  0004  RET	0
     })
   )
@@ -139,59 +143,46 @@ be_local_closure(class_Matter_Control_Message_process_incoming_control_message, 
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20received_X20control_X20message_X20),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(inspect),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(opcode),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(parse_MsgCounterSyncReq),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(parse_MsgCounterSyncRsp),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
-    /* K11  */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_Control_Message,     /* shared constants */
     be_str_weak(process_incoming_control_message),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0xB80E0400,  //  0001  GETNGBL	R3	K2
-      0x8C0C0703,  //  0002  GETMET	R3	R3	K3
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0xB80E1A00,  //  0001  GETNGBL	R3	K13
+      0x8C0C070E,  //  0002  GETMET	R3	R3	K14
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C0C0400,  //  0004  CALL	R3	2
-      0x000E0203,  //  0005  ADD	R3	K1	R3
-      0x58100004,  //  0006  LDCONST	R4	K4
+      0x000E1803,  //  0005  ADD	R3	K12	R3
+      0x5810000F,  //  0006  LDCONST	R4	K15
       0x7C080400,  //  0007  CALL	R2	2
-      0x88080305,  //  0008  GETMBR	R2	R1	K5
-      0x1C080506,  //  0009  EQ	R2	R2	K6
+      0x88080310,  //  0008  GETMBR	R2	R1	K16
+      0x1C080511,  //  0009  EQ	R2	R2	K17
       0x780A0004,  //  000A  JMPF	R2	#0010
-      0x8C080107,  //  000B  GETMET	R2	R0	K7
+      0x8C080112,  //  000B  GETMET	R2	R0	K18
       0x5C100200,  //  000C  MOVE	R4	R1
       0x7C080400,  //  000D  CALL	R2	2
       0x80040400,  //  000E  RET	1	R2
       0x70020010,  //  000F  JMP		#0021
-      0x88080305,  //  0010  GETMBR	R2	R1	K5
-      0x1C080508,  //  0011  EQ	R2	R2	K8
+      0x88080310,  //  0010  GETMBR	R2	R1	K16
+      0x1C080513,  //  0011  EQ	R2	R2	K19
       0x780A0004,  //  0012  JMPF	R2	#0018
-      0x8C080109,  //  0013  GETMET	R2	R0	K9
+      0x8C080114,  //  0013  GETMET	R2	R0	K20
       0x5C100200,  //  0014  MOVE	R4	R1
       0x7C080400,  //  0015  CALL	R2	2
       0x80040400,  //  0016  RET	1	R2
       0x70020008,  //  0017  JMP		#0021
-      0xB80A0000,  //  0018  GETNGBL	R2	K0
+      0xB80A0200,  //  0018  GETNGBL	R2	K1
       0x600C0018,  //  0019  GETGBL	R3	G24
-      0x5810000A,  //  001A  LDCONST	R4	K10
-      0x88140305,  //  001B  GETMBR	R5	R1	K5
+      0x58100015,  //  001A  LDCONST	R4	K21
+      0x88140310,  //  001B  GETMBR	R5	R1	K16
       0x7C0C0400,  //  001C  CALL	R3	2
-      0x5810000B,  //  001D  LDCONST	R4	K11
+      0x58100007,  //  001D  LDCONST	R4	K7
       0x7C080400,  //  001E  CALL	R2	2
       0x50080000,  //  001F  LDBOOL	R2	0	0
       0x80040400,  //  0020  RET	1	R2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_EventHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_EventHandler.h
@@ -3,6 +3,69 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_EventHandler' ktab size: 59, total: 86 (saved 216 bytes)
+static const bvalue be_ktab_class_Matter_EventHandler[59] = {
+  /* K0   */  be_nested_str_weak(tasmota),
+  /* K1   */  be_nested_str_weak(log),
+  /* K2   */  be_nested_str_weak(MTR_X3A_X20Events_X20queues_X20sizes_X3A_X20critical_X20_X25s_X2C_X20info_X20_X25s_X2C_X20debug_X20_X25s),
+  /* K3   */  be_nested_str_weak(queue_critical),
+  /* K4   */  be_nested_str_weak(queue_info),
+  /* K5   */  be_nested_str_weak(queue_debug),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(priority),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(stop_iteration),
+  /* K11  */  be_nested_str_weak(MTR_X3A_X20Events_X20by_X20types_X3A_X20critical_X20_X25s_X2C_X20info_X20_X25s_X2C_X20debug_X20_X25s),
+  /* K12  */  be_nested_str_weak(counter_event_no),
+  /* K13  */  be_nested_str_weak(add),
+  /* K14  */  be_nested_str_weak(counter_event_no_persisted),
+  /* K15  */  be_nested_str_weak(load_event_no_persisted),
+  /* K16  */  be_nested_str_weak(persist),
+  /* K17  */  be_nested_str_weak(find),
+  /* K18  */  be_nested_str_weak(EVENT_NO_KEY),
+  /* K19  */  be_nested_str_weak(0),
+  /* K20  */  be_nested_str_weak(int64),
+  /* K21  */  be_nested_str_weak(fromstring),
+  /* K22  */  be_nested_str_weak(EVENT_NO_INCR),
+  /* K23  */  be_nested_str_weak(setmember),
+  /* K24  */  be_nested_str_weak(tostring),
+  /* K25  */  be_nested_str_weak(save),
+  /* K26  */  be_nested_str_weak(push),
+  /* K27  */  be_nested_str_weak(EVENT_QUEUE_SIZE_MAX),
+  /* K28  */  be_nested_str_weak(pop),
+  /* K29  */  be_const_int(0),
+  /* K30  */  be_nested_str_weak(matter),
+  /* K31  */  be_nested_str_weak(EVENT_DEBUG),
+  /* K32  */  be_nested_str_weak(EVENT_INFO),
+  /* K33  */  be_nested_str_weak(compact),
+  /* K34  */  be_nested_str_weak(device),
+  /* K35  */  be_nested_str_weak(EventQueued),
+  /* K36  */  be_nested_str_weak(get_next_event_no),
+  /* K37  */  be_nested_str_weak(loglevel),
+  /* K38  */  be_const_int(3),
+  /* K39  */  be_nested_str_weak(),
+  /* K40  */  be_nested_str_weak(_X2C_X20),
+  /* K41  */  be_nested_str_weak(val),
+  /* K42  */  be_nested_str_weak(_X25i_X2E_X25i_X2E_X25i_X2E_X25i),
+  /* K43  */  be_nested_str_weak(CRIT_X20_X20),
+  /* K44  */  be_nested_str_weak(INFO_X20_X20),
+  /* K45  */  be_nested_str_weak(DEBUG_X20),
+  /* K46  */  be_nested_str_weak(get_event_name),
+  /* K47  */  be_nested_str_weak(_X28),
+  /* K48  */  be_nested_str_weak(_X29_X20),
+  /* K49  */  be_nested_str_weak(MTR_X3A_X20_X2BAdd_Event_X20_X28_X25s_X258s_X29_X20_X5B_X2502X_X5D_X2504X_X2F_X2502X_X20_X25s_X2D_X20_X25s),
+  /* K50  */  be_nested_str_weak(event_no),
+  /* K51  */  be_nested_str_weak(endpoint),
+  /* K52  */  be_nested_str_weak(cluster),
+  /* K53  */  be_nested_str_weak(event_id),
+  /* K54  */  be_nested_str_weak(queue_event),
+  /* K55  */  be_nested_str_weak(message_handler),
+  /* K56  */  be_nested_str_weak(im),
+  /* K57  */  be_nested_str_weak(subs_shop),
+  /* K58  */  be_nested_str_weak(event_published),
+};
+
 
 extern const bclass be_class_Matter_EventHandler;
 
@@ -13,26 +76,13 @@ be_local_closure(class_Matter_EventHandler_dump,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20Events_X20queues_X20sizes_X3A_X20critical_X20_X25s_X2C_X20info_X20_X25s_X2C_X20debug_X20_X25s),
-    /* K3   */  be_nested_str_weak(queue_critical),
-    /* K4   */  be_nested_str_weak(queue_info),
-    /* K5   */  be_nested_str_weak(queue_debug),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(priority),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20Events_X20by_X20types_X3A_X20critical_X20_X25s_X2C_X20info_X20_X25s_X2C_X20debug_X20_X25s),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(dump),
     &be_const_str_solidified,
     ( &(const binstruction[74]) {  /* code */
@@ -123,19 +173,17 @@ be_local_closure(class_Matter_EventHandler_get_last_event_no,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(counter_event_no),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(get_last_event_no),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -150,34 +198,28 @@ be_local_closure(class_Matter_EventHandler_get_next_event_no,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(counter_event_no),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(counter_event_no_persisted),
-    /* K4   */  be_nested_str_weak(load_event_no_persisted),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(get_next_event_no),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x580C0009,  //  0002  LDCONST	R3	K9
       0x7C040400,  //  0003  CALL	R1	2
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0x88040100,  //  0005  GETMBR	R1	R0	K0
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0x90021801,  //  0004  SETMBR	R0	K12	R1
+      0x8804010C,  //  0005  GETMBR	R1	R0	K12
+      0x8808010E,  //  0006  GETMBR	R2	R0	K14
       0x28040202,  //  0007  GE	R1	R1	R2
       0x78060001,  //  0008  JMPF	R1	#000B
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x8C04010F,  //  0009  GETMET	R1	R0	K15
       0x7C040200,  //  000A  CALL	R1	1
-      0x88040100,  //  000B  GETMBR	R1	R0	K0
+      0x8804010C,  //  000B  GETMBR	R1	R0	K12
       0x80040200,  //  000C  RET	1	R1
     })
   )
@@ -192,54 +234,40 @@ be_local_closure(class_Matter_EventHandler_load_event_no_persisted,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(persist),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(EVENT_NO_KEY),
-    /* K3   */  be_nested_str_weak(0),
-    /* K4   */  be_nested_str_weak(counter_event_no),
-    /* K5   */  be_nested_str_weak(int64),
-    /* K6   */  be_nested_str_weak(fromstring),
-    /* K7   */  be_nested_str_weak(counter_event_no_persisted),
-    /* K8   */  be_nested_str_weak(add),
-    /* K9   */  be_nested_str_weak(EVENT_NO_INCR),
-    /* K10  */  be_nested_str_weak(setmember),
-    /* K11  */  be_nested_str_weak(tostring),
-    /* K12  */  be_nested_str_weak(save),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(load_event_no_persisted),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA4062000,  //  0000  IMPORT	R1	K16
       0x60080008,  //  0001  GETGBL	R2	G8
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
-      0x88140102,  //  0003  GETMBR	R5	R0	K2
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x8C0C0311,  //  0002  GETMET	R3	R1	K17
+      0x88140112,  //  0003  GETMBR	R5	R0	K18
+      0x58180013,  //  0004  LDCONST	R6	K19
       0x7C0C0600,  //  0005  CALL	R3	3
       0x7C080200,  //  0006  CALL	R2	1
-      0xB80E0A00,  //  0007  GETNGBL	R3	K5
-      0x8C0C0706,  //  0008  GETMET	R3	R3	K6
+      0xB80E2800,  //  0007  GETNGBL	R3	K20
+      0x8C0C0715,  //  0008  GETMET	R3	R3	K21
       0x5C140400,  //  0009  MOVE	R5	R2
       0x7C0C0400,  //  000A  CALL	R3	2
-      0x90020803,  //  000B  SETMBR	R0	K4	R3
-      0x880C0104,  //  000C  GETMBR	R3	R0	K4
-      0x8C0C0708,  //  000D  GETMET	R3	R3	K8
-      0x88140109,  //  000E  GETMBR	R5	R0	K9
+      0x90021803,  //  000B  SETMBR	R0	K12	R3
+      0x880C010C,  //  000C  GETMBR	R3	R0	K12
+      0x8C0C070D,  //  000D  GETMET	R3	R3	K13
+      0x88140116,  //  000E  GETMBR	R5	R0	K22
       0x7C0C0400,  //  000F  CALL	R3	2
-      0x90020E03,  //  0010  SETMBR	R0	K7	R3
-      0x8C0C030A,  //  0011  GETMET	R3	R1	K10
-      0x88140102,  //  0012  GETMBR	R5	R0	K2
-      0x88180107,  //  0013  GETMBR	R6	R0	K7
-      0x8C180D0B,  //  0014  GETMET	R6	R6	K11
+      0x90021C03,  //  0010  SETMBR	R0	K14	R3
+      0x8C0C0317,  //  0011  GETMET	R3	R1	K23
+      0x88140112,  //  0012  GETMBR	R5	R0	K18
+      0x8818010E,  //  0013  GETMBR	R6	R0	K14
+      0x8C180D18,  //  0014  GETMET	R6	R6	K24
       0x7C180200,  //  0015  CALL	R6	1
       0x7C0C0600,  //  0016  CALL	R3	3
-      0x8C0C030C,  //  0017  GETMET	R3	R1	K12
+      0x8C0C0319,  //  0017  GETMET	R3	R1	K25
       0x7C0C0200,  //  0018  CALL	R3	1
       0x80000000,  //  0019  RET	0
     })
@@ -255,80 +283,68 @@ be_local_closure(class_Matter_EventHandler_queue_event,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(priority),
-    /* K1   */  be_nested_str_weak(queue_debug),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(EVENT_QUEUE_SIZE_MAX),
-    /* K4   */  be_nested_str_weak(pop),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(EVENT_DEBUG),
-    /* K8   */  be_nested_str_weak(queue_info),
-    /* K9   */  be_nested_str_weak(EVENT_INFO),
-    /* K10  */  be_nested_str_weak(queue_critical),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(queue_event),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x88080308,  //  0000  GETMBR	R2	R1	K8
+      0x880C0105,  //  0001  GETMBR	R3	R0	K5
+      0x8C0C071A,  //  0002  GETMET	R3	R3	K26
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C0C0400,  //  0004  CALL	R3	2
       0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x88100105,  //  0006  GETMBR	R4	R0	K5
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x88100103,  //  0008  GETMBR	R4	R0	K3
+      0x8810011B,  //  0008  GETMBR	R4	R0	K27
       0x240C0604,  //  0009  GT	R3	R3	R4
       0x780E0029,  //  000A  JMPF	R3	#0035
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x8C0C0704,  //  000C  GETMET	R3	R3	K4
-      0x58140005,  //  000D  LDCONST	R5	K5
+      0x880C0105,  //  000B  GETMBR	R3	R0	K5
+      0x8C0C071C,  //  000C  GETMET	R3	R3	K28
+      0x5814001D,  //  000D  LDCONST	R5	K29
       0x7C0C0400,  //  000E  CALL	R3	2
-      0x88100700,  //  000F  GETMBR	R4	R3	K0
-      0xB8160C00,  //  0010  GETNGBL	R5	K6
-      0x88140B07,  //  0011  GETMBR	R5	R5	K7
+      0x88100708,  //  000F  GETMBR	R4	R3	K8
+      0xB8163C00,  //  0010  GETNGBL	R5	K30
+      0x88140B1F,  //  0011  GETMBR	R5	R5	K31
       0x24100805,  //  0012  GT	R4	R4	R5
       0x78120020,  //  0013  JMPF	R4	#0035
-      0x88100108,  //  0014  GETMBR	R4	R0	K8
-      0x8C100902,  //  0015  GETMET	R4	R4	K2
+      0x88100104,  //  0014  GETMBR	R4	R0	K4
+      0x8C10091A,  //  0015  GETMET	R4	R4	K26
       0x5C180600,  //  0016  MOVE	R6	R3
       0x7C100400,  //  0017  CALL	R4	2
       0x6010000C,  //  0018  GETGBL	R4	G12
-      0x88140108,  //  0019  GETMBR	R5	R0	K8
+      0x88140104,  //  0019  GETMBR	R5	R0	K4
       0x7C100200,  //  001A  CALL	R4	1
-      0x88140103,  //  001B  GETMBR	R5	R0	K3
+      0x8814011B,  //  001B  GETMBR	R5	R0	K27
       0x24100805,  //  001C  GT	R4	R4	R5
       0x78120016,  //  001D  JMPF	R4	#0035
-      0x88100108,  //  001E  GETMBR	R4	R0	K8
-      0x8C100904,  //  001F  GETMET	R4	R4	K4
-      0x58180005,  //  0020  LDCONST	R6	K5
+      0x88100104,  //  001E  GETMBR	R4	R0	K4
+      0x8C10091C,  //  001F  GETMET	R4	R4	K28
+      0x5818001D,  //  0020  LDCONST	R6	K29
       0x7C100400,  //  0021  CALL	R4	2
-      0x88140900,  //  0022  GETMBR	R5	R4	K0
-      0xB81A0C00,  //  0023  GETNGBL	R6	K6
-      0x88180D09,  //  0024  GETMBR	R6	R6	K9
+      0x88140908,  //  0022  GETMBR	R5	R4	K8
+      0xB81A3C00,  //  0023  GETNGBL	R6	K30
+      0x88180D20,  //  0024  GETMBR	R6	R6	K32
       0x24140A06,  //  0025  GT	R5	R5	R6
       0x7816000D,  //  0026  JMPF	R5	#0035
-      0x8814010A,  //  0027  GETMBR	R5	R0	K10
-      0x8C140B02,  //  0028  GETMET	R5	R5	K2
+      0x88140103,  //  0027  GETMBR	R5	R0	K3
+      0x8C140B1A,  //  0028  GETMET	R5	R5	K26
       0x5C1C0800,  //  0029  MOVE	R7	R4
       0x7C140400,  //  002A  CALL	R5	2
       0x6014000C,  //  002B  GETGBL	R5	G12
-      0x8818010A,  //  002C  GETMBR	R6	R0	K10
+      0x88180103,  //  002C  GETMBR	R6	R0	K3
       0x7C140200,  //  002D  CALL	R5	1
-      0x88180103,  //  002E  GETMBR	R6	R0	K3
+      0x8818011B,  //  002E  GETMBR	R6	R0	K27
       0x24140A06,  //  002F  GT	R5	R5	R6
       0x78160003,  //  0030  JMPF	R5	#0035
-      0x8814010A,  //  0031  GETMBR	R5	R0	K10
-      0x8C140B04,  //  0032  GETMET	R5	R5	K4
-      0x581C0005,  //  0033  LDCONST	R7	K5
+      0x88140103,  //  0031  GETMBR	R5	R0	K3
+      0x8C140B1C,  //  0032  GETMET	R5	R5	K28
+      0x581C001D,  //  0033  LDCONST	R7	K29
       0x7C140400,  //  0034  CALL	R5	2
       0x80000000,  //  0035  RET	0
     })
@@ -344,19 +360,17 @@ be_local_closure(class_Matter_EventHandler_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(compact),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040121,  //  0000  GETMET	R1	R0	K33
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -372,33 +386,27 @@ be_local_closure(class_Matter_EventHandler_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(queue_debug),
-    /* K2   */  be_nested_str_weak(queue_info),
-    /* K3   */  be_nested_str_weak(queue_critical),
-    /* K4   */  be_nested_str_weak(load_event_no_persisted),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024401,  //  0000  SETMBR	R0	K34	R1
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0x90020A02,  //  0003  SETMBR	R0	K5	R2
       0x60080012,  //  0004  GETGBL	R2	G18
       0x7C080000,  //  0005  CALL	R2	0
-      0x90020402,  //  0006  SETMBR	R0	K2	R2
+      0x90020802,  //  0006  SETMBR	R0	K4	R2
       0x60080012,  //  0007  GETGBL	R2	G18
       0x7C080000,  //  0008  CALL	R2	0
       0x90020602,  //  0009  SETMBR	R0	K3	R2
-      0x8C080104,  //  000A  GETMET	R2	R0	K4
+      0x8C08010F,  //  000A  GETMET	R2	R0	K15
       0x7C080200,  //  000B  CALL	R2	1
       0x80000000,  //  000C  RET	0
     })
@@ -414,7 +422,7 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -465,19 +473,14 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(counter_event_no),
-    /* K1   */  be_nested_str_weak(queue_debug),
-    /* K2   */  be_nested_str_weak(queue_info),
-    /* K3   */  be_nested_str_weak(queue_critical),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(find_min_no),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0004,  //  0002  JMPF	R2	#0008
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
+      0x8808010C,  //  0003  GETMBR	R2	R0	K12
       0x28080202,  //  0004  GE	R2	R1	R2
       0x780A0001,  //  0005  JMPF	R2	#0008
       0x4C080000,  //  0006  LDNIL	R2
@@ -486,13 +489,13 @@ be_local_closure(class_Matter_EventHandler_find_min_no,   /* name */
       0x4C0C0000,  //  0009  LDNIL	R3
       0x5C100400,  //  000A  MOVE	R4	R2
       0x5C140600,  //  000B  MOVE	R5	R3
-      0x88180101,  //  000C  GETMBR	R6	R0	K1
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
       0x5C1C0200,  //  000D  MOVE	R7	R1
       0x7C100600,  //  000E  CALL	R4	3
       0x5C0C0800,  //  000F  MOVE	R3	R4
       0x5C100400,  //  0010  MOVE	R4	R2
       0x5C140600,  //  0011  MOVE	R5	R3
-      0x88180102,  //  0012  GETMBR	R6	R0	K2
+      0x88180104,  //  0012  GETMBR	R6	R0	K4
       0x5C1C0200,  //  0013  MOVE	R7	R1
       0x7C100600,  //  0014  CALL	R4	3
       0x5C0C0800,  //  0015  MOVE	R3	R4
@@ -516,51 +519,19 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
   be_nested_proto(
     23,                          /* nstack */
     9,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(EventQueued),
-    /* K2   */  be_nested_str_weak(get_next_event_no),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(loglevel),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(_X2C_X20),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(val),
-    /* K10  */  be_nested_str_weak(_X25i_X2E_X25i_X2E_X25i_X2E_X25i),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(CRIT_X20_X20),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(INFO_X20_X20),
-    /* K15  */  be_nested_str_weak(DEBUG_X20),
-    /* K16  */  be_nested_str_weak(get_event_name),
-    /* K17  */  be_nested_str_weak(_X28),
-    /* K18  */  be_nested_str_weak(_X29_X20),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X2BAdd_Event_X20_X28_X25s_X258s_X29_X20_X5B_X2502X_X5D_X2504X_X2F_X2502X_X20_X25s_X2D_X20_X25s),
-    /* K21  */  be_nested_str_weak(event_no),
-    /* K22  */  be_nested_str_weak(endpoint),
-    /* K23  */  be_nested_str_weak(cluster),
-    /* K24  */  be_nested_str_weak(event_id),
-    /* K25  */  be_nested_str_weak(queue_event),
-    /* K26  */  be_nested_str_weak(device),
-    /* K27  */  be_nested_str_weak(message_handler),
-    /* K28  */  be_nested_str_weak(im),
-    /* K29  */  be_nested_str_weak(subs_shop),
-    /* K30  */  be_nested_str_weak(event_published),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(publish_event),
     &be_const_str_solidified,
     ( &(const binstruction[112]) {  /* code */
-      0xB8260000,  //  0000  GETNGBL	R9	K0
-      0x8C241301,  //  0001  GETMET	R9	R9	K1
-      0x8C2C0102,  //  0002  GETMET	R11	R0	K2
+      0xB8263C00,  //  0000  GETNGBL	R9	K30
+      0x8C241323,  //  0001  GETMET	R9	R9	K35
+      0x8C2C0124,  //  0002  GETMET	R11	R0	K36
       0x7C2C0200,  //  0003  CALL	R11	1
       0x5C300200,  //  0004  MOVE	R12	R1
       0x5C340400,  //  0005  MOVE	R13	R2
@@ -571,12 +542,12 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
       0x5C480E00,  //  000A  MOVE	R18	R7
       0x5C4C1000,  //  000B  MOVE	R19	R8
       0x7C241400,  //  000C  CALL	R9	10
-      0xB82A0600,  //  000D  GETNGBL	R10	K3
-      0x8C281504,  //  000E  GETMET	R10	R10	K4
-      0x58300005,  //  000F  LDCONST	R12	K5
+      0xB82A0000,  //  000D  GETNGBL	R10	K0
+      0x8C281525,  //  000E  GETMET	R10	R10	K37
+      0x58300026,  //  000F  LDCONST	R12	K38
       0x7C280400,  //  0010  CALL	R10	2
       0x782A0052,  //  0011  JMPF	R10	#0065
-      0x58280006,  //  0012  LDCONST	R10	K6
+      0x58280027,  //  0012  LDCONST	R10	K39
       0x4C2C0000,  //  0013  LDNIL	R11
       0x202C0C0B,  //  0014  NE	R11	R6	R11
       0x782E0003,  //  0015  JMPF	R11	#001A
@@ -590,7 +561,7 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
       0x602C0008,  //  001D  GETGBL	R11	G8
       0x5C300E00,  //  001E  MOVE	R12	R7
       0x7C2C0200,  //  001F  CALL	R11	1
-      0x002E0E0B,  //  0020  ADD	R11	K7	R11
+      0x002E500B,  //  0020  ADD	R11	K40	R11
       0x0028140B,  //  0021  ADD	R10	R10	R11
       0x4C2C0000,  //  0022  LDNIL	R11
       0x202C100B,  //  0023  NE	R11	R8	R11
@@ -598,16 +569,16 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
       0x602C0008,  //  0025  GETGBL	R11	G8
       0x5C301000,  //  0026  MOVE	R12	R8
       0x7C2C0200,  //  0027  CALL	R11	1
-      0x002E0E0B,  //  0028  ADD	R11	K7	R11
+      0x002E500B,  //  0028  ADD	R11	K40	R11
       0x0028140B,  //  0029  ADD	R10	R10	R11
       0x542E0027,  //  002A  LDINT	R11	40
       0x1C2C040B,  //  002B  EQ	R11	R2	R11
       0x782E0014,  //  002C  JMPF	R11	#0042
-      0x1C2C0708,  //  002D  EQ	R11	R3	K8
+      0x1C2C071D,  //  002D  EQ	R11	R3	K29
       0x782E0012,  //  002E  JMPF	R11	#0042
-      0x882C0D09,  //  002F  GETMBR	R11	R6	K9
+      0x882C0D29,  //  002F  GETMBR	R11	R6	K41
       0x60300018,  //  0030  GETGBL	R12	G24
-      0x5834000A,  //  0031  LDCONST	R13	K10
+      0x5834002A,  //  0031  LDCONST	R13	K42
       0x543A0017,  //  0032  LDINT	R14	24
       0x3C38160E,  //  0033  SHR	R14	R11	R14
       0x543E00FE,  //  0034  LDINT	R15	255
@@ -624,49 +595,49 @@ be_local_closure(class_Matter_EventHandler_publish_event,   /* name */
       0x2C441611,  //  003F  AND	R17	R11	R17
       0x7C300A00,  //  0040  CALL	R12	5
       0x5C281800,  //  0041  MOVE	R10	R12
-      0x1C2C0B0B,  //  0042  EQ	R11	R5	K11
+      0x1C2C0B06,  //  0042  EQ	R11	R5	K6
       0x782E0001,  //  0043  JMPF	R11	#0046
-      0x582C000C,  //  0044  LDCONST	R11	K12
+      0x582C002B,  //  0044  LDCONST	R11	K43
       0x70020004,  //  0045  JMP		#004B
-      0x1C2C0B0D,  //  0046  EQ	R11	R5	K13
+      0x1C2C0B09,  //  0046  EQ	R11	R5	K9
       0x782E0001,  //  0047  JMPF	R11	#004A
-      0x582C000E,  //  0048  LDCONST	R11	K14
+      0x582C002C,  //  0048  LDCONST	R11	K44
       0x70020000,  //  0049  JMP		#004B
-      0x582C000F,  //  004A  LDCONST	R11	K15
-      0xB8320000,  //  004B  GETNGBL	R12	K0
-      0x8C301910,  //  004C  GETMET	R12	R12	K16
+      0x582C002D,  //  004A  LDCONST	R11	K45
+      0xB8323C00,  //  004B  GETNGBL	R12	K30
+      0x8C30192E,  //  004C  GETMET	R12	R12	K46
       0x5C380400,  //  004D  MOVE	R14	R2
       0x5C3C0600,  //  004E  MOVE	R15	R3
       0x7C300600,  //  004F  CALL	R12	3
       0x4C340000,  //  0050  LDNIL	R13
       0x2034180D,  //  0051  NE	R13	R12	R13
       0x78360002,  //  0052  JMPF	R13	#0056
-      0x0036220C,  //  0053  ADD	R13	K17	R12
-      0x00341B12,  //  0054  ADD	R13	R13	K18
+      0x00365E0C,  //  0053  ADD	R13	K47	R12
+      0x00341B30,  //  0054  ADD	R13	R13	K48
       0x70020000,  //  0055  JMP		#0057
-      0x58340006,  //  0056  LDCONST	R13	K6
+      0x58340027,  //  0056  LDCONST	R13	K39
       0x5C301A00,  //  0057  MOVE	R12	R13
-      0xB8362600,  //  0058  GETNGBL	R13	K19
+      0xB8360200,  //  0058  GETNGBL	R13	K1
       0x60380018,  //  0059  GETGBL	R14	G24
-      0x583C0014,  //  005A  LDCONST	R15	K20
+      0x583C0031,  //  005A  LDCONST	R15	K49
       0x5C401600,  //  005B  MOVE	R16	R11
-      0x88441315,  //  005C  GETMBR	R17	R9	K21
-      0x88481316,  //  005D  GETMBR	R18	R9	K22
-      0x884C1317,  //  005E  GETMBR	R19	R9	K23
-      0x88501318,  //  005F  GETMBR	R20	R9	K24
+      0x88441332,  //  005C  GETMBR	R17	R9	K50
+      0x88481333,  //  005D  GETMBR	R18	R9	K51
+      0x884C1334,  //  005E  GETMBR	R19	R9	K52
+      0x88501335,  //  005F  GETMBR	R20	R9	K53
       0x5C541800,  //  0060  MOVE	R21	R12
       0x5C581400,  //  0061  MOVE	R22	R10
       0x7C381000,  //  0062  CALL	R14	8
-      0x583C000B,  //  0063  LDCONST	R15	K11
+      0x583C0006,  //  0063  LDCONST	R15	K6
       0x7C340400,  //  0064  CALL	R13	2
-      0x8C280119,  //  0065  GETMET	R10	R0	K25
+      0x8C280136,  //  0065  GETMET	R10	R0	K54
       0x5C301200,  //  0066  MOVE	R12	R9
       0x7C280400,  //  0067  CALL	R10	2
-      0x8828011A,  //  0068  GETMBR	R10	R0	K26
-      0x8828151B,  //  0069  GETMBR	R10	R10	K27
-      0x8828151C,  //  006A  GETMBR	R10	R10	K28
-      0x8828151D,  //  006B  GETMBR	R10	R10	K29
-      0x8C28151E,  //  006C  GETMET	R10	R10	K30
+      0x88280122,  //  0068  GETMBR	R10	R0	K34
+      0x88281537,  //  0069  GETMBR	R10	R10	K55
+      0x88281538,  //  006A  GETMBR	R10	R10	K56
+      0x88281539,  //  006B  GETMBR	R10	R10	K57
+      0x8C28153A,  //  006C  GETMET	R10	R10	K58
       0x5C301200,  //  006D  MOVE	R12	R9
       0x7C280400,  //  006E  CALL	R10	2
       0x80000000,  //  006F  RET	0
@@ -683,7 +654,7 @@ be_local_closure(class_Matter_EventHandler_compact,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -721,23 +692,19 @@ be_local_closure(class_Matter_EventHandler_compact,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(queue_debug),
-    /* K1   */  be_nested_str_weak(queue_info),
-    /* K2   */  be_nested_str_weak(queue_critical),
-    }),
+    &be_ktab_class_Matter_EventHandler,     /* shared constants */
     be_str_weak(compact),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x84040000,  //  0000  CLOSURE	R1	P0
       0x5C080200,  //  0001  MOVE	R2	R1
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x880C0105,  //  0002  GETMBR	R3	R0	K5
       0x7C080200,  //  0003  CALL	R2	1
       0x5C080200,  //  0004  MOVE	R2	R1
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x880C0104,  //  0005  GETMBR	R3	R0	K4
       0x7C080200,  //  0006  CALL	R2	1
       0x5C080200,  //  0007  MOVE	R2	R1
-      0x880C0102,  //  0008  GETMBR	R3	R0	K2
+      0x880C0103,  //  0008  GETMBR	R3	R0	K3
       0x7C080200,  //  0009  CALL	R2	1
       0x80000000,  //  000A  RET	0
     })
@@ -776,6 +743,40 @@ be_local_class(Matter_EventHandler,
     })),
     be_str_weak(Matter_EventHandler)
 );
+// compact class 'Matter_EventQueued' ktab size: 30, total: 43 (saved 104 bytes)
+static const bvalue be_ktab_class_Matter_EventQueued[30] = {
+  /* K0   */  be_nested_str_weak(raw_tlv),
+  /* K1   */  be_nested_str_weak(eventreport2raw),
+  /* K2   */  be_nested_str_weak(endpoint),
+  /* K3   */  be_nested_str_weak(cluster),
+  /* K4   */  be_nested_str_weak(event_id),
+  /* K5   */  be_nested_str_weak(is_urgent),
+  /* K6   */  be_nested_str_weak(priority),
+  /* K7   */  be_nested_str_weak(event_no),
+  /* K8   */  be_nested_str_weak(epoch_timestamp),
+  /* K9   */  be_nested_str_weak(data0),
+  /* K10  */  be_nested_str_weak(data1),
+  /* K11  */  be_nested_str_weak(data2),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(matter),
+  /* K14  */  be_nested_str_weak(EVENT_CRITICAL),
+  /* K15  */  be_nested_str_weak(tasmota),
+  /* K16  */  be_nested_str_weak(rtc),
+  /* K17  */  be_nested_str_weak(utc),
+  /* K18  */  be_const_int(1700000000),
+  /* K19  */  be_nested_str_weak(config_time),
+  /* K20  */  be_nested_str_weak(add),
+  /* K21  */  be_const_int(1),
+  /* K22  */  be_const_int(2),
+  /* K23  */  be_const_int(1),
+  /* K24  */  be_nested_str_weak(eventpath2raw),
+  /* K25  */  be_nested_str_weak(low32),
+  /* K26  */  be_nested_str_weak(high32),
+  /* K27  */  be_nested_str_weak(tag_sub),
+  /* K28  */  be_const_int(0),
+  /* K29  */  be_nested_str_weak(tlv2raw),
+};
+
 
 extern const bclass be_class_Matter_EventQueued;
 
@@ -786,26 +787,13 @@ be_local_closure(class_Matter_EventQueued_to_raw_bytes,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(raw_tlv),
-    /* K1   */  be_nested_str_weak(eventreport2raw),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(event_id),
-    /* K5   */  be_nested_str_weak(is_urgent),
-    /* K6   */  be_nested_str_weak(priority),
-    /* K7   */  be_nested_str_weak(event_no),
-    /* K8   */  be_nested_str_weak(epoch_timestamp),
-    /* K9   */  be_nested_str_weak(data0),
-    /* K10  */  be_nested_str_weak(data1),
-    /* K11  */  be_nested_str_weak(data2),
-    }),
+    &be_ktab_class_Matter_EventQueued,     /* shared constants */
     be_str_weak(to_raw_bytes),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -845,69 +833,50 @@ be_local_closure(class_Matter_EventQueued_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     10,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_no),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(event_id),
-    /* K4   */  be_nested_str_weak(is_urgent),
-    /* K5   */  be_nested_str_weak(priority),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(EVENT_CRITICAL),
-    /* K9   */  be_nested_str_weak(epoch_timestamp),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(rtc),
-    /* K12  */  be_nested_str_weak(utc),
-    /* K13  */  be_const_int(1700000000),
-    /* K14  */  be_nested_str_weak(config_time),
-    /* K15  */  be_nested_str_weak(data0),
-    /* K16  */  be_nested_str_weak(data1),
-    /* K17  */  be_nested_str_weak(data2),
-    }),
+    &be_ktab_class_Matter_EventQueued,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x90020604,  //  0003  SETMBR	R0	K3	R4
-      0x90020805,  //  0004  SETMBR	R0	K4	R5
-      0x90020A06,  //  0005  SETMBR	R0	K5	R6
-      0x88280105,  //  0006  GETMBR	R10	R0	K5
-      0x14281506,  //  0007  LT	R10	R10	K6
+      0x90020E01,  //  0000  SETMBR	R0	K7	R1
+      0x90020402,  //  0001  SETMBR	R0	K2	R2
+      0x90020603,  //  0002  SETMBR	R0	K3	R3
+      0x90020804,  //  0003  SETMBR	R0	K4	R4
+      0x90020A05,  //  0004  SETMBR	R0	K5	R5
+      0x90020C06,  //  0005  SETMBR	R0	K6	R6
+      0x88280106,  //  0006  GETMBR	R10	R0	K6
+      0x1428150C,  //  0007  LT	R10	R10	K12
       0x782A0000,  //  0008  JMPF	R10	#000A
-      0x90020B06,  //  0009  SETMBR	R0	K5	K6
-      0x88280105,  //  000A  GETMBR	R10	R0	K5
-      0xB82E0E00,  //  000B  GETNGBL	R11	K7
-      0x882C1708,  //  000C  GETMBR	R11	R11	K8
+      0x90020D0C,  //  0009  SETMBR	R0	K6	K12
+      0x88280106,  //  000A  GETMBR	R10	R0	K6
+      0xB82E1A00,  //  000B  GETNGBL	R11	K13
+      0x882C170E,  //  000C  GETMBR	R11	R11	K14
       0x2428140B,  //  000D  GT	R10	R10	R11
       0x782A0002,  //  000E  JMPF	R10	#0012
-      0xB82A0E00,  //  000F  GETNGBL	R10	K7
-      0x88281508,  //  0010  GETMBR	R10	R10	K8
-      0x90020A0A,  //  0011  SETMBR	R0	K5	R10
-      0xB82A1400,  //  0012  GETNGBL	R10	K10
-      0x8C28150B,  //  0013  GETMET	R10	R10	K11
-      0x5830000C,  //  0014  LDCONST	R12	K12
+      0xB82A1A00,  //  000F  GETNGBL	R10	K13
+      0x8828150E,  //  0010  GETMBR	R10	R10	K14
+      0x90020C0A,  //  0011  SETMBR	R0	K6	R10
+      0xB82A1E00,  //  0012  GETNGBL	R10	K15
+      0x8C281510,  //  0013  GETMET	R10	R10	K16
+      0x58300011,  //  0014  LDCONST	R12	K17
       0x7C280400,  //  0015  CALL	R10	2
-      0x9002120A,  //  0016  SETMBR	R0	K9	R10
-      0x88280109,  //  0017  GETMBR	R10	R0	K9
-      0x1428150D,  //  0018  LT	R10	R10	K13
+      0x9002100A,  //  0016  SETMBR	R0	K8	R10
+      0x88280108,  //  0017  GETMBR	R10	R0	K8
+      0x14281512,  //  0018  LT	R10	R10	K18
       0x782A0004,  //  0019  JMPF	R10	#001F
-      0xB82A1400,  //  001A  GETNGBL	R10	K10
-      0x8C28150B,  //  001B  GETMET	R10	R10	K11
-      0x5830000E,  //  001C  LDCONST	R12	K14
+      0xB82A1E00,  //  001A  GETNGBL	R10	K15
+      0x8C281510,  //  001B  GETMET	R10	R10	K16
+      0x58300013,  //  001C  LDCONST	R12	K19
       0x7C280400,  //  001D  CALL	R10	2
-      0x9002120A,  //  001E  SETMBR	R0	K9	R10
-      0x90021E07,  //  001F  SETMBR	R0	K15	R7
-      0x90022008,  //  0020  SETMBR	R0	K16	R8
-      0x90022209,  //  0021  SETMBR	R0	K17	R9
+      0x9002100A,  //  001E  SETMBR	R0	K8	R10
+      0x90021207,  //  001F  SETMBR	R0	K9	R7
+      0x90021408,  //  0020  SETMBR	R0	K10	R8
+      0x90021609,  //  0021  SETMBR	R0	K11	R9
       0x80000000,  //  0022  RET	0
     })
   )
@@ -922,15 +891,13 @@ be_local_closure(class_Matter_EventQueued_compact,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(raw_tlv),
-    }),
+    &be_ktab_class_Matter_EventQueued,     /* shared constants */
     be_str_weak(compact),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
@@ -950,109 +917,105 @@ be_local_closure(class_Matter_EventQueued_eventpath2raw,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_EventQueued,     /* shared constants */
     be_str_weak(eventpath2raw),
     &be_const_str_solidified,
     ( &(const binstruction[91]) {  /* code */
-      0x8C180300,  //  0000  GETMET	R6	R1	K0
+      0x8C180314,  //  0000  GETMET	R6	R1	K20
       0x542236FF,  //  0001  LDINT	R8	14080
       0x5425FFFD,  //  0002  LDINT	R9	-2
       0x7C180600,  //  0003  CALL	R6	3
       0x541A00FE,  //  0004  LDINT	R6	255
       0x18180406,  //  0005  LE	R6	R2	R6
       0x781A0008,  //  0006  JMPF	R6	#0010
-      0x8C180300,  //  0007  GETMET	R6	R1	K0
+      0x8C180314,  //  0007  GETMET	R6	R1	K20
       0x54222400,  //  0008  LDINT	R8	9217
       0x5425FFFD,  //  0009  LDINT	R9	-2
       0x7C180600,  //  000A  CALL	R6	3
-      0x8C180300,  //  000B  GETMET	R6	R1	K0
+      0x8C180314,  //  000B  GETMET	R6	R1	K20
       0x5C200400,  //  000C  MOVE	R8	R2
-      0x58240001,  //  000D  LDCONST	R9	K1
+      0x58240015,  //  000D  LDCONST	R9	K21
       0x7C180600,  //  000E  CALL	R6	3
       0x70020007,  //  000F  JMP		#0018
-      0x8C180300,  //  0010  GETMET	R6	R1	K0
+      0x8C180314,  //  0010  GETMET	R6	R1	K20
       0x54222500,  //  0011  LDINT	R8	9473
       0x5425FFFD,  //  0012  LDINT	R9	-2
       0x7C180600,  //  0013  CALL	R6	3
-      0x8C180300,  //  0014  GETMET	R6	R1	K0
+      0x8C180314,  //  0014  GETMET	R6	R1	K20
       0x5C200400,  //  0015  MOVE	R8	R2
-      0x58240002,  //  0016  LDCONST	R9	K2
+      0x58240016,  //  0016  LDCONST	R9	K22
       0x7C180600,  //  0017  CALL	R6	3
       0x541A00FE,  //  0018  LDINT	R6	255
       0x18180606,  //  0019  LE	R6	R3	R6
       0x781A0008,  //  001A  JMPF	R6	#0024
-      0x8C180300,  //  001B  GETMET	R6	R1	K0
+      0x8C180314,  //  001B  GETMET	R6	R1	K20
       0x54222401,  //  001C  LDINT	R8	9218
       0x5425FFFD,  //  001D  LDINT	R9	-2
       0x7C180600,  //  001E  CALL	R6	3
-      0x8C180300,  //  001F  GETMET	R6	R1	K0
+      0x8C180314,  //  001F  GETMET	R6	R1	K20
       0x5C200600,  //  0020  MOVE	R8	R3
-      0x58240001,  //  0021  LDCONST	R9	K1
+      0x58240015,  //  0021  LDCONST	R9	K21
       0x7C180600,  //  0022  CALL	R6	3
       0x70020013,  //  0023  JMP		#0038
       0x541AFFFE,  //  0024  LDINT	R6	65535
       0x18180606,  //  0025  LE	R6	R3	R6
       0x781A0008,  //  0026  JMPF	R6	#0030
-      0x8C180300,  //  0027  GETMET	R6	R1	K0
+      0x8C180314,  //  0027  GETMET	R6	R1	K20
       0x54222501,  //  0028  LDINT	R8	9474
       0x5425FFFD,  //  0029  LDINT	R9	-2
       0x7C180600,  //  002A  CALL	R6	3
-      0x8C180300,  //  002B  GETMET	R6	R1	K0
+      0x8C180314,  //  002B  GETMET	R6	R1	K20
       0x5C200600,  //  002C  MOVE	R8	R3
-      0x58240002,  //  002D  LDCONST	R9	K2
+      0x58240016,  //  002D  LDCONST	R9	K22
       0x7C180600,  //  002E  CALL	R6	3
       0x70020007,  //  002F  JMP		#0038
-      0x8C180300,  //  0030  GETMET	R6	R1	K0
+      0x8C180314,  //  0030  GETMET	R6	R1	K20
       0x54222601,  //  0031  LDINT	R8	9730
       0x5425FFFD,  //  0032  LDINT	R9	-2
       0x7C180600,  //  0033  CALL	R6	3
-      0x8C180300,  //  0034  GETMET	R6	R1	K0
+      0x8C180314,  //  0034  GETMET	R6	R1	K20
       0x5C200600,  //  0035  MOVE	R8	R3
       0x54260003,  //  0036  LDINT	R9	4
       0x7C180600,  //  0037  CALL	R6	3
       0x541A00FE,  //  0038  LDINT	R6	255
       0x18180806,  //  0039  LE	R6	R4	R6
       0x781A0008,  //  003A  JMPF	R6	#0044
-      0x8C180300,  //  003B  GETMET	R6	R1	K0
+      0x8C180314,  //  003B  GETMET	R6	R1	K20
       0x54222402,  //  003C  LDINT	R8	9219
       0x5425FFFD,  //  003D  LDINT	R9	-2
       0x7C180600,  //  003E  CALL	R6	3
-      0x8C180300,  //  003F  GETMET	R6	R1	K0
+      0x8C180314,  //  003F  GETMET	R6	R1	K20
       0x5C200800,  //  0040  MOVE	R8	R4
-      0x58240001,  //  0041  LDCONST	R9	K1
+      0x58240015,  //  0041  LDCONST	R9	K21
       0x7C180600,  //  0042  CALL	R6	3
       0x70020007,  //  0043  JMP		#004C
-      0x8C180300,  //  0044  GETMET	R6	R1	K0
+      0x8C180314,  //  0044  GETMET	R6	R1	K20
       0x54222502,  //  0045  LDINT	R8	9475
       0x5425FFFD,  //  0046  LDINT	R9	-2
       0x7C180600,  //  0047  CALL	R6	3
-      0x8C180300,  //  0048  GETMET	R6	R1	K0
+      0x8C180314,  //  0048  GETMET	R6	R1	K20
       0x5C200800,  //  0049  MOVE	R8	R4
-      0x58240002,  //  004A  LDCONST	R9	K2
+      0x58240016,  //  004A  LDCONST	R9	K22
       0x7C180600,  //  004B  CALL	R6	3
       0x78160004,  //  004C  JMPF	R5	#0052
-      0x8C180300,  //  004D  GETMET	R6	R1	K0
+      0x8C180314,  //  004D  GETMET	R6	R1	K20
       0x54222903,  //  004E  LDINT	R8	10500
       0x5425FFFD,  //  004F  LDINT	R9	-2
       0x7C180600,  //  0050  CALL	R6	3
       0x70020003,  //  0051  JMP		#0056
-      0x8C180300,  //  0052  GETMET	R6	R1	K0
+      0x8C180314,  //  0052  GETMET	R6	R1	K20
       0x54222803,  //  0053  LDINT	R8	10244
       0x5425FFFD,  //  0054  LDINT	R9	-2
       0x7C180600,  //  0055  CALL	R6	3
-      0x8C180300,  //  0056  GETMET	R6	R1	K0
+      0x8C180314,  //  0056  GETMET	R6	R1	K20
       0x54220017,  //  0057  LDINT	R8	24
-      0x58240001,  //  0058  LDCONST	R9	K1
+      0x58240015,  //  0058  LDCONST	R9	K21
       0x7C180600,  //  0059  CALL	R6	3
       0x80000000,  //  005A  RET	0
     })
@@ -1068,107 +1031,97 @@ be_local_closure(class_Matter_EventQueued_eventreport2raw,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     12,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(eventpath2raw),
-    /* K3   */  be_nested_str_weak(low32),
-    /* K4   */  be_nested_str_weak(high32),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(tlv2raw),
-    /* K8   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_EventQueued,     /* shared constants */
     be_str_weak(eventreport2raw),
     &be_const_str_solidified,
     ( &(const binstruction[83]) {  /* code */
-      0x8C300300,  //  0000  GETMET	R12	R1	K0
+      0x8C300314,  //  0000  GETMET	R12	R1	K20
       0x543A0014,  //  0001  LDINT	R14	21
-      0x583C0001,  //  0002  LDCONST	R15	K1
+      0x583C0017,  //  0002  LDCONST	R15	K23
       0x7C300600,  //  0003  CALL	R12	3
-      0x8C300300,  //  0004  GETMET	R12	R1	K0
+      0x8C300314,  //  0004  GETMET	R12	R1	K20
       0x543A3500,  //  0005  LDINT	R14	13569
       0x543DFFFD,  //  0006  LDINT	R15	-2
       0x7C300600,  //  0007  CALL	R12	3
-      0x8C300102,  //  0008  GETMET	R12	R0	K2
+      0x8C300118,  //  0008  GETMET	R12	R0	K24
       0x5C380200,  //  0009  MOVE	R14	R1
       0x5C3C0400,  //  000A  MOVE	R15	R2
       0x5C400600,  //  000B  MOVE	R16	R3
       0x5C440800,  //  000C  MOVE	R17	R4
       0x5C480A00,  //  000D  MOVE	R18	R5
       0x7C300C00,  //  000E  CALL	R12	6
-      0x8C300300,  //  000F  GETMET	R12	R1	K0
+      0x8C300314,  //  000F  GETMET	R12	R1	K20
       0x543A2700,  //  0010  LDINT	R14	9985
       0x543DFFFD,  //  0011  LDINT	R15	-2
       0x7C300600,  //  0012  CALL	R12	3
-      0x8C300300,  //  0013  GETMET	R12	R1	K0
-      0x8C380F03,  //  0014  GETMET	R14	R7	K3
+      0x8C300314,  //  0013  GETMET	R12	R1	K20
+      0x8C380F19,  //  0014  GETMET	R14	R7	K25
       0x7C380200,  //  0015  CALL	R14	1
       0x543E0003,  //  0016  LDINT	R15	4
       0x7C300600,  //  0017  CALL	R12	3
-      0x8C300300,  //  0018  GETMET	R12	R1	K0
-      0x8C380F04,  //  0019  GETMET	R14	R7	K4
+      0x8C300314,  //  0018  GETMET	R12	R1	K20
+      0x8C380F1A,  //  0019  GETMET	R14	R7	K26
       0x7C380200,  //  001A  CALL	R14	1
       0x543E0003,  //  001B  LDINT	R15	4
       0x7C300600,  //  001C  CALL	R12	3
-      0x8C300300,  //  001D  GETMET	R12	R1	K0
+      0x8C300314,  //  001D  GETMET	R12	R1	K20
       0x543A2401,  //  001E  LDINT	R14	9218
       0x543DFFFD,  //  001F  LDINT	R15	-2
       0x7C300600,  //  0020  CALL	R12	3
-      0x8C300300,  //  0021  GETMET	R12	R1	K0
+      0x8C300314,  //  0021  GETMET	R12	R1	K20
       0x5C380C00,  //  0022  MOVE	R14	R6
-      0x583C0001,  //  0023  LDCONST	R15	K1
+      0x583C0017,  //  0023  LDCONST	R15	K23
       0x7C300600,  //  0024  CALL	R12	3
-      0x8C300300,  //  0025  GETMET	R12	R1	K0
+      0x8C300314,  //  0025  GETMET	R12	R1	K20
       0x543A2602,  //  0026  LDINT	R14	9731
       0x543DFFFD,  //  0027  LDINT	R15	-2
       0x7C300600,  //  0028  CALL	R12	3
-      0x8C300300,  //  0029  GETMET	R12	R1	K0
+      0x8C300314,  //  0029  GETMET	R12	R1	K20
       0x5C381000,  //  002A  MOVE	R14	R8
       0x543E0003,  //  002B  LDINT	R15	4
       0x7C300600,  //  002C  CALL	R12	3
-      0x8C300300,  //  002D  GETMET	R12	R1	K0
+      0x8C300314,  //  002D  GETMET	R12	R1	K20
       0x543A3506,  //  002E  LDINT	R14	13575
       0x543DFFFD,  //  002F  LDINT	R15	-2
       0x7C300600,  //  0030  CALL	R12	3
       0x4C300000,  //  0031  LDNIL	R12
       0x2030120C,  //  0032  NE	R12	R9	R12
       0x78320003,  //  0033  JMPF	R12	#0038
-      0x90260B06,  //  0034  SETMBR	R9	K5	K6
-      0x8C301307,  //  0035  GETMET	R12	R9	K7
+      0x9026371C,  //  0034  SETMBR	R9	K27	K28
+      0x8C30131D,  //  0035  GETMET	R12	R9	K29
       0x5C380200,  //  0036  MOVE	R14	R1
       0x7C300400,  //  0037  CALL	R12	2
       0x4C300000,  //  0038  LDNIL	R12
       0x2030140C,  //  0039  NE	R12	R10	R12
       0x78320003,  //  003A  JMPF	R12	#003F
-      0x902A0B01,  //  003B  SETMBR	R10	K5	K1
-      0x8C301507,  //  003C  GETMET	R12	R10	K7
+      0x902A3717,  //  003B  SETMBR	R10	K27	K23
+      0x8C30151D,  //  003C  GETMET	R12	R10	K29
       0x5C380200,  //  003D  MOVE	R14	R1
       0x7C300400,  //  003E  CALL	R12	2
       0x4C300000,  //  003F  LDNIL	R12
       0x2030160C,  //  0040  NE	R12	R11	R12
       0x78320003,  //  0041  JMPF	R12	#0046
-      0x902E0B08,  //  0042  SETMBR	R11	K5	K8
-      0x8C301707,  //  0043  GETMET	R12	R11	K7
+      0x902E3716,  //  0042  SETMBR	R11	K27	K22
+      0x8C30171D,  //  0043  GETMET	R12	R11	K29
       0x5C380200,  //  0044  MOVE	R14	R1
       0x7C300400,  //  0045  CALL	R12	2
-      0x8C300300,  //  0046  GETMET	R12	R1	K0
+      0x8C300314,  //  0046  GETMET	R12	R1	K20
       0x543A0017,  //  0047  LDINT	R14	24
-      0x583C0001,  //  0048  LDCONST	R15	K1
+      0x583C0017,  //  0048  LDCONST	R15	K23
       0x7C300600,  //  0049  CALL	R12	3
-      0x8C300300,  //  004A  GETMET	R12	R1	K0
+      0x8C300314,  //  004A  GETMET	R12	R1	K20
       0x543A0017,  //  004B  LDINT	R14	24
-      0x583C0001,  //  004C  LDCONST	R15	K1
+      0x583C0017,  //  004C  LDCONST	R15	K23
       0x7C300600,  //  004D  CALL	R12	3
-      0x8C300300,  //  004E  GETMET	R12	R1	K0
+      0x8C300314,  //  004E  GETMET	R12	R1	K20
       0x543A0017,  //  004F  LDINT	R14	24
-      0x583C0001,  //  0050  LDCONST	R15	K1
+      0x583C0017,  //  0050  LDCONST	R15	K23
       0x7C300600,  //  0051  CALL	R12	3
       0x80000000,  //  0052  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
@@ -3,6 +3,16 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Expirable' ktab size: 6, total: 13 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_Expirable[6] = {
+  /* K0   */  be_nested_str_weak(_expiration),
+  /* K1   */  be_nested_str_weak(_persist),
+  /* K2   */  be_nested_str_weak(tasmota),
+  /* K3   */  be_nested_str_weak(rtc_utc),
+  /* K4   */  be_nested_str_weak(_list),
+  /* K5   */  be_nested_str_weak(set_expire_time),
+};
+
 
 extern const bclass be_class_Matter_Expirable;
 
@@ -13,13 +23,13 @@ be_local_closure(class_Matter_Expirable_before_remove,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(before_remove),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -37,15 +47,13 @@ be_local_closure(class_Matter_Expirable_set_no_expiration,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_expiration),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(set_no_expiration),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
@@ -65,20 +73,18 @@ be_local_closure(class_Matter_Expirable_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
       0x80000000,  //  0002  RET	0
     })
   )
@@ -93,15 +99,13 @@ be_local_closure(class_Matter_Expirable_set_expire_time,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_expiration),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(set_expire_time),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -123,32 +127,28 @@ be_local_closure(class_Matter_Expirable_has_expired,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(rtc_utc),
-    /* K2   */  be_nested_str_weak(_expiration),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(has_expired),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0003,  //  0002  JMPF	R2	#0007
-      0xB80A0000,  //  0003  GETNGBL	R2	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
       0x7C080200,  //  0005  CALL	R2	1
       0x5C040400,  //  0006  MOVE	R1	R2
-      0x88080102,  //  0007  GETMBR	R2	R0	K2
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
       0x4C0C0000,  //  0008  LDNIL	R3
       0x20080403,  //  0009  NE	R2	R2	R3
       0x780A0002,  //  000A  JMPF	R2	#000E
-      0x88080102,  //  000B  GETMBR	R2	R0	K2
+      0x88080100,  //  000B  GETMBR	R2	R0	K0
       0x28080202,  //  000C  GE	R2	R1	R2
       0x80040400,  //  000D  RET	1	R2
       0x50080000,  //  000E  LDBOOL	R2	0	0
@@ -166,19 +166,17 @@ be_local_closure(class_Matter_Expirable_set_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_list),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(set_parent_list),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020801,  //  0000  SETMBR	R0	K4	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -193,13 +191,13 @@ be_local_closure(class_Matter_Expirable_hydrate_post,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(hydrate_post),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -217,17 +215,13 @@ be_local_closure(class_Matter_Expirable_set_expire_in_seconds,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(rtc_utc),
-    /* K2   */  be_nested_str_weak(set_expire_time),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(set_expire_in_seconds),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -238,11 +232,11 @@ be_local_closure(class_Matter_Expirable_set_expire_in_seconds,   /* name */
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C0C0403,  //  0005  EQ	R3	R2	R3
       0x780E0003,  //  0006  JMPF	R3	#000B
-      0xB80E0000,  //  0007  GETNGBL	R3	K0
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0xB80E0400,  //  0007  GETNGBL	R3	K2
+      0x8C0C0703,  //  0008  GETMET	R3	R3	K3
       0x7C0C0200,  //  0009  CALL	R3	1
       0x5C080600,  //  000A  MOVE	R2	R3
-      0x8C0C0102,  //  000B  GETMET	R3	R0	K2
+      0x8C0C0105,  //  000B  GETMET	R3	R0	K5
       0x00140401,  //  000C  ADD	R5	R2	R1
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80000000,  //  000E  RET	0
@@ -259,19 +253,17 @@ be_local_closure(class_Matter_Expirable_get_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_list),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(get_parent_list),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -286,19 +278,17 @@ be_local_closure(class_Matter_Expirable_does_persist,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(does_persist),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -313,22 +303,20 @@ be_local_closure(class_Matter_Expirable_set_persist,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
-    }),
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(set_persist),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x60080017,  //  0000  GETGBL	R2	G23
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -343,13 +331,13 @@ be_local_closure(class_Matter_Expirable_persist_pre,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(persist_pre),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -367,13 +355,13 @@ be_local_closure(class_Matter_Expirable_persist_post,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Expirable,     /* shared constants */
     be_str_weak(persist_post),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -411,6 +399,27 @@ be_local_class(Matter_Expirable,
     })),
     be_str_weak(Matter_Expirable)
 );
+// compact class 'Matter_Expirable_list' ktab size: 17, total: 25 (saved 64 bytes)
+static const bvalue be_ktab_class_Matter_Expirable_list[17] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(_persist),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_nested_str_weak(before_remove),
+  /* K4   */  be_nested_str_weak(remove),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(Expirable),
+  /* K7   */  be_nested_str_weak(type_error),
+  /* K8   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
+  /* K9   */  be_nested_str_weak(set_parent_list),
+  /* K10  */  be_nested_str_weak(push),
+  /* K11  */  be_nested_str_weak(remove_expired),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(has_expired),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str_weak(iter),
+  /* K16  */  be_nested_str_weak(setitem),
+};
+
 
 extern const bclass be_class_Matter_Expirable_list;
 
@@ -421,17 +430,13 @@ be_local_closure(class_Matter_Expirable_list_count_persistables,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(_persist),
-    /* K2   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(count_persistables),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -462,17 +467,13 @@ be_local_closure(class_Matter_Expirable_list_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(before_remove),
-    /* K2   */  be_nested_str_weak(remove),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(remove),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
@@ -487,12 +488,12 @@ be_local_closure(class_Matter_Expirable_list_remove,   /* name */
       0x14080202,  //  0008  LT	R2	R1	R2
       0x780A0002,  //  0009  JMPF	R2	#000D
       0x94080001,  //  000A  GETIDX	R2	R0	R1
-      0x8C080501,  //  000B  GETMET	R2	R2	K1
+      0x8C080503,  //  000B  GETMET	R2	R2	K3
       0x7C080200,  //  000C  CALL	R2	1
       0x60080003,  //  000D  GETGBL	R2	G3
       0x5C0C0000,  //  000E  MOVE	R3	R0
       0x7C080200,  //  000F  CALL	R2	1
-      0x8C080502,  //  0010  GETMET	R2	R2	K2
+      0x8C080504,  //  0010  GETMET	R2	R2	K4
       0x5C100200,  //  0011  MOVE	R4	R1
       0x7C080400,  //  0012  CALL	R2	2
       0x80040400,  //  0013  RET	1	R2
@@ -510,37 +511,30 @@ be_local_closure(class_Matter_Expirable_list_push,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Expirable),
-    /* K2   */  be_nested_str_weak(type_error),
-    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
-    /* K4   */  be_nested_str_weak(set_parent_list),
-    /* K5   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(push),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0x6008000F,  //  0000  GETGBL	R2	G15
       0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0xB8120A00,  //  0002  GETNGBL	R4	K5
+      0x88100906,  //  0003  GETMBR	R4	R4	K6
       0x7C080400,  //  0004  CALL	R2	2
       0x740A0000,  //  0005  JMPT	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C080304,  //  0007  GETMET	R2	R1	K4
+      0xB0060F08,  //  0006  RAISE	1	K7	K8
+      0x8C080309,  //  0007  GETMET	R2	R1	K9
       0x5C100000,  //  0008  MOVE	R4	R0
       0x7C080400,  //  0009  CALL	R2	2
       0x60080003,  //  000A  GETGBL	R2	G3
       0x5C0C0000,  //  000B  MOVE	R3	R0
       0x7C080200,  //  000C  CALL	R2	1
-      0x8C080505,  //  000D  GETMET	R2	R2	K5
+      0x8C08050A,  //  000D  GETMET	R2	R2	K10
       0x5C100200,  //  000E  MOVE	R4	R1
       0x7C080400,  //  000F  CALL	R2	2
       0x80040400,  //  0010  RET	1	R2
@@ -557,19 +551,17 @@ be_local_closure(class_Matter_Expirable_list_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010B,  //  0000  GETMET	R1	R0	K11
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -585,42 +577,36 @@ be_local_closure(class_Matter_Expirable_list_remove_expired,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(has_expired),
-    /* K2   */  be_nested_str_weak(_persist),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(remove_expired),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x58080000,  //  0001  LDCONST	R2	K0
+      0x5808000C,  //  0001  LDCONST	R2	K12
       0x600C000C,  //  0002  GETGBL	R3	G12
       0x5C100000,  //  0003  MOVE	R4	R0
       0x7C0C0200,  //  0004  CALL	R3	1
       0x140C0403,  //  0005  LT	R3	R2	R3
       0x780E000D,  //  0006  JMPF	R3	#0015
       0x940C0002,  //  0007  GETIDX	R3	R0	R2
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x8C0C070D,  //  0008  GETMET	R3	R3	K13
       0x7C0C0200,  //  0009  CALL	R3	1
       0x780E0007,  //  000A  JMPF	R3	#0013
       0x940C0002,  //  000B  GETIDX	R3	R0	R2
-      0x880C0702,  //  000C  GETMBR	R3	R3	K2
+      0x880C0701,  //  000C  GETMBR	R3	R3	K1
       0x780E0000,  //  000D  JMPF	R3	#000F
       0x50040200,  //  000E  LDBOOL	R1	1	0
-      0x8C0C0103,  //  000F  GETMET	R3	R0	K3
+      0x8C0C0104,  //  000F  GETMET	R3	R0	K4
       0x5C140400,  //  0010  MOVE	R5	R2
       0x7C0C0400,  //  0011  CALL	R3	2
       0x70020000,  //  0012  JMP		#0014
-      0x00080504,  //  0013  ADD	R2	R2	K4
+      0x0008050E,  //  0013  ADD	R2	R2	K14
       0x7001FFEC,  //  0014  JMP		#0002
       0x80040200,  //  0015  RET	1	R1
     })
@@ -636,7 +622,7 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -671,13 +657,11 @@ be_local_closure(class_Matter_Expirable_list_persistables,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(iter),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(persistables),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010F,  //  0000  GETMET	R1	R0	K15
       0x7C040200,  //  0001  CALL	R1	1
       0x84080000,  //  0002  CLOSURE	R2	P0
       0xA0000000,  //  0003  CLOSE	R0
@@ -695,37 +679,30 @@ be_local_closure(class_Matter_Expirable_list_setitem,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Expirable),
-    /* K2   */  be_nested_str_weak(type_error),
-    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
-    /* K4   */  be_nested_str_weak(set_parent_list),
-    /* K5   */  be_nested_str_weak(setitem),
-    }),
+    &be_ktab_class_Matter_Expirable_list,     /* shared constants */
     be_str_weak(setitem),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x600C000F,  //  0000  GETGBL	R3	G15
       0x5C100400,  //  0001  MOVE	R4	R2
-      0xB8160000,  //  0002  GETNGBL	R5	K0
-      0x88140B01,  //  0003  GETMBR	R5	R5	K1
+      0xB8160A00,  //  0002  GETNGBL	R5	K5
+      0x88140B06,  //  0003  GETMBR	R5	R5	K6
       0x7C0C0400,  //  0004  CALL	R3	2
       0x740E0000,  //  0005  JMPT	R3	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0xB0060F08,  //  0006  RAISE	1	K7	K8
+      0x8C0C0509,  //  0007  GETMET	R3	R2	K9
       0x5C140000,  //  0008  MOVE	R5	R0
       0x7C0C0400,  //  0009  CALL	R3	2
       0x600C0003,  //  000A  GETGBL	R3	G3
       0x5C100000,  //  000B  MOVE	R4	R0
       0x7C0C0200,  //  000C  CALL	R3	1
-      0x8C0C0705,  //  000D  GETMET	R3	R3	K5
+      0x8C0C0710,  //  000D  GETMET	R3	R3	K16
       0x5C140200,  //  000E  MOVE	R5	R1
       0x5C180400,  //  000F  MOVE	R6	R2
       0x7C0C0600,  //  0010  CALL	R3	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
@@ -3,6 +3,123 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_Fabric;
+// compact class 'Matter_Fabric' ktab size: 112, total: 212 (saved 800 bytes)
+static const bvalue be_ktab_class_Matter_Fabric[112] = {
+  /* K0   */  be_nested_str_weak(icac),
+  /* K1   */  be_nested_str_weak(log),
+  /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+  /* K3   */  be_nested_str_weak(get_fabric_id),
+  /* K4   */  be_nested_str_weak(copy),
+  /* K5   */  be_nested_str_weak(reverse),
+  /* K6   */  be_nested_str_weak(tohex),
+  /* K7   */  be_const_int(3),
+  /* K8   */  be_nested_str_weak(no_private_key),
+  /* K9   */  be_nested_str_weak(fabric_compressed),
+  /* K10  */  be_nested_str_weak(fabric_id),
+  /* K11  */  be_nested_str_weak(admin_subject),
+  /* K12  */  be_nested_str_weak(admin_vendor),
+  /* K13  */  be_nested_str_weak(noc),
+  /* K14  */  be_const_class(be_class_Matter_Fabric),
+  /* K15  */  be_nested_str_weak(string),
+  /* K16  */  be_nested_str_weak(introspect),
+  /* K17  */  be_nested_str_weak(matter),
+  /* K18  */  be_nested_str_weak(Fabric),
+  /* K19  */  be_nested_str_weak(keys),
+  /* K20  */  be_const_int(0),
+  /* K21  */  be_nested_str_weak(_),
+  /* K22  */  be_nested_str_weak(find),
+  /* K23  */  be_nested_str_weak(0x),
+  /* K24  */  be_nested_str_weak(set),
+  /* K25  */  be_nested_str_weak(fromhex),
+  /* K26  */  be_const_int(2),
+  /* K27  */  be_const_int(2147483647),
+  /* K28  */  be_nested_str_weak(_X24_X24),
+  /* K29  */  be_nested_str_weak(fromb64),
+  /* K30  */  be_nested_str_weak(stop_iteration),
+  /* K31  */  be_nested_str_weak(hydrate_post),
+  /* K32  */  be_nested_str_weak(root_ca_certificate),
+  /* K33  */  be_nested_str_weak(json),
+  /* K34  */  be_nested_str_weak(persist_pre),
+  /* K35  */  be_nested_str_weak(members),
+  /* K36  */  be_nested_str_weak(get),
+  /* K37  */  be_nested_str_weak(function),
+  /* K38  */  be_const_int(0),
+  /* K39  */  be_nested_str_weak(push),
+  /* K40  */  be_nested_str_weak(sort),
+  /* K41  */  be_nested_str_weak(tob64),
+  /* K42  */  be_nested_str_weak(_X25s_X3A_X25s),
+  /* K43  */  be_nested_str_weak(dump),
+  /* K44  */  be_nested_str_weak(_sessions),
+  /* K45  */  be_nested_str_weak(persistables),
+  /* K46  */  be_nested_str_weak(tojson),
+  /* K47  */  be_nested_str_weak(_X5B),
+  /* K48  */  be_nested_str_weak(concat),
+  /* K49  */  be_nested_str_weak(_X2C),
+  /* K50  */  be_nested_str_weak(_X5D),
+  /* K51  */  be_nested_str_weak(_X22_sessions_X22_X3A),
+  /* K52  */  be_nested_str_weak(persist_post),
+  /* K53  */  be_nested_str_weak(_X7B),
+  /* K54  */  be_nested_str_weak(_X7D),
+  /* K55  */  be_nested_str_weak(_counter_group_data_snd_impl),
+  /* K56  */  be_nested_str_weak(reset),
+  /* K57  */  be_nested_str_weak(counter_group_data_snd),
+  /* K58  */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
+  /* K59  */  be_nested_str_weak(counter_group_ctrl_snd),
+  /* K60  */  be_nested_str_weak(val),
+  /* K61  */  be_nested_str_weak(ipk_epoch_key),
+  /* K62  */  be_nested_str_weak(device_id),
+  /* K63  */  be_nested_str_weak(fabric_parent),
+  /* K64  */  be_nested_str_weak(get_fabric_index),
+  /* K65  */  be_nested_str_weak(deleted),
+  /* K66  */  be_nested_str_weak(int64),
+  /* K67  */  be_nested_str_weak(frombytes),
+  /* K68  */  be_nested_str_weak(get_old_recent_session),
+  /* K69  */  be_nested_str_weak(set_no_expiration),
+  /* K70  */  be_nested_str_weak(set_persist),
+  /* K71  */  be_nested_str_weak(assign_fabric_index),
+  /* K72  */  be_nested_str_weak(_store),
+  /* K73  */  be_nested_str_weak(add_fabric),
+  /* K74  */  be_nested_str_weak(next),
+  /* K75  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
+  /* K76  */  be_nested_str_weak(Counter),
+  /* K77  */  be_nested_str_weak(is_greater),
+  /* K78  */  be_nested_str_weak(_GROUP_SND_INCR),
+  /* K79  */  be_nested_str_weak(does_persist),
+  /* K80  */  be_nested_str_weak(save),
+  /* K81  */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
+  /* K82  */  be_nested_str_weak(get_admin_vendor_name),
+  /* K83  */  be_nested_str_weak(TLV),
+  /* K84  */  be_nested_str_weak(parse),
+  /* K85  */  be_nested_str_weak(findsubval),
+  /* K86  */  be_nested_str_weak(fabric_index),
+  /* K87  */  be_nested_str_weak(write),
+  /* K88  */  be_nested_str_weak(_X2C_X22_sessions_X22_X3A_X5B),
+  /* K89  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
+  /* K90  */  be_nested_str_weak(set_expire_in_seconds),
+  /* K91  */  be_nested_str_weak(set_fabric_index),
+  /* K92  */  be_nested_str_weak(next_fabric_idx),
+  /* K93  */  be_nested_str_weak(last_used),
+  /* K94  */  be_const_int(1),
+  /* K95  */  be_nested_str_weak(crypto),
+  /* K96  */  be_nested_str_weak(Expirable_list),
+  /* K97  */  be_nested_str_weak(fabric_label),
+  /* K98  */  be_nested_str_weak(),
+  /* K99  */  be_nested_str_weak(created),
+  /* K100 */  be_nested_str_weak(tasmota),
+  /* K101 */  be_nested_str_weak(rtc_utc),
+  /* K102 */  be_nested_str_weak(_MAX_CASE),
+  /* K103 */  be_nested_str_weak(get_oldest_session),
+  /* K104 */  be_nested_str_weak(remove),
+  /* K105 */  be_nested_str_weak(remove_session),
+  /* K106 */  be_nested_str_weak(HKDF_SHA256),
+  /* K107 */  be_nested_str_weak(fromstring),
+  /* K108 */  be_nested_str_weak(_GROUP_KEY),
+  /* K109 */  be_nested_str_weak(derive),
+  /* K110 */  be_nested_str_weak(get_vendor_name),
+  /* K111 */  be_nested_str_weak(0x_X2504X),
+};
+
 
 extern const bclass be_class_Matter_Fabric;
 
@@ -13,15 +130,13 @@ be_local_closure(class_Matter_Fabric_get_icac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(icac),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_icac),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -40,37 +155,29 @@ be_local_closure(class_Matter_Fabric_before_remove,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
-    /* K2   */  be_nested_str_weak(get_fabric_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(before_remove),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0xB8060200,  //  0000  GETNGBL	R1	K1
       0x60080018,  //  0001  GETGBL	R2	G24
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100102,  //  0003  GETMET	R4	R0	K2
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x8C100103,  //  0003  GETMET	R4	R0	K3
       0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x8C100904,  //  0005  GETMET	R4	R4	K4
       0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x8C100905,  //  0007  GETMET	R4	R4	K5
       0x7C100200,  //  0008  CALL	R4	1
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x8C100906,  //  0009  GETMET	R4	R4	K6
       0x7C100200,  //  000A  CALL	R4	1
       0x7C080400,  //  000B  CALL	R2	2
-      0x580C0006,  //  000C  LDCONST	R3	K6
+      0x580C0007,  //  000C  LDCONST	R3	K7
       0x7C040400,  //  000D  CALL	R1	2
       0x80000000,  //  000E  RET	0
     })
@@ -86,19 +193,17 @@ be_local_closure(class_Matter_Fabric_get_pk,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(no_private_key),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_pk),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -113,19 +218,17 @@ be_local_closure(class_Matter_Fabric_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_compressed),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_fabric_compressed),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -140,19 +243,17 @@ be_local_closure(class_Matter_Fabric_get_fabric_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_id),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_fabric_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010A,  //  0000  GETMBR	R1	R0	K10
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -167,21 +268,18 @@ be_local_closure(class_Matter_Fabric_set_admin_subject_vendor,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_subject),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_admin_subject_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90021601,  //  0000  SETMBR	R0	K11	R1
+      0x90021802,  //  0001  SETMBR	R0	K12	R2
       0x80000000,  //  0002  RET	0
     })
   )
@@ -196,19 +294,17 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_vendor),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_admin_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -223,19 +319,17 @@ be_local_closure(class_Matter_Fabric_get_noc,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_noc),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -250,109 +344,90 @@ be_local_closure(class_Matter_Fabric_fromjson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Fabric),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Fabric),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(0x),
-    /* K10  */  be_nested_str_weak(set),
-    /* K11  */  be_nested_str_weak(fromhex),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_const_int(2147483647),
-    /* K14  */  be_nested_str_weak(_X24_X24),
-    /* K15  */  be_nested_str_weak(fromb64),
-    /* K16  */  be_nested_str_weak(stop_iteration),
-    /* K17  */  be_nested_str_weak(hydrate_post),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(fromjson),
     &be_const_str_solidified,
     ( &(const binstruction[76]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0xB8160600,  //  0003  GETNGBL	R5	K3
-      0x8C140B04,  //  0004  GETMET	R5	R5	K4
+      0x5808000E,  //  0000  LDCONST	R2	K14
+      0xA40E1E00,  //  0001  IMPORT	R3	K15
+      0xA4122000,  //  0002  IMPORT	R4	K16
+      0xB8162200,  //  0003  GETNGBL	R5	K17
+      0x8C140B12,  //  0004  GETMET	R5	R5	K18
       0x5C1C0000,  //  0005  MOVE	R7	R0
       0x7C140400,  //  0006  CALL	R5	2
       0x60180010,  //  0007  GETGBL	R6	G16
-      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
+      0x8C1C0313,  //  0008  GETMET	R7	R1	K19
       0x7C1C0200,  //  0009  CALL	R7	1
       0x7C180200,  //  000A  CALL	R6	1
       0xA8020039,  //  000B  EXBLK	0	#0046
       0x5C1C0C00,  //  000C  MOVE	R7	R6
       0x7C1C0000,  //  000D  CALL	R7	0
-      0x94200F06,  //  000E  GETIDX	R8	R7	K6
-      0x1C201107,  //  000F  EQ	R8	R8	K7
+      0x94200F14,  //  000E  GETIDX	R8	R7	K20
+      0x1C201115,  //  000F  EQ	R8	R8	K21
       0x78220000,  //  0010  JMPF	R8	#0012
       0x7001FFF9,  //  0011  JMP		#000C
       0x94200207,  //  0012  GETIDX	R8	R1	R7
       0x60240004,  //  0013  GETGBL	R9	G4
       0x5C281000,  //  0014  MOVE	R10	R8
       0x7C240200,  //  0015  CALL	R9	1
-      0x1C241301,  //  0016  EQ	R9	R9	K1
+      0x1C24130F,  //  0016  EQ	R9	R9	K15
       0x78260027,  //  0017  JMPF	R9	#0040
-      0x8C240708,  //  0018  GETMET	R9	R3	K8
+      0x8C240716,  //  0018  GETMET	R9	R3	K22
       0x5C2C1000,  //  0019  MOVE	R11	R8
-      0x58300009,  //  001A  LDCONST	R12	K9
+      0x58300017,  //  001A  LDCONST	R12	K23
       0x7C240600,  //  001B  CALL	R9	3
-      0x1C241306,  //  001C  EQ	R9	R9	K6
+      0x1C241314,  //  001C  EQ	R9	R9	K20
       0x7826000A,  //  001D  JMPF	R9	#0029
-      0x8C24090A,  //  001E  GETMET	R9	R4	K10
+      0x8C240918,  //  001E  GETMET	R9	R4	K24
       0x5C2C0A00,  //  001F  MOVE	R11	R5
       0x5C300E00,  //  0020  MOVE	R12	R7
       0x60340015,  //  0021  GETGBL	R13	G21
       0x7C340000,  //  0022  CALL	R13	0
-      0x8C341B0B,  //  0023  GETMET	R13	R13	K11
-      0x403E190D,  //  0024  CONNECT	R15	K12	K13
+      0x8C341B19,  //  0023  GETMET	R13	R13	K25
+      0x403E351B,  //  0024  CONNECT	R15	K26	K27
       0x943C100F,  //  0025  GETIDX	R15	R8	R15
       0x7C340400,  //  0026  CALL	R13	2
       0x7C240800,  //  0027  CALL	R9	4
       0x70020015,  //  0028  JMP		#003F
-      0x8C240708,  //  0029  GETMET	R9	R3	K8
+      0x8C240716,  //  0029  GETMET	R9	R3	K22
       0x5C2C1000,  //  002A  MOVE	R11	R8
-      0x5830000E,  //  002B  LDCONST	R12	K14
+      0x5830001C,  //  002B  LDCONST	R12	K28
       0x7C240600,  //  002C  CALL	R9	3
-      0x1C241306,  //  002D  EQ	R9	R9	K6
+      0x1C241314,  //  002D  EQ	R9	R9	K20
       0x7826000A,  //  002E  JMPF	R9	#003A
-      0x8C24090A,  //  002F  GETMET	R9	R4	K10
+      0x8C240918,  //  002F  GETMET	R9	R4	K24
       0x5C2C0A00,  //  0030  MOVE	R11	R5
       0x5C300E00,  //  0031  MOVE	R12	R7
       0x60340015,  //  0032  GETGBL	R13	G21
       0x7C340000,  //  0033  CALL	R13	0
-      0x8C341B0F,  //  0034  GETMET	R13	R13	K15
-      0x403E190D,  //  0035  CONNECT	R15	K12	K13
+      0x8C341B1D,  //  0034  GETMET	R13	R13	K29
+      0x403E351B,  //  0035  CONNECT	R15	K26	K27
       0x943C100F,  //  0036  GETIDX	R15	R8	R15
       0x7C340400,  //  0037  CALL	R13	2
       0x7C240800,  //  0038  CALL	R9	4
       0x70020004,  //  0039  JMP		#003F
-      0x8C24090A,  //  003A  GETMET	R9	R4	K10
+      0x8C240918,  //  003A  GETMET	R9	R4	K24
       0x5C2C0A00,  //  003B  MOVE	R11	R5
       0x5C300E00,  //  003C  MOVE	R12	R7
       0x5C341000,  //  003D  MOVE	R13	R8
       0x7C240800,  //  003E  CALL	R9	4
       0x70020004,  //  003F  JMP		#0045
-      0x8C24090A,  //  0040  GETMET	R9	R4	K10
+      0x8C240918,  //  0040  GETMET	R9	R4	K24
       0x5C2C0A00,  //  0041  MOVE	R11	R5
       0x5C300E00,  //  0042  MOVE	R12	R7
       0x5C341000,  //  0043  MOVE	R13	R8
       0x7C240800,  //  0044  CALL	R9	4
       0x7001FFC5,  //  0045  JMP		#000C
-      0x58180010,  //  0046  LDCONST	R6	K16
+      0x5818001E,  //  0046  LDCONST	R6	K30
       0xAC180200,  //  0047  CATCH	R6	1	0
       0xB0080000,  //  0048  RAISE	2	R0	R0
-      0x8C180B11,  //  0049  GETMET	R6	R5	K17
+      0x8C180B1F,  //  0049  GETMET	R6	R5	K31
       0x7C180200,  //  004A  CALL	R6	1
       0x80040A00,  //  004B  RET	1	R5
     })
@@ -368,19 +443,17 @@ be_local_closure(class_Matter_Fabric_set_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024001,  //  0000  SETMBR	R0	K32	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -395,79 +468,51 @@ be_local_closure(class_Matter_Fabric_tojson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(persist_pre),
-    /* K3   */  be_nested_str_weak(members),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(function),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(stop_iteration),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(sort),
-    /* K12  */  be_nested_str_weak(_X24_X24),
-    /* K13  */  be_nested_str_weak(tob64),
-    /* K14  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K15  */  be_nested_str_weak(dump),
-    /* K16  */  be_nested_str_weak(_sessions),
-    /* K17  */  be_nested_str_weak(persistables),
-    /* K18  */  be_nested_str_weak(tojson),
-    /* K19  */  be_nested_str_weak(_X5B),
-    /* K20  */  be_nested_str_weak(concat),
-    /* K21  */  be_nested_str_weak(_X2C),
-    /* K22  */  be_nested_str_weak(_X5D),
-    /* K23  */  be_nested_str_weak(_X22_sessions_X22_X3A),
-    /* K24  */  be_nested_str_weak(persist_post),
-    /* K25  */  be_nested_str_weak(_X7B),
-    /* K26  */  be_nested_str_weak(_X7D),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(tojson),
     &be_const_str_solidified,
     ( &(const binstruction[119]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
+      0xA4064200,  //  0000  IMPORT	R1	K33
+      0xA40A2000,  //  0001  IMPORT	R2	K16
+      0x8C0C0122,  //  0002  GETMET	R3	R0	K34
       0x7C0C0200,  //  0003  CALL	R3	1
       0x600C0012,  //  0004  GETGBL	R3	G18
       0x7C0C0000,  //  0005  CALL	R3	0
       0x60100010,  //  0006  GETGBL	R4	G16
-      0x8C140503,  //  0007  GETMET	R5	R2	K3
+      0x8C140523,  //  0007  GETMET	R5	R2	K35
       0x5C1C0000,  //  0008  MOVE	R7	R0
       0x7C140400,  //  0009  CALL	R5	2
       0x7C100200,  //  000A  CALL	R4	1
       0xA8020011,  //  000B  EXBLK	0	#001E
       0x5C140800,  //  000C  MOVE	R5	R4
       0x7C140000,  //  000D  CALL	R5	0
-      0x8C180504,  //  000E  GETMET	R6	R2	K4
+      0x8C180524,  //  000E  GETMET	R6	R2	K36
       0x5C200000,  //  000F  MOVE	R8	R0
       0x5C240A00,  //  0010  MOVE	R9	R5
       0x7C180600,  //  0011  CALL	R6	3
       0x601C0004,  //  0012  GETGBL	R7	G4
       0x5C200C00,  //  0013  MOVE	R8	R6
       0x7C1C0200,  //  0014  CALL	R7	1
-      0x201C0F05,  //  0015  NE	R7	R7	K5
+      0x201C0F25,  //  0015  NE	R7	R7	K37
       0x781E0005,  //  0016  JMPF	R7	#001D
-      0x941C0B06,  //  0017  GETIDX	R7	R5	K6
-      0x201C0F07,  //  0018  NE	R7	R7	K7
+      0x941C0B26,  //  0017  GETIDX	R7	R5	K38
+      0x201C0F15,  //  0018  NE	R7	R7	K21
       0x781E0002,  //  0019  JMPF	R7	#001D
-      0x8C1C0708,  //  001A  GETMET	R7	R3	K8
+      0x8C1C0727,  //  001A  GETMET	R7	R3	K39
       0x5C240A00,  //  001B  MOVE	R9	R5
       0x7C1C0400,  //  001C  CALL	R7	2
       0x7001FFED,  //  001D  JMP		#000C
-      0x58100009,  //  001E  LDCONST	R4	K9
+      0x5810001E,  //  001E  LDCONST	R4	K30
       0xAC100200,  //  001F  CATCH	R4	1	0
       0xB0080000,  //  0020  RAISE	2	R0	R0
-      0xB8121400,  //  0021  GETNGBL	R4	K10
-      0x8C10090B,  //  0022  GETMET	R4	R4	K11
+      0xB8122200,  //  0021  GETNGBL	R4	K17
+      0x8C100928,  //  0022  GETMET	R4	R4	K40
       0x5C180600,  //  0023  MOVE	R6	R3
       0x7C100400,  //  0024  CALL	R4	2
       0x5C0C0800,  //  0025  MOVE	R3	R4
@@ -479,7 +524,7 @@ be_local_closure(class_Matter_Fabric_tojson,   /* name */
       0xA8020020,  //  002B  EXBLK	0	#004D
       0x5C180A00,  //  002C  MOVE	R6	R5
       0x7C180000,  //  002D  CALL	R6	0
-      0x8C1C0504,  //  002E  GETMET	R7	R2	K4
+      0x8C1C0524,  //  002E  GETMET	R7	R2	K36
       0x5C240000,  //  002F  MOVE	R9	R0
       0x5C280C00,  //  0030  MOVE	R10	R6
       0x7C1C0600,  //  0031  CALL	R7	3
@@ -492,65 +537,65 @@ be_local_closure(class_Matter_Fabric_tojson,   /* name */
       0x60280015,  //  0038  GETGBL	R10	G21
       0x7C200400,  //  0039  CALL	R8	2
       0x78220003,  //  003A  JMPF	R8	#003F
-      0x8C200F0D,  //  003B  GETMET	R8	R7	K13
+      0x8C200F29,  //  003B  GETMET	R8	R7	K41
       0x7C200200,  //  003C  CALL	R8	1
-      0x00221808,  //  003D  ADD	R8	K12	R8
+      0x00223808,  //  003D  ADD	R8	K28	R8
       0x5C1C1000,  //  003E  MOVE	R7	R8
-      0x8C200908,  //  003F  GETMET	R8	R4	K8
+      0x8C200927,  //  003F  GETMET	R8	R4	K39
       0x60280018,  //  0040  GETGBL	R10	G24
-      0x582C000E,  //  0041  LDCONST	R11	K14
-      0x8C30030F,  //  0042  GETMET	R12	R1	K15
+      0x582C002A,  //  0041  LDCONST	R11	K42
+      0x8C30032B,  //  0042  GETMET	R12	R1	K43
       0x60380008,  //  0043  GETGBL	R14	G8
       0x5C3C0C00,  //  0044  MOVE	R15	R6
       0x7C380200,  //  0045  CALL	R14	1
       0x7C300400,  //  0046  CALL	R12	2
-      0x8C34030F,  //  0047  GETMET	R13	R1	K15
+      0x8C34032B,  //  0047  GETMET	R13	R1	K43
       0x5C3C0E00,  //  0048  MOVE	R15	R7
       0x7C340400,  //  0049  CALL	R13	2
       0x7C280600,  //  004A  CALL	R10	3
       0x7C200400,  //  004B  CALL	R8	2
       0x7001FFDE,  //  004C  JMP		#002C
-      0x58140009,  //  004D  LDCONST	R5	K9
+      0x5814001E,  //  004D  LDCONST	R5	K30
       0xAC140200,  //  004E  CATCH	R5	1	0
       0xB0080000,  //  004F  RAISE	2	R0	R0
       0x60140012,  //  0050  GETGBL	R5	G18
       0x7C140000,  //  0051  CALL	R5	0
       0x60180010,  //  0052  GETGBL	R6	G16
-      0x881C0110,  //  0053  GETMBR	R7	R0	K16
-      0x8C1C0F11,  //  0054  GETMET	R7	R7	K17
+      0x881C012C,  //  0053  GETMBR	R7	R0	K44
+      0x8C1C0F2D,  //  0054  GETMET	R7	R7	K45
       0x7C1C0200,  //  0055  CALL	R7	1
       0x7C180200,  //  0056  CALL	R6	1
       0xA8020006,  //  0057  EXBLK	0	#005F
       0x5C1C0C00,  //  0058  MOVE	R7	R6
       0x7C1C0000,  //  0059  CALL	R7	0
-      0x8C200B08,  //  005A  GETMET	R8	R5	K8
-      0x8C280F12,  //  005B  GETMET	R10	R7	K18
+      0x8C200B27,  //  005A  GETMET	R8	R5	K39
+      0x8C280F2E,  //  005B  GETMET	R10	R7	K46
       0x7C280200,  //  005C  CALL	R10	1
       0x7C200400,  //  005D  CALL	R8	2
       0x7001FFF8,  //  005E  JMP		#0058
-      0x58180009,  //  005F  LDCONST	R6	K9
+      0x5818001E,  //  005F  LDCONST	R6	K30
       0xAC180200,  //  0060  CATCH	R6	1	0
       0xB0080000,  //  0061  RAISE	2	R0	R0
       0x6018000C,  //  0062  GETGBL	R6	G12
       0x5C1C0A00,  //  0063  MOVE	R7	R5
       0x7C180200,  //  0064  CALL	R6	1
-      0x24180D06,  //  0065  GT	R6	R6	K6
+      0x24180D26,  //  0065  GT	R6	R6	K38
       0x781A0007,  //  0066  JMPF	R6	#006F
-      0x8C180B14,  //  0067  GETMET	R6	R5	K20
-      0x58200015,  //  0068  LDCONST	R8	K21
+      0x8C180B30,  //  0067  GETMET	R6	R5	K48
+      0x58200031,  //  0068  LDCONST	R8	K49
       0x7C180400,  //  0069  CALL	R6	2
-      0x001A2606,  //  006A  ADD	R6	K19	R6
-      0x00180D16,  //  006B  ADD	R6	R6	K22
-      0x8C1C0908,  //  006C  GETMET	R7	R4	K8
-      0x00262E06,  //  006D  ADD	R9	K23	R6
+      0x001A5E06,  //  006A  ADD	R6	K47	R6
+      0x00180D32,  //  006B  ADD	R6	R6	K50
+      0x8C1C0927,  //  006C  GETMET	R7	R4	K39
+      0x00266606,  //  006D  ADD	R9	K51	R6
       0x7C1C0400,  //  006E  CALL	R7	2
-      0x8C180118,  //  006F  GETMET	R6	R0	K24
+      0x8C180134,  //  006F  GETMET	R6	R0	K52
       0x7C180200,  //  0070  CALL	R6	1
-      0x8C180914,  //  0071  GETMET	R6	R4	K20
-      0x58200015,  //  0072  LDCONST	R8	K21
+      0x8C180930,  //  0071  GETMET	R6	R4	K48
+      0x58200031,  //  0072  LDCONST	R8	K49
       0x7C180400,  //  0073  CALL	R6	2
-      0x001A3206,  //  0074  ADD	R6	K25	R6
-      0x00180D1A,  //  0075  ADD	R6	R6	K26
+      0x001A6A06,  //  0074  ADD	R6	K53	R6
+      0x00180D36,  //  0075  ADD	R6	R6	K54
       0x80040C00,  //  0076  RET	1	R6
     })
   )
@@ -565,39 +610,32 @@ be_local_closure(class_Matter_Fabric_hydrate_post,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
-    /* K1   */  be_nested_str_weak(reset),
-    /* K2   */  be_nested_str_weak(counter_group_data_snd),
-    /* K3   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
-    /* K4   */  be_nested_str_weak(counter_group_ctrl_snd),
-    /* K5   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(hydrate_post),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x88040137,  //  0000  GETMBR	R1	R0	K55
+      0x8C040338,  //  0001  GETMET	R1	R1	K56
+      0x880C0139,  //  0002  GETMBR	R3	R0	K57
       0x7C040400,  //  0003  CALL	R1	2
-      0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C040301,  //  0005  GETMET	R1	R1	K1
-      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x8804013A,  //  0004  GETMBR	R1	R0	K58
+      0x8C040338,  //  0005  GETMET	R1	R1	K56
+      0x880C013B,  //  0006  GETMBR	R3	R0	K59
       0x7C040400,  //  0007  CALL	R1	2
-      0x88040100,  //  0008  GETMBR	R1	R0	K0
-      0x8C040305,  //  0009  GETMET	R1	R1	K5
+      0x88040137,  //  0008  GETMBR	R1	R0	K55
+      0x8C04033C,  //  0009  GETMET	R1	R1	K60
       0x7C040200,  //  000A  CALL	R1	1
-      0x90020401,  //  000B  SETMBR	R0	K2	R1
-      0x88040103,  //  000C  GETMBR	R1	R0	K3
-      0x8C040305,  //  000D  GETMET	R1	R1	K5
+      0x90027201,  //  000B  SETMBR	R0	K57	R1
+      0x8804013A,  //  000C  GETMBR	R1	R0	K58
+      0x8C04033C,  //  000D  GETMET	R1	R1	K60
       0x7C040200,  //  000E  CALL	R1	1
-      0x90020801,  //  000F  SETMBR	R0	K4	R1
+      0x90027601,  //  000F  SETMBR	R0	K59	R1
       0x80000000,  //  0010  RET	0
     })
   )
@@ -612,19 +650,17 @@ be_local_closure(class_Matter_Fabric_set_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90027A01,  //  0000  SETMBR	R0	K61	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -639,33 +675,27 @@ be_local_closure(class_Matter_Fabric_set_fabric_device,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_id),
-    /* K1   */  be_nested_str_weak(device_id),
-    /* K2   */  be_nested_str_weak(fabric_compressed),
-    /* K3   */  be_nested_str_weak(fabric_parent),
-    /* K4   */  be_nested_str_weak(get_fabric_index),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_fabric_device),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x90021401,  //  0000  SETMBR	R0	K10	R1
+      0x90027C02,  //  0001  SETMBR	R0	K62	R2
+      0x90021203,  //  0002  SETMBR	R0	K9	R3
       0x4C140000,  //  0003  LDNIL	R5
       0x20140805,  //  0004  NE	R5	R4	R5
       0x78160002,  //  0005  JMPF	R5	#0009
-      0x8C140904,  //  0006  GETMET	R5	R4	K4
+      0x8C140940,  //  0006  GETMET	R5	R4	K64
       0x7C140200,  //  0007  CALL	R5	1
       0x70020000,  //  0008  JMP		#000A
       0x4C140000,  //  0009  LDNIL	R5
-      0x90020605,  //  000A  SETMBR	R0	K3	R5
+      0x90027E05,  //  000A  SETMBR	R0	K63	R5
       0x80000000,  //  000B  RET	0
     })
   )
@@ -680,19 +710,17 @@ be_local_closure(class_Matter_Fabric_get_device_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device_id),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_device_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804013E,  //  0000  GETMBR	R1	R0	K62
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -707,19 +735,17 @@ be_local_closure(class_Matter_Fabric_get_admin_subject,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_subject),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_admin_subject),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010B,  //  0000  GETMBR	R1	R0	K11
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -734,19 +760,17 @@ be_local_closure(class_Matter_Fabric_is_marked_for_deletion,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(deleted),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(is_marked_for_deletion),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040141,  //  0000  GETMBR	R1	R0	K65
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
@@ -763,23 +787,19 @@ be_local_closure(class_Matter_Fabric_get_fabric_id_as_int64,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int64),
-    /* K1   */  be_nested_str_weak(frombytes),
-    /* K2   */  be_nested_str_weak(fabric_id),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_fabric_id_as_int64),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0xB8068400,  //  0000  GETNGBL	R1	K66
+      0x8C040343,  //  0001  GETMET	R1	R1	K67
+      0x880C010A,  //  0002  GETMBR	R3	R0	K10
       0x7C040400,  //  0003  CALL	R1	2
       0x80040200,  //  0004  RET	1	R1
     })
@@ -795,19 +815,17 @@ be_local_closure(class_Matter_Fabric_get_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040120,  //  0000  GETMBR	R1	R0	K32
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -822,19 +840,17 @@ be_local_closure(class_Matter_Fabric_get_oldest_session,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_oldest_session),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040144,  //  0000  GETMET	R1	R0	K68
       0x500C0200,  //  0001  LDBOOL	R3	1	0
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
@@ -851,31 +867,25 @@ be_local_closure(class_Matter_Fabric_fabric_completed,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_no_expiration),
-    /* K1   */  be_nested_str_weak(set_persist),
-    /* K2   */  be_nested_str_weak(assign_fabric_index),
-    /* K3   */  be_nested_str_weak(_store),
-    /* K4   */  be_nested_str_weak(add_fabric),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(fabric_completed),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040145,  //  0000  GETMET	R1	R0	K69
       0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x8C040146,  //  0002  GETMET	R1	R0	K70
       0x500C0200,  //  0003  LDBOOL	R3	1	0
       0x7C040400,  //  0004  CALL	R1	2
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x8C040147,  //  0005  GETMET	R1	R0	K71
       0x7C040200,  //  0006  CALL	R1	1
-      0x88040103,  //  0007  GETMBR	R1	R0	K3
-      0x8C040304,  //  0008  GETMET	R1	R1	K4
+      0x88040148,  //  0007  GETMBR	R1	R0	K72
+      0x8C040349,  //  0008  GETMET	R1	R1	K73
       0x5C0C0000,  //  0009  MOVE	R3	R0
       0x7C040400,  //  000A  CALL	R1	2
       0x80000000,  //  000B  RET	0
@@ -892,53 +902,40 @@ be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Counter),
-    /* K7   */  be_nested_str_weak(is_greater),
-    /* K8   */  be_nested_str_weak(counter_group_data_snd),
-    /* K9   */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K10  */  be_nested_str_weak(does_persist),
-    /* K11  */  be_nested_str_weak(save),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(counter_group_data_snd_next),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040137,  //  0000  GETMBR	R1	R0	K55
+      0x8C04034A,  //  0001  GETMET	R1	R1	K74
       0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0xB80A0200,  //  0003  GETNGBL	R2	K1
       0x600C0018,  //  0004  GETGBL	R3	G24
-      0x58100003,  //  0005  LDCONST	R4	K3
+      0x5810004B,  //  0005  LDCONST	R4	K75
       0x5C140200,  //  0006  MOVE	R5	R1
       0x7C0C0400,  //  0007  CALL	R3	2
-      0x58100004,  //  0008  LDCONST	R4	K4
+      0x58100007,  //  0008  LDCONST	R4	K7
       0x7C080400,  //  0009  CALL	R2	2
-      0xB80A0A00,  //  000A  GETNGBL	R2	K5
-      0x88080506,  //  000B  GETMBR	R2	R2	K6
-      0x8C080507,  //  000C  GETMET	R2	R2	K7
+      0xB80A2200,  //  000A  GETNGBL	R2	K17
+      0x8808054C,  //  000B  GETMBR	R2	R2	K76
+      0x8C08054D,  //  000C  GETMET	R2	R2	K77
       0x5C100200,  //  000D  MOVE	R4	R1
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x88140139,  //  000E  GETMBR	R5	R0	K57
       0x7C080600,  //  000F  CALL	R2	3
       0x780A0007,  //  0010  JMPF	R2	#0019
-      0x88080109,  //  0011  GETMBR	R2	R0	K9
+      0x8808014E,  //  0011  GETMBR	R2	R0	K78
       0x00080202,  //  0012  ADD	R2	R1	R2
-      0x90021002,  //  0013  SETMBR	R0	K8	R2
-      0x8C08010A,  //  0014  GETMET	R2	R0	K10
+      0x90027202,  //  0013  SETMBR	R0	K57	R2
+      0x8C08014F,  //  0014  GETMET	R2	R0	K79
       0x7C080200,  //  0015  CALL	R2	1
       0x780A0001,  //  0016  JMPF	R2	#0019
-      0x8C08010B,  //  0017  GETMET	R2	R0	K11
+      0x8C080150,  //  0017  GETMET	R2	R0	K80
       0x7C080200,  //  0018  CALL	R2	1
       0x80040200,  //  0019  RET	1	R1
     })
@@ -954,21 +951,18 @@ be_local_closure(class_Matter_Fabric_set_noc_icac,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    /* K1   */  be_nested_str_weak(icac),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_noc_icac),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90021A01,  //  0000  SETMBR	R0	K13	R1
+      0x90020002,  //  0001  SETMBR	R0	K0	R2
       0x80000000,  //  0002  RET	0
     })
   )
@@ -983,19 +977,17 @@ be_local_closure(class_Matter_Fabric_set_pk,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(no_private_key),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_pk),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021001,  //  0000  SETMBR	R0	K8	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1010,19 +1002,17 @@ be_local_closure(class_Matter_Fabric_get_newest_session,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_newest_session),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040144,  //  0000  GETMET	R1	R0	K68
       0x500C0000,  //  0001  LDBOOL	R3	0	0
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
@@ -1039,37 +1029,28 @@ be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
-    /* K2   */  be_nested_str_weak(get_fabric_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K7   */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(log_new_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0xB8060200,  //  0000  GETNGBL	R1	K1
       0x60080018,  //  0001  GETGBL	R2	G24
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100102,  //  0003  GETMET	R4	R0	K2
+      0x580C0051,  //  0002  LDCONST	R3	K81
+      0x8C100103,  //  0003  GETMET	R4	R0	K3
       0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x8C100904,  //  0005  GETMET	R4	R4	K4
       0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x8C100905,  //  0007  GETMET	R4	R4	K5
       0x7C100200,  //  0008  CALL	R4	1
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x8C100906,  //  0009  GETMET	R4	R4	K6
       0x7C100200,  //  000A  CALL	R4	1
-      0x8C140106,  //  000B  GETMET	R5	R0	K6
+      0x8C140152,  //  000B  GETMET	R5	R0	K82
       0x7C140200,  //  000C  CALL	R5	1
       0x7C080600,  //  000D  CALL	R2	3
       0x580C0007,  //  000E  LDCONST	R3	K7
@@ -1088,30 +1069,24 @@ be_local_closure(class_Matter_Fabric_get_ca_pub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(findsubval),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_ca_pub),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040120,  //  0000  GETMBR	R1	R0	K32
       0x78060008,  //  0001  JMPF	R1	#000B
-      0xB80A0200,  //  0002  GETNGBL	R2	K1
-      0x88080502,  //  0003  GETMBR	R2	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0xB80A2200,  //  0002  GETNGBL	R2	K17
+      0x88080553,  //  0003  GETMBR	R2	R2	K83
+      0x8C080554,  //  0004  GETMET	R2	R2	K84
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x8C0C0555,  //  0007  GETMET	R3	R2	K85
       0x54160008,  //  0008  LDINT	R5	9
       0x7C0C0400,  //  0009  CALL	R3	2
       0x80040600,  //  000A  RET	1	R3
@@ -1129,19 +1104,17 @@ be_local_closure(class_Matter_Fabric_get_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_fabric_index),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040156,  //  0000  GETMBR	R1	R0	K86
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1156,81 +1129,54 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(write),
-    /* K3   */  be_nested_str_weak(_X7B),
-    /* K4   */  be_nested_str_weak(persist_pre),
-    /* K5   */  be_nested_str_weak(members),
-    /* K6   */  be_nested_str_weak(get),
-    /* K7   */  be_nested_str_weak(function),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(_),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(sort),
-    /* K14  */  be_nested_str_weak(_X24_X24),
-    /* K15  */  be_nested_str_weak(tob64),
-    /* K16  */  be_nested_str_weak(_X2C),
-    /* K17  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K18  */  be_nested_str_weak(dump),
-    /* K19  */  be_nested_str_weak(_sessions),
-    /* K20  */  be_nested_str_weak(persistables),
-    /* K21  */  be_nested_str_weak(_X2C_X22_sessions_X22_X3A_X5B),
-    /* K22  */  be_nested_str_weak(tojson),
-    /* K23  */  be_nested_str_weak(_X5D),
-    /* K24  */  be_nested_str_weak(persist_post),
-    /* K25  */  be_nested_str_weak(_X7D),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(writejson),
     &be_const_str_solidified,
     ( &(const binstruction[125]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100302,  //  0002  GETMET	R4	R1	K2
-      0x58180003,  //  0003  LDCONST	R6	K3
+      0xA40A4200,  //  0000  IMPORT	R2	K33
+      0xA40E2000,  //  0001  IMPORT	R3	K16
+      0x8C100357,  //  0002  GETMET	R4	R1	K87
+      0x58180035,  //  0003  LDCONST	R6	K53
       0x7C100400,  //  0004  CALL	R4	2
-      0x8C100104,  //  0005  GETMET	R4	R0	K4
+      0x8C100122,  //  0005  GETMET	R4	R0	K34
       0x7C100200,  //  0006  CALL	R4	1
       0x60100012,  //  0007  GETGBL	R4	G18
       0x7C100000,  //  0008  CALL	R4	0
       0x60140010,  //  0009  GETGBL	R5	G16
-      0x8C180705,  //  000A  GETMET	R6	R3	K5
+      0x8C180723,  //  000A  GETMET	R6	R3	K35
       0x5C200000,  //  000B  MOVE	R8	R0
       0x7C180400,  //  000C  CALL	R6	2
       0x7C140200,  //  000D  CALL	R5	1
       0xA8020011,  //  000E  EXBLK	0	#0021
       0x5C180A00,  //  000F  MOVE	R6	R5
       0x7C180000,  //  0010  CALL	R6	0
-      0x8C1C0706,  //  0011  GETMET	R7	R3	K6
+      0x8C1C0724,  //  0011  GETMET	R7	R3	K36
       0x5C240000,  //  0012  MOVE	R9	R0
       0x5C280C00,  //  0013  MOVE	R10	R6
       0x7C1C0600,  //  0014  CALL	R7	3
       0x60200004,  //  0015  GETGBL	R8	G4
       0x5C240E00,  //  0016  MOVE	R9	R7
       0x7C200200,  //  0017  CALL	R8	1
-      0x20201107,  //  0018  NE	R8	R8	K7
+      0x20201125,  //  0018  NE	R8	R8	K37
       0x78220005,  //  0019  JMPF	R8	#0020
-      0x94200D08,  //  001A  GETIDX	R8	R6	K8
-      0x20201109,  //  001B  NE	R8	R8	K9
+      0x94200D26,  //  001A  GETIDX	R8	R6	K38
+      0x20201115,  //  001B  NE	R8	R8	K21
       0x78220002,  //  001C  JMPF	R8	#0020
-      0x8C20090A,  //  001D  GETMET	R8	R4	K10
+      0x8C200927,  //  001D  GETMET	R8	R4	K39
       0x5C280C00,  //  001E  MOVE	R10	R6
       0x7C200400,  //  001F  CALL	R8	2
       0x7001FFED,  //  0020  JMP		#000F
-      0x5814000B,  //  0021  LDCONST	R5	K11
+      0x5814001E,  //  0021  LDCONST	R5	K30
       0xAC140200,  //  0022  CATCH	R5	1	0
       0xB0080000,  //  0023  RAISE	2	R0	R0
-      0xB8161800,  //  0024  GETNGBL	R5	K12
-      0x8C140B0D,  //  0025  GETMET	R5	R5	K13
+      0xB8162200,  //  0024  GETNGBL	R5	K17
+      0x8C140B28,  //  0025  GETMET	R5	R5	K40
       0x5C1C0800,  //  0026  MOVE	R7	R4
       0x7C140400,  //  0027  CALL	R5	2
       0x5C100A00,  //  0028  MOVE	R4	R5
@@ -1241,7 +1187,7 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
       0xA8020026,  //  002D  EXBLK	0	#0055
       0x5C1C0C00,  //  002E  MOVE	R7	R6
       0x7C1C0000,  //  002F  CALL	R7	0
-      0x8C200706,  //  0030  GETMET	R8	R3	K6
+      0x8C200724,  //  0030  GETMET	R8	R3	K36
       0x5C280000,  //  0031  MOVE	R10	R0
       0x5C2C0E00,  //  0032  MOVE	R11	R7
       0x7C200600,  //  0033  CALL	R8	3
@@ -1254,68 +1200,68 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
       0x602C0015,  //  003A  GETGBL	R11	G21
       0x7C240400,  //  003B  CALL	R9	2
       0x78260003,  //  003C  JMPF	R9	#0041
-      0x8C24110F,  //  003D  GETMET	R9	R8	K15
+      0x8C241129,  //  003D  GETMET	R9	R8	K41
       0x7C240200,  //  003E  CALL	R9	1
-      0x00261C09,  //  003F  ADD	R9	K14	R9
+      0x00263809,  //  003F  ADD	R9	K28	R9
       0x5C201200,  //  0040  MOVE	R8	R9
       0x5C240A00,  //  0041  MOVE	R9	R5
       0x74260002,  //  0042  JMPT	R9	#0046
-      0x8C240302,  //  0043  GETMET	R9	R1	K2
-      0x582C0010,  //  0044  LDCONST	R11	K16
+      0x8C240357,  //  0043  GETMET	R9	R1	K87
+      0x582C0031,  //  0044  LDCONST	R11	K49
       0x7C240400,  //  0045  CALL	R9	2
-      0x8C240302,  //  0046  GETMET	R9	R1	K2
+      0x8C240357,  //  0046  GETMET	R9	R1	K87
       0x602C0018,  //  0047  GETGBL	R11	G24
-      0x58300011,  //  0048  LDCONST	R12	K17
-      0x8C340512,  //  0049  GETMET	R13	R2	K18
+      0x5830002A,  //  0048  LDCONST	R12	K42
+      0x8C34052B,  //  0049  GETMET	R13	R2	K43
       0x603C0008,  //  004A  GETGBL	R15	G8
       0x5C400E00,  //  004B  MOVE	R16	R7
       0x7C3C0200,  //  004C  CALL	R15	1
       0x7C340400,  //  004D  CALL	R13	2
-      0x8C380512,  //  004E  GETMET	R14	R2	K18
+      0x8C38052B,  //  004E  GETMET	R14	R2	K43
       0x5C401000,  //  004F  MOVE	R16	R8
       0x7C380400,  //  0050  CALL	R14	2
       0x7C2C0600,  //  0051  CALL	R11	3
       0x7C240400,  //  0052  CALL	R9	2
       0x50140000,  //  0053  LDBOOL	R5	0	0
       0x7001FFD8,  //  0054  JMP		#002E
-      0x5818000B,  //  0055  LDCONST	R6	K11
+      0x5818001E,  //  0055  LDCONST	R6	K30
       0xAC180200,  //  0056  CATCH	R6	1	0
       0xB0080000,  //  0057  RAISE	2	R0	R0
       0x50180200,  //  0058  LDBOOL	R6	1	0
       0x601C0010,  //  0059  GETGBL	R7	G16
-      0x88200113,  //  005A  GETMBR	R8	R0	K19
-      0x8C201114,  //  005B  GETMET	R8	R8	K20
+      0x8820012C,  //  005A  GETMBR	R8	R0	K44
+      0x8C20112D,  //  005B  GETMET	R8	R8	K45
       0x7C200200,  //  005C  CALL	R8	1
       0x7C1C0200,  //  005D  CALL	R7	1
       0xA802000F,  //  005E  EXBLK	0	#006F
       0x5C200E00,  //  005F  MOVE	R8	R7
       0x7C200000,  //  0060  CALL	R8	0
       0x781A0003,  //  0061  JMPF	R6	#0066
-      0x8C240302,  //  0062  GETMET	R9	R1	K2
-      0x582C0015,  //  0063  LDCONST	R11	K21
+      0x8C240357,  //  0062  GETMET	R9	R1	K87
+      0x582C0058,  //  0063  LDCONST	R11	K88
       0x7C240400,  //  0064  CALL	R9	2
       0x70020002,  //  0065  JMP		#0069
-      0x8C240302,  //  0066  GETMET	R9	R1	K2
-      0x582C0010,  //  0067  LDCONST	R11	K16
+      0x8C240357,  //  0066  GETMET	R9	R1	K87
+      0x582C0031,  //  0067  LDCONST	R11	K49
       0x7C240400,  //  0068  CALL	R9	2
-      0x8C240302,  //  0069  GETMET	R9	R1	K2
-      0x8C2C1116,  //  006A  GETMET	R11	R8	K22
+      0x8C240357,  //  0069  GETMET	R9	R1	K87
+      0x8C2C112E,  //  006A  GETMET	R11	R8	K46
       0x7C2C0200,  //  006B  CALL	R11	1
       0x7C240400,  //  006C  CALL	R9	2
       0x50180000,  //  006D  LDBOOL	R6	0	0
       0x7001FFEF,  //  006E  JMP		#005F
-      0x581C000B,  //  006F  LDCONST	R7	K11
+      0x581C001E,  //  006F  LDCONST	R7	K30
       0xAC1C0200,  //  0070  CATCH	R7	1	0
       0xB0080000,  //  0071  RAISE	2	R0	R0
       0x5C1C0C00,  //  0072  MOVE	R7	R6
       0x741E0002,  //  0073  JMPT	R7	#0077
-      0x8C1C0302,  //  0074  GETMET	R7	R1	K2
-      0x58240017,  //  0075  LDCONST	R9	K23
+      0x8C1C0357,  //  0074  GETMET	R7	R1	K87
+      0x58240032,  //  0075  LDCONST	R9	K50
       0x7C1C0400,  //  0076  CALL	R7	2
-      0x8C1C0118,  //  0077  GETMET	R7	R0	K24
+      0x8C1C0134,  //  0077  GETMET	R7	R0	K52
       0x7C1C0200,  //  0078  CALL	R7	1
-      0x8C1C0302,  //  0079  GETMET	R7	R1	K2
-      0x58240019,  //  007A  LDCONST	R9	K25
+      0x8C1C0357,  //  0079  GETMET	R7	R1	K87
+      0x58240036,  //  007A  LDCONST	R9	K54
       0x7C1C0400,  //  007B  CALL	R7	2
       0x80000000,  //  007C  RET	0
     })
@@ -1331,53 +1277,40 @@ be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Counter),
-    /* K7   */  be_nested_str_weak(is_greater),
-    /* K8   */  be_nested_str_weak(counter_group_ctrl_snd),
-    /* K9   */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K10  */  be_nested_str_weak(does_persist),
-    /* K11  */  be_nested_str_weak(save),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(counter_group_ctrl_snd_next),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8804013A,  //  0000  GETMBR	R1	R0	K58
+      0x8C04034A,  //  0001  GETMET	R1	R1	K74
       0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0xB80A0200,  //  0003  GETNGBL	R2	K1
       0x600C0018,  //  0004  GETGBL	R3	G24
-      0x58100003,  //  0005  LDCONST	R4	K3
+      0x58100059,  //  0005  LDCONST	R4	K89
       0x5C140200,  //  0006  MOVE	R5	R1
       0x7C0C0400,  //  0007  CALL	R3	2
-      0x58100004,  //  0008  LDCONST	R4	K4
+      0x58100007,  //  0008  LDCONST	R4	K7
       0x7C080400,  //  0009  CALL	R2	2
-      0xB80A0A00,  //  000A  GETNGBL	R2	K5
-      0x88080506,  //  000B  GETMBR	R2	R2	K6
-      0x8C080507,  //  000C  GETMET	R2	R2	K7
+      0xB80A2200,  //  000A  GETNGBL	R2	K17
+      0x8808054C,  //  000B  GETMBR	R2	R2	K76
+      0x8C08054D,  //  000C  GETMET	R2	R2	K77
       0x5C100200,  //  000D  MOVE	R4	R1
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x8814013B,  //  000E  GETMBR	R5	R0	K59
       0x7C080600,  //  000F  CALL	R2	3
       0x780A0007,  //  0010  JMPF	R2	#0019
-      0x88080109,  //  0011  GETMBR	R2	R0	K9
+      0x8808014E,  //  0011  GETMBR	R2	R0	K78
       0x00080202,  //  0012  ADD	R2	R1	R2
-      0x90021002,  //  0013  SETMBR	R0	K8	R2
-      0x8C08010A,  //  0014  GETMET	R2	R0	K10
+      0x90027602,  //  0013  SETMBR	R0	K59	R2
+      0x8C08014F,  //  0014  GETMET	R2	R0	K79
       0x7C080200,  //  0015  CALL	R2	1
       0x780A0001,  //  0016  JMPF	R2	#0019
-      0x8C08010B,  //  0017  GETMET	R2	R0	K11
+      0x8C080150,  //  0017  GETMET	R2	R0	K80
       0x7C080200,  //  0018  CALL	R2	1
       0x80040200,  //  0019  RET	1	R1
     })
@@ -1393,28 +1326,23 @@ be_local_closure(class_Matter_Fabric_fabric_candidate,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(assign_fabric_index),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(add_fabric),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(fabric_candidate),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04015A,  //  0000  GETMET	R1	R0	K90
       0x540E0077,  //  0001  LDINT	R3	120
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x8C040147,  //  0003  GETMET	R1	R0	K71
       0x7C040200,  //  0004  CALL	R1	1
-      0x88040102,  //  0005  GETMBR	R1	R0	K2
-      0x8C040303,  //  0006  GETMET	R1	R1	K3
+      0x88040148,  //  0005  GETMBR	R1	R0	K72
+      0x8C040349,  //  0006  GETMET	R1	R1	K73
       0x5C0C0000,  //  0007  MOVE	R3	R0
       0x7C040400,  //  0008  CALL	R1	2
       0x80000000,  //  0009  RET	0
@@ -1431,29 +1359,24 @@ be_local_closure(class_Matter_Fabric_assign_fabric_index,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_fabric_index),
-    /* K1   */  be_nested_str_weak(set_fabric_index),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(next_fabric_idx),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(assign_fabric_index),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040140,  //  0000  GETMET	R1	R0	K64
       0x7C040200,  //  0001  CALL	R1	1
       0x4C080000,  //  0002  LDNIL	R2
       0x1C040202,  //  0003  EQ	R1	R1	R2
       0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C040101,  //  0005  GETMET	R1	R0	K1
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x8C04015B,  //  0005  GETMET	R1	R0	K91
+      0x880C0148,  //  0006  GETMBR	R3	R0	K72
+      0x8C0C075C,  //  0007  GETMET	R3	R3	K92
       0x7C0C0200,  //  0008  CALL	R3	1
       0x7C040400,  //  0009  CALL	R1	2
       0x80000000,  //  000A  RET	0
@@ -1470,49 +1393,44 @@ be_local_closure(class_Matter_Fabric_get_old_recent_session,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(last_used),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_old_recent_session),
     &be_const_str_solidified,
     ( &(const binstruction[30]) {  /* code */
       0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x880C012C,  //  0001  GETMBR	R3	R0	K44
       0x7C080200,  //  0002  CALL	R2	1
-      0x1C080501,  //  0003  EQ	R2	R2	K1
+      0x1C080514,  //  0003  EQ	R2	R2	K20
       0x780A0001,  //  0004  JMPF	R2	#0007
       0x4C080000,  //  0005  LDNIL	R2
       0x80040400,  //  0006  RET	1	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x94080501,  //  0008  GETIDX	R2	R2	K1
-      0x880C0502,  //  0009  GETMBR	R3	R2	K2
-      0x58100003,  //  000A  LDCONST	R4	K3
+      0x8808012C,  //  0007  GETMBR	R2	R0	K44
+      0x94080514,  //  0008  GETIDX	R2	R2	K20
+      0x880C055D,  //  0009  GETMBR	R3	R2	K93
+      0x5810005E,  //  000A  LDCONST	R4	K94
       0x6014000C,  //  000B  GETGBL	R5	G12
-      0x88180100,  //  000C  GETMBR	R6	R0	K0
+      0x8818012C,  //  000C  GETMBR	R6	R0	K44
       0x7C140200,  //  000D  CALL	R5	1
       0x14140805,  //  000E  LT	R5	R4	R5
       0x7816000C,  //  000F  JMPF	R5	#001D
-      0x88140100,  //  0010  GETMBR	R5	R0	K0
+      0x8814012C,  //  0010  GETMBR	R5	R0	K44
       0x94140A04,  //  0011  GETIDX	R5	R5	R4
-      0x88140B02,  //  0012  GETMBR	R5	R5	K2
+      0x88140B5D,  //  0012  GETMBR	R5	R5	K93
       0x78060001,  //  0013  JMPF	R1	#0016
       0x14180A03,  //  0014  LT	R6	R5	R3
       0x70020000,  //  0015  JMP		#0017
       0x24180A03,  //  0016  GT	R6	R5	R3
       0x781A0002,  //  0017  JMPF	R6	#001B
-      0x88180100,  //  0018  GETMBR	R6	R0	K0
+      0x8818012C,  //  0018  GETMBR	R6	R0	K44
       0x94080C04,  //  0019  GETIDX	R2	R6	R4
       0x5C0C0A00,  //  001A  MOVE	R3	R5
-      0x00100903,  //  001B  ADD	R4	R4	K3
+      0x0010095E,  //  001B  ADD	R4	R4	K94
       0x7001FFED,  //  001C  JMP		#000B
       0x80040400,  //  001D  RET	1	R2
     })
@@ -1528,65 +1446,47 @@ be_local_closure(class_Matter_Fabric_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(_sessions),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Expirable_list),
-    /* K5   */  be_nested_str_weak(fabric_label),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(created),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(rtc_utc),
-    /* K10  */  be_nested_str_weak(_counter_group_data_snd_impl),
-    /* K11  */  be_nested_str_weak(Counter),
-    /* K12  */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
-    /* K13  */  be_nested_str_weak(counter_group_data_snd),
-    /* K14  */  be_nested_str_weak(next),
-    /* K15  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K16  */  be_nested_str_weak(counter_group_ctrl_snd),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0xB80E0600,  //  0002  GETNGBL	R3	K3
-      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
+      0xA40ABE00,  //  0000  IMPORT	R2	K95
+      0x90029001,  //  0001  SETMBR	R0	K72	R1
+      0xB80E2200,  //  0002  GETNGBL	R3	K17
+      0x8C0C0760,  //  0003  GETMET	R3	R3	K96
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x90020403,  //  0005  SETMBR	R0	K2	R3
-      0x90020B06,  //  0006  SETMBR	R0	K5	K6
-      0xB80E1000,  //  0007  GETNGBL	R3	K8
-      0x8C0C0709,  //  0008  GETMET	R3	R3	K9
+      0x90025803,  //  0005  SETMBR	R0	K44	R3
+      0x9002C362,  //  0006  SETMBR	R0	K97	K98
+      0xB80EC800,  //  0007  GETNGBL	R3	K100
+      0x8C0C0765,  //  0008  GETMET	R3	R3	K101
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x90020E03,  //  000A  SETMBR	R0	K7	R3
-      0xB80E0600,  //  000B  GETNGBL	R3	K3
-      0x8C0C070B,  //  000C  GETMET	R3	R3	K11
+      0x9002C603,  //  000A  SETMBR	R0	K99	R3
+      0xB80E2200,  //  000B  GETNGBL	R3	K17
+      0x8C0C074C,  //  000C  GETMET	R3	R3	K76
       0x7C0C0200,  //  000D  CALL	R3	1
-      0x90021403,  //  000E  SETMBR	R0	K10	R3
-      0xB80E0600,  //  000F  GETNGBL	R3	K3
-      0x8C0C070B,  //  0010  GETMET	R3	R3	K11
+      0x90026E03,  //  000E  SETMBR	R0	K55	R3
+      0xB80E2200,  //  000F  GETNGBL	R3	K17
+      0x8C0C074C,  //  0010  GETMET	R3	R3	K76
       0x7C0C0200,  //  0011  CALL	R3	1
-      0x90021803,  //  0012  SETMBR	R0	K12	R3
-      0x880C010A,  //  0013  GETMBR	R3	R0	K10
-      0x8C0C070E,  //  0014  GETMET	R3	R3	K14
+      0x90027403,  //  0012  SETMBR	R0	K58	R3
+      0x880C0137,  //  0013  GETMBR	R3	R0	K55
+      0x8C0C074A,  //  0014  GETMET	R3	R3	K74
       0x7C0C0200,  //  0015  CALL	R3	1
-      0x8810010F,  //  0016  GETMBR	R4	R0	K15
+      0x8810014E,  //  0016  GETMBR	R4	R0	K78
       0x000C0604,  //  0017  ADD	R3	R3	R4
-      0x90021A03,  //  0018  SETMBR	R0	K13	R3
-      0x880C010A,  //  0019  GETMBR	R3	R0	K10
-      0x8C0C070E,  //  001A  GETMET	R3	R3	K14
+      0x90027203,  //  0018  SETMBR	R0	K57	R3
+      0x880C0137,  //  0019  GETMBR	R3	R0	K55
+      0x8C0C074A,  //  001A  GETMET	R3	R3	K74
       0x7C0C0200,  //  001B  CALL	R3	1
-      0x8810010F,  //  001C  GETMBR	R4	R0	K15
+      0x8810014E,  //  001C  GETMBR	R4	R0	K78
       0x000C0604,  //  001D  ADD	R3	R3	R4
-      0x90022003,  //  001E  SETMBR	R0	K16	R3
+      0x90027603,  //  001E  SETMBR	R0	K59	R3
       0x80000000,  //  001F  RET	0
     })
   )
@@ -1601,19 +1501,17 @@ be_local_closure(class_Matter_Fabric_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804013D,  //  0000  GETMBR	R1	R0	K61
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1628,54 +1526,45 @@ be_local_closure(class_Matter_Fabric_add_session,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(_MAX_CASE),
-    /* K3   */  be_nested_str_weak(get_oldest_session),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_nested_str_weak(_store),
-    /* K6   */  be_nested_str_weak(remove_session),
-    /* K7   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(add_session),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808012C,  //  0000  GETMBR	R2	R0	K44
+      0x8C080516,  //  0001  GETMET	R2	R2	K22
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C080403,  //  0005  EQ	R2	R2	R3
       0x780A0017,  //  0006  JMPF	R2	#001F
       0x6008000C,  //  0007  GETGBL	R2	G12
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x880C012C,  //  0008  GETMBR	R3	R0	K44
       0x7C080200,  //  0009  CALL	R2	1
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x880C0166,  //  000A  GETMBR	R3	R0	K102
       0x28080403,  //  000B  GE	R2	R2	R3
       0x780A000D,  //  000C  JMPF	R2	#001B
-      0x8C080103,  //  000D  GETMET	R2	R0	K3
+      0x8C080167,  //  000D  GETMET	R2	R0	K103
       0x7C080200,  //  000E  CALL	R2	1
-      0x880C0100,  //  000F  GETMBR	R3	R0	K0
-      0x8C0C0704,  //  0010  GETMET	R3	R3	K4
-      0x88140100,  //  0011  GETMBR	R5	R0	K0
-      0x8C140B01,  //  0012  GETMET	R5	R5	K1
+      0x880C012C,  //  000F  GETMBR	R3	R0	K44
+      0x8C0C0768,  //  0010  GETMET	R3	R3	K104
+      0x8814012C,  //  0011  GETMBR	R5	R0	K44
+      0x8C140B16,  //  0012  GETMET	R5	R5	K22
       0x5C1C0400,  //  0013  MOVE	R7	R2
       0x7C140400,  //  0014  CALL	R5	2
       0x7C0C0400,  //  0015  CALL	R3	2
-      0x880C0105,  //  0016  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0017  GETMET	R3	R3	K6
+      0x880C0148,  //  0016  GETMBR	R3	R0	K72
+      0x8C0C0769,  //  0017  GETMET	R3	R3	K105
       0x5C140400,  //  0018  MOVE	R5	R2
       0x7C0C0400,  //  0019  CALL	R3	2
       0x7001FFEB,  //  001A  JMP		#0007
-      0x88080100,  //  001B  GETMBR	R2	R0	K0
-      0x8C080507,  //  001C  GETMET	R2	R2	K7
+      0x8808012C,  //  001B  GETMBR	R2	R0	K44
+      0x8C080527,  //  001C  GETMET	R2	R2	K39
       0x5C100200,  //  001D  MOVE	R4	R1
       0x7C080400,  //  001E  CALL	R2	2
       0x80000000,  //  001F  RET	0
@@ -1692,19 +1581,17 @@ be_local_closure(class_Matter_Fabric_set_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(set_fabric_index),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x9002AC01,  //  0000  SETMBR	R0	K86	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1719,23 +1606,19 @@ be_local_closure(class_Matter_Fabric_get_device_id_as_int64,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int64),
-    /* K1   */  be_nested_str_weak(frombytes),
-    /* K2   */  be_nested_str_weak(device_id),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_device_id_as_int64),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0xB8068400,  //  0000  GETNGBL	R1	K66
+      0x8C040343,  //  0001  GETMET	R1	R1	K67
+      0x880C013E,  //  0002  GETMBR	R3	R0	K62
       0x7C040400,  //  0003  CALL	R1	2
       0x80040200,  //  0004  RET	1	R1
     })
@@ -1751,19 +1634,17 @@ be_local_closure(class_Matter_Fabric_get_fabric_label,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_label),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_fabric_label),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040161,  //  0000  GETMBR	R1	R0	K97
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1778,45 +1659,37 @@ be_local_closure(class_Matter_Fabric_get_ipk_group_key,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(_GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_ipk_group_key),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804013D,  //  0000  GETMBR	R1	R0	K61
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x88040109,  //  0004  GETMBR	R1	R0	K9
       0x4C080000,  //  0005  LDNIL	R2
       0x1C040202,  //  0006  EQ	R1	R1	R2
       0x78060001,  //  0007  JMPF	R1	#000A
       0x4C040000,  //  0008  LDNIL	R1
       0x80040200,  //  0009  RET	1	R1
-      0xA4060400,  //  000A  IMPORT	R1	K2
-      0x8C080303,  //  000B  GETMET	R2	R1	K3
+      0xA406BE00,  //  000A  IMPORT	R1	K95
+      0x8C08036A,  //  000B  GETMET	R2	R1	K106
       0x7C080200,  //  000C  CALL	R2	1
       0x600C0015,  //  000D  GETGBL	R3	G21
       0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
+      0x8C0C076B,  //  000F  GETMET	R3	R3	K107
+      0x8814016C,  //  0010  GETMBR	R5	R0	K108
       0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C100506,  //  0012  GETMET	R4	R2	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
-      0x881C0101,  //  0014  GETMBR	R7	R0	K1
+      0x8C10056D,  //  0012  GETMET	R4	R2	K109
+      0x8818013D,  //  0013  GETMBR	R6	R0	K61
+      0x881C0109,  //  0014  GETMBR	R7	R0	K9
       0x5C200600,  //  0015  MOVE	R8	R3
       0x5426000F,  //  0016  LDINT	R9	16
       0x7C100A00,  //  0017  CALL	R4	5
@@ -1834,24 +1707,20 @@ be_local_closure(class_Matter_Fabric_mark_for_deletion,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(deleted),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(rtc_utc),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(mark_for_deletion),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0xB806C800,  //  0000  GETNGBL	R1	K100
+      0x8C040365,  //  0001  GETMET	R1	R1	K101
       0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0x90028201,  //  0003  SETMBR	R0	K65	R1
       0x80000000,  //  0004  RET	0
     })
   )
@@ -1866,29 +1735,23 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor_name,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_vendor),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(get_vendor_name),
-    /* K4   */  be_nested_str_weak(0x_X2504X),
-    }),
+    &be_ktab_class_Matter_Fabric,     /* shared constants */
     be_str_weak(get_admin_vendor_name),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
       0x4C080000,  //  0001  LDNIL	R2
       0x1C080202,  //  0002  EQ	R2	R1	R2
       0x780A0000,  //  0003  JMPF	R2	#0005
-      0x80060200,  //  0004  RET	1	K1
-      0xB80A0400,  //  0005  GETNGBL	R2	K2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x8006C400,  //  0004  RET	1	K98
+      0xB80A2200,  //  0005  GETNGBL	R2	K17
+      0x8C08056E,  //  0006  GETMET	R2	R2	K110
       0x5C100200,  //  0007  MOVE	R4	R1
       0x7C080400,  //  0008  CALL	R2	2
       0x4C0C0000,  //  0009  LDNIL	R3
@@ -1897,7 +1760,7 @@ be_local_closure(class_Matter_Fabric_get_admin_vendor_name,   /* name */
       0x80040400,  //  000C  RET	1	R2
       0x70020004,  //  000D  JMP		#0013
       0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100004,  //  000F  LDCONST	R4	K4
+      0x5810006F,  //  000F  LDCONST	R4	K111
       0x5C140200,  //  0010  MOVE	R5	R1
       0x7C0C0400,  //  0011  CALL	R3	2
       0x80040600,  //  0012  RET	1	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -3,6 +3,89 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_HTTP_async' ktab size: 79, total: 152 (saved 584 bytes)
+static const bvalue be_ktab_class_Matter_HTTP_async[79] = {
+  /* K0   */  be_nested_str_weak(is_chunked),
+  /* K1   */  be_nested_str_weak(chunk_size),
+  /* K2   */  be_nested_str_weak(global),
+  /* K3   */  be_nested_str_weak(_re_http_chunk),
+  /* K4   */  be_nested_str_weak(match2),
+  /* K5   */  be_nested_str_weak(response),
+  /* K6   */  be_nested_str_weak(response_offset),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(0x),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(status),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(),
+  /* K13  */  be_nested_str_weak(close),
+  /* K14  */  be_nested_str_weak(payload),
+  /* K15  */  be_const_int(2147483647),
+  /* K16  */  be_nested_str_weak(string),
+  /* K17  */  be_nested_str_weak(tolower),
+  /* K18  */  be_nested_str_weak(transfer_X2Dencoding),
+  /* K19  */  be_nested_str_weak(chunked),
+  /* K20  */  be_nested_str_weak(find),
+  /* K21  */  be_nested_str_weak(_X40),
+  /* K22  */  be_const_int(0),
+  /* K23  */  be_nested_str_weak(auth),
+  /* K24  */  be_nested_str_weak(fromstring),
+  /* K25  */  be_const_int(1),
+  /* K26  */  be_nested_str_weak(tob64),
+  /* K27  */  be_nested_str_weak(init),
+  /* K28  */  be_nested_str_weak(compile_re),
+  /* K29  */  be_nested_str_weak(phase),
+  /* K30  */  be_nested_str_weak(parse_http_status_line),
+  /* K31  */  be_nested_str_weak(parse_http_headers),
+  /* K32  */  be_const_int(2),
+  /* K33  */  be_nested_str_weak(parse_http_payload),
+  /* K34  */  be_nested_str_weak(http_status),
+  /* K35  */  be_nested_str_weak(event_http_failed),
+  /* K36  */  be_nested_str_weak(reset),
+  /* K37  */  be_nested_str_weak(cmd),
+  /* K38  */  be_nested_str_weak(begin),
+  /* K39  */  be_nested_str_weak(send_http),
+  /* K40  */  be_nested_str_weak(_re_http_header),
+  /* K41  */  be_nested_str_weak(event_http_header),
+  /* K42  */  be_nested_str_weak(_re_http_body),
+  /* K43  */  be_nested_str_weak(event_http_headers_end),
+  /* K44  */  be_nested_str_weak(receive),
+  /* K45  */  be_nested_str_weak(event_http_timeout),
+  /* K46  */  be_nested_str_weak(re),
+  /* K47  */  be_nested_str_weak(contains),
+  /* K48  */  be_nested_str_weak(_re_http_status),
+  /* K49  */  be_nested_str_weak(compile),
+  /* K50  */  be_nested_str_weak(HTTP_STATUS_REGEX),
+  /* K51  */  be_nested_str_weak(HTTP_HEADER_REGEX),
+  /* K52  */  be_nested_str_weak(HTTP_BODY_REGEX),
+  /* K53  */  be_nested_str_weak(HTTP_CHUNK_REGEX),
+  /* K54  */  be_nested_str_weak(event_http_finished),
+  /* K55  */  be_nested_str_weak(timeout),
+  /* K56  */  be_nested_str_weak(set_timeout),
+  /* K57  */  be_nested_str_weak(SPINLOCK),
+  /* K58  */  be_nested_str_weak(loop),
+  /* K59  */  be_nested_str_weak(tasmota),
+  /* K60  */  be_nested_str_weak(delay),
+  /* K61  */  be_nested_str_weak(addr),
+  /* K62  */  be_nested_str_weak(_X3A),
+  /* K63  */  be_nested_str_weak(_X5B),
+  /* K64  */  be_nested_str_weak(_X5D),
+  /* K65  */  be_nested_str_weak(HTTP_GET),
+  /* K66  */  be_nested_str_weak(port),
+  /* K67  */  be_nested_str_weak(HTTP_GET_AUTH),
+  /* K68  */  be_nested_str_weak(write),
+  /* K69  */  be_const_int(2147483647),
+  /* K70  */  be_nested_str_weak(status_code),
+  /* K71  */  be_const_int(1),
+  /* K72  */  be_nested_str_weak(tcp_connected),
+  /* K73  */  be_nested_str_weak(millis),
+  /* K74  */  be_nested_str_weak(time_start),
+  /* K75  */  be_nested_str_weak(tcp),
+  /* K76  */  be_nested_str_weak(available),
+  /* K77  */  be_nested_str_weak(read),
+  /* K78  */  be_nested_str_weak(parse_http_response),
+};
+
 
 extern const bclass be_class_Matter_HTTP_async;
 
@@ -13,30 +96,13 @@ be_local_closure(class_Matter_HTTP_async_parse_http_payload,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(is_chunked),
-    /* K1   */  be_nested_str_weak(chunk_size),
-    /* K2   */  be_nested_str_weak(global),
-    /* K3   */  be_nested_str_weak(_re_http_chunk),
-    /* K4   */  be_nested_str_weak(match2),
-    /* K5   */  be_nested_str_weak(response),
-    /* K6   */  be_nested_str_weak(response_offset),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(0x),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(),
-    /* K13  */  be_nested_str_weak(close),
-    /* K14  */  be_nested_str_weak(payload),
-    /* K15  */  be_const_int(2147483647),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(parse_http_payload),
     &be_const_str_solidified,
     ( &(const binstruction[82]) {  /* code */
@@ -135,13 +201,13 @@ be_local_closure(class_Matter_HTTP_async_event_http_finished,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_finished),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -159,40 +225,34 @@ be_local_closure(class_Matter_HTTP_async_event_http_header,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tolower),
-    /* K2   */  be_nested_str_weak(transfer_X2Dencoding),
-    /* K3   */  be_nested_str_weak(chunked),
-    /* K4   */  be_nested_str_weak(is_chunked),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_header),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100701,  //  0001  GETMET	R4	R3	K1
+      0xA40E2000,  //  0000  IMPORT	R3	K16
+      0x8C100711,  //  0001  GETMET	R4	R3	K17
       0x5C180200,  //  0002  MOVE	R6	R1
       0x7C100400,  //  0003  CALL	R4	2
       0x5C040800,  //  0004  MOVE	R1	R4
-      0x8C100701,  //  0005  GETMET	R4	R3	K1
+      0x8C100711,  //  0005  GETMET	R4	R3	K17
       0x5C180400,  //  0006  MOVE	R6	R2
       0x7C100400,  //  0007  CALL	R4	2
       0x5C080800,  //  0008  MOVE	R2	R4
-      0x1C100302,  //  0009  EQ	R4	R1	K2
+      0x1C100312,  //  0009  EQ	R4	R1	K18
       0x78120006,  //  000A  JMPF	R4	#0012
-      0x8C100701,  //  000B  GETMET	R4	R3	K1
+      0x8C100711,  //  000B  GETMET	R4	R3	K17
       0x5C180400,  //  000C  MOVE	R6	R2
       0x7C100400,  //  000D  CALL	R4	2
-      0x1C100903,  //  000E  EQ	R4	R4	K3
+      0x1C100913,  //  000E  EQ	R4	R4	K19
       0x78120001,  //  000F  JMPF	R4	#0012
       0x50100200,  //  0010  LDBOOL	R4	1	0
-      0x90020804,  //  0011  SETMBR	R0	K4	R4
+      0x90020004,  //  0011  SETMBR	R0	K0	R4
       0x80000000,  //  0012  RET	0
     })
   )
@@ -207,62 +267,50 @@ be_local_closure(class_Matter_HTTP_async_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(_X40),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(auth),
-    /* K5   */  be_nested_str_weak(fromstring),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(tob64),
-    /* K8   */  be_const_int(2147483647),
-    /* K9   */  be_nested_str_weak(init),
-    /* K10  */  be_nested_str_weak(compile_re),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[36]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
+      0xA4162000,  //  0000  IMPORT	R5	K16
       0x60180008,  //  0001  GETGBL	R6	G8
       0x5C1C0200,  //  0002  MOVE	R7	R1
       0x7C180200,  //  0003  CALL	R6	1
       0x5C040C00,  //  0004  MOVE	R1	R6
-      0x8C180B01,  //  0005  GETMET	R6	R5	K1
+      0x8C180B14,  //  0005  GETMET	R6	R5	K20
       0x5C200200,  //  0006  MOVE	R8	R1
-      0x58240002,  //  0007  LDCONST	R9	K2
+      0x58240015,  //  0007  LDCONST	R9	K21
       0x7C180600,  //  0008  CALL	R6	3
-      0x281C0D03,  //  0009  GE	R7	R6	K3
+      0x281C0D16,  //  0009  GE	R7	R6	K22
       0x781E000C,  //  000A  JMPF	R7	#0018
       0x601C0015,  //  000B  GETGBL	R7	G21
       0x7C1C0000,  //  000C  CALL	R7	0
-      0x8C1C0F05,  //  000D  GETMET	R7	R7	K5
-      0x04240D06,  //  000E  SUB	R9	R6	K6
-      0x40260609,  //  000F  CONNECT	R9	K3	R9
+      0x8C1C0F18,  //  000D  GETMET	R7	R7	K24
+      0x04240D19,  //  000E  SUB	R9	R6	K25
+      0x40262C09,  //  000F  CONNECT	R9	K22	R9
       0x94240209,  //  0010  GETIDX	R9	R1	R9
       0x7C1C0400,  //  0011  CALL	R7	2
-      0x8C1C0F07,  //  0012  GETMET	R7	R7	K7
+      0x8C1C0F1A,  //  0012  GETMET	R7	R7	K26
       0x7C1C0200,  //  0013  CALL	R7	1
-      0x90020807,  //  0014  SETMBR	R0	K4	R7
-      0x001C0D06,  //  0015  ADD	R7	R6	K6
-      0x401C0F08,  //  0016  CONNECT	R7	R7	K8
+      0x90022E07,  //  0014  SETMBR	R0	K23	R7
+      0x001C0D19,  //  0015  ADD	R7	R6	K25
+      0x401C0F0F,  //  0016  CONNECT	R7	R7	K15
       0x94040207,  //  0017  GETIDX	R1	R1	R7
       0x601C0003,  //  0018  GETGBL	R7	G3
       0x5C200000,  //  0019  MOVE	R8	R0
       0x7C1C0200,  //  001A  CALL	R7	1
-      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
+      0x8C1C0F1B,  //  001B  GETMET	R7	R7	K27
       0x5C240200,  //  001C  MOVE	R9	R1
       0x5C280400,  //  001D  MOVE	R10	R2
       0x5C2C0600,  //  001E  MOVE	R11	R3
       0x5C300800,  //  001F  MOVE	R12	R4
       0x7C1C0A00,  //  0020  CALL	R7	5
-      0x8C1C010A,  //  0021  GETMET	R7	R0	K10
+      0x8C1C011C,  //  0021  GETMET	R7	R0	K28
       0x7C1C0200,  //  0022  CALL	R7	1
       0x80000000,  //  0023  RET	0
     })
@@ -278,13 +326,13 @@ be_local_closure(class_Matter_HTTP_async_event_http_failed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_failed),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -302,40 +350,32 @@ be_local_closure(class_Matter_HTTP_async_parse_http_response,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(phase),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(parse_http_status_line),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(parse_http_headers),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(parse_http_payload),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(parse_http_response),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x8804011D,  //  0000  GETMBR	R1	R0	K29
+      0x1C040316,  //  0001  EQ	R1	R1	K22
       0x78060002,  //  0002  JMPF	R1	#0006
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x8C04011E,  //  0003  GETMET	R1	R0	K30
       0x7C040200,  //  0004  CALL	R1	1
       0x7002000A,  //  0005  JMP		#0011
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x1C040303,  //  0007  EQ	R1	R1	K3
+      0x8804011D,  //  0006  GETMBR	R1	R0	K29
+      0x1C040319,  //  0007  EQ	R1	R1	K25
       0x78060002,  //  0008  JMPF	R1	#000C
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x8C04011F,  //  0009  GETMET	R1	R0	K31
       0x7C040200,  //  000A  CALL	R1	1
       0x70020004,  //  000B  JMP		#0011
-      0x88040100,  //  000C  GETMBR	R1	R0	K0
-      0x1C040305,  //  000D  EQ	R1	R1	K5
+      0x8804011D,  //  000C  GETMBR	R1	R0	K29
+      0x1C040320,  //  000D  EQ	R1	R1	K32
       0x78060001,  //  000E  JMPF	R1	#0011
-      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x8C040121,  //  000F  GETMET	R1	R0	K33
       0x7C040200,  //  0010  CALL	R1	1
       0x80000000,  //  0011  RET	0
     })
@@ -351,22 +391,19 @@ be_local_closure(class_Matter_HTTP_async_event_refused,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_status),
-    /* K1   */  be_nested_str_weak(event_http_failed),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_refused),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x5405FFFE,  //  0000  LDINT	R1	-1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x90024401,  //  0001  SETMBR	R0	K34	R1
+      0x8C040123,  //  0002  GETMET	R1	R0	K35
       0x7C040200,  //  0003  CALL	R1	1
       0x80000000,  //  0004  RET	0
     })
@@ -382,45 +419,33 @@ be_local_closure(class_Matter_HTTP_async_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(cmd),
-    /* K2   */  be_nested_str_weak(response),
-    /* K3   */  be_nested_str_weak(response_offset),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(payload),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(phase),
-    /* K8   */  be_nested_str_weak(http_status),
-    /* K9   */  be_nested_str_weak(is_chunked),
-    /* K10  */  be_nested_str_weak(chunk_size),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040324,  //  0003  GETMET	R1	R1	K36
       0x7C040200,  //  0004  CALL	R1	1
       0x4C040000,  //  0005  LDNIL	R1
-      0x90020201,  //  0006  SETMBR	R0	K1	R1
+      0x90024A01,  //  0006  SETMBR	R0	K37	R1
       0x4C040000,  //  0007  LDNIL	R1
-      0x90020401,  //  0008  SETMBR	R0	K2	R1
-      0x90020704,  //  0009  SETMBR	R0	K3	K4
-      0x90020B06,  //  000A  SETMBR	R0	K5	K6
-      0x90020F04,  //  000B  SETMBR	R0	K7	K4
-      0x90021104,  //  000C  SETMBR	R0	K8	K4
+      0x90020A01,  //  0008  SETMBR	R0	K5	R1
+      0x90020D16,  //  0009  SETMBR	R0	K6	K22
+      0x90021D0C,  //  000A  SETMBR	R0	K14	K12
+      0x90023B16,  //  000B  SETMBR	R0	K29	K22
+      0x90024516,  //  000C  SETMBR	R0	K34	K22
       0x50040000,  //  000D  LDBOOL	R1	0	0
-      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x90020001,  //  000E  SETMBR	R0	K0	R1
       0x4C040000,  //  000F  LDNIL	R1
-      0x90021401,  //  0010  SETMBR	R0	K10	R1
+      0x90020201,  //  0010  SETMBR	R0	K1	R1
       0x80000000,  //  0011  RET	0
     })
   )
@@ -435,25 +460,22 @@ be_local_closure(class_Matter_HTTP_async_begin,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(begin),
-    /* K1   */  be_nested_str_weak(cmd),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(begin),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080526,  //  0003  GETMET	R2	R2	K38
       0x7C080200,  //  0004  CALL	R2	1
-      0x90020201,  //  0005  SETMBR	R0	K1	R1
+      0x90024A01,  //  0005  SETMBR	R0	K37	R1
       0x80040400,  //  0006  RET	1	R2
     })
   )
@@ -468,19 +490,17 @@ be_local_closure(class_Matter_HTTP_async_event_established,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_http),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_established),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040127,  //  0000  GETMET	R1	R0	K39
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -496,66 +516,48 @@ be_local_closure(class_Matter_HTTP_async_parse_http_headers,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_re_http_header),
-    /* K2   */  be_nested_str_weak(match2),
-    /* K3   */  be_nested_str_weak(response),
-    /* K4   */  be_nested_str_weak(response_offset),
-    /* K5   */  be_nested_str_weak(event_http_header),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(_re_http_body),
-    /* K10  */  be_nested_str_weak(event_http_headers_end),
-    /* K11  */  be_nested_str_weak(phase),
-    /* K12  */  be_nested_str_weak(parse_http_payload),
-    /* K13  */  be_nested_str_weak(close),
-    /* K14  */  be_nested_str_weak(status),
-    /* K15  */  be_nested_str_weak(http_status),
-    /* K16  */  be_nested_str_weak(event_http_failed),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(parse_http_headers),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
       0x50040200,  //  0000  LDBOOL	R1	1	0
       0x7806002B,  //  0001  JMPF	R1	#002E
-      0xB8060000,  //  0002  GETNGBL	R1	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x88100104,  //  0006  GETMBR	R4	R0	K4
+      0xB8060400,  //  0002  GETNGBL	R1	K2
+      0x88040328,  //  0003  GETMBR	R1	R1	K40
+      0x8C040304,  //  0004  GETMET	R1	R1	K4
+      0x880C0105,  //  0005  GETMBR	R3	R0	K5
+      0x88100106,  //  0006  GETMBR	R4	R0	K6
       0x7C040600,  //  0007  CALL	R1	3
       0x78060008,  //  0008  JMPF	R1	#0012
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x94100306,  //  000A  GETIDX	R4	R1	K6
-      0x94140307,  //  000B  GETIDX	R5	R1	K7
+      0x8C080129,  //  0009  GETMET	R2	R0	K41
+      0x94100319,  //  000A  GETIDX	R4	R1	K25
+      0x94140320,  //  000B  GETIDX	R5	R1	K32
       0x7C080600,  //  000C  CALL	R2	3
-      0x88080104,  //  000D  GETMBR	R2	R0	K4
-      0x940C0308,  //  000E  GETIDX	R3	R1	K8
+      0x88080106,  //  000D  GETMBR	R2	R0	K6
+      0x940C0307,  //  000E  GETIDX	R3	R1	K7
       0x00080403,  //  000F  ADD	R2	R2	R3
-      0x90020802,  //  0010  SETMBR	R0	K4	R2
+      0x90020C02,  //  0010  SETMBR	R0	K6	R2
       0x7002001A,  //  0011  JMP		#002D
-      0xB80A0000,  //  0012  GETNGBL	R2	K0
-      0x88080509,  //  0013  GETMBR	R2	R2	K9
-      0x8C080502,  //  0014  GETMET	R2	R2	K2
-      0x88100103,  //  0015  GETMBR	R4	R0	K3
-      0x88140104,  //  0016  GETMBR	R5	R0	K4
+      0xB80A0400,  //  0012  GETNGBL	R2	K2
+      0x8808052A,  //  0013  GETMBR	R2	R2	K42
+      0x8C080504,  //  0014  GETMET	R2	R2	K4
+      0x88100105,  //  0015  GETMBR	R4	R0	K5
+      0x88140106,  //  0016  GETMBR	R5	R0	K6
       0x7C080600,  //  0017  CALL	R2	3
       0x780A0004,  //  0018  JMPF	R2	#001E
-      0x8C0C010A,  //  0019  GETMET	R3	R0	K10
+      0x8C0C012B,  //  0019  GETMET	R3	R0	K43
       0x7C0C0200,  //  001A  CALL	R3	1
-      0x90021707,  //  001B  SETMBR	R0	K11	K7
-      0x8C0C010C,  //  001C  GETMET	R3	R0	K12
+      0x90023B20,  //  001B  SETMBR	R0	K29	K32
+      0x8C0C0121,  //  001C  GETMET	R3	R0	K33
       0x7C0C0200,  //  001D  CALL	R3	1
       0x600C000C,  //  001E  GETGBL	R3	G12
-      0x88100103,  //  001F  GETMBR	R4	R0	K3
+      0x88100105,  //  001F  GETMBR	R4	R0	K5
       0x7C0C0200,  //  0020  CALL	R3	1
       0x541203FF,  //  0021  LDINT	R4	1024
       0x240C0604,  //  0022  GT	R3	R3	R4
@@ -563,10 +565,10 @@ be_local_closure(class_Matter_HTTP_async_parse_http_headers,   /* name */
       0x8C0C010D,  //  0024  GETMET	R3	R0	K13
       0x7C0C0200,  //  0025  CALL	R3	1
       0x540DFFFB,  //  0026  LDINT	R3	-4
-      0x90021C03,  //  0027  SETMBR	R0	K14	R3
+      0x90021403,  //  0027  SETMBR	R0	K10	R3
       0x540DFFFE,  //  0028  LDINT	R3	-1
-      0x90021E03,  //  0029  SETMBR	R0	K15	R3
-      0x8C0C0110,  //  002A  GETMET	R3	R0	K16
+      0x90024403,  //  0029  SETMBR	R0	K34	R3
+      0x8C0C0123,  //  002A  GETMET	R3	R0	K35
       0x7C0C0200,  //  002B  CALL	R3	1
       0x80000600,  //  002C  RET	0
       0x7001FFD1,  //  002D  JMP		#0000
@@ -584,19 +586,17 @@ be_local_closure(class_Matter_HTTP_async_event_available,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(receive),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_available),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04012C,  //  0000  GETMET	R1	R0	K44
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -612,22 +612,19 @@ be_local_closure(class_Matter_HTTP_async_event_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_status),
-    /* K1   */  be_nested_str_weak(event_http_timeout),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x5405FFFD,  //  0000  LDINT	R1	-2
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x90024401,  //  0001  SETMBR	R0	K34	R1
+      0x8C04012D,  //  0002  GETMET	R1	R0	K45
       0x7C040200,  //  0003  CALL	R1	1
       0x80000000,  //  0004  RET	0
     })
@@ -643,55 +640,42 @@ be_local_closure(class_Matter_HTTP_async_compile_re,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(re),
-    /* K1   */  be_nested_str_weak(global),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(_re_http_status),
-    /* K4   */  be_nested_str_weak(compile),
-    /* K5   */  be_nested_str_weak(HTTP_STATUS_REGEX),
-    /* K6   */  be_nested_str_weak(_re_http_header),
-    /* K7   */  be_nested_str_weak(HTTP_HEADER_REGEX),
-    /* K8   */  be_nested_str_weak(_re_http_body),
-    /* K9   */  be_nested_str_weak(HTTP_BODY_REGEX),
-    /* K10  */  be_nested_str_weak(_re_http_chunk),
-    /* K11  */  be_nested_str_weak(HTTP_CHUNK_REGEX),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(compile_re),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
+      0xA4065C00,  //  0000  IMPORT	R1	K46
+      0xB80A0400,  //  0001  GETNGBL	R2	K2
+      0x8C08052F,  //  0002  GETMET	R2	R2	K47
+      0x58100030,  //  0003  LDCONST	R4	K48
       0x7C080400,  //  0004  CALL	R2	2
       0x740A0013,  //  0005  JMPT	R2	#001A
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x8C0C0304,  //  0007  GETMET	R3	R1	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0xB80A0400,  //  0006  GETNGBL	R2	K2
+      0x8C0C0331,  //  0007  GETMET	R3	R1	K49
+      0x88140132,  //  0008  GETMBR	R5	R0	K50
       0x7C0C0400,  //  0009  CALL	R3	2
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0xB80A0200,  //  000B  GETNGBL	R2	K1
-      0x8C0C0304,  //  000C  GETMET	R3	R1	K4
-      0x88140107,  //  000D  GETMBR	R5	R0	K7
+      0x900A6003,  //  000A  SETMBR	R2	K48	R3
+      0xB80A0400,  //  000B  GETNGBL	R2	K2
+      0x8C0C0331,  //  000C  GETMET	R3	R1	K49
+      0x88140133,  //  000D  GETMBR	R5	R0	K51
       0x7C0C0400,  //  000E  CALL	R3	2
-      0x900A0C03,  //  000F  SETMBR	R2	K6	R3
-      0xB80A0200,  //  0010  GETNGBL	R2	K1
-      0x8C0C0304,  //  0011  GETMET	R3	R1	K4
-      0x88140109,  //  0012  GETMBR	R5	R0	K9
+      0x900A5003,  //  000F  SETMBR	R2	K40	R3
+      0xB80A0400,  //  0010  GETNGBL	R2	K2
+      0x8C0C0331,  //  0011  GETMET	R3	R1	K49
+      0x88140134,  //  0012  GETMBR	R5	R0	K52
       0x7C0C0400,  //  0013  CALL	R3	2
-      0x900A1003,  //  0014  SETMBR	R2	K8	R3
-      0xB80A0200,  //  0015  GETNGBL	R2	K1
-      0x8C0C0304,  //  0016  GETMET	R3	R1	K4
-      0x8814010B,  //  0017  GETMBR	R5	R0	K11
+      0x900A5403,  //  0014  SETMBR	R2	K42	R3
+      0xB80A0400,  //  0015  GETNGBL	R2	K2
+      0x8C0C0331,  //  0016  GETMET	R3	R1	K49
+      0x88140135,  //  0017  GETMBR	R5	R0	K53
       0x7C0C0400,  //  0018  CALL	R3	2
-      0x900A1403,  //  0019  SETMBR	R2	K10	R3
+      0x900A0603,  //  0019  SETMBR	R2	K3	R3
       0x80000000,  //  001A  RET	0
     })
   )
@@ -706,26 +690,21 @@ be_local_closure(class_Matter_HTTP_async_event_closed,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_status),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(event_http_finished),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_closed),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x88040122,  //  0000  GETMBR	R1	R0	K34
+      0x1C040316,  //  0001  EQ	R1	R1	K22
       0x78060002,  //  0002  JMPF	R1	#0006
-      0x90020102,  //  0003  SETMBR	R0	K0	K2
-      0x8C040103,  //  0004  GETMET	R1	R0	K3
+      0x90024509,  //  0003  SETMBR	R0	K34	K9
+      0x8C040136,  //  0004  GETMET	R1	R0	K54
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -741,57 +720,46 @@ be_local_closure(class_Matter_HTTP_async_begin_sync,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(timeout),
-    /* K1   */  be_nested_str_weak(set_timeout),
-    /* K2   */  be_nested_str_weak(SPINLOCK),
-    /* K3   */  be_nested_str_weak(begin),
-    /* K4   */  be_nested_str_weak(http_status),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(loop),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(delay),
-    /* K9   */  be_nested_str_weak(payload),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(begin_sync),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0137,  //  0000  GETMBR	R3	R0	K55
       0x4C100000,  //  0001  LDNIL	R4
       0x20100404,  //  0002  NE	R4	R2	R4
       0x78120002,  //  0003  JMPF	R4	#0007
-      0x8C100101,  //  0004  GETMET	R4	R0	K1
+      0x8C100138,  //  0004  GETMET	R4	R0	K56
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C100400,  //  0006  CALL	R4	2
       0x4C100000,  //  0007  LDNIL	R4
-      0x88140102,  //  0008  GETMBR	R5	R0	K2
-      0x8C180103,  //  0009  GETMET	R6	R0	K3
+      0x88140139,  //  0008  GETMBR	R5	R0	K57
+      0x8C180126,  //  0009  GETMET	R6	R0	K38
       0x5C200200,  //  000A  MOVE	R8	R1
       0x7C180400,  //  000B  CALL	R6	2
       0x781A0009,  //  000C  JMPF	R6	#0017
-      0x881C0104,  //  000D  GETMBR	R7	R0	K4
-      0x1C1C0F05,  //  000E  EQ	R7	R7	K5
+      0x881C0122,  //  000D  GETMBR	R7	R0	K34
+      0x1C1C0F16,  //  000E  EQ	R7	R7	K22
       0x781E0006,  //  000F  JMPF	R7	#0017
-      0x8C1C0106,  //  0010  GETMET	R7	R0	K6
+      0x8C1C013A,  //  0010  GETMET	R7	R0	K58
       0x7C1C0200,  //  0011  CALL	R7	1
-      0xB81E0E00,  //  0012  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0013  GETMET	R7	R7	K8
+      0xB81E7600,  //  0012  GETNGBL	R7	K59
+      0x8C1C0F3C,  //  0013  GETMET	R7	R7	K60
       0x5C240A00,  //  0014  MOVE	R9	R5
       0x7C1C0400,  //  0015  CALL	R7	2
       0x7001FFF5,  //  0016  JMP		#000D
-      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
+      0x8C1C0138,  //  0017  GETMET	R7	R0	K56
       0x5C240600,  //  0018  MOVE	R9	R3
       0x7C1C0400,  //  0019  CALL	R7	2
-      0x881C0104,  //  001A  GETMBR	R7	R0	K4
-      0x241C0F05,  //  001B  GT	R7	R7	K5
+      0x881C0122,  //  001A  GETMBR	R7	R0	K34
+      0x241C0F16,  //  001B  GT	R7	R7	K22
       0x781E0001,  //  001C  JMPF	R7	#001F
-      0x881C0109,  //  001D  GETMBR	R7	R0	K9
+      0x881C010E,  //  001D  GETMBR	R7	R0	K14
       0x70020000,  //  001E  JMP		#0020
       0x4C1C0000,  //  001F  LDNIL	R7
       0x80040E00,  //  0020  RET	1	R7
@@ -808,70 +776,50 @@ be_local_closure(class_Matter_HTTP_async_send_http,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(response),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(addr),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(_X3A),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_X5B),
-    /* K8   */  be_nested_str_weak(_X5D),
-    /* K9   */  be_nested_str_weak(auth),
-    /* K10  */  be_nested_str_weak(HTTP_GET),
-    /* K11  */  be_nested_str_weak(cmd),
-    /* K12  */  be_nested_str_weak(port),
-    /* K13  */  be_nested_str_weak(HTTP_GET_AUTH),
-    /* K14  */  be_nested_str_weak(write),
-    /* K15  */  be_nested_str_weak(close),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(http_status),
-    /* K18  */  be_nested_str_weak(event_http_failed),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(send_http),
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x90020302,  //  0001  SETMBR	R0	K1	K2
-      0x88080103,  //  0002  GETMBR	R2	R0	K3
-      0x8C0C0304,  //  0003  GETMET	R3	R1	K4
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0x90020B0C,  //  0001  SETMBR	R0	K5	K12
+      0x8808013D,  //  0002  GETMBR	R2	R0	K61
+      0x8C0C0314,  //  0003  GETMET	R3	R1	K20
       0x5C140400,  //  0004  MOVE	R5	R2
-      0x58180005,  //  0005  LDCONST	R6	K5
+      0x5818003E,  //  0005  LDCONST	R6	K62
       0x7C0C0600,  //  0006  CALL	R3	3
-      0x280C0706,  //  0007  GE	R3	R3	K6
+      0x280C0707,  //  0007  GE	R3	R3	K7
       0x780E0002,  //  0008  JMPF	R3	#000C
-      0x000E0E02,  //  0009  ADD	R3	K7	R2
-      0x000C0708,  //  000A  ADD	R3	R3	K8
+      0x000E7E02,  //  0009  ADD	R3	K63	R2
+      0x000C0740,  //  000A  ADD	R3	R3	K64
       0x5C080600,  //  000B  MOVE	R2	R3
       0x4C0C0000,  //  000C  LDNIL	R3
-      0x88100109,  //  000D  GETMBR	R4	R0	K9
+      0x88100117,  //  000D  GETMBR	R4	R0	K23
       0x4C140000,  //  000E  LDNIL	R5
       0x1C100805,  //  000F  EQ	R4	R4	R5
       0x78120007,  //  0010  JMPF	R4	#0019
       0x60100018,  //  0011  GETGBL	R4	G24
-      0x8814010A,  //  0012  GETMBR	R5	R0	K10
-      0x8818010B,  //  0013  GETMBR	R6	R0	K11
+      0x88140141,  //  0012  GETMBR	R5	R0	K65
+      0x88180125,  //  0013  GETMBR	R6	R0	K37
       0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x8820010C,  //  0015  GETMBR	R8	R0	K12
+      0x88200142,  //  0015  GETMBR	R8	R0	K66
       0x7C100800,  //  0016  CALL	R4	4
       0x5C0C0800,  //  0017  MOVE	R3	R4
       0x70020007,  //  0018  JMP		#0021
       0x60100018,  //  0019  GETGBL	R4	G24
-      0x8814010D,  //  001A  GETMBR	R5	R0	K13
-      0x8818010B,  //  001B  GETMBR	R6	R0	K11
+      0x88140143,  //  001A  GETMBR	R5	R0	K67
+      0x88180125,  //  001B  GETMBR	R6	R0	K37
       0x5C1C0400,  //  001C  MOVE	R7	R2
-      0x8820010C,  //  001D  GETMBR	R8	R0	K12
-      0x88240109,  //  001E  GETMBR	R9	R0	K9
+      0x88200142,  //  001D  GETMBR	R8	R0	K66
+      0x88240117,  //  001E  GETMBR	R9	R0	K23
       0x7C100A00,  //  001F  CALL	R4	5
       0x5C0C0800,  //  0020  MOVE	R3	R4
-      0x8C10010E,  //  0021  GETMET	R4	R0	K14
+      0x8C100144,  //  0021  GETMET	R4	R0	K68
       0x5C180600,  //  0022  MOVE	R6	R3
       0x7C100400,  //  0023  CALL	R4	2
       0x6014000C,  //  0024  GETGBL	R5	G12
@@ -879,13 +827,13 @@ be_local_closure(class_Matter_HTTP_async_send_http,   /* name */
       0x7C140200,  //  0026  CALL	R5	1
       0x20140805,  //  0027  NE	R5	R4	R5
       0x78160007,  //  0028  JMPF	R5	#0031
-      0x8C14010F,  //  0029  GETMET	R5	R0	K15
+      0x8C14010D,  //  0029  GETMET	R5	R0	K13
       0x7C140200,  //  002A  CALL	R5	1
       0x5415FFFB,  //  002B  LDINT	R5	-4
-      0x90022005,  //  002C  SETMBR	R0	K16	R5
+      0x90021405,  //  002C  SETMBR	R0	K10	R5
       0x5415FFFE,  //  002D  LDINT	R5	-1
-      0x90022205,  //  002E  SETMBR	R0	K17	R5
-      0x8C140112,  //  002F  GETMET	R5	R0	K18
+      0x90024405,  //  002E  SETMBR	R0	K34	R5
+      0x8C140123,  //  002F  GETMET	R5	R0	K35
       0x7C140200,  //  0030  CALL	R5	1
       0x80000000,  //  0031  RET	0
     })
@@ -901,30 +849,25 @@ be_local_closure(class_Matter_HTTP_async_event_http_headers_end,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(response_offset),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(response),
-    /* K3   */  be_const_int(2147483647),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_headers_end),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x24040301,  //  0001  GT	R1	R1	K1
+      0x88040106,  //  0000  GETMBR	R1	R0	K6
+      0x24040316,  //  0001  GT	R1	R1	K22
       0x78060005,  //  0002  JMPF	R1	#0009
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x40040303,  //  0004  CONNECT	R1	R1	K3
-      0x88080102,  //  0005  GETMBR	R2	R0	K2
+      0x88040106,  //  0003  GETMBR	R1	R0	K6
+      0x40040345,  //  0004  CONNECT	R1	R1	K69
+      0x88080105,  //  0005  GETMBR	R2	R0	K5
       0x94040401,  //  0006  GETIDX	R1	R2	R1
-      0x90020401,  //  0007  SETMBR	R0	K2	R1
-      0x90020101,  //  0008  SETMBR	R0	K0	K1
+      0x90020A01,  //  0007  SETMBR	R0	K5	R1
+      0x90020D16,  //  0008  SETMBR	R0	K6	K22
       0x80000000,  //  0009  RET	0
     })
   )
@@ -939,19 +882,17 @@ be_local_closure(class_Matter_HTTP_async_event_http_status_code,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status_code),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_status_code),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90028C01,  //  0000  SETMBR	R0	K70	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -966,56 +907,43 @@ be_local_closure(class_Matter_HTTP_async_parse_http_status_line,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_re_http_status),
-    /* K2   */  be_nested_str_weak(match2),
-    /* K3   */  be_nested_str_weak(response),
-    /* K4   */  be_nested_str_weak(response_offset),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status_code),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(phase),
-    /* K9   */  be_nested_str_weak(parse_http_headers),
-    /* K10  */  be_nested_str_weak(close),
-    /* K11  */  be_nested_str_weak(status),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(parse_http_status_line),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C040302,  //  0002  GETMET	R1	R1	K2
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x88100104,  //  0004  GETMBR	R4	R0	K4
+      0xB8060400,  //  0000  GETNGBL	R1	K2
+      0x88040330,  //  0001  GETMBR	R1	R1	K48
+      0x8C040304,  //  0002  GETMET	R1	R1	K4
+      0x880C0105,  //  0003  GETMBR	R3	R0	K5
+      0x88100106,  //  0004  GETMBR	R4	R0	K6
       0x7C040600,  //  0005  CALL	R1	3
       0x78060009,  //  0006  JMPF	R1	#0011
-      0x94080305,  //  0007  GETIDX	R2	R1	K5
-      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x94080307,  //  0007  GETIDX	R2	R1	K7
+      0x90020C02,  //  0008  SETMBR	R0	K6	R2
       0x60080009,  //  0009  GETGBL	R2	G9
-      0x940C0307,  //  000A  GETIDX	R3	R1	K7
+      0x940C0347,  //  000A  GETIDX	R3	R1	K71
       0x7C080200,  //  000B  CALL	R2	1
-      0x90020C02,  //  000C  SETMBR	R0	K6	R2
-      0x90021107,  //  000D  SETMBR	R0	K8	K7
-      0x8C080109,  //  000E  GETMET	R2	R0	K9
+      0x90028C02,  //  000C  SETMBR	R0	K70	R2
+      0x90023B47,  //  000D  SETMBR	R0	K29	K71
+      0x8C08011F,  //  000E  GETMET	R2	R0	K31
       0x7C080200,  //  000F  CALL	R2	1
       0x70020009,  //  0010  JMP		#001B
       0x6008000C,  //  0011  GETGBL	R2	G12
-      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
       0x7C080200,  //  0013  CALL	R2	1
       0x540E0063,  //  0014  LDINT	R3	100
       0x24080403,  //  0015  GT	R2	R2	R3
       0x780A0003,  //  0016  JMPF	R2	#001B
-      0x8C08010A,  //  0017  GETMET	R2	R0	K10
+      0x8C08010D,  //  0017  GETMET	R2	R0	K13
       0x7C080200,  //  0018  CALL	R2	1
       0x5409FFFB,  //  0019  LDINT	R2	-4
-      0x90021602,  //  001A  SETMBR	R0	K11	R2
+      0x90021402,  //  001A  SETMBR	R0	K10	R2
       0x80000000,  //  001B  RET	0
     })
   )
@@ -1030,13 +958,13 @@ be_local_closure(class_Matter_HTTP_async_event_http_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(event_http_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -1054,78 +982,62 @@ be_local_closure(class_Matter_HTTP_async_receive,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(time_start),
-    /* K4   */  be_nested_str_weak(timeout),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(close),
-    /* K7   */  be_nested_str_weak(http_status),
-    /* K8   */  be_nested_str_weak(event_http_timeout),
-    /* K9   */  be_nested_str_weak(tcp),
-    /* K10  */  be_nested_str_weak(available),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(read),
-    /* K13  */  be_nested_str_weak(response),
-    /* K14  */  be_nested_str_weak(parse_http_response),
-    }),
+    &be_ktab_class_Matter_HTTP_async,     /* shared constants */
     be_str_weak(receive),
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040148,  //  0000  GETMBR	R1	R0	K72
       0x50080200,  //  0001  LDBOOL	R2	1	0
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0xB8067600,  //  0005  GETNGBL	R1	K59
+      0x8C040349,  //  0006  GETMET	R1	R1	K73
       0x7C040200,  //  0007  CALL	R1	1
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x8808014A,  //  0008  GETMBR	R2	R0	K74
       0x04040202,  //  0009  SUB	R1	R1	R2
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x88080137,  //  000A  GETMBR	R2	R0	K55
       0x24040202,  //  000B  GT	R1	R1	R2
       0x78060008,  //  000C  JMPF	R1	#0016
       0x5405FFFC,  //  000D  LDINT	R1	-3
-      0x90020A01,  //  000E  SETMBR	R0	K5	R1
-      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x90021401,  //  000E  SETMBR	R0	K10	R1
+      0x8C04010D,  //  000F  GETMET	R1	R0	K13
       0x7C040200,  //  0010  CALL	R1	1
       0x5405FFFD,  //  0011  LDINT	R1	-2
-      0x90020E01,  //  0012  SETMBR	R0	K7	R1
-      0x8C040108,  //  0013  GETMET	R1	R0	K8
+      0x90024401,  //  0012  SETMBR	R0	K34	R1
+      0x8C04012D,  //  0013  GETMET	R1	R0	K45
       0x7C040200,  //  0014  CALL	R1	1
       0x70020018,  //  0015  JMP		#002F
-      0x88040109,  //  0016  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0017  GETMET	R1	R1	K10
+      0x8804014B,  //  0016  GETMBR	R1	R0	K75
+      0x8C04034C,  //  0017  GETMET	R1	R1	K76
       0x7C040200,  //  0018  CALL	R1	1
-      0x5808000B,  //  0019  LDCONST	R2	K11
-      0x240C030B,  //  001A  GT	R3	R1	K11
+      0x58080016,  //  0019  LDCONST	R2	K22
+      0x240C0316,  //  001A  GT	R3	R1	K22
       0x780E000E,  //  001B  JMPF	R3	#002B
-      0x880C0109,  //  001C  GETMBR	R3	R0	K9
-      0x8C0C070C,  //  001D  GETMET	R3	R3	K12
+      0x880C014B,  //  001C  GETMBR	R3	R0	K75
+      0x8C0C074D,  //  001D  GETMET	R3	R3	K77
       0x7C0C0200,  //  001E  CALL	R3	1
-      0x8810010D,  //  001F  GETMBR	R4	R0	K13
+      0x88100105,  //  001F  GETMBR	R4	R0	K5
       0x00100803,  //  0020  ADD	R4	R4	R3
-      0x90021A04,  //  0021  SETMBR	R0	K13	R4
+      0x90020A04,  //  0021  SETMBR	R0	K5	R4
       0x6010000C,  //  0022  GETGBL	R4	G12
       0x5C140600,  //  0023  MOVE	R5	R3
       0x7C100200,  //  0024  CALL	R4	1
       0x00080404,  //  0025  ADD	R2	R2	R4
-      0x88100109,  //  0026  GETMBR	R4	R0	K9
-      0x8C10090A,  //  0027  GETMET	R4	R4	K10
+      0x8810014B,  //  0026  GETMBR	R4	R0	K75
+      0x8C10094C,  //  0027  GETMET	R4	R4	K76
       0x7C100200,  //  0028  CALL	R4	1
       0x5C040800,  //  0029  MOVE	R1	R4
       0x7001FFEE,  //  002A  JMP		#001A
-      0x240C050B,  //  002B  GT	R3	R2	K11
+      0x240C0516,  //  002B  GT	R3	R2	K22
       0x780E0001,  //  002C  JMPF	R3	#002F
-      0x8C0C010E,  //  002D  GETMET	R3	R0	K14
+      0x8C0C014E,  //  002D  GETMET	R3	R0	K78
       0x7C0C0200,  //  002E  CALL	R3	1
       0x80000000,  //  002F  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -3,6 +3,95 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_HTTP_remote' ktab size: 85, total: 161 (saved 608 bytes)
+static const bvalue be_ktab_class_Matter_HTTP_remote[85] = {
+  /* K0   */  be_nested_str_weak(probe_update_time_map),
+  /* K1   */  be_nested_str_weak(contains),
+  /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
+  /* K3   */  be_nested_str_weak(matter),
+  /* K4   */  be_nested_str_weak(jitter),
+  /* K5   */  be_nested_str_weak(add_async_cb),
+  /* K6   */  be_const_int(0),
+  /* K7   */  be_nested_str_weak(async_cb_map),
+  /* K8   */  be_nested_str_weak(keys),
+  /* K9   */  be_nested_str_weak(current_cmd),
+  /* K10  */  be_nested_str_weak(stop_iteration),
+  /* K11  */  be_nested_str_weak(info),
+  /* K12  */  be_nested_str_weak(find),
+  /* K13  */  be_nested_str_weak(DeviceName),
+  /* K14  */  be_nested_str_weak(Tasmota),
+  /* K15  */  be_nested_str_weak(name),
+  /* K16  */  be_nested_str_weak(remove),
+  /* K17  */  be_nested_str_weak(log),
+  /* K18  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20name_X3D_X27_X25s_X27),
+  /* K19  */  be_nested_str_weak(addr),
+  /* K20  */  be_const_int(3),
+  /* K21  */  be_nested_str_weak(change_schedule),
+  /* K22  */  be_nested_str_weak(UPDATE_CMD0),
+  /* K23  */  be_nested_str_weak(UPDATE_TIME2),
+  /* K24  */  be_const_int(2),
+  /* K25  */  be_nested_str_weak(Version),
+  /* K26  */  be_nested_str_weak(Hardware),
+  /* K27  */  be_nested_str_weak(version),
+  /* K28  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20version_X3D_X27_X25s_X27),
+  /* K29  */  be_nested_str_weak(hardware),
+  /* K30  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20hardware_X3D_X27_X25s_X27),
+  /* K31  */  be_nested_str_weak(UPDATE_CMD2),
+  /* K32  */  be_nested_str_weak(Mac),
+  /* K33  */  be_nested_str_weak(mac),
+  /* K34  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20mac_X3D_X27_X25s_X27),
+  /* K35  */  be_nested_str_weak(UPDATE_CMD5),
+  /* K36  */  be_nested_str_weak(info_changed),
+  /* K37  */  be_nested_str_weak(reachable),
+  /* K38  */  be_nested_str_weak(reachable_utc),
+  /* K39  */  be_nested_str_weak(tasmota),
+  /* K40  */  be_nested_str_weak(rtc_utc),
+  /* K41  */  be_nested_str_weak(payload),
+  /* K42  */  be_nested_str_weak(nil),
+  /* K43  */  be_nested_str_weak(_X2E_X2E_X2E),
+  /* K44  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+  /* K45  */  be_nested_str_weak(millis),
+  /* K46  */  be_nested_str_weak(time_start),
+  /* K47  */  be_nested_str_weak(dispatch_cb),
+  /* K48  */  be_nested_str_weak(http_status),
+  /* K49  */  be_nested_str_weak(string),
+  /* K50  */  be_nested_str_weak(webserver),
+  /* K51  */  be_nested_str_weak(wifi),
+  /* K52  */  be_nested_str_weak(up),
+  /* K53  */  be_nested_str_weak(eth),
+  /* K54  */  be_nested_str_weak(_X2Fcm_X3Fcmnd_X3D),
+  /* K55  */  be_nested_str_weak(tr),
+  /* K56  */  be_nested_str_weak(_X20),
+  /* K57  */  be_nested_str_weak(_X2B),
+  /* K58  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
+  /* K59  */  be_nested_str_weak(port),
+  /* K60  */  be_nested_str_weak(begin),
+  /* K61  */  be_nested_str_weak(device),
+  /* K62  */  be_nested_str_weak(save_param),
+  /* K63  */  be_nested_str_weak(seconds_to_dhm),
+  /* K64  */  be_nested_str_weak(init),
+  /* K65  */  be_nested_str_weak(add_schedule),
+  /* K66  */  be_nested_str_weak(UPDATE_TIME),
+  /* K67  */  be_nested_str_weak(device_is_alive),
+  /* K68  */  be_nested_str_weak(json),
+  /* K69  */  be_nested_str_weak(load),
+  /* K70  */  be_nested_str_weak(STATUS_PREFIX),
+  /* K71  */  be_const_int(1),
+  /* K72  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20failed_X20to_X20parse_X20JSON_X20response_X20payload_X3D_X25s),
+  /* K73  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
+  /* K74  */  be_nested_str_weak(begin_sync),
+  /* K75  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X2Dresp_X20_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+  /* K76  */  be_const_int(0),
+  /* K77  */  be_nested_str_weak(time_reached),
+  /* K78  */  be_nested_str_weak(tcp_connected),
+  /* K79  */  be_nested_str_weak(probe_async),
+  /* K80  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
+  /* K81  */  be_const_int(3),
+  /* K82  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
+  /* K83  */  be_nested_str_weak(phase),
+  /* K84  */  be_nested_str_weak(status),
+};
+
 
 extern const bclass be_class_Matter_HTTP_remote;
 
@@ -13,20 +102,13 @@ be_local_closure(class_Matter_HTTP_remote_add_schedule,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_update_time_map),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(jitter),
-    /* K5   */  be_nested_str_weak(add_async_cb),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(add_schedule),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
@@ -68,34 +150,28 @@ be_local_closure(class_Matter_HTTP_remote_dispatch_cb,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(async_cb_map),
-    /* K2   */  be_nested_str_weak(keys),
-    /* K3   */  be_nested_str_weak(current_cmd),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(dispatch_cb),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x580C0006,  //  0000  LDCONST	R3	K6
       0x60100010,  //  0001  GETGBL	R4	G16
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x8C140B02,  //  0003  GETMET	R5	R5	K2
+      0x88140107,  //  0002  GETMBR	R5	R0	K7
+      0x8C140B08,  //  0003  GETMET	R5	R5	K8
       0x7C140200,  //  0004  CALL	R5	1
       0x7C100200,  //  0005  CALL	R4	1
       0xA802000F,  //  0006  EXBLK	0	#0017
       0x5C140800,  //  0007  MOVE	R5	R4
       0x7C140000,  //  0008  CALL	R5	0
-      0x88180101,  //  0009  GETMBR	R6	R0	K1
+      0x88180107,  //  0009  GETMBR	R6	R0	K7
       0x94180C05,  //  000A  GETIDX	R6	R6	R5
-      0x881C0103,  //  000B  GETMBR	R7	R0	K3
+      0x881C0109,  //  000B  GETMBR	R7	R0	K9
       0x1C1C0C07,  //  000C  EQ	R7	R6	R7
       0x741E0002,  //  000D  JMPT	R7	#0011
       0x4C1C0000,  //  000E  LDNIL	R7
@@ -104,10 +180,10 @@ be_local_closure(class_Matter_HTTP_remote_dispatch_cb,   /* name */
       0x5C1C0A00,  //  0011  MOVE	R7	R5
       0x5C200200,  //  0012  MOVE	R8	R1
       0x5C240400,  //  0013  MOVE	R9	R2
-      0x88280103,  //  0014  GETMBR	R10	R0	K3
+      0x88280109,  //  0014  GETMBR	R10	R0	K9
       0x7C1C0600,  //  0015  CALL	R7	3
       0x7001FFEF,  //  0016  JMP		#0007
-      0x58100004,  //  0017  LDCONST	R4	K4
+      0x5810000A,  //  0017  LDCONST	R4	K10
       0xAC100200,  //  0018  CATCH	R4	1	0
       0xB0080000,  //  0019  RAISE	2	R0	R0
       0x80000000,  //  001A  RET	0
@@ -124,19 +200,17 @@ be_local_closure(class_Matter_HTTP_remote_get_info,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(info),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(get_info),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010B,  //  0000  GETMBR	R1	R0	K11
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -151,183 +225,155 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(DeviceName),
-    /* K3   */  be_nested_str_weak(Tasmota),
-    /* K4   */  be_nested_str_weak(info),
-    /* K5   */  be_nested_str_weak(name),
-    /* K6   */  be_nested_str_weak(remove),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20name_X3D_X27_X25s_X27),
-    /* K9   */  be_nested_str_weak(addr),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(change_schedule),
-    /* K12  */  be_nested_str_weak(UPDATE_CMD0),
-    /* K13  */  be_nested_str_weak(UPDATE_TIME2),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(Version),
-    /* K16  */  be_nested_str_weak(Hardware),
-    /* K17  */  be_nested_str_weak(version),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20version_X3D_X27_X25s_X27),
-    /* K19  */  be_nested_str_weak(hardware),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20hardware_X3D_X27_X25s_X27),
-    /* K21  */  be_nested_str_weak(UPDATE_CMD2),
-    /* K22  */  be_nested_str_weak(Mac),
-    /* K23  */  be_nested_str_weak(mac),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20mac_X3D_X27_X25s_X27),
-    /* K25  */  be_nested_str_weak(UPDATE_CMD5),
-    /* K26  */  be_nested_str_weak(info_changed),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(parse_status_http),
     &be_const_str_solidified,
     ( &(const binstruction[141]) {  /* code */
       0x500C0000,  //  0000  LDBOOL	R3	0	0
-      0x1C100500,  //  0001  EQ	R4	R2	K0
+      0x1C100506,  //  0001  EQ	R4	R2	K6
       0x78120023,  //  0002  JMPF	R4	#0027
-      0x8C100301,  //  0003  GETMET	R4	R1	K1
-      0x58180002,  //  0004  LDCONST	R6	K2
+      0x8C10030C,  //  0003  GETMET	R4	R1	K12
+      0x5818000D,  //  0004  LDCONST	R6	K13
       0x7C100400,  //  0005  CALL	R4	2
-      0x1C140903,  //  0006  EQ	R5	R4	K3
+      0x1C14090E,  //  0006  EQ	R5	R4	K14
       0x78160000,  //  0007  JMPF	R5	#0009
       0x4C100000,  //  0008  LDNIL	R4
-      0x88140104,  //  0009  GETMBR	R5	R0	K4
-      0x8C140B01,  //  000A  GETMET	R5	R5	K1
-      0x581C0005,  //  000B  LDCONST	R7	K5
+      0x8814010B,  //  0009  GETMBR	R5	R0	K11
+      0x8C140B0C,  //  000A  GETMET	R5	R5	K12
+      0x581C000F,  //  000B  LDCONST	R7	K15
       0x7C140400,  //  000C  CALL	R5	2
       0x20140A04,  //  000D  NE	R5	R5	R4
       0x78160012,  //  000E  JMPF	R5	#0022
       0x4C140000,  //  000F  LDNIL	R5
       0x20140805,  //  0010  NE	R5	R4	R5
       0x78160002,  //  0011  JMPF	R5	#0015
-      0x88140104,  //  0012  GETMBR	R5	R0	K4
-      0x98160A04,  //  0013  SETIDX	R5	K5	R4
+      0x8814010B,  //  0012  GETMBR	R5	R0	K11
+      0x98161E04,  //  0013  SETIDX	R5	K15	R4
       0x70020003,  //  0014  JMP		#0019
-      0x88140104,  //  0015  GETMBR	R5	R0	K4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x581C0005,  //  0017  LDCONST	R7	K5
+      0x8814010B,  //  0015  GETMBR	R5	R0	K11
+      0x8C140B10,  //  0016  GETMET	R5	R5	K16
+      0x581C000F,  //  0017  LDCONST	R7	K15
       0x7C140400,  //  0018  CALL	R5	2
-      0xB8160E00,  //  0019  GETNGBL	R5	K7
+      0xB8162200,  //  0019  GETNGBL	R5	K17
       0x60180018,  //  001A  GETGBL	R6	G24
-      0x581C0008,  //  001B  LDCONST	R7	K8
-      0x88200109,  //  001C  GETMBR	R8	R0	K9
+      0x581C0012,  //  001B  LDCONST	R7	K18
+      0x88200113,  //  001C  GETMBR	R8	R0	K19
       0x5C240800,  //  001D  MOVE	R9	R4
       0x7C180600,  //  001E  CALL	R6	3
-      0x581C000A,  //  001F  LDCONST	R7	K10
+      0x581C0014,  //  001F  LDCONST	R7	K20
       0x7C140400,  //  0020  CALL	R5	2
       0x500C0200,  //  0021  LDBOOL	R3	1	0
-      0x8C14010B,  //  0022  GETMET	R5	R0	K11
-      0x881C010C,  //  0023  GETMBR	R7	R0	K12
-      0x8820010D,  //  0024  GETMBR	R8	R0	K13
+      0x8C140115,  //  0022  GETMET	R5	R0	K21
+      0x881C0116,  //  0023  GETMBR	R7	R0	K22
+      0x88200117,  //  0024  GETMBR	R8	R0	K23
       0x7C140600,  //  0025  CALL	R5	3
       0x70020061,  //  0026  JMP		#0089
-      0x1C10050E,  //  0027  EQ	R4	R2	K14
+      0x1C100518,  //  0027  EQ	R4	R2	K24
       0x7812003C,  //  0028  JMPF	R4	#0066
-      0x8C100301,  //  0029  GETMET	R4	R1	K1
-      0x5818000F,  //  002A  LDCONST	R6	K15
+      0x8C10030C,  //  0029  GETMET	R4	R1	K12
+      0x58180019,  //  002A  LDCONST	R6	K25
       0x7C100400,  //  002B  CALL	R4	2
-      0x8C140301,  //  002C  GETMET	R5	R1	K1
-      0x581C0010,  //  002D  LDCONST	R7	K16
+      0x8C14030C,  //  002C  GETMET	R5	R1	K12
+      0x581C001A,  //  002D  LDCONST	R7	K26
       0x7C140400,  //  002E  CALL	R5	2
-      0x88180104,  //  002F  GETMBR	R6	R0	K4
-      0x8C180D01,  //  0030  GETMET	R6	R6	K1
-      0x58200011,  //  0031  LDCONST	R8	K17
+      0x8818010B,  //  002F  GETMBR	R6	R0	K11
+      0x8C180D0C,  //  0030  GETMET	R6	R6	K12
+      0x5820001B,  //  0031  LDCONST	R8	K27
       0x7C180400,  //  0032  CALL	R6	2
       0x20180C04,  //  0033  NE	R6	R6	R4
       0x781A0012,  //  0034  JMPF	R6	#0048
       0x4C180000,  //  0035  LDNIL	R6
       0x20180806,  //  0036  NE	R6	R4	R6
       0x781A0002,  //  0037  JMPF	R6	#003B
-      0x88180104,  //  0038  GETMBR	R6	R0	K4
-      0x981A2204,  //  0039  SETIDX	R6	K17	R4
+      0x8818010B,  //  0038  GETMBR	R6	R0	K11
+      0x981A3604,  //  0039  SETIDX	R6	K27	R4
       0x70020003,  //  003A  JMP		#003F
-      0x88180104,  //  003B  GETMBR	R6	R0	K4
-      0x8C180D06,  //  003C  GETMET	R6	R6	K6
-      0x58200011,  //  003D  LDCONST	R8	K17
+      0x8818010B,  //  003B  GETMBR	R6	R0	K11
+      0x8C180D10,  //  003C  GETMET	R6	R6	K16
+      0x5820001B,  //  003D  LDCONST	R8	K27
       0x7C180400,  //  003E  CALL	R6	2
-      0xB81A0E00,  //  003F  GETNGBL	R6	K7
+      0xB81A2200,  //  003F  GETNGBL	R6	K17
       0x601C0018,  //  0040  GETGBL	R7	G24
-      0x58200012,  //  0041  LDCONST	R8	K18
-      0x88240109,  //  0042  GETMBR	R9	R0	K9
+      0x5820001C,  //  0041  LDCONST	R8	K28
+      0x88240113,  //  0042  GETMBR	R9	R0	K19
       0x5C280800,  //  0043  MOVE	R10	R4
       0x7C1C0600,  //  0044  CALL	R7	3
-      0x5820000A,  //  0045  LDCONST	R8	K10
+      0x58200014,  //  0045  LDCONST	R8	K20
       0x7C180400,  //  0046  CALL	R6	2
       0x500C0200,  //  0047  LDBOOL	R3	1	0
-      0x88180104,  //  0048  GETMBR	R6	R0	K4
-      0x8C180D01,  //  0049  GETMET	R6	R6	K1
-      0x58200013,  //  004A  LDCONST	R8	K19
+      0x8818010B,  //  0048  GETMBR	R6	R0	K11
+      0x8C180D0C,  //  0049  GETMET	R6	R6	K12
+      0x5820001D,  //  004A  LDCONST	R8	K29
       0x7C180400,  //  004B  CALL	R6	2
       0x20180C05,  //  004C  NE	R6	R6	R5
       0x781A0012,  //  004D  JMPF	R6	#0061
       0x4C180000,  //  004E  LDNIL	R6
       0x20180A06,  //  004F  NE	R6	R5	R6
       0x781A0002,  //  0050  JMPF	R6	#0054
-      0x88180104,  //  0051  GETMBR	R6	R0	K4
-      0x981A2605,  //  0052  SETIDX	R6	K19	R5
+      0x8818010B,  //  0051  GETMBR	R6	R0	K11
+      0x981A3A05,  //  0052  SETIDX	R6	K29	R5
       0x70020003,  //  0053  JMP		#0058
-      0x88180104,  //  0054  GETMBR	R6	R0	K4
-      0x8C180D06,  //  0055  GETMET	R6	R6	K6
-      0x58200013,  //  0056  LDCONST	R8	K19
+      0x8818010B,  //  0054  GETMBR	R6	R0	K11
+      0x8C180D10,  //  0055  GETMET	R6	R6	K16
+      0x5820001D,  //  0056  LDCONST	R8	K29
       0x7C180400,  //  0057  CALL	R6	2
-      0xB81A0E00,  //  0058  GETNGBL	R6	K7
+      0xB81A2200,  //  0058  GETNGBL	R6	K17
       0x601C0018,  //  0059  GETGBL	R7	G24
-      0x58200014,  //  005A  LDCONST	R8	K20
-      0x88240109,  //  005B  GETMBR	R9	R0	K9
+      0x5820001E,  //  005A  LDCONST	R8	K30
+      0x88240113,  //  005B  GETMBR	R9	R0	K19
       0x5C280A00,  //  005C  MOVE	R10	R5
       0x7C1C0600,  //  005D  CALL	R7	3
-      0x5820000A,  //  005E  LDCONST	R8	K10
+      0x58200014,  //  005E  LDCONST	R8	K20
       0x7C180400,  //  005F  CALL	R6	2
       0x500C0200,  //  0060  LDBOOL	R3	1	0
-      0x8C18010B,  //  0061  GETMET	R6	R0	K11
-      0x88200115,  //  0062  GETMBR	R8	R0	K21
-      0x8824010D,  //  0063  GETMBR	R9	R0	K13
+      0x8C180115,  //  0061  GETMET	R6	R0	K21
+      0x8820011F,  //  0062  GETMBR	R8	R0	K31
+      0x88240117,  //  0063  GETMBR	R9	R0	K23
       0x7C180600,  //  0064  CALL	R6	3
       0x70020022,  //  0065  JMP		#0089
       0x54120004,  //  0066  LDINT	R4	5
       0x1C100404,  //  0067  EQ	R4	R2	R4
       0x7812001F,  //  0068  JMPF	R4	#0089
-      0x8C100301,  //  0069  GETMET	R4	R1	K1
-      0x58180016,  //  006A  LDCONST	R6	K22
+      0x8C10030C,  //  0069  GETMET	R4	R1	K12
+      0x58180020,  //  006A  LDCONST	R6	K32
       0x7C100400,  //  006B  CALL	R4	2
-      0x88140104,  //  006C  GETMBR	R5	R0	K4
-      0x8C140B01,  //  006D  GETMET	R5	R5	K1
-      0x581C0017,  //  006E  LDCONST	R7	K23
+      0x8814010B,  //  006C  GETMBR	R5	R0	K11
+      0x8C140B0C,  //  006D  GETMET	R5	R5	K12
+      0x581C0021,  //  006E  LDCONST	R7	K33
       0x7C140400,  //  006F  CALL	R5	2
       0x20140A04,  //  0070  NE	R5	R5	R4
       0x78160012,  //  0071  JMPF	R5	#0085
       0x4C140000,  //  0072  LDNIL	R5
       0x20140805,  //  0073  NE	R5	R4	R5
       0x78160002,  //  0074  JMPF	R5	#0078
-      0x88140104,  //  0075  GETMBR	R5	R0	K4
-      0x98162E04,  //  0076  SETIDX	R5	K23	R4
+      0x8814010B,  //  0075  GETMBR	R5	R0	K11
+      0x98164204,  //  0076  SETIDX	R5	K33	R4
       0x70020003,  //  0077  JMP		#007C
-      0x88140104,  //  0078  GETMBR	R5	R0	K4
-      0x8C140B06,  //  0079  GETMET	R5	R5	K6
-      0x581C0017,  //  007A  LDCONST	R7	K23
+      0x8814010B,  //  0078  GETMBR	R5	R0	K11
+      0x8C140B10,  //  0079  GETMET	R5	R5	K16
+      0x581C0021,  //  007A  LDCONST	R7	K33
       0x7C140400,  //  007B  CALL	R5	2
-      0xB8160E00,  //  007C  GETNGBL	R5	K7
+      0xB8162200,  //  007C  GETNGBL	R5	K17
       0x60180018,  //  007D  GETGBL	R6	G24
-      0x581C0018,  //  007E  LDCONST	R7	K24
-      0x88200109,  //  007F  GETMBR	R8	R0	K9
+      0x581C0022,  //  007E  LDCONST	R7	K34
+      0x88200113,  //  007F  GETMBR	R8	R0	K19
       0x5C240800,  //  0080  MOVE	R9	R4
       0x7C180600,  //  0081  CALL	R6	3
-      0x581C000A,  //  0082  LDCONST	R7	K10
+      0x581C0014,  //  0082  LDCONST	R7	K20
       0x7C140400,  //  0083  CALL	R5	2
       0x500C0200,  //  0084  LDBOOL	R3	1	0
-      0x8C14010B,  //  0085  GETMET	R5	R0	K11
-      0x881C0119,  //  0086  GETMBR	R7	R0	K25
-      0x8820010D,  //  0087  GETMBR	R8	R0	K13
+      0x8C140115,  //  0085  GETMET	R5	R0	K21
+      0x881C0123,  //  0086  GETMBR	R7	R0	K35
+      0x88200117,  //  0087  GETMBR	R8	R0	K23
       0x7C140600,  //  0088  CALL	R5	3
       0x780E0001,  //  0089  JMPF	R3	#008C
-      0x8C10011A,  //  008A  GETMET	R4	R0	K26
+      0x8C100124,  //  008A  GETMET	R4	R0	K36
       0x7C100200,  //  008B  CALL	R4	1
       0x80000000,  //  008C  RET	0
     })
@@ -343,19 +389,17 @@ be_local_closure(class_Matter_HTTP_remote_set_info,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(info),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(set_info),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021601,  //  0000  SETMBR	R0	K11	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -370,31 +414,26 @@ be_local_closure(class_Matter_HTTP_remote_device_is_alive,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reachable),
-    /* K1   */  be_nested_str_weak(reachable_utc),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(rtc_utc),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(device_is_alive),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x78060006,  //  0000  JMPF	R1	#0008
       0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x90020002,  //  0002  SETMBR	R0	K0	R2
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x90024A02,  //  0002  SETMBR	R0	K37	R2
+      0xB80A4E00,  //  0003  GETNGBL	R2	K39
+      0x8C080528,  //  0004  GETMET	R2	R2	K40
       0x7C080200,  //  0005  CALL	R2	1
-      0x90020202,  //  0006  SETMBR	R0	K1	R2
+      0x90024C02,  //  0006  SETMBR	R0	K38	R2
       0x70020001,  //  0007  JMP		#000A
       0x50080000,  //  0008  LDBOOL	R2	0	0
-      0x90020002,  //  0009  SETMBR	R0	K0	R2
+      0x90024A02,  //  0009  SETMBR	R0	K37	R2
       0x80000000,  //  000A  RET	0
     })
   )
@@ -409,43 +448,28 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(payload),
-    /* K2   */  be_nested_str_weak(nil),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(millis),
-    /* K9   */  be_nested_str_weak(time_start),
-    /* K10  */  be_nested_str_weak(addr),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(dispatch_cb),
-    /* K13  */  be_nested_str_weak(http_status),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(event_http_finished),
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
-      0x88040101,  //  0005  GETMBR	R1	R0	K1
+      0x88040129,  //  0005  GETMBR	R1	R0	K41
       0x4C080000,  //  0006  LDNIL	R2
       0x20040202,  //  0007  NE	R1	R1	R2
       0x78060001,  //  0008  JMPF	R1	#000B
-      0x88040101,  //  0009  GETMBR	R1	R0	K1
+      0x88040129,  //  0009  GETMBR	R1	R0	K41
       0x70020000,  //  000A  JMP		#000C
-      0x58040002,  //  000B  LDCONST	R1	K2
+      0x5804002A,  //  000B  LDCONST	R1	K42
       0x6008000C,  //  000C  GETGBL	R2	G12
       0x5C0C0200,  //  000D  MOVE	R3	R1
       0x7C080200,  //  000E  CALL	R2	1
@@ -453,29 +477,29 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
       0x24080403,  //  0010  GT	R2	R2	R3
       0x780A0004,  //  0011  JMPF	R2	#0017
       0x540A001C,  //  0012  LDINT	R2	29
-      0x400A0602,  //  0013  CONNECT	R2	K3	R2
+      0x400A0C02,  //  0013  CONNECT	R2	K6	R2
       0x94080202,  //  0014  GETIDX	R2	R1	R2
-      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x0008052B,  //  0015  ADD	R2	R2	K43
       0x5C040400,  //  0016  MOVE	R1	R2
-      0xB80A0A00,  //  0017  GETNGBL	R2	K5
+      0xB80A2200,  //  0017  GETNGBL	R2	K17
       0x600C0018,  //  0018  GETGBL	R3	G24
-      0x58100006,  //  0019  LDCONST	R4	K6
-      0xB8160E00,  //  001A  GETNGBL	R5	K7
-      0x8C140B08,  //  001B  GETMET	R5	R5	K8
+      0x5810002C,  //  0019  LDCONST	R4	K44
+      0xB8164E00,  //  001A  GETNGBL	R5	K39
+      0x8C140B2D,  //  001B  GETMET	R5	R5	K45
       0x7C140200,  //  001C  CALL	R5	1
-      0x88180109,  //  001D  GETMBR	R6	R0	K9
+      0x8818012E,  //  001D  GETMBR	R6	R0	K46
       0x04140A06,  //  001E  SUB	R5	R5	R6
-      0x8818010A,  //  001F  GETMBR	R6	R0	K10
+      0x88180113,  //  001F  GETMBR	R6	R0	K19
       0x601C000C,  //  0020  GETGBL	R7	G12
-      0x88200101,  //  0021  GETMBR	R8	R0	K1
+      0x88200129,  //  0021  GETMBR	R8	R0	K41
       0x7C1C0200,  //  0022  CALL	R7	1
       0x5C200200,  //  0023  MOVE	R8	R1
       0x7C0C0A00,  //  0024  CALL	R3	5
-      0x5810000B,  //  0025  LDCONST	R4	K11
+      0x58100014,  //  0025  LDCONST	R4	K20
       0x7C080400,  //  0026  CALL	R2	2
-      0x8C08010C,  //  0027  GETMET	R2	R0	K12
-      0x8810010D,  //  0028  GETMBR	R4	R0	K13
-      0x88140101,  //  0029  GETMBR	R5	R0	K1
+      0x8C08012F,  //  0027  GETMET	R2	R0	K47
+      0x88100130,  //  0028  GETMBR	R4	R0	K48
+      0x88140129,  //  0029  GETMBR	R5	R0	K41
       0x7C080600,  //  002A  CALL	R2	3
       0x80000000,  //  002B  RET	0
     })
@@ -491,64 +515,47 @@ be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(webserver),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(wifi),
-    /* K4   */  be_nested_str_weak(up),
-    /* K5   */  be_nested_str_weak(eth),
-    /* K6   */  be_nested_str_weak(current_cmd),
-    /* K7   */  be_nested_str_weak(_X2Fcm_X3Fcmnd_X3D),
-    /* K8   */  be_nested_str_weak(tr),
-    /* K9   */  be_nested_str_weak(_X20),
-    /* K10  */  be_nested_str_weak(_X2B),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
-    /* K13  */  be_nested_str_weak(addr),
-    /* K14  */  be_nested_str_weak(port),
-    /* K15  */  be_nested_str_weak(begin),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(probe_async),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
+      0xA40A6200,  //  0000  IMPORT	R2	K49
+      0xA40E6400,  //  0001  IMPORT	R3	K50
+      0xB8124E00,  //  0002  GETNGBL	R4	K39
+      0x8C100933,  //  0003  GETMET	R4	R4	K51
       0x7C100200,  //  0004  CALL	R4	1
-      0x94100904,  //  0005  GETIDX	R4	R4	K4
+      0x94100934,  //  0005  GETIDX	R4	R4	K52
       0x74120006,  //  0006  JMPT	R4	#000E
-      0xB8120400,  //  0007  GETNGBL	R4	K2
-      0x8C100905,  //  0008  GETMET	R4	R4	K5
+      0xB8124E00,  //  0007  GETNGBL	R4	K39
+      0x8C100935,  //  0008  GETMET	R4	R4	K53
       0x7C100200,  //  0009  CALL	R4	1
-      0x94100904,  //  000A  GETIDX	R4	R4	K4
+      0x94100934,  //  000A  GETIDX	R4	R4	K52
       0x74120001,  //  000B  JMPT	R4	#000E
       0x4C100000,  //  000C  LDNIL	R4
       0x80040800,  //  000D  RET	1	R4
-      0x90020C01,  //  000E  SETMBR	R0	K6	R1
-      0x8C100508,  //  000F  GETMET	R4	R2	K8
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x8C100537,  //  000F  GETMET	R4	R2	K55
       0x5C180200,  //  0010  MOVE	R6	R1
-      0x581C0009,  //  0011  LDCONST	R7	K9
-      0x5820000A,  //  0012  LDCONST	R8	K10
+      0x581C0038,  //  0011  LDCONST	R7	K56
+      0x58200039,  //  0012  LDCONST	R8	K57
       0x7C100800,  //  0013  CALL	R4	4
-      0x00120E04,  //  0014  ADD	R4	K7	R4
-      0xB8161600,  //  0015  GETNGBL	R5	K11
+      0x00126C04,  //  0014  ADD	R4	K54	R4
+      0xB8162200,  //  0015  GETNGBL	R5	K17
       0x60180018,  //  0016  GETGBL	R6	G24
-      0x581C000C,  //  0017  LDCONST	R7	K12
-      0x8820010D,  //  0018  GETMBR	R8	R0	K13
-      0x8824010E,  //  0019  GETMBR	R9	R0	K14
+      0x581C003A,  //  0017  LDCONST	R7	K58
+      0x88200113,  //  0018  GETMBR	R8	R0	K19
+      0x8824013B,  //  0019  GETMBR	R9	R0	K59
       0x5C280800,  //  001A  MOVE	R10	R4
       0x7C180800,  //  001B  CALL	R6	4
       0x541E0003,  //  001C  LDINT	R7	4
       0x7C140400,  //  001D  CALL	R5	2
-      0x8C14010F,  //  001E  GETMET	R5	R0	K15
+      0x8C14013C,  //  001E  GETMET	R5	R0	K60
       0x5C1C0800,  //  001F  MOVE	R7	R4
       0x7C140400,  //  0020  CALL	R5	2
       0x80000000,  //  0021  RET	0
@@ -565,21 +572,18 @@ be_local_closure(class_Matter_HTTP_remote_info_changed,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(save_param),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(info_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8804013D,  //  0000  GETMBR	R1	R0	K61
+      0x8C04033E,  //  0001  GETMET	R1	R1	K62
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -595,37 +599,30 @@ be_local_closure(class_Matter_HTTP_remote_web_last_seen,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(reachable_utc),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(rtc_utc),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(seconds_to_dhm),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(web_last_seen),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA4066400,  //  0000  IMPORT	R1	K50
       0x5409FFFE,  //  0001  LDINT	R2	-1
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x880C0126,  //  0002  GETMBR	R3	R0	K38
       0x4C100000,  //  0003  LDNIL	R4
       0x200C0604,  //  0004  NE	R3	R3	R4
       0x780E0005,  //  0005  JMPF	R3	#000C
-      0xB80E0400,  //  0006  GETNGBL	R3	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0xB80E4E00,  //  0006  GETNGBL	R3	K39
+      0x8C0C0728,  //  0007  GETMET	R3	R3	K40
       0x7C0C0200,  //  0008  CALL	R3	1
-      0x88100101,  //  0009  GETMBR	R4	R0	K1
+      0x88100126,  //  0009  GETMBR	R4	R0	K38
       0x040C0604,  //  000A  SUB	R3	R3	R4
       0x5C080600,  //  000B  MOVE	R2	R3
-      0xB80E0800,  //  000C  GETNGBL	R3	K4
-      0x8C0C0705,  //  000D  GETMET	R3	R3	K5
+      0xB80E0600,  //  000C  GETNGBL	R3	K3
+      0x8C0C073F,  //  000D  GETMET	R3	R3	K63
       0x5C140400,  //  000E  MOVE	R5	R2
       0x7C0C0400,  //  000F  CALL	R3	2
       0x80040600,  //  0010  RET	1	R3
@@ -642,7 +639,7 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -739,42 +736,28 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(probe_update_time_map),
-    /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
-    /* K3   */  be_nested_str_weak(async_cb_map),
-    /* K4   */  be_nested_str_weak(current_cmd),
-    /* K5   */  be_nested_str_weak(reachable),
-    /* K6   */  be_nested_str_weak(init),
-    /* K7   */  be_nested_str_weak(info),
-    /* K8   */  be_nested_str_weak(add_schedule),
-    /* K9   */  be_nested_str_weak(UPDATE_CMD0),
-    /* K10  */  be_nested_str_weak(UPDATE_TIME),
-    /* K11  */  be_nested_str_weak(UPDATE_CMD2),
-    /* K12  */  be_nested_str_weak(UPDATE_CMD5),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90027A01,  //  0000  SETMBR	R0	K61	R1
       0x60140013,  //  0001  GETGBL	R5	G19
       0x7C140000,  //  0002  CALL	R5	0
-      0x90020205,  //  0003  SETMBR	R0	K1	R5
+      0x90020005,  //  0003  SETMBR	R0	K0	R5
       0x60140013,  //  0004  GETGBL	R5	G19
       0x7C140000,  //  0005  CALL	R5	0
       0x90020405,  //  0006  SETMBR	R0	K2	R5
       0x60140013,  //  0007  GETGBL	R5	G19
       0x7C140000,  //  0008  CALL	R5	0
-      0x90020605,  //  0009  SETMBR	R0	K3	R5
+      0x90020E05,  //  0009  SETMBR	R0	K7	R5
       0x4C140000,  //  000A  LDNIL	R5
-      0x90020805,  //  000B  SETMBR	R0	K4	R5
+      0x90021205,  //  000B  SETMBR	R0	K9	R5
       0x50140000,  //  000C  LDBOOL	R5	0	0
-      0x90020A05,  //  000D  SETMBR	R0	K5	R5
+      0x90024A05,  //  000D  SETMBR	R0	K37	R5
       0x60140003,  //  000E  GETGBL	R5	G3
       0x5C180000,  //  000F  MOVE	R6	R0
       0x7C140200,  //  0010  CALL	R5	1
-      0x8C140B06,  //  0011  GETMET	R5	R5	K6
+      0x8C140B40,  //  0011  GETMET	R5	R5	K64
       0x5C1C0400,  //  0012  MOVE	R7	R2
       0x5422004F,  //  0013  LDINT	R8	80
       0x5C240600,  //  0014  MOVE	R9	R3
@@ -782,22 +765,22 @@ be_local_closure(class_Matter_HTTP_remote_init,   /* name */
       0x7C140A00,  //  0016  CALL	R5	5
       0x60140013,  //  0017  GETGBL	R5	G19
       0x7C140000,  //  0018  CALL	R5	0
-      0x90020E05,  //  0019  SETMBR	R0	K7	R5
-      0x88140100,  //  001A  GETMBR	R5	R0	K0
+      0x90021605,  //  0019  SETMBR	R0	K11	R5
+      0x8814013D,  //  001A  GETMBR	R5	R0	K61
       0x7816000E,  //  001B  JMPF	R5	#002B
-      0x8C140108,  //  001C  GETMET	R5	R0	K8
-      0x881C0109,  //  001D  GETMBR	R7	R0	K9
-      0x8820010A,  //  001E  GETMBR	R8	R0	K10
+      0x8C140141,  //  001C  GETMET	R5	R0	K65
+      0x881C0116,  //  001D  GETMBR	R7	R0	K22
+      0x88200142,  //  001E  GETMBR	R8	R0	K66
       0x84240000,  //  001F  CLOSURE	R9	P0
       0x7C140800,  //  0020  CALL	R5	4
-      0x8C140108,  //  0021  GETMET	R5	R0	K8
-      0x881C010B,  //  0022  GETMBR	R7	R0	K11
-      0x8820010A,  //  0023  GETMBR	R8	R0	K10
+      0x8C140141,  //  0021  GETMET	R5	R0	K65
+      0x881C011F,  //  0022  GETMBR	R7	R0	K31
+      0x88200142,  //  0023  GETMBR	R8	R0	K66
       0x84240001,  //  0024  CLOSURE	R9	P1
       0x7C140800,  //  0025  CALL	R5	4
-      0x8C140108,  //  0026  GETMET	R5	R0	K8
-      0x881C010C,  //  0027  GETMBR	R7	R0	K12
-      0x8820010A,  //  0028  GETMBR	R8	R0	K10
+      0x8C140141,  //  0026  GETMET	R5	R0	K65
+      0x881C0123,  //  0027  GETMBR	R7	R0	K35
+      0x88200142,  //  0028  GETMBR	R8	R0	K66
       0x84240002,  //  0029  CLOSURE	R9	P2
       0x7C140800,  //  002A  CALL	R5	4
       0xA0000000,  //  002B  CLOSE	R0
@@ -815,19 +798,13 @@ be_local_closure(class_Matter_HTTP_remote_change_schedule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_update_time_map),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(jitter),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(change_schedule),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -858,44 +835,32 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
   be_nested_proto(
     14,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(device_is_alive),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(json),
-    /* K4   */  be_nested_str_weak(load),
-    /* K5   */  be_nested_str_weak(STATUS_PREFIX),
-    /* K6   */  be_nested_str_weak(contains),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20failed_X20to_X20parse_X20JSON_X20response_X20payload_X3D_X25s),
-    /* K10  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(parse_status_response_and_call_method),
     &be_const_str_solidified,
     ( &(const binstruction[57]) {  /* code */
       0x4C180000,  //  0000  LDNIL	R6
       0x20180206,  //  0001  NE	R6	R1	R6
       0x781A0034,  //  0002  JMPF	R6	#0038
-      0x24180300,  //  0003  GT	R6	R1	K0
+      0x24180306,  //  0003  GT	R6	R1	K6
       0x781A0032,  //  0004  JMPF	R6	#0038
-      0x8C180101,  //  0005  GETMET	R6	R0	K1
+      0x8C180143,  //  0005  GETMET	R6	R0	K67
       0x50200200,  //  0006  LDBOOL	R8	1	0
       0x7C180400,  //  0007  CALL	R6	2
       0x5C180400,  //  0008  MOVE	R6	R2
       0x601C0004,  //  0009  GETGBL	R7	G4
       0x5C200C00,  //  000A  MOVE	R8	R6
       0x7C1C0200,  //  000B  CALL	R7	1
-      0x1C1C0F02,  //  000C  EQ	R7	R7	K2
+      0x1C1C0F31,  //  000C  EQ	R7	R7	K49
       0x781E0004,  //  000D  JMPF	R7	#0013
-      0xA41E0600,  //  000E  IMPORT	R7	K3
-      0x8C200F04,  //  000F  GETMET	R8	R7	K4
+      0xA41E8800,  //  000E  IMPORT	R7	K68
+      0x8C200F45,  //  000F  GETMET	R8	R7	K69
       0x5C280C00,  //  0010  MOVE	R10	R6
       0x7C200400,  //  0011  CALL	R8	2
       0x5C181000,  //  0012  MOVE	R6	R8
@@ -903,8 +868,8 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
       0x4C200000,  //  0014  LDNIL	R8
       0x20200C08,  //  0015  NE	R8	R6	R8
       0x78220019,  //  0016  JMPF	R8	#0031
-      0x58200000,  //  0017  LDCONST	R8	K0
-      0x88240105,  //  0018  GETMBR	R9	R0	K5
+      0x58200006,  //  0017  LDCONST	R8	K6
+      0x88240146,  //  0018  GETMBR	R9	R0	K70
       0x6028000C,  //  0019  GETGBL	R10	G12
       0x5C2C1200,  //  001A  MOVE	R11	R9
       0x7C280200,  //  001B  CALL	R10	1
@@ -914,14 +879,14 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
       0x4C2C0000,  //  001F  LDNIL	R11
       0x202C140B,  //  0020  NE	R11	R10	R11
       0x782E0006,  //  0021  JMPF	R11	#0029
-      0x8C2C0D06,  //  0022  GETMET	R11	R6	K6
+      0x8C2C0D01,  //  0022  GETMET	R11	R6	K1
       0x5C341400,  //  0023  MOVE	R13	R10
       0x7C2C0400,  //  0024  CALL	R11	2
       0x782E0002,  //  0025  JMPF	R11	#0029
       0x94180C0A,  //  0026  GETIDX	R6	R6	R10
       0x5C1C1000,  //  0027  MOVE	R7	R8
       0x70020001,  //  0028  JMP		#002B
-      0x00201107,  //  0029  ADD	R8	R8	K7
+      0x00201147,  //  0029  ADD	R8	R8	K71
       0x7001FFED,  //  002A  JMP		#0019
       0x5C280A00,  //  002B  MOVE	R10	R5
       0x5C2C0800,  //  002C  MOVE	R11	R4
@@ -929,12 +894,12 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
       0x5C340E00,  //  002E  MOVE	R13	R7
       0x7C280600,  //  002F  CALL	R10	3
       0x70020006,  //  0030  JMP		#0038
-      0xB8221000,  //  0031  GETNGBL	R8	K8
+      0xB8222200,  //  0031  GETNGBL	R8	K17
       0x60240018,  //  0032  GETGBL	R9	G24
-      0x58280009,  //  0033  LDCONST	R10	K9
+      0x58280048,  //  0033  LDCONST	R10	K72
       0x5C2C0400,  //  0034  MOVE	R11	R2
       0x7C240400,  //  0035  CALL	R9	2
-      0x5828000A,  //  0036  LDCONST	R10	K10
+      0x58280014,  //  0036  LDCONST	R10	K20
       0x7C200400,  //  0037  CALL	R8	2
       0x80000000,  //  0038  RET	0
     })
@@ -950,68 +915,43 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(webserver),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(wifi),
-    /* K4   */  be_nested_str_weak(up),
-    /* K5   */  be_nested_str_weak(eth),
-    /* K6   */  be_nested_str_weak(current_cmd),
-    /* K7   */  be_nested_str_weak(_X2Fcm_X3Fcmnd_X3D),
-    /* K8   */  be_nested_str_weak(tr),
-    /* K9   */  be_nested_str_weak(_X20),
-    /* K10  */  be_nested_str_weak(_X2B),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
-    /* K13  */  be_nested_str_weak(addr),
-    /* K14  */  be_nested_str_weak(port),
-    /* K15  */  be_nested_str_weak(begin_sync),
-    /* K16  */  be_nested_str_weak(nil),
-    /* K17  */  be_const_int(0),
-    /* K18  */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X2Dresp_X20_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
-    /* K20  */  be_nested_str_weak(millis),
-    /* K21  */  be_nested_str_weak(time_start),
-    /* K22  */  be_nested_str_weak(payload),
-    /* K23  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(call_sync),
     &be_const_str_solidified,
     ( &(const binstruction[70]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0xA40E6200,  //  0000  IMPORT	R3	K49
+      0xA4126400,  //  0001  IMPORT	R4	K50
+      0xB8164E00,  //  0002  GETNGBL	R5	K39
+      0x8C140B33,  //  0003  GETMET	R5	R5	K51
       0x7C140200,  //  0004  CALL	R5	1
-      0x94140B04,  //  0005  GETIDX	R5	R5	K4
+      0x94140B34,  //  0005  GETIDX	R5	R5	K52
       0x74160006,  //  0006  JMPT	R5	#000E
-      0xB8160400,  //  0007  GETNGBL	R5	K2
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0xB8164E00,  //  0007  GETNGBL	R5	K39
+      0x8C140B35,  //  0008  GETMET	R5	R5	K53
       0x7C140200,  //  0009  CALL	R5	1
-      0x94140B04,  //  000A  GETIDX	R5	R5	K4
+      0x94140B34,  //  000A  GETIDX	R5	R5	K52
       0x74160001,  //  000B  JMPT	R5	#000E
       0x4C140000,  //  000C  LDNIL	R5
       0x80040A00,  //  000D  RET	1	R5
       0x4C140000,  //  000E  LDNIL	R5
-      0x90020C05,  //  000F  SETMBR	R0	K6	R5
-      0x8C140708,  //  0010  GETMET	R5	R3	K8
+      0x90021205,  //  000F  SETMBR	R0	K9	R5
+      0x8C140737,  //  0010  GETMET	R5	R3	K55
       0x5C1C0200,  //  0011  MOVE	R7	R1
-      0x58200009,  //  0012  LDCONST	R8	K9
-      0x5824000A,  //  0013  LDCONST	R9	K10
+      0x58200038,  //  0012  LDCONST	R8	K56
+      0x58240039,  //  0013  LDCONST	R9	K57
       0x7C140800,  //  0014  CALL	R5	4
-      0x00160E05,  //  0015  ADD	R5	K7	R5
-      0xB81A1600,  //  0016  GETNGBL	R6	K11
+      0x00166C05,  //  0015  ADD	R5	K54	R5
+      0xB81A2200,  //  0016  GETNGBL	R6	K17
       0x601C0018,  //  0017  GETGBL	R7	G24
-      0x5820000C,  //  0018  LDCONST	R8	K12
-      0x8824010D,  //  0019  GETMBR	R9	R0	K13
-      0x8828010E,  //  001A  GETMBR	R10	R0	K14
+      0x58200049,  //  0018  LDCONST	R8	K73
+      0x88240113,  //  0019  GETMBR	R9	R0	K19
+      0x8828013B,  //  001A  GETMBR	R10	R0	K59
       0x5C2C0A00,  //  001B  MOVE	R11	R5
       0x7C1C0800,  //  001C  CALL	R7	4
       0x54220003,  //  001D  LDINT	R8	4
@@ -1019,14 +959,14 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
       0x60180003,  //  001F  GETGBL	R6	G3
       0x5C1C0000,  //  0020  MOVE	R7	R0
       0x7C180200,  //  0021  CALL	R6	1
-      0x8C180D0F,  //  0022  GETMET	R6	R6	K15
+      0x8C180D4A,  //  0022  GETMET	R6	R6	K74
       0x5C200A00,  //  0023  MOVE	R8	R5
       0x5C240400,  //  0024  MOVE	R9	R2
       0x7C180600,  //  0025  CALL	R6	3
       0x781A0001,  //  0026  JMPF	R6	#0029
       0x5C1C0C00,  //  0027  MOVE	R7	R6
       0x70020000,  //  0028  JMP		#002A
-      0x581C0010,  //  0029  LDCONST	R7	K16
+      0x581C002A,  //  0029  LDCONST	R7	K42
       0x6020000C,  //  002A  GETGBL	R8	G12
       0x5C240E00,  //  002B  MOVE	R9	R7
       0x7C200200,  //  002C  CALL	R8	1
@@ -1034,25 +974,25 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
       0x24201009,  //  002E  GT	R8	R8	R9
       0x78220004,  //  002F  JMPF	R8	#0035
       0x5422001C,  //  0030  LDINT	R8	29
-      0x40222208,  //  0031  CONNECT	R8	K17	R8
+      0x40220C08,  //  0031  CONNECT	R8	K6	R8
       0x94200E08,  //  0032  GETIDX	R8	R7	R8
-      0x00201112,  //  0033  ADD	R8	R8	K18
+      0x0020112B,  //  0033  ADD	R8	R8	K43
       0x5C1C1000,  //  0034  MOVE	R7	R8
-      0xB8221600,  //  0035  GETNGBL	R8	K11
+      0xB8222200,  //  0035  GETNGBL	R8	K17
       0x60240018,  //  0036  GETGBL	R9	G24
-      0x58280013,  //  0037  LDCONST	R10	K19
-      0xB82E0400,  //  0038  GETNGBL	R11	K2
-      0x8C2C1714,  //  0039  GETMET	R11	R11	K20
+      0x5828004B,  //  0037  LDCONST	R10	K75
+      0xB82E4E00,  //  0038  GETNGBL	R11	K39
+      0x8C2C172D,  //  0039  GETMET	R11	R11	K45
       0x7C2C0200,  //  003A  CALL	R11	1
-      0x88300115,  //  003B  GETMBR	R12	R0	K21
+      0x8830012E,  //  003B  GETMBR	R12	R0	K46
       0x042C160C,  //  003C  SUB	R11	R11	R12
-      0x8830010D,  //  003D  GETMBR	R12	R0	K13
+      0x88300113,  //  003D  GETMBR	R12	R0	K19
       0x6034000C,  //  003E  GETGBL	R13	G12
-      0x88380116,  //  003F  GETMBR	R14	R0	K22
+      0x88380129,  //  003F  GETMBR	R14	R0	K41
       0x7C340200,  //  0040  CALL	R13	1
       0x5C380E00,  //  0041  MOVE	R14	R7
       0x7C240A00,  //  0042  CALL	R9	5
-      0x58280017,  //  0043  LDCONST	R10	K23
+      0x58280014,  //  0043  LDCONST	R10	K20
       0x7C200400,  //  0044  CALL	R8	2
       0x80040C00,  //  0045  RET	1	R6
     })
@@ -1068,62 +1008,51 @@ be_local_closure(class_Matter_HTTP_remote_scheduler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_next_timestamp_map),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    /* K6   */  be_nested_str_weak(tcp_connected),
-    /* K7   */  be_nested_str_weak(millis),
-    /* K8   */  be_nested_str_weak(probe_update_time_map),
-    /* K9   */  be_nested_str_weak(probe_async),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(scheduler),
     &be_const_str_solidified,
     ( &(const binstruction[66]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
       0x60080010,  //  0001  GETGBL	R2	G16
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0003  GETMET	R3	R3	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x8C0C0708,  //  0003  GETMET	R3	R3	K8
       0x7C0C0200,  //  0004  CALL	R3	1
       0x7C080200,  //  0005  CALL	R2	1
       0xA802000A,  //  0006  EXBLK	0	#0012
       0x5C0C0400,  //  0007  MOVE	R3	R2
       0x7C0C0000,  //  0008  CALL	R3	0
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x88100102,  //  0009  GETMBR	R4	R0	K2
       0x94100803,  //  000A  GETIDX	R4	R4	R3
-      0x1C100902,  //  000B  EQ	R4	R4	K2
+      0x1C10094C,  //  000B  EQ	R4	R4	K76
       0x78120001,  //  000C  JMPF	R4	#000F
       0x5C040600,  //  000D  MOVE	R1	R3
       0x70020000,  //  000E  JMP		#0010
       0x7001FFF6,  //  000F  JMP		#0007
       0xA8040001,  //  0010  EXBLK	1	1
       0x70020002,  //  0011  JMP		#0015
-      0x58080003,  //  0012  LDCONST	R2	K3
+      0x5808000A,  //  0012  LDCONST	R2	K10
       0xAC080200,  //  0013  CATCH	R2	1	0
       0xB0080000,  //  0014  RAISE	2	R0	R0
       0x4C080000,  //  0015  LDNIL	R2
       0x1C080202,  //  0016  EQ	R2	R1	R2
       0x780A0015,  //  0017  JMPF	R2	#002E
       0x60080010,  //  0018  GETGBL	R2	G16
-      0x880C0100,  //  0019  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  001A  GETMET	R3	R3	K1
+      0x880C0102,  //  0019  GETMBR	R3	R0	K2
+      0x8C0C0708,  //  001A  GETMET	R3	R3	K8
       0x7C0C0200,  //  001B  CALL	R3	1
       0x7C080200,  //  001C  CALL	R2	1
       0xA802000C,  //  001D  EXBLK	0	#002B
       0x5C0C0400,  //  001E  MOVE	R3	R2
       0x7C0C0000,  //  001F  CALL	R3	0
-      0xB8120800,  //  0020  GETNGBL	R4	K4
-      0x8C100905,  //  0021  GETMET	R4	R4	K5
-      0x88180100,  //  0022  GETMBR	R6	R0	K0
+      0xB8124E00,  //  0020  GETNGBL	R4	K39
+      0x8C10094D,  //  0021  GETMET	R4	R4	K77
+      0x88180102,  //  0022  GETMBR	R6	R0	K2
       0x94180C03,  //  0023  GETIDX	R6	R6	R3
       0x7C100400,  //  0024  CALL	R4	2
       0x78120001,  //  0025  JMPF	R4	#0028
@@ -1132,26 +1061,26 @@ be_local_closure(class_Matter_HTTP_remote_scheduler,   /* name */
       0x7001FFF4,  //  0028  JMP		#001E
       0xA8040001,  //  0029  EXBLK	1	1
       0x70020002,  //  002A  JMP		#002E
-      0x58080003,  //  002B  LDCONST	R2	K3
+      0x5808000A,  //  002B  LDCONST	R2	K10
       0xAC080200,  //  002C  CATCH	R2	1	0
       0xB0080000,  //  002D  RAISE	2	R0	R0
       0x4C080000,  //  002E  LDNIL	R2
       0x1C080202,  //  002F  EQ	R2	R1	R2
       0x780A0000,  //  0030  JMPF	R2	#0032
       0x80000400,  //  0031  RET	0
-      0x88080106,  //  0032  GETMBR	R2	R0	K6
+      0x8808014E,  //  0032  GETMBR	R2	R0	K78
       0x780A0002,  //  0033  JMPF	R2	#0037
-      0x88080100,  //  0034  GETMBR	R2	R0	K0
-      0x98080302,  //  0035  SETIDX	R2	R1	K2
+      0x88080102,  //  0034  GETMBR	R2	R0	K2
+      0x9808034C,  //  0035  SETIDX	R2	R1	K76
       0x80000400,  //  0036  RET	0
-      0x88080100,  //  0037  GETMBR	R2	R0	K0
-      0xB80E0800,  //  0038  GETNGBL	R3	K4
-      0x8C0C0707,  //  0039  GETMET	R3	R3	K7
-      0x88140108,  //  003A  GETMBR	R5	R0	K8
+      0x88080102,  //  0037  GETMBR	R2	R0	K2
+      0xB80E4E00,  //  0038  GETNGBL	R3	K39
+      0x8C0C072D,  //  0039  GETMET	R3	R3	K45
+      0x88140100,  //  003A  GETMBR	R5	R0	K0
       0x94140A01,  //  003B  GETIDX	R5	R5	R1
       0x7C0C0400,  //  003C  CALL	R3	2
       0x98080203,  //  003D  SETIDX	R2	R1	R3
-      0x8C080109,  //  003E  GETMET	R2	R0	K9
+      0x8C08014F,  //  003E  GETMET	R2	R0	K79
       0x5C100200,  //  003F  MOVE	R4	R1
       0x7C080400,  //  0040  CALL	R2	2
       0x80000000,  //  0041  RET	0
@@ -1168,34 +1097,27 @@ be_local_closure(class_Matter_HTTP_remote_event_http_failed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(dispatch_cb),
-    /* K5   */  be_nested_str_weak(http_status),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(event_http_failed),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x58080002,  //  0006  LDCONST	R2	K2
-      0x580C0003,  //  0007  LDCONST	R3	K3
+      0xB8062200,  //  0005  GETNGBL	R1	K17
+      0x58080050,  //  0006  LDCONST	R2	K80
+      0x580C0051,  //  0007  LDCONST	R3	K81
       0x7C040400,  //  0008  CALL	R1	2
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x880C0105,  //  000A  GETMBR	R3	R0	K5
+      0x8C04012F,  //  0009  GETMET	R1	R0	K47
+      0x880C0130,  //  000A  GETMBR	R3	R0	K48
       0x4C100000,  //  000B  LDNIL	R4
       0x7C040600,  //  000C  CALL	R1	3
       0x80000000,  //  000D  RET	0
@@ -1212,19 +1134,17 @@ be_local_closure(class_Matter_HTTP_remote_add_async_cb,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(async_cb_map),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(add_async_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0107,  //  0000  GETMBR	R3	R0	K7
       0x980C0202,  //  0001  SETIDX	R3	R1	R2
       0x80000000,  //  0002  RET	0
     })
@@ -1240,45 +1160,35 @@ be_local_closure(class_Matter_HTTP_remote_event_http_timeout,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
-    /* K3   */  be_nested_str_weak(http_status),
-    /* K4   */  be_nested_str_weak(phase),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(payload),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(dispatch_cb),
-    }),
+    &be_ktab_class_Matter_HTTP_remote,     /* shared constants */
     be_str_weak(event_http_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0xB8062200,  //  0005  GETNGBL	R1	K17
       0x60080018,  //  0006  GETGBL	R2	G24
-      0x580C0002,  //  0007  LDCONST	R3	K2
-      0x88100103,  //  0008  GETMBR	R4	R0	K3
-      0x88140104,  //  0009  GETMBR	R5	R0	K4
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x580C0052,  //  0007  LDCONST	R3	K82
+      0x88100130,  //  0008  GETMBR	R4	R0	K48
+      0x88140153,  //  0009  GETMBR	R5	R0	K83
+      0x88180154,  //  000A  GETMBR	R6	R0	K84
       0x601C000C,  //  000B  GETGBL	R7	G12
-      0x88200106,  //  000C  GETMBR	R8	R0	K6
+      0x88200129,  //  000C  GETMBR	R8	R0	K41
       0x7C1C0200,  //  000D  CALL	R7	1
       0x7C080A00,  //  000E  CALL	R2	5
-      0x580C0007,  //  000F  LDCONST	R3	K7
+      0x580C0014,  //  000F  LDCONST	R3	K20
       0x7C040400,  //  0010  CALL	R1	2
-      0x8C040108,  //  0011  GETMET	R1	R0	K8
-      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x8C04012F,  //  0011  GETMET	R1	R0	K47
+      0x880C0130,  //  0012  GETMBR	R3	R0	K48
       0x4C100000,  //  0013  LDNIL	R4
       0x7C040600,  //  0014  CALL	R1	3
       0x80000000,  //  0015  RET	0

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -3,6 +3,217 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_IM;
+// compact class 'Matter_IM' ktab size: 206, total: 507 (saved 2408 bytes)
+static const bvalue be_ktab_class_Matter_IM[206] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(WriteRequestMessage),
+  /* K2   */  be_nested_str_weak(from_TLV),
+  /* K3   */  be_nested_str_weak(Path),
+  /* K4   */  be_nested_str_weak(suppress_response),
+  /* K5   */  be_nested_str_weak(write_requests),
+  /* K6   */  be_nested_str_weak(WriteResponseMessage),
+  /* K7   */  be_nested_str_weak(write_responses),
+  /* K8   */  be_nested_str_weak(PathGenerator),
+  /* K9   */  be_nested_str_weak(device),
+  /* K10  */  be_nested_str_weak(path),
+  /* K11  */  be_nested_str_weak(data),
+  /* K12  */  be_nested_str_weak(copy),
+  /* K13  */  be_nested_str_weak(cluster),
+  /* K14  */  be_nested_str_weak(attribute),
+  /* K15  */  be_nested_str_weak(status),
+  /* K16  */  be_nested_str_weak(INVALID_ACTION),
+  /* K17  */  be_nested_str_weak(write_single_attribute_status_to_bytes),
+  /* K18  */  be_nested_str_weak(endpoint),
+  /* K19  */  be_nested_str_weak(tasmota),
+  /* K20  */  be_nested_str_weak(loglevel),
+  /* K21  */  be_const_int(3),
+  /* K22  */  be_nested_str_weak(get_attribute_name),
+  /* K23  */  be_nested_str_weak(log),
+  /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+  /* K25  */  be_nested_str_weak(_X20_X28),
+  /* K26  */  be_nested_str_weak(_X29),
+  /* K27  */  be_nested_str_weak(),
+  /* K28  */  be_nested_str_weak(start),
+  /* K29  */  be_nested_str_weak(is_direct),
+  /* K30  */  be_nested_str_weak(next_attribute),
+  /* K31  */  be_nested_str_weak(msg),
+  /* K32  */  be_nested_str_weak(get_pi),
+  /* K33  */  be_nested_str_weak(UNSUPPORTED_WRITE),
+  /* K34  */  be_nested_str_weak(write_attribute),
+  /* K35  */  be_nested_str_weak(session),
+  /* K36  */  be_nested_str_weak(SUCCESS),
+  /* K37  */  be_nested_str_weak(stop_iteration),
+  /* K38  */  be_nested_str_weak(send_queue),
+  /* K39  */  be_nested_str_weak(push),
+  /* K40  */  be_nested_str_weak(IM_WriteResponse),
+  /* K41  */  be_nested_str_weak(add),
+  /* K42  */  be_const_int(1),
+  /* K43  */  be_const_int(2),
+  /* K44  */  be_const_int(355795236),
+  /* K45  */  be_nested_str_weak(path2raw),
+  /* K46  */  be_nested_str_weak(tag_sub),
+  /* K47  */  be_nested_str_weak(tlv2raw),
+  /* K48  */  be_nested_str_weak(ReadRequestMessage),
+  /* K49  */  be_nested_str_weak(fabric_filtered),
+  /* K50  */  be_nested_str_weak(attributes_requests),
+  /* K51  */  be_nested_str_weak(updates),
+  /* K52  */  be_nested_str_weak(AttributePathIB),
+  /* K53  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+  /* K54  */  be_nested_str_weak(local_session_id),
+  /* K55  */  be_nested_str_weak(subscription_id),
+  /* K56  */  be_nested_str_weak(is_keep_alive),
+  /* K57  */  be_nested_str_weak(process_read_or_subscribe_request_pull),
+  /* K58  */  be_nested_str_weak(update_event_generator_array),
+  /* K59  */  be_nested_str_weak(IM_ReportDataSubscribed_Pull),
+  /* K60  */  be_nested_str_weak(_message_handler),
+  /* K61  */  be_nested_str_weak(send_enqueued),
+  /* K62  */  be_nested_str_weak(process_read_or_subscribe_request_event_pull),
+  /* K63  */  be_nested_str_weak(IM_ReportData_Pull),
+  /* K64  */  be_const_int(0),
+  /* K65  */  be_const_int(1),
+  /* K66  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+  /* K67  */  be_nested_str_weak(TimedRequestMessage),
+  /* K68  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
+  /* K69  */  be_nested_str_weak(timeout),
+  /* K70  */  be_nested_str_weak(send_status),
+  /* K71  */  be_nested_str_weak(subs_shop),
+  /* K72  */  be_nested_str_weak(every_50ms),
+  /* K73  */  be_nested_str_weak(InvokeRequestMessage),
+  /* K74  */  be_nested_str_weak(invoke_requests),
+  /* K75  */  be_nested_str_weak(InvokeResponseMessage),
+  /* K76  */  be_nested_str_weak(invoke_responses),
+  /* K77  */  be_nested_str_weak(command_path),
+  /* K78  */  be_nested_str_weak(command),
+  /* K79  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+  /* K80  */  be_nested_str_weak(get_command_name),
+  /* K81  */  be_nested_str_weak(invoke_request),
+  /* K82  */  be_nested_str_weak(command_fields),
+  /* K83  */  be_nested_str_weak(_X28),
+  /* K84  */  be_nested_str_weak(_X29_X20),
+  /* K85  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+  /* K86  */  be_nested_str_weak(invokeresponse2raw),
+  /* K87  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
+  /* K88  */  be_nested_str_weak(exchange_id),
+  /* K89  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
+  /* K90  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
+  /* K91  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
+  /* K92  */  be_const_int(0),
+  /* K93  */  be_nested_str_weak(IM_InvokeResponse),
+  /* K94  */  be_nested_str_weak(event_requests),
+  /* K95  */  be_nested_str_weak(get_node_id),
+  /* K96  */  be_nested_str_weak(parse_event_filters_min_no),
+  /* K97  */  be_nested_str_weak(event_filters),
+  /* K98  */  be_nested_str_weak(EventGenerator),
+  /* K99  */  be_nested_str_weak(event),
+  /* K100 */  be_nested_str_weak(get_event_name),
+  /* K101 */  be_nested_str_weak(_X2502X),
+  /* K102 */  be_nested_str_weak(_X2A_X2A),
+  /* K103 */  be_nested_str_weak(_X2504X),
+  /* K104 */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+  /* K105 */  be_nested_str_weak(_X20_X28_X3E_X25s_X29),
+  /* K106 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X29_X20_X5B_X25s_X5D_X25s_X2F_X25s_X20_X25s_X25s),
+  /* K107 */  be_nested_str_weak(finished),
+  /* K108 */  be_nested_str_weak(ready),
+  /* K109 */  be_nested_str_weak(send_im),
+  /* K110 */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+  /* K111 */  be_nested_str_weak(resp),
+  /* K112 */  be_nested_str_weak(SubscribeRequestMessage),
+  /* K113 */  be_nested_str_weak(keep_subscriptions),
+  /* K114 */  be_nested_str_weak(remove_by_session),
+  /* K115 */  be_nested_str_weak(new_subscription),
+  /* K116 */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i_X20fabric_filtered_X3D_X25s),
+  /* K117 */  be_nested_str_weak(concat),
+  /* K118 */  be_nested_str_weak(_X20),
+  /* K119 */  be_nested_str_weak(min_interval),
+  /* K120 */  be_nested_str_weak(max_interval),
+  /* K121 */  be_nested_str_weak(set_event_generator_or_arr),
+  /* K122 */  be_nested_str_weak(IM_SubscribeResponse_Pull),
+  /* K123 */  be_nested_str_weak(send_encrypted_ack),
+  /* K124 */  be_nested_str_weak(time_reached),
+  /* K125 */  be_nested_str_weak(expiration),
+  /* K126 */  be_nested_str_weak(reached_timeout),
+  /* K127 */  be_nested_str_weak(remove),
+  /* K128 */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+  /* K129 */  be_nested_str_weak(ack_received),
+  /* K130 */  be_nested_str_weak(get_exchangeid),
+  /* K131 */  be_nested_str_weak(TLV),
+  /* K132 */  be_nested_str_weak(AttributeStatusIB),
+  /* K133 */  be_nested_str_weak(StatusIB),
+  /* K134 */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20_X25s_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+  /* K135 */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20IGNORED),
+  /* K136 */  be_nested_str_weak(IM_Subscription_Shop),
+  /* K137 */  be_nested_str_weak(read_request_solo),
+  /* K138 */  be_nested_str_weak(ReadRequestMessage_solo),
+  /* K139 */  be_nested_str_weak(invoke_request_solo),
+  /* K140 */  be_nested_str_weak(InvokeRequestMessage_solo),
+  /* K141 */  be_nested_str_weak(tlv_solo),
+  /* K142 */  be_nested_str_weak(Matter_TLV_item),
+  /* K143 */  be_nested_str_weak(expire_sendqueue),
+  /* K144 */  be_nested_str_weak(MTR_X3A_X20_X3ECommand1_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+  /* K145 */  be_const_int(354943030),
+  /* K146 */  be_const_int(405077761),
+  /* K147 */  be_nested_str_weak(build_response),
+  /* K148 */  be_nested_str_weak(message_handler),
+  /* K149 */  be_nested_str_weak(raw),
+  /* K150 */  be_nested_str_weak(clear),
+  /* K151 */  be_nested_str_weak(encode_frame),
+  /* K152 */  be_nested_str_weak(encrypt),
+  /* K153 */  be_nested_str_weak(send_response_frame),
+  /* K154 */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25s),
+  /* K155 */  be_nested_str_weak(IM_SubscribedHeartbeat),
+  /* K156 */  be_nested_str_weak(resolve_attribute_read_solo),
+  /* K157 */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+  /* K158 */  be_nested_str_weak(read_attribute),
+  /* K159 */  be_nested_str_weak(is_list),
+  /* K160 */  be_nested_str_weak(is_array),
+  /* K161 */  be_nested_str_weak(encode_len),
+  /* K162 */  be_nested_str_weak(MAX_MESSAGE),
+  /* K163 */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Response_X20to_X20big_X2C_X20revert_X20to_X20non_X2Dsolo),
+  /* K164 */  be_nested_str_weak(parse),
+  /* K165 */  be_nested_str_weak(app_payload_idx),
+  /* K166 */  be_nested_str_weak(process_read_request_pull),
+  /* K167 */  be_nested_str_weak(attributedata2raw),
+  /* K168 */  be_const_int(405077761),
+  /* K169 */  be_nested_str_weak(attributestatus2raw),
+  /* K170 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
+  /* K171 */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+  /* K172 */  be_nested_str_weak(message_counter),
+  /* K173 */  be_nested_str_weak(ack_message_counter),
+  /* K174 */  be_nested_str_weak(to_str_val),
+  /* K175 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+  /* K176 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+  /* K177 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+  /* K178 */  be_const_class(be_class_Matter_IM),
+  /* K179 */  be_nested_str_weak(int64),
+  /* K180 */  be_nested_str_weak(toint64),
+  /* K181 */  be_nested_str_weak(node),
+  /* K182 */  be_nested_str_weak(tobytes),
+  /* K183 */  be_nested_str_weak(MTR_X3A_X20node_id_X20filter_X20_X25s_X20doesn_X27t_X20match_X20_X25s),
+  /* K184 */  be_nested_str_weak(tohex),
+  /* K185 */  be_nested_str_weak(event_min),
+  /* K186 */  be_nested_str_weak(findsubval),
+  /* K187 */  be_nested_str_weak(status_ok_received),
+  /* K188 */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
+  /* K189 */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+  /* K190 */  be_nested_str_weak(status_error_received),
+  /* K191 */  be_nested_str_weak(Matter_TLV_array),
+  /* K192 */  be_nested_str_weak(val),
+  /* K193 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+  /* K194 */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+  /* K195 */  be_nested_str_weak(IM_Status),
+  /* K196 */  be_nested_str_weak(opcode),
+  /* K197 */  be_nested_str_weak(from_raw),
+  /* K198 */  be_nested_str_weak(process_read_request_solo),
+  /* K199 */  be_nested_str_weak(process_invoke_request_solo),
+  /* K200 */  be_nested_str_weak(process_status_response),
+  /* K201 */  be_nested_str_weak(send_ack_now),
+  /* K202 */  be_nested_str_weak(subscribe_request),
+  /* K203 */  be_nested_str_weak(process_write_request),
+  /* K204 */  be_nested_str_weak(process_invoke_request),
+  /* K205 */  be_nested_str_weak(process_timed_request),
+};
+
 
 extern const bclass be_class_Matter_IM;
 
@@ -13,55 +224,13 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
   be_nested_proto(
     21,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(WriteRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(Path),
-    /* K4   */  be_nested_str_weak(suppress_response),
-    /* K5   */  be_nested_str_weak(write_requests),
-    /* K6   */  be_nested_str_weak(WriteResponseMessage),
-    /* K7   */  be_nested_str_weak(write_responses),
-    /* K8   */  be_nested_str_weak(PathGenerator),
-    /* K9   */  be_nested_str_weak(device),
-    /* K10  */  be_nested_str_weak(path),
-    /* K11  */  be_nested_str_weak(data),
-    /* K12  */  be_nested_str_weak(copy),
-    /* K13  */  be_nested_str_weak(cluster),
-    /* K14  */  be_nested_str_weak(attribute),
-    /* K15  */  be_nested_str_weak(status),
-    /* K16  */  be_nested_str_weak(INVALID_ACTION),
-    /* K17  */  be_nested_str_weak(write_single_attribute_status_to_bytes),
-    /* K18  */  be_nested_str_weak(endpoint),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(loglevel),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(get_attribute_name),
-    /* K23  */  be_nested_str_weak(log),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K25  */  be_nested_str_weak(_X20_X28),
-    /* K26  */  be_nested_str_weak(_X29),
-    /* K27  */  be_nested_str_weak(),
-    /* K28  */  be_nested_str_weak(start),
-    /* K29  */  be_nested_str_weak(is_direct),
-    /* K30  */  be_nested_str_weak(next_attribute),
-    /* K31  */  be_nested_str_weak(msg),
-    /* K32  */  be_nested_str_weak(get_pi),
-    /* K33  */  be_nested_str_weak(UNSUPPORTED_WRITE),
-    /* K34  */  be_nested_str_weak(write_attribute),
-    /* K35  */  be_nested_str_weak(session),
-    /* K36  */  be_nested_str_weak(SUCCESS),
-    /* K37  */  be_nested_str_weak(stop_iteration),
-    /* K38  */  be_nested_str_weak(send_queue),
-    /* K39  */  be_nested_str_weak(push),
-    /* K40  */  be_nested_str_weak(IM_WriteResponse),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_write_request),
     &be_const_str_solidified,
     ( &(const binstruction[145]) {  /* code */
@@ -223,128 +392,121 @@ be_local_closure(class_Matter_IM_path2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(attribute),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(path2raw),
     &be_const_str_solidified,
     ( &(const binstruction[107]) {  /* code */
-      0x8C140300,  //  0000  GETMET	R5	R1	K0
+      0x8C140329,  //  0000  GETMET	R5	R1	K41
       0x541E0036,  //  0001  LDINT	R7	55
-      0x58200001,  //  0002  LDCONST	R8	K1
+      0x5820002A,  //  0002  LDCONST	R8	K42
       0x7C140600,  //  0003  CALL	R5	3
-      0x8C140300,  //  0004  GETMET	R5	R1	K0
+      0x8C140329,  //  0004  GETMET	R5	R1	K41
       0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200001,  //  0006  LDCONST	R8	K1
+      0x5820002A,  //  0006  LDCONST	R8	K42
       0x7C140600,  //  0007  CALL	R5	3
-      0x88140502,  //  0008  GETMBR	R5	R2	K2
+      0x88140512,  //  0008  GETMBR	R5	R2	K18
       0x541A00FE,  //  0009  LDINT	R6	255
       0x18140A06,  //  000A  LE	R5	R5	R6
       0x78160008,  //  000B  JMPF	R5	#0015
-      0x8C140300,  //  000C  GETMET	R5	R1	K0
+      0x8C140329,  //  000C  GETMET	R5	R1	K41
       0x541E2401,  //  000D  LDINT	R7	9218
       0x5421FFFD,  //  000E  LDINT	R8	-2
       0x7C140600,  //  000F  CALL	R5	3
-      0x8C140300,  //  0010  GETMET	R5	R1	K0
-      0x881C0502,  //  0011  GETMBR	R7	R2	K2
-      0x58200001,  //  0012  LDCONST	R8	K1
+      0x8C140329,  //  0010  GETMET	R5	R1	K41
+      0x881C0512,  //  0011  GETMBR	R7	R2	K18
+      0x5820002A,  //  0012  LDCONST	R8	K42
       0x7C140600,  //  0013  CALL	R5	3
       0x70020007,  //  0014  JMP		#001D
-      0x8C140300,  //  0015  GETMET	R5	R1	K0
+      0x8C140329,  //  0015  GETMET	R5	R1	K41
       0x541E2501,  //  0016  LDINT	R7	9474
       0x5421FFFD,  //  0017  LDINT	R8	-2
       0x7C140600,  //  0018  CALL	R5	3
-      0x8C140300,  //  0019  GETMET	R5	R1	K0
-      0x881C0502,  //  001A  GETMBR	R7	R2	K2
-      0x58200003,  //  001B  LDCONST	R8	K3
+      0x8C140329,  //  0019  GETMET	R5	R1	K41
+      0x881C0512,  //  001A  GETMBR	R7	R2	K18
+      0x5820002B,  //  001B  LDCONST	R8	K43
       0x7C140600,  //  001C  CALL	R5	3
-      0x88140504,  //  001D  GETMBR	R5	R2	K4
+      0x8814050D,  //  001D  GETMBR	R5	R2	K13
       0x541A00FE,  //  001E  LDINT	R6	255
       0x18140A06,  //  001F  LE	R5	R5	R6
       0x78160008,  //  0020  JMPF	R5	#002A
-      0x8C140300,  //  0021  GETMET	R5	R1	K0
+      0x8C140329,  //  0021  GETMET	R5	R1	K41
       0x541E2402,  //  0022  LDINT	R7	9219
       0x5421FFFD,  //  0023  LDINT	R8	-2
       0x7C140600,  //  0024  CALL	R5	3
-      0x8C140300,  //  0025  GETMET	R5	R1	K0
-      0x881C0504,  //  0026  GETMBR	R7	R2	K4
-      0x58200001,  //  0027  LDCONST	R8	K1
+      0x8C140329,  //  0025  GETMET	R5	R1	K41
+      0x881C050D,  //  0026  GETMBR	R7	R2	K13
+      0x5820002A,  //  0027  LDCONST	R8	K42
       0x7C140600,  //  0028  CALL	R5	3
       0x70020014,  //  0029  JMP		#003F
-      0x88140504,  //  002A  GETMBR	R5	R2	K4
+      0x8814050D,  //  002A  GETMBR	R5	R2	K13
       0x541AFFFE,  //  002B  LDINT	R6	65535
       0x18140A06,  //  002C  LE	R5	R5	R6
       0x78160008,  //  002D  JMPF	R5	#0037
-      0x8C140300,  //  002E  GETMET	R5	R1	K0
+      0x8C140329,  //  002E  GETMET	R5	R1	K41
       0x541E2502,  //  002F  LDINT	R7	9475
       0x5421FFFD,  //  0030  LDINT	R8	-2
       0x7C140600,  //  0031  CALL	R5	3
-      0x8C140300,  //  0032  GETMET	R5	R1	K0
-      0x881C0504,  //  0033  GETMBR	R7	R2	K4
-      0x58200003,  //  0034  LDCONST	R8	K3
+      0x8C140329,  //  0032  GETMET	R5	R1	K41
+      0x881C050D,  //  0033  GETMBR	R7	R2	K13
+      0x5820002B,  //  0034  LDCONST	R8	K43
       0x7C140600,  //  0035  CALL	R5	3
       0x70020007,  //  0036  JMP		#003F
-      0x8C140300,  //  0037  GETMET	R5	R1	K0
+      0x8C140329,  //  0037  GETMET	R5	R1	K41
       0x541E2602,  //  0038  LDINT	R7	9731
       0x5421FFFD,  //  0039  LDINT	R8	-2
       0x7C140600,  //  003A  CALL	R5	3
-      0x8C140300,  //  003B  GETMET	R5	R1	K0
-      0x881C0504,  //  003C  GETMBR	R7	R2	K4
+      0x8C140329,  //  003B  GETMET	R5	R1	K41
+      0x881C050D,  //  003C  GETMBR	R7	R2	K13
       0x54220003,  //  003D  LDINT	R8	4
       0x7C140600,  //  003E  CALL	R5	3
-      0x88140505,  //  003F  GETMBR	R5	R2	K5
+      0x8814050E,  //  003F  GETMBR	R5	R2	K14
       0x541A00FE,  //  0040  LDINT	R6	255
       0x18140A06,  //  0041  LE	R5	R5	R6
       0x78160008,  //  0042  JMPF	R5	#004C
-      0x8C140300,  //  0043  GETMET	R5	R1	K0
+      0x8C140329,  //  0043  GETMET	R5	R1	K41
       0x541E2403,  //  0044  LDINT	R7	9220
       0x5421FFFD,  //  0045  LDINT	R8	-2
       0x7C140600,  //  0046  CALL	R5	3
-      0x8C140300,  //  0047  GETMET	R5	R1	K0
-      0x881C0505,  //  0048  GETMBR	R7	R2	K5
-      0x58200001,  //  0049  LDCONST	R8	K1
+      0x8C140329,  //  0047  GETMET	R5	R1	K41
+      0x881C050E,  //  0048  GETMBR	R7	R2	K14
+      0x5820002A,  //  0049  LDCONST	R8	K42
       0x7C140600,  //  004A  CALL	R5	3
       0x70020014,  //  004B  JMP		#0061
-      0x88140505,  //  004C  GETMBR	R5	R2	K5
+      0x8814050E,  //  004C  GETMBR	R5	R2	K14
       0x541AFFFE,  //  004D  LDINT	R6	65535
       0x18140A06,  //  004E  LE	R5	R5	R6
       0x78160008,  //  004F  JMPF	R5	#0059
-      0x8C140300,  //  0050  GETMET	R5	R1	K0
+      0x8C140329,  //  0050  GETMET	R5	R1	K41
       0x541E2503,  //  0051  LDINT	R7	9476
       0x5421FFFD,  //  0052  LDINT	R8	-2
       0x7C140600,  //  0053  CALL	R5	3
-      0x8C140300,  //  0054  GETMET	R5	R1	K0
-      0x881C0505,  //  0055  GETMBR	R7	R2	K5
-      0x58200003,  //  0056  LDCONST	R8	K3
+      0x8C140329,  //  0054  GETMET	R5	R1	K41
+      0x881C050E,  //  0055  GETMBR	R7	R2	K14
+      0x5820002B,  //  0056  LDCONST	R8	K43
       0x7C140600,  //  0057  CALL	R5	3
       0x70020007,  //  0058  JMP		#0061
-      0x8C140300,  //  0059  GETMET	R5	R1	K0
+      0x8C140329,  //  0059  GETMET	R5	R1	K41
       0x541E2603,  //  005A  LDINT	R7	9732
       0x5421FFFD,  //  005B  LDINT	R8	-2
       0x7C140600,  //  005C  CALL	R5	3
-      0x8C140300,  //  005D  GETMET	R5	R1	K0
-      0x881C0505,  //  005E  GETMBR	R7	R2	K5
+      0x8C140329,  //  005D  GETMET	R5	R1	K41
+      0x881C050E,  //  005E  GETMBR	R7	R2	K14
       0x54220003,  //  005F  LDINT	R8	4
       0x7C140600,  //  0060  CALL	R5	3
       0x78120003,  //  0061  JMPF	R4	#0066
-      0x8C140300,  //  0062  GETMET	R5	R1	K0
+      0x8C140329,  //  0062  GETMET	R5	R1	K41
       0x541E3404,  //  0063  LDINT	R7	13317
       0x5421FFFD,  //  0064  LDINT	R8	-2
       0x7C140600,  //  0065  CALL	R5	3
-      0x8C140300,  //  0066  GETMET	R5	R1	K0
+      0x8C140329,  //  0066  GETMET	R5	R1	K41
       0x541E0017,  //  0067  LDINT	R7	24
-      0x58200001,  //  0068  LDCONST	R8	K1
+      0x5820002A,  //  0068  LDCONST	R8	K42
       0x7C140600,  //  0069  CALL	R5	3
       0x80000000,  //  006A  RET	0
     })
@@ -360,43 +522,35 @@ be_local_closure(class_Matter_IM_attributedata2raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(355795236),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(path2raw),
-    /* K4   */  be_nested_str_weak(tag_sub),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(tlv2raw),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(attributedata2raw),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C140300,  //  0000  GETMET	R5	R1	K0
-      0x581C0001,  //  0001  LDCONST	R7	K1
+      0x8C140329,  //  0000  GETMET	R5	R1	K41
+      0x581C002C,  //  0001  LDCONST	R7	K44
       0x5421FFFB,  //  0002  LDINT	R8	-4
       0x7C140600,  //  0003  CALL	R5	3
-      0x8C140300,  //  0004  GETMET	R5	R1	K0
-      0x581C0002,  //  0005  LDCONST	R7	K2
+      0x8C140329,  //  0004  GETMET	R5	R1	K41
+      0x581C002A,  //  0005  LDCONST	R7	K42
       0x5421FFFD,  //  0006  LDINT	R8	-2
       0x7C140600,  //  0007  CALL	R5	3
-      0x8C140103,  //  0008  GETMET	R5	R0	K3
+      0x8C14012D,  //  0008  GETMET	R5	R0	K45
       0x5C1C0200,  //  0009  MOVE	R7	R1
       0x5C200400,  //  000A  MOVE	R8	R2
-      0x58240002,  //  000B  LDCONST	R9	K2
+      0x5824002A,  //  000B  LDCONST	R9	K42
       0x5C280800,  //  000C  MOVE	R10	R4
       0x7C140A00,  //  000D  CALL	R5	5
-      0x900E0905,  //  000E  SETMBR	R3	K4	K5
-      0x8C140706,  //  000F  GETMET	R5	R3	K6
+      0x900E5D2B,  //  000E  SETMBR	R3	K46	K43
+      0x8C14072F,  //  000F  GETMET	R5	R3	K47
       0x5C1C0200,  //  0010  MOVE	R7	R1
       0x7C140400,  //  0011  CALL	R5	2
-      0x8C140300,  //  0012  GETMET	R5	R1	K0
+      0x8C140329,  //  0012  GETMET	R5	R1	K41
       0x541E1817,  //  0013  LDINT	R7	6168
       0x5421FFFD,  //  0014  LDINT	R8	-2
       0x7C140600,  //  0015  CALL	R5	3
@@ -414,103 +568,78 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ReadRequestMessage),
-    /* K3   */  be_nested_str_weak(fabric_filtered),
-    /* K4   */  be_nested_str_weak(attributes_requests),
-    /* K5   */  be_nested_str_weak(updates),
-    /* K6   */  be_nested_str_weak(AttributePathIB),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K14  */  be_nested_str_weak(local_session_id),
-    /* K15  */  be_nested_str_weak(subscription_id),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(is_keep_alive),
-    /* K18  */  be_nested_str_weak(process_read_or_subscribe_request_pull),
-    /* K19  */  be_nested_str_weak(update_event_generator_array),
-    /* K20  */  be_nested_str_weak(IM_ReportDataSubscribed_Pull),
-    /* K21  */  be_nested_str_weak(_message_handler),
-    /* K22  */  be_nested_str_weak(send_queue),
-    /* K23  */  be_nested_str_weak(send_enqueued),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(send_subscribe_update),
     &be_const_str_solidified,
     ( &(const binstruction[64]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x88080323,  //  0000  GETMBR	R2	R1	K35
+      0xB80E0000,  //  0001  GETNGBL	R3	K0
+      0x8C0C0730,  //  0002  GETMET	R3	R3	K48
       0x7C0C0200,  //  0003  CALL	R3	1
       0x50100000,  //  0004  LDBOOL	R4	0	0
-      0x900E0604,  //  0005  SETMBR	R3	K3	R4
+      0x900E6204,  //  0005  SETMBR	R3	K49	R4
       0x60100012,  //  0006  GETGBL	R4	G18
       0x7C100000,  //  0007  CALL	R4	0
-      0x900E0804,  //  0008  SETMBR	R3	K4	R4
+      0x900E6404,  //  0008  SETMBR	R3	K50	R4
       0x60100010,  //  0009  GETGBL	R4	G16
-      0x88140305,  //  000A  GETMBR	R5	R1	K5
+      0x88140333,  //  000A  GETMBR	R5	R1	K51
       0x7C100200,  //  000B  CALL	R4	1
       0xA802000F,  //  000C  EXBLK	0	#001D
       0x5C140800,  //  000D  MOVE	R5	R4
       0x7C140000,  //  000E  CALL	R5	0
-      0xB81A0200,  //  000F  GETNGBL	R6	K1
-      0x8C180D06,  //  0010  GETMET	R6	R6	K6
+      0xB81A0000,  //  000F  GETNGBL	R6	K0
+      0x8C180D34,  //  0010  GETMET	R6	R6	K52
       0x7C180200,  //  0011  CALL	R6	1
-      0x881C0B07,  //  0012  GETMBR	R7	R5	K7
-      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
-      0x881C0B08,  //  0014  GETMBR	R7	R5	K8
-      0x901A1007,  //  0015  SETMBR	R6	K8	R7
-      0x881C0B09,  //  0016  GETMBR	R7	R5	K9
-      0x901A1207,  //  0017  SETMBR	R6	K9	R7
-      0x881C0704,  //  0018  GETMBR	R7	R3	K4
-      0x8C1C0F0A,  //  0019  GETMET	R7	R7	K10
+      0x881C0B12,  //  0012  GETMBR	R7	R5	K18
+      0x901A2407,  //  0013  SETMBR	R6	K18	R7
+      0x881C0B0D,  //  0014  GETMBR	R7	R5	K13
+      0x901A1A07,  //  0015  SETMBR	R6	K13	R7
+      0x881C0B0E,  //  0016  GETMBR	R7	R5	K14
+      0x901A1C07,  //  0017  SETMBR	R6	K14	R7
+      0x881C0732,  //  0018  GETMBR	R7	R3	K50
+      0x8C1C0F27,  //  0019  GETMET	R7	R7	K39
       0x5C240C00,  //  001A  MOVE	R9	R6
       0x7C1C0400,  //  001B  CALL	R7	2
       0x7001FFEF,  //  001C  JMP		#000D
-      0x5810000B,  //  001D  LDCONST	R4	K11
+      0x58100025,  //  001D  LDCONST	R4	K37
       0xAC100200,  //  001E  CATCH	R4	1	0
       0xB0080000,  //  001F  RAISE	2	R0	R0
-      0xB8121800,  //  0020  GETNGBL	R4	K12
+      0xB8122E00,  //  0020  GETNGBL	R4	K23
       0x60140018,  //  0021  GETGBL	R5	G24
-      0x5818000D,  //  0022  LDCONST	R6	K13
-      0x881C050E,  //  0023  GETMBR	R7	R2	K14
-      0x8820030F,  //  0024  GETMBR	R8	R1	K15
+      0x58180035,  //  0022  LDCONST	R6	K53
+      0x881C0536,  //  0023  GETMBR	R7	R2	K54
+      0x88200337,  //  0024  GETMBR	R8	R1	K55
       0x7C140600,  //  0025  CALL	R5	3
-      0x58180010,  //  0026  LDCONST	R6	K16
+      0x58180015,  //  0026  LDCONST	R6	K21
       0x7C100400,  //  0027  CALL	R4	2
       0x50100000,  //  0028  LDBOOL	R4	0	0
-      0x90062204,  //  0029  SETMBR	R1	K17	R4
-      0x8C100112,  //  002A  GETMET	R4	R0	K18
+      0x90067004,  //  0029  SETMBR	R1	K56	R4
+      0x8C100139,  //  002A  GETMET	R4	R0	K57
       0x5C180600,  //  002B  MOVE	R6	R3
       0x4C1C0000,  //  002C  LDNIL	R7
       0x7C100600,  //  002D  CALL	R4	3
-      0x8C140313,  //  002E  GETMET	R5	R1	K19
+      0x8C14033A,  //  002E  GETMET	R5	R1	K58
       0x7C140200,  //  002F  CALL	R5	1
-      0xB81A0200,  //  0030  GETNGBL	R6	K1
-      0x8C180D14,  //  0031  GETMET	R6	R6	K20
-      0x88200515,  //  0032  GETMBR	R8	R2	K21
+      0xB81A0000,  //  0030  GETNGBL	R6	K0
+      0x8C180D3B,  //  0031  GETMET	R6	R6	K59
+      0x8820053C,  //  0032  GETMBR	R8	R2	K60
       0x5C240400,  //  0033  MOVE	R9	R2
       0x5C280800,  //  0034  MOVE	R10	R4
       0x5C2C0A00,  //  0035  MOVE	R11	R5
       0x5C300200,  //  0036  MOVE	R12	R1
       0x7C180C00,  //  0037  CALL	R6	6
-      0x881C0116,  //  0038  GETMBR	R7	R0	K22
-      0x8C1C0F0A,  //  0039  GETMET	R7	R7	K10
+      0x881C0126,  //  0038  GETMBR	R7	R0	K38
+      0x8C1C0F27,  //  0039  GETMET	R7	R7	K39
       0x5C240C00,  //  003A  MOVE	R9	R6
       0x7C1C0400,  //  003B  CALL	R7	2
-      0x8C1C0117,  //  003C  GETMET	R7	R0	K23
-      0x88240515,  //  003D  GETMBR	R9	R2	K21
+      0x8C1C013D,  //  003C  GETMET	R7	R0	K61
+      0x8824053C,  //  003D  GETMBR	R9	R2	K60
       0x7C1C0400,  //  003E  CALL	R7	2
       0x80000000,  //  003F  RET	0
     })
@@ -526,43 +655,34 @@ be_local_closure(class_Matter_IM_process_read_request_pull,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(ReadRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(process_read_or_subscribe_request_pull),
-    /* K4   */  be_nested_str_weak(process_read_or_subscribe_request_event_pull),
-    /* K5   */  be_nested_str_weak(send_queue),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(IM_ReportData_Pull),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_read_request_pull),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C0C0730,  //  0001  GETMET	R3	R3	K48
       0x7C0C0200,  //  0002  CALL	R3	1
       0x8C0C0702,  //  0003  GETMET	R3	R3	K2
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
-      0x8C100103,  //  0006  GETMET	R4	R0	K3
+      0x8C100139,  //  0006  GETMET	R4	R0	K57
       0x5C180600,  //  0007  MOVE	R6	R3
       0x5C1C0200,  //  0008  MOVE	R7	R1
       0x7C100600,  //  0009  CALL	R4	3
-      0x8C140104,  //  000A  GETMET	R5	R0	K4
+      0x8C14013E,  //  000A  GETMET	R5	R0	K62
       0x5C1C0600,  //  000B  MOVE	R7	R3
       0x5C200200,  //  000C  MOVE	R8	R1
       0x7C140600,  //  000D  CALL	R5	3
-      0x88180105,  //  000E  GETMBR	R6	R0	K5
-      0x8C180D06,  //  000F  GETMET	R6	R6	K6
+      0x88180126,  //  000E  GETMBR	R6	R0	K38
+      0x8C180D27,  //  000F  GETMET	R6	R6	K39
       0xB8220000,  //  0010  GETNGBL	R8	K0
-      0x8C201107,  //  0011  GETMET	R8	R8	K7
+      0x8C20113F,  //  0011  GETMET	R8	R8	K63
       0x5C280200,  //  0012  MOVE	R10	R1
       0x5C2C0800,  //  0013  MOVE	R11	R4
       0x5C300A00,  //  0014  MOVE	R12	R5
@@ -583,152 +703,126 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_pull,   /* na
   be_nested_proto(
     16,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attributes_requests),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(PathGenerator),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(start),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(fabric_filtered),
-    /* K11  */  be_nested_str_weak(push),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(loglevel),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(Path),
-    /* K16  */  be_nested_str_weak(get_attribute_name),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K19  */  be_nested_str_weak(session),
-    /* K20  */  be_nested_str_weak(local_session_id),
-    /* K21  */  be_nested_str_weak(_X20_X28),
-    /* K22  */  be_nested_str_weak(_X29),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_read_or_subscribe_request_pull),
     &be_const_str_solidified,
     ( &(const binstruction[115]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x880C0332,  //  0000  GETMBR	R3	R1	K50
       0x4C100000,  //  0001  LDNIL	R4
       0x200C0604,  //  0002  NE	R3	R3	R4
       0x780E006C,  //  0003  JMPF	R3	#0071
       0x4C0C0000,  //  0004  LDNIL	R3
-      0x88100300,  //  0005  GETMBR	R4	R1	K0
+      0x88100332,  //  0005  GETMBR	R4	R1	K50
       0x78120003,  //  0006  JMPF	R4	#000B
       0x6010000C,  //  0007  GETGBL	R4	G12
-      0x88140300,  //  0008  GETMBR	R5	R1	K0
+      0x88140332,  //  0008  GETMBR	R5	R1	K50
       0x7C100200,  //  0009  CALL	R4	1
       0x70020000,  //  000A  JMP		#000C
-      0x58100001,  //  000B  LDCONST	R4	K1
-      0x24140902,  //  000C  GT	R5	R4	K2
+      0x58100040,  //  000B  LDCONST	R4	K64
+      0x24140941,  //  000C  GT	R5	R4	K65
       0x78160002,  //  000D  JMPF	R5	#0011
       0x60140012,  //  000E  GETGBL	R5	G18
       0x7C140000,  //  000F  CALL	R5	0
       0x5C0C0A00,  //  0010  MOVE	R3	R5
       0x60140010,  //  0011  GETGBL	R5	G16
-      0x88180300,  //  0012  GETMBR	R6	R1	K0
+      0x88180332,  //  0012  GETMBR	R6	R1	K50
       0x7C140200,  //  0013  CALL	R5	1
       0xA8020057,  //  0014  EXBLK	0	#006D
       0x5C180A00,  //  0015  MOVE	R6	R5
       0x7C180000,  //  0016  CALL	R6	0
-      0xB81E0600,  //  0017  GETNGBL	R7	K3
-      0x8C1C0F04,  //  0018  GETMET	R7	R7	K4
-      0x88240105,  //  0019  GETMBR	R9	R0	K5
+      0xB81E0000,  //  0017  GETNGBL	R7	K0
+      0x8C1C0F08,  //  0018  GETMET	R7	R7	K8
+      0x88240109,  //  0019  GETMBR	R9	R0	K9
       0x7C1C0400,  //  001A  CALL	R7	2
-      0x8C200F06,  //  001B  GETMET	R8	R7	K6
-      0x88280D07,  //  001C  GETMBR	R10	R6	K7
-      0x882C0D08,  //  001D  GETMBR	R11	R6	K8
-      0x88300D09,  //  001E  GETMBR	R12	R6	K9
-      0x8834030A,  //  001F  GETMBR	R13	R1	K10
+      0x8C200F1C,  //  001B  GETMET	R8	R7	K28
+      0x88280D12,  //  001C  GETMBR	R10	R6	K18
+      0x882C0D0D,  //  001D  GETMBR	R11	R6	K13
+      0x88300D0E,  //  001E  GETMBR	R12	R6	K14
+      0x88340331,  //  001F  GETMBR	R13	R1	K49
       0x7C200A00,  //  0020  CALL	R8	5
-      0x24200902,  //  0021  GT	R8	R4	K2
+      0x24200941,  //  0021  GT	R8	R4	K65
       0x78220003,  //  0022  JMPF	R8	#0027
-      0x8C20070B,  //  0023  GETMET	R8	R3	K11
+      0x8C200727,  //  0023  GETMET	R8	R3	K39
       0x5C280E00,  //  0024  MOVE	R10	R7
       0x7C200400,  //  0025  CALL	R8	2
       0x70020000,  //  0026  JMP		#0028
       0x5C0C0E00,  //  0027  MOVE	R3	R7
-      0xB8221800,  //  0028  GETNGBL	R8	K12
-      0x8C20110D,  //  0029  GETMET	R8	R8	K13
-      0x5828000E,  //  002A  LDCONST	R10	K14
+      0xB8222600,  //  0028  GETNGBL	R8	K19
+      0x8C201114,  //  0029  GETMET	R8	R8	K20
+      0x58280015,  //  002A  LDCONST	R10	K21
       0x7C200400,  //  002B  CALL	R8	2
       0x7822003E,  //  002C  JMPF	R8	#006C
-      0x88200D07,  //  002D  GETMBR	R8	R6	K7
+      0x88200D12,  //  002D  GETMBR	R8	R6	K18
       0x4C240000,  //  002E  LDNIL	R9
       0x1C201009,  //  002F  EQ	R8	R8	R9
       0x74220007,  //  0030  JMPT	R8	#0039
-      0x88200D08,  //  0031  GETMBR	R8	R6	K8
+      0x88200D0D,  //  0031  GETMBR	R8	R6	K13
       0x4C240000,  //  0032  LDNIL	R9
       0x1C201009,  //  0033  EQ	R8	R8	R9
       0x74220003,  //  0034  JMPT	R8	#0039
-      0x88200D09,  //  0035  GETMBR	R8	R6	K9
+      0x88200D0E,  //  0035  GETMBR	R8	R6	K14
       0x4C240000,  //  0036  LDNIL	R9
       0x1C201009,  //  0037  EQ	R8	R8	R9
       0x78220032,  //  0038  JMPF	R8	#006C
-      0xB8220600,  //  0039  GETNGBL	R8	K3
-      0x8C20110F,  //  003A  GETMET	R8	R8	K15
+      0xB8220000,  //  0039  GETNGBL	R8	K0
+      0x8C201103,  //  003A  GETMET	R8	R8	K3
       0x7C200200,  //  003B  CALL	R8	1
-      0x88240D07,  //  003C  GETMBR	R9	R6	K7
-      0x90220E09,  //  003D  SETMBR	R8	K7	R9
-      0x88240D08,  //  003E  GETMBR	R9	R6	K8
-      0x90221009,  //  003F  SETMBR	R8	K8	R9
-      0x88240D09,  //  0040  GETMBR	R9	R6	K9
-      0x90221209,  //  0041  SETMBR	R8	K9	R9
-      0x8824030A,  //  0042  GETMBR	R9	R1	K10
-      0x90221409,  //  0043  SETMBR	R8	K10	R9
+      0x88240D12,  //  003C  GETMBR	R9	R6	K18
+      0x90222409,  //  003D  SETMBR	R8	K18	R9
+      0x88240D0D,  //  003E  GETMBR	R9	R6	K13
+      0x90221A09,  //  003F  SETMBR	R8	K13	R9
+      0x88240D0E,  //  0040  GETMBR	R9	R6	K14
+      0x90221C09,  //  0041  SETMBR	R8	K14	R9
+      0x88240331,  //  0042  GETMBR	R9	R1	K49
+      0x90226209,  //  0043  SETMBR	R8	K49	R9
       0x60240008,  //  0044  GETGBL	R9	G8
       0x5C281000,  //  0045  MOVE	R10	R8
       0x7C240200,  //  0046  CALL	R9	1
-      0x88280D08,  //  0047  GETMBR	R10	R6	K8
+      0x88280D0D,  //  0047  GETMBR	R10	R6	K13
       0x4C2C0000,  //  0048  LDNIL	R11
       0x2028140B,  //  0049  NE	R10	R10	R11
       0x782A0017,  //  004A  JMPF	R10	#0063
-      0x88280D09,  //  004B  GETMBR	R10	R6	K9
+      0x88280D0E,  //  004B  GETMBR	R10	R6	K14
       0x4C2C0000,  //  004C  LDNIL	R11
       0x2028140B,  //  004D  NE	R10	R10	R11
       0x782A0013,  //  004E  JMPF	R10	#0063
-      0xB82A0600,  //  004F  GETNGBL	R10	K3
-      0x8C281510,  //  0050  GETMET	R10	R10	K16
-      0x88300D08,  //  0051  GETMBR	R12	R6	K8
-      0x88340D09,  //  0052  GETMBR	R13	R6	K9
+      0xB82A0000,  //  004F  GETNGBL	R10	K0
+      0x8C281516,  //  0050  GETMET	R10	R10	K22
+      0x88300D0D,  //  0051  GETMBR	R12	R6	K13
+      0x88340D0E,  //  0052  GETMBR	R13	R6	K14
       0x7C280600,  //  0053  CALL	R10	3
-      0xB82E2200,  //  0054  GETNGBL	R11	K17
+      0xB82E2E00,  //  0054  GETNGBL	R11	K23
       0x60300018,  //  0055  GETGBL	R12	G24
-      0x58340012,  //  0056  LDCONST	R13	K18
-      0x88380513,  //  0057  GETMBR	R14	R2	K19
-      0x88381D14,  //  0058  GETMBR	R14	R14	K20
+      0x58340042,  //  0056  LDCONST	R13	K66
+      0x88380523,  //  0057  GETMBR	R14	R2	K35
+      0x88381D36,  //  0058  GETMBR	R14	R14	K54
       0x782A0002,  //  0059  JMPF	R10	#005D
-      0x003E2A0A,  //  005A  ADD	R15	K21	R10
-      0x003C1F16,  //  005B  ADD	R15	R15	K22
+      0x003E320A,  //  005A  ADD	R15	K25	R10
+      0x003C1F1A,  //  005B  ADD	R15	R15	K26
       0x70020000,  //  005C  JMP		#005E
-      0x583C0017,  //  005D  LDCONST	R15	K23
+      0x583C001B,  //  005D  LDCONST	R15	K27
       0x003C120F,  //  005E  ADD	R15	R9	R15
       0x7C300600,  //  005F  CALL	R12	3
-      0x5834000E,  //  0060  LDCONST	R13	K14
+      0x58340015,  //  0060  LDCONST	R13	K21
       0x7C2C0400,  //  0061  CALL	R11	2
       0x70020008,  //  0062  JMP		#006C
-      0xB82A2200,  //  0063  GETNGBL	R10	K17
+      0xB82A2E00,  //  0063  GETNGBL	R10	K23
       0x602C0018,  //  0064  GETGBL	R11	G24
-      0x58300012,  //  0065  LDCONST	R12	K18
-      0x88340513,  //  0066  GETMBR	R13	R2	K19
-      0x88341B14,  //  0067  GETMBR	R13	R13	K20
+      0x58300042,  //  0065  LDCONST	R12	K66
+      0x88340523,  //  0066  GETMBR	R13	R2	K35
+      0x88341B36,  //  0067  GETMBR	R13	R13	K54
       0x5C381200,  //  0068  MOVE	R14	R9
       0x7C2C0600,  //  0069  CALL	R11	3
-      0x5830000E,  //  006A  LDCONST	R12	K14
+      0x58300015,  //  006A  LDCONST	R12	K21
       0x7C280400,  //  006B  CALL	R10	2
       0x7001FFA7,  //  006C  JMP		#0015
-      0x58140018,  //  006D  LDCONST	R5	K24
+      0x58140025,  //  006D  LDCONST	R5	K37
       0xAC140200,  //  006E  CATCH	R5	1	0
       0xB0080000,  //  006F  RAISE	2	R0	R0
       0x80040600,  //  0070  RET	1	R3
@@ -747,47 +841,35 @@ be_local_closure(class_Matter_IM_process_timed_request,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TimedRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(timeout),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(send_status),
-    /* K10  */  be_nested_str_weak(SUCCESS),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_timed_request),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C0C0743,  //  0001  GETMET	R3	R3	K67
       0x7C0C0200,  //  0002  CALL	R3	1
       0x8C0C0702,  //  0003  GETMET	R3	R3	K2
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
-      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0xB8122E00,  //  0006  GETNGBL	R4	K23
       0x60140018,  //  0007  GETGBL	R5	G24
-      0x58180004,  //  0008  LDCONST	R6	K4
-      0x881C0305,  //  0009  GETMBR	R7	R1	K5
-      0x881C0F06,  //  000A  GETMBR	R7	R7	K6
-      0x88200707,  //  000B  GETMBR	R8	R3	K7
+      0x58180044,  //  0008  LDCONST	R6	K68
+      0x881C0323,  //  0009  GETMBR	R7	R1	K35
+      0x881C0F36,  //  000A  GETMBR	R7	R7	K54
+      0x88200745,  //  000B  GETMBR	R8	R3	K69
       0x7C140600,  //  000C  CALL	R5	3
-      0x58180008,  //  000D  LDCONST	R6	K8
+      0x58180015,  //  000D  LDCONST	R6	K21
       0x7C100400,  //  000E  CALL	R4	2
-      0x8C100109,  //  000F  GETMET	R4	R0	K9
+      0x8C100146,  //  000F  GETMET	R4	R0	K70
       0x5C180200,  //  0010  MOVE	R6	R1
       0xB81E0000,  //  0011  GETNGBL	R7	K0
-      0x881C0F0A,  //  0012  GETMBR	R7	R7	K10
+      0x881C0F24,  //  0012  GETMBR	R7	R7	K36
       0x7C100600,  //  0013  CALL	R4	3
       0x50100200,  //  0014  LDBOOL	R4	1	0
       0x80040800,  //  0015  RET	1	R4
@@ -804,21 +886,18 @@ be_local_closure(class_Matter_IM_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs_shop),
-    /* K1   */  be_nested_str_weak(every_50ms),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040147,  //  0000  GETMBR	R1	R0	K71
+      0x8C040348,  //  0001  GETMET	R1	R1	K72
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -834,270 +913,228 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(msg),
-    /* K3   */  be_nested_str_weak(InvokeRequestMessage),
-    /* K4   */  be_nested_str_weak(from_TLV),
-    /* K5   */  be_nested_str_weak(invoke_requests),
-    /* K6   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K7   */  be_nested_str_weak(suppress_response),
-    /* K8   */  be_nested_str_weak(invoke_responses),
-    /* K9   */  be_nested_str_weak(endpoint),
-    /* K10  */  be_nested_str_weak(command_path),
-    /* K11  */  be_nested_str_weak(cluster),
-    /* K12  */  be_nested_str_weak(command),
-    /* K13  */  be_nested_str_weak(status),
-    /* K14  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K15  */  be_nested_str_weak(get_command_name),
-    /* K16  */  be_nested_str_weak(device),
-    /* K17  */  be_nested_str_weak(invoke_request),
-    /* K18  */  be_nested_str_weak(session),
-    /* K19  */  be_nested_str_weak(command_fields),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(_X28),
-    /* K22  */  be_nested_str_weak(_X29_X20),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K25  */  be_nested_str_weak(local_session_id),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(SUCCESS),
-    /* K28  */  be_nested_str_weak(invokeresponse2raw),
-    /* K29  */  be_nested_str_weak(push),
-    /* K30  */  be_nested_str_weak(tasmota),
-    /* K31  */  be_nested_str_weak(loglevel),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
-    /* K33  */  be_nested_str_weak(exchange_id),
-    /* K34  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
-    /* K36  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
-    /* K37  */  be_nested_str_weak(stop_iteration),
-    /* K38  */  be_const_int(0),
-    /* K39  */  be_nested_str_weak(send_queue),
-    /* K40  */  be_nested_str_weak(IM_InvokeResponse),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[222]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C0C0703,  //  0001  GETMET	R3	R3	K3
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x900E0401,  //  0003  SETMBR	R3	K2	R1
+      0x900E3E01,  //  0003  SETMBR	R3	K31	R1
       0xB8120000,  //  0004  GETNGBL	R4	K0
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x8C100949,  //  0005  GETMET	R4	R4	K73
       0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x8C100902,  //  0007  GETMET	R4	R4	K2
       0x5C180400,  //  0008  MOVE	R6	R2
       0x7C100400,  //  0009  CALL	R4	2
-      0x88140905,  //  000A  GETMBR	R5	R4	K5
+      0x8814094A,  //  000A  GETMBR	R5	R4	K74
       0x4C180000,  //  000B  LDNIL	R6
       0x20140A06,  //  000C  NE	R5	R5	R6
       0x781600CE,  //  000D  JMPF	R5	#00DD
       0xB8160000,  //  000E  GETNGBL	R5	K0
-      0x8C140B06,  //  000F  GETMET	R5	R5	K6
+      0x8C140B4B,  //  000F  GETMET	R5	R5	K75
       0x7C140200,  //  0010  CALL	R5	1
       0x50180000,  //  0011  LDBOOL	R6	0	0
-      0x90160E06,  //  0012  SETMBR	R5	K7	R6
+      0x90160806,  //  0012  SETMBR	R5	K4	R6
       0x60180012,  //  0013  GETGBL	R6	G18
       0x7C180000,  //  0014  CALL	R6	0
-      0x90161006,  //  0015  SETMBR	R5	K8	R6
+      0x90169806,  //  0015  SETMBR	R5	K76	R6
       0x60180010,  //  0016  GETGBL	R6	G16
-      0x881C0905,  //  0017  GETMBR	R7	R4	K5
+      0x881C094A,  //  0017  GETMBR	R7	R4	K74
       0x7C180200,  //  0018  CALL	R6	1
       0xA80200AD,  //  0019  EXBLK	0	#00C8
       0x5C1C0C00,  //  001A  MOVE	R7	R6
       0x7C1C0000,  //  001B  CALL	R7	0
-      0x88200F0A,  //  001C  GETMBR	R8	R7	K10
-      0x88201109,  //  001D  GETMBR	R8	R8	K9
-      0x900E1208,  //  001E  SETMBR	R3	K9	R8
-      0x88200F0A,  //  001F  GETMBR	R8	R7	K10
-      0x8820110B,  //  0020  GETMBR	R8	R8	K11
-      0x900E1608,  //  0021  SETMBR	R3	K11	R8
-      0x88200F0A,  //  0022  GETMBR	R8	R7	K10
-      0x8820110C,  //  0023  GETMBR	R8	R8	K12
-      0x900E1808,  //  0024  SETMBR	R3	K12	R8
+      0x88200F4D,  //  001C  GETMBR	R8	R7	K77
+      0x88201112,  //  001D  GETMBR	R8	R8	K18
+      0x900E2408,  //  001E  SETMBR	R3	K18	R8
+      0x88200F4D,  //  001F  GETMBR	R8	R7	K77
+      0x8820110D,  //  0020  GETMBR	R8	R8	K13
+      0x900E1A08,  //  0021  SETMBR	R3	K13	R8
+      0x88200F4D,  //  0022  GETMBR	R8	R7	K77
+      0x8820114E,  //  0023  GETMBR	R8	R8	K78
+      0x900E9C08,  //  0024  SETMBR	R3	K78	R8
       0xB8220000,  //  0025  GETNGBL	R8	K0
-      0x8820110E,  //  0026  GETMBR	R8	R8	K14
-      0x900E1A08,  //  0027  SETMBR	R3	K13	R8
+      0x8820114F,  //  0026  GETMBR	R8	R8	K79
+      0x900E1E08,  //  0027  SETMBR	R3	K15	R8
       0xB8220000,  //  0028  GETNGBL	R8	K0
-      0x8C20110F,  //  0029  GETMET	R8	R8	K15
-      0x8828070B,  //  002A  GETMBR	R10	R3	K11
-      0x882C070C,  //  002B  GETMBR	R11	R3	K12
+      0x8C201150,  //  0029  GETMET	R8	R8	K80
+      0x8828070D,  //  002A  GETMBR	R10	R3	K13
+      0x882C074E,  //  002B  GETMBR	R11	R3	K78
       0x7C200600,  //  002C  CALL	R8	3
       0x60240008,  //  002D  GETGBL	R9	G8
       0x5C280600,  //  002E  MOVE	R10	R3
       0x7C240200,  //  002F  CALL	R9	1
-      0x88280110,  //  0030  GETMBR	R10	R0	K16
-      0x8C281511,  //  0031  GETMET	R10	R10	K17
-      0x88300312,  //  0032  GETMBR	R12	R1	K18
-      0x88340F13,  //  0033  GETMBR	R13	R7	K19
+      0x88280109,  //  0030  GETMBR	R10	R0	K9
+      0x8C281551,  //  0031  GETMET	R10	R10	K81
+      0x88300323,  //  0032  GETMBR	R12	R1	K35
+      0x88340F52,  //  0033  GETMBR	R13	R7	K82
       0x5C380600,  //  0034  MOVE	R14	R3
       0x7C280800,  //  0035  CALL	R10	4
-      0x882C0714,  //  0036  GETMBR	R11	R3	K20
+      0x882C0717,  //  0036  GETMBR	R11	R3	K23
       0x4C300000,  //  0037  LDNIL	R12
       0x202C160C,  //  0038  NE	R11	R11	R12
       0x782E0005,  //  0039  JMPF	R11	#0040
       0x602C0008,  //  003A  GETGBL	R11	G8
-      0x88300714,  //  003B  GETMBR	R12	R3	K20
+      0x88300717,  //  003B  GETMBR	R12	R3	K23
       0x7C2C0200,  //  003C  CALL	R11	1
-      0x002E2A0B,  //  003D  ADD	R11	K21	R11
-      0x002C1716,  //  003E  ADD	R11	R11	K22
+      0x002EA60B,  //  003D  ADD	R11	K83	R11
+      0x002C1754,  //  003E  ADD	R11	R11	K84
       0x70020000,  //  003F  JMP		#0041
-      0x582C0017,  //  0040  LDCONST	R11	K23
-      0xB8322800,  //  0041  GETNGBL	R12	K20
+      0x582C001B,  //  0040  LDCONST	R11	K27
+      0xB8322E00,  //  0041  GETNGBL	R12	K23
       0x60340018,  //  0042  GETGBL	R13	G24
-      0x58380018,  //  0043  LDCONST	R14	K24
-      0x883C0312,  //  0044  GETMBR	R15	R1	K18
-      0x883C1F19,  //  0045  GETMBR	R15	R15	K25
+      0x58380055,  //  0043  LDCONST	R14	K85
+      0x883C0323,  //  0044  GETMBR	R15	R1	K35
+      0x883C1F36,  //  0045  GETMBR	R15	R15	K54
       0x5C401200,  //  0046  MOVE	R16	R9
       0x78220001,  //  0047  JMPF	R8	#004A
       0x5C441000,  //  0048  MOVE	R17	R8
       0x70020000,  //  0049  JMP		#004B
-      0x58440017,  //  004A  LDCONST	R17	K23
+      0x5844001B,  //  004A  LDCONST	R17	K27
       0x5C481600,  //  004B  MOVE	R18	R11
       0x7C340A00,  //  004C  CALL	R13	5
-      0x5838001A,  //  004D  LDCONST	R14	K26
+      0x58380015,  //  004D  LDCONST	R14	K21
       0x7C300400,  //  004E  CALL	R12	2
       0x4C300000,  //  004F  LDNIL	R12
-      0x900E280C,  //  0050  SETMBR	R3	K20	R12
+      0x900E2E0C,  //  0050  SETMBR	R3	K23	R12
       0x60300015,  //  0051  GETGBL	R12	G21
       0x5436001F,  //  0052  LDINT	R13	32
       0x7C300200,  //  0053  CALL	R12	1
       0x50340200,  //  0054  LDBOOL	R13	1	0
       0x1C34140D,  //  0055  EQ	R13	R10	R13
       0x74360004,  //  0056  JMPT	R13	#005C
-      0x8834070D,  //  0057  GETMBR	R13	R3	K13
+      0x8834070F,  //  0057  GETMBR	R13	R3	K15
       0xB83A0000,  //  0058  GETNGBL	R14	K0
-      0x88381D1B,  //  0059  GETMBR	R14	R14	K27
+      0x88381D24,  //  0059  GETMBR	R14	R14	K36
       0x1C341A0E,  //  005A  EQ	R13	R13	R14
       0x7836001A,  //  005B  JMPF	R13	#0077
       0xB8360000,  //  005C  GETNGBL	R13	K0
-      0x88341B1B,  //  005D  GETMBR	R13	R13	K27
-      0x900E1A0D,  //  005E  SETMBR	R3	K13	R13
-      0x8C34011C,  //  005F  GETMET	R13	R0	K28
+      0x88341B24,  //  005D  GETMBR	R13	R13	K36
+      0x900E1E0D,  //  005E  SETMBR	R3	K15	R13
+      0x8C340156,  //  005F  GETMET	R13	R0	K86
       0x5C3C1800,  //  0060  MOVE	R15	R12
       0x5C400600,  //  0061  MOVE	R16	R3
       0x4C440000,  //  0062  LDNIL	R17
       0x7C340800,  //  0063  CALL	R13	4
-      0x88340B08,  //  0064  GETMBR	R13	R5	K8
-      0x8C341B1D,  //  0065  GETMET	R13	R13	K29
+      0x88340B4C,  //  0064  GETMBR	R13	R5	K76
+      0x8C341B27,  //  0065  GETMET	R13	R13	K39
       0x5C3C1800,  //  0066  MOVE	R15	R12
       0x7C340400,  //  0067  CALL	R13	2
-      0xB8363C00,  //  0068  GETNGBL	R13	K30
-      0x8C341B1F,  //  0069  GETMET	R13	R13	K31
-      0x583C001A,  //  006A  LDCONST	R15	K26
+      0xB8362600,  //  0068  GETNGBL	R13	K19
+      0x8C341B14,  //  0069  GETMET	R13	R13	K20
+      0x583C0015,  //  006A  LDCONST	R15	K21
       0x7C340400,  //  006B  CALL	R13	2
       0x78360008,  //  006C  JMPF	R13	#0076
-      0xB8362800,  //  006D  GETNGBL	R13	K20
+      0xB8362E00,  //  006D  GETNGBL	R13	K23
       0x60380018,  //  006E  GETGBL	R14	G24
-      0x583C0020,  //  006F  LDCONST	R15	K32
-      0x88400312,  //  0070  GETMBR	R16	R1	K18
-      0x88402119,  //  0071  GETMBR	R16	R16	K25
-      0x88440321,  //  0072  GETMBR	R17	R1	K33
+      0x583C0057,  //  006F  LDCONST	R15	K87
+      0x88400323,  //  0070  GETMBR	R16	R1	K35
+      0x88402136,  //  0071  GETMBR	R16	R16	K54
+      0x88440358,  //  0072  GETMBR	R17	R1	K88
       0x7C380600,  //  0073  CALL	R14	3
-      0x583C001A,  //  0074  LDCONST	R15	K26
+      0x583C0015,  //  0074  LDCONST	R15	K21
       0x7C340400,  //  0075  CALL	R13	2
       0x7002004F,  //  0076  JMP		#00C7
       0x4C340000,  //  0077  LDNIL	R13
       0x2034140D,  //  0078  NE	R13	R10	R13
       0x78360021,  //  0079  JMPF	R13	#009C
-      0x8C34011C,  //  007A  GETMET	R13	R0	K28
+      0x8C340156,  //  007A  GETMET	R13	R0	K86
       0x5C3C1800,  //  007B  MOVE	R15	R12
       0x5C400600,  //  007C  MOVE	R16	R3
       0x5C441400,  //  007D  MOVE	R17	R10
       0x7C340800,  //  007E  CALL	R13	4
-      0x88340B08,  //  007F  GETMBR	R13	R5	K8
-      0x8C341B1D,  //  0080  GETMET	R13	R13	K29
+      0x88340B4C,  //  007F  GETMBR	R13	R5	K76
+      0x8C341B27,  //  0080  GETMET	R13	R13	K39
       0x5C3C1800,  //  0081  MOVE	R15	R12
       0x7C340400,  //  0082  CALL	R13	2
       0xB8360000,  //  0083  GETNGBL	R13	K0
-      0x8C341B0F,  //  0084  GETMET	R13	R13	K15
-      0x883C070B,  //  0085  GETMBR	R15	R3	K11
-      0x8840070C,  //  0086  GETMBR	R16	R3	K12
+      0x8C341B50,  //  0084  GETMET	R13	R13	K80
+      0x883C070D,  //  0085  GETMBR	R15	R3	K13
+      0x8840074E,  //  0086  GETMBR	R16	R3	K78
       0x7C340600,  //  0087  CALL	R13	3
       0x5C201A00,  //  0088  MOVE	R8	R13
       0x5C341000,  //  0089  MOVE	R13	R8
       0x74360000,  //  008A  JMPT	R13	#008C
-      0x58200017,  //  008B  LDCONST	R8	K23
-      0xB8363C00,  //  008C  GETNGBL	R13	K30
-      0x8C341B1F,  //  008D  GETMET	R13	R13	K31
-      0x583C001A,  //  008E  LDCONST	R15	K26
+      0x5820001B,  //  008B  LDCONST	R8	K27
+      0xB8362600,  //  008C  GETNGBL	R13	K19
+      0x8C341B14,  //  008D  GETMET	R13	R13	K20
+      0x583C0015,  //  008E  LDCONST	R15	K21
       0x7C340400,  //  008F  CALL	R13	2
       0x78360009,  //  0090  JMPF	R13	#009B
-      0xB8362800,  //  0091  GETNGBL	R13	K20
+      0xB8362E00,  //  0091  GETNGBL	R13	K23
       0x60380018,  //  0092  GETGBL	R14	G24
-      0x583C0022,  //  0093  LDCONST	R15	K34
-      0x88400312,  //  0094  GETMBR	R16	R1	K18
-      0x88402119,  //  0095  GETMBR	R16	R16	K25
+      0x583C0059,  //  0093  LDCONST	R15	K89
+      0x88400323,  //  0094  GETMBR	R16	R1	K35
+      0x88402136,  //  0095  GETMBR	R16	R16	K54
       0x5C440600,  //  0096  MOVE	R17	R3
       0x5C481000,  //  0097  MOVE	R18	R8
       0x7C380800,  //  0098  CALL	R14	4
-      0x583C001A,  //  0099  LDCONST	R15	K26
+      0x583C0015,  //  0099  LDCONST	R15	K21
       0x7C340400,  //  009A  CALL	R13	2
       0x7002002A,  //  009B  JMP		#00C7
-      0x8834070D,  //  009C  GETMBR	R13	R3	K13
+      0x8834070F,  //  009C  GETMBR	R13	R3	K15
       0x4C380000,  //  009D  LDNIL	R14
       0x20341A0E,  //  009E  NE	R13	R13	R14
       0x78360018,  //  009F  JMPF	R13	#00B9
-      0x8C34011C,  //  00A0  GETMET	R13	R0	K28
+      0x8C340156,  //  00A0  GETMET	R13	R0	K86
       0x5C3C1800,  //  00A1  MOVE	R15	R12
       0x5C400600,  //  00A2  MOVE	R16	R3
       0x4C440000,  //  00A3  LDNIL	R17
       0x7C340800,  //  00A4  CALL	R13	4
-      0x88340B08,  //  00A5  GETMBR	R13	R5	K8
-      0x8C341B1D,  //  00A6  GETMET	R13	R13	K29
+      0x88340B4C,  //  00A5  GETMBR	R13	R5	K76
+      0x8C341B27,  //  00A6  GETMET	R13	R13	K39
       0x5C3C1800,  //  00A7  MOVE	R15	R12
       0x7C340400,  //  00A8  CALL	R13	2
-      0xB8363C00,  //  00A9  GETNGBL	R13	K30
-      0x8C341B1F,  //  00AA  GETMET	R13	R13	K31
-      0x583C001A,  //  00AB  LDCONST	R15	K26
+      0xB8362600,  //  00A9  GETNGBL	R13	K19
+      0x8C341B14,  //  00AA  GETMET	R13	R13	K20
+      0x583C0015,  //  00AB  LDCONST	R15	K21
       0x7C340400,  //  00AC  CALL	R13	2
       0x78360009,  //  00AD  JMPF	R13	#00B8
-      0xB8362800,  //  00AE  GETNGBL	R13	K20
+      0xB8362E00,  //  00AE  GETNGBL	R13	K23
       0x60380018,  //  00AF  GETGBL	R14	G24
-      0x583C0023,  //  00B0  LDCONST	R15	K35
-      0x88400312,  //  00B1  GETMBR	R16	R1	K18
-      0x88402119,  //  00B2  GETMBR	R16	R16	K25
-      0x8844070D,  //  00B3  GETMBR	R17	R3	K13
-      0x88480321,  //  00B4  GETMBR	R18	R1	K33
+      0x583C005A,  //  00B0  LDCONST	R15	K90
+      0x88400323,  //  00B1  GETMBR	R16	R1	K35
+      0x88402136,  //  00B2  GETMBR	R16	R16	K54
+      0x8844070F,  //  00B3  GETMBR	R17	R3	K15
+      0x88480358,  //  00B4  GETMBR	R18	R1	K88
       0x7C380800,  //  00B5  CALL	R14	4
-      0x583C001A,  //  00B6  LDCONST	R15	K26
+      0x583C0015,  //  00B6  LDCONST	R15	K21
       0x7C340400,  //  00B7  CALL	R13	2
       0x7002000D,  //  00B8  JMP		#00C7
-      0xB8363C00,  //  00B9  GETNGBL	R13	K30
-      0x8C341B1F,  //  00BA  GETMET	R13	R13	K31
-      0x583C001A,  //  00BB  LDCONST	R15	K26
+      0xB8362600,  //  00B9  GETNGBL	R13	K19
+      0x8C341B14,  //  00BA  GETMET	R13	R13	K20
+      0x583C0015,  //  00BB  LDCONST	R15	K21
       0x7C340400,  //  00BC  CALL	R13	2
       0x78360008,  //  00BD  JMPF	R13	#00C7
-      0xB8362800,  //  00BE  GETNGBL	R13	K20
+      0xB8362E00,  //  00BE  GETNGBL	R13	K23
       0x60380018,  //  00BF  GETGBL	R14	G24
-      0x583C0024,  //  00C0  LDCONST	R15	K36
-      0x88400312,  //  00C1  GETMBR	R16	R1	K18
-      0x88402119,  //  00C2  GETMBR	R16	R16	K25
-      0x88440321,  //  00C3  GETMBR	R17	R1	K33
+      0x583C005B,  //  00C0  LDCONST	R15	K91
+      0x88400323,  //  00C1  GETMBR	R16	R1	K35
+      0x88402136,  //  00C2  GETMBR	R16	R16	K54
+      0x88440358,  //  00C3  GETMBR	R17	R1	K88
       0x7C380600,  //  00C4  CALL	R14	3
-      0x583C001A,  //  00C5  LDCONST	R15	K26
+      0x583C0015,  //  00C5  LDCONST	R15	K21
       0x7C340400,  //  00C6  CALL	R13	2
       0x7001FF51,  //  00C7  JMP		#001A
       0x58180025,  //  00C8  LDCONST	R6	K37
       0xAC180200,  //  00C9  CATCH	R6	1	0
       0xB0080000,  //  00CA  RAISE	2	R0	R0
       0x6018000C,  //  00CB  GETGBL	R6	G12
-      0x881C0B08,  //  00CC  GETMBR	R7	R5	K8
+      0x881C0B4C,  //  00CC  GETMBR	R7	R5	K76
       0x7C180200,  //  00CD  CALL	R6	1
-      0x24180D26,  //  00CE  GT	R6	R6	K38
+      0x24180D5C,  //  00CE  GT	R6	R6	K92
       0x781A0008,  //  00CF  JMPF	R6	#00D9
-      0x88180127,  //  00D0  GETMBR	R6	R0	K39
-      0x8C180D1D,  //  00D1  GETMET	R6	R6	K29
+      0x88180126,  //  00D0  GETMBR	R6	R0	K38
+      0x8C180D27,  //  00D1  GETMET	R6	R6	K39
       0xB8220000,  //  00D2  GETNGBL	R8	K0
-      0x8C201128,  //  00D3  GETMET	R8	R8	K40
+      0x8C20115D,  //  00D3  GETMET	R8	R8	K93
       0x5C280200,  //  00D4  MOVE	R10	R1
       0x5C2C0A00,  //  00D5  MOVE	R11	R5
       0x7C200600,  //  00D6  CALL	R8	3
@@ -1121,49 +1158,17 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,  
   be_nested_proto(
     24,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_requests),
-    /* K1   */  be_nested_str_weak(get_node_id),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(parse_event_filters_min_no),
-    /* K5   */  be_nested_str_weak(event_filters),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(EventGenerator),
-    /* K8   */  be_nested_str_weak(device),
-    /* K9   */  be_nested_str_weak(start),
-    /* K10  */  be_nested_str_weak(endpoint),
-    /* K11  */  be_nested_str_weak(cluster),
-    /* K12  */  be_nested_str_weak(event),
-    /* K13  */  be_nested_str_weak(push),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(loglevel),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(),
-    /* K18  */  be_nested_str_weak(get_event_name),
-    /* K19  */  be_nested_str_weak(_X28),
-    /* K20  */  be_nested_str_weak(_X29_X20),
-    /* K21  */  be_nested_str_weak(_X2502X),
-    /* K22  */  be_nested_str_weak(_X2A_X2A),
-    /* K23  */  be_nested_str_weak(_X2504X),
-    /* K24  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K25  */  be_nested_str_weak(_X20_X28_X3E_X25s_X29),
-    /* K26  */  be_nested_str_weak(log),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X29_X20_X5B_X25s_X5D_X25s_X2F_X25s_X20_X25s_X25s),
-    /* K28  */  be_nested_str_weak(session),
-    /* K29  */  be_nested_str_weak(local_session_id),
-    /* K30  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_read_or_subscribe_request_event_pull),
     &be_const_str_solidified,
     ( &(const binstruction[140]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x880C035E,  //  0000  GETMBR	R3	R1	K94
       0x4C100000,  //  0001  LDNIL	R4
       0x200C0604,  //  0002  NE	R3	R3	R4
       0x780E0085,  //  0003  JMPF	R3	#008A
@@ -1171,133 +1176,133 @@ be_local_closure(class_Matter_IM_process_read_or_subscribe_request_event_pull,  
       0x4C100000,  //  0005  LDNIL	R4
       0x20100404,  //  0006  NE	R4	R2	R4
       0x78120002,  //  0007  JMPF	R4	#000B
-      0x8C100501,  //  0008  GETMET	R4	R2	K1
+      0x8C10055F,  //  0008  GETMET	R4	R2	K95
       0x7C100200,  //  0009  CALL	R4	1
       0x70020000,  //  000A  JMP		#000C
       0x4C100000,  //  000B  LDNIL	R4
-      0x88140300,  //  000C  GETMBR	R5	R1	K0
+      0x8814035E,  //  000C  GETMBR	R5	R1	K94
       0x78160003,  //  000D  JMPF	R5	#0012
       0x6014000C,  //  000E  GETGBL	R5	G12
-      0x88180300,  //  000F  GETMBR	R6	R1	K0
+      0x8818035E,  //  000F  GETMBR	R6	R1	K94
       0x7C140200,  //  0010  CALL	R5	1
       0x70020000,  //  0011  JMP		#0013
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x24180B03,  //  0013  GT	R6	R5	K3
+      0x5814005C,  //  0012  LDCONST	R5	K92
+      0x24180B2A,  //  0013  GT	R6	R5	K42
       0x781A0002,  //  0014  JMPF	R6	#0018
       0x60180012,  //  0015  GETGBL	R6	G18
       0x7C180000,  //  0016  CALL	R6	0
       0x5C0C0C00,  //  0017  MOVE	R3	R6
-      0x8C180104,  //  0018  GETMET	R6	R0	K4
-      0x88200305,  //  0019  GETMBR	R8	R1	K5
+      0x8C180160,  //  0018  GETMET	R6	R0	K96
+      0x88200361,  //  0019  GETMBR	R8	R1	K97
       0x5C240800,  //  001A  MOVE	R9	R4
       0x7C180600,  //  001B  CALL	R6	3
-      0x881C0300,  //  001C  GETMBR	R7	R1	K0
+      0x881C035E,  //  001C  GETMBR	R7	R1	K94
       0x781E006A,  //  001D  JMPF	R7	#0089
       0x601C0010,  //  001E  GETGBL	R7	G16
-      0x88200300,  //  001F  GETMBR	R8	R1	K0
+      0x8820035E,  //  001F  GETMBR	R8	R1	K94
       0x7C1C0200,  //  0020  CALL	R7	1
       0xA8020063,  //  0021  EXBLK	0	#0086
       0x5C200E00,  //  0022  MOVE	R8	R7
       0x7C200000,  //  0023  CALL	R8	0
-      0xB8260C00,  //  0024  GETNGBL	R9	K6
-      0x8C241307,  //  0025  GETMET	R9	R9	K7
-      0x882C0108,  //  0026  GETMBR	R11	R0	K8
+      0xB8260000,  //  0024  GETNGBL	R9	K0
+      0x8C241362,  //  0025  GETMET	R9	R9	K98
+      0x882C0109,  //  0026  GETMBR	R11	R0	K9
       0x7C240400,  //  0027  CALL	R9	2
-      0x8C281309,  //  0028  GETMET	R10	R9	K9
-      0x8830110A,  //  0029  GETMBR	R12	R8	K10
-      0x8834110B,  //  002A  GETMBR	R13	R8	K11
-      0x8838110C,  //  002B  GETMBR	R14	R8	K12
+      0x8C28131C,  //  0028  GETMET	R10	R9	K28
+      0x88301112,  //  0029  GETMBR	R12	R8	K18
+      0x8834110D,  //  002A  GETMBR	R13	R8	K13
+      0x88381163,  //  002B  GETMBR	R14	R8	K99
       0x5C3C0C00,  //  002C  MOVE	R15	R6
       0x7C280A00,  //  002D  CALL	R10	5
-      0x24280B03,  //  002E  GT	R10	R5	K3
+      0x24280B2A,  //  002E  GT	R10	R5	K42
       0x782A0003,  //  002F  JMPF	R10	#0034
-      0x8C28070D,  //  0030  GETMET	R10	R3	K13
+      0x8C280727,  //  0030  GETMET	R10	R3	K39
       0x5C301200,  //  0031  MOVE	R12	R9
       0x7C280400,  //  0032  CALL	R10	2
       0x70020000,  //  0033  JMP		#0035
       0x5C0C1200,  //  0034  MOVE	R3	R9
-      0xB82A1C00,  //  0035  GETNGBL	R10	K14
-      0x8C28150F,  //  0036  GETMET	R10	R10	K15
-      0x58300010,  //  0037  LDCONST	R12	K16
+      0xB82A2600,  //  0035  GETNGBL	R10	K19
+      0x8C281514,  //  0036  GETMET	R10	R10	K20
+      0x58300015,  //  0037  LDCONST	R12	K21
       0x7C280400,  //  0038  CALL	R10	2
       0x782A004A,  //  0039  JMPF	R10	#0085
-      0x58280011,  //  003A  LDCONST	R10	K17
-      0x882C110B,  //  003B  GETMBR	R11	R8	K11
+      0x5828001B,  //  003A  LDCONST	R10	K27
+      0x882C110D,  //  003B  GETMBR	R11	R8	K13
       0x4C300000,  //  003C  LDNIL	R12
       0x202C160C,  //  003D  NE	R11	R11	R12
       0x782E0011,  //  003E  JMPF	R11	#0051
-      0x882C110C,  //  003F  GETMBR	R11	R8	K12
+      0x882C1163,  //  003F  GETMBR	R11	R8	K99
       0x4C300000,  //  0040  LDNIL	R12
       0x202C160C,  //  0041  NE	R11	R11	R12
       0x782E000D,  //  0042  JMPF	R11	#0051
-      0xB82E0C00,  //  0043  GETNGBL	R11	K6
-      0x8C2C1712,  //  0044  GETMET	R11	R11	K18
-      0x8834110B,  //  0045  GETMBR	R13	R8	K11
-      0x8838110C,  //  0046  GETMBR	R14	R8	K12
+      0xB82E0000,  //  0043  GETNGBL	R11	K0
+      0x8C2C1764,  //  0044  GETMET	R11	R11	K100
+      0x8834110D,  //  0045  GETMBR	R13	R8	K13
+      0x88381163,  //  0046  GETMBR	R14	R8	K99
       0x7C2C0600,  //  0047  CALL	R11	3
       0x5C281600,  //  0048  MOVE	R10	R11
       0x4C2C0000,  //  0049  LDNIL	R11
       0x202C140B,  //  004A  NE	R11	R10	R11
       0x782E0002,  //  004B  JMPF	R11	#004F
-      0x002E260A,  //  004C  ADD	R11	K19	R10
-      0x002C1714,  //  004D  ADD	R11	R11	K20
+      0x002EA60A,  //  004C  ADD	R11	K83	R10
+      0x002C1754,  //  004D  ADD	R11	R11	K84
       0x70020000,  //  004E  JMP		#0050
-      0x582C0011,  //  004F  LDCONST	R11	K17
+      0x582C001B,  //  004F  LDCONST	R11	K27
       0x5C281600,  //  0050  MOVE	R10	R11
-      0x882C110A,  //  0051  GETMBR	R11	R8	K10
+      0x882C1112,  //  0051  GETMBR	R11	R8	K18
       0x4C300000,  //  0052  LDNIL	R12
       0x202C160C,  //  0053  NE	R11	R11	R12
       0x782E0004,  //  0054  JMPF	R11	#005A
       0x602C0018,  //  0055  GETGBL	R11	G24
-      0x58300015,  //  0056  LDCONST	R12	K21
-      0x8834110A,  //  0057  GETMBR	R13	R8	K10
+      0x58300065,  //  0056  LDCONST	R12	K101
+      0x88341112,  //  0057  GETMBR	R13	R8	K18
       0x7C2C0400,  //  0058  CALL	R11	2
       0x70020000,  //  0059  JMP		#005B
-      0x582C0016,  //  005A  LDCONST	R11	K22
-      0x8830110B,  //  005B  GETMBR	R12	R8	K11
+      0x582C0066,  //  005A  LDCONST	R11	K102
+      0x8830110D,  //  005B  GETMBR	R12	R8	K13
       0x4C340000,  //  005C  LDNIL	R13
       0x2030180D,  //  005D  NE	R12	R12	R13
       0x78320004,  //  005E  JMPF	R12	#0064
       0x60300018,  //  005F  GETGBL	R12	G24
-      0x58340017,  //  0060  LDCONST	R13	K23
-      0x8838110B,  //  0061  GETMBR	R14	R8	K11
+      0x58340067,  //  0060  LDCONST	R13	K103
+      0x8838110D,  //  0061  GETMBR	R14	R8	K13
       0x7C300400,  //  0062  CALL	R12	2
       0x70020000,  //  0063  JMP		#0065
-      0x58300018,  //  0064  LDCONST	R12	K24
-      0x8834110C,  //  0065  GETMBR	R13	R8	K12
+      0x58300068,  //  0064  LDCONST	R12	K104
+      0x88341163,  //  0065  GETMBR	R13	R8	K99
       0x4C380000,  //  0066  LDNIL	R14
       0x20341A0E,  //  0067  NE	R13	R13	R14
       0x78360004,  //  0068  JMPF	R13	#006E
       0x60340018,  //  0069  GETGBL	R13	G24
-      0x58380015,  //  006A  LDCONST	R14	K21
-      0x883C110C,  //  006B  GETMBR	R15	R8	K12
+      0x58380065,  //  006A  LDCONST	R14	K101
+      0x883C1163,  //  006B  GETMBR	R15	R8	K99
       0x7C340400,  //  006C  CALL	R13	2
       0x70020000,  //  006D  JMP		#006F
-      0x58340016,  //  006E  LDCONST	R13	K22
+      0x58340066,  //  006E  LDCONST	R13	K102
       0x4C380000,  //  006F  LDNIL	R14
       0x20380C0E,  //  0070  NE	R14	R6	R14
       0x783A0004,  //  0071  JMPF	R14	#0077
       0x60380018,  //  0072  GETGBL	R14	G24
-      0x583C0019,  //  0073  LDCONST	R15	K25
+      0x583C0069,  //  0073  LDCONST	R15	K105
       0x5C400C00,  //  0074  MOVE	R16	R6
       0x7C380400,  //  0075  CALL	R14	2
       0x70020000,  //  0076  JMP		#0078
-      0x58380011,  //  0077  LDCONST	R14	K17
-      0xB83E3400,  //  0078  GETNGBL	R15	K26
+      0x5838001B,  //  0077  LDCONST	R14	K27
+      0xB83E2E00,  //  0078  GETNGBL	R15	K23
       0x60400018,  //  0079  GETGBL	R16	G24
-      0x5844001B,  //  007A  LDCONST	R17	K27
-      0x8848051C,  //  007B  GETMBR	R18	R2	K28
-      0x8848251D,  //  007C  GETMBR	R18	R18	K29
+      0x5844006A,  //  007A  LDCONST	R17	K106
+      0x88480523,  //  007B  GETMBR	R18	R2	K35
+      0x88482536,  //  007C  GETMBR	R18	R18	K54
       0x5C4C1600,  //  007D  MOVE	R19	R11
       0x5C501800,  //  007E  MOVE	R20	R12
       0x5C541A00,  //  007F  MOVE	R21	R13
       0x5C581400,  //  0080  MOVE	R22	R10
       0x5C5C1C00,  //  0081  MOVE	R23	R14
       0x7C400E00,  //  0082  CALL	R16	7
-      0x58440010,  //  0083  LDCONST	R17	K16
+      0x58440015,  //  0083  LDCONST	R17	K21
       0x7C3C0400,  //  0084  CALL	R15	2
       0x7001FF9B,  //  0085  JMP		#0022
-      0x581C001E,  //  0086  LDCONST	R7	K30
+      0x581C0025,  //  0086  LDCONST	R7	K37
       0xAC1C0200,  //  0087  CATCH	R7	1	0
       0xB0080000,  //  0088  RAISE	2	R0	R0
       0x80040600,  //  0089  RET	1	R3
@@ -1316,49 +1321,39 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(finished),
-    /* K3   */  be_nested_str_weak(ready),
-    /* K4   */  be_nested_str_weak(send_im),
-    /* K5   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    /* K6   */  be_nested_str_weak(resp),
-    /* K7   */  be_nested_str_weak(exchange_id),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(send_enqueued),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080040,  //  0000  LDCONST	R2	K64
       0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x88100126,  //  0002  GETMBR	R4	R0	K38
       0x7C0C0200,  //  0003  CALL	R3	1
       0x140C0403,  //  0004  LT	R3	R2	R3
       0x780E0011,  //  0005  JMPF	R3	#0018
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x880C0126,  //  0006  GETMBR	R3	R0	K38
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x88100702,  //  0008  GETMBR	R4	R3	K2
+      0x8810076B,  //  0008  GETMBR	R4	R3	K107
       0x74120004,  //  0009  JMPT	R4	#000F
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x8810076C,  //  000A  GETMBR	R4	R3	K108
       0x78120002,  //  000B  JMPF	R4	#000F
-      0x8C100704,  //  000C  GETMET	R4	R3	K4
+      0x8C10076D,  //  000C  GETMET	R4	R3	K109
       0x5C180200,  //  000D  MOVE	R6	R1
       0x7C100400,  //  000E  CALL	R4	2
-      0x88100702,  //  000F  GETMBR	R4	R3	K2
+      0x8810076B,  //  000F  GETMBR	R4	R3	K107
       0x78120004,  //  0010  JMPF	R4	#0016
-      0x8C100105,  //  0011  GETMET	R4	R0	K5
-      0x88180706,  //  0012  GETMBR	R6	R3	K6
-      0x88180D07,  //  0013  GETMBR	R6	R6	K7
+      0x8C10016E,  //  0011  GETMET	R4	R0	K110
+      0x8818076F,  //  0012  GETMBR	R6	R3	K111
+      0x88180D58,  //  0013  GETMBR	R6	R6	K88
       0x7C100400,  //  0014  CALL	R4	2
       0x70020000,  //  0015  JMP		#0017
-      0x00080508,  //  0016  ADD	R2	R2	K8
+      0x00080541,  //  0016  ADD	R2	R2	K65
       0x7001FFE8,  //  0017  JMP		#0001
       0x80000000,  //  0018  RET	0
     })
@@ -1374,140 +1369,104 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(SubscribeRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(keep_subscriptions),
-    /* K4   */  be_nested_str_weak(subs_shop),
-    /* K5   */  be_nested_str_weak(remove_by_session),
-    /* K6   */  be_nested_str_weak(session),
-    /* K7   */  be_nested_str_weak(new_subscription),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(loglevel),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(attributes_requests),
-    /* K12  */  be_nested_str_weak(Path),
-    /* K13  */  be_nested_str_weak(msg),
-    /* K14  */  be_nested_str_weak(endpoint),
-    /* K15  */  be_nested_str_weak(cluster),
-    /* K16  */  be_nested_str_weak(attribute),
-    /* K17  */  be_nested_str_weak(push),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i_X20fabric_filtered_X3D_X25s),
-    /* K21  */  be_nested_str_weak(local_session_id),
-    /* K22  */  be_nested_str_weak(concat),
-    /* K23  */  be_nested_str_weak(_X20),
-    /* K24  */  be_nested_str_weak(min_interval),
-    /* K25  */  be_nested_str_weak(max_interval),
-    /* K26  */  be_const_int(1),
-    /* K27  */  be_const_int(0),
-    /* K28  */  be_nested_str_weak(subscription_id),
-    /* K29  */  be_nested_str_weak(fabric_filtered),
-    /* K30  */  be_nested_str_weak(process_read_or_subscribe_request_pull),
-    /* K31  */  be_nested_str_weak(process_read_or_subscribe_request_event_pull),
-    /* K32  */  be_nested_str_weak(set_event_generator_or_arr),
-    /* K33  */  be_nested_str_weak(send_queue),
-    /* K34  */  be_nested_str_weak(IM_SubscribeResponse_Pull),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
     ( &(const binstruction[96]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C0C0770,  //  0001  GETMET	R3	R3	K112
       0x7C0C0200,  //  0002  CALL	R3	1
       0x8C0C0702,  //  0003  GETMET	R3	R3	K2
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
-      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x88100771,  //  0006  GETMBR	R4	R3	K113
       0x74120003,  //  0007  JMPT	R4	#000C
-      0x88100104,  //  0008  GETMBR	R4	R0	K4
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
-      0x88180306,  //  000A  GETMBR	R6	R1	K6
+      0x88100147,  //  0008  GETMBR	R4	R0	K71
+      0x8C100972,  //  0009  GETMET	R4	R4	K114
+      0x88180323,  //  000A  GETMBR	R6	R1	K35
       0x7C100400,  //  000B  CALL	R4	2
-      0x88100104,  //  000C  GETMBR	R4	R0	K4
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
-      0x88180306,  //  000E  GETMBR	R6	R1	K6
+      0x88100147,  //  000C  GETMBR	R4	R0	K71
+      0x8C100973,  //  000D  GETMET	R4	R4	K115
+      0x88180323,  //  000E  GETMBR	R6	R1	K35
       0x5C1C0600,  //  000F  MOVE	R7	R3
       0x7C100600,  //  0010  CALL	R4	3
-      0xB8161000,  //  0011  GETNGBL	R5	K8
-      0x8C140B09,  //  0012  GETMET	R5	R5	K9
-      0x581C000A,  //  0013  LDCONST	R7	K10
+      0xB8162600,  //  0011  GETNGBL	R5	K19
+      0x8C140B14,  //  0012  GETMET	R5	R5	K20
+      0x581C0015,  //  0013  LDCONST	R7	K21
       0x7C140400,  //  0014  CALL	R5	2
       0x78160032,  //  0015  JMPF	R5	#0049
-      0x8814070B,  //  0016  GETMBR	R5	R3	K11
+      0x88140732,  //  0016  GETMBR	R5	R3	K50
       0x4C180000,  //  0017  LDNIL	R6
       0x20140A06,  //  0018  NE	R5	R5	R6
       0x7816002E,  //  0019  JMPF	R5	#0049
       0x60140012,  //  001A  GETGBL	R5	G18
       0x7C140000,  //  001B  CALL	R5	0
       0xB81A0000,  //  001C  GETNGBL	R6	K0
-      0x8C180D0C,  //  001D  GETMET	R6	R6	K12
+      0x8C180D03,  //  001D  GETMET	R6	R6	K3
       0x7C180200,  //  001E  CALL	R6	1
-      0x901A1A01,  //  001F  SETMBR	R6	K13	R1
+      0x901A3E01,  //  001F  SETMBR	R6	K31	R1
       0x601C0010,  //  0020  GETGBL	R7	G16
-      0x8820070B,  //  0021  GETMBR	R8	R3	K11
+      0x88200732,  //  0021  GETMBR	R8	R3	K50
       0x7C1C0200,  //  0022  CALL	R7	1
       0xA802000D,  //  0023  EXBLK	0	#0032
       0x5C200E00,  //  0024  MOVE	R8	R7
       0x7C200000,  //  0025  CALL	R8	0
-      0x8824110E,  //  0026  GETMBR	R9	R8	K14
-      0x901A1C09,  //  0027  SETMBR	R6	K14	R9
-      0x8824110F,  //  0028  GETMBR	R9	R8	K15
-      0x901A1E09,  //  0029  SETMBR	R6	K15	R9
-      0x88241110,  //  002A  GETMBR	R9	R8	K16
-      0x901A2009,  //  002B  SETMBR	R6	K16	R9
-      0x8C240B11,  //  002C  GETMET	R9	R5	K17
+      0x88241112,  //  0026  GETMBR	R9	R8	K18
+      0x901A2409,  //  0027  SETMBR	R6	K18	R9
+      0x8824110D,  //  0028  GETMBR	R9	R8	K13
+      0x901A1A09,  //  0029  SETMBR	R6	K13	R9
+      0x8824110E,  //  002A  GETMBR	R9	R8	K14
+      0x901A1C09,  //  002B  SETMBR	R6	K14	R9
+      0x8C240B27,  //  002C  GETMET	R9	R5	K39
       0x602C0008,  //  002D  GETGBL	R11	G8
       0x5C300C00,  //  002E  MOVE	R12	R6
       0x7C2C0200,  //  002F  CALL	R11	1
       0x7C240400,  //  0030  CALL	R9	2
       0x7001FFF1,  //  0031  JMP		#0024
-      0x581C0012,  //  0032  LDCONST	R7	K18
+      0x581C0025,  //  0032  LDCONST	R7	K37
       0xAC1C0200,  //  0033  CATCH	R7	1	0
       0xB0080000,  //  0034  RAISE	2	R0	R0
-      0xB81E2600,  //  0035  GETNGBL	R7	K19
+      0xB81E2E00,  //  0035  GETNGBL	R7	K23
       0x60200018,  //  0036  GETGBL	R8	G24
-      0x58240014,  //  0037  LDCONST	R9	K20
-      0x88280306,  //  0038  GETMBR	R10	R1	K6
-      0x88281515,  //  0039  GETMBR	R10	R10	K21
-      0x8C2C0B16,  //  003A  GETMET	R11	R5	K22
-      0x58340017,  //  003B  LDCONST	R13	K23
+      0x58240074,  //  0037  LDCONST	R9	K116
+      0x88280323,  //  0038  GETMBR	R10	R1	K35
+      0x88281536,  //  0039  GETMBR	R10	R10	K54
+      0x8C2C0B75,  //  003A  GETMET	R11	R5	K117
+      0x58340076,  //  003B  LDCONST	R13	K118
       0x7C2C0400,  //  003C  CALL	R11	2
-      0x88300918,  //  003D  GETMBR	R12	R4	K24
-      0x88340919,  //  003E  GETMBR	R13	R4	K25
-      0x88380703,  //  003F  GETMBR	R14	R3	K3
+      0x88300977,  //  003D  GETMBR	R12	R4	K119
+      0x88340978,  //  003E  GETMBR	R13	R4	K120
+      0x88380771,  //  003F  GETMBR	R14	R3	K113
       0x783A0001,  //  0040  JMPF	R14	#0043
-      0x5838001A,  //  0041  LDCONST	R14	K26
+      0x5838002A,  //  0041  LDCONST	R14	K42
       0x70020000,  //  0042  JMP		#0044
-      0x5838001B,  //  0043  LDCONST	R14	K27
-      0x883C091C,  //  0044  GETMBR	R15	R4	K28
-      0x8840071D,  //  0045  GETMBR	R16	R3	K29
+      0x5838005C,  //  0043  LDCONST	R14	K92
+      0x883C0937,  //  0044  GETMBR	R15	R4	K55
+      0x88400731,  //  0045  GETMBR	R16	R3	K49
       0x7C201000,  //  0046  CALL	R8	8
-      0x5824000A,  //  0047  LDCONST	R9	K10
+      0x58240015,  //  0047  LDCONST	R9	K21
       0x7C1C0400,  //  0048  CALL	R7	2
-      0x8C14011E,  //  0049  GETMET	R5	R0	K30
+      0x8C140139,  //  0049  GETMET	R5	R0	K57
       0x5C1C0600,  //  004A  MOVE	R7	R3
       0x5C200200,  //  004B  MOVE	R8	R1
       0x7C140600,  //  004C  CALL	R5	3
-      0x8C18011F,  //  004D  GETMET	R6	R0	K31
+      0x8C18013E,  //  004D  GETMET	R6	R0	K62
       0x5C200600,  //  004E  MOVE	R8	R3
       0x5C240200,  //  004F  MOVE	R9	R1
       0x7C180600,  //  0050  CALL	R6	3
-      0x8C1C0920,  //  0051  GETMET	R7	R4	K32
+      0x8C1C0979,  //  0051  GETMET	R7	R4	K121
       0x5C240C00,  //  0052  MOVE	R9	R6
       0x7C1C0400,  //  0053  CALL	R7	2
-      0x881C0121,  //  0054  GETMBR	R7	R0	K33
-      0x8C1C0F11,  //  0055  GETMET	R7	R7	K17
+      0x881C0126,  //  0054  GETMBR	R7	R0	K38
+      0x8C1C0F27,  //  0055  GETMET	R7	R7	K39
       0xB8260000,  //  0056  GETNGBL	R9	K0
-      0x8C241322,  //  0057  GETMET	R9	R9	K34
+      0x8C24137A,  //  0057  GETMET	R9	R9	K122
       0x5C2C0200,  //  0058  MOVE	R11	R1
       0x5C300A00,  //  0059  MOVE	R12	R5
       0x5C340C00,  //  005A  MOVE	R13	R6
@@ -1529,17 +1488,13 @@ be_local_closure(class_Matter_IM_send_ack_now,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(_message_handler),
-    /* K2   */  be_nested_str_weak(send_encrypted_ack),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(send_ack_now),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
@@ -1547,9 +1502,9 @@ be_local_closure(class_Matter_IM_send_ack_now,   /* name */
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
       0x80000400,  //  0003  RET	0
-      0x88080300,  //  0004  GETMBR	R2	R1	K0
-      0x88080501,  //  0005  GETMBR	R2	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0x88080323,  //  0004  GETMBR	R2	R1	K35
+      0x8808053C,  //  0005  GETMBR	R2	R2	K60
+      0x8C08057B,  //  0006  GETMET	R2	R2	K123
       0x5C100200,  //  0007  MOVE	R4	R1
       0x50140000,  //  0008  LDBOOL	R5	0	0
       0x7C080600,  //  0009  CALL	R2	3
@@ -1567,46 +1522,37 @@ be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(reached_timeout),
-    /* K6   */  be_nested_str_weak(remove),
-    /* K7   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(expire_sendqueue),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804005C,  //  0000  LDCONST	R1	K92
       0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x880C0126,  //  0002  GETMBR	R3	R0	K38
       0x7C080200,  //  0003  CALL	R2	1
       0x14080202,  //  0004  LT	R2	R1	R2
       0x780A000F,  //  0005  JMPF	R2	#0016
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x88080126,  //  0006  GETMBR	R2	R0	K38
       0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
+      0xB80E2600,  //  0008  GETNGBL	R3	K19
+      0x8C0C077C,  //  0009  GETMET	R3	R3	K124
+      0x8814057D,  //  000A  GETMBR	R5	R2	K125
       0x7C0C0400,  //  000B  CALL	R3	2
       0x780E0006,  //  000C  JMPF	R3	#0014
-      0x8C0C0505,  //  000D  GETMET	R3	R2	K5
+      0x8C0C057E,  //  000D  GETMET	R3	R2	K126
       0x7C0C0200,  //  000E  CALL	R3	1
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
-      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x880C0126,  //  000F  GETMBR	R3	R0	K38
+      0x8C0C077F,  //  0010  GETMET	R3	R3	K127
       0x5C140200,  //  0011  MOVE	R5	R1
       0x7C0C0400,  //  0012  CALL	R3	2
       0x70020000,  //  0013  JMP		#0015
-      0x00040307,  //  0014  ADD	R1	R1	K7
+      0x00040341,  //  0014  ADD	R1	R1	K65
       0x7001FFEA,  //  0015  JMP		#0001
       0x4C080000,  //  0016  LDNIL	R2
       0x80040400,  //  0017  RET	1	R2
@@ -1623,33 +1569,27 @@ be_local_closure(class_Matter_IM_process_incoming_ack,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    /* K2   */  be_nested_str_weak(ack_received),
-    /* K3   */  be_nested_str_weak(finished),
-    /* K4   */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_incoming_ack),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x8C080180,  //  0000  GETMET	R2	R0	K128
+      0x88100358,  //  0001  GETMBR	R4	R1	K88
       0x7C080400,  //  0002  CALL	R2	2
       0x780A0008,  //  0003  JMPF	R2	#000D
-      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
+      0x8C0C0581,  //  0004  GETMET	R3	R2	K129
       0x5C140200,  //  0005  MOVE	R5	R1
       0x7C0C0400,  //  0006  CALL	R3	2
-      0x88100503,  //  0007  GETMBR	R4	R2	K3
+      0x8810056B,  //  0007  GETMBR	R4	R2	K107
       0x78120002,  //  0008  JMPF	R4	#000C
-      0x8C100104,  //  0009  GETMET	R4	R0	K4
-      0x88180301,  //  000A  GETMBR	R6	R1	K1
+      0x8C10016E,  //  0009  GETMET	R4	R0	K110
+      0x88180358,  //  000A  GETMBR	R6	R1	K88
       0x7C100400,  //  000B  CALL	R4	2
       0x80040600,  //  000C  RET	1	R3
       0x500C0000,  //  000D  LDBOOL	R3	0	0
@@ -1667,19 +1607,13 @@ be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(get_exchangeid),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(remove_sendqueue_by_exchangeid),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -1687,24 +1621,24 @@ be_local_closure(class_Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
       0x80000400,  //  0003  RET	0
-      0x58080000,  //  0004  LDCONST	R2	K0
+      0x58080040,  //  0004  LDCONST	R2	K64
       0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x88100126,  //  0006  GETMBR	R4	R0	K38
       0x7C0C0200,  //  0007  CALL	R3	1
       0x140C0403,  //  0008  LT	R3	R2	R3
       0x780E000C,  //  0009  JMPF	R3	#0017
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x880C0126,  //  000A  GETMBR	R3	R0	K38
       0x940C0602,  //  000B  GETIDX	R3	R3	R2
-      0x8C0C0702,  //  000C  GETMET	R3	R3	K2
+      0x8C0C0782,  //  000C  GETMET	R3	R3	K130
       0x7C0C0200,  //  000D  CALL	R3	1
       0x1C0C0601,  //  000E  EQ	R3	R3	R1
       0x780E0004,  //  000F  JMPF	R3	#0015
-      0x880C0101,  //  0010  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
+      0x880C0126,  //  0010  GETMBR	R3	R0	K38
+      0x8C0C077F,  //  0011  GETMET	R3	R3	K127
       0x5C140400,  //  0012  MOVE	R5	R2
       0x7C0C0400,  //  0013  CALL	R3	2
       0x70020000,  //  0014  JMP		#0016
-      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x0008052A,  //  0015  ADD	R2	R2	K42
       0x7001FFED,  //  0016  JMP		#0005
       0x80000000,  //  0017  RET	0
     })
@@ -1720,120 +1654,94 @@ be_local_closure(class_Matter_IM_write_single_attribute_status_to_bytes,   /* na
   be_nested_proto(
     16,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(get_attribute_name),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(_X20_X28),
-    /* K6   */  be_nested_str_weak(_X29),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(status),
-    /* K9   */  be_nested_str_weak(AttributeStatusIB),
-    /* K10  */  be_nested_str_weak(path),
-    /* K11  */  be_nested_str_weak(AttributePathIB),
-    /* K12  */  be_nested_str_weak(StatusIB),
-    /* K13  */  be_nested_str_weak(endpoint),
-    /* K14  */  be_nested_str_weak(write_responses),
-    /* K15  */  be_nested_str_weak(push),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20_X25s_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-    /* K18  */  be_nested_str_weak(SUCCESS),
-    /* K19  */  be_const_int(0),
-    /* K20  */  be_const_int(2),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(tasmota),
-    /* K23  */  be_nested_str_weak(loglevel),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3EWrite_Attr_X25s_X25s_X20_X2D_X20IGNORED),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(write_single_attribute_status_to_bytes),
     &be_const_str_solidified,
     ( &(const binstruction[86]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88100983,  //  0001  GETMBR	R4	R4	K131
       0xB8160000,  //  0002  GETNGBL	R5	K0
-      0x8C140B02,  //  0003  GETMET	R5	R5	K2
-      0x881C0503,  //  0004  GETMBR	R7	R2	K3
-      0x88200504,  //  0005  GETMBR	R8	R2	K4
+      0x8C140B16,  //  0003  GETMET	R5	R5	K22
+      0x881C050D,  //  0004  GETMBR	R7	R2	K13
+      0x8820050E,  //  0005  GETMBR	R8	R2	K14
       0x7C140600,  //  0006  CALL	R5	3
       0x78160002,  //  0007  JMPF	R5	#000B
-      0x001A0A05,  //  0008  ADD	R6	K5	R5
-      0x00180D06,  //  0009  ADD	R6	R6	K6
+      0x001A3205,  //  0008  ADD	R6	K25	R5
+      0x00180D1A,  //  0009  ADD	R6	R6	K26
       0x70020000,  //  000A  JMP		#000C
-      0x58180007,  //  000B  LDCONST	R6	K7
+      0x5818001B,  //  000B  LDCONST	R6	K27
       0x5C140C00,  //  000C  MOVE	R5	R6
-      0x88180508,  //  000D  GETMBR	R6	R2	K8
+      0x8818050F,  //  000D  GETMBR	R6	R2	K15
       0x4C1C0000,  //  000E  LDNIL	R7
       0x20180C07,  //  000F  NE	R6	R6	R7
       0x781A0034,  //  0010  JMPF	R6	#0046
       0xB81A0000,  //  0011  GETNGBL	R6	K0
-      0x8C180D09,  //  0012  GETMET	R6	R6	K9
+      0x8C180D84,  //  0012  GETMET	R6	R6	K132
       0x7C180200,  //  0013  CALL	R6	1
       0xB81E0000,  //  0014  GETNGBL	R7	K0
-      0x8C1C0F0B,  //  0015  GETMET	R7	R7	K11
+      0x8C1C0F34,  //  0015  GETMET	R7	R7	K52
       0x7C1C0200,  //  0016  CALL	R7	1
       0x901A1407,  //  0017  SETMBR	R6	K10	R7
       0xB81E0000,  //  0018  GETNGBL	R7	K0
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
+      0x8C1C0F85,  //  0019  GETMET	R7	R7	K133
       0x7C1C0200,  //  001A  CALL	R7	1
-      0x901A1007,  //  001B  SETMBR	R6	K8	R7
+      0x901A1E07,  //  001B  SETMBR	R6	K15	R7
       0x881C0D0A,  //  001C  GETMBR	R7	R6	K10
-      0x8820050D,  //  001D  GETMBR	R8	R2	K13
-      0x901E1A08,  //  001E  SETMBR	R7	K13	R8
+      0x88200512,  //  001D  GETMBR	R8	R2	K18
+      0x901E2408,  //  001E  SETMBR	R7	K18	R8
       0x881C0D0A,  //  001F  GETMBR	R7	R6	K10
-      0x88200503,  //  0020  GETMBR	R8	R2	K3
-      0x901E0608,  //  0021  SETMBR	R7	K3	R8
+      0x8820050D,  //  0020  GETMBR	R8	R2	K13
+      0x901E1A08,  //  0021  SETMBR	R7	K13	R8
       0x881C0D0A,  //  0022  GETMBR	R7	R6	K10
-      0x88200504,  //  0023  GETMBR	R8	R2	K4
-      0x901E0808,  //  0024  SETMBR	R7	K4	R8
-      0x881C0D08,  //  0025  GETMBR	R7	R6	K8
-      0x88200508,  //  0026  GETMBR	R8	R2	K8
-      0x901E1008,  //  0027  SETMBR	R7	K8	R8
-      0x881C030E,  //  0028  GETMBR	R7	R1	K14
-      0x8C1C0F0F,  //  0029  GETMET	R7	R7	K15
+      0x8820050E,  //  0023  GETMBR	R8	R2	K14
+      0x901E1C08,  //  0024  SETMBR	R7	K14	R8
+      0x881C0D0F,  //  0025  GETMBR	R7	R6	K15
+      0x8820050F,  //  0026  GETMBR	R8	R2	K15
+      0x901E1E08,  //  0027  SETMBR	R7	K15	R8
+      0x881C0307,  //  0028  GETMBR	R7	R1	K7
+      0x8C1C0F27,  //  0029  GETMET	R7	R7	K39
       0x5C240C00,  //  002A  MOVE	R9	R6
       0x7C1C0400,  //  002B  CALL	R7	2
-      0xB81E2000,  //  002C  GETNGBL	R7	K16
+      0xB81E2E00,  //  002C  GETNGBL	R7	K23
       0x60200018,  //  002D  GETGBL	R8	G24
-      0x58240011,  //  002E  LDCONST	R9	K17
+      0x58240086,  //  002E  LDCONST	R9	K134
       0x60280008,  //  002F  GETGBL	R10	G8
       0x5C2C0400,  //  0030  MOVE	R11	R2
       0x7C280200,  //  0031  CALL	R10	1
       0x5C2C0A00,  //  0032  MOVE	R11	R5
       0x5C300600,  //  0033  MOVE	R12	R3
-      0x88340508,  //  0034  GETMBR	R13	R2	K8
-      0x88380508,  //  0035  GETMBR	R14	R2	K8
+      0x8834050F,  //  0034  GETMBR	R13	R2	K15
+      0x8838050F,  //  0035  GETMBR	R14	R2	K15
       0xB83E0000,  //  0036  GETNGBL	R15	K0
-      0x883C1F12,  //  0037  GETMBR	R15	R15	K18
+      0x883C1F24,  //  0037  GETMBR	R15	R15	K36
       0x1C381C0F,  //  0038  EQ	R14	R14	R15
       0x783A0001,  //  0039  JMPF	R14	#003C
-      0x58380012,  //  003A  LDCONST	R14	K18
+      0x58380024,  //  003A  LDCONST	R14	K36
       0x70020000,  //  003B  JMP		#003D
-      0x58380007,  //  003C  LDCONST	R14	K7
+      0x5838001B,  //  003C  LDCONST	R14	K27
       0x7C200C00,  //  003D  CALL	R8	6
-      0x8824050D,  //  003E  GETMBR	R9	R2	K13
-      0x20241313,  //  003F  NE	R9	R9	K19
+      0x88240512,  //  003E  GETMBR	R9	R2	K18
+      0x20241340,  //  003F  NE	R9	R9	K64
       0x78260001,  //  0040  JMPF	R9	#0043
-      0x58240014,  //  0041  LDCONST	R9	K20
+      0x5824002B,  //  0041  LDCONST	R9	K43
       0x70020000,  //  0042  JMP		#0044
       0x58240015,  //  0043  LDCONST	R9	K21
       0x7C1C0400,  //  0044  CALL	R7	2
       0x7002000E,  //  0045  JMP		#0055
-      0xB81A2C00,  //  0046  GETNGBL	R6	K22
-      0x8C180D17,  //  0047  GETMET	R6	R6	K23
+      0xB81A2600,  //  0046  GETNGBL	R6	K19
+      0x8C180D14,  //  0047  GETMET	R6	R6	K20
       0x58200015,  //  0048  LDCONST	R8	K21
       0x7C180400,  //  0049  CALL	R6	2
       0x781A0009,  //  004A  JMPF	R6	#0055
-      0xB81A2000,  //  004B  GETNGBL	R6	K16
+      0xB81A2E00,  //  004B  GETNGBL	R6	K23
       0x601C0018,  //  004C  GETGBL	R7	G24
-      0x58200018,  //  004D  LDCONST	R8	K24
+      0x58200087,  //  004D  LDCONST	R8	K135
       0x60240008,  //  004E  GETGBL	R9	G8
       0x5C280400,  //  004F  MOVE	R10	R2
       0x7C240200,  //  0050  CALL	R9	1
@@ -1855,51 +1763,38 @@ be_local_closure(class_Matter_IM_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(subs_shop),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
-    /* K5   */  be_nested_str_weak(read_request_solo),
-    /* K6   */  be_nested_str_weak(ReadRequestMessage_solo),
-    /* K7   */  be_nested_str_weak(invoke_request_solo),
-    /* K8   */  be_nested_str_weak(InvokeRequestMessage_solo),
-    /* K9   */  be_nested_str_weak(tlv_solo),
-    /* K10  */  be_nested_str_weak(TLV),
-    /* K11  */  be_nested_str_weak(Matter_TLV_item),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021201,  //  0000  SETMBR	R0	K9	R1
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0xB80A0600,  //  0004  GETNGBL	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x90024C02,  //  0003  SETMBR	R0	K38	R2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x8C080588,  //  0005  GETMET	R2	R2	K136
       0x5C100000,  //  0006  MOVE	R4	R0
       0x7C080400,  //  0007  CALL	R2	2
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x90028E02,  //  0008  SETMBR	R0	K71	R2
+      0xB80A0000,  //  0009  GETNGBL	R2	K0
+      0x8C08058A,  //  000A  GETMET	R2	R2	K138
       0x7C080200,  //  000B  CALL	R2	1
-      0x90020A02,  //  000C  SETMBR	R0	K5	R2
-      0xB80A0600,  //  000D  GETNGBL	R2	K3
-      0x8C080508,  //  000E  GETMET	R2	R2	K8
+      0x90031202,  //  000C  SETMBR	R0	K137	R2
+      0xB80A0000,  //  000D  GETNGBL	R2	K0
+      0x8C08058C,  //  000E  GETMET	R2	R2	K140
       0x7C080200,  //  000F  CALL	R2	1
-      0x90020E02,  //  0010  SETMBR	R0	K7	R2
-      0xB80A0600,  //  0011  GETNGBL	R2	K3
-      0x8808050A,  //  0012  GETMBR	R2	R2	K10
-      0x8C08050B,  //  0013  GETMET	R2	R2	K11
+      0x90031602,  //  0010  SETMBR	R0	K139	R2
+      0xB80A0000,  //  0011  GETNGBL	R2	K0
+      0x88080583,  //  0012  GETMBR	R2	R2	K131
+      0x8C08058E,  //  0013  GETMET	R2	R2	K142
       0x7C080200,  //  0014  CALL	R2	1
-      0x90021202,  //  0015  SETMBR	R0	K9	R2
+      0x90031A02,  //  0015  SETMBR	R0	K141	R2
       0x80000000,  //  0016  RET	0
     })
   )
@@ -1914,19 +1809,17 @@ be_local_closure(class_Matter_IM_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expire_sendqueue),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04018F,  //  0000  GETMET	R1	R0	K143
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -1942,239 +1835,200 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[38]) {     /* constants */
-    /* K0   */  be_nested_str_weak(msg),
-    /* K1   */  be_nested_str_weak(status),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K4   */  be_nested_str_weak(get_command_name),
-    /* K5   */  be_nested_str_weak(cluster),
-    /* K6   */  be_nested_str_weak(command),
-    /* K7   */  be_nested_str_weak(device),
-    /* K8   */  be_nested_str_weak(invoke_request),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(command_fields),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(_X28),
-    /* K13  */  be_nested_str_weak(_X29_X20),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(loglevel),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand1_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K19  */  be_nested_str_weak(local_session_id),
-    /* K20  */  be_nested_str_weak(add),
-    /* K21  */  be_const_int(354943030),
-    /* K22  */  be_const_int(1),
-    /* K23  */  be_nested_str_weak(SUCCESS),
-    /* K24  */  be_nested_str_weak(invokeresponse2raw),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
-    /* K26  */  be_nested_str_weak(exchange_id),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
-    /* K30  */  be_const_int(405077761),
-    /* K31  */  be_nested_str_weak(build_response),
-    /* K32  */  be_nested_str_weak(message_handler),
-    /* K33  */  be_nested_str_weak(raw),
-    /* K34  */  be_nested_str_weak(clear),
-    /* K35  */  be_nested_str_weak(encode_frame),
-    /* K36  */  be_nested_str_weak(encrypt),
-    /* K37  */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_invoke_request_solo),
     &be_const_str_solidified,
     ( &(const binstruction[188]) {  /* code */
-      0x900A0001,  //  0000  SETMBR	R2	K0	R1
-      0xB80E0400,  //  0001  GETNGBL	R3	K2
-      0x880C0703,  //  0002  GETMBR	R3	R3	K3
-      0x900A0203,  //  0003  SETMBR	R2	K1	R3
-      0xB80E0400,  //  0004  GETNGBL	R3	K2
-      0x8C0C0704,  //  0005  GETMET	R3	R3	K4
-      0x88140505,  //  0006  GETMBR	R5	R2	K5
-      0x88180506,  //  0007  GETMBR	R6	R2	K6
+      0x900A3E01,  //  0000  SETMBR	R2	K31	R1
+      0xB80E0000,  //  0001  GETNGBL	R3	K0
+      0x880C074F,  //  0002  GETMBR	R3	R3	K79
+      0x900A1E03,  //  0003  SETMBR	R2	K15	R3
+      0xB80E0000,  //  0004  GETNGBL	R3	K0
+      0x8C0C0750,  //  0005  GETMET	R3	R3	K80
+      0x8814050D,  //  0006  GETMBR	R5	R2	K13
+      0x8818054E,  //  0007  GETMBR	R6	R2	K78
       0x7C0C0600,  //  0008  CALL	R3	3
       0x60100008,  //  0009  GETGBL	R4	G8
       0x5C140400,  //  000A  MOVE	R5	R2
       0x7C100200,  //  000B  CALL	R4	1
-      0x88140107,  //  000C  GETMBR	R5	R0	K7
-      0x8C140B08,  //  000D  GETMET	R5	R5	K8
-      0x881C0309,  //  000E  GETMBR	R7	R1	K9
-      0x8820050A,  //  000F  GETMBR	R8	R2	K10
+      0x88140109,  //  000C  GETMBR	R5	R0	K9
+      0x8C140B51,  //  000D  GETMET	R5	R5	K81
+      0x881C0323,  //  000E  GETMBR	R7	R1	K35
+      0x88200552,  //  000F  GETMBR	R8	R2	K82
       0x5C240400,  //  0010  MOVE	R9	R2
       0x7C140800,  //  0011  CALL	R5	4
-      0x8818050B,  //  0012  GETMBR	R6	R2	K11
+      0x88180517,  //  0012  GETMBR	R6	R2	K23
       0x4C1C0000,  //  0013  LDNIL	R7
       0x20180C07,  //  0014  NE	R6	R6	R7
       0x781A0005,  //  0015  JMPF	R6	#001C
       0x60180008,  //  0016  GETGBL	R6	G8
-      0x881C050B,  //  0017  GETMBR	R7	R2	K11
+      0x881C0517,  //  0017  GETMBR	R7	R2	K23
       0x7C180200,  //  0018  CALL	R6	1
-      0x001A1806,  //  0019  ADD	R6	K12	R6
-      0x00180D0D,  //  001A  ADD	R6	R6	K13
+      0x001AA606,  //  0019  ADD	R6	K83	R6
+      0x00180D54,  //  001A  ADD	R6	R6	K84
       0x70020000,  //  001B  JMP		#001D
-      0x5818000E,  //  001C  LDCONST	R6	K14
-      0xB81E1E00,  //  001D  GETNGBL	R7	K15
-      0x8C1C0F10,  //  001E  GETMET	R7	R7	K16
-      0x58240011,  //  001F  LDCONST	R9	K17
+      0x5818001B,  //  001C  LDCONST	R6	K27
+      0xB81E2600,  //  001D  GETNGBL	R7	K19
+      0x8C1C0F14,  //  001E  GETMET	R7	R7	K20
+      0x58240015,  //  001F  LDCONST	R9	K21
       0x7C1C0400,  //  0020  CALL	R7	2
       0x781E000D,  //  0021  JMPF	R7	#0030
-      0xB81E1600,  //  0022  GETNGBL	R7	K11
+      0xB81E2E00,  //  0022  GETNGBL	R7	K23
       0x60200018,  //  0023  GETGBL	R8	G24
-      0x58240012,  //  0024  LDCONST	R9	K18
-      0x88280309,  //  0025  GETMBR	R10	R1	K9
-      0x88281513,  //  0026  GETMBR	R10	R10	K19
+      0x58240090,  //  0024  LDCONST	R9	K144
+      0x88280323,  //  0025  GETMBR	R10	R1	K35
+      0x88281536,  //  0026  GETMBR	R10	R10	K54
       0x5C2C0800,  //  0027  MOVE	R11	R4
       0x780E0001,  //  0028  JMPF	R3	#002B
       0x5C300600,  //  0029  MOVE	R12	R3
       0x70020000,  //  002A  JMP		#002C
-      0x5830000E,  //  002B  LDCONST	R12	K14
+      0x5830001B,  //  002B  LDCONST	R12	K27
       0x5C340C00,  //  002C  MOVE	R13	R6
       0x7C200A00,  //  002D  CALL	R8	5
-      0x58240011,  //  002E  LDCONST	R9	K17
+      0x58240015,  //  002E  LDCONST	R9	K21
       0x7C1C0400,  //  002F  CALL	R7	2
       0x4C1C0000,  //  0030  LDNIL	R7
-      0x900A1607,  //  0031  SETMBR	R2	K11	R7
+      0x900A2E07,  //  0031  SETMBR	R2	K23	R7
       0x601C0015,  //  0032  GETGBL	R7	G21
       0x5422002F,  //  0033  LDINT	R8	48
       0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C200F14,  //  0035  GETMET	R8	R7	K20
-      0x58280015,  //  0036  LDCONST	R10	K21
+      0x8C200F29,  //  0035  GETMET	R8	R7	K41
+      0x58280091,  //  0036  LDCONST	R10	K145
       0x542DFFFB,  //  0037  LDINT	R11	-4
       0x7C200600,  //  0038  CALL	R8	3
-      0x8C200F14,  //  0039  GETMET	R8	R7	K20
-      0x58280016,  //  003A  LDCONST	R10	K22
-      0x582C0016,  //  003B  LDCONST	R11	K22
+      0x8C200F29,  //  0039  GETMET	R8	R7	K41
+      0x5828002A,  //  003A  LDCONST	R10	K42
+      0x582C002A,  //  003B  LDCONST	R11	K42
       0x7C200600,  //  003C  CALL	R8	3
       0x50200200,  //  003D  LDBOOL	R8	1	0
       0x1C200A08,  //  003E  EQ	R8	R5	R8
       0x74220004,  //  003F  JMPT	R8	#0045
-      0x88200501,  //  0040  GETMBR	R8	R2	K1
-      0xB8260400,  //  0041  GETNGBL	R9	K2
-      0x88241317,  //  0042  GETMBR	R9	R9	K23
+      0x8820050F,  //  0040  GETMBR	R8	R2	K15
+      0xB8260000,  //  0041  GETNGBL	R9	K0
+      0x88241324,  //  0042  GETMBR	R9	R9	K36
       0x1C201009,  //  0043  EQ	R8	R8	R9
       0x78220016,  //  0044  JMPF	R8	#005C
-      0xB8220400,  //  0045  GETNGBL	R8	K2
-      0x88201117,  //  0046  GETMBR	R8	R8	K23
-      0x900A0208,  //  0047  SETMBR	R2	K1	R8
-      0x8C200118,  //  0048  GETMET	R8	R0	K24
+      0xB8220000,  //  0045  GETNGBL	R8	K0
+      0x88201124,  //  0046  GETMBR	R8	R8	K36
+      0x900A1E08,  //  0047  SETMBR	R2	K15	R8
+      0x8C200156,  //  0048  GETMET	R8	R0	K86
       0x5C280E00,  //  0049  MOVE	R10	R7
       0x5C2C0400,  //  004A  MOVE	R11	R2
       0x4C300000,  //  004B  LDNIL	R12
       0x7C200800,  //  004C  CALL	R8	4
-      0xB8221E00,  //  004D  GETNGBL	R8	K15
-      0x8C201110,  //  004E  GETMET	R8	R8	K16
-      0x58280011,  //  004F  LDCONST	R10	K17
+      0xB8222600,  //  004D  GETNGBL	R8	K19
+      0x8C201114,  //  004E  GETMET	R8	R8	K20
+      0x58280015,  //  004F  LDCONST	R10	K21
       0x7C200400,  //  0050  CALL	R8	2
       0x78220008,  //  0051  JMPF	R8	#005B
-      0xB8221600,  //  0052  GETNGBL	R8	K11
+      0xB8222E00,  //  0052  GETNGBL	R8	K23
       0x60240018,  //  0053  GETGBL	R9	G24
-      0x58280019,  //  0054  LDCONST	R10	K25
-      0x882C0309,  //  0055  GETMBR	R11	R1	K9
-      0x882C1713,  //  0056  GETMBR	R11	R11	K19
-      0x8830031A,  //  0057  GETMBR	R12	R1	K26
+      0x58280057,  //  0054  LDCONST	R10	K87
+      0x882C0323,  //  0055  GETMBR	R11	R1	K35
+      0x882C1736,  //  0056  GETMBR	R11	R11	K54
+      0x88300358,  //  0057  GETMBR	R12	R1	K88
       0x7C240600,  //  0058  CALL	R9	3
-      0x58280011,  //  0059  LDCONST	R10	K17
+      0x58280015,  //  0059  LDCONST	R10	K21
       0x7C200400,  //  005A  CALL	R8	2
       0x70020043,  //  005B  JMP		#00A0
       0x4C200000,  //  005C  LDNIL	R8
       0x20200A08,  //  005D  NE	R8	R5	R8
       0x78220017,  //  005E  JMPF	R8	#0077
-      0x8C200118,  //  005F  GETMET	R8	R0	K24
+      0x8C200156,  //  005F  GETMET	R8	R0	K86
       0x5C280E00,  //  0060  MOVE	R10	R7
       0x5C2C0400,  //  0061  MOVE	R11	R2
       0x5C300A00,  //  0062  MOVE	R12	R5
       0x7C200800,  //  0063  CALL	R8	4
       0x5C200600,  //  0064  MOVE	R8	R3
       0x74220000,  //  0065  JMPT	R8	#0067
-      0x580C000E,  //  0066  LDCONST	R3	K14
-      0xB8221E00,  //  0067  GETNGBL	R8	K15
-      0x8C201110,  //  0068  GETMET	R8	R8	K16
-      0x58280011,  //  0069  LDCONST	R10	K17
+      0x580C001B,  //  0066  LDCONST	R3	K27
+      0xB8222600,  //  0067  GETNGBL	R8	K19
+      0x8C201114,  //  0068  GETMET	R8	R8	K20
+      0x58280015,  //  0069  LDCONST	R10	K21
       0x7C200400,  //  006A  CALL	R8	2
       0x78220009,  //  006B  JMPF	R8	#0076
-      0xB8221600,  //  006C  GETNGBL	R8	K11
+      0xB8222E00,  //  006C  GETNGBL	R8	K23
       0x60240018,  //  006D  GETGBL	R9	G24
-      0x5828001B,  //  006E  LDCONST	R10	K27
-      0x882C0309,  //  006F  GETMBR	R11	R1	K9
-      0x882C1713,  //  0070  GETMBR	R11	R11	K19
+      0x58280059,  //  006E  LDCONST	R10	K89
+      0x882C0323,  //  006F  GETMBR	R11	R1	K35
+      0x882C1736,  //  0070  GETMBR	R11	R11	K54
       0x5C300400,  //  0071  MOVE	R12	R2
       0x5C340600,  //  0072  MOVE	R13	R3
       0x7C240800,  //  0073  CALL	R9	4
-      0x58280011,  //  0074  LDCONST	R10	K17
+      0x58280015,  //  0074  LDCONST	R10	K21
       0x7C200400,  //  0075  CALL	R8	2
       0x70020028,  //  0076  JMP		#00A0
-      0x88200501,  //  0077  GETMBR	R8	R2	K1
+      0x8820050F,  //  0077  GETMBR	R8	R2	K15
       0x4C240000,  //  0078  LDNIL	R9
       0x20201009,  //  0079  NE	R8	R8	R9
       0x78220014,  //  007A  JMPF	R8	#0090
-      0x8C200118,  //  007B  GETMET	R8	R0	K24
+      0x8C200156,  //  007B  GETMET	R8	R0	K86
       0x5C280E00,  //  007C  MOVE	R10	R7
       0x5C2C0400,  //  007D  MOVE	R11	R2
       0x4C300000,  //  007E  LDNIL	R12
       0x7C200800,  //  007F  CALL	R8	4
-      0xB8221E00,  //  0080  GETNGBL	R8	K15
-      0x8C201110,  //  0081  GETMET	R8	R8	K16
-      0x58280011,  //  0082  LDCONST	R10	K17
+      0xB8222600,  //  0080  GETNGBL	R8	K19
+      0x8C201114,  //  0081  GETMET	R8	R8	K20
+      0x58280015,  //  0082  LDCONST	R10	K21
       0x7C200400,  //  0083  CALL	R8	2
       0x78220009,  //  0084  JMPF	R8	#008F
-      0xB8221600,  //  0085  GETNGBL	R8	K11
+      0xB8222E00,  //  0085  GETNGBL	R8	K23
       0x60240018,  //  0086  GETGBL	R9	G24
-      0x5828001C,  //  0087  LDCONST	R10	K28
-      0x882C0309,  //  0088  GETMBR	R11	R1	K9
-      0x882C1713,  //  0089  GETMBR	R11	R11	K19
-      0x88300501,  //  008A  GETMBR	R12	R2	K1
-      0x8834031A,  //  008B  GETMBR	R13	R1	K26
+      0x5828005A,  //  0087  LDCONST	R10	K90
+      0x882C0323,  //  0088  GETMBR	R11	R1	K35
+      0x882C1736,  //  0089  GETMBR	R11	R11	K54
+      0x8830050F,  //  008A  GETMBR	R12	R2	K15
+      0x88340358,  //  008B  GETMBR	R13	R1	K88
       0x7C240800,  //  008C  CALL	R9	4
-      0x58280011,  //  008D  LDCONST	R10	K17
+      0x58280015,  //  008D  LDCONST	R10	K21
       0x7C200400,  //  008E  CALL	R8	2
       0x7002000F,  //  008F  JMP		#00A0
-      0xB8221E00,  //  0090  GETNGBL	R8	K15
-      0x8C201110,  //  0091  GETMET	R8	R8	K16
-      0x58280011,  //  0092  LDCONST	R10	K17
+      0xB8222600,  //  0090  GETNGBL	R8	K19
+      0x8C201114,  //  0091  GETMET	R8	R8	K20
+      0x58280015,  //  0092  LDCONST	R10	K21
       0x7C200400,  //  0093  CALL	R8	2
       0x78220008,  //  0094  JMPF	R8	#009E
-      0xB8221600,  //  0095  GETNGBL	R8	K11
+      0xB8222E00,  //  0095  GETNGBL	R8	K23
       0x60240018,  //  0096  GETGBL	R9	G24
-      0x5828001D,  //  0097  LDCONST	R10	K29
-      0x882C0309,  //  0098  GETMBR	R11	R1	K9
-      0x882C1713,  //  0099  GETMBR	R11	R11	K19
-      0x8830031A,  //  009A  GETMBR	R12	R1	K26
+      0x5828005B,  //  0097  LDCONST	R10	K91
+      0x882C0323,  //  0098  GETMBR	R11	R1	K35
+      0x882C1736,  //  0099  GETMBR	R11	R11	K54
+      0x88300358,  //  009A  GETMBR	R12	R1	K88
       0x7C240600,  //  009B  CALL	R9	3
-      0x58280011,  //  009C  LDCONST	R10	K17
+      0x58280015,  //  009C  LDCONST	R10	K21
       0x7C200400,  //  009D  CALL	R8	2
       0x50200000,  //  009E  LDBOOL	R8	0	0
       0x80041000,  //  009F  RET	1	R8
-      0x8C200F14,  //  00A0  GETMET	R8	R7	K20
-      0x5828001E,  //  00A1  LDCONST	R10	K30
+      0x8C200F29,  //  00A0  GETMET	R8	R7	K41
+      0x58280092,  //  00A1  LDCONST	R10	K146
       0x542DFFFB,  //  00A2  LDINT	R11	-4
       0x7C200600,  //  00A3  CALL	R8	3
-      0x8C200F14,  //  00A4  GETMET	R8	R7	K20
+      0x8C200F29,  //  00A4  GETMET	R8	R7	K41
       0x542A0017,  //  00A5  LDINT	R10	24
-      0x582C0016,  //  00A6  LDCONST	R11	K22
+      0x582C002A,  //  00A6  LDCONST	R11	K42
       0x7C200600,  //  00A7  CALL	R8	3
-      0x8C20031F,  //  00A8  GETMET	R8	R1	K31
+      0x8C200393,  //  00A8  GETMET	R8	R1	K147
       0x542A0008,  //  00A9  LDINT	R10	9
       0x502C0200,  //  00AA  LDBOOL	R11	1	0
       0x7C200600,  //  00AB  CALL	R8	3
-      0x88240107,  //  00AC  GETMBR	R9	R0	K7
-      0x88241320,  //  00AD  GETMBR	R9	R9	K32
-      0x88280321,  //  00AE  GETMBR	R10	R1	K33
-      0x8C2C1522,  //  00AF  GETMET	R11	R10	K34
+      0x88240109,  //  00AC  GETMBR	R9	R0	K9
+      0x88241394,  //  00AD  GETMBR	R9	R9	K148
+      0x88280395,  //  00AE  GETMBR	R10	R1	K149
+      0x8C2C1596,  //  00AF  GETMET	R11	R10	K150
       0x7C2C0200,  //  00B0  CALL	R11	1
-      0x8C2C1123,  //  00B1  GETMET	R11	R8	K35
+      0x8C2C1197,  //  00B1  GETMET	R11	R8	K151
       0x5C340E00,  //  00B2  MOVE	R13	R7
       0x5C381400,  //  00B3  MOVE	R14	R10
       0x7C2C0600,  //  00B4  CALL	R11	3
-      0x8C2C1124,  //  00B5  GETMET	R11	R8	K36
+      0x8C2C1198,  //  00B5  GETMET	R11	R8	K152
       0x7C2C0200,  //  00B6  CALL	R11	1
-      0x8C2C1325,  //  00B7  GETMET	R11	R9	K37
+      0x8C2C1399,  //  00B7  GETMET	R11	R9	K153
       0x5C341000,  //  00B8  MOVE	R13	R8
       0x7C2C0400,  //  00B9  CALL	R11	2
       0x502C0200,  //  00BA  LDBOOL	R11	1	0
@@ -2192,59 +2046,43 @@ be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(loglevel),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25s),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(subscription_id),
-    /* K8   */  be_nested_str_weak(is_keep_alive),
-    /* K9   */  be_nested_str_weak(send_queue),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(IM_SubscribedHeartbeat),
-    /* K13  */  be_nested_str_weak(_message_handler),
-    /* K14  */  be_nested_str_weak(send_enqueued),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(send_subscribe_heartbeat),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0x88080323,  //  0000  GETMBR	R2	R1	K35
+      0xB80E2600,  //  0001  GETNGBL	R3	K19
+      0x8C0C0714,  //  0002  GETMET	R3	R3	K20
+      0x58140015,  //  0003  LDCONST	R5	K21
       0x7C0C0400,  //  0004  CALL	R3	2
       0x780E0007,  //  0005  JMPF	R3	#000E
-      0xB80E0800,  //  0006  GETNGBL	R3	K4
+      0xB80E2E00,  //  0006  GETNGBL	R3	K23
       0x60100018,  //  0007  GETGBL	R4	G24
-      0x58140005,  //  0008  LDCONST	R5	K5
-      0x88180506,  //  0009  GETMBR	R6	R2	K6
-      0x881C0307,  //  000A  GETMBR	R7	R1	K7
+      0x5814009A,  //  0008  LDCONST	R5	K154
+      0x88180536,  //  0009  GETMBR	R6	R2	K54
+      0x881C0337,  //  000A  GETMBR	R7	R1	K55
       0x7C100600,  //  000B  CALL	R4	3
-      0x58140003,  //  000C  LDCONST	R5	K3
+      0x58140015,  //  000C  LDCONST	R5	K21
       0x7C0C0400,  //  000D  CALL	R3	2
       0x500C0200,  //  000E  LDBOOL	R3	1	0
-      0x90061003,  //  000F  SETMBR	R1	K8	R3
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
-      0xB8161600,  //  0012  GETNGBL	R5	K11
-      0x8C140B0C,  //  0013  GETMET	R5	R5	K12
-      0x881C050D,  //  0014  GETMBR	R7	R2	K13
+      0x90067003,  //  000F  SETMBR	R1	K56	R3
+      0x880C0126,  //  0010  GETMBR	R3	R0	K38
+      0x8C0C0727,  //  0011  GETMET	R3	R3	K39
+      0xB8160000,  //  0012  GETNGBL	R5	K0
+      0x8C140B9B,  //  0013  GETMET	R5	R5	K155
+      0x881C053C,  //  0014  GETMBR	R7	R2	K60
       0x5C200400,  //  0015  MOVE	R8	R2
       0x5C240200,  //  0016  MOVE	R9	R1
       0x7C140800,  //  0017  CALL	R5	4
       0x7C0C0400,  //  0018  CALL	R3	2
-      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
-      0x8814050D,  //  001A  GETMBR	R5	R2	K13
+      0x8C0C013D,  //  0019  GETMET	R3	R0	K61
+      0x8814053C,  //  001A  GETMBR	R5	R2	K60
       0x7C0C0400,  //  001B  CALL	R3	2
       0x80000000,  //  001C  RET	0
     })
@@ -2260,18 +2098,13 @@ be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(get_exchangeid),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(find_sendqueue_by_exchangeid),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
@@ -2280,20 +2113,20 @@ be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0x58080000,  //  0005  LDCONST	R2	K0
+      0x58080040,  //  0005  LDCONST	R2	K64
       0x600C000C,  //  0006  GETGBL	R3	G12
-      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x88100126,  //  0007  GETMBR	R4	R0	K38
       0x7C0C0200,  //  0008  CALL	R3	1
       0x140C0403,  //  0009  LT	R3	R2	R3
       0x780E0008,  //  000A  JMPF	R3	#0014
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x880C0126,  //  000B  GETMBR	R3	R0	K38
       0x940C0602,  //  000C  GETIDX	R3	R3	R2
-      0x8C100702,  //  000D  GETMET	R4	R3	K2
+      0x8C100782,  //  000D  GETMET	R4	R3	K130
       0x7C100200,  //  000E  CALL	R4	1
       0x1C100801,  //  000F  EQ	R4	R4	R1
       0x78120000,  //  0010  JMPF	R4	#0012
       0x80040600,  //  0011  RET	1	R3
-      0x00080503,  //  0012  ADD	R2	R2	K3
+      0x0008052A,  //  0012  ADD	R2	R2	K42
       0x7001FFF1,  //  0013  JMP		#0006
       0x4C0C0000,  //  0014  LDNIL	R3
       0x80040600,  //  0015  RET	1	R3
@@ -2310,75 +2143,22 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[52]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(INVALID_ACTION),
-    /* K3   */  be_nested_str_weak(msg),
-    /* K4   */  be_nested_str_weak(device),
-    /* K5   */  be_nested_str_weak(resolve_attribute_read_solo),
-    /* K6   */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K7   */  be_nested_str_weak(read_attribute),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(tlv_solo),
-    /* K10  */  be_nested_str_weak(is_list),
-    /* K11  */  be_nested_str_weak(is_array),
-    /* K12  */  be_nested_str_weak(encode_len),
-    /* K13  */  be_nested_str_weak(IM_ReportData_Pull),
-    /* K14  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Response_X20to_X20big_X2C_X20revert_X20to_X20non_X2Dsolo),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(TLV),
-    /* K19  */  be_nested_str_weak(parse),
-    /* K20  */  be_nested_str_weak(raw),
-    /* K21  */  be_nested_str_weak(app_payload_idx),
-    /* K22  */  be_nested_str_weak(process_read_request_pull),
-    /* K23  */  be_nested_str_weak(add),
-    /* K24  */  be_const_int(1),
-    /* K25  */  be_nested_str_weak(attributedata2raw),
-    /* K26  */  be_const_int(405077761),
-    /* K27  */  be_nested_str_weak(attributestatus2raw),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
-    /* K29  */  be_nested_str_weak(local_session_id),
-    /* K30  */  be_nested_str_weak(build_response),
-    /* K31  */  be_nested_str_weak(message_handler),
-    /* K32  */  be_nested_str_weak(clear),
-    /* K33  */  be_nested_str_weak(encode_frame),
-    /* K34  */  be_nested_str_weak(encrypt),
-    /* K35  */  be_nested_str_weak(tasmota),
-    /* K36  */  be_nested_str_weak(loglevel),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
-    /* K38  */  be_nested_str_weak(message_counter),
-    /* K39  */  be_nested_str_weak(exchange_id),
-    /* K40  */  be_nested_str_weak(ack_message_counter),
-    /* K41  */  be_nested_str_weak(send_response_frame),
-    /* K42  */  be_nested_str_weak(get_attribute_name),
-    /* K43  */  be_nested_str_weak(cluster),
-    /* K44  */  be_nested_str_weak(attribute),
-    /* K45  */  be_nested_str_weak(_X20_X28),
-    /* K46  */  be_nested_str_weak(_X29),
-    /* K47  */  be_nested_str_weak(),
-    /* K48  */  be_nested_str_weak(to_str_val),
-    /* K49  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-    /* K50  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_read_request_solo),
     &be_const_str_solidified,
     ( &(const binstruction[242]) {  /* code */
-      0xB80E0200,  //  0000  GETNGBL	R3	K1
-      0x880C0702,  //  0001  GETMBR	R3	R3	K2
-      0x900A0003,  //  0002  SETMBR	R2	K0	R3
-      0x900A0601,  //  0003  SETMBR	R2	K3	R1
-      0x880C0104,  //  0004  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  0005  GETMET	R3	R3	K5
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0710,  //  0001  GETMBR	R3	R3	K16
+      0x900A1E03,  //  0002  SETMBR	R2	K15	R3
+      0x900A3E01,  //  0003  SETMBR	R2	K31	R1
+      0x880C0109,  //  0004  GETMBR	R3	R0	K9
+      0x8C0C079C,  //  0005  GETMET	R3	R3	K156
       0x5C140400,  //  0006  MOVE	R5	R2
       0x7C0C0400,  //  0007  CALL	R3	2
       0x4C100000,  //  0008  LDNIL	R4
@@ -2386,43 +2166,43 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
       0x4C180000,  //  000A  LDNIL	R6
       0x20180606,  //  000B  NE	R6	R3	R6
       0x781A0008,  //  000C  JMPF	R6	#0016
-      0xB81A0200,  //  000D  GETNGBL	R6	K1
-      0x88180D06,  //  000E  GETMBR	R6	R6	K6
-      0x900A0006,  //  000F  SETMBR	R2	K0	R6
-      0x8C180707,  //  0010  GETMET	R6	R3	K7
-      0x88200308,  //  0011  GETMBR	R8	R1	K8
+      0xB81A0000,  //  000D  GETNGBL	R6	K0
+      0x88180D9D,  //  000E  GETMBR	R6	R6	K157
+      0x900A1E06,  //  000F  SETMBR	R2	K15	R6
+      0x8C18079E,  //  0010  GETMET	R6	R3	K158
+      0x88200323,  //  0011  GETMBR	R8	R1	K35
       0x5C240400,  //  0012  MOVE	R9	R2
-      0x88280109,  //  0013  GETMBR	R10	R0	K9
+      0x8828018D,  //  0013  GETMBR	R10	R0	K141
       0x7C180800,  //  0014  CALL	R6	4
       0x5C100C00,  //  0015  MOVE	R4	R6
       0x4C180000,  //  0016  LDNIL	R6
       0x20180806,  //  0017  NE	R6	R4	R6
       0x781A0036,  //  0018  JMPF	R6	#0050
-      0x8818090A,  //  0019  GETMBR	R6	R4	K10
+      0x8818099F,  //  0019  GETMBR	R6	R4	K159
       0x741A0001,  //  001A  JMPT	R6	#001D
-      0x8818090B,  //  001B  GETMBR	R6	R4	K11
+      0x881809A0,  //  001B  GETMBR	R6	R4	K160
       0x781A0018,  //  001C  JMPF	R6	#0036
-      0x8C18090C,  //  001D  GETMET	R6	R4	K12
+      0x8C1809A1,  //  001D  GETMET	R6	R4	K161
       0x7C180200,  //  001E  CALL	R6	1
-      0xB81E0200,  //  001F  GETNGBL	R7	K1
-      0x881C0F0D,  //  0020  GETMBR	R7	R7	K13
-      0x881C0F0E,  //  0021  GETMBR	R7	R7	K14
+      0xB81E0000,  //  001F  GETNGBL	R7	K0
+      0x881C0F3F,  //  0020  GETMBR	R7	R7	K63
+      0x881C0FA2,  //  0021  GETMBR	R7	R7	K162
       0x24180C07,  //  0022  GT	R6	R6	R7
       0x781A0011,  //  0023  JMPF	R6	#0036
       0x4C100000,  //  0024  LDNIL	R4
-      0xB81A1E00,  //  0025  GETNGBL	R6	K15
+      0xB81A2E00,  //  0025  GETNGBL	R6	K23
       0x601C0018,  //  0026  GETGBL	R7	G24
-      0x58200010,  //  0027  LDCONST	R8	K16
+      0x582000A3,  //  0027  LDCONST	R8	K163
       0x7C1C0200,  //  0028  CALL	R7	1
-      0x58200011,  //  0029  LDCONST	R8	K17
+      0x58200015,  //  0029  LDCONST	R8	K21
       0x7C180400,  //  002A  CALL	R6	2
-      0xB81A0200,  //  002B  GETNGBL	R6	K1
-      0x88180D12,  //  002C  GETMBR	R6	R6	K18
-      0x8C180D13,  //  002D  GETMET	R6	R6	K19
-      0x88200314,  //  002E  GETMBR	R8	R1	K20
-      0x88240315,  //  002F  GETMBR	R9	R1	K21
+      0xB81A0000,  //  002B  GETNGBL	R6	K0
+      0x88180D83,  //  002C  GETMBR	R6	R6	K131
+      0x8C180DA4,  //  002D  GETMET	R6	R6	K164
+      0x88200395,  //  002E  GETMBR	R8	R1	K149
+      0x882403A5,  //  002F  GETMBR	R9	R1	K165
       0x7C180600,  //  0030  CALL	R6	3
-      0x8C1C0116,  //  0031  GETMET	R7	R0	K22
+      0x8C1C01A6,  //  0031  GETMET	R7	R0	K166
       0x5C240200,  //  0032  MOVE	R9	R1
       0x5C280C00,  //  0033  MOVE	R10	R6
       0x7C1C0600,  //  0034  CALL	R7	3
@@ -2431,29 +2211,29 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
       0x541E002F,  //  0037  LDINT	R7	48
       0x7C180200,  //  0038  CALL	R6	1
       0x5C140C00,  //  0039  MOVE	R5	R6
-      0x8C180B17,  //  003A  GETMET	R6	R5	K23
+      0x8C180B29,  //  003A  GETMET	R6	R5	K41
       0x54220014,  //  003B  LDINT	R8	21
-      0x58240018,  //  003C  LDCONST	R9	K24
+      0x5824002A,  //  003C  LDCONST	R9	K42
       0x7C180600,  //  003D  CALL	R6	3
-      0x8C180B17,  //  003E  GETMET	R6	R5	K23
+      0x8C180B29,  //  003E  GETMET	R6	R5	K41
       0x54223600,  //  003F  LDINT	R8	13825
       0x5425FFFD,  //  0040  LDINT	R9	-2
       0x7C180600,  //  0041  CALL	R6	3
-      0x8C180119,  //  0042  GETMET	R6	R0	K25
+      0x8C1801A7,  //  0042  GETMET	R6	R0	K167
       0x5C200A00,  //  0043  MOVE	R8	R5
       0x5C240400,  //  0044  MOVE	R9	R2
       0x5C280800,  //  0045  MOVE	R10	R4
       0x7C180800,  //  0046  CALL	R6	4
-      0x8C180B17,  //  0047  GETMET	R6	R5	K23
-      0x5820001A,  //  0048  LDCONST	R8	K26
+      0x8C180B29,  //  0047  GETMET	R6	R5	K41
+      0x582000A8,  //  0048  LDCONST	R8	K168
       0x5425FFFB,  //  0049  LDINT	R9	-4
       0x7C180600,  //  004A  CALL	R6	3
-      0x8C180B17,  //  004B  GETMET	R6	R5	K23
+      0x8C180B29,  //  004B  GETMET	R6	R5	K41
       0x54220017,  //  004C  LDINT	R8	24
-      0x58240018,  //  004D  LDCONST	R9	K24
+      0x5824002A,  //  004D  LDCONST	R9	K42
       0x7C180600,  //  004E  CALL	R6	3
       0x70020028,  //  004F  JMP		#0079
-      0x88180500,  //  0050  GETMBR	R6	R2	K0
+      0x8818050F,  //  0050  GETMBR	R6	R2	K15
       0x4C1C0000,  //  0051  LDNIL	R7
       0x20180C07,  //  0052  NE	R6	R6	R7
       0x781A0019,  //  0053  JMPF	R6	#006E
@@ -2461,157 +2241,157 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
       0x541E002F,  //  0055  LDINT	R7	48
       0x7C180200,  //  0056  CALL	R6	1
       0x5C140C00,  //  0057  MOVE	R5	R6
-      0x8C180B17,  //  0058  GETMET	R6	R5	K23
+      0x8C180B29,  //  0058  GETMET	R6	R5	K41
       0x54220014,  //  0059  LDINT	R8	21
-      0x58240018,  //  005A  LDCONST	R9	K24
+      0x5824002A,  //  005A  LDCONST	R9	K42
       0x7C180600,  //  005B  CALL	R6	3
-      0x8C180B17,  //  005C  GETMET	R6	R5	K23
+      0x8C180B29,  //  005C  GETMET	R6	R5	K41
       0x54223600,  //  005D  LDINT	R8	13825
       0x5425FFFD,  //  005E  LDINT	R9	-2
       0x7C180600,  //  005F  CALL	R6	3
-      0x8C18011B,  //  0060  GETMET	R6	R0	K27
+      0x8C1801A9,  //  0060  GETMET	R6	R0	K169
       0x5C200A00,  //  0061  MOVE	R8	R5
       0x5C240400,  //  0062  MOVE	R9	R2
-      0x88280500,  //  0063  GETMBR	R10	R2	K0
+      0x8828050F,  //  0063  GETMBR	R10	R2	K15
       0x7C180800,  //  0064  CALL	R6	4
-      0x8C180B17,  //  0065  GETMET	R6	R5	K23
-      0x5820001A,  //  0066  LDCONST	R8	K26
+      0x8C180B29,  //  0065  GETMET	R6	R5	K41
+      0x582000A8,  //  0066  LDCONST	R8	K168
       0x5425FFFB,  //  0067  LDINT	R9	-4
       0x7C180600,  //  0068  CALL	R6	3
-      0x8C180B17,  //  0069  GETMET	R6	R5	K23
+      0x8C180B29,  //  0069  GETMET	R6	R5	K41
       0x54220017,  //  006A  LDINT	R8	24
-      0x58240018,  //  006B  LDCONST	R9	K24
+      0x5824002A,  //  006B  LDCONST	R9	K42
       0x7C180600,  //  006C  CALL	R6	3
       0x7002000A,  //  006D  JMP		#0079
-      0xB81A1E00,  //  006E  GETNGBL	R6	K15
+      0xB81A2E00,  //  006E  GETNGBL	R6	K23
       0x601C0018,  //  006F  GETGBL	R7	G24
-      0x5820001C,  //  0070  LDCONST	R8	K28
-      0x88240308,  //  0071  GETMBR	R9	R1	K8
-      0x8824131D,  //  0072  GETMBR	R9	R9	K29
+      0x582000AA,  //  0070  LDCONST	R8	K170
+      0x88240323,  //  0071  GETMBR	R9	R1	K35
+      0x88241336,  //  0072  GETMBR	R9	R9	K54
       0x5C280400,  //  0073  MOVE	R10	R2
       0x7C1C0600,  //  0074  CALL	R7	3
-      0x58200011,  //  0075  LDCONST	R8	K17
+      0x58200015,  //  0075  LDCONST	R8	K21
       0x7C180400,  //  0076  CALL	R6	2
       0x50180000,  //  0077  LDBOOL	R6	0	0
       0x80040C00,  //  0078  RET	1	R6
-      0x8C18031E,  //  0079  GETMET	R6	R1	K30
+      0x8C180393,  //  0079  GETMET	R6	R1	K147
       0x54220004,  //  007A  LDINT	R8	5
       0x50240200,  //  007B  LDBOOL	R9	1	0
       0x7C180600,  //  007C  CALL	R6	3
-      0x881C0104,  //  007D  GETMBR	R7	R0	K4
-      0x881C0F1F,  //  007E  GETMBR	R7	R7	K31
-      0x88200314,  //  007F  GETMBR	R8	R1	K20
-      0x8C241120,  //  0080  GETMET	R9	R8	K32
+      0x881C0109,  //  007D  GETMBR	R7	R0	K9
+      0x881C0F94,  //  007E  GETMBR	R7	R7	K148
+      0x88200395,  //  007F  GETMBR	R8	R1	K149
+      0x8C241196,  //  0080  GETMET	R9	R8	K150
       0x7C240200,  //  0081  CALL	R9	1
-      0x8C240D21,  //  0082  GETMET	R9	R6	K33
+      0x8C240D97,  //  0082  GETMET	R9	R6	K151
       0x5C2C0A00,  //  0083  MOVE	R11	R5
       0x5C301000,  //  0084  MOVE	R12	R8
       0x7C240600,  //  0085  CALL	R9	3
-      0x8C240D22,  //  0086  GETMET	R9	R6	K34
+      0x8C240D98,  //  0086  GETMET	R9	R6	K152
       0x7C240200,  //  0087  CALL	R9	1
-      0xB8264600,  //  0088  GETNGBL	R9	K35
-      0x8C241324,  //  0089  GETMET	R9	R9	K36
+      0xB8262600,  //  0088  GETNGBL	R9	K19
+      0x8C241314,  //  0089  GETMET	R9	R9	K20
       0x542E0003,  //  008A  LDINT	R11	4
       0x7C240400,  //  008B  CALL	R9	2
       0x7826000A,  //  008C  JMPF	R9	#0098
-      0xB8261E00,  //  008D  GETNGBL	R9	K15
+      0xB8262E00,  //  008D  GETNGBL	R9	K23
       0x60280018,  //  008E  GETGBL	R10	G24
-      0x582C0025,  //  008F  LDCONST	R11	K37
-      0x88300D08,  //  0090  GETMBR	R12	R6	K8
-      0x8830191D,  //  0091  GETMBR	R12	R12	K29
-      0x88340D26,  //  0092  GETMBR	R13	R6	K38
-      0x88380D27,  //  0093  GETMBR	R14	R6	K39
-      0x883C0D28,  //  0094  GETMBR	R15	R6	K40
+      0x582C00AB,  //  008F  LDCONST	R11	K171
+      0x88300D23,  //  0090  GETMBR	R12	R6	K35
+      0x88301936,  //  0091  GETMBR	R12	R12	K54
+      0x88340DAC,  //  0092  GETMBR	R13	R6	K172
+      0x88380D58,  //  0093  GETMBR	R14	R6	K88
+      0x883C0DAD,  //  0094  GETMBR	R15	R6	K173
       0x7C280A00,  //  0095  CALL	R10	5
       0x542E0003,  //  0096  LDINT	R11	4
       0x7C240400,  //  0097  CALL	R9	2
-      0x8C240F29,  //  0098  GETMET	R9	R7	K41
+      0x8C240F99,  //  0098  GETMET	R9	R7	K153
       0x5C2C0C00,  //  0099  MOVE	R11	R6
       0x7C240400,  //  009A  CALL	R9	2
       0x4C240000,  //  009B  LDNIL	R9
-      0xB82A4600,  //  009C  GETNGBL	R10	K35
-      0x8C281524,  //  009D  GETMET	R10	R10	K36
-      0x58300011,  //  009E  LDCONST	R12	K17
+      0xB82A2600,  //  009C  GETNGBL	R10	K19
+      0x8C281514,  //  009D  GETMET	R10	R10	K20
+      0x58300015,  //  009E  LDCONST	R12	K21
       0x7C280400,  //  009F  CALL	R10	2
       0x782A000B,  //  00A0  JMPF	R10	#00AD
-      0xB82A0200,  //  00A1  GETNGBL	R10	K1
-      0x8C28152A,  //  00A2  GETMET	R10	R10	K42
-      0x8830052B,  //  00A3  GETMBR	R12	R2	K43
-      0x8834052C,  //  00A4  GETMBR	R13	R2	K44
+      0xB82A0000,  //  00A1  GETNGBL	R10	K0
+      0x8C281516,  //  00A2  GETMET	R10	R10	K22
+      0x8830050D,  //  00A3  GETMBR	R12	R2	K13
+      0x8834050E,  //  00A4  GETMBR	R13	R2	K14
       0x7C280600,  //  00A5  CALL	R10	3
       0x5C241400,  //  00A6  MOVE	R9	R10
       0x78260002,  //  00A7  JMPF	R9	#00AB
-      0x002A5A09,  //  00A8  ADD	R10	K45	R9
-      0x0028152E,  //  00A9  ADD	R10	R10	K46
+      0x002A3209,  //  00A8  ADD	R10	K25	R9
+      0x0028151A,  //  00A9  ADD	R10	R10	K26
       0x70020000,  //  00AA  JMP		#00AC
-      0x5828002F,  //  00AB  LDCONST	R10	K47
+      0x5828001B,  //  00AB  LDCONST	R10	K27
       0x5C241400,  //  00AC  MOVE	R9	R10
       0x4C280000,  //  00AD  LDNIL	R10
       0x2028080A,  //  00AE  NE	R10	R4	R10
       0x782A0012,  //  00AF  JMPF	R10	#00C3
-      0xB82A4600,  //  00B0  GETNGBL	R10	K35
-      0x8C281524,  //  00B1  GETMET	R10	R10	K36
-      0x58300011,  //  00B2  LDCONST	R12	K17
+      0xB82A2600,  //  00B0  GETNGBL	R10	K19
+      0x8C281514,  //  00B1  GETMET	R10	R10	K20
+      0x58300015,  //  00B2  LDCONST	R12	K21
       0x7C280400,  //  00B3  CALL	R10	2
       0x782A000C,  //  00B4  JMPF	R10	#00C2
-      0x8C280930,  //  00B5  GETMET	R10	R4	K48
+      0x8C2809AE,  //  00B5  GETMET	R10	R4	K174
       0x7C280200,  //  00B6  CALL	R10	1
-      0xB82E1E00,  //  00B7  GETNGBL	R11	K15
+      0xB82E2E00,  //  00B7  GETNGBL	R11	K23
       0x60300018,  //  00B8  GETGBL	R12	G24
-      0x58340031,  //  00B9  LDCONST	R13	K49
-      0x88380308,  //  00BA  GETMBR	R14	R1	K8
-      0x88381D1D,  //  00BB  GETMBR	R14	R14	K29
+      0x583400AF,  //  00B9  LDCONST	R13	K175
+      0x88380323,  //  00BA  GETMBR	R14	R1	K35
+      0x88381D36,  //  00BB  GETMBR	R14	R14	K54
       0x5C3C0400,  //  00BC  MOVE	R15	R2
       0x5C401200,  //  00BD  MOVE	R16	R9
       0x5C441400,  //  00BE  MOVE	R17	R10
       0x7C300A00,  //  00BF  CALL	R12	5
-      0x58340011,  //  00C0  LDCONST	R13	K17
+      0x58340015,  //  00C0  LDCONST	R13	K21
       0x7C2C0400,  //  00C1  CALL	R11	2
       0x7002002C,  //  00C2  JMP		#00F0
-      0x88280500,  //  00C3  GETMBR	R10	R2	K0
+      0x8828050F,  //  00C3  GETMBR	R10	R2	K15
       0x4C2C0000,  //  00C4  LDNIL	R11
       0x2028140B,  //  00C5  NE	R10	R10	R11
       0x782A0019,  //  00C6  JMPF	R10	#00E1
-      0x88280500,  //  00C7  GETMBR	R10	R2	K0
-      0xB82E0200,  //  00C8  GETNGBL	R11	K1
-      0x882C1706,  //  00C9  GETMBR	R11	R11	K6
+      0x8828050F,  //  00C7  GETMBR	R10	R2	K15
+      0xB82E0000,  //  00C8  GETNGBL	R11	K0
+      0x882C179D,  //  00C9  GETMBR	R11	R11	K157
       0x1C28140B,  //  00CA  EQ	R10	R10	R11
       0x782A0001,  //  00CB  JMPF	R10	#00CE
-      0x58280006,  //  00CC  LDCONST	R10	K6
+      0x5828009D,  //  00CC  LDCONST	R10	K157
       0x70020000,  //  00CD  JMP		#00CF
-      0x5828002F,  //  00CE  LDCONST	R10	K47
-      0xB82E4600,  //  00CF  GETNGBL	R11	K35
-      0x8C2C1724,  //  00D0  GETMET	R11	R11	K36
-      0x58340011,  //  00D1  LDCONST	R13	K17
+      0x5828001B,  //  00CE  LDCONST	R10	K27
+      0xB82E2600,  //  00CF  GETNGBL	R11	K19
+      0x8C2C1714,  //  00D0  GETMET	R11	R11	K20
+      0x58340015,  //  00D1  LDCONST	R13	K21
       0x7C2C0400,  //  00D2  CALL	R11	2
       0x782E000B,  //  00D3  JMPF	R11	#00E0
-      0xB82E1E00,  //  00D4  GETNGBL	R11	K15
+      0xB82E2E00,  //  00D4  GETNGBL	R11	K23
       0x60300018,  //  00D5  GETGBL	R12	G24
-      0x58340032,  //  00D6  LDCONST	R13	K50
-      0x88380308,  //  00D7  GETMBR	R14	R1	K8
-      0x88381D1D,  //  00D8  GETMBR	R14	R14	K29
+      0x583400B0,  //  00D6  LDCONST	R13	K176
+      0x88380323,  //  00D7  GETMBR	R14	R1	K35
+      0x88381D36,  //  00D8  GETMBR	R14	R14	K54
       0x5C3C0400,  //  00D9  MOVE	R15	R2
       0x5C401200,  //  00DA  MOVE	R16	R9
-      0x88440500,  //  00DB  GETMBR	R17	R2	K0
+      0x8844050F,  //  00DB  GETMBR	R17	R2	K15
       0x5C481400,  //  00DC  MOVE	R18	R10
       0x7C300C00,  //  00DD  CALL	R12	6
-      0x58340011,  //  00DE  LDCONST	R13	K17
+      0x58340015,  //  00DE  LDCONST	R13	K21
       0x7C2C0400,  //  00DF  CALL	R11	2
       0x7002000E,  //  00E0  JMP		#00F0
-      0xB82A4600,  //  00E1  GETNGBL	R10	K35
-      0x8C281524,  //  00E2  GETMET	R10	R10	K36
-      0x58300011,  //  00E3  LDCONST	R12	K17
+      0xB82A2600,  //  00E1  GETNGBL	R10	K19
+      0x8C281514,  //  00E2  GETMET	R10	R10	K20
+      0x58300015,  //  00E3  LDCONST	R12	K21
       0x7C280400,  //  00E4  CALL	R10	2
       0x782A0009,  //  00E5  JMPF	R10	#00F0
-      0xB82A1E00,  //  00E6  GETNGBL	R10	K15
+      0xB82A2E00,  //  00E6  GETNGBL	R10	K23
       0x602C0018,  //  00E7  GETGBL	R11	G24
-      0x58300033,  //  00E8  LDCONST	R12	K51
-      0x88340308,  //  00E9  GETMBR	R13	R1	K8
-      0x88341B1D,  //  00EA  GETMBR	R13	R13	K29
+      0x583000B1,  //  00E8  LDCONST	R12	K177
+      0x88340323,  //  00E9  GETMBR	R13	R1	K35
+      0x88341B36,  //  00EA  GETMBR	R13	R13	K54
       0x5C380400,  //  00EB  MOVE	R14	R2
       0x5C3C1200,  //  00EC  MOVE	R15	R9
       0x7C2C0800,  //  00ED  CALL	R11	4
-      0x58300011,  //  00EE  LDCONST	R12	K17
+      0x58300015,  //  00EE  LDCONST	R12	K21
       0x7C280400,  //  00EF  CALL	R10	2
       0x50280200,  //  00F0  LDBOOL	R10	1	0
       0x80041400,  //  00F1  RET	1	R10
@@ -2628,29 +2408,17 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_IM),
-    /* K1   */  be_nested_str_weak(int64),
-    /* K2   */  be_nested_str_weak(toint64),
-    /* K3   */  be_nested_str_weak(node),
-    /* K4   */  be_nested_str_weak(tobytes),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20node_id_X20filter_X20_X25s_X20doesn_X27t_X20match_X20_X25s),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_nested_str_weak(event_min),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(parse_event_filters_min_no),
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x580800B2,  //  0000  LDCONST	R2	K178
       0x4C0C0000,  //  0001  LDNIL	R3
       0x4C100000,  //  0002  LDNIL	R4
       0x20100004,  //  0003  NE	R4	R0	R4
@@ -2661,33 +2429,33 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
       0xA8020024,  //  0008  EXBLK	0	#002E
       0x5C140800,  //  0009  MOVE	R5	R4
       0x7C140000,  //  000A  CALL	R5	0
-      0xB81A0200,  //  000B  GETNGBL	R6	K1
-      0x8C180D02,  //  000C  GETMET	R6	R6	K2
-      0x88200B03,  //  000D  GETMBR	R8	R5	K3
+      0xB81B6600,  //  000B  GETNGBL	R6	K179
+      0x8C180DB4,  //  000C  GETMET	R6	R6	K180
+      0x88200BB5,  //  000D  GETMBR	R8	R5	K181
       0x7C180400,  //  000E  CALL	R6	2
       0x781A0012,  //  000F  JMPF	R6	#0023
       0x78060011,  //  0010  JMPF	R1	#0023
-      0x881C0B03,  //  0011  GETMBR	R7	R5	K3
-      0x8C1C0F04,  //  0012  GETMET	R7	R7	K4
+      0x881C0BB5,  //  0011  GETMBR	R7	R5	K181
+      0x8C1C0FB6,  //  0012  GETMET	R7	R7	K182
       0x7C1C0200,  //  0013  CALL	R7	1
       0x201C0E01,  //  0014  NE	R7	R7	R1
       0x781E000C,  //  0015  JMPF	R7	#0023
-      0xB81E0A00,  //  0016  GETNGBL	R7	K5
-      0x8C1C0F06,  //  0017  GETMET	R7	R7	K6
+      0xB81E2600,  //  0016  GETNGBL	R7	K19
+      0x8C1C0F17,  //  0017  GETMET	R7	R7	K23
       0x60240018,  //  0018  GETGBL	R9	G24
-      0x58280007,  //  0019  LDCONST	R10	K7
-      0x8C2C0D04,  //  001A  GETMET	R11	R6	K4
+      0x582800B7,  //  0019  LDCONST	R10	K183
+      0x8C2C0DB6,  //  001A  GETMET	R11	R6	K182
       0x7C2C0200,  //  001B  CALL	R11	1
-      0x8C2C1708,  //  001C  GETMET	R11	R11	K8
+      0x8C2C17B8,  //  001C  GETMET	R11	R11	K184
       0x7C2C0200,  //  001D  CALL	R11	1
-      0x8C300308,  //  001E  GETMET	R12	R1	K8
+      0x8C3003B8,  //  001E  GETMET	R12	R1	K184
       0x7C300200,  //  001F  CALL	R12	1
       0x7C240600,  //  0020  CALL	R9	3
       0x7C1C0400,  //  0021  CALL	R7	2
       0x7001FFE5,  //  0022  JMP		#0009
-      0xB81E0200,  //  0023  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0024  GETMET	R7	R7	K2
-      0x88240B09,  //  0025  GETMBR	R9	R5	K9
+      0xB81F6600,  //  0023  GETNGBL	R7	K179
+      0x8C1C0FB4,  //  0024  GETMET	R7	R7	K180
+      0x88240BB9,  //  0025  GETMBR	R9	R5	K185
       0x7C1C0400,  //  0026  CALL	R7	2
       0x4C200000,  //  0027  LDNIL	R8
       0x1C200608,  //  0028  EQ	R8	R3	R8
@@ -2696,7 +2464,7 @@ be_local_closure(class_Matter_IM_parse_event_filters_min_no,   /* name */
       0x78220000,  //  002B  JMPF	R8	#002D
       0x5C0C0E00,  //  002C  MOVE	R3	R7
       0x7001FFDA,  //  002D  JMP		#0009
-      0x5810000A,  //  002E  LDCONST	R4	K10
+      0x58100025,  //  002E  LDCONST	R4	K37
       0xAC100200,  //  002F  CATCH	R4	1	0
       0xB0080000,  //  0030  RAISE	2	R0	R0
       0x80040600,  //  0031  RET	1	R3
@@ -2713,172 +2481,160 @@ be_local_closure(class_Matter_IM_invokeresponse2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(command),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(SUCCESS),
-    /* K9   */  be_nested_str_weak(tag_sub),
-    /* K10  */  be_nested_str_weak(tlv2raw),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(invokeresponse2raw),
     &be_const_str_solidified,
     ( &(const binstruction[148]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
+      0x8C100329,  //  0000  GETMET	R4	R1	K41
       0x541A0014,  //  0001  LDINT	R6	21
-      0x581C0001,  //  0002  LDCONST	R7	K1
+      0x581C002A,  //  0002  LDCONST	R7	K42
       0x7C100600,  //  0003  CALL	R4	3
       0x4C100000,  //  0004  LDNIL	R4
       0x1C100604,  //  0005  EQ	R4	R3	R4
       0x78120004,  //  0006  JMPF	R4	#000C
-      0x8C100300,  //  0007  GETMET	R4	R1	K0
+      0x8C100329,  //  0007  GETMET	R4	R1	K41
       0x541A3500,  //  0008  LDINT	R6	13569
       0x541DFFFD,  //  0009  LDINT	R7	-2
       0x7C100600,  //  000A  CALL	R4	3
       0x70020003,  //  000B  JMP		#0010
-      0x8C100300,  //  000C  GETMET	R4	R1	K0
+      0x8C100329,  //  000C  GETMET	R4	R1	K41
       0x541A34FF,  //  000D  LDINT	R6	13568
       0x541DFFFD,  //  000E  LDINT	R7	-2
       0x7C100600,  //  000F  CALL	R4	3
-      0x8C100300,  //  0010  GETMET	R4	R1	K0
+      0x8C100329,  //  0010  GETMET	R4	R1	K41
       0x541A36FF,  //  0011  LDINT	R6	14080
       0x541DFFFD,  //  0012  LDINT	R7	-2
       0x7C100600,  //  0013  CALL	R4	3
-      0x88100502,  //  0014  GETMBR	R4	R2	K2
+      0x88100512,  //  0014  GETMBR	R4	R2	K18
       0x541600FE,  //  0015  LDINT	R5	255
       0x18100805,  //  0016  LE	R4	R4	R5
       0x78120008,  //  0017  JMPF	R4	#0021
-      0x8C100300,  //  0018  GETMET	R4	R1	K0
+      0x8C100329,  //  0018  GETMET	R4	R1	K41
       0x541A23FF,  //  0019  LDINT	R6	9216
       0x541DFFFD,  //  001A  LDINT	R7	-2
       0x7C100600,  //  001B  CALL	R4	3
-      0x8C100300,  //  001C  GETMET	R4	R1	K0
-      0x88180502,  //  001D  GETMBR	R6	R2	K2
-      0x581C0001,  //  001E  LDCONST	R7	K1
+      0x8C100329,  //  001C  GETMET	R4	R1	K41
+      0x88180512,  //  001D  GETMBR	R6	R2	K18
+      0x581C002A,  //  001E  LDCONST	R7	K42
       0x7C100600,  //  001F  CALL	R4	3
       0x70020007,  //  0020  JMP		#0029
-      0x8C100300,  //  0021  GETMET	R4	R1	K0
+      0x8C100329,  //  0021  GETMET	R4	R1	K41
       0x541A24FF,  //  0022  LDINT	R6	9472
       0x541DFFFD,  //  0023  LDINT	R7	-2
       0x7C100600,  //  0024  CALL	R4	3
-      0x8C100300,  //  0025  GETMET	R4	R1	K0
-      0x88180502,  //  0026  GETMBR	R6	R2	K2
-      0x581C0003,  //  0027  LDCONST	R7	K3
+      0x8C100329,  //  0025  GETMET	R4	R1	K41
+      0x88180512,  //  0026  GETMBR	R6	R2	K18
+      0x581C002B,  //  0027  LDCONST	R7	K43
       0x7C100600,  //  0028  CALL	R4	3
-      0x88100504,  //  0029  GETMBR	R4	R2	K4
+      0x8810050D,  //  0029  GETMBR	R4	R2	K13
       0x541600FE,  //  002A  LDINT	R5	255
       0x18100805,  //  002B  LE	R4	R4	R5
       0x78120008,  //  002C  JMPF	R4	#0036
-      0x8C100300,  //  002D  GETMET	R4	R1	K0
+      0x8C100329,  //  002D  GETMET	R4	R1	K41
       0x541A2400,  //  002E  LDINT	R6	9217
       0x541DFFFD,  //  002F  LDINT	R7	-2
       0x7C100600,  //  0030  CALL	R4	3
-      0x8C100300,  //  0031  GETMET	R4	R1	K0
-      0x88180504,  //  0032  GETMBR	R6	R2	K4
-      0x581C0001,  //  0033  LDCONST	R7	K1
+      0x8C100329,  //  0031  GETMET	R4	R1	K41
+      0x8818050D,  //  0032  GETMBR	R6	R2	K13
+      0x581C002A,  //  0033  LDCONST	R7	K42
       0x7C100600,  //  0034  CALL	R4	3
       0x70020014,  //  0035  JMP		#004B
-      0x88100504,  //  0036  GETMBR	R4	R2	K4
+      0x8810050D,  //  0036  GETMBR	R4	R2	K13
       0x5416FFFE,  //  0037  LDINT	R5	65535
       0x18100805,  //  0038  LE	R4	R4	R5
       0x78120008,  //  0039  JMPF	R4	#0043
-      0x8C100300,  //  003A  GETMET	R4	R1	K0
+      0x8C100329,  //  003A  GETMET	R4	R1	K41
       0x541A2500,  //  003B  LDINT	R6	9473
       0x541DFFFD,  //  003C  LDINT	R7	-2
       0x7C100600,  //  003D  CALL	R4	3
-      0x8C100300,  //  003E  GETMET	R4	R1	K0
-      0x88180504,  //  003F  GETMBR	R6	R2	K4
-      0x581C0003,  //  0040  LDCONST	R7	K3
+      0x8C100329,  //  003E  GETMET	R4	R1	K41
+      0x8818050D,  //  003F  GETMBR	R6	R2	K13
+      0x581C002B,  //  0040  LDCONST	R7	K43
       0x7C100600,  //  0041  CALL	R4	3
       0x70020007,  //  0042  JMP		#004B
-      0x8C100300,  //  0043  GETMET	R4	R1	K0
+      0x8C100329,  //  0043  GETMET	R4	R1	K41
       0x541A2600,  //  0044  LDINT	R6	9729
       0x541DFFFD,  //  0045  LDINT	R7	-2
       0x7C100600,  //  0046  CALL	R4	3
-      0x8C100300,  //  0047  GETMET	R4	R1	K0
-      0x88180504,  //  0048  GETMBR	R6	R2	K4
+      0x8C100329,  //  0047  GETMET	R4	R1	K41
+      0x8818050D,  //  0048  GETMBR	R6	R2	K13
       0x541E0003,  //  0049  LDINT	R7	4
       0x7C100600,  //  004A  CALL	R4	3
-      0x88100505,  //  004B  GETMBR	R4	R2	K5
+      0x8810054E,  //  004B  GETMBR	R4	R2	K78
       0x541600FE,  //  004C  LDINT	R5	255
       0x18100805,  //  004D  LE	R4	R4	R5
       0x78120008,  //  004E  JMPF	R4	#0058
-      0x8C100300,  //  004F  GETMET	R4	R1	K0
+      0x8C100329,  //  004F  GETMET	R4	R1	K41
       0x541A2401,  //  0050  LDINT	R6	9218
       0x541DFFFD,  //  0051  LDINT	R7	-2
       0x7C100600,  //  0052  CALL	R4	3
-      0x8C100300,  //  0053  GETMET	R4	R1	K0
-      0x88180505,  //  0054  GETMBR	R6	R2	K5
-      0x581C0001,  //  0055  LDCONST	R7	K1
+      0x8C100329,  //  0053  GETMET	R4	R1	K41
+      0x8818054E,  //  0054  GETMBR	R6	R2	K78
+      0x581C002A,  //  0055  LDCONST	R7	K42
       0x7C100600,  //  0056  CALL	R4	3
       0x70020014,  //  0057  JMP		#006D
-      0x88100505,  //  0058  GETMBR	R4	R2	K5
+      0x8810054E,  //  0058  GETMBR	R4	R2	K78
       0x5416FFFE,  //  0059  LDINT	R5	65535
       0x18100805,  //  005A  LE	R4	R4	R5
       0x78120008,  //  005B  JMPF	R4	#0065
-      0x8C100300,  //  005C  GETMET	R4	R1	K0
+      0x8C100329,  //  005C  GETMET	R4	R1	K41
       0x541A2501,  //  005D  LDINT	R6	9474
       0x541DFFFD,  //  005E  LDINT	R7	-2
       0x7C100600,  //  005F  CALL	R4	3
-      0x8C100300,  //  0060  GETMET	R4	R1	K0
-      0x88180505,  //  0061  GETMBR	R6	R2	K5
-      0x581C0003,  //  0062  LDCONST	R7	K3
+      0x8C100329,  //  0060  GETMET	R4	R1	K41
+      0x8818054E,  //  0061  GETMBR	R6	R2	K78
+      0x581C002B,  //  0062  LDCONST	R7	K43
       0x7C100600,  //  0063  CALL	R4	3
       0x70020007,  //  0064  JMP		#006D
-      0x8C100300,  //  0065  GETMET	R4	R1	K0
+      0x8C100329,  //  0065  GETMET	R4	R1	K41
       0x541A2601,  //  0066  LDINT	R6	9730
       0x541DFFFD,  //  0067  LDINT	R7	-2
       0x7C100600,  //  0068  CALL	R4	3
-      0x8C100300,  //  0069  GETMET	R4	R1	K0
-      0x88180505,  //  006A  GETMBR	R6	R2	K5
+      0x8C100329,  //  0069  GETMET	R4	R1	K41
+      0x8818054E,  //  006A  GETMBR	R6	R2	K78
       0x541E0003,  //  006B  LDINT	R7	4
       0x7C100600,  //  006C  CALL	R4	3
-      0x8C100300,  //  006D  GETMET	R4	R1	K0
+      0x8C100329,  //  006D  GETMET	R4	R1	K41
       0x541A0017,  //  006E  LDINT	R6	24
-      0x581C0001,  //  006F  LDCONST	R7	K1
+      0x581C002A,  //  006F  LDCONST	R7	K42
       0x7C100600,  //  0070  CALL	R4	3
       0x4C100000,  //  0071  LDNIL	R4
       0x1C100604,  //  0072  EQ	R4	R3	R4
       0x78120016,  //  0073  JMPF	R4	#008B
-      0x88100506,  //  0074  GETMBR	R4	R2	K6
+      0x8810050F,  //  0074  GETMBR	R4	R2	K15
       0x4C140000,  //  0075  LDNIL	R5
       0x1C140805,  //  0076  EQ	R5	R4	R5
       0x78160001,  //  0077  JMPF	R5	#007A
-      0xB8160E00,  //  0078  GETNGBL	R5	K7
-      0x88100B08,  //  0079  GETMBR	R4	R5	K8
-      0x8C140300,  //  007A  GETMET	R5	R1	K0
+      0xB8160000,  //  0078  GETNGBL	R5	K0
+      0x88100B24,  //  0079  GETMBR	R4	R5	K36
+      0x8C140329,  //  007A  GETMET	R5	R1	K41
       0x541E3500,  //  007B  LDINT	R7	13569
       0x5421FFFD,  //  007C  LDINT	R8	-2
       0x7C140600,  //  007D  CALL	R5	3
-      0x8C140300,  //  007E  GETMET	R5	R1	K0
+      0x8C140329,  //  007E  GETMET	R5	R1	K41
       0x541E23FF,  //  007F  LDINT	R7	9216
       0x5421FFFD,  //  0080  LDINT	R8	-2
       0x7C140600,  //  0081  CALL	R5	3
-      0x8C140300,  //  0082  GETMET	R5	R1	K0
-      0x881C0506,  //  0083  GETMBR	R7	R2	K6
-      0x58200001,  //  0084  LDCONST	R8	K1
+      0x8C140329,  //  0082  GETMET	R5	R1	K41
+      0x881C050F,  //  0083  GETMBR	R7	R2	K15
+      0x5820002A,  //  0084  LDCONST	R8	K42
       0x7C140600,  //  0085  CALL	R5	3
-      0x8C140300,  //  0086  GETMET	R5	R1	K0
+      0x8C140329,  //  0086  GETMET	R5	R1	K41
       0x541E0017,  //  0087  LDINT	R7	24
-      0x58200001,  //  0088  LDCONST	R8	K1
+      0x5820002A,  //  0088  LDCONST	R8	K42
       0x7C140600,  //  0089  CALL	R5	3
       0x70020003,  //  008A  JMP		#008F
-      0x900E1301,  //  008B  SETMBR	R3	K9	K1
-      0x8C10070A,  //  008C  GETMET	R4	R3	K10
+      0x900E5D2A,  //  008B  SETMBR	R3	K46	K42
+      0x8C10072F,  //  008C  GETMET	R4	R3	K47
       0x5C180200,  //  008D  MOVE	R6	R1
       0x7C100400,  //  008E  CALL	R4	2
-      0x8C100300,  //  008F  GETMET	R4	R1	K0
+      0x8C100329,  //  008F  GETMET	R4	R1	K41
       0x541A1817,  //  0090  LDINT	R6	6168
       0x541DFFFD,  //  0091  LDINT	R7	-2
       0x7C100600,  //  0092  CALL	R4	3
@@ -2896,72 +2652,56 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(findsubval),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K3   */  be_nested_str_weak(exchange_id),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(SUCCESS),
-    /* K6   */  be_nested_str_weak(status_ok_received),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(local_session_id),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(status_error_received),
-    /* K14  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_status_response),
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
-      0x8C0C0500,  //  0000  GETMET	R3	R2	K0
-      0x58140001,  //  0001  LDCONST	R5	K1
+      0x8C0C05BA,  //  0000  GETMET	R3	R2	K186
+      0x5814005C,  //  0001  LDCONST	R5	K92
       0x541A00FE,  //  0002  LDINT	R6	255
       0x7C0C0600,  //  0003  CALL	R3	3
-      0x8C100102,  //  0004  GETMET	R4	R0	K2
-      0x88180303,  //  0005  GETMBR	R6	R1	K3
+      0x8C100180,  //  0004  GETMET	R4	R0	K128
+      0x88180358,  //  0005  GETMBR	R6	R1	K88
       0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x88140B05,  //  0008  GETMBR	R5	R5	K5
+      0xB8160000,  //  0007  GETNGBL	R5	K0
+      0x88140B24,  //  0008  GETMBR	R5	R5	K36
       0x1C140605,  //  0009  EQ	R5	R3	R5
       0x7816000F,  //  000A  JMPF	R5	#001B
       0x78120004,  //  000B  JMPF	R4	#0011
-      0x8C140906,  //  000C  GETMET	R5	R4	K6
+      0x8C1409BB,  //  000C  GETMET	R5	R4	K187
       0x5C1C0200,  //  000D  MOVE	R7	R1
       0x7C140400,  //  000E  CALL	R5	2
       0x80040A00,  //  000F  RET	1	R5
       0x70020008,  //  0010  JMP		#001A
-      0xB8160E00,  //  0011  GETNGBL	R5	K7
+      0xB8162E00,  //  0011  GETNGBL	R5	K23
       0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x88200309,  //  0014  GETMBR	R8	R1	K9
-      0x8820110A,  //  0015  GETMBR	R8	R8	K10
-      0x88240303,  //  0016  GETMBR	R9	R1	K3
+      0x581C00BC,  //  0013  LDCONST	R7	K188
+      0x88200323,  //  0014  GETMBR	R8	R1	K35
+      0x88201136,  //  0015  GETMBR	R8	R8	K54
+      0x88240358,  //  0016  GETMBR	R9	R1	K88
       0x7C180600,  //  0017  CALL	R6	3
       0x541E0003,  //  0018  LDINT	R7	4
       0x7C140400,  //  0019  CALL	R5	2
       0x7002000D,  //  001A  JMP		#0029
-      0xB8160E00,  //  001B  GETNGBL	R5	K7
+      0xB8162E00,  //  001B  GETNGBL	R5	K23
       0x60180018,  //  001C  GETGBL	R6	G24
-      0x581C000B,  //  001D  LDCONST	R7	K11
+      0x581C00BD,  //  001D  LDCONST	R7	K189
       0x5C200600,  //  001E  MOVE	R8	R3
       0x7C180400,  //  001F  CALL	R6	2
-      0x581C000C,  //  0020  LDCONST	R7	K12
+      0x581C0015,  //  0020  LDCONST	R7	K21
       0x7C140400,  //  0021  CALL	R5	2
       0x78120005,  //  0022  JMPF	R4	#0029
-      0x8C14090D,  //  0023  GETMET	R5	R4	K13
+      0x8C1409BE,  //  0023  GETMET	R5	R4	K190
       0x5C1C0200,  //  0024  MOVE	R7	R1
       0x7C140400,  //  0025  CALL	R5	2
-      0x8C14010E,  //  0026  GETMET	R5	R0	K14
-      0x881C0303,  //  0027  GETMBR	R7	R1	K3
+      0x8C14016E,  //  0026  GETMET	R5	R0	K110
+      0x881C0358,  //  0027  GETMBR	R7	R1	K88
       0x7C140400,  //  0028  CALL	R5	2
       0x50140000,  //  0029  LDBOOL	R5	0	0
       0x80040A00,  //  002A  RET	1	R5
@@ -2978,68 +2718,61 @@ be_local_closure(class_Matter_IM_attributestatus2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(path2raw),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(status),
-    /* K5   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(attributestatus2raw),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
+      0x8C100329,  //  0000  GETMET	R4	R1	K41
       0x541A0014,  //  0001  LDINT	R6	21
-      0x581C0001,  //  0002  LDCONST	R7	K1
+      0x581C002A,  //  0002  LDCONST	R7	K42
       0x7C100600,  //  0003  CALL	R4	3
-      0x8C100300,  //  0004  GETMET	R4	R1	K0
+      0x8C100329,  //  0004  GETMET	R4	R1	K41
       0x541A34FF,  //  0005  LDINT	R6	13568
       0x541DFFFD,  //  0006  LDINT	R7	-2
       0x7C100600,  //  0007  CALL	R4	3
-      0x8C100102,  //  0008  GETMET	R4	R0	K2
+      0x8C10012D,  //  0008  GETMET	R4	R0	K45
       0x5C180200,  //  0009  MOVE	R6	R1
       0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x58200003,  //  000B  LDCONST	R8	K3
+      0x58200040,  //  000B  LDCONST	R8	K64
       0x7C100800,  //  000C  CALL	R4	4
-      0x8C100300,  //  000D  GETMET	R4	R1	K0
+      0x8C100329,  //  000D  GETMET	R4	R1	K41
       0x541A3500,  //  000E  LDINT	R6	13569
       0x541DFFFD,  //  000F  LDINT	R7	-2
       0x7C100600,  //  0010  CALL	R4	3
-      0x88100504,  //  0011  GETMBR	R4	R2	K4
+      0x8810050F,  //  0011  GETMBR	R4	R2	K15
       0x541600FE,  //  0012  LDINT	R5	255
       0x18100805,  //  0013  LE	R4	R4	R5
       0x78120008,  //  0014  JMPF	R4	#001E
-      0x8C100300,  //  0015  GETMET	R4	R1	K0
+      0x8C100329,  //  0015  GETMET	R4	R1	K41
       0x541A23FF,  //  0016  LDINT	R6	9216
       0x541DFFFD,  //  0017  LDINT	R7	-2
       0x7C100600,  //  0018  CALL	R4	3
-      0x8C100300,  //  0019  GETMET	R4	R1	K0
-      0x88180504,  //  001A  GETMBR	R6	R2	K4
-      0x581C0001,  //  001B  LDCONST	R7	K1
+      0x8C100329,  //  0019  GETMET	R4	R1	K41
+      0x8818050F,  //  001A  GETMBR	R6	R2	K15
+      0x581C002A,  //  001B  LDCONST	R7	K42
       0x7C100600,  //  001C  CALL	R4	3
       0x70020007,  //  001D  JMP		#0026
-      0x8C100300,  //  001E  GETMET	R4	R1	K0
+      0x8C100329,  //  001E  GETMET	R4	R1	K41
       0x541A24FF,  //  001F  LDINT	R6	9472
       0x541DFFFD,  //  0020  LDINT	R7	-2
       0x7C100600,  //  0021  CALL	R4	3
-      0x8C100300,  //  0022  GETMET	R4	R1	K0
-      0x88180504,  //  0023  GETMBR	R6	R2	K4
-      0x581C0005,  //  0024  LDCONST	R7	K5
+      0x8C100329,  //  0022  GETMET	R4	R1	K41
+      0x8818050F,  //  0023  GETMBR	R6	R2	K15
+      0x581C002B,  //  0024  LDCONST	R7	K43
       0x7C100600,  //  0025  CALL	R4	3
-      0x8C100300,  //  0026  GETMET	R4	R1	K0
+      0x8C100329,  //  0026  GETMET	R4	R1	K41
       0x541A1817,  //  0027  LDINT	R6	6168
       0x541DFFFD,  //  0028  LDINT	R7	-2
       0x7C100600,  //  0029  CALL	R4	3
-      0x8C100300,  //  002A  GETMET	R4	R1	K0
+      0x8C100329,  //  002A  GETMET	R4	R1	K41
       0x541A0017,  //  002B  LDINT	R6	24
-      0x581C0001,  //  002C  LDCONST	R7	K1
+      0x581C002A,  //  002C  LDCONST	R7	K42
       0x7C100600,  //  002D  CALL	R4	3
       0x80000000,  //  002E  RET	0
     })
@@ -3055,69 +2788,37 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
   be_nested_proto(
     21,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(loglevel),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(get_attribute_name),
-    /* K6   */  be_nested_str_weak(cluster),
-    /* K7   */  be_nested_str_weak(attribute),
-    /* K8   */  be_nested_str_weak(_X20_X28),
-    /* K9   */  be_nested_str_weak(_X29),
-    /* K10  */  be_nested_str_weak(),
-    /* K11  */  be_nested_str_weak(status),
-    /* K12  */  be_nested_str_weak(read_attribute),
-    /* K13  */  be_nested_str_weak(tlv_solo),
-    /* K14  */  be_nested_str_weak(to_str_val),
-    /* K15  */  be_nested_str_weak(is_list),
-    /* K16  */  be_nested_str_weak(is_array),
-    /* K17  */  be_nested_str_weak(encode_len),
-    /* K18  */  be_nested_str_weak(IM_ReportData_Pull),
-    /* K19  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K20  */  be_nested_str_weak(Matter_TLV_array),
-    /* K21  */  be_nested_str_weak(attributedata2raw),
-    /* K22  */  be_nested_str_weak(push),
-    /* K23  */  be_nested_str_weak(val),
-    /* K24  */  be_nested_str_weak(stop_iteration),
-    /* K25  */  be_nested_str_weak(log),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-    /* K27  */  be_nested_str_weak(local_session_id),
-    /* K28  */  be_nested_str_weak(attributestatus2raw),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-    /* K30  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(read_single_attribute_to_bytes),
     &be_const_str_solidified,
     ( &(const binstruction[165]) {  /* code */
       0xB8160000,  //  0000  GETNGBL	R5	K0
-      0x88140B01,  //  0001  GETMBR	R5	R5	K1
+      0x88140B83,  //  0001  GETMBR	R5	R5	K131
       0x4C180000,  //  0002  LDNIL	R6
-      0xB81E0400,  //  0003  GETNGBL	R7	K2
-      0x8C1C0F03,  //  0004  GETMET	R7	R7	K3
-      0x58240004,  //  0005  LDCONST	R9	K4
+      0xB81E2600,  //  0003  GETNGBL	R7	K19
+      0x8C1C0F14,  //  0004  GETMET	R7	R7	K20
+      0x58240015,  //  0005  LDCONST	R9	K21
       0x7C1C0400,  //  0006  CALL	R7	2
       0x781E000B,  //  0007  JMPF	R7	#0014
       0xB81E0000,  //  0008  GETNGBL	R7	K0
-      0x8C1C0F05,  //  0009  GETMET	R7	R7	K5
-      0x88240506,  //  000A  GETMBR	R9	R2	K6
-      0x88280507,  //  000B  GETMBR	R10	R2	K7
+      0x8C1C0F16,  //  0009  GETMET	R7	R7	K22
+      0x8824050D,  //  000A  GETMBR	R9	R2	K13
+      0x8828050E,  //  000B  GETMBR	R10	R2	K14
       0x7C1C0600,  //  000C  CALL	R7	3
       0x5C180E00,  //  000D  MOVE	R6	R7
       0x781A0002,  //  000E  JMPF	R6	#0012
-      0x001E1006,  //  000F  ADD	R7	K8	R6
-      0x001C0F09,  //  0010  ADD	R7	R7	K9
+      0x001E3206,  //  000F  ADD	R7	K25	R6
+      0x001C0F1A,  //  0010  ADD	R7	R7	K26
       0x70020000,  //  0011  JMP		#0013
-      0x581C000A,  //  0012  LDCONST	R7	K10
+      0x581C001B,  //  0012  LDCONST	R7	K27
       0x5C180E00,  //  0013  MOVE	R6	R7
-      0x881C050B,  //  0014  GETMBR	R7	R2	K11
+      0x881C050F,  //  0014  GETMBR	R7	R2	K15
       0x4C200000,  //  0015  LDNIL	R8
       0x201C0E08,  //  0016  NE	R7	R7	R8
       0x4C200000,  //  0017  LDNIL	R8
@@ -3125,34 +2826,34 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
       0x4C280000,  //  0019  LDNIL	R10
       0x2028020A,  //  001A  NE	R10	R1	R10
       0x782A0005,  //  001B  JMPF	R10	#0022
-      0x8C28030C,  //  001C  GETMET	R10	R1	K12
+      0x8C28039E,  //  001C  GETMET	R10	R1	K158
       0x5C300600,  //  001D  MOVE	R12	R3
       0x5C340400,  //  001E  MOVE	R13	R2
-      0x8838010D,  //  001F  GETMBR	R14	R0	K13
+      0x8838018D,  //  001F  GETMBR	R14	R0	K141
       0x7C280800,  //  0020  CALL	R10	4
       0x5C201400,  //  0021  MOVE	R8	R10
       0x4C280000,  //  0022  LDNIL	R10
       0x2028100A,  //  0023  NE	R10	R8	R10
       0x782A0057,  //  0024  JMPF	R10	#007D
-      0x5828000A,  //  0025  LDCONST	R10	K10
-      0xB82E0400,  //  0026  GETNGBL	R11	K2
-      0x8C2C1703,  //  0027  GETMET	R11	R11	K3
-      0x58340004,  //  0028  LDCONST	R13	K4
+      0x5828001B,  //  0025  LDCONST	R10	K27
+      0xB82E2600,  //  0026  GETNGBL	R11	K19
+      0x8C2C1714,  //  0027  GETMET	R11	R11	K20
+      0x58340015,  //  0028  LDCONST	R13	K21
       0x7C2C0400,  //  0029  CALL	R11	2
       0x782E0003,  //  002A  JMPF	R11	#002F
       0x78120002,  //  002B  JMPF	R4	#002F
-      0x8C2C110E,  //  002C  GETMET	R11	R8	K14
+      0x8C2C11AE,  //  002C  GETMET	R11	R8	K174
       0x7C2C0200,  //  002D  CALL	R11	1
       0x5C281600,  //  002E  MOVE	R10	R11
-      0x882C110F,  //  002F  GETMBR	R11	R8	K15
+      0x882C119F,  //  002F  GETMBR	R11	R8	K159
       0x742E0001,  //  0030  JMPT	R11	#0033
-      0x882C1110,  //  0031  GETMBR	R11	R8	K16
+      0x882C11A0,  //  0031  GETMBR	R11	R8	K160
       0x782E002F,  //  0032  JMPF	R11	#0063
-      0x8C2C1111,  //  0033  GETMET	R11	R8	K17
+      0x8C2C11A1,  //  0033  GETMET	R11	R8	K161
       0x7C2C0200,  //  0034  CALL	R11	1
       0xB8320000,  //  0035  GETNGBL	R12	K0
-      0x88301912,  //  0036  GETMBR	R12	R12	K18
-      0x88301913,  //  0037  GETMBR	R12	R12	K19
+      0x8830193F,  //  0036  GETMBR	R12	R12	K63
+      0x883019A2,  //  0037  GETMBR	R12	R12	K162
       0x242C160C,  //  0038  GT	R11	R11	R12
       0x782E0028,  //  0039  JMPF	R11	#0063
       0x602C0012,  //  003A  GETGBL	R11	G18
@@ -3161,19 +2862,19 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
       0x602C0015,  //  003D  GETGBL	R11	G21
       0x5432002F,  //  003E  LDINT	R12	48
       0x7C2C0200,  //  003F  CALL	R11	1
-      0x8C300B14,  //  0040  GETMET	R12	R5	K20
+      0x8C300BBF,  //  0040  GETMET	R12	R5	K191
       0x7C300200,  //  0041  CALL	R12	1
-      0x8C340115,  //  0042  GETMET	R13	R0	K21
+      0x8C3401A7,  //  0042  GETMET	R13	R0	K167
       0x5C3C1600,  //  0043  MOVE	R15	R11
       0x5C400400,  //  0044  MOVE	R16	R2
       0x5C441800,  //  0045  MOVE	R17	R12
       0x50480000,  //  0046  LDBOOL	R18	0	0
       0x7C340A00,  //  0047  CALL	R13	5
-      0x8C341316,  //  0048  GETMET	R13	R9	K22
+      0x8C341327,  //  0048  GETMET	R13	R9	K39
       0x5C3C1600,  //  0049  MOVE	R15	R11
       0x7C340400,  //  004A  CALL	R13	2
       0x60340010,  //  004B  GETGBL	R13	G16
-      0x88381117,  //  004C  GETMBR	R14	R8	K23
+      0x883811C0,  //  004C  GETMBR	R14	R8	K192
       0x7C340200,  //  004D  CALL	R13	1
       0xA802000F,  //  004E  EXBLK	0	#005F
       0x5C381A00,  //  004F  MOVE	R14	R13
@@ -3182,17 +2883,17 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
       0x5442002F,  //  0052  LDINT	R16	48
       0x7C3C0200,  //  0053  CALL	R15	1
       0x5C2C1E00,  //  0054  MOVE	R11	R15
-      0x8C3C0115,  //  0055  GETMET	R15	R0	K21
+      0x8C3C01A7,  //  0055  GETMET	R15	R0	K167
       0x5C441600,  //  0056  MOVE	R17	R11
       0x5C480400,  //  0057  MOVE	R18	R2
       0x5C4C1C00,  //  0058  MOVE	R19	R14
       0x50500200,  //  0059  LDBOOL	R20	1	0
       0x7C3C0A00,  //  005A  CALL	R15	5
-      0x8C3C1316,  //  005B  GETMET	R15	R9	K22
+      0x8C3C1327,  //  005B  GETMET	R15	R9	K39
       0x5C441600,  //  005C  MOVE	R17	R11
       0x7C3C0400,  //  005D  CALL	R15	2
       0x7001FFEF,  //  005E  JMP		#004F
-      0x58340018,  //  005F  LDCONST	R13	K24
+      0x58340025,  //  005F  LDCONST	R13	K37
       0xAC340200,  //  0060  CATCH	R13	1	0
       0xB0080000,  //  0061  RAISE	2	R0	R0
       0x70020008,  //  0062  JMP		#006C
@@ -3200,29 +2901,29 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
       0x5432002F,  //  0064  LDINT	R12	48
       0x7C2C0200,  //  0065  CALL	R11	1
       0x5C241600,  //  0066  MOVE	R9	R11
-      0x8C2C0115,  //  0067  GETMET	R11	R0	K21
+      0x8C2C01A7,  //  0067  GETMET	R11	R0	K167
       0x5C341200,  //  0068  MOVE	R13	R9
       0x5C380400,  //  0069  MOVE	R14	R2
       0x5C3C1000,  //  006A  MOVE	R15	R8
       0x7C2C0800,  //  006B  CALL	R11	4
-      0xB82E0400,  //  006C  GETNGBL	R11	K2
-      0x8C2C1703,  //  006D  GETMET	R11	R11	K3
-      0x58340004,  //  006E  LDCONST	R13	K4
+      0xB82E2600,  //  006C  GETNGBL	R11	K19
+      0x8C2C1714,  //  006D  GETMET	R11	R11	K20
+      0x58340015,  //  006E  LDCONST	R13	K21
       0x7C2C0400,  //  006F  CALL	R11	2
       0x782E000A,  //  0070  JMPF	R11	#007C
       0x78120009,  //  0071  JMPF	R4	#007C
-      0xB82E3200,  //  0072  GETNGBL	R11	K25
+      0xB82E2E00,  //  0072  GETNGBL	R11	K23
       0x60300018,  //  0073  GETGBL	R12	G24
-      0x5834001A,  //  0074  LDCONST	R13	K26
-      0x8838071B,  //  0075  GETMBR	R14	R3	K27
+      0x583400C1,  //  0074  LDCONST	R13	K193
+      0x88380736,  //  0075  GETMBR	R14	R3	K54
       0x5C3C0400,  //  0076  MOVE	R15	R2
       0x5C400C00,  //  0077  MOVE	R16	R6
       0x5C441400,  //  0078  MOVE	R17	R10
       0x7C300A00,  //  0079  CALL	R12	5
-      0x58340004,  //  007A  LDCONST	R13	K4
+      0x58340015,  //  007A  LDCONST	R13	K21
       0x7C2C0400,  //  007B  CALL	R11	2
       0x70020026,  //  007C  JMP		#00A4
-      0x8828050B,  //  007D  GETMBR	R10	R2	K11
+      0x8828050F,  //  007D  GETMBR	R10	R2	K15
       0x4C2C0000,  //  007E  LDNIL	R11
       0x2028140B,  //  007F  NE	R10	R10	R11
       0x782A0022,  //  0080  JMPF	R10	#00A4
@@ -3231,35 +2932,35 @@ be_local_closure(class_Matter_IM_read_single_attribute_to_bytes,   /* name */
       0x542E002F,  //  0083  LDINT	R11	48
       0x7C280200,  //  0084  CALL	R10	1
       0x5C241400,  //  0085  MOVE	R9	R10
-      0x8C28011C,  //  0086  GETMET	R10	R0	K28
+      0x8C2801A9,  //  0086  GETMET	R10	R0	K169
       0x5C301200,  //  0087  MOVE	R12	R9
       0x5C340400,  //  0088  MOVE	R13	R2
-      0x8838050B,  //  0089  GETMBR	R14	R2	K11
+      0x8838050F,  //  0089  GETMBR	R14	R2	K15
       0x7C280800,  //  008A  CALL	R10	4
-      0xB82A0400,  //  008B  GETNGBL	R10	K2
-      0x8C281503,  //  008C  GETMET	R10	R10	K3
-      0x58300004,  //  008D  LDCONST	R12	K4
+      0xB82A2600,  //  008B  GETNGBL	R10	K19
+      0x8C281514,  //  008C  GETMET	R10	R10	K20
+      0x58300015,  //  008D  LDCONST	R12	K21
       0x7C280400,  //  008E  CALL	R10	2
       0x782A0013,  //  008F  JMPF	R10	#00A4
-      0xB82A3200,  //  0090  GETNGBL	R10	K25
+      0xB82A2E00,  //  0090  GETNGBL	R10	K23
       0x602C0018,  //  0091  GETGBL	R11	G24
-      0x5830001D,  //  0092  LDCONST	R12	K29
-      0x8834071B,  //  0093  GETMBR	R13	R3	K27
+      0x583000C2,  //  0092  LDCONST	R12	K194
+      0x88340736,  //  0093  GETMBR	R13	R3	K54
       0x60380008,  //  0094  GETGBL	R14	G8
       0x5C3C0400,  //  0095  MOVE	R15	R2
       0x7C380200,  //  0096  CALL	R14	1
       0x5C3C0C00,  //  0097  MOVE	R15	R6
-      0x8840050B,  //  0098  GETMBR	R16	R2	K11
-      0x8844050B,  //  0099  GETMBR	R17	R2	K11
+      0x8840050F,  //  0098  GETMBR	R16	R2	K15
+      0x8844050F,  //  0099  GETMBR	R17	R2	K15
       0xB84A0000,  //  009A  GETNGBL	R18	K0
-      0x8848251E,  //  009B  GETMBR	R18	R18	K30
+      0x8848259D,  //  009B  GETMBR	R18	R18	K157
       0x1C442212,  //  009C  EQ	R17	R17	R18
       0x78460001,  //  009D  JMPF	R17	#00A0
-      0x5844001E,  //  009E  LDCONST	R17	K30
+      0x5844009D,  //  009E  LDCONST	R17	K157
       0x70020000,  //  009F  JMP		#00A1
-      0x5844000A,  //  00A0  LDCONST	R17	K10
+      0x5844001B,  //  00A0  LDCONST	R17	K27
       0x7C2C0C00,  //  00A1  CALL	R11	6
-      0x58300004,  //  00A2  LDCONST	R12	K4
+      0x58300015,  //  00A2  LDCONST	R12	K21
       0x7C280400,  //  00A3  CALL	R10	2
       0x80041200,  //  00A4  RET	1	R9
     })
@@ -3275,25 +2976,20 @@ be_local_closure(class_Matter_IM_send_status,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_Status),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(send_status),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x880C0126,  //  0000  GETMBR	R3	R0	K38
+      0x8C0C0727,  //  0001  GETMET	R3	R3	K39
+      0xB8160000,  //  0002  GETNGBL	R5	K0
+      0x8C140BC3,  //  0003  GETMET	R5	R5	K195
       0x5C1C0200,  //  0004  MOVE	R7	R1
       0x5C200400,  //  0005  MOVE	R8	R2
       0x7C140600,  //  0006  CALL	R5	3
@@ -3312,50 +3008,28 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(opcode),
-    /* K1   */  be_const_int(2),
-    /* K2   */  be_nested_str_weak(read_request_solo),
-    /* K3   */  be_nested_str_weak(from_raw),
-    /* K4   */  be_nested_str_weak(raw),
-    /* K5   */  be_nested_str_weak(app_payload_idx),
-    /* K6   */  be_nested_str_weak(process_read_request_solo),
-    /* K7   */  be_nested_str_weak(invoke_request_solo),
-    /* K8   */  be_nested_str_weak(process_invoke_request_solo),
-    /* K9   */  be_nested_str_weak(matter),
-    /* K10  */  be_nested_str_weak(TLV),
-    /* K11  */  be_nested_str_weak(parse),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(process_status_response),
-    /* K14  */  be_nested_str_weak(send_ack_now),
-    /* K15  */  be_nested_str_weak(process_read_request_pull),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(subscribe_request),
-    /* K18  */  be_nested_str_weak(process_write_request),
-    /* K19  */  be_nested_str_weak(process_invoke_request),
-    /* K20  */  be_nested_str_weak(process_timed_request),
-    }),
+    &be_ktab_class_Matter_IM,     /* shared constants */
     be_str_weak(process_incoming),
     &be_const_str_solidified,
     ( &(const binstruction[124]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x1C0C0501,  //  0001  EQ	R3	R2	K1
+      0x880803C4,  //  0000  GETMBR	R2	R1	K196
+      0x1C0C052B,  //  0001  EQ	R3	R2	K43
       0x780E000D,  //  0002  JMPF	R3	#0011
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
-      0x88140304,  //  0005  GETMBR	R5	R1	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
+      0x880C0189,  //  0003  GETMBR	R3	R0	K137
+      0x8C0C07C5,  //  0004  GETMET	R3	R3	K197
+      0x88140395,  //  0005  GETMBR	R5	R1	K149
+      0x881803A5,  //  0006  GETMBR	R6	R1	K165
       0x7C0C0600,  //  0007  CALL	R3	3
       0x4C100000,  //  0008  LDNIL	R4
       0x20100604,  //  0009  NE	R4	R3	R4
       0x78120004,  //  000A  JMPF	R4	#0010
-      0x8C100106,  //  000B  GETMET	R4	R0	K6
+      0x8C1001C6,  //  000B  GETMET	R4	R0	K198
       0x5C180200,  //  000C  MOVE	R6	R1
       0x5C1C0600,  //  000D  MOVE	R7	R3
       0x7C100600,  //  000E  CALL	R4	3
@@ -3364,50 +3038,50 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
       0x540E0007,  //  0011  LDINT	R3	8
       0x1C0C0403,  //  0012  EQ	R3	R2	R3
       0x780E000C,  //  0013  JMPF	R3	#0021
-      0x880C0107,  //  0014  GETMBR	R3	R0	K7
-      0x8C0C0703,  //  0015  GETMET	R3	R3	K3
-      0x88140304,  //  0016  GETMBR	R5	R1	K4
-      0x88180305,  //  0017  GETMBR	R6	R1	K5
+      0x880C018B,  //  0014  GETMBR	R3	R0	K139
+      0x8C0C07C5,  //  0015  GETMET	R3	R3	K197
+      0x88140395,  //  0016  GETMBR	R5	R1	K149
+      0x881803A5,  //  0017  GETMBR	R6	R1	K165
       0x7C0C0600,  //  0018  CALL	R3	3
       0x4C100000,  //  0019  LDNIL	R4
       0x20100604,  //  001A  NE	R4	R3	R4
       0x78120004,  //  001B  JMPF	R4	#0021
-      0x8C100108,  //  001C  GETMET	R4	R0	K8
+      0x8C1001C7,  //  001C  GETMET	R4	R0	K199
       0x5C180200,  //  001D  MOVE	R6	R1
       0x5C1C0600,  //  001E  MOVE	R7	R3
       0x7C100600,  //  001F  CALL	R4	3
       0x80040800,  //  0020  RET	1	R4
-      0xB80E1200,  //  0021  GETNGBL	R3	K9
-      0x880C070A,  //  0022  GETMBR	R3	R3	K10
-      0x8C0C070B,  //  0023  GETMET	R3	R3	K11
-      0x88140304,  //  0024  GETMBR	R5	R1	K4
-      0x88180305,  //  0025  GETMBR	R6	R1	K5
+      0xB80E0000,  //  0021  GETNGBL	R3	K0
+      0x880C0783,  //  0022  GETMBR	R3	R3	K131
+      0x8C0C07A4,  //  0023  GETMET	R3	R3	K164
+      0x88140395,  //  0024  GETMBR	R5	R1	K149
+      0x881803A5,  //  0025  GETMBR	R6	R1	K165
       0x7C0C0600,  //  0026  CALL	R3	3
-      0x1C10050C,  //  0027  EQ	R4	R2	K12
+      0x1C10052A,  //  0027  EQ	R4	R2	K42
       0x78120005,  //  0028  JMPF	R4	#002F
-      0x8C10010D,  //  0029  GETMET	R4	R0	K13
+      0x8C1001C8,  //  0029  GETMET	R4	R0	K200
       0x5C180200,  //  002A  MOVE	R6	R1
       0x5C1C0600,  //  002B  MOVE	R7	R3
       0x7C100600,  //  002C  CALL	R4	3
       0x80040800,  //  002D  RET	1	R4
       0x7002004A,  //  002E  JMP		#007A
-      0x1C100501,  //  002F  EQ	R4	R2	K1
+      0x1C10052B,  //  002F  EQ	R4	R2	K43
       0x78120008,  //  0030  JMPF	R4	#003A
-      0x8C10010E,  //  0031  GETMET	R4	R0	K14
+      0x8C1001C9,  //  0031  GETMET	R4	R0	K201
       0x5C180200,  //  0032  MOVE	R6	R1
       0x7C100400,  //  0033  CALL	R4	2
-      0x8C10010F,  //  0034  GETMET	R4	R0	K15
+      0x8C1001A6,  //  0034  GETMET	R4	R0	K166
       0x5C180200,  //  0035  MOVE	R6	R1
       0x5C1C0600,  //  0036  MOVE	R7	R3
       0x7C100600,  //  0037  CALL	R4	3
       0x80040800,  //  0038  RET	1	R4
       0x7002003F,  //  0039  JMP		#007A
-      0x1C100510,  //  003A  EQ	R4	R2	K16
+      0x1C100515,  //  003A  EQ	R4	R2	K21
       0x78120008,  //  003B  JMPF	R4	#0045
-      0x8C10010E,  //  003C  GETMET	R4	R0	K14
+      0x8C1001C9,  //  003C  GETMET	R4	R0	K201
       0x5C180200,  //  003D  MOVE	R6	R1
       0x7C100400,  //  003E  CALL	R4	2
-      0x8C100111,  //  003F  GETMET	R4	R0	K17
+      0x8C1001CA,  //  003F  GETMET	R4	R0	K202
       0x5C180200,  //  0040  MOVE	R6	R1
       0x5C1C0600,  //  0041  MOVE	R7	R3
       0x7C100600,  //  0042  CALL	R4	3
@@ -3428,10 +3102,10 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
       0x54120005,  //  0051  LDINT	R4	6
       0x1C100404,  //  0052  EQ	R4	R2	R4
       0x78120008,  //  0053  JMPF	R4	#005D
-      0x8C10010E,  //  0054  GETMET	R4	R0	K14
+      0x8C1001C9,  //  0054  GETMET	R4	R0	K201
       0x5C180200,  //  0055  MOVE	R6	R1
       0x7C100400,  //  0056  CALL	R4	2
-      0x8C100112,  //  0057  GETMET	R4	R0	K18
+      0x8C1001CB,  //  0057  GETMET	R4	R0	K203
       0x5C180200,  //  0058  MOVE	R6	R1
       0x5C1C0600,  //  0059  MOVE	R7	R3
       0x7C100600,  //  005A  CALL	R4	3
@@ -3446,7 +3120,7 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
       0x54120007,  //  0063  LDINT	R4	8
       0x1C100404,  //  0064  EQ	R4	R2	R4
       0x78120005,  //  0065  JMPF	R4	#006C
-      0x8C100113,  //  0066  GETMET	R4	R0	K19
+      0x8C1001CC,  //  0066  GETMET	R4	R0	K204
       0x5C180200,  //  0067  MOVE	R6	R1
       0x5C1C0600,  //  0068  MOVE	R7	R3
       0x7C100600,  //  0069  CALL	R4	3
@@ -3461,7 +3135,7 @@ be_local_closure(class_Matter_IM_process_incoming,   /* name */
       0x54120009,  //  0072  LDINT	R4	10
       0x1C100404,  //  0073  EQ	R4	R2	R4
       0x78120004,  //  0074  JMPF	R4	#007A
-      0x8C100114,  //  0075  GETMET	R4	R0	K20
+      0x8C1001CD,  //  0075  GETMET	R4	R0	K205
       0x5C180200,  //  0076  MOVE	R6	R1
       0x5C1C0600,  //  0077  MOVE	R7	R3
       0x7C100600,  //  0078  CALL	R4	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
@@ -3,6 +3,20 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_IM_base' ktab size: 10, total: 11 (saved 8 bytes)
+static const bvalue be_ktab_class_Matter_IM_base[10] = {
+  /* K0   */  be_nested_str_weak(add_array),
+  /* K1   */  be_nested_str_weak(add_obj),
+  /* K2   */  be_nested_str_weak(stop_iteration),
+  /* K3   */  be_nested_str_weak(_X3C),
+  /* K4   */  be_nested_str_weak(_X3A),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(inspect),
+  /* K7   */  be_nested_str_weak(_X3E),
+  /* K8   */  be_nested_str_weak(push),
+  /* K9   */  be_nested_str_weak(from_TLV),
+};
+
 
 extern const bclass be_class_Matter_IM_base;
 
@@ -13,17 +27,13 @@ be_local_closure(class_Matter_IM_base_to_TLV_array,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add_array),
-    /* K1   */  be_nested_str_weak(add_obj),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM_base,     /* shared constants */
     be_str_weak(to_TLV_array),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -63,33 +73,27 @@ be_local_closure(class_Matter_IM_base_tostring,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_X3C),
-    /* K1   */  be_nested_str_weak(_X3A),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(inspect),
-    /* K4   */  be_nested_str_weak(_X3E),
-    }),
+    &be_ktab_class_Matter_IM_base,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60040005,  //  0000  GETGBL	R1	G5
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x00060001,  //  0003  ADD	R1	K0	R1
-      0x00040301,  //  0004  ADD	R1	R1	K1
-      0xB80A0400,  //  0005  GETNGBL	R2	K2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x00060601,  //  0003  ADD	R1	K3	R1
+      0x00040304,  //  0004  ADD	R1	R1	K4
+      0xB80A0A00,  //  0005  GETNGBL	R2	K5
+      0x8C080506,  //  0006  GETMET	R2	R2	K6
       0x5C100000,  //  0007  MOVE	R4	R0
       0x7C080400,  //  0008  CALL	R2	2
       0x00040202,  //  0009  ADD	R1	R1	R2
-      0x00040304,  //  000A  ADD	R1	R1	K4
+      0x00040307,  //  000A  ADD	R1	R1	K7
       0x80040200,  //  000B  RET	1	R1
     })
   )
@@ -104,17 +108,13 @@ be_local_closure(class_Matter_IM_base_from_TLV_array,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(push),
-    /* K1   */  be_nested_str_weak(from_TLV),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM_base,     /* shared constants */
     be_str_weak(from_TLV_array),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
@@ -131,10 +131,10 @@ be_local_closure(class_Matter_IM_base_from_TLV_array,   /* name */
       0xA8020009,  //  000A  EXBLK	0	#0015
       0x5C140800,  //  000B  MOVE	R5	R4
       0x7C140000,  //  000C  CALL	R5	0
-      0x8C180700,  //  000D  GETMET	R6	R3	K0
+      0x8C180708,  //  000D  GETMET	R6	R3	K8
       0x5C200400,  //  000E  MOVE	R8	R2
       0x7C200000,  //  000F  CALL	R8	0
-      0x8C201101,  //  0010  GETMET	R8	R8	K1
+      0x8C201109,  //  0010  GETMET	R8	R8	K9
       0x5C280A00,  //  0011  MOVE	R10	R5
       0x7C200400,  //  0012  CALL	R8	2
       0x7C180400,  //  0013  CALL	R6	2
@@ -208,6 +208,39 @@ be_local_class(Matter_IM_Message_base,
     })),
     be_str_weak(Matter_IM_Message_base)
 );
+// compact class 'Matter_AttributePathIB' ktab size: 29, total: 43 (saved 112 bytes)
+static const bvalue be_ktab_class_Matter_AttributePathIB[29] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_list),
+  /* K3   */  be_nested_str_weak(add_TLV),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(BOOL),
+  /* K6   */  be_nested_str_weak(tag_compression),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_nested_str_weak(U8),
+  /* K9   */  be_nested_str_weak(node),
+  /* K10  */  be_const_int(2),
+  /* K11  */  be_nested_str_weak(U2),
+  /* K12  */  be_nested_str_weak(endpoint),
+  /* K13  */  be_const_int(3),
+  /* K14  */  be_nested_str_weak(U4),
+  /* K15  */  be_nested_str_weak(cluster),
+  /* K16  */  be_nested_str_weak(attribute),
+  /* K17  */  be_nested_str_weak(list_index),
+  /* K18  */  be_nested_str_weak(),
+  /* K19  */  be_nested_str_weak(node_X3D_X25s_X20),
+  /* K20  */  be_nested_str_weak(_X5B_X2502X_X5D),
+  /* K21  */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
+  /* K22  */  be_nested_str_weak(_X2504X_X2F),
+  /* K23  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
+  /* K24  */  be_nested_str_weak(_X2504X),
+  /* K25  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+  /* K26  */  be_nested_str_weak(Exception_X3E_X20),
+  /* K27  */  be_nested_str_weak(_X2C_X20),
+  /* K28  */  be_nested_str_weak(findsubval),
+};
+
 
 extern const bclass be_class_Matter_AttributePathIB;
 
@@ -218,32 +251,13 @@ be_local_closure(class_Matter_AttributePathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_list),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(BOOL),
-    /* K6   */  be_nested_str_weak(tag_compression),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U8),
-    /* K9   */  be_nested_str_weak(node),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(U2),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(U4),
-    /* K15  */  be_nested_str_weak(cluster),
-    /* K16  */  be_nested_str_weak(attribute),
-    /* K17  */  be_nested_str_weak(list_index),
-    }),
+    &be_ktab_class_Matter_AttributePathIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
@@ -295,72 +309,57 @@ be_local_closure(class_Matter_AttributePathIB_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(node),
-    /* K2   */  be_nested_str_weak(node_X3D_X25s_X20),
-    /* K3   */  be_nested_str_weak(endpoint),
-    /* K4   */  be_nested_str_weak(_X5B_X2502X_X5D),
-    /* K5   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
-    /* K6   */  be_nested_str_weak(cluster),
-    /* K7   */  be_nested_str_weak(_X2504X_X2F),
-    /* K8   */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(_X2504X),
-    /* K11  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K12  */  be_nested_str_weak(Exception_X3E_X20),
-    /* K13  */  be_nested_str_weak(_X2C_X20),
-    }),
+    &be_ktab_class_Matter_AttributePathIB,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[61]) {  /* code */
       0xA802002C,  //  0000  EXBLK	0	#002E
-      0x58040000,  //  0001  LDCONST	R1	K0
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x58040012,  //  0001  LDCONST	R1	K18
+      0x88080109,  //  0002  GETMBR	R2	R0	K9
       0x780A0004,  //  0003  JMPF	R2	#0009
       0x60080018,  //  0004  GETGBL	R2	G24
-      0x580C0002,  //  0005  LDCONST	R3	K2
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x580C0013,  //  0005  LDCONST	R3	K19
+      0x88100109,  //  0006  GETMBR	R4	R0	K9
       0x7C080400,  //  0007  CALL	R2	2
       0x00040202,  //  0008  ADD	R1	R1	R2
-      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x8808010C,  //  0009  GETMBR	R2	R0	K12
       0x4C0C0000,  //  000A  LDNIL	R3
       0x20080403,  //  000B  NE	R2	R2	R3
       0x780A0004,  //  000C  JMPF	R2	#0012
       0x60080018,  //  000D  GETGBL	R2	G24
-      0x580C0004,  //  000E  LDCONST	R3	K4
-      0x88100103,  //  000F  GETMBR	R4	R0	K3
+      0x580C0014,  //  000E  LDCONST	R3	K20
+      0x8810010C,  //  000F  GETMBR	R4	R0	K12
       0x7C080400,  //  0010  CALL	R2	2
       0x70020000,  //  0011  JMP		#0013
-      0x58080005,  //  0012  LDCONST	R2	K5
+      0x58080015,  //  0012  LDCONST	R2	K21
       0x00040202,  //  0013  ADD	R1	R1	R2
-      0x88080106,  //  0014  GETMBR	R2	R0	K6
+      0x8808010F,  //  0014  GETMBR	R2	R0	K15
       0x4C0C0000,  //  0015  LDNIL	R3
       0x20080403,  //  0016  NE	R2	R2	R3
       0x780A0004,  //  0017  JMPF	R2	#001D
       0x60080018,  //  0018  GETGBL	R2	G24
-      0x580C0007,  //  0019  LDCONST	R3	K7
-      0x88100106,  //  001A  GETMBR	R4	R0	K6
+      0x580C0016,  //  0019  LDCONST	R3	K22
+      0x8810010F,  //  001A  GETMBR	R4	R0	K15
       0x7C080400,  //  001B  CALL	R2	2
       0x70020000,  //  001C  JMP		#001E
-      0x58080008,  //  001D  LDCONST	R2	K8
+      0x58080017,  //  001D  LDCONST	R2	K23
       0x00040202,  //  001E  ADD	R1	R1	R2
-      0x88080109,  //  001F  GETMBR	R2	R0	K9
+      0x88080110,  //  001F  GETMBR	R2	R0	K16
       0x4C0C0000,  //  0020  LDNIL	R3
       0x20080403,  //  0021  NE	R2	R2	R3
       0x780A0004,  //  0022  JMPF	R2	#0028
       0x60080018,  //  0023  GETGBL	R2	G24
-      0x580C000A,  //  0024  LDCONST	R3	K10
-      0x88100109,  //  0025  GETMBR	R4	R0	K9
+      0x580C0018,  //  0024  LDCONST	R3	K24
+      0x88100110,  //  0025  GETMBR	R4	R0	K16
       0x7C080400,  //  0026  CALL	R2	2
       0x70020000,  //  0027  JMP		#0029
-      0x5808000B,  //  0028  LDCONST	R2	K11
+      0x58080019,  //  0028  LDCONST	R2	K25
       0x00040202,  //  0029  ADD	R1	R1	R2
       0xA8040001,  //  002A  EXBLK	1	1
       0x80040200,  //  002B  RET	1	R1
@@ -371,8 +370,8 @@ be_local_closure(class_Matter_AttributePathIB_tostring,   /* name */
       0x600C0008,  //  0030  GETGBL	R3	G8
       0x5C100200,  //  0031  MOVE	R4	R1
       0x7C0C0200,  //  0032  CALL	R3	1
-      0x000E1803,  //  0033  ADD	R3	K12	R3
-      0x000C070D,  //  0034  ADD	R3	R3	K13
+      0x000E3403,  //  0033  ADD	R3	K26	R3
+      0x000C071B,  //  0034  ADD	R3	R3	K27
       0x60100008,  //  0035  GETGBL	R4	G8
       0x5C140400,  //  0036  MOVE	R5	R2
       0x7C100200,  //  0037  CALL	R4	1
@@ -394,25 +393,13 @@ be_local_closure(class_Matter_AttributePathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_compression),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(node),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(endpoint),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(cluster),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(list_index),
-    }),
+    &be_ktab_class_Matter_AttributePathIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[30]) {  /* code */
@@ -421,30 +408,30 @@ be_local_closure(class_Matter_AttributePathIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
+      0x8C08031C,  //  0005  GETMET	R2	R1	K28
+      0x58100004,  //  0006  LDCONST	R4	K4
       0x7C080400,  //  0007  CALL	R2	2
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080301,  //  0009  GETMET	R2	R1	K1
-      0x58100004,  //  000A  LDCONST	R4	K4
+      0x90020C02,  //  0008  SETMBR	R0	K6	R2
+      0x8C08031C,  //  0009  GETMET	R2	R1	K28
+      0x58100007,  //  000A  LDCONST	R4	K7
       0x7C080400,  //  000B  CALL	R2	2
-      0x90020602,  //  000C  SETMBR	R0	K3	R2
-      0x8C080301,  //  000D  GETMET	R2	R1	K1
-      0x58100006,  //  000E  LDCONST	R4	K6
+      0x90021202,  //  000C  SETMBR	R0	K9	R2
+      0x8C08031C,  //  000D  GETMET	R2	R1	K28
+      0x5810000A,  //  000E  LDCONST	R4	K10
       0x7C080400,  //  000F  CALL	R2	2
-      0x90020A02,  //  0010  SETMBR	R0	K5	R2
-      0x8C080301,  //  0011  GETMET	R2	R1	K1
-      0x58100008,  //  0012  LDCONST	R4	K8
+      0x90021802,  //  0010  SETMBR	R0	K12	R2
+      0x8C08031C,  //  0011  GETMET	R2	R1	K28
+      0x5810000D,  //  0012  LDCONST	R4	K13
       0x7C080400,  //  0013  CALL	R2	2
-      0x90020E02,  //  0014  SETMBR	R0	K7	R2
-      0x8C080301,  //  0015  GETMET	R2	R1	K1
+      0x90021E02,  //  0014  SETMBR	R0	K15	R2
+      0x8C08031C,  //  0015  GETMET	R2	R1	K28
       0x54120003,  //  0016  LDINT	R4	4
       0x7C080400,  //  0017  CALL	R2	2
-      0x90021202,  //  0018  SETMBR	R0	K9	R2
-      0x8C080301,  //  0019  GETMET	R2	R1	K1
+      0x90022002,  //  0018  SETMBR	R0	K16	R2
+      0x8C08031C,  //  0019  GETMET	R2	R1	K28
       0x54120004,  //  001A  LDINT	R4	5
       0x7C080400,  //  001B  CALL	R2	2
-      0x90021402,  //  001C  SETMBR	R0	K10	R2
+      0x90022202,  //  001C  SETMBR	R0	K17	R2
       0x80040000,  //  001D  RET	1	R0
     })
   )
@@ -473,6 +460,24 @@ be_local_class(Matter_AttributePathIB,
     })),
     be_str_weak(Matter_AttributePathIB)
 );
+// compact class 'Matter_ClusterPathIB' ktab size: 14, total: 20 (saved 48 bytes)
+static const bvalue be_ktab_class_Matter_ClusterPathIB[14] = {
+  /* K0   */  be_nested_str_weak(node),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(endpoint),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(cluster),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_nested_str_weak(matter),
+  /* K8   */  be_nested_str_weak(TLV),
+  /* K9   */  be_nested_str_weak(Matter_TLV_list),
+  /* K10  */  be_nested_str_weak(add_TLV),
+  /* K11  */  be_nested_str_weak(U8),
+  /* K12  */  be_nested_str_weak(U2),
+  /* K13  */  be_nested_str_weak(U4),
+};
+
 
 extern const bclass be_class_Matter_ClusterPathIB;
 
@@ -483,21 +488,13 @@ be_local_closure(class_Matter_ClusterPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(endpoint),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(cluster),
-    /* K6   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_ClusterPathIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -532,48 +529,34 @@ be_local_closure(class_Matter_ClusterPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_list),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(node),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(endpoint),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(cluster),
-    }),
+    &be_ktab_class_Matter_ClusterPathIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060E00,  //  0000  GETNGBL	R1	K7
+      0x88040308,  //  0001  GETMBR	R1	R1	K8
+      0x8C080309,  //  0002  GETMET	R2	R1	K9
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x8C0C050A,  //  0004  GETMET	R3	R2	K10
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x8818030B,  //  0006  GETMBR	R6	R1	K11
+      0x881C0100,  //  0007  GETMBR	R7	R0	K0
       0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180308,  //  000B  GETMBR	R6	R1	K8
-      0x881C0109,  //  000C  GETMBR	R7	R0	K9
+      0x8C0C050A,  //  0009  GETMET	R3	R2	K10
+      0x58140004,  //  000A  LDCONST	R5	K4
+      0x8818030C,  //  000B  GETMBR	R6	R1	K12
+      0x881C0103,  //  000C  GETMBR	R7	R0	K3
       0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0503,  //  000E  GETMET	R3	R2	K3
-      0x5814000A,  //  000F  LDCONST	R5	K10
-      0x8818030B,  //  0010  GETMBR	R6	R1	K11
-      0x881C010C,  //  0011  GETMBR	R7	R0	K12
+      0x8C0C050A,  //  000E  GETMET	R3	R2	K10
+      0x58140006,  //  000F  LDCONST	R5	K6
+      0x8818030D,  //  0010  GETMBR	R6	R1	K13
+      0x881C0105,  //  0011  GETMBR	R7	R0	K5
       0x7C0C0800,  //  0012  CALL	R3	4
       0x80040400,  //  0013  RET	1	R2
     })
@@ -599,6 +582,24 @@ be_local_class(Matter_ClusterPathIB,
     })),
     be_str_weak(Matter_ClusterPathIB)
 );
+// compact class 'Matter_DataVersionFilterIB' ktab size: 14, total: 19 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_DataVersionFilterIB[14] = {
+  /* K0   */  be_nested_str_weak(path),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(ClusterPathIB),
+  /* K3   */  be_nested_str_weak(from_TLV),
+  /* K4   */  be_nested_str_weak(findsub),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(data_version),
+  /* K7   */  be_nested_str_weak(findsubval),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K11  */  be_nested_str_weak(add_obj),
+  /* K12  */  be_nested_str_weak(add_TLV),
+  /* K13  */  be_nested_str_weak(U4),
+};
+
 
 extern const bclass be_class_Matter_DataVersionFilterIB;
 
@@ -609,23 +610,13 @@ be_local_closure(class_Matter_DataVersionFilterIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ClusterPathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(data_version),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_DataVersionFilterIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
@@ -661,39 +652,28 @@ be_local_closure(class_Matter_DataVersionFilterIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(path),
-    /* K6   */  be_nested_str_weak(add_TLV),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U4),
-    /* K9   */  be_nested_str_weak(data_version),
-    }),
+    &be_ktab_class_Matter_DataVersionFilterIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040309,  //  0001  GETMBR	R1	R1	K9
+      0x8C08030A,  //  0002  GETMET	R2	R1	K10
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180105,  //  0006  GETMBR	R6	R0	K5
+      0x8C0C050B,  //  0004  GETMET	R3	R2	K11
+      0x58140005,  //  0005  LDCONST	R5	K5
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
       0x7C0C0600,  //  0007  CALL	R3	3
-      0x8C0C0506,  //  0008  GETMET	R3	R2	K6
-      0x58140007,  //  0009  LDCONST	R5	K7
-      0x88180308,  //  000A  GETMBR	R6	R1	K8
-      0x881C0109,  //  000B  GETMBR	R7	R0	K9
+      0x8C0C050C,  //  0008  GETMET	R3	R2	K12
+      0x58140008,  //  0009  LDCONST	R5	K8
+      0x8818030D,  //  000A  GETMBR	R6	R1	K13
+      0x881C0106,  //  000B  GETMBR	R7	R0	K6
       0x7C0C0800,  //  000C  CALL	R3	4
       0x80040400,  //  000D  RET	1	R2
     })
@@ -718,6 +698,26 @@ be_local_class(Matter_DataVersionFilterIB,
     })),
     be_str_weak(Matter_DataVersionFilterIB)
 );
+// compact class 'Matter_AttributeDataIB' ktab size: 16, total: 23 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_AttributeDataIB[16] = {
+  /* K0   */  be_nested_str_weak(data_version),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(path),
+  /* K4   */  be_nested_str_weak(matter),
+  /* K5   */  be_nested_str_weak(AttributePathIB),
+  /* K6   */  be_nested_str_weak(from_TLV),
+  /* K7   */  be_nested_str_weak(findsub),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(data),
+  /* K10  */  be_const_int(2),
+  /* K11  */  be_nested_str_weak(TLV),
+  /* K12  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K13  */  be_nested_str_weak(add_TLV),
+  /* K14  */  be_nested_str_weak(U4),
+  /* K15  */  be_nested_str_weak(add_obj),
+};
+
 
 extern const bclass be_class_Matter_AttributeDataIB;
 
@@ -728,25 +728,13 @@ be_local_closure(class_Matter_AttributeDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(data_version),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(path),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(AttributePathIB),
-    /* K6   */  be_nested_str_weak(from_TLV),
-    /* K7   */  be_nested_str_weak(findsub),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(data),
-    /* K10  */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_AttributeDataIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -786,45 +774,32 @@ be_local_closure(class_Matter_AttributeDataIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U4),
-    /* K6   */  be_nested_str_weak(data_version),
-    /* K7   */  be_nested_str_weak(add_obj),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(path),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(data),
-    }),
+    &be_ktab_class_Matter_AttributeDataIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060800,  //  0000  GETNGBL	R1	K4
+      0x8804030B,  //  0001  GETMBR	R1	R1	K11
+      0x8C08030C,  //  0002  GETMET	R2	R1	K12
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x8C0C050D,  //  0004  GETMET	R3	R2	K13
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x8818030E,  //  0006  GETMBR	R6	R1	K14
+      0x881C0100,  //  0007  GETMBR	R7	R0	K0
       0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0507,  //  0009  GETMET	R3	R2	K7
+      0x8C0C050F,  //  0009  GETMET	R3	R2	K15
       0x58140008,  //  000A  LDCONST	R5	K8
-      0x88180109,  //  000B  GETMBR	R6	R0	K9
+      0x88180103,  //  000B  GETMBR	R6	R0	K3
       0x7C0C0600,  //  000C  CALL	R3	3
-      0x8C0C0507,  //  000D  GETMET	R3	R2	K7
+      0x8C0C050F,  //  000D  GETMET	R3	R2	K15
       0x5814000A,  //  000E  LDCONST	R5	K10
-      0x8818010B,  //  000F  GETMBR	R6	R0	K11
+      0x88180109,  //  000F  GETMBR	R6	R0	K9
       0x7C0C0600,  //  0010  CALL	R3	3
       0x80040400,  //  0011  RET	1	R2
     })
@@ -850,6 +825,22 @@ be_local_class(Matter_AttributeDataIB,
     })),
     be_str_weak(Matter_AttributeDataIB)
 );
+// compact class 'Matter_AttributeReportIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_AttributeReportIB[12] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K3   */  be_nested_str_weak(add_obj),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(attribute_status),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_nested_str_weak(attribute_data),
+  /* K8   */  be_nested_str_weak(AttributeStatusIB),
+  /* K9   */  be_nested_str_weak(from_TLV),
+  /* K10  */  be_nested_str_weak(findsub),
+  /* K11  */  be_nested_str_weak(AttributeDataIB),
+};
+
 
 extern const bclass be_class_Matter_AttributeReportIB;
 
@@ -860,22 +851,13 @@ be_local_closure(class_Matter_AttributeReportIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(attribute_status),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(attribute_data),
-    }),
+    &be_ktab_class_Matter_AttributeReportIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -905,23 +887,13 @@ be_local_closure(class_Matter_AttributeReportIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_status),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(AttributeStatusIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(attribute_data),
-    /* K7   */  be_nested_str_weak(AttributeDataIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_AttributeReportIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -930,24 +902,24 @@ be_local_closure(class_Matter_AttributeReportIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0xB80A0200,  //  0005  GETNGBL	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0xB80A0000,  //  0005  GETNGBL	R2	K0
+      0x8C080508,  //  0006  GETMET	R2	R2	K8
       0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x8C100304,  //  0009  GETMET	R4	R1	K4
-      0x58180005,  //  000A  LDCONST	R6	K5
+      0x8C080509,  //  0008  GETMET	R2	R2	K9
+      0x8C10030A,  //  0009  GETMET	R4	R1	K10
+      0x58180004,  //  000A  LDCONST	R6	K4
       0x7C100400,  //  000B  CALL	R4	2
       0x7C080400,  //  000C  CALL	R2	2
-      0x90020002,  //  000D  SETMBR	R0	K0	R2
-      0xB80A0200,  //  000E  GETNGBL	R2	K1
-      0x8C080507,  //  000F  GETMET	R2	R2	K7
+      0x90020A02,  //  000D  SETMBR	R0	K5	R2
+      0xB80A0000,  //  000E  GETNGBL	R2	K0
+      0x8C08050B,  //  000F  GETMET	R2	R2	K11
       0x7C080200,  //  0010  CALL	R2	1
-      0x8C080503,  //  0011  GETMET	R2	R2	K3
-      0x8C100304,  //  0012  GETMET	R4	R1	K4
-      0x58180008,  //  0013  LDCONST	R6	K8
+      0x8C080509,  //  0011  GETMET	R2	R2	K9
+      0x8C10030A,  //  0012  GETMET	R4	R1	K10
+      0x58180006,  //  0013  LDCONST	R6	K6
       0x7C100400,  //  0014  CALL	R4	2
       0x7C080400,  //  0015  CALL	R2	2
-      0x90020C02,  //  0016  SETMBR	R0	K6	R2
+      0x90020E02,  //  0016  SETMBR	R0	K7	R2
       0x80040000,  //  0017  RET	1	R0
     })
   )
@@ -971,6 +943,20 @@ be_local_class(Matter_AttributeReportIB,
     })),
     be_str_weak(Matter_AttributeReportIB)
 );
+// compact class 'Matter_EventFilterIB' ktab size: 10, total: 14 (saved 32 bytes)
+static const bvalue be_ktab_class_Matter_EventFilterIB[10] = {
+  /* K0   */  be_nested_str_weak(node),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(event_min),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(TLV),
+  /* K7   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K8   */  be_nested_str_weak(add_TLV),
+  /* K9   */  be_nested_str_weak(U8),
+};
+
 
 extern const bclass be_class_Matter_EventFilterIB;
 
@@ -981,19 +967,13 @@ be_local_closure(class_Matter_EventFilterIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(event_min),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_EventFilterIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -1024,39 +1004,29 @@ be_local_closure(class_Matter_EventFilterIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(node),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(event_min),
-    }),
+    &be_ktab_class_Matter_EventFilterIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060A00,  //  0000  GETNGBL	R1	K5
+      0x88040306,  //  0001  GETMBR	R1	R1	K6
+      0x8C080307,  //  0002  GETMET	R2	R1	K7
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x8C0C0508,  //  0004  GETMET	R3	R2	K8
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x88180309,  //  0006  GETMBR	R6	R1	K9
+      0x881C0100,  //  0007  GETMBR	R7	R0	K0
       0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180305,  //  000B  GETMBR	R6	R1	K5
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
+      0x8C0C0508,  //  0009  GETMET	R3	R2	K8
+      0x58140004,  //  000A  LDCONST	R5	K4
+      0x88180309,  //  000B  GETMBR	R6	R1	K9
+      0x881C0103,  //  000C  GETMBR	R7	R0	K3
       0x7C0C0800,  //  000D  CALL	R3	4
       0x80040400,  //  000E  RET	1	R2
     })
@@ -1081,6 +1051,28 @@ be_local_class(Matter_EventFilterIB,
     })),
     be_str_weak(Matter_EventFilterIB)
 );
+// compact class 'Matter_EventPathIB' ktab size: 18, total: 27 (saved 72 bytes)
+static const bvalue be_ktab_class_Matter_EventPathIB[18] = {
+  /* K0   */  be_nested_str_weak(node),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(endpoint),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(cluster),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_nested_str_weak(event),
+  /* K8   */  be_const_int(3),
+  /* K9   */  be_nested_str_weak(is_urgent),
+  /* K10  */  be_nested_str_weak(matter),
+  /* K11  */  be_nested_str_weak(TLV),
+  /* K12  */  be_nested_str_weak(Matter_TLV_list),
+  /* K13  */  be_nested_str_weak(add_TLV),
+  /* K14  */  be_nested_str_weak(U8),
+  /* K15  */  be_nested_str_weak(U2),
+  /* K16  */  be_nested_str_weak(U4),
+  /* K17  */  be_nested_str_weak(BOOL),
+};
+
 
 extern const bclass be_class_Matter_EventPathIB;
 
@@ -1091,24 +1083,13 @@ be_local_closure(class_Matter_EventPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(endpoint),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(cluster),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(event),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(is_urgent),
-    }),
+    &be_ktab_class_Matter_EventPathIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
@@ -1151,66 +1132,48 @@ be_local_closure(class_Matter_EventPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_list),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(node),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(endpoint),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(cluster),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(event),
-    /* K15  */  be_nested_str_weak(BOOL),
-    /* K16  */  be_nested_str_weak(is_urgent),
-    }),
+    &be_ktab_class_Matter_EventPathIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0xB80A1400,  //  0000  GETNGBL	R2	K10
+      0x8808050B,  //  0001  GETMBR	R2	R2	K11
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C0C0203,  //  0003  EQ	R3	R1	R3
       0x780E0002,  //  0004  JMPF	R3	#0008
-      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x8C0C050C,  //  0005  GETMET	R3	R2	K12
       0x7C0C0200,  //  0006  CALL	R3	1
       0x5C040600,  //  0007  MOVE	R1	R3
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x58140004,  //  0009  LDCONST	R5	K4
-      0x88180505,  //  000A  GETMBR	R6	R2	K5
-      0x881C0106,  //  000B  GETMBR	R7	R0	K6
+      0x8C0C030D,  //  0008  GETMET	R3	R1	K13
+      0x58140002,  //  0009  LDCONST	R5	K2
+      0x8818050E,  //  000A  GETMBR	R6	R2	K14
+      0x881C0100,  //  000B  GETMBR	R7	R0	K0
       0x7C0C0800,  //  000C  CALL	R3	4
-      0x8C0C0303,  //  000D  GETMET	R3	R1	K3
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0x88180508,  //  000F  GETMBR	R6	R2	K8
-      0x881C0109,  //  0010  GETMBR	R7	R0	K9
+      0x8C0C030D,  //  000D  GETMET	R3	R1	K13
+      0x58140004,  //  000E  LDCONST	R5	K4
+      0x8818050F,  //  000F  GETMBR	R6	R2	K15
+      0x881C0103,  //  0010  GETMBR	R7	R0	K3
       0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C0C0303,  //  0012  GETMET	R3	R1	K3
-      0x5814000A,  //  0013  LDCONST	R5	K10
-      0x8818050B,  //  0014  GETMBR	R6	R2	K11
-      0x881C010C,  //  0015  GETMBR	R7	R0	K12
+      0x8C0C030D,  //  0012  GETMET	R3	R1	K13
+      0x58140006,  //  0013  LDCONST	R5	K6
+      0x88180510,  //  0014  GETMBR	R6	R2	K16
+      0x881C0105,  //  0015  GETMBR	R7	R0	K5
       0x7C0C0800,  //  0016  CALL	R3	4
-      0x8C0C0303,  //  0017  GETMET	R3	R1	K3
-      0x5814000D,  //  0018  LDCONST	R5	K13
-      0x8818050B,  //  0019  GETMBR	R6	R2	K11
-      0x881C010E,  //  001A  GETMBR	R7	R0	K14
+      0x8C0C030D,  //  0017  GETMET	R3	R1	K13
+      0x58140008,  //  0018  LDCONST	R5	K8
+      0x88180510,  //  0019  GETMBR	R6	R2	K16
+      0x881C0107,  //  001A  GETMBR	R7	R0	K7
       0x7C0C0800,  //  001B  CALL	R3	4
-      0x8C0C0303,  //  001C  GETMET	R3	R1	K3
+      0x8C0C030D,  //  001C  GETMET	R3	R1	K13
       0x54160003,  //  001D  LDINT	R5	4
-      0x8818050F,  //  001E  GETMBR	R6	R2	K15
-      0x881C0110,  //  001F  GETMBR	R7	R0	K16
+      0x88180511,  //  001E  GETMBR	R6	R2	K17
+      0x881C0109,  //  001F  GETMBR	R7	R0	K9
       0x7C0C0800,  //  0020  CALL	R3	4
       0x80040200,  //  0021  RET	1	R1
     })
@@ -1238,6 +1201,35 @@ be_local_class(Matter_EventPathIB,
     })),
     be_str_weak(Matter_EventPathIB)
 );
+// compact class 'Matter_EventDataIB' ktab size: 25, total: 38 (saved 104 bytes)
+static const bvalue be_ktab_class_Matter_EventDataIB[25] = {
+  /* K0   */  be_nested_str_weak(path),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(EventPathIB),
+  /* K3   */  be_nested_str_weak(from_TLV),
+  /* K4   */  be_nested_str_weak(findsub),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(event_number),
+  /* K7   */  be_nested_str_weak(findsubval),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(priority),
+  /* K10  */  be_const_int(2),
+  /* K11  */  be_nested_str_weak(epoch_timestamp),
+  /* K12  */  be_const_int(3),
+  /* K13  */  be_nested_str_weak(system_timestamp),
+  /* K14  */  be_nested_str_weak(delta_epoch_timestamp),
+  /* K15  */  be_nested_str_weak(delta_system_timestamp),
+  /* K16  */  be_nested_str_weak(data),
+  /* K17  */  be_nested_str_weak(TLV),
+  /* K18  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K19  */  be_nested_str_weak(to_TLV),
+  /* K20  */  be_nested_str_weak(add_list),
+  /* K21  */  be_nested_str_weak(add_TLV),
+  /* K22  */  be_nested_str_weak(U8),
+  /* K23  */  be_nested_str_weak(U1),
+  /* K24  */  be_nested_str_weak(add_obj),
+};
+
 
 extern const bclass be_class_Matter_EventDataIB;
 
@@ -1248,31 +1240,13 @@ be_local_closure(class_Matter_EventDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(EventPathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(event_number),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(priority),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(epoch_timestamp),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(system_timestamp),
-    /* K14  */  be_nested_str_weak(delta_epoch_timestamp),
-    /* K15  */  be_nested_str_weak(delta_system_timestamp),
-    /* K16  */  be_nested_str_weak(data),
-    }),
+    &be_ktab_class_Matter_EventDataIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
@@ -1332,87 +1306,65 @@ be_local_closure(class_Matter_EventDataIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(path),
-    /* K4   */  be_nested_str_weak(to_TLV),
-    /* K5   */  be_nested_str_weak(add_list),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(add_TLV),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(U8),
-    /* K10  */  be_nested_str_weak(event_number),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_nested_str_weak(priority),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(epoch_timestamp),
-    /* K16  */  be_nested_str_weak(system_timestamp),
-    /* K17  */  be_nested_str_weak(delta_epoch_timestamp),
-    /* K18  */  be_nested_str_weak(delta_system_timestamp),
-    /* K19  */  be_nested_str_weak(add_obj),
-    /* K20  */  be_nested_str_weak(data),
-    }),
+    &be_ktab_class_Matter_EventDataIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[51]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0x88080511,  //  0001  GETMBR	R2	R2	K17
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C0C0203,  //  0003  EQ	R3	R1	R3
       0x780E0002,  //  0004  JMPF	R3	#0008
-      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x8C0C0512,  //  0005  GETMET	R3	R2	K18
       0x7C0C0200,  //  0006  CALL	R3	1
       0x5C040600,  //  0007  MOVE	R1	R3
-      0x880C0103,  //  0008  GETMBR	R3	R0	K3
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
       0x780E0005,  //  0009  JMPF	R3	#0010
-      0x880C0103,  //  000A  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  000B  GETMET	R3	R3	K4
-      0x8C140305,  //  000C  GETMET	R5	R1	K5
-      0x581C0006,  //  000D  LDCONST	R7	K6
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x8C0C0713,  //  000B  GETMET	R3	R3	K19
+      0x8C140314,  //  000C  GETMET	R5	R1	K20
+      0x581C0005,  //  000D  LDCONST	R7	K5
       0x7C140400,  //  000E  CALL	R5	2
       0x7C0C0400,  //  000F  CALL	R3	2
-      0x8C0C0307,  //  0010  GETMET	R3	R1	K7
+      0x8C0C0315,  //  0010  GETMET	R3	R1	K21
       0x58140008,  //  0011  LDCONST	R5	K8
-      0x88180509,  //  0012  GETMBR	R6	R2	K9
-      0x881C010A,  //  0013  GETMBR	R7	R0	K10
+      0x88180516,  //  0012  GETMBR	R6	R2	K22
+      0x881C0106,  //  0013  GETMBR	R7	R0	K6
       0x7C0C0800,  //  0014  CALL	R3	4
-      0x8C0C0307,  //  0015  GETMET	R3	R1	K7
-      0x5814000B,  //  0016  LDCONST	R5	K11
-      0x8818050C,  //  0017  GETMBR	R6	R2	K12
-      0x881C010D,  //  0018  GETMBR	R7	R0	K13
+      0x8C0C0315,  //  0015  GETMET	R3	R1	K21
+      0x5814000A,  //  0016  LDCONST	R5	K10
+      0x88180517,  //  0017  GETMBR	R6	R2	K23
+      0x881C0109,  //  0018  GETMBR	R7	R0	K9
       0x7C0C0800,  //  0019  CALL	R3	4
-      0x8C0C0307,  //  001A  GETMET	R3	R1	K7
-      0x5814000E,  //  001B  LDCONST	R5	K14
-      0x88180509,  //  001C  GETMBR	R6	R2	K9
-      0x881C010F,  //  001D  GETMBR	R7	R0	K15
+      0x8C0C0315,  //  001A  GETMET	R3	R1	K21
+      0x5814000C,  //  001B  LDCONST	R5	K12
+      0x88180516,  //  001C  GETMBR	R6	R2	K22
+      0x881C010B,  //  001D  GETMBR	R7	R0	K11
       0x7C0C0800,  //  001E  CALL	R3	4
-      0x8C0C0307,  //  001F  GETMET	R3	R1	K7
+      0x8C0C0315,  //  001F  GETMET	R3	R1	K21
       0x54160003,  //  0020  LDINT	R5	4
-      0x88180509,  //  0021  GETMBR	R6	R2	K9
-      0x881C0110,  //  0022  GETMBR	R7	R0	K16
+      0x88180516,  //  0021  GETMBR	R6	R2	K22
+      0x881C010D,  //  0022  GETMBR	R7	R0	K13
       0x7C0C0800,  //  0023  CALL	R3	4
-      0x8C0C0307,  //  0024  GETMET	R3	R1	K7
+      0x8C0C0315,  //  0024  GETMET	R3	R1	K21
       0x54160004,  //  0025  LDINT	R5	5
-      0x88180509,  //  0026  GETMBR	R6	R2	K9
-      0x881C0111,  //  0027  GETMBR	R7	R0	K17
+      0x88180516,  //  0026  GETMBR	R6	R2	K22
+      0x881C010E,  //  0027  GETMBR	R7	R0	K14
       0x7C0C0800,  //  0028  CALL	R3	4
-      0x8C0C0307,  //  0029  GETMET	R3	R1	K7
+      0x8C0C0315,  //  0029  GETMET	R3	R1	K21
       0x54160005,  //  002A  LDINT	R5	6
-      0x88180509,  //  002B  GETMBR	R6	R2	K9
-      0x881C0112,  //  002C  GETMBR	R7	R0	K18
+      0x88180516,  //  002B  GETMBR	R6	R2	K22
+      0x881C010F,  //  002C  GETMBR	R7	R0	K15
       0x7C0C0800,  //  002D  CALL	R3	4
-      0x8C0C0313,  //  002E  GETMET	R3	R1	K19
+      0x8C0C0318,  //  002E  GETMET	R3	R1	K24
       0x54160006,  //  002F  LDINT	R5	7
-      0x88180114,  //  0030  GETMBR	R6	R0	K20
+      0x88180110,  //  0030  GETMBR	R6	R0	K16
       0x7C0C0600,  //  0031  CALL	R3	3
       0x80040200,  //  0032  RET	1	R1
     })
@@ -1443,6 +1395,22 @@ be_local_class(Matter_EventDataIB,
     })),
     be_str_weak(Matter_EventDataIB)
 );
+// compact class 'Matter_EventReportIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_EventReportIB[12] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K3   */  be_nested_str_weak(add_obj),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(event_status),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_nested_str_weak(event_data),
+  /* K8   */  be_nested_str_weak(EventStatusIB),
+  /* K9   */  be_nested_str_weak(from_TLV),
+  /* K10  */  be_nested_str_weak(findsub),
+  /* K11  */  be_nested_str_weak(EventDataIB),
+};
+
 
 extern const bclass be_class_Matter_EventReportIB;
 
@@ -1453,22 +1421,13 @@ be_local_closure(class_Matter_EventReportIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(event_status),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(event_data),
-    }),
+    &be_ktab_class_Matter_EventReportIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -1498,23 +1457,13 @@ be_local_closure(class_Matter_EventReportIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_status),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(EventStatusIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(event_data),
-    /* K7   */  be_nested_str_weak(EventDataIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_EventReportIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -1523,24 +1472,24 @@ be_local_closure(class_Matter_EventReportIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0xB80A0200,  //  0005  GETNGBL	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0xB80A0000,  //  0005  GETNGBL	R2	K0
+      0x8C080508,  //  0006  GETMET	R2	R2	K8
       0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x8C100304,  //  0009  GETMET	R4	R1	K4
-      0x58180005,  //  000A  LDCONST	R6	K5
+      0x8C080509,  //  0008  GETMET	R2	R2	K9
+      0x8C10030A,  //  0009  GETMET	R4	R1	K10
+      0x58180004,  //  000A  LDCONST	R6	K4
       0x7C100400,  //  000B  CALL	R4	2
       0x7C080400,  //  000C  CALL	R2	2
-      0x90020002,  //  000D  SETMBR	R0	K0	R2
-      0xB80A0200,  //  000E  GETNGBL	R2	K1
-      0x8C080507,  //  000F  GETMET	R2	R2	K7
+      0x90020A02,  //  000D  SETMBR	R0	K5	R2
+      0xB80A0000,  //  000E  GETNGBL	R2	K0
+      0x8C08050B,  //  000F  GETMET	R2	R2	K11
       0x7C080200,  //  0010  CALL	R2	1
-      0x8C080503,  //  0011  GETMET	R2	R2	K3
-      0x8C100304,  //  0012  GETMET	R4	R1	K4
-      0x58180008,  //  0013  LDCONST	R6	K8
+      0x8C080509,  //  0011  GETMET	R2	R2	K9
+      0x8C10030A,  //  0012  GETMET	R4	R1	K10
+      0x58180006,  //  0013  LDCONST	R6	K6
       0x7C100400,  //  0014  CALL	R4	2
       0x7C080400,  //  0015  CALL	R2	2
-      0x90020C02,  //  0016  SETMBR	R0	K6	R2
+      0x90020E02,  //  0016  SETMBR	R0	K7	R2
       0x80040000,  //  0017  RET	1	R0
     })
   )
@@ -1564,6 +1513,23 @@ be_local_class(Matter_EventReportIB,
     })),
     be_str_weak(Matter_EventReportIB)
 );
+// compact class 'Matter_CommandPathIB' ktab size: 13, total: 19 (saved 48 bytes)
+static const bvalue be_ktab_class_Matter_CommandPathIB[13] = {
+  /* K0   */  be_nested_str_weak(endpoint),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(cluster),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(command),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_nested_str_weak(matter),
+  /* K8   */  be_nested_str_weak(TLV),
+  /* K9   */  be_nested_str_weak(Matter_TLV_list),
+  /* K10  */  be_nested_str_weak(add_TLV),
+  /* K11  */  be_nested_str_weak(U2),
+  /* K12  */  be_nested_str_weak(U4),
+};
+
 
 extern const bclass be_class_Matter_CommandPathIB;
 
@@ -1574,21 +1540,13 @@ be_local_closure(class_Matter_CommandPathIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(command),
-    /* K6   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_CommandPathIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -1623,47 +1581,34 @@ be_local_closure(class_Matter_CommandPathIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_list),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U2),
-    /* K6   */  be_nested_str_weak(endpoint),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(U4),
-    /* K9   */  be_nested_str_weak(cluster),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(command),
-    }),
+    &be_ktab_class_Matter_CommandPathIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060E00,  //  0000  GETNGBL	R1	K7
+      0x88040308,  //  0001  GETMBR	R1	R1	K8
+      0x8C080309,  //  0002  GETMET	R2	R1	K9
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x8C0C050A,  //  0004  GETMET	R3	R2	K10
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x8818030B,  //  0006  GETMBR	R6	R1	K11
+      0x881C0100,  //  0007  GETMBR	R7	R0	K0
       0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
-      0x58140007,  //  000A  LDCONST	R5	K7
-      0x88180308,  //  000B  GETMBR	R6	R1	K8
-      0x881C0109,  //  000C  GETMBR	R7	R0	K9
+      0x8C0C050A,  //  0009  GETMET	R3	R2	K10
+      0x58140004,  //  000A  LDCONST	R5	K4
+      0x8818030C,  //  000B  GETMBR	R6	R1	K12
+      0x881C0103,  //  000C  GETMBR	R7	R0	K3
       0x7C0C0800,  //  000D  CALL	R3	4
-      0x8C0C0503,  //  000E  GETMET	R3	R2	K3
-      0x5814000A,  //  000F  LDCONST	R5	K10
-      0x88180308,  //  0010  GETMBR	R6	R1	K8
-      0x881C010B,  //  0011  GETMBR	R7	R0	K11
+      0x8C0C050A,  //  000E  GETMET	R3	R2	K10
+      0x58140006,  //  000F  LDCONST	R5	K6
+      0x8818030C,  //  0010  GETMBR	R6	R1	K12
+      0x881C0105,  //  0011  GETMBR	R7	R0	K5
       0x7C0C0800,  //  0012  CALL	R3	4
       0x80040400,  //  0013  RET	1	R2
     })
@@ -1689,6 +1634,21 @@ be_local_class(Matter_CommandPathIB,
     })),
     be_str_weak(Matter_CommandPathIB)
 );
+// compact class 'Matter_CommandDataIB' ktab size: 11, total: 16 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_CommandDataIB[11] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K3   */  be_nested_str_weak(add_obj),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(command_path),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_nested_str_weak(command_fields),
+  /* K8   */  be_nested_str_weak(CommandPathIB),
+  /* K9   */  be_nested_str_weak(from_TLV),
+  /* K10  */  be_nested_str_weak(findsub),
+};
+
 
 extern const bclass be_class_Matter_CommandDataIB;
 
@@ -1699,22 +1659,13 @@ be_local_closure(class_Matter_CommandDataIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(command_path),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(command_fields),
-    }),
+    &be_ktab_class_Matter_CommandDataIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -1744,22 +1695,13 @@ be_local_closure(class_Matter_CommandDataIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(command_path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(CommandPathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(command_fields),
-    /* K7   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_CommandDataIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
@@ -1768,19 +1710,19 @@ be_local_closure(class_Matter_CommandDataIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0xB80A0200,  //  0005  GETNGBL	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0xB80A0000,  //  0005  GETNGBL	R2	K0
+      0x8C080508,  //  0006  GETMET	R2	R2	K8
       0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x8C100304,  //  0009  GETMET	R4	R1	K4
-      0x58180005,  //  000A  LDCONST	R6	K5
+      0x8C080509,  //  0008  GETMET	R2	R2	K9
+      0x8C10030A,  //  0009  GETMET	R4	R1	K10
+      0x58180004,  //  000A  LDCONST	R6	K4
       0x7C100400,  //  000B  CALL	R4	2
       0x7C080400,  //  000C  CALL	R2	2
-      0x90020002,  //  000D  SETMBR	R0	K0	R2
-      0x8C080304,  //  000E  GETMET	R2	R1	K4
-      0x58100007,  //  000F  LDCONST	R4	K7
+      0x90020A02,  //  000D  SETMBR	R0	K5	R2
+      0x8C08030A,  //  000E  GETMET	R2	R1	K10
+      0x58100006,  //  000F  LDCONST	R4	K6
       0x7C080400,  //  0010  CALL	R2	2
-      0x90020C02,  //  0011  SETMBR	R0	K6	R2
+      0x90020E02,  //  0011  SETMBR	R0	K7	R2
       0x80040000,  //  0012  RET	1	R0
     })
   )
@@ -1804,6 +1746,22 @@ be_local_class(Matter_CommandDataIB,
     })),
     be_str_weak(Matter_CommandDataIB)
 );
+// compact class 'Matter_InvokeResponseIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_InvokeResponseIB[12] = {
+  /* K0   */  be_nested_str_weak(command),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(CommandDataIB),
+  /* K3   */  be_nested_str_weak(from_TLV),
+  /* K4   */  be_nested_str_weak(findsub),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(status),
+  /* K7   */  be_nested_str_weak(CommandStatusIB),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K11  */  be_nested_str_weak(add_obj),
+};
+
 
 extern const bclass be_class_Matter_InvokeResponseIB;
 
@@ -1814,23 +1772,13 @@ be_local_closure(class_Matter_InvokeResponseIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(command),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(CommandDataIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(CommandStatusIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_InvokeResponseIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -1871,36 +1819,27 @@ be_local_closure(class_Matter_InvokeResponseIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(command),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(status),
-    }),
+    &be_ktab_class_Matter_InvokeResponseIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040309,  //  0001  GETMBR	R1	R1	K9
+      0x8C08030A,  //  0002  GETMET	R2	R1	K10
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180105,  //  0006  GETMBR	R6	R0	K5
+      0x8C0C050B,  //  0004  GETMET	R3	R2	K11
+      0x58140005,  //  0005  LDCONST	R5	K5
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
       0x7C0C0600,  //  0007  CALL	R3	3
-      0x8C0C0503,  //  0008  GETMET	R3	R2	K3
-      0x58140006,  //  0009  LDCONST	R5	K6
-      0x88180107,  //  000A  GETMBR	R6	R0	K7
+      0x8C0C050B,  //  0008  GETMET	R3	R2	K11
+      0x58140008,  //  0009  LDCONST	R5	K8
+      0x88180106,  //  000A  GETMBR	R6	R0	K6
       0x7C0C0600,  //  000B  CALL	R3	3
       0x80040400,  //  000C  RET	1	R2
     })
@@ -1925,6 +1864,22 @@ be_local_class(Matter_InvokeResponseIB,
     })),
     be_str_weak(Matter_InvokeResponseIB)
 );
+// compact class 'Matter_CommandStatusIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_CommandStatusIB[12] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K3   */  be_nested_str_weak(add_obj),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(command_path),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_nested_str_weak(status),
+  /* K8   */  be_nested_str_weak(CommandPathIB),
+  /* K9   */  be_nested_str_weak(from_TLV),
+  /* K10  */  be_nested_str_weak(findsub),
+  /* K11  */  be_nested_str_weak(StatusIB),
+};
+
 
 extern const bclass be_class_Matter_CommandStatusIB;
 
@@ -1935,22 +1890,13 @@ be_local_closure(class_Matter_CommandStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(command_path),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(status),
-    }),
+    &be_ktab_class_Matter_CommandStatusIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -1980,23 +1926,13 @@ be_local_closure(class_Matter_CommandStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(command_path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(CommandPathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(StatusIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_CommandStatusIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -2005,24 +1941,24 @@ be_local_closure(class_Matter_CommandStatusIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0xB80A0200,  //  0005  GETNGBL	R2	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0xB80A0000,  //  0005  GETNGBL	R2	K0
+      0x8C080508,  //  0006  GETMET	R2	R2	K8
       0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x8C100304,  //  0009  GETMET	R4	R1	K4
-      0x58180005,  //  000A  LDCONST	R6	K5
+      0x8C080509,  //  0008  GETMET	R2	R2	K9
+      0x8C10030A,  //  0009  GETMET	R4	R1	K10
+      0x58180004,  //  000A  LDCONST	R6	K4
       0x7C100400,  //  000B  CALL	R4	2
       0x7C080400,  //  000C  CALL	R2	2
-      0x90020002,  //  000D  SETMBR	R0	K0	R2
-      0xB80A0200,  //  000E  GETNGBL	R2	K1
-      0x8C080507,  //  000F  GETMET	R2	R2	K7
+      0x90020A02,  //  000D  SETMBR	R0	K5	R2
+      0xB80A0000,  //  000E  GETNGBL	R2	K0
+      0x8C08050B,  //  000F  GETMET	R2	R2	K11
       0x7C080200,  //  0010  CALL	R2	1
-      0x8C080503,  //  0011  GETMET	R2	R2	K3
-      0x8C100304,  //  0012  GETMET	R4	R1	K4
-      0x58180008,  //  0013  LDCONST	R6	K8
+      0x8C080509,  //  0011  GETMET	R2	R2	K9
+      0x8C10030A,  //  0012  GETMET	R4	R1	K10
+      0x58180006,  //  0013  LDCONST	R6	K6
       0x7C100400,  //  0014  CALL	R4	2
       0x7C080400,  //  0015  CALL	R2	2
-      0x90020C02,  //  0016  SETMBR	R0	K6	R2
+      0x90020E02,  //  0016  SETMBR	R0	K7	R2
       0x80040000,  //  0017  RET	1	R0
     })
   )
@@ -2046,6 +1982,22 @@ be_local_class(Matter_CommandStatusIB,
     })),
     be_str_weak(Matter_CommandStatusIB)
 );
+// compact class 'Matter_EventStatusIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_EventStatusIB[12] = {
+  /* K0   */  be_nested_str_weak(path),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(EventPathIB),
+  /* K3   */  be_nested_str_weak(from_TLV),
+  /* K4   */  be_nested_str_weak(findsub),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(status),
+  /* K7   */  be_nested_str_weak(StatusIB),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K11  */  be_nested_str_weak(add_obj),
+};
+
 
 extern const bclass be_class_Matter_EventStatusIB;
 
@@ -2056,23 +2008,13 @@ be_local_closure(class_Matter_EventStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(EventPathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(StatusIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_EventStatusIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -2113,36 +2055,27 @@ be_local_closure(class_Matter_EventStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(path),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(status),
-    }),
+    &be_ktab_class_Matter_EventStatusIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040309,  //  0001  GETMBR	R1	R1	K9
+      0x8C08030A,  //  0002  GETMET	R2	R1	K10
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180105,  //  0006  GETMBR	R6	R0	K5
+      0x8C0C050B,  //  0004  GETMET	R3	R2	K11
+      0x58140005,  //  0005  LDCONST	R5	K5
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
       0x7C0C0600,  //  0007  CALL	R3	3
-      0x8C0C0503,  //  0008  GETMET	R3	R2	K3
-      0x58140006,  //  0009  LDCONST	R5	K6
-      0x88180107,  //  000A  GETMBR	R6	R0	K7
+      0x8C0C050B,  //  0008  GETMET	R3	R2	K11
+      0x58140008,  //  0009  LDCONST	R5	K8
+      0x88180106,  //  000A  GETMBR	R6	R0	K6
       0x7C0C0600,  //  000B  CALL	R3	3
       0x80040400,  //  000C  RET	1	R2
     })
@@ -2167,6 +2100,22 @@ be_local_class(Matter_EventStatusIB,
     })),
     be_str_weak(Matter_EventStatusIB)
 );
+// compact class 'Matter_AttributeStatusIB' ktab size: 12, total: 17 (saved 40 bytes)
+static const bvalue be_ktab_class_Matter_AttributeStatusIB[12] = {
+  /* K0   */  be_nested_str_weak(path),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(AttributePathIB),
+  /* K3   */  be_nested_str_weak(from_TLV),
+  /* K4   */  be_nested_str_weak(findsub),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(status),
+  /* K7   */  be_nested_str_weak(StatusIB),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K11  */  be_nested_str_weak(add_obj),
+};
+
 
 extern const bclass be_class_Matter_AttributeStatusIB;
 
@@ -2177,23 +2126,13 @@ be_local_closure(class_Matter_AttributeStatusIB_from_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(AttributePathIB),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(findsub),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(StatusIB),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_AttributeStatusIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -2234,36 +2173,27 @@ be_local_closure(class_Matter_AttributeStatusIB_to_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_obj),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(path),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(status),
-    }),
+    &be_ktab_class_Matter_AttributeStatusIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040309,  //  0001  GETMBR	R1	R1	K9
+      0x8C08030A,  //  0002  GETMET	R2	R1	K10
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180105,  //  0006  GETMBR	R6	R0	K5
+      0x8C0C050B,  //  0004  GETMET	R3	R2	K11
+      0x58140005,  //  0005  LDCONST	R5	K5
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
       0x7C0C0600,  //  0007  CALL	R3	3
-      0x8C0C0503,  //  0008  GETMET	R3	R2	K3
-      0x58140006,  //  0009  LDCONST	R5	K6
-      0x88180107,  //  000A  GETMBR	R6	R0	K7
+      0x8C0C050B,  //  0008  GETMET	R3	R2	K11
+      0x58140008,  //  0009  LDCONST	R5	K8
+      0x88180106,  //  000A  GETMBR	R6	R0	K6
       0x7C0C0600,  //  000B  CALL	R3	3
       0x80040400,  //  000C  RET	1	R2
     })
@@ -2288,6 +2218,20 @@ be_local_class(Matter_AttributeStatusIB,
     })),
     be_str_weak(Matter_AttributeStatusIB)
 );
+// compact class 'Matter_StatusIB' ktab size: 10, total: 14 (saved 32 bytes)
+static const bvalue be_ktab_class_Matter_StatusIB[10] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K3   */  be_nested_str_weak(add_TLV),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(U2),
+  /* K6   */  be_nested_str_weak(status),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_nested_str_weak(cluster_status),
+  /* K9   */  be_nested_str_weak(findsubval),
+};
+
 
 extern const bclass be_class_Matter_StatusIB;
 
@@ -2298,23 +2242,13 @@ be_local_closure(class_Matter_StatusIB_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U2),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(cluster_status),
-    }),
+    &be_ktab_class_Matter_StatusIB,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -2346,19 +2280,13 @@ be_local_closure(class_Matter_StatusIB_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(cluster_status),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_StatusIB,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -2367,14 +2295,14 @@ be_local_closure(class_Matter_StatusIB_from_TLV,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
+      0x8C080309,  //  0005  GETMET	R2	R1	K9
+      0x58100004,  //  0006  LDCONST	R4	K4
       0x7C080400,  //  0007  CALL	R2	2
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080301,  //  0009  GETMET	R2	R1	K1
-      0x58100004,  //  000A  LDCONST	R4	K4
+      0x90020C02,  //  0008  SETMBR	R0	K6	R2
+      0x8C080309,  //  0009  GETMET	R2	R1	K9
+      0x58100007,  //  000A  LDCONST	R4	K7
       0x7C080400,  //  000B  CALL	R2	2
-      0x90020602,  //  000C  SETMBR	R0	K3	R2
+      0x90021002,  //  000C  SETMBR	R0	K8	R2
       0x80040000,  //  000D  RET	1	R0
     })
   )
@@ -2398,6 +2326,20 @@ be_local_class(Matter_StatusIB,
     })),
     be_str_weak(Matter_StatusIB)
 );
+// compact class 'Matter_StatusResponseMessage' ktab size: 10, total: 12 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_StatusResponseMessage[10] = {
+  /* K0   */  be_nested_str_weak(status),
+  /* K1   */  be_nested_str_weak(findsubval),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str_weak(matter),
+  /* K4   */  be_nested_str_weak(TLV),
+  /* K5   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K6   */  be_nested_str_weak(add_TLV),
+  /* K7   */  be_nested_str_weak(U4),
+  /* K8   */  be_nested_str_weak(U1),
+  /* K9   */  be_nested_str_weak(InteractionModelRevision),
+};
+
 
 extern const bclass be_class_Matter_StatusResponseMessage;
 
@@ -2408,17 +2350,13 @@ be_local_closure(class_Matter_StatusResponseMessage_from_TLV,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_StatusResponseMessage,     /* shared constants */
     be_str_weak(from_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -2445,39 +2383,29 @@ be_local_closure(class_Matter_StatusResponseMessage_to_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K3   */  be_nested_str_weak(add_TLV),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(U4),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(InteractionModelRevision),
-    }),
+    &be_ktab_class_Matter_StatusResponseMessage,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8060600,  //  0000  GETNGBL	R1	K3
+      0x88040304,  //  0001  GETMBR	R1	R1	K4
+      0x8C080305,  //  0002  GETMET	R2	R1	K5
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0x88180305,  //  0006  GETMBR	R6	R1	K5
-      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x8C0C0506,  //  0004  GETMET	R3	R2	K6
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x88180307,  //  0006  GETMBR	R6	R1	K7
+      0x881C0100,  //  0007  GETMBR	R7	R0	K0
       0x7C0C0800,  //  0008  CALL	R3	4
-      0x8C0C0503,  //  0009  GETMET	R3	R2	K3
+      0x8C0C0506,  //  0009  GETMET	R3	R2	K6
       0x541600FE,  //  000A  LDINT	R5	255
-      0x88180307,  //  000B  GETMBR	R6	R1	K7
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
+      0x88180308,  //  000B  GETMBR	R6	R1	K8
+      0x881C0109,  //  000C  GETMBR	R7	R0	K9
       0x7C0C0800,  //  000D  CALL	R3	4
       0x80040400,  //  000E  RET	1	R2
     })
@@ -3358,6 +3286,27 @@ be_local_class(Matter_InvokeRequestMessage,
     })),
     be_str_weak(Matter_InvokeRequestMessage)
 );
+// compact class 'Matter_InvokeRequestMessage_solo' ktab size: 17, total: 20 (saved 24 bytes)
+static const bvalue be_ktab_class_Matter_InvokeRequestMessage_solo[17] = {
+  /* K0   */  be_nested_str_weak(reset),
+  /* K1   */  be_nested_str_weak(SuppressResponse),
+  /* K2   */  be_nested_str_weak(TimedRequest),
+  /* K3   */  be_nested_str_weak(command_fields),
+  /* K4   */  be_nested_str_weak(get),
+  /* K5   */  be_const_int(1),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_const_int(3),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(endpoint),
+  /* K10  */  be_nested_str_weak(cluster),
+  /* K11  */  be_nested_str_weak(command),
+  /* K12  */  be_nested_str_weak(matter),
+  /* K13  */  be_nested_str_weak(TLV),
+  /* K14  */  be_nested_str_weak(parse),
+  /* K15  */  be_nested_str_weak(next_idx),
+  /* K16  */  be_const_int(620691736),
+};
+
 
 extern const bclass be_class_Matter_InvokeRequestMessage_solo;
 
@@ -3368,18 +3317,13 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_reset,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(SuppressResponse),
-    /* K2   */  be_nested_str_weak(TimedRequest),
-    /* K3   */  be_nested_str_weak(command_fields),
-    }),
+    &be_ktab_class_Matter_InvokeRequestMessage_solo,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -3406,30 +3350,13 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(get),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(SuppressResponse),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(command),
-    /* K10  */  be_nested_str_weak(command_fields),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(TLV),
-    /* K13  */  be_nested_str_weak(parse),
-    /* K14  */  be_nested_str_weak(next_idx),
-    /* K15  */  be_const_int(620691736),
-    }),
+    &be_ktab_class_Matter_InvokeRequestMessage_solo,     /* shared constants */
     be_str_weak(from_raw),
     &be_const_str_solidified,
     ( &(const binstruction[170]) {  /* code */
@@ -3439,17 +3366,17 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x5C100200,  //  0003  MOVE	R4	R1
       0x7C0C0200,  //  0004  CALL	R3	1
       0x4C100000,  //  0005  LDNIL	R4
-      0x8C140301,  //  0006  GETMET	R5	R1	K1
+      0x8C140304,  //  0006  GETMET	R5	R1	K4
       0x5C1C0400,  //  0007  MOVE	R7	R2
-      0x58200002,  //  0008  LDCONST	R8	K2
+      0x58200005,  //  0008  LDCONST	R8	K5
       0x7C140600,  //  0009  CALL	R5	3
       0x541A0014,  //  000A  LDINT	R6	21
       0x20140A06,  //  000B  NE	R5	R5	R6
       0x78160001,  //  000C  JMPF	R5	#000F
       0x4C140000,  //  000D  LDNIL	R5
       0x80040A00,  //  000E  RET	1	R5
-      0x00080502,  //  000F  ADD	R2	R2	K2
-      0x8C140301,  //  0010  GETMET	R5	R1	K1
+      0x00080505,  //  000F  ADD	R2	R2	K5
+      0x8C140304,  //  0010  GETMET	R5	R1	K4
       0x5C1C0400,  //  0011  MOVE	R7	R2
       0x5421FFFD,  //  0012  LDINT	R8	-2
       0x7C140600,  //  0013  CALL	R5	3
@@ -3462,9 +3389,9 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x78160003,  //  001A  JMPF	R5	#001F
       0x541628FF,  //  001B  LDINT	R5	10496
       0x1C140805,  //  001C  EQ	R5	R4	R5
-      0x90020605,  //  001D  SETMBR	R0	K3	R5
-      0x00080504,  //  001E  ADD	R2	R2	K4
-      0x8C140301,  //  001F  GETMET	R5	R1	K1
+      0x90020205,  //  001D  SETMBR	R0	K1	R5
+      0x00080506,  //  001E  ADD	R2	R2	K6
+      0x8C140304,  //  001F  GETMET	R5	R1	K4
       0x5C1C0400,  //  0020  MOVE	R7	R2
       0x5421FFFD,  //  0021  LDINT	R8	-2
       0x7C140600,  //  0022  CALL	R5	3
@@ -3477,9 +3404,9 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x78160003,  //  0029  JMPF	R5	#002E
       0x54162900,  //  002A  LDINT	R5	10497
       0x1C140805,  //  002B  EQ	R5	R4	R5
-      0x90020605,  //  002C  SETMBR	R0	K3	R5
-      0x00080504,  //  002D  ADD	R2	R2	K4
-      0x8C140301,  //  002E  GETMET	R5	R1	K1
+      0x90020205,  //  002C  SETMBR	R0	K1	R5
+      0x00080506,  //  002D  ADD	R2	R2	K6
+      0x8C140304,  //  002E  GETMET	R5	R1	K4
       0x5C1C0400,  //  002F  MOVE	R7	R2
       0x5421FFFD,  //  0030  LDINT	R8	-2
       0x7C140600,  //  0031  CALL	R5	3
@@ -3488,18 +3415,18 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x78160001,  //  0034  JMPF	R5	#0037
       0x4C140000,  //  0035  LDNIL	R5
       0x80040A00,  //  0036  RET	1	R5
-      0x00080504,  //  0037  ADD	R2	R2	K4
-      0x8C140301,  //  0038  GETMET	R5	R1	K1
+      0x00080506,  //  0037  ADD	R2	R2	K6
+      0x8C140304,  //  0038  GETMET	R5	R1	K4
       0x5C1C0400,  //  0039  MOVE	R7	R2
-      0x58200002,  //  003A  LDCONST	R8	K2
+      0x58200005,  //  003A  LDCONST	R8	K5
       0x7C140600,  //  003B  CALL	R5	3
       0x541A0014,  //  003C  LDINT	R6	21
       0x20140A06,  //  003D  NE	R5	R5	R6
       0x78160001,  //  003E  JMPF	R5	#0041
       0x4C140000,  //  003F  LDNIL	R5
       0x80040A00,  //  0040  RET	1	R5
-      0x00080502,  //  0041  ADD	R2	R2	K2
-      0x8C140301,  //  0042  GETMET	R5	R1	K1
+      0x00080505,  //  0041  ADD	R2	R2	K5
+      0x8C140304,  //  0042  GETMET	R5	R1	K4
       0x5C1C0400,  //  0043  MOVE	R7	R2
       0x5421FFFD,  //  0044  LDINT	R8	-2
       0x7C140600,  //  0045  CALL	R5	3
@@ -3508,65 +3435,65 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x78160001,  //  0048  JMPF	R5	#004B
       0x4C140000,  //  0049  LDNIL	R5
       0x80040A00,  //  004A  RET	1	R5
-      0x00080504,  //  004B  ADD	R2	R2	K4
+      0x00080506,  //  004B  ADD	R2	R2	K6
       0x14140403,  //  004C  LT	R5	R2	R3
       0x7816002C,  //  004D  JMPF	R5	#007B
-      0x8C140301,  //  004E  GETMET	R5	R1	K1
-      0x001C0502,  //  004F  ADD	R7	R2	K2
-      0x58200002,  //  0050  LDCONST	R8	K2
+      0x8C140304,  //  004E  GETMET	R5	R1	K4
+      0x001C0505,  //  004F  ADD	R7	R2	K5
+      0x58200005,  //  0050  LDCONST	R8	K5
       0x7C140600,  //  0051  CALL	R5	3
-      0x8C180301,  //  0052  GETMET	R6	R1	K1
+      0x8C180304,  //  0052  GETMET	R6	R1	K4
       0x5C200400,  //  0053  MOVE	R8	R2
-      0x58240002,  //  0054  LDCONST	R9	K2
+      0x58240005,  //  0054  LDCONST	R9	K5
       0x7C180600,  //  0055  CALL	R6	3
       0x541E0023,  //  0056  LDINT	R7	36
       0x1C1C0C07,  //  0057  EQ	R7	R6	R7
       0x781E0006,  //  0058  JMPF	R7	#0060
-      0x8C1C0301,  //  0059  GETMET	R7	R1	K1
-      0x00240504,  //  005A  ADD	R9	R2	K4
-      0x58280002,  //  005B  LDCONST	R10	K2
+      0x8C1C0304,  //  0059  GETMET	R7	R1	K4
+      0x00240506,  //  005A  ADD	R9	R2	K6
+      0x58280005,  //  005B  LDCONST	R10	K5
       0x7C1C0600,  //  005C  CALL	R7	3
       0x5C100E00,  //  005D  MOVE	R4	R7
-      0x00080505,  //  005E  ADD	R2	R2	K5
+      0x00080507,  //  005E  ADD	R2	R2	K7
       0x7002000B,  //  005F  JMP		#006C
       0x541E0024,  //  0060  LDINT	R7	37
       0x1C1C0C07,  //  0061  EQ	R7	R6	R7
       0x781E0007,  //  0062  JMPF	R7	#006B
-      0x8C1C0301,  //  0063  GETMET	R7	R1	K1
-      0x00240504,  //  0064  ADD	R9	R2	K4
-      0x58280004,  //  0065  LDCONST	R10	K4
+      0x8C1C0304,  //  0063  GETMET	R7	R1	K4
+      0x00240506,  //  0064  ADD	R9	R2	K6
+      0x58280006,  //  0065  LDCONST	R10	K6
       0x7C1C0600,  //  0066  CALL	R7	3
       0x5C100E00,  //  0067  MOVE	R4	R7
       0x541E0003,  //  0068  LDINT	R7	4
       0x00080407,  //  0069  ADD	R2	R2	R7
       0x70020000,  //  006A  JMP		#006C
       0x7002000E,  //  006B  JMP		#007B
-      0x1C1C0B06,  //  006C  EQ	R7	R5	K6
+      0x1C1C0B08,  //  006C  EQ	R7	R5	K8
       0x781E0001,  //  006D  JMPF	R7	#0070
-      0x90020E04,  //  006E  SETMBR	R0	K7	R4
+      0x90021204,  //  006E  SETMBR	R0	K9	R4
       0x70020009,  //  006F  JMP		#007A
-      0x1C1C0B02,  //  0070  EQ	R7	R5	K2
+      0x1C1C0B05,  //  0070  EQ	R7	R5	K5
       0x781E0001,  //  0071  JMPF	R7	#0074
-      0x90021004,  //  0072  SETMBR	R0	K8	R4
+      0x90021404,  //  0072  SETMBR	R0	K10	R4
       0x70020005,  //  0073  JMP		#007A
-      0x1C1C0B04,  //  0074  EQ	R7	R5	K4
+      0x1C1C0B06,  //  0074  EQ	R7	R5	K6
       0x781E0001,  //  0075  JMPF	R7	#0078
-      0x90021204,  //  0076  SETMBR	R0	K9	R4
+      0x90021604,  //  0076  SETMBR	R0	K11	R4
       0x70020001,  //  0077  JMP		#007A
       0x4C1C0000,  //  0078  LDNIL	R7
       0x80040E00,  //  0079  RET	1	R7
       0x7001FFD0,  //  007A  JMP		#004C
-      0x8C140301,  //  007B  GETMET	R5	R1	K1
+      0x8C140304,  //  007B  GETMET	R5	R1	K4
       0x5C1C0400,  //  007C  MOVE	R7	R2
-      0x58200002,  //  007D  LDCONST	R8	K2
+      0x58200005,  //  007D  LDCONST	R8	K5
       0x7C140600,  //  007E  CALL	R5	3
       0x541A0017,  //  007F  LDINT	R6	24
       0x20140A06,  //  0080  NE	R5	R5	R6
       0x78160001,  //  0081  JMPF	R5	#0084
       0x4C140000,  //  0082  LDNIL	R5
       0x80040A00,  //  0083  RET	1	R5
-      0x00080502,  //  0084  ADD	R2	R2	K2
-      0x8C140301,  //  0085  GETMET	R5	R1	K1
+      0x00080505,  //  0084  ADD	R2	R2	K5
+      0x8C140304,  //  0085  GETMET	R5	R1	K4
       0x5C1C0400,  //  0086  MOVE	R7	R2
       0x5421FFFD,  //  0087  LDINT	R8	-2
       0x7C140600,  //  0088  CALL	R5	3
@@ -3575,16 +3502,16 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x78160001,  //  008B  JMPF	R5	#008E
       0x4C140000,  //  008C  LDNIL	R5
       0x80040A00,  //  008D  RET	1	R5
-      0xB8161600,  //  008E  GETNGBL	R5	K11
-      0x88140B0C,  //  008F  GETMBR	R5	R5	K12
-      0x8C140B0D,  //  0090  GETMET	R5	R5	K13
+      0xB8161800,  //  008E  GETNGBL	R5	K12
+      0x88140B0D,  //  008F  GETMBR	R5	R5	K13
+      0x8C140B0E,  //  0090  GETMET	R5	R5	K14
       0x5C1C0200,  //  0091  MOVE	R7	R1
       0x5C200400,  //  0092  MOVE	R8	R2
       0x7C140600,  //  0093  CALL	R5	3
-      0x90021405,  //  0094  SETMBR	R0	K10	R5
-      0x8814010A,  //  0095  GETMBR	R5	R0	K10
-      0x88080B0E,  //  0096  GETMBR	R2	R5	K14
-      0x8C180301,  //  0097  GETMET	R6	R1	K1
+      0x90020605,  //  0094  SETMBR	R0	K3	R5
+      0x88140103,  //  0095  GETMBR	R5	R0	K3
+      0x88080B0F,  //  0096  GETMBR	R2	R5	K15
+      0x8C180304,  //  0097  GETMET	R6	R1	K4
       0x5C200400,  //  0098  MOVE	R8	R2
       0x5425FFFD,  //  0099  LDINT	R9	-2
       0x7C180600,  //  009A  CALL	R6	3
@@ -3593,12 +3520,12 @@ be_local_closure(class_Matter_InvokeRequestMessage_solo_from_raw,   /* name */
       0x781A0001,  //  009D  JMPF	R6	#00A0
       0x4C180000,  //  009E  LDNIL	R6
       0x80040C00,  //  009F  RET	1	R6
-      0x00080504,  //  00A0  ADD	R2	R2	K4
-      0x8C140301,  //  00A1  GETMET	R5	R1	K1
+      0x00080506,  //  00A0  ADD	R2	R2	K6
+      0x8C140304,  //  00A1  GETMET	R5	R1	K4
       0x5C1C0400,  //  00A2  MOVE	R7	R2
       0x5421FFFB,  //  00A3  LDINT	R8	-4
       0x7C140600,  //  00A4  CALL	R5	3
-      0x20140B0F,  //  00A5  NE	R5	R5	K15
+      0x20140B10,  //  00A5  NE	R5	R5	K16
       0x78160001,  //  00A6  JMPF	R5	#00A9
       0x4C140000,  //  00A7  LDNIL	R5
       0x80040A00,  //  00A8  RET	1	R5

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -3,6 +3,38 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_IM_Message' ktab size: 28, total: 48 (saved 160 bytes)
+static const bvalue be_ktab_class_Matter_IM_Message[28] = {
+  /* K0   */  be_nested_str_weak(resp),
+  /* K1   */  be_nested_str_weak(build_response),
+  /* K2   */  be_nested_str_weak(ready),
+  /* K3   */  be_nested_str_weak(expiration),
+  /* K4   */  be_nested_str_weak(tasmota),
+  /* K5   */  be_nested_str_weak(millis),
+  /* K6   */  be_nested_str_weak(MSG_TIMEOUT),
+  /* K7   */  be_nested_str_weak(last_counter),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(finishing),
+  /* K10  */  be_nested_str_weak(finished),
+  /* K11  */  be_nested_str_weak(data),
+  /* K12  */  be_nested_str_weak(reset),
+  /* K13  */  be_nested_str_weak(to_TLV),
+  /* K14  */  be_nested_str_weak(tlv2raw),
+  /* K15  */  be_nested_str_weak(encode_frame),
+  /* K16  */  be_nested_str_weak(encrypt),
+  /* K17  */  be_nested_str_weak(loglevel),
+  /* K18  */  be_nested_str_weak(log),
+  /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25s_X20exch_X3D_X25s_X20rack_X3D_X25s),
+  /* K20  */  be_nested_str_weak(session),
+  /* K21  */  be_nested_str_weak(local_session_id),
+  /* K22  */  be_nested_str_weak(message_counter),
+  /* K23  */  be_nested_str_weak(exchange_id),
+  /* K24  */  be_nested_str_weak(ack_message_counter),
+  /* K25  */  be_nested_str_weak(send_response_frame),
+  /* K26  */  be_nested_str_weak(opcode),
+  /* K27  */  be_nested_str_weak(x_flag_r),
+};
+
 
 extern const bclass be_class_Matter_IM_Message;
 
@@ -13,26 +45,13 @@ be_local_closure(class_Matter_IM_Message_reset,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(build_response),
-    /* K2   */  be_nested_str_weak(ready),
-    /* K3   */  be_nested_str_weak(expiration),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(millis),
-    /* K6   */  be_nested_str_weak(MSG_TIMEOUT),
-    /* K7   */  be_nested_str_weak(last_counter),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(finishing),
-    /* K10  */  be_nested_str_weak(finished),
-    /* K11  */  be_nested_str_weak(data),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
@@ -75,19 +94,17 @@ be_local_closure(class_Matter_IM_Message_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x8C10010C,  //  0000  GETMET	R4	R0	K12
       0x5C180200,  //  0001  MOVE	R6	R1
       0x5C1C0400,  //  0002  MOVE	R7	R2
       0x5C200600,  //  0003  MOVE	R8	R3
@@ -106,69 +123,50 @@ be_local_closure(class_Matter_IM_Message_send_im,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(data),
-    /* K2   */  be_nested_str_weak(to_TLV),
-    /* K3   */  be_nested_str_weak(tlv2raw),
-    /* K4   */  be_nested_str_weak(encode_frame),
-    /* K5   */  be_nested_str_weak(encrypt),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(loglevel),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25s_X20exch_X3D_X25s_X20rack_X3D_X25s),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_nested_str_weak(message_counter),
-    /* K13  */  be_nested_str_weak(exchange_id),
-    /* K14  */  be_nested_str_weak(ack_message_counter),
-    /* K15  */  be_nested_str_weak(send_response_frame),
-    /* K16  */  be_nested_str_weak(last_counter),
-    /* K17  */  be_nested_str_weak(finishing),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(send_im),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x880C010B,  //  0001  GETMBR	R3	R0	K11
+      0x8C0C070D,  //  0002  GETMET	R3	R3	K13
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x8C0C070E,  //  0004  GETMET	R3	R3	K14
       0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100504,  //  0006  GETMET	R4	R2	K4
+      0x8C10050F,  //  0006  GETMET	R4	R2	K15
       0x5C180600,  //  0007  MOVE	R6	R3
       0x7C100400,  //  0008  CALL	R4	2
-      0x8C100505,  //  0009  GETMET	R4	R2	K5
+      0x8C100510,  //  0009  GETMET	R4	R2	K16
       0x7C100200,  //  000A  CALL	R4	1
-      0xB8120C00,  //  000B  GETNGBL	R4	K6
-      0x8C100907,  //  000C  GETMET	R4	R4	K7
+      0xB8120800,  //  000B  GETNGBL	R4	K4
+      0x8C100911,  //  000C  GETMET	R4	R4	K17
       0x541A0003,  //  000D  LDINT	R6	4
       0x7C100400,  //  000E  CALL	R4	2
       0x7812000A,  //  000F  JMPF	R4	#001B
-      0xB8121000,  //  0010  GETNGBL	R4	K8
+      0xB8122400,  //  0010  GETNGBL	R4	K18
       0x60140018,  //  0011  GETGBL	R5	G24
-      0x58180009,  //  0012  LDCONST	R6	K9
-      0x881C050A,  //  0013  GETMBR	R7	R2	K10
-      0x881C0F0B,  //  0014  GETMBR	R7	R7	K11
-      0x8820050C,  //  0015  GETMBR	R8	R2	K12
-      0x8824050D,  //  0016  GETMBR	R9	R2	K13
-      0x8828050E,  //  0017  GETMBR	R10	R2	K14
+      0x58180013,  //  0012  LDCONST	R6	K19
+      0x881C0514,  //  0013  GETMBR	R7	R2	K20
+      0x881C0F15,  //  0014  GETMBR	R7	R7	K21
+      0x88200516,  //  0015  GETMBR	R8	R2	K22
+      0x88240517,  //  0016  GETMBR	R9	R2	K23
+      0x88280518,  //  0017  GETMBR	R10	R2	K24
       0x7C140A00,  //  0018  CALL	R5	5
       0x541A0003,  //  0019  LDINT	R6	4
       0x7C100400,  //  001A  CALL	R4	2
-      0x8C10030F,  //  001B  GETMET	R4	R1	K15
+      0x8C100319,  //  001B  GETMET	R4	R1	K25
       0x5C180400,  //  001C  MOVE	R6	R2
       0x7C100400,  //  001D  CALL	R4	2
-      0x8810050C,  //  001E  GETMBR	R4	R2	K12
-      0x90022004,  //  001F  SETMBR	R0	K16	R4
+      0x88100516,  //  001E  GETMBR	R4	R2	K22
+      0x90020E04,  //  001F  SETMBR	R0	K7	R4
       0x50100200,  //  0020  LDBOOL	R4	1	0
-      0x90022204,  //  0021  SETMBR	R0	K17	R4
+      0x90021204,  //  0021  SETMBR	R0	K9	R4
       0x80000000,  //  0022  RET	0
     })
   )
@@ -183,13 +181,13 @@ be_local_closure(class_Matter_IM_Message_status_error_received,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(status_error_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -207,21 +205,18 @@ be_local_closure(class_Matter_IM_Message_get_exchangeid,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(get_exchangeid),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040317,  //  0001  GETMBR	R1	R1	K23
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -236,34 +231,27 @@ be_local_closure(class_Matter_IM_Message_ack_received,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(finishing),
-    /* K1   */  be_nested_str_weak(finished),
-    /* K2   */  be_nested_str_weak(expiration),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(millis),
-    /* K5   */  be_nested_str_weak(MSG_TIMEOUT),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(ack_received),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080109,  //  0000  GETMBR	R2	R0	K9
       0x780A0002,  //  0001  JMPF	R2	#0005
       0x50080200,  //  0002  LDBOOL	R2	1	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0x90021402,  //  0003  SETMBR	R0	K10	R2
       0x70020005,  //  0004  JMP		#000B
-      0xB80A0600,  //  0005  GETNGBL	R2	K3
-      0x8C080504,  //  0006  GETMET	R2	R2	K4
+      0xB80A0800,  //  0005  GETNGBL	R2	K4
+      0x8C080505,  //  0006  GETMET	R2	R2	K5
       0x7C080200,  //  0007  CALL	R2	1
-      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x880C0106,  //  0008  GETMBR	R3	R0	K6
       0x00080403,  //  0009  ADD	R2	R2	R3
-      0x90020402,  //  000A  SETMBR	R0	K2	R2
+      0x90020602,  //  000A  SETMBR	R0	K3	R2
       0x50080000,  //  000B  LDBOOL	R2	0	0
       0x80040400,  //  000C  RET	1	R2
     })
@@ -279,13 +267,13 @@ be_local_closure(class_Matter_IM_Message_reached_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(reached_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -303,43 +291,33 @@ be_local_closure(class_Matter_IM_Message_status_ok_received,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expiration),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
-    /* K4   */  be_nested_str_weak(resp),
-    /* K5   */  be_nested_str_weak(build_response),
-    /* K6   */  be_nested_str_weak(opcode),
-    /* K7   */  be_nested_str_weak(x_flag_r),
-    /* K8   */  be_nested_str_weak(ready),
-    }),
+    &be_ktab_class_Matter_IM_Message,     /* shared constants */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0xB80A0200,  //  0000  GETNGBL	R2	K1
-      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0xB80A0800,  //  0000  GETNGBL	R2	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
       0x7C080200,  //  0002  CALL	R2	1
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x880C0106,  //  0003  GETMBR	R3	R0	K6
       0x00080403,  //  0004  ADD	R2	R2	R3
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x90020602,  //  0005  SETMBR	R0	K3	R2
       0x78060007,  //  0006  JMPF	R1	#000F
-      0x8C080305,  //  0007  GETMET	R2	R1	K5
-      0x88100104,  //  0008  GETMBR	R4	R0	K4
-      0x88100906,  //  0009  GETMBR	R4	R4	K6
-      0x88140104,  //  000A  GETMBR	R5	R0	K4
-      0x88140B07,  //  000B  GETMBR	R5	R5	K7
-      0x88180104,  //  000C  GETMBR	R6	R0	K4
+      0x8C080301,  //  0007  GETMET	R2	R1	K1
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x8810091A,  //  0009  GETMBR	R4	R4	K26
+      0x88140100,  //  000A  GETMBR	R5	R0	K0
+      0x88140B1B,  //  000B  GETMBR	R5	R5	K27
+      0x88180100,  //  000C  GETMBR	R6	R0	K0
       0x7C080800,  //  000D  CALL	R2	4
-      0x90020802,  //  000E  SETMBR	R0	K4	R2
+      0x90020002,  //  000E  SETMBR	R0	K0	R2
       0x50080200,  //  000F  LDBOOL	R2	1	0
-      0x90021002,  //  0010  SETMBR	R0	K8	R2
+      0x90020402,  //  0010  SETMBR	R0	K2	R2
       0x50080200,  //  0011  LDBOOL	R2	1	0
       0x80040400,  //  0012  RET	1	R2
     })
@@ -539,6 +517,61 @@ be_local_class(Matter_IM_WriteResponse,
     })),
     be_str_weak(Matter_IM_WriteResponse)
 );
+// compact class 'Matter_IM_ReportData_Pull' ktab size: 51, total: 57 (saved 48 bytes)
+static const bvalue be_ktab_class_Matter_IM_ReportData_Pull[51] = {
+  /* K0   */  be_nested_str_weak(resp),
+  /* K1   */  be_nested_str_weak(data),
+  /* K2   */  be_nested_str_weak(device),
+  /* K3   */  be_nested_str_weak(debug),
+  /* K4   */  be_nested_str_weak(data_ev),
+  /* K5   */  be_nested_str_weak(event_generator_or_arr),
+  /* K6   */  be_nested_str_weak(generator_or_arr),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(next_attribute),
+  /* K9   */  be_nested_str_weak(is_direct),
+  /* K10  */  be_nested_str_weak(im),
+  /* K11  */  be_nested_str_weak(read_single_attribute_to_bytes),
+  /* K12  */  be_nested_str_weak(get_pi),
+  /* K13  */  be_nested_str_weak(session),
+  /* K14  */  be_nested_str_weak(MAX_MESSAGE),
+  /* K15  */  be_nested_str_weak(append),
+  /* K16  */  be_nested_str_weak(remove),
+  /* K17  */  be_nested_str_weak(next_event),
+  /* K18  */  be_nested_str_weak(tasmota),
+  /* K19  */  be_nested_str_weak(loglevel),
+  /* K20  */  be_const_int(3),
+  /* K21  */  be_nested_str_weak(),
+  /* K22  */  be_nested_str_weak(data0),
+  /* K23  */  be_nested_str_weak(_X20_X2D_X20),
+  /* K24  */  be_nested_str_weak(data1),
+  /* K25  */  be_nested_str_weak(_X2C_X20),
+  /* K26  */  be_nested_str_weak(data2),
+  /* K27  */  be_nested_str_weak(log),
+  /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X7C_X258s_X29_X20_X5B_X2502X_X5D_X2504X_X2F_X2502X_X25s),
+  /* K29  */  be_nested_str_weak(local_session_id),
+  /* K30  */  be_nested_str_weak(event_no),
+  /* K31  */  be_nested_str_weak(endpoint),
+  /* K32  */  be_nested_str_weak(cluster),
+  /* K33  */  be_nested_str_weak(event_id),
+  /* K34  */  be_nested_str_weak(to_raw_bytes),
+  /* K35  */  be_nested_str_weak(add),
+  /* K36  */  be_const_int(1),
+  /* K37  */  be_nested_str_weak(subscription_id),
+  /* K38  */  be_const_int(2),
+  /* K39  */  be_nested_str_weak(suppress_response),
+  /* K40  */  be_nested_str_weak(encode_frame),
+  /* K41  */  be_nested_str_weak(encrypt),
+  /* K42  */  be_nested_str_weak(send_response_frame),
+  /* K43  */  be_nested_str_weak(last_counter),
+  /* K44  */  be_nested_str_weak(message_counter),
+  /* K45  */  be_nested_str_weak(ready),
+  /* K46  */  be_nested_str_weak(finishing),
+  /* K47  */  be_nested_str_weak(status_ok_received),
+  /* K48  */  be_nested_str_weak(_message_handler),
+  /* K49  */  be_nested_str_weak(send_encrypted_ack),
+  /* K50  */  be_nested_str_weak(init),
+};
+
 
 extern const bclass be_class_Matter_IM_ReportData_Pull;
 
@@ -549,61 +582,13 @@ be_local_closure(class_Matter_IM_ReportData_Pull_send_im,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[47]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(data),
-    /* K2   */  be_nested_str_weak(device),
-    /* K3   */  be_nested_str_weak(debug),
-    /* K4   */  be_nested_str_weak(data_ev),
-    /* K5   */  be_nested_str_weak(event_generator_or_arr),
-    /* K6   */  be_nested_str_weak(generator_or_arr),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(next_attribute),
-    /* K9   */  be_nested_str_weak(is_direct),
-    /* K10  */  be_nested_str_weak(im),
-    /* K11  */  be_nested_str_weak(read_single_attribute_to_bytes),
-    /* K12  */  be_nested_str_weak(get_pi),
-    /* K13  */  be_nested_str_weak(session),
-    /* K14  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K15  */  be_nested_str_weak(append),
-    /* K16  */  be_nested_str_weak(remove),
-    /* K17  */  be_nested_str_weak(next_event),
-    /* K18  */  be_nested_str_weak(tasmota),
-    /* K19  */  be_nested_str_weak(loglevel),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(),
-    /* K22  */  be_nested_str_weak(data0),
-    /* K23  */  be_nested_str_weak(_X20_X2D_X20),
-    /* K24  */  be_nested_str_weak(data1),
-    /* K25  */  be_nested_str_weak(_X2C_X20),
-    /* K26  */  be_nested_str_weak(data2),
-    /* K27  */  be_nested_str_weak(log),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Event_X28_X256i_X7C_X258s_X29_X20_X5B_X2502X_X5D_X2504X_X2F_X2502X_X25s),
-    /* K29  */  be_nested_str_weak(local_session_id),
-    /* K30  */  be_nested_str_weak(event_no),
-    /* K31  */  be_nested_str_weak(endpoint),
-    /* K32  */  be_nested_str_weak(cluster),
-    /* K33  */  be_nested_str_weak(event_id),
-    /* K34  */  be_nested_str_weak(to_raw_bytes),
-    /* K35  */  be_nested_str_weak(add),
-    /* K36  */  be_const_int(1),
-    /* K37  */  be_nested_str_weak(subscription_id),
-    /* K38  */  be_const_int(2),
-    /* K39  */  be_nested_str_weak(suppress_response),
-    /* K40  */  be_nested_str_weak(encode_frame),
-    /* K41  */  be_nested_str_weak(encrypt),
-    /* K42  */  be_nested_str_weak(send_response_frame),
-    /* K43  */  be_nested_str_weak(last_counter),
-    /* K44  */  be_nested_str_weak(message_counter),
-    /* K45  */  be_nested_str_weak(ready),
-    /* K46  */  be_nested_str_weak(finishing),
-    }),
+    &be_ktab_class_Matter_IM_ReportData_Pull,     /* shared constants */
     be_str_weak(send_im),
     &be_const_str_solidified,
     ( &(const binstruction[361]) {  /* code */
@@ -981,33 +966,27 @@ be_local_closure(class_Matter_IM_ReportData_Pull_status_ok_received,   /* name *
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status_ok_received),
-    /* K1   */  be_nested_str_weak(finishing),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(_message_handler),
-    /* K4   */  be_nested_str_weak(send_encrypted_ack),
-    }),
+    &be_ktab_class_Matter_IM_ReportData_Pull,     /* shared constants */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C08052F,  //  0003  GETMET	R2	R2	K47
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x8808012E,  //  0006  GETMBR	R2	R0	K46
       0x740A0005,  //  0007  JMPT	R2	#000E
-      0x88080302,  //  0008  GETMBR	R2	R1	K2
-      0x88080503,  //  0009  GETMBR	R2	R2	K3
-      0x8C080504,  //  000A  GETMET	R2	R2	K4
+      0x8808030D,  //  0008  GETMBR	R2	R1	K13
+      0x88080530,  //  0009  GETMBR	R2	R2	K48
+      0x8C080531,  //  000A  GETMET	R2	R2	K49
       0x5C100200,  //  000B  MOVE	R4	R1
       0x50140000,  //  000C  LDBOOL	R5	0	0
       0x7C080600,  //  000D  CALL	R2	3
@@ -1026,19 +1005,17 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_subscription_id,   /* name 
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subscription_id),
-    }),
+    &be_ktab_class_Matter_IM_ReportData_Pull,     /* shared constants */
     be_str_weak(set_subscription_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024A01,  //  0000  SETMBR	R0	K37	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1053,19 +1030,17 @@ be_local_closure(class_Matter_IM_ReportData_Pull_set_suppress_response,   /* nam
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(suppress_response),
-    }),
+    &be_ktab_class_Matter_IM_ReportData_Pull,     /* shared constants */
     be_str_weak(set_suppress_response),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024E01,  //  0000  SETMBR	R0	K39	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1080,30 +1055,26 @@ be_local_closure(class_Matter_IM_ReportData_Pull_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(generator_or_arr),
-    /* K2   */  be_nested_str_weak(event_generator_or_arr),
-    }),
+    &be_ktab_class_Matter_IM_ReportData_Pull,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100932,  //  0003  GETMET	R4	R4	K50
       0x5C180200,  //  0004  MOVE	R6	R1
       0x541E0004,  //  0005  LDINT	R7	5
       0x50200200,  //  0006  LDBOOL	R8	1	0
       0x7C100800,  //  0007  CALL	R4	4
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x90020403,  //  0009  SETMBR	R0	K2	R3
+      0x90020C02,  //  0008  SETMBR	R0	K6	R2
+      0x90020A03,  //  0009  SETMBR	R0	K5	R3
       0x80000000,  //  000A  RET	0
     })
   )
@@ -1134,6 +1105,44 @@ be_local_class(Matter_IM_ReportData_Pull,
     })),
     be_str_weak(Matter_IM_ReportData_Pull)
 );
+// compact class 'Matter_IM_ReportDataSubscribed_Pull' ktab size: 34, total: 46 (saved 96 bytes)
+static const bvalue be_ktab_class_Matter_IM_ReportDataSubscribed_Pull[34] = {
+  /* K0   */  be_nested_str_weak(ack_received),
+  /* K1   */  be_nested_str_weak(report_data_phase),
+  /* K2   */  be_nested_str_weak(sub),
+  /* K3   */  be_nested_str_weak(is_keep_alive),
+  /* K4   */  be_nested_str_weak(re_arm),
+  /* K5   */  be_nested_str_weak(ready),
+  /* K6   */  be_nested_str_weak(generator_or_arr),
+  /* K7   */  be_nested_str_weak(event_generator_or_arr),
+  /* K8   */  be_nested_str_weak(send_im),
+  /* K9   */  be_nested_str_weak(finishing),
+  /* K10  */  be_nested_str_weak(finished),
+  /* K11  */  be_nested_str_weak(resp),
+  /* K12  */  be_nested_str_weak(build_standalone_ack),
+  /* K13  */  be_nested_str_weak(encode_frame),
+  /* K14  */  be_nested_str_weak(encrypt),
+  /* K15  */  be_nested_str_weak(tasmota),
+  /* K16  */  be_nested_str_weak(loglevel),
+  /* K17  */  be_nested_str_weak(log),
+  /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
+  /* K19  */  be_nested_str_weak(session),
+  /* K20  */  be_nested_str_weak(local_session_id),
+  /* K21  */  be_nested_str_weak(ack_message_counter),
+  /* K22  */  be_nested_str_weak(message_counter),
+  /* K23  */  be_nested_str_weak(send_response_frame),
+  /* K24  */  be_nested_str_weak(last_counter),
+  /* K25  */  be_nested_str_weak(init),
+  /* K26  */  be_nested_str_weak(matter),
+  /* K27  */  be_nested_str_weak(Frame),
+  /* K28  */  be_nested_str_weak(initiate_response),
+  /* K29  */  be_nested_str_weak(set_subscription_id),
+  /* K30  */  be_nested_str_weak(subscription_id),
+  /* K31  */  be_nested_str_weak(set_suppress_response),
+  /* K32  */  be_nested_str_weak(remove_self),
+  /* K33  */  be_nested_str_weak(status_ok_received),
+};
+
 
 extern const bclass be_class_Matter_IM_ReportDataSubscribed_Pull;
 
@@ -1144,19 +1153,13 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_ack_received,   /* na
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ack_received),
-    /* K1   */  be_nested_str_weak(report_data_phase),
-    /* K2   */  be_nested_str_weak(sub),
-    /* K3   */  be_nested_str_weak(is_keep_alive),
-    /* K4   */  be_nested_str_weak(re_arm),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(ack_received),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
@@ -1193,115 +1196,91 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_send_im,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ready),
-    /* K1   */  be_nested_str_weak(generator_or_arr),
-    /* K2   */  be_nested_str_weak(event_generator_or_arr),
-    /* K3   */  be_nested_str_weak(report_data_phase),
-    /* K4   */  be_nested_str_weak(send_im),
-    /* K5   */  be_nested_str_weak(finishing),
-    /* K6   */  be_nested_str_weak(finished),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(build_standalone_ack),
-    /* K9   */  be_nested_str_weak(encode_frame),
-    /* K10  */  be_nested_str_weak(encrypt),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(loglevel),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
-    /* K15  */  be_nested_str_weak(session),
-    /* K16  */  be_nested_str_weak(local_session_id),
-    /* K17  */  be_nested_str_weak(ack_message_counter),
-    /* K18  */  be_nested_str_weak(message_counter),
-    /* K19  */  be_nested_str_weak(send_response_frame),
-    /* K20  */  be_nested_str_weak(last_counter),
-    /* K21  */  be_nested_str_weak(sub),
-    /* K22  */  be_nested_str_weak(re_arm),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(send_im),
     &be_const_str_solidified,
     ( &(const binstruction[77]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080105,  //  0000  GETMBR	R2	R0	K5
       0x740A0001,  //  0001  JMPT	R2	#0004
       0x50080000,  //  0002  LDBOOL	R2	0	0
       0x80040400,  //  0003  RET	1	R2
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x88080106,  //  0004  GETMBR	R2	R0	K6
       0x4C0C0000,  //  0005  LDNIL	R3
       0x20080403,  //  0006  NE	R2	R2	R3
       0x740A0003,  //  0007  JMPT	R2	#000C
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x88080107,  //  0008  GETMBR	R2	R0	K7
       0x4C0C0000,  //  0009  LDNIL	R3
       0x20080403,  //  000A  NE	R2	R2	R3
       0x780A0031,  //  000B  JMPF	R2	#003E
-      0x88080103,  //  000C  GETMBR	R2	R0	K3
+      0x88080101,  //  000C  GETMBR	R2	R0	K1
       0x780A000F,  //  000D  JMPF	R2	#001E
       0x60080003,  //  000E  GETGBL	R2	G3
       0x5C0C0000,  //  000F  MOVE	R3	R0
       0x7C080200,  //  0010  CALL	R2	1
-      0x8C080504,  //  0011  GETMET	R2	R2	K4
+      0x8C080508,  //  0011  GETMET	R2	R2	K8
       0x5C100200,  //  0012  MOVE	R4	R1
       0x7C080400,  //  0013  CALL	R2	2
-      0x88080105,  //  0014  GETMBR	R2	R0	K5
+      0x88080109,  //  0014  GETMBR	R2	R0	K9
       0x740A0000,  //  0015  JMPT	R2	#0017
       0x80000400,  //  0016  RET	0
       0x50080000,  //  0017  LDBOOL	R2	0	0
-      0x90020602,  //  0018  SETMBR	R0	K3	R2
+      0x90020202,  //  0018  SETMBR	R0	K1	R2
       0x50080000,  //  0019  LDBOOL	R2	0	0
-      0x90020002,  //  001A  SETMBR	R0	K0	R2
+      0x90020A02,  //  001A  SETMBR	R0	K5	R2
       0x50080000,  //  001B  LDBOOL	R2	0	0
-      0x90020C02,  //  001C  SETMBR	R0	K6	R2
+      0x90021402,  //  001C  SETMBR	R0	K10	R2
       0x7002001E,  //  001D  JMP		#003D
-      0x88080107,  //  001E  GETMBR	R2	R0	K7
-      0x8C080508,  //  001F  GETMET	R2	R2	K8
+      0x8808010B,  //  001E  GETMBR	R2	R0	K11
+      0x8C08050C,  //  001F  GETMET	R2	R2	K12
       0x50100000,  //  0020  LDBOOL	R4	0	0
       0x7C080400,  //  0021  CALL	R2	2
-      0x8C0C0509,  //  0022  GETMET	R3	R2	K9
+      0x8C0C050D,  //  0022  GETMET	R3	R2	K13
       0x7C0C0200,  //  0023  CALL	R3	1
-      0x8C0C050A,  //  0024  GETMET	R3	R2	K10
+      0x8C0C050E,  //  0024  GETMET	R3	R2	K14
       0x7C0C0200,  //  0025  CALL	R3	1
-      0xB80E1600,  //  0026  GETNGBL	R3	K11
-      0x8C0C070C,  //  0027  GETMET	R3	R3	K12
+      0xB80E1E00,  //  0026  GETNGBL	R3	K15
+      0x8C0C0710,  //  0027  GETMET	R3	R3	K16
       0x54160003,  //  0028  LDINT	R5	4
       0x7C0C0400,  //  0029  CALL	R3	2
       0x780E0009,  //  002A  JMPF	R3	#0035
-      0xB80E1A00,  //  002B  GETNGBL	R3	K13
+      0xB80E2200,  //  002B  GETNGBL	R3	K17
       0x60100018,  //  002C  GETGBL	R4	G24
-      0x5814000E,  //  002D  LDCONST	R5	K14
-      0x8818050F,  //  002E  GETMBR	R6	R2	K15
-      0x88180D10,  //  002F  GETMBR	R6	R6	K16
-      0x881C0511,  //  0030  GETMBR	R7	R2	K17
-      0x88200512,  //  0031  GETMBR	R8	R2	K18
+      0x58140012,  //  002D  LDCONST	R5	K18
+      0x88180513,  //  002E  GETMBR	R6	R2	K19
+      0x88180D14,  //  002F  GETMBR	R6	R6	K20
+      0x881C0515,  //  0030  GETMBR	R7	R2	K21
+      0x88200516,  //  0031  GETMBR	R8	R2	K22
       0x7C100800,  //  0032  CALL	R4	4
       0x54160003,  //  0033  LDINT	R5	4
       0x7C0C0400,  //  0034  CALL	R3	2
-      0x8C0C0313,  //  0035  GETMET	R3	R1	K19
+      0x8C0C0317,  //  0035  GETMET	R3	R1	K23
       0x5C140400,  //  0036  MOVE	R5	R2
       0x7C0C0400,  //  0037  CALL	R3	2
-      0x880C0512,  //  0038  GETMBR	R3	R2	K18
-      0x90022803,  //  0039  SETMBR	R0	K20	R3
-      0x880C0115,  //  003A  GETMBR	R3	R0	K21
-      0x8C0C0716,  //  003B  GETMET	R3	R3	K22
+      0x880C0516,  //  0038  GETMBR	R3	R2	K22
+      0x90023003,  //  0039  SETMBR	R0	K24	R3
+      0x880C0102,  //  003A  GETMBR	R3	R0	K2
+      0x8C0C0704,  //  003B  GETMET	R3	R3	K4
       0x7C0C0200,  //  003C  CALL	R3	1
       0x7002000D,  //  003D  JMP		#004C
-      0x88080103,  //  003E  GETMBR	R2	R0	K3
+      0x88080101,  //  003E  GETMBR	R2	R0	K1
       0x780A0008,  //  003F  JMPF	R2	#0049
       0x60080003,  //  0040  GETGBL	R2	G3
       0x5C0C0000,  //  0041  MOVE	R3	R0
       0x7C080200,  //  0042  CALL	R2	1
-      0x8C080504,  //  0043  GETMET	R2	R2	K4
+      0x8C080508,  //  0043  GETMET	R2	R2	K8
       0x5C100200,  //  0044  MOVE	R4	R1
       0x7C080400,  //  0045  CALL	R2	2
       0x50080000,  //  0046  LDBOOL	R2	0	0
-      0x90020602,  //  0047  SETMBR	R0	K3	R2
+      0x90020202,  //  0047  SETMBR	R0	K1	R2
       0x70020002,  //  0048  JMP		#004C
-      0x88080115,  //  0049  GETMBR	R2	R0	K21
-      0x8C080516,  //  004A  GETMET	R2	R2	K22
+      0x88080102,  //  0049  GETMBR	R2	R0	K2
+      0x8C080504,  //  004A  GETMET	R2	R2	K4
       0x7C080200,  //  004B  CALL	R2	1
       0x80000000,  //  004C  RET	0
     })
@@ -1317,51 +1296,40 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_init,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(resp),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Frame),
-    /* K4   */  be_nested_str_weak(initiate_response),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(report_data_phase),
-    /* K7   */  be_nested_str_weak(set_subscription_id),
-    /* K8   */  be_nested_str_weak(subscription_id),
-    /* K9   */  be_nested_str_weak(set_suppress_response),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
       0x60180003,  //  0000  GETGBL	R6	G3
       0x5C1C0000,  //  0001  MOVE	R7	R0
       0x7C180200,  //  0002  CALL	R6	1
-      0x8C180D00,  //  0003  GETMET	R6	R6	K0
+      0x8C180D19,  //  0003  GETMET	R6	R6	K25
       0x4C200000,  //  0004  LDNIL	R8
       0x5C240600,  //  0005  MOVE	R9	R3
       0x5C280800,  //  0006  MOVE	R10	R4
       0x7C180800,  //  0007  CALL	R6	4
-      0xB81A0400,  //  0008  GETNGBL	R6	K2
-      0x88180D03,  //  0009  GETMBR	R6	R6	K3
-      0x8C180D04,  //  000A  GETMET	R6	R6	K4
+      0xB81A3400,  //  0008  GETNGBL	R6	K26
+      0x88180D1B,  //  0009  GETMBR	R6	R6	K27
+      0x8C180D1C,  //  000A  GETMET	R6	R6	K28
       0x5C200200,  //  000B  MOVE	R8	R1
       0x5C240400,  //  000C  MOVE	R9	R2
       0x542A0004,  //  000D  LDINT	R10	5
       0x502C0200,  //  000E  LDBOOL	R11	1	0
       0x7C180A00,  //  000F  CALL	R6	5
-      0x90020206,  //  0010  SETMBR	R0	K1	R6
-      0x90020A05,  //  0011  SETMBR	R0	K5	R5
+      0x90021606,  //  0010  SETMBR	R0	K11	R6
+      0x90020405,  //  0011  SETMBR	R0	K2	R5
       0x50180200,  //  0012  LDBOOL	R6	1	0
-      0x90020C06,  //  0013  SETMBR	R0	K6	R6
-      0x8C180107,  //  0014  GETMET	R6	R0	K7
-      0x88200B08,  //  0015  GETMBR	R8	R5	K8
+      0x90020206,  //  0013  SETMBR	R0	K1	R6
+      0x8C18011D,  //  0014  GETMET	R6	R0	K29
+      0x88200B1E,  //  0015  GETMBR	R8	R5	K30
       0x7C180400,  //  0016  CALL	R6	2
-      0x8C180109,  //  0017  GETMET	R6	R0	K9
+      0x8C18011F,  //  0017  GETMET	R6	R0	K31
       0x50200000,  //  0018  LDBOOL	R8	0	0
       0x7C180400,  //  0019  CALL	R6	2
       0x80000000,  //  001A  RET	0
@@ -1378,21 +1346,18 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_error_received
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sub),
-    /* K1   */  be_nested_str_weak(remove_self),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(status_error_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080520,  //  0001  GETMET	R2	R2	K32
       0x7C080200,  //  0002  CALL	R2	1
       0x80000000,  //  0003  RET	0
     })
@@ -1408,21 +1373,18 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_reached_timeout,   /*
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sub),
-    /* K1   */  be_nested_str_weak(remove_self),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(reached_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040320,  //  0001  GETMET	R1	R1	K32
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -1438,38 +1400,33 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_Pull_status_ok_received,  
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(report_data_phase),
-    /* K1   */  be_nested_str_weak(status_ok_received),
-    /* K2   */  be_nested_str_weak(sub),
-    /* K3   */  be_nested_str_weak(re_arm),
-    }),
+    &be_ktab_class_Matter_IM_ReportDataSubscribed_Pull,     /* shared constants */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
       0x780A0007,  //  0001  JMPF	R2	#000A
       0x60080003,  //  0002  GETGBL	R2	G3
       0x5C0C0000,  //  0003  MOVE	R3	R0
       0x7C080200,  //  0004  CALL	R2	1
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x8C080521,  //  0005  GETMET	R2	R2	K33
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
       0x80040400,  //  0008  RET	1	R2
       0x7002000A,  //  0009  JMP		#0015
       0x88080102,  //  000A  GETMBR	R2	R0	K2
-      0x8C080503,  //  000B  GETMET	R2	R2	K3
+      0x8C080504,  //  000B  GETMET	R2	R2	K4
       0x7C080200,  //  000C  CALL	R2	1
       0x60080003,  //  000D  GETGBL	R2	G3
       0x5C0C0000,  //  000E  MOVE	R3	R0
       0x7C080200,  //  000F  CALL	R2	1
-      0x8C080501,  //  0010  GETMET	R2	R2	K1
+      0x8C080521,  //  0010  GETMET	R2	R2	K33
       0x4C100000,  //  0011  LDNIL	R4
       0x7C080400,  //  0012  CALL	R2	2
       0x50080000,  //  0013  LDBOOL	R2	0	0
@@ -1501,6 +1458,23 @@ be_local_class(Matter_IM_ReportDataSubscribed_Pull,
     })),
     be_str_weak(Matter_IM_ReportDataSubscribed_Pull)
 );
+// compact class 'Matter_IM_SubscribedHeartbeat' ktab size: 13, total: 16 (saved 24 bytes)
+static const bvalue be_ktab_class_Matter_IM_SubscribedHeartbeat[13] = {
+  /* K0   */  be_nested_str_weak(sub),
+  /* K1   */  be_nested_str_weak(remove_self),
+  /* K2   */  be_nested_str_weak(send_im),
+  /* K3   */  be_nested_str_weak(ready),
+  /* K4   */  be_nested_str_weak(ack_received),
+  /* K5   */  be_nested_str_weak(init),
+  /* K6   */  be_nested_str_weak(resp),
+  /* K7   */  be_nested_str_weak(matter),
+  /* K8   */  be_nested_str_weak(Frame),
+  /* K9   */  be_nested_str_weak(initiate_response),
+  /* K10  */  be_nested_str_weak(set_subscription_id),
+  /* K11  */  be_nested_str_weak(subscription_id),
+  /* K12  */  be_nested_str_weak(set_suppress_response),
+};
+
 
 extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 
@@ -1511,16 +1485,13 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_error_received,   /*
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sub),
-    /* K1   */  be_nested_str_weak(remove_self),
-    }),
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(status_error_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -1542,27 +1513,24 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_send_im,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_im),
-    /* K1   */  be_nested_str_weak(ready),
-    }),
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(send_im),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x50080000,  //  0006  LDBOOL	R2	0	0
-      0x90020202,  //  0007  SETMBR	R0	K1	R2
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
       0x80000000,  //  0008  RET	0
     })
   )
@@ -1577,22 +1545,20 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ack_received),
-    }),
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(ack_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080504,  //  0003  GETMET	R2	R2	K4
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x50080000,  //  0006  LDBOOL	R2	0	0
@@ -1610,16 +1576,13 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_reached_timeout,   /* name 
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sub),
-    /* K1   */  be_nested_str_weak(remove_self),
-    }),
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(reached_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -1640,13 +1603,13 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_status_ok_received,   /* na
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -1665,48 +1628,38 @@ be_local_closure(class_Matter_IM_SubscribedHeartbeat_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(resp),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Frame),
-    /* K4   */  be_nested_str_weak(initiate_response),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(set_subscription_id),
-    /* K7   */  be_nested_str_weak(subscription_id),
-    /* K8   */  be_nested_str_weak(set_suppress_response),
-    }),
+    &be_ktab_class_Matter_IM_SubscribedHeartbeat,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100905,  //  0003  GETMET	R4	R4	K5
       0x4C180000,  //  0004  LDNIL	R6
       0x4C1C0000,  //  0005  LDNIL	R7
       0x4C200000,  //  0006  LDNIL	R8
       0x7C100800,  //  0007  CALL	R4	4
-      0xB8120400,  //  0008  GETNGBL	R4	K2
-      0x88100903,  //  0009  GETMBR	R4	R4	K3
-      0x8C100904,  //  000A  GETMET	R4	R4	K4
+      0xB8120E00,  //  0008  GETNGBL	R4	K7
+      0x88100908,  //  0009  GETMBR	R4	R4	K8
+      0x8C100909,  //  000A  GETMET	R4	R4	K9
       0x5C180200,  //  000B  MOVE	R6	R1
       0x5C1C0400,  //  000C  MOVE	R7	R2
       0x54220004,  //  000D  LDINT	R8	5
       0x50240200,  //  000E  LDBOOL	R9	1	0
       0x7C100A00,  //  000F  CALL	R4	5
-      0x90020204,  //  0010  SETMBR	R0	K1	R4
-      0x90020A03,  //  0011  SETMBR	R0	K5	R3
-      0x8C100106,  //  0012  GETMET	R4	R0	K6
-      0x88180707,  //  0013  GETMBR	R6	R3	K7
+      0x90020C04,  //  0010  SETMBR	R0	K6	R4
+      0x90020003,  //  0011  SETMBR	R0	K0	R3
+      0x8C10010A,  //  0012  GETMET	R4	R0	K10
+      0x8818070B,  //  0013  GETMBR	R6	R3	K11
       0x7C100400,  //  0014  CALL	R4	2
-      0x8C100108,  //  0015  GETMET	R4	R0	K8
+      0x8C10010C,  //  0015  GETMET	R4	R0	K12
       0x50180200,  //  0016  LDBOOL	R6	1	0
       0x7C100400,  //  0017  CALL	R4	2
       0x80000000,  //  0018  RET	0
@@ -1735,6 +1688,39 @@ be_local_class(Matter_IM_SubscribedHeartbeat,
     })),
     be_str_weak(Matter_IM_SubscribedHeartbeat)
 );
+// compact class 'Matter_IM_SubscribeResponse_Pull' ktab size: 29, total: 36 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_IM_SubscribeResponse_Pull[29] = {
+  /* K0   */  be_nested_str_weak(init),
+  /* K1   */  be_nested_str_weak(sub),
+  /* K2   */  be_nested_str_weak(report_data_phase),
+  /* K3   */  be_nested_str_weak(set_subscription_id),
+  /* K4   */  be_nested_str_weak(subscription_id),
+  /* K5   */  be_nested_str_weak(tasmota),
+  /* K6   */  be_nested_str_weak(loglevel),
+  /* K7   */  be_const_int(3),
+  /* K8   */  be_nested_str_weak(log),
+  /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+  /* K10  */  be_nested_str_weak(session),
+  /* K11  */  be_nested_str_weak(local_session_id),
+  /* K12  */  be_nested_str_weak(status_ok_received),
+  /* K13  */  be_nested_str_weak(finishing),
+  /* K14  */  be_nested_str_weak(send_im),
+  /* K15  */  be_nested_str_weak(ready),
+  /* K16  */  be_nested_str_weak(resp),
+  /* K17  */  be_nested_str_weak(matter),
+  /* K18  */  be_nested_str_weak(SubscribeResponseMessage),
+  /* K19  */  be_nested_str_weak(max_interval),
+  /* K20  */  be_nested_str_weak(opcode),
+  /* K21  */  be_nested_str_weak(encode_frame),
+  /* K22  */  be_nested_str_weak(to_TLV),
+  /* K23  */  be_nested_str_weak(tlv2raw),
+  /* K24  */  be_nested_str_weak(encrypt),
+  /* K25  */  be_nested_str_weak(send_response_frame),
+  /* K26  */  be_nested_str_weak(last_counter),
+  /* K27  */  be_nested_str_weak(message_counter),
+  /* K28  */  be_nested_str_weak(re_arm),
+};
+
 
 extern const bclass be_class_Matter_IM_SubscribeResponse_Pull;
 
@@ -1745,19 +1731,13 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(sub),
-    /* K2   */  be_nested_str_weak(report_data_phase),
-    /* K3   */  be_nested_str_weak(set_subscription_id),
-    /* K4   */  be_nested_str_weak(subscription_id),
-    }),
+    &be_ktab_class_Matter_IM_SubscribeResponse_Pull,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -1789,55 +1769,42 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_status_ok_received,   /*
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(loglevel),
-    /* K2   */  be_const_int(3),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(sub),
-    /* K8   */  be_nested_str_weak(subscription_id),
-    /* K9   */  be_nested_str_weak(status_ok_received),
-    /* K10  */  be_nested_str_weak(report_data_phase),
-    /* K11  */  be_nested_str_weak(finishing),
-    }),
+    &be_ktab_class_Matter_IM_SubscribeResponse_Pull,     /* shared constants */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
+      0xB80A0A00,  //  0000  GETNGBL	R2	K5
+      0x8C080506,  //  0001  GETMET	R2	R2	K6
+      0x58100007,  //  0002  LDCONST	R4	K7
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0009,  //  0004  JMPF	R2	#000F
-      0xB80A0600,  //  0005  GETNGBL	R2	K3
+      0xB80A1000,  //  0005  GETNGBL	R2	K8
       0x600C0018,  //  0006  GETGBL	R3	G24
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x88140305,  //  0008  GETMBR	R5	R1	K5
-      0x88140B06,  //  0009  GETMBR	R5	R5	K6
-      0x88180107,  //  000A  GETMBR	R6	R0	K7
-      0x88180D08,  //  000B  GETMBR	R6	R6	K8
+      0x58100009,  //  0007  LDCONST	R4	K9
+      0x8814030A,  //  0008  GETMBR	R5	R1	K10
+      0x88140B0B,  //  0009  GETMBR	R5	R5	K11
+      0x88180101,  //  000A  GETMBR	R6	R0	K1
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
       0x7C0C0600,  //  000C  CALL	R3	3
-      0x58100002,  //  000D  LDCONST	R4	K2
+      0x58100007,  //  000D  LDCONST	R4	K7
       0x7C080400,  //  000E  CALL	R2	2
       0x60080003,  //  000F  GETGBL	R2	G3
       0x5C0C0000,  //  0010  MOVE	R3	R0
       0x7C080200,  //  0011  CALL	R2	1
-      0x8C080509,  //  0012  GETMET	R2	R2	K9
+      0x8C08050C,  //  0012  GETMET	R2	R2	K12
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
       0x80040400,  //  0015  RET	1	R2
-      0x8808010A,  //  0016  GETMBR	R2	R0	K10
+      0x88080102,  //  0016  GETMBR	R2	R0	K2
       0x740A0001,  //  0017  JMPT	R2	#001A
       0x50080200,  //  0018  LDBOOL	R2	1	0
-      0x90021602,  //  0019  SETMBR	R0	K11	R2
+      0x90021A02,  //  0019  SETMBR	R0	K13	R2
     })
   )
 );
@@ -1851,84 +1818,64 @@ be_local_closure(class_Matter_IM_SubscribeResponse_Pull_send_im,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(report_data_phase),
-    /* K1   */  be_nested_str_weak(send_im),
-    /* K2   */  be_nested_str_weak(finishing),
-    /* K3   */  be_nested_str_weak(ready),
-    /* K4   */  be_nested_str_weak(resp),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K7   */  be_nested_str_weak(subscription_id),
-    /* K8   */  be_nested_str_weak(sub),
-    /* K9   */  be_nested_str_weak(max_interval),
-    /* K10  */  be_nested_str_weak(opcode),
-    /* K11  */  be_nested_str_weak(encode_frame),
-    /* K12  */  be_nested_str_weak(to_TLV),
-    /* K13  */  be_nested_str_weak(tlv2raw),
-    /* K14  */  be_nested_str_weak(encrypt),
-    /* K15  */  be_nested_str_weak(send_response_frame),
-    /* K16  */  be_nested_str_weak(last_counter),
-    /* K17  */  be_nested_str_weak(message_counter),
-    /* K18  */  be_nested_str_weak(re_arm),
-    }),
+    &be_ktab_class_Matter_IM_SubscribeResponse_Pull,     /* shared constants */
     be_str_weak(send_im),
     &be_const_str_solidified,
     ( &(const binstruction[49]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
       0x780A000E,  //  0001  JMPF	R2	#0011
       0x60080003,  //  0002  GETGBL	R2	G3
       0x5C0C0000,  //  0003  MOVE	R3	R0
       0x7C080200,  //  0004  CALL	R2	1
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x8C08050E,  //  0005  GETMET	R2	R2	K14
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x8808010D,  //  0008  GETMBR	R2	R0	K13
       0x780A0003,  //  0009  JMPF	R2	#000E
       0x50080000,  //  000A  LDBOOL	R2	0	0
-      0x90020002,  //  000B  SETMBR	R0	K0	R2
+      0x90020402,  //  000B  SETMBR	R0	K2	R2
       0x50080000,  //  000C  LDBOOL	R2	0	0
-      0x90020402,  //  000D  SETMBR	R0	K2	R2
+      0x90021A02,  //  000D  SETMBR	R0	K13	R2
       0x50080000,  //  000E  LDBOOL	R2	0	0
-      0x90020602,  //  000F  SETMBR	R0	K3	R2
+      0x90021E02,  //  000F  SETMBR	R0	K15	R2
       0x7002001E,  //  0010  JMP		#0030
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0xB80E0A00,  //  0012  GETNGBL	R3	K5
-      0x8C0C0706,  //  0013  GETMET	R3	R3	K6
+      0x88080110,  //  0011  GETMBR	R2	R0	K16
+      0xB80E2200,  //  0012  GETNGBL	R3	K17
+      0x8C0C0712,  //  0013  GETMET	R3	R3	K18
       0x7C0C0200,  //  0014  CALL	R3	1
-      0x88100108,  //  0015  GETMBR	R4	R0	K8
-      0x88100907,  //  0016  GETMBR	R4	R4	K7
-      0x900E0E04,  //  0017  SETMBR	R3	K7	R4
-      0x88100108,  //  0018  GETMBR	R4	R0	K8
-      0x88100909,  //  0019  GETMBR	R4	R4	K9
-      0x900E1204,  //  001A  SETMBR	R3	K9	R4
-      0x88100104,  //  001B  GETMBR	R4	R0	K4
+      0x88100101,  //  0015  GETMBR	R4	R0	K1
+      0x88100904,  //  0016  GETMBR	R4	R4	K4
+      0x900E0804,  //  0017  SETMBR	R3	K4	R4
+      0x88100101,  //  0018  GETMBR	R4	R0	K1
+      0x88100913,  //  0019  GETMBR	R4	R4	K19
+      0x900E2604,  //  001A  SETMBR	R3	K19	R4
+      0x88100110,  //  001B  GETMBR	R4	R0	K16
       0x54160003,  //  001C  LDINT	R5	4
-      0x90121405,  //  001D  SETMBR	R4	K10	R5
-      0x8C10050B,  //  001E  GETMET	R4	R2	K11
-      0x8C18070C,  //  001F  GETMET	R6	R3	K12
+      0x90122805,  //  001D  SETMBR	R4	K20	R5
+      0x8C100515,  //  001E  GETMET	R4	R2	K21
+      0x8C180716,  //  001F  GETMET	R6	R3	K22
       0x7C180200,  //  0020  CALL	R6	1
-      0x8C180D0D,  //  0021  GETMET	R6	R6	K13
+      0x8C180D17,  //  0021  GETMET	R6	R6	K23
       0x7C180200,  //  0022  CALL	R6	1
       0x7C100400,  //  0023  CALL	R4	2
-      0x8C10050E,  //  0024  GETMET	R4	R2	K14
+      0x8C100518,  //  0024  GETMET	R4	R2	K24
       0x7C100200,  //  0025  CALL	R4	1
-      0x8C10030F,  //  0026  GETMET	R4	R1	K15
+      0x8C100319,  //  0026  GETMET	R4	R1	K25
       0x5C180400,  //  0027  MOVE	R6	R2
       0x7C100400,  //  0028  CALL	R4	2
-      0x88100511,  //  0029  GETMBR	R4	R2	K17
-      0x90022004,  //  002A  SETMBR	R0	K16	R4
-      0x88100108,  //  002B  GETMBR	R4	R0	K8
-      0x8C100912,  //  002C  GETMET	R4	R4	K18
+      0x8810051B,  //  0029  GETMBR	R4	R2	K27
+      0x90023404,  //  002A  SETMBR	R0	K26	R4
+      0x88100101,  //  002B  GETMBR	R4	R0	K1
+      0x8C10091C,  //  002C  GETMET	R4	R4	K28
       0x7C100200,  //  002D  CALL	R4	1
       0x50100200,  //  002E  LDBOOL	R4	1	0
-      0x90020404,  //  002F  SETMBR	R0	K2	R4
+      0x90021A04,  //  002F  SETMBR	R0	K13	R4
       0x80000000,  //  0030  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -3,6 +3,60 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_IM_Subscription' ktab size: 50, total: 79 (saved 232 bytes)
+static const bvalue be_ktab_class_Matter_IM_Subscription[50] = {
+  /* K0   */  be_nested_str_weak(update_event_no),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(event_generators),
+  /* K3   */  be_nested_str_weak(event_is_match),
+  /* K4   */  be_nested_str_weak(event_no),
+  /* K5   */  be_nested_str_weak(add),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(path_list),
+  /* K9   */  be_nested_str_weak(endpoint),
+  /* K10  */  be_nested_str_weak(cluster),
+  /* K11  */  be_nested_str_weak(attribute),
+  /* K12  */  be_nested_str_weak(_add_attribute_unique_path),
+  /* K13  */  be_nested_str_weak(updates),
+  /* K14  */  be_nested_str_weak(clear),
+  /* K15  */  be_nested_str_weak(wait_status),
+  /* K16  */  be_nested_str_weak(subs_shop),
+  /* K17  */  be_nested_str_weak(subscription_id),
+  /* K18  */  be_nested_str_weak(session),
+  /* K19  */  be_nested_str_weak(min_interval_floor),
+  /* K20  */  be_const_int(0),
+  /* K21  */  be_nested_str_weak(min_interval),
+  /* K22  */  be_nested_str_weak(max_interval_ceiling),
+  /* K23  */  be_nested_str_weak(max_interval),
+  /* K24  */  be_nested_str_weak(fabric_filtered),
+  /* K25  */  be_nested_str_weak(im),
+  /* K26  */  be_nested_str_weak(device),
+  /* K27  */  be_nested_str_weak(attributes_requests),
+  /* K28  */  be_nested_str_weak(push),
+  /* K29  */  be_nested_str_weak(matter),
+  /* K30  */  be_nested_str_weak(Path),
+  /* K31  */  be_nested_str_weak(stop_iteration),
+  /* K32  */  be_nested_str_weak(IM),
+  /* K33  */  be_nested_str_weak(parse_event_filters_min_no),
+  /* K34  */  be_nested_str_weak(event_filters),
+  /* K35  */  be_nested_str_weak(clear_before_arm),
+  /* K36  */  be_nested_str_weak(is_keep_alive),
+  /* K37  */  be_nested_str_weak(restart_from),
+  /* K38  */  be_nested_str_weak(resize),
+  /* K39  */  be_nested_str_weak(tasmota),
+  /* K40  */  be_nested_str_weak(millis),
+  /* K41  */  be_nested_str_weak(expiration),
+  /* K42  */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
+  /* K43  */  be_nested_str_weak(not_before),
+  /* K44  */  be_const_int(1),
+  /* K45  */  be_nested_str_weak(log),
+  /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2ESub_Done_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D_X25i),
+  /* K47  */  be_const_int(3),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20_X2DSub_Del_X20_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D),
+  /* K49  */  be_nested_str_weak(remove_sub),
+};
+
 
 extern const bclass be_class_Matter_IM_Subscription;
 
@@ -13,21 +67,13 @@ be_local_closure(class_Matter_IM_Subscription_event_published,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_event_no),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(event_generators),
-    /* K3   */  be_nested_str_weak(event_is_match),
-    /* K4   */  be_nested_str_weak(event_no),
-    /* K5   */  be_nested_str_weak(add),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(event_published),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -68,57 +114,49 @@ be_local_closure(class_Matter_IM_Subscription_attribute_updated_ctx,   /* name *
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(path_list),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(_add_attribute_unique_path),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(attribute_updated_ctx),
     &be_const_str_solidified,
     ( &(const binstruction[38]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x580C0007,  //  0000  LDCONST	R3	K7
       0x6010000C,  //  0001  GETGBL	R4	G12
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x88140108,  //  0002  GETMBR	R5	R0	K8
       0x7C100200,  //  0003  CALL	R4	1
       0x14100604,  //  0004  LT	R4	R3	R4
       0x7812001E,  //  0005  JMPF	R4	#0025
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x88100108,  //  0006  GETMBR	R4	R0	K8
       0x94100803,  //  0007  GETIDX	R4	R4	R3
-      0x88140902,  //  0008  GETMBR	R5	R4	K2
+      0x88140909,  //  0008  GETMBR	R5	R4	K9
       0x4C180000,  //  0009  LDNIL	R6
       0x1C140A06,  //  000A  EQ	R5	R5	R6
       0x74160003,  //  000B  JMPT	R5	#0010
-      0x88140902,  //  000C  GETMBR	R5	R4	K2
-      0x88180302,  //  000D  GETMBR	R6	R1	K2
+      0x88140909,  //  000C  GETMBR	R5	R4	K9
+      0x88180309,  //  000D  GETMBR	R6	R1	K9
       0x1C140A06,  //  000E  EQ	R5	R5	R6
       0x78160012,  //  000F  JMPF	R5	#0023
-      0x88140903,  //  0010  GETMBR	R5	R4	K3
+      0x8814090A,  //  0010  GETMBR	R5	R4	K10
       0x4C180000,  //  0011  LDNIL	R6
       0x1C140A06,  //  0012  EQ	R5	R5	R6
       0x74160003,  //  0013  JMPT	R5	#0018
-      0x88140903,  //  0014  GETMBR	R5	R4	K3
-      0x88180303,  //  0015  GETMBR	R6	R1	K3
+      0x8814090A,  //  0014  GETMBR	R5	R4	K10
+      0x8818030A,  //  0015  GETMBR	R6	R1	K10
       0x1C140A06,  //  0016  EQ	R5	R5	R6
       0x7816000A,  //  0017  JMPF	R5	#0023
-      0x88140904,  //  0018  GETMBR	R5	R4	K4
+      0x8814090B,  //  0018  GETMBR	R5	R4	K11
       0x4C180000,  //  0019  LDNIL	R6
       0x1C140A06,  //  001A  EQ	R5	R5	R6
       0x74160003,  //  001B  JMPT	R5	#0020
-      0x88140904,  //  001C  GETMBR	R5	R4	K4
-      0x88180304,  //  001D  GETMBR	R6	R1	K4
+      0x8814090B,  //  001C  GETMBR	R5	R4	K11
+      0x8818030B,  //  001D  GETMBR	R6	R1	K11
       0x1C140A06,  //  001E  EQ	R5	R5	R6
       0x78160002,  //  001F  JMPF	R5	#0023
-      0x8C140105,  //  0020  GETMET	R5	R0	K5
+      0x8C14010C,  //  0020  GETMET	R5	R0	K12
       0x5C1C0200,  //  0021  MOVE	R7	R1
       0x7C140400,  //  0022  CALL	R5	2
       0x000C0706,  //  0023  ADD	R3	R3	K6
@@ -137,28 +175,23 @@ be_local_closure(class_Matter_IM_Subscription_clear_before_arm,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(updates),
-    /* K1   */  be_nested_str_weak(clear),
-    /* K2   */  be_nested_str_weak(wait_status),
-    /* K3   */  be_nested_str_weak(update_event_no),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(clear_before_arm),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x8C04030E,  //  0001  GETMET	R1	R1	K14
       0x7C040200,  //  0002  CALL	R1	1
       0x50040200,  //  0003  LDBOOL	R1	1	0
-      0x90020401,  //  0004  SETMBR	R0	K2	R1
+      0x90021E01,  //  0004  SETMBR	R0	K15	R1
       0x4C040000,  //  0005  LDNIL	R1
-      0x90020601,  //  0006  SETMBR	R0	K3	R1
+      0x90020001,  //  0006  SETMBR	R0	K0	R1
       0x80000000,  //  0007  RET	0
     })
   )
@@ -173,57 +206,29 @@ be_local_closure(class_Matter_IM_Subscription_init,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs_shop),
-    /* K1   */  be_nested_str_weak(subscription_id),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(min_interval_floor),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(min_interval),
-    /* K6   */  be_nested_str_weak(max_interval_ceiling),
-    /* K7   */  be_nested_str_weak(max_interval),
-    /* K8   */  be_nested_str_weak(wait_status),
-    /* K9   */  be_nested_str_weak(fabric_filtered),
-    /* K10  */  be_nested_str_weak(im),
-    /* K11  */  be_nested_str_weak(device),
-    /* K12  */  be_nested_str_weak(path_list),
-    /* K13  */  be_nested_str_weak(attributes_requests),
-    /* K14  */  be_nested_str_weak(push),
-    /* K15  */  be_nested_str_weak(matter),
-    /* K16  */  be_nested_str_weak(Path),
-    /* K17  */  be_nested_str_weak(endpoint),
-    /* K18  */  be_nested_str_weak(cluster),
-    /* K19  */  be_nested_str_weak(attribute),
-    /* K20  */  be_nested_str_weak(stop_iteration),
-    /* K21  */  be_nested_str_weak(IM),
-    /* K22  */  be_nested_str_weak(parse_event_filters_min_no),
-    /* K23  */  be_nested_str_weak(event_filters),
-    /* K24  */  be_nested_str_weak(updates),
-    /* K25  */  be_nested_str_weak(clear_before_arm),
-    /* K26  */  be_nested_str_weak(is_keep_alive),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[69]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x88140903,  //  0003  GETMBR	R5	R4	K3
-      0x14180B04,  //  0004  LT	R6	R5	K4
+      0x90022001,  //  0000  SETMBR	R0	K16	R1
+      0x90022202,  //  0001  SETMBR	R0	K17	R2
+      0x90022403,  //  0002  SETMBR	R0	K18	R3
+      0x88140913,  //  0003  GETMBR	R5	R4	K19
+      0x14180B14,  //  0004  LT	R6	R5	K20
       0x781A0000,  //  0005  JMPF	R6	#0007
-      0x58140004,  //  0006  LDCONST	R5	K4
+      0x58140014,  //  0006  LDCONST	R5	K20
       0x541A003B,  //  0007  LDINT	R6	60
       0x24180A06,  //  0008  GT	R6	R5	R6
       0x781A0000,  //  0009  JMPF	R6	#000B
       0x5416003B,  //  000A  LDINT	R5	60
-      0x90020A05,  //  000B  SETMBR	R0	K5	R5
-      0x88180906,  //  000C  GETMBR	R6	R4	K6
+      0x90022A05,  //  000B  SETMBR	R0	K21	R5
+      0x88180916,  //  000C  GETMBR	R6	R4	K22
       0x541E003B,  //  000D  LDINT	R7	60
       0x141C0C07,  //  000E  LT	R7	R6	R7
       0x781E0000,  //  000F  JMPF	R7	#0011
@@ -233,52 +238,52 @@ be_local_closure(class_Matter_IM_Subscription_init,   /* name */
       0x781E0000,  //  0013  JMPF	R7	#0015
       0x541A0E0F,  //  0014  LDINT	R6	3600
       0x541A003B,  //  0015  LDINT	R6	60
-      0x90020E06,  //  0016  SETMBR	R0	K7	R6
+      0x90022E06,  //  0016  SETMBR	R0	K23	R6
       0x501C0000,  //  0017  LDBOOL	R7	0	0
-      0x90021007,  //  0018  SETMBR	R0	K8	R7
-      0x881C0909,  //  0019  GETMBR	R7	R4	K9
-      0x90021207,  //  001A  SETMBR	R0	K9	R7
-      0x881C030A,  //  001B  GETMBR	R7	R1	K10
-      0x881C0F0B,  //  001C  GETMBR	R7	R7	K11
+      0x90021E07,  //  0018  SETMBR	R0	K15	R7
+      0x881C0918,  //  0019  GETMBR	R7	R4	K24
+      0x90023007,  //  001A  SETMBR	R0	K24	R7
+      0x881C0319,  //  001B  GETMBR	R7	R1	K25
+      0x881C0F1A,  //  001C  GETMBR	R7	R7	K26
       0x60200012,  //  001D  GETGBL	R8	G18
       0x7C200000,  //  001E  CALL	R8	0
-      0x90021808,  //  001F  SETMBR	R0	K12	R8
-      0x8820090D,  //  0020  GETMBR	R8	R4	K13
+      0x90021008,  //  001F  SETMBR	R0	K8	R8
+      0x8820091B,  //  0020  GETMBR	R8	R4	K27
       0x4C240000,  //  0021  LDNIL	R9
       0x20201009,  //  0022  NE	R8	R8	R9
       0x78220012,  //  0023  JMPF	R8	#0037
       0x60200010,  //  0024  GETGBL	R8	G16
-      0x8824090D,  //  0025  GETMBR	R9	R4	K13
+      0x8824091B,  //  0025  GETMBR	R9	R4	K27
       0x7C200200,  //  0026  CALL	R8	1
       0xA802000B,  //  0027  EXBLK	0	#0034
       0x5C241000,  //  0028  MOVE	R9	R8
       0x7C240000,  //  0029  CALL	R9	0
-      0x8828010C,  //  002A  GETMBR	R10	R0	K12
-      0x8C28150E,  //  002B  GETMET	R10	R10	K14
-      0xB8321E00,  //  002C  GETNGBL	R12	K15
-      0x8C301910,  //  002D  GETMET	R12	R12	K16
-      0x88381311,  //  002E  GETMBR	R14	R9	K17
-      0x883C1312,  //  002F  GETMBR	R15	R9	K18
-      0x88401313,  //  0030  GETMBR	R16	R9	K19
+      0x88280108,  //  002A  GETMBR	R10	R0	K8
+      0x8C28151C,  //  002B  GETMET	R10	R10	K28
+      0xB8323A00,  //  002C  GETNGBL	R12	K29
+      0x8C30191E,  //  002D  GETMET	R12	R12	K30
+      0x88381309,  //  002E  GETMBR	R14	R9	K9
+      0x883C130A,  //  002F  GETMBR	R15	R9	K10
+      0x8840130B,  //  0030  GETMBR	R16	R9	K11
       0x7C300800,  //  0031  CALL	R12	4
       0x7C280400,  //  0032  CALL	R10	2
       0x7001FFF3,  //  0033  JMP		#0028
-      0x58200014,  //  0034  LDCONST	R8	K20
+      0x5820001F,  //  0034  LDCONST	R8	K31
       0xAC200200,  //  0035  CATCH	R8	1	0
       0xB0080000,  //  0036  RAISE	2	R0	R0
-      0xB8221E00,  //  0037  GETNGBL	R8	K15
-      0x88201115,  //  0038  GETMBR	R8	R8	K21
-      0x8C201116,  //  0039  GETMET	R8	R8	K22
-      0x88280917,  //  003A  GETMBR	R10	R4	K23
+      0xB8223A00,  //  0037  GETNGBL	R8	K29
+      0x88201120,  //  0038  GETMBR	R8	R8	K32
+      0x8C201121,  //  0039  GETMET	R8	R8	K33
+      0x88280922,  //  003A  GETMBR	R10	R4	K34
       0x4C2C0000,  //  003B  LDNIL	R11
       0x7C200600,  //  003C  CALL	R8	3
       0x60240012,  //  003D  GETGBL	R9	G18
       0x7C240000,  //  003E  CALL	R9	0
-      0x90023009,  //  003F  SETMBR	R0	K24	R9
-      0x8C240119,  //  0040  GETMET	R9	R0	K25
+      0x90021A09,  //  003F  SETMBR	R0	K13	R9
+      0x8C240123,  //  0040  GETMET	R9	R0	K35
       0x7C240200,  //  0041  CALL	R9	1
       0x50240000,  //  0042  LDBOOL	R9	0	0
-      0x90023409,  //  0043  SETMBR	R0	K26	R9
+      0x90024809,  //  0043  SETMBR	R0	K36	R9
       0x80000000,  //  0044  RET	0
     })
   )
@@ -293,49 +298,41 @@ be_local_closure(class_Matter_IM_Subscription__add_attribute_unique_path,   /* n
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(updates),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(_add_attribute_unique_path),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080001,  //  0000  LDCONST	R2	K1
       0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x8810010D,  //  0002  GETMBR	R4	R0	K13
       0x7C0C0200,  //  0003  CALL	R3	1
       0x140C0403,  //  0004  LT	R3	R2	R3
       0x780E0010,  //  0005  JMPF	R3	#0017
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x880C010D,  //  0006  GETMBR	R3	R0	K13
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x88100702,  //  0008  GETMBR	R4	R3	K2
-      0x88140302,  //  0009  GETMBR	R5	R1	K2
+      0x88100709,  //  0008  GETMBR	R4	R3	K9
+      0x88140309,  //  0009  GETMBR	R5	R1	K9
       0x1C100805,  //  000A  EQ	R4	R4	R5
       0x78120008,  //  000B  JMPF	R4	#0015
-      0x88100703,  //  000C  GETMBR	R4	R3	K3
-      0x88140303,  //  000D  GETMBR	R5	R1	K3
+      0x8810070A,  //  000C  GETMBR	R4	R3	K10
+      0x8814030A,  //  000D  GETMBR	R5	R1	K10
       0x1C100805,  //  000E  EQ	R4	R4	R5
       0x78120004,  //  000F  JMPF	R4	#0015
-      0x88100704,  //  0010  GETMBR	R4	R3	K4
-      0x88140304,  //  0011  GETMBR	R5	R1	K4
+      0x8810070B,  //  0010  GETMBR	R4	R3	K11
+      0x8814030B,  //  0011  GETMBR	R5	R1	K11
       0x1C100805,  //  0012  EQ	R4	R4	R5
       0x78120000,  //  0013  JMPF	R4	#0015
       0x80000800,  //  0014  RET	0
-      0x00080505,  //  0015  ADD	R2	R2	K5
+      0x00080506,  //  0015  ADD	R2	R2	K6
       0x7001FFE9,  //  0016  JMP		#0001
-      0x880C0101,  //  0017  GETMBR	R3	R0	K1
-      0x8C0C0706,  //  0018  GETMET	R3	R3	K6
+      0x880C010D,  //  0017  GETMBR	R3	R0	K13
+      0x8C0C071C,  //  0018  GETMET	R3	R3	K28
       0x5C140200,  //  0019  MOVE	R5	R1
       0x7C0C0400,  //  001A  CALL	R3	2
       0x80000000,  //  001B  RET	0
@@ -352,67 +349,60 @@ be_local_closure(class_Matter_IM_Subscription_update_event_generator_array,   /*
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_generators),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(restart_from),
-    /* K4   */  be_nested_str_weak(update_event_no),
-    /* K5   */  be_nested_str_weak(resize),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(update_event_generator_array),
     &be_const_str_solidified,
     ( &(const binstruction[46]) {  /* code */
       0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080102,  //  0001  GETMBR	R2	R0	K2
       0x7C040200,  //  0002  CALL	R1	1
-      0x1C040301,  //  0003  EQ	R1	R1	K1
+      0x1C040307,  //  0003  EQ	R1	R1	K7
       0x78060002,  //  0004  JMPF	R1	#0008
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
       0x70020024,  //  0007  JMP		#002D
       0x6004000C,  //  0008  GETGBL	R1	G12
-      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x88080102,  //  0009  GETMBR	R2	R0	K2
       0x7C040200,  //  000A  CALL	R1	1
-      0x1C040302,  //  000B  EQ	R1	R1	K2
+      0x1C040306,  //  000B  EQ	R1	R1	K6
       0x78060008,  //  000C  JMPF	R1	#0016
-      0x88040100,  //  000D  GETMBR	R1	R0	K0
-      0x94040301,  //  000E  GETIDX	R1	R1	K1
-      0x8C040303,  //  000F  GETMET	R1	R1	K3
-      0x880C0104,  //  0010  GETMBR	R3	R0	K4
+      0x88040102,  //  000D  GETMBR	R1	R0	K2
+      0x94040307,  //  000E  GETIDX	R1	R1	K7
+      0x8C040325,  //  000F  GETMET	R1	R1	K37
+      0x880C0100,  //  0010  GETMBR	R3	R0	K0
       0x7C040400,  //  0011  CALL	R1	2
-      0x88040100,  //  0012  GETMBR	R1	R0	K0
-      0x94040301,  //  0013  GETIDX	R1	R1	K1
+      0x88040102,  //  0012  GETMBR	R1	R0	K2
+      0x94040307,  //  0013  GETIDX	R1	R1	K7
       0x80040200,  //  0014  RET	1	R1
       0x70020016,  //  0015  JMP		#002D
       0x60040012,  //  0016  GETGBL	R1	G18
       0x7C040000,  //  0017  CALL	R1	0
-      0x8C080305,  //  0018  GETMET	R2	R1	K5
+      0x8C080326,  //  0018  GETMET	R2	R1	K38
       0x6010000C,  //  0019  GETGBL	R4	G12
-      0x88140100,  //  001A  GETMBR	R5	R0	K0
+      0x88140102,  //  001A  GETMBR	R5	R0	K2
       0x7C100200,  //  001B  CALL	R4	1
       0x7C080400,  //  001C  CALL	R2	2
-      0x58080001,  //  001D  LDCONST	R2	K1
+      0x58080007,  //  001D  LDCONST	R2	K7
       0x600C000C,  //  001E  GETGBL	R3	G12
-      0x88100100,  //  001F  GETMBR	R4	R0	K0
+      0x88100102,  //  001F  GETMBR	R4	R0	K2
       0x7C0C0200,  //  0020  CALL	R3	1
       0x140C0403,  //  0021  LT	R3	R2	R3
       0x780E0009,  //  0022  JMPF	R3	#002D
-      0x880C0100,  //  0023  GETMBR	R3	R0	K0
+      0x880C0102,  //  0023  GETMBR	R3	R0	K2
       0x940C0602,  //  0024  GETIDX	R3	R3	R2
-      0x8C0C0703,  //  0025  GETMET	R3	R3	K3
-      0x88140104,  //  0026  GETMBR	R5	R0	K4
+      0x8C0C0725,  //  0025  GETMET	R3	R3	K37
+      0x88140100,  //  0026  GETMBR	R5	R0	K0
       0x7C0C0400,  //  0027  CALL	R3	2
-      0x880C0100,  //  0028  GETMBR	R3	R0	K0
+      0x880C0102,  //  0028  GETMBR	R3	R0	K2
       0x940C0602,  //  0029  GETIDX	R3	R3	R2
       0x98040403,  //  002A  SETIDX	R1	R2	R3
-      0x00080502,  //  002B  ADD	R2	R2	K2
+      0x00080506,  //  002B  ADD	R2	R2	K6
       0x7001FFF0,  //  002C  JMP		#001E
       0x80000000,  //  002D  RET	0
     })
@@ -428,60 +418,45 @@ be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(wait_status),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(expiration),
-    /* K4   */  be_nested_str_weak(max_interval),
-    /* K5   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
-    /* K6   */  be_nested_str_weak(not_before),
-    /* K7   */  be_nested_str_weak(min_interval),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(is_keep_alive),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X2ESub_Done_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D_X25i),
-    /* K12  */  be_nested_str_weak(subscription_id),
-    /* K13  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(re_arm),
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010F,  //  0000  GETMBR	R1	R0	K15
       0x74060000,  //  0001  JMPT	R1	#0003
       0x80000200,  //  0002  RET	0
       0x50040000,  //  0003  LDBOOL	R1	0	0
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x90021E01,  //  0004  SETMBR	R0	K15	R1
+      0xB8064E00,  //  0005  GETNGBL	R1	K39
+      0x8C040328,  //  0006  GETMET	R1	R1	K40
       0x7C040200,  //  0007  CALL	R1	1
-      0x88080104,  //  0008  GETMBR	R2	R0	K4
-      0x880C0105,  //  0009  GETMBR	R3	R0	K5
+      0x88080117,  //  0008  GETMBR	R2	R0	K23
+      0x880C012A,  //  0009  GETMBR	R3	R0	K42
       0x04080403,  //  000A  SUB	R2	R2	R3
       0x540E03E7,  //  000B  LDINT	R3	1000
       0x08080403,  //  000C  MUL	R2	R2	R3
       0x00080202,  //  000D  ADD	R2	R1	R2
-      0x90020602,  //  000E  SETMBR	R0	K3	R2
-      0x88080107,  //  000F  GETMBR	R2	R0	K7
+      0x90025202,  //  000E  SETMBR	R0	K41	R2
+      0x88080115,  //  000F  GETMBR	R2	R0	K21
       0x540E03E7,  //  0010  LDINT	R3	1000
       0x08080403,  //  0011  MUL	R2	R2	R3
       0x00080202,  //  0012  ADD	R2	R1	R2
-      0x04080508,  //  0013  SUB	R2	R2	K8
-      0x90020C02,  //  0014  SETMBR	R0	K6	R2
-      0x88080109,  //  0015  GETMBR	R2	R0	K9
+      0x0408052C,  //  0013  SUB	R2	R2	K44
+      0x90025602,  //  0014  SETMBR	R0	K43	R2
+      0x88080124,  //  0015  GETMBR	R2	R0	K36
       0x740A0006,  //  0016  JMPT	R2	#001E
-      0xB80A1400,  //  0017  GETNGBL	R2	K10
+      0xB80A5A00,  //  0017  GETNGBL	R2	K45
       0x600C0018,  //  0018  GETGBL	R3	G24
-      0x5810000B,  //  0019  LDCONST	R4	K11
-      0x8814010C,  //  001A  GETMBR	R5	R0	K12
+      0x5810002E,  //  0019  LDCONST	R4	K46
+      0x88140111,  //  001A  GETMBR	R5	R0	K17
       0x7C0C0400,  //  001B  CALL	R3	2
-      0x5810000D,  //  001C  LDCONST	R4	K13
+      0x5810002F,  //  001C  LDCONST	R4	K47
       0x7C080400,  //  001D  CALL	R2	2
       0x80000000,  //  001E  RET	0
     })
@@ -497,15 +472,13 @@ be_local_closure(class_Matter_IM_Subscription_set_event_generator_or_arr,   /* n
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_generators),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(set_event_generator_or_arr),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
@@ -514,19 +487,19 @@ be_local_closure(class_Matter_IM_Subscription_set_event_generator_or_arr,   /* n
       0x780A0003,  //  0002  JMPF	R2	#0007
       0x60080012,  //  0003  GETGBL	R2	G18
       0x7C080000,  //  0004  CALL	R2	0
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x90020402,  //  0005  SETMBR	R0	K2	R2
       0x7002000A,  //  0006  JMP		#0012
       0x6008000F,  //  0007  GETGBL	R2	G15
       0x5C0C0200,  //  0008  MOVE	R3	R1
       0x60100012,  //  0009  GETGBL	R4	G18
       0x7C080400,  //  000A  CALL	R2	2
       0x780A0001,  //  000B  JMPF	R2	#000E
-      0x90020001,  //  000C  SETMBR	R0	K0	R1
+      0x90020401,  //  000C  SETMBR	R0	K2	R1
       0x70020003,  //  000D  JMP		#0012
       0x60080012,  //  000E  GETGBL	R2	G18
       0x7C080000,  //  000F  CALL	R2	0
       0x400C0401,  //  0010  CONNECT	R3	R2	R1
-      0x90020002,  //  0011  SETMBR	R0	K0	R2
+      0x90020402,  //  0011  SETMBR	R0	K2	R2
       0x80000000,  //  0012  RET	0
     })
   )
@@ -541,32 +514,25 @@ be_local_closure(class_Matter_IM_Subscription_remove_self,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DSub_Del_X20_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D),
-    /* K2   */  be_nested_str_weak(subscription_id),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(subs_shop),
-    /* K5   */  be_nested_str_weak(remove_sub),
-    }),
+    &be_ktab_class_Matter_IM_Subscription,     /* shared constants */
     be_str_weak(remove_self),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0xB8065A00,  //  0000  GETNGBL	R1	K45
       0x60080008,  //  0001  GETGBL	R2	G8
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x880C0111,  //  0002  GETMBR	R3	R0	K17
       0x7C080200,  //  0003  CALL	R2	1
-      0x000A0202,  //  0004  ADD	R2	K1	R2
-      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x000A6002,  //  0004  ADD	R2	K48	R2
+      0x580C002F,  //  0005  LDCONST	R3	K47
       0x7C040400,  //  0006  CALL	R1	2
-      0x88040104,  //  0007  GETMBR	R1	R0	K4
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x88040110,  //  0007  GETMBR	R1	R0	K16
+      0x8C040331,  //  0008  GETMET	R1	R1	K49
       0x5C0C0000,  //  0009  MOVE	R3	R0
       0x7C040400,  //  000A  CALL	R1	2
       0x80000000,  //  000B  RET	0
@@ -611,6 +577,43 @@ be_local_class(Matter_IM_Subscription,
     })),
     be_str_weak(Matter_IM_Subscription)
 );
+// compact class 'Matter_IM_Subscription_Shop' ktab size: 33, total: 51 (saved 144 bytes)
+static const bvalue be_ktab_class_Matter_IM_Subscription_Shop[33] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(subs),
+  /* K2   */  be_nested_str_weak(wait_status),
+  /* K3   */  be_nested_str_weak(tasmota),
+  /* K4   */  be_nested_str_weak(time_reached),
+  /* K5   */  be_nested_str_weak(not_before),
+  /* K6   */  be_nested_str_weak(updates),
+  /* K7   */  be_nested_str_weak(update_event_no),
+  /* K8   */  be_nested_str_weak(im),
+  /* K9   */  be_nested_str_weak(send_subscribe_update),
+  /* K10  */  be_nested_str_weak(clear_before_arm),
+  /* K11  */  be_const_int(1),
+  /* K12  */  be_nested_str_weak(expiration),
+  /* K13  */  be_nested_str_weak(send_subscribe_heartbeat),
+  /* K14  */  be_nested_str_weak(re_arm),
+  /* K15  */  be_nested_str_weak(attribute_updated_ctx),
+  /* K16  */  be_const_int(1),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(remove),
+  /* K19  */  be_nested_str_weak(crypto),
+  /* K20  */  be_nested_str_weak(random),
+  /* K21  */  be_const_int(2),
+  /* K22  */  be_nested_str_weak(get),
+  /* K23  */  be_nested_str_weak(get_by_id),
+  /* K24  */  be_nested_str_weak(matter),
+  /* K25  */  be_nested_str_weak(IM_Subscription),
+  /* K26  */  be_nested_str_weak(push),
+  /* K27  */  be_nested_str_weak(event_published),
+  /* K28  */  be_nested_str_weak(session),
+  /* K29  */  be_nested_str_weak(_sessions),
+  /* K30  */  be_nested_str_weak(remove_by_session),
+  /* K31  */  be_nested_str_weak(stop_iteration),
+  /* K32  */  be_nested_str_weak(subscription_id),
+};
+
 
 extern const bclass be_class_Matter_IM_Subscription_Shop;
 
@@ -621,29 +624,13 @@ be_local_closure(class_Matter_IM_Subscription_Shop_every_50ms,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(wait_status),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(time_reached),
-    /* K5   */  be_nested_str_weak(not_before),
-    /* K6   */  be_nested_str_weak(updates),
-    /* K7   */  be_nested_str_weak(update_event_no),
-    /* K8   */  be_nested_str_weak(im),
-    /* K9   */  be_nested_str_weak(send_subscribe_update),
-    /* K10  */  be_nested_str_weak(clear_before_arm),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(expiration),
-    /* K13  */  be_nested_str_weak(send_subscribe_heartbeat),
-    /* K14  */  be_nested_str_weak(re_arm),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[58]) {  /* code */
@@ -718,20 +705,17 @@ be_local_closure(class_Matter_IM_Subscription_Shop_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(im),
-    /* K1   */  be_nested_str_weak(subs),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021001,  //  0000  SETMBR	R0	K8	R1
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x90020202,  //  0003  SETMBR	R0	K1	R2
@@ -749,18 +733,13 @@ be_local_closure(class_Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* n
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(attribute_updated_ctx),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(attribute_updated_ctx),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -772,11 +751,11 @@ be_local_closure(class_Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* n
       0x78120007,  //  0005  JMPF	R4	#000E
       0x88100101,  //  0006  GETMBR	R4	R0	K1
       0x94100803,  //  0007  GETIDX	R4	R4	R3
-      0x8C100902,  //  0008  GETMET	R4	R4	K2
+      0x8C10090F,  //  0008  GETMET	R4	R4	K15
       0x5C180200,  //  0009  MOVE	R6	R1
       0x5C1C0400,  //  000A  MOVE	R7	R2
       0x7C100600,  //  000B  CALL	R4	3
-      0x000C0703,  //  000C  ADD	R3	R3	K3
+      0x000C0710,  //  000C  ADD	R3	R3	K16
       0x7001FFF2,  //  000D  JMP		#0001
       0x80000000,  //  000E  RET	0
     })
@@ -792,22 +771,17 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_sub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(remove_sub),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080011,  //  0000  LDCONST	R2	K17
       0x600C000C,  //  0001  GETGBL	R3	G12
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
@@ -818,11 +792,11 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_sub,   /* name */
       0x1C0C0601,  //  0008  EQ	R3	R3	R1
       0x780E0004,  //  0009  JMPF	R3	#000F
       0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  000B  GETMET	R3	R3	K2
+      0x8C0C0712,  //  000B  GETMET	R3	R3	K18
       0x5C140400,  //  000C  MOVE	R5	R2
       0x7C0C0400,  //  000D  CALL	R3	2
       0x70020000,  //  000E  JMP		#0010
-      0x00080503,  //  000F  ADD	R2	R2	K3
+      0x0008050B,  //  000F  ADD	R2	R2	K11
       0x7001FFEF,  //  0010  JMP		#0001
       0x80000000,  //  0011  RET	0
     })
@@ -838,58 +812,47 @@ be_local_closure(class_Matter_IM_Subscription_Shop_new_subscription,   /* name *
   be_nested_proto(
     13,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_by_id),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(IM_Subscription),
-    /* K8   */  be_nested_str_weak(subs),
-    /* K9   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(new_subscription),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x8C140901,  //  0001  GETMET	R5	R4	K1
-      0x581C0002,  //  0002  LDCONST	R7	K2
+      0xA4122600,  //  0000  IMPORT	R4	K19
+      0x8C140914,  //  0001  GETMET	R5	R4	K20
+      0x581C0015,  //  0002  LDCONST	R7	K21
       0x7C140400,  //  0003  CALL	R5	2
-      0x8C140B03,  //  0004  GETMET	R5	R5	K3
-      0x581C0004,  //  0005  LDCONST	R7	K4
-      0x58200002,  //  0006  LDCONST	R8	K2
+      0x8C140B16,  //  0004  GETMET	R5	R5	K22
+      0x581C0000,  //  0005  LDCONST	R7	K0
+      0x58200015,  //  0006  LDCONST	R8	K21
       0x7C140600,  //  0007  CALL	R5	3
-      0x8C180105,  //  0008  GETMET	R6	R0	K5
+      0x8C180117,  //  0008  GETMET	R6	R0	K23
       0x5C200A00,  //  0009  MOVE	R8	R5
       0x7C180400,  //  000A  CALL	R6	2
       0x781A0008,  //  000B  JMPF	R6	#0015
-      0x8C180901,  //  000C  GETMET	R6	R4	K1
-      0x58200002,  //  000D  LDCONST	R8	K2
+      0x8C180914,  //  000C  GETMET	R6	R4	K20
+      0x58200015,  //  000D  LDCONST	R8	K21
       0x7C180400,  //  000E  CALL	R6	2
-      0x8C180D03,  //  000F  GETMET	R6	R6	K3
-      0x58200004,  //  0010  LDCONST	R8	K4
-      0x58240002,  //  0011  LDCONST	R9	K2
+      0x8C180D16,  //  000F  GETMET	R6	R6	K22
+      0x58200000,  //  0010  LDCONST	R8	K0
+      0x58240015,  //  0011  LDCONST	R9	K21
       0x7C180600,  //  0012  CALL	R6	3
       0x5C140C00,  //  0013  MOVE	R5	R6
       0x7001FFF2,  //  0014  JMP		#0008
-      0xB81A0C00,  //  0015  GETNGBL	R6	K6
-      0x8C180D07,  //  0016  GETMET	R6	R6	K7
+      0xB81A3000,  //  0015  GETNGBL	R6	K24
+      0x8C180D19,  //  0016  GETMET	R6	R6	K25
       0x5C200000,  //  0017  MOVE	R8	R0
       0x5C240A00,  //  0018  MOVE	R9	R5
       0x5C280200,  //  0019  MOVE	R10	R1
       0x5C2C0400,  //  001A  MOVE	R11	R2
       0x5C300600,  //  001B  MOVE	R12	R3
       0x7C180C00,  //  001C  CALL	R6	6
-      0x881C0108,  //  001D  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
+      0x881C0101,  //  001D  GETMBR	R7	R0	K1
+      0x8C1C0F1A,  //  001E  GETMET	R7	R7	K26
       0x5C240C00,  //  001F  MOVE	R9	R6
       0x7C1C0400,  //  0020  CALL	R7	2
       0x80040C00,  //  0021  RET	1	R6
@@ -906,22 +869,17 @@ be_local_closure(class_Matter_IM_Subscription_Shop_event_published,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(event_published),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(event_published),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080011,  //  0000  LDCONST	R2	K17
       0x600C000C,  //  0001  GETGBL	R3	G12
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
@@ -929,10 +887,10 @@ be_local_closure(class_Matter_IM_Subscription_Shop_event_published,   /* name */
       0x780E0006,  //  0005  JMPF	R3	#000D
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C0C0702,  //  0008  GETMET	R3	R3	K2
+      0x8C0C071B,  //  0008  GETMET	R3	R3	K27
       0x5C140200,  //  0009  MOVE	R5	R1
       0x7C0C0400,  //  000A  CALL	R3	2
-      0x00080503,  //  000B  ADD	R2	R2	K3
+      0x00080510,  //  000B  ADD	R2	R2	K16
       0x7001FFF3,  //  000C  JMP		#0001
       0x80000000,  //  000D  RET	0
     })
@@ -948,23 +906,17 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_session,   /* name 
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(remove_by_session),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080011,  //  0000  LDCONST	R2	K17
       0x600C000C,  //  0001  GETGBL	R3	G12
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
@@ -972,15 +924,15 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_session,   /* name 
       0x780E000B,  //  0005  JMPF	R3	#0012
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
+      0x880C071C,  //  0008  GETMBR	R3	R3	K28
       0x1C0C0601,  //  0009  EQ	R3	R3	R1
       0x780E0004,  //  000A  JMPF	R3	#0010
       0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
+      0x8C0C0712,  //  000C  GETMET	R3	R3	K18
       0x5C140400,  //  000D  MOVE	R5	R2
       0x7C0C0400,  //  000E  CALL	R3	2
       0x70020000,  //  000F  JMP		#0011
-      0x00080504,  //  0010  ADD	R2	R2	K4
+      0x0008050B,  //  0010  ADD	R2	R2	K11
       0x7001FFEE,  //  0011  JMP		#0001
       0x80000000,  //  0012  RET	0
     })
@@ -996,31 +948,27 @@ be_local_closure(class_Matter_IM_Subscription_Shop_remove_by_fabric,   /* name *
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_nested_str_weak(remove_by_session),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(remove_by_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
       0x60080010,  //  0000  GETGBL	R2	G16
-      0x880C0300,  //  0001  GETMBR	R3	R1	K0
+      0x880C031D,  //  0001  GETMBR	R3	R1	K29
       0x7C080200,  //  0002  CALL	R2	1
       0xA8020005,  //  0003  EXBLK	0	#000A
       0x5C0C0400,  //  0004  MOVE	R3	R2
       0x7C0C0000,  //  0005  CALL	R3	0
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x8C10011E,  //  0006  GETMET	R4	R0	K30
       0x5C180600,  //  0007  MOVE	R6	R3
       0x7C100400,  //  0008  CALL	R4	2
       0x7001FFF9,  //  0009  JMP		#0004
-      0x58080002,  //  000A  LDCONST	R2	K2
+      0x5808001F,  //  000A  LDCONST	R2	K31
       0xAC080200,  //  000B  CATCH	R2	1	0
       0xB0080000,  //  000C  RAISE	2	R0	R0
       0x80000000,  //  000D  RET	0
@@ -1037,22 +985,17 @@ be_local_closure(class_Matter_IM_Subscription_Shop_get_by_id,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(subscription_id),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_IM_Subscription_Shop,     /* shared constants */
     be_str_weak(get_by_id),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080011,  //  0000  LDCONST	R2	K17
       0x600C000C,  //  0001  GETGBL	R3	G12
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
@@ -1060,13 +1003,13 @@ be_local_closure(class_Matter_IM_Subscription_Shop_get_by_id,   /* name */
       0x780E0009,  //  0005  JMPF	R3	#0010
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
+      0x880C0720,  //  0008  GETMBR	R3	R3	K32
       0x1C0C0601,  //  0009  EQ	R3	R3	R1
       0x780E0002,  //  000A  JMPF	R3	#000E
       0x880C0101,  //  000B  GETMBR	R3	R0	K1
       0x940C0602,  //  000C  GETIDX	R3	R3	R2
       0x80040600,  //  000D  RET	1	R3
-      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x0008050B,  //  000E  ADD	R2	R2	K11
       0x7001FFF0,  //  000F  JMP		#0001
       0x80000000,  //  0010  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -3,6 +3,88 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_Frame;
+// compact class 'Matter_Frame' ktab size: 77, total: 200 (saved 984 bytes)
+static const bvalue be_ktab_class_Matter_Frame[77] = {
+  /* K0   */  be_nested_str_weak(session),
+  /* K1   */  be_nested_str_weak(get_node_id),
+  /* K2   */  be_nested_str_weak(crypto),
+  /* K3   */  be_nested_str_weak(raw),
+  /* K4   */  be_nested_str_weak(payload_idx),
+  /* K5   */  be_nested_str_weak(get_r2i),
+  /* K6   */  be_nested_str_weak(message_handler),
+  /* K7   */  be_nested_str_weak(_n_bytes),
+  /* K8   */  be_nested_str_weak(clear),
+  /* K9   */  be_nested_str_weak(add),
+  /* K10  */  be_nested_str_weak(flags),
+  /* K11  */  be_const_int(1),
+  /* K12  */  be_nested_str_weak(message_counter),
+  /* K13  */  be_nested_str_weak(is_CASE),
+  /* K14  */  be_nested_str_weak(get_device_id),
+  /* K15  */  be_nested_str_weak(resize),
+  /* K16  */  be_nested_str_weak(AES_CCM),
+  /* K17  */  be_nested_str_weak(encrypt1),
+  /* K18  */  be_const_int(0),
+  /* K19  */  be_nested_str_weak(remote_ip),
+  /* K20  */  be_nested_str_weak(remote_port),
+  /* K21  */  be_const_int(0),
+  /* K22  */  be_nested_str_weak(flag_s),
+  /* K23  */  be_nested_str_weak(flag_dsiz),
+  /* K24  */  be_const_int(3),
+  /* K25  */  be_nested_str_weak(local_session_id),
+  /* K26  */  be_const_int(2),
+  /* K27  */  be_nested_str_weak(sec_flags),
+  /* K28  */  be_nested_str_weak(sec_p),
+  /* K29  */  be_nested_str_weak(sec_c),
+  /* K30  */  be_nested_str_weak(sec_sesstype),
+  /* K31  */  be_nested_str_weak(source_node_id),
+  /* K32  */  be_nested_str_weak(dest_node_id_8),
+  /* K33  */  be_nested_str_weak(dest_node_id_2),
+  /* K34  */  be_nested_str_weak(x_flags),
+  /* K35  */  be_nested_str_weak(x_flag_v),
+  /* K36  */  be_nested_str_weak(x_flag_r),
+  /* K37  */  be_nested_str_weak(x_flag_a),
+  /* K38  */  be_nested_str_weak(x_flag_i),
+  /* K39  */  be_nested_str_weak(opcode),
+  /* K40  */  be_nested_str_weak(exchange_id),
+  /* K41  */  be_nested_str_weak(protocol_id),
+  /* K42  */  be_nested_str_weak(ack_message_counter),
+  /* K43  */  be_nested_str_weak(app_payload_idx),
+  /* K44  */  be_nested_str_weak(get),
+  /* K45  */  be_nested_str_weak(getbits),
+  /* K46  */  be_nested_str_weak(sec_mx),
+  /* K47  */  be_nested_str_weak(matter),
+  /* K48  */  be_nested_str_weak(Frame),
+  /* K49  */  be_nested_str_weak(decode_header),
+  /* K50  */  be_nested_str_weak(decode_payload),
+  /* K51  */  be_const_int(1),
+  /* K52  */  be_nested_str_weak(initiator_session_id),
+  /* K53  */  be_nested_str_weak(counter_snd_next),
+  /* K54  */  be_nested_str_weak(_counter_insecure_snd),
+  /* K55  */  be_nested_str_weak(next),
+  /* K56  */  be_nested_str_weak(get_opcode_name),
+  /* K57  */  be_nested_str_weak(0x_X2502X),
+  /* K58  */  be_nested_str_weak(log),
+  /* K59  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
+  /* K60  */  be_const_int(3),
+  /* K61  */  be_nested_str_weak(get_i2r),
+  /* K62  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X20Compute_X20Privacy_X20TODO),
+  /* K63  */  be_const_int(2),
+  /* K64  */  be_nested_str_weak(get_i2r_privacy),
+  /* K65  */  be_const_int(2147483647),
+  /* K66  */  be_nested_str_weak(AES_CTR),
+  /* K67  */  be_nested_str_weak(decrypt),
+  /* K68  */  be_nested_str_weak(peer_node_id),
+  /* K69  */  be_nested_str_weak(decrypt1),
+  /* K70  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
+  /* K71  */  be_const_class(be_class_Matter_Frame),
+  /* K72  */  be_nested_str_weak(_ip),
+  /* K73  */  be_nested_str_weak(_port),
+  /* K74  */  be_nested_str_weak(_exchange_id),
+  /* K75  */  be_nested_str_weak(x_flag_sx),
+  /* K76  */  be_nested_str_weak(vendor_id),
+};
+
 
 extern const bclass be_class_Matter_Frame;
 
@@ -13,16 +95,13 @@ be_local_closure(class_Matter_Frame_get_node_id,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(get_node_id),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(get_node_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
@@ -47,82 +126,63 @@ be_local_closure(class_Matter_Frame_encrypt,   /* name */
   be_nested_proto(
     23,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(raw),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(payload_idx),
-    /* K4   */  be_nested_str_weak(get_r2i),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(_n_bytes),
-    /* K7   */  be_nested_str_weak(clear),
-    /* K8   */  be_nested_str_weak(add),
-    /* K9   */  be_nested_str_weak(flags),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(is_CASE),
-    /* K13  */  be_nested_str_weak(get_device_id),
-    /* K14  */  be_nested_str_weak(resize),
-    /* K15  */  be_nested_str_weak(AES_CCM),
-    /* K16  */  be_nested_str_weak(encrypt1),
-    /* K17  */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(encrypt),
     &be_const_str_solidified,
     ( &(const binstruction[63]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0xA4060400,  //  0000  IMPORT	R1	K2
+      0x88080103,  //  0001  GETMBR	R2	R0	K3
+      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x88100104,  //  0003  GETMBR	R4	R0	K4
       0x5416000F,  //  0004  LDINT	R5	16
-      0x8C180704,  //  0005  GETMET	R6	R3	K4
+      0x8C180705,  //  0005  GETMET	R6	R3	K5
       0x7C180200,  //  0006  CALL	R6	1
-      0x881C0105,  //  0007  GETMBR	R7	R0	K5
-      0x881C0F06,  //  0008  GETMBR	R7	R7	K6
-      0x8C200F07,  //  0009  GETMET	R8	R7	K7
+      0x881C0106,  //  0007  GETMBR	R7	R0	K6
+      0x881C0F07,  //  0008  GETMBR	R7	R7	K7
+      0x8C200F08,  //  0009  GETMET	R8	R7	K8
       0x7C200200,  //  000A  CALL	R8	1
-      0x8C200F08,  //  000B  GETMET	R8	R7	K8
-      0x88280109,  //  000C  GETMBR	R10	R0	K9
-      0x582C000A,  //  000D  LDCONST	R11	K10
+      0x8C200F09,  //  000B  GETMET	R8	R7	K9
+      0x8828010A,  //  000C  GETMBR	R10	R0	K10
+      0x582C000B,  //  000D  LDCONST	R11	K11
       0x7C200600,  //  000E  CALL	R8	3
-      0x8C200F08,  //  000F  GETMET	R8	R7	K8
-      0x8828010B,  //  0010  GETMBR	R10	R0	K11
+      0x8C200F09,  //  000F  GETMET	R8	R7	K9
+      0x8828010C,  //  0010  GETMBR	R10	R0	K12
       0x542E0003,  //  0011  LDINT	R11	4
       0x7C200600,  //  0012  CALL	R8	3
-      0x8C20070C,  //  0013  GETMET	R8	R3	K12
+      0x8C20070D,  //  0013  GETMET	R8	R3	K13
       0x7C200200,  //  0014  CALL	R8	1
       0x78220005,  //  0015  JMPF	R8	#001C
-      0x8C20070D,  //  0016  GETMET	R8	R3	K13
+      0x8C20070E,  //  0016  GETMET	R8	R3	K14
       0x7C200200,  //  0017  CALL	R8	1
       0x78220002,  //  0018  JMPF	R8	#001C
-      0x8C20070D,  //  0019  GETMET	R8	R3	K13
+      0x8C20070E,  //  0019  GETMET	R8	R3	K14
       0x7C200200,  //  001A  CALL	R8	1
       0x40200E08,  //  001B  CONNECT	R8	R7	R8
-      0x8C200F0E,  //  001C  GETMET	R8	R7	K14
+      0x8C200F0F,  //  001C  GETMET	R8	R7	K15
       0x542A000C,  //  001D  LDINT	R10	13
       0x7C200400,  //  001E  CALL	R8	2
-      0x8C20050E,  //  001F  GETMET	R8	R2	K14
+      0x8C20050F,  //  001F  GETMET	R8	R2	K15
       0x6028000C,  //  0020  GETGBL	R10	G12
       0x5C2C0400,  //  0021  MOVE	R11	R2
       0x7C280200,  //  0022  CALL	R10	1
       0x00281405,  //  0023  ADD	R10	R10	R5
       0x7C200400,  //  0024  CALL	R8	2
-      0x8820030F,  //  0025  GETMBR	R8	R1	K15
-      0x8C201110,  //  0026  GETMET	R8	R8	K16
+      0x88200310,  //  0025  GETMBR	R8	R1	K16
+      0x8C201111,  //  0026  GETMET	R8	R8	K17
       0x5C280C00,  //  0027  MOVE	R10	R6
       0x5C2C0E00,  //  0028  MOVE	R11	R7
-      0x58300011,  //  0029  LDCONST	R12	K17
+      0x58300012,  //  0029  LDCONST	R12	K18
       0x6034000C,  //  002A  GETGBL	R13	G12
       0x5C380E00,  //  002B  MOVE	R14	R7
       0x7C340200,  //  002C  CALL	R13	1
       0x5C380400,  //  002D  MOVE	R14	R2
-      0x583C0011,  //  002E  LDCONST	R15	K17
+      0x583C0012,  //  002E  LDCONST	R15	K18
       0x5C400800,  //  002F  MOVE	R16	R4
       0x5C440400,  //  0030  MOVE	R17	R2
       0x5C480800,  //  0031  MOVE	R18	R4
@@ -152,25 +212,20 @@ be_local_closure(class_Matter_Frame_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(raw),
-    /* K2   */  be_nested_str_weak(remote_ip),
-    /* K3   */  be_nested_str_weak(remote_port),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x90020604,  //  0003  SETMBR	R0	K3	R4
+      0x90020C01,  //  0000  SETMBR	R0	K6	R1
+      0x90020602,  //  0001  SETMBR	R0	K3	R2
+      0x90022603,  //  0002  SETMBR	R0	K19	R3
+      0x90022804,  //  0003  SETMBR	R0	K20	R4
       0x80000000,  //  0004  RET	0
     })
   )
@@ -185,43 +240,13 @@ be_local_closure(class_Matter_Frame_encode_frame,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(flags),
-    /* K2   */  be_nested_str_weak(flag_s),
-    /* K3   */  be_nested_str_weak(flag_dsiz),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(add),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(local_session_id),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(sec_flags),
-    /* K10  */  be_nested_str_weak(sec_p),
-    /* K11  */  be_nested_str_weak(sec_c),
-    /* K12  */  be_nested_str_weak(sec_sesstype),
-    /* K13  */  be_nested_str_weak(message_counter),
-    /* K14  */  be_nested_str_weak(source_node_id),
-    /* K15  */  be_nested_str_weak(dest_node_id_8),
-    /* K16  */  be_nested_str_weak(dest_node_id_2),
-    /* K17  */  be_nested_str_weak(payload_idx),
-    /* K18  */  be_nested_str_weak(x_flags),
-    /* K19  */  be_nested_str_weak(x_flag_v),
-    /* K20  */  be_nested_str_weak(x_flag_r),
-    /* K21  */  be_nested_str_weak(x_flag_a),
-    /* K22  */  be_nested_str_weak(x_flag_i),
-    /* K23  */  be_nested_str_weak(opcode),
-    /* K24  */  be_nested_str_weak(exchange_id),
-    /* K25  */  be_nested_str_weak(protocol_id),
-    /* K26  */  be_nested_str_weak(ack_message_counter),
-    /* K27  */  be_nested_str_weak(app_payload_idx),
-    /* K28  */  be_nested_str_weak(raw),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(encode_frame),
     &be_const_str_solidified,
     ( &(const binstruction[161]) {  /* code */
@@ -235,156 +260,156 @@ be_local_closure(class_Matter_Frame_encode_frame,   /* name */
       0x5C180200,  //  0007  MOVE	R6	R1
       0x7C140200,  //  0008  CALL	R5	1
       0x70020000,  //  0009  JMP		#000B
-      0x58140000,  //  000A  LDCONST	R5	K0
+      0x58140015,  //  000A  LDCONST	R5	K21
       0x00100805,  //  000B  ADD	R4	R4	R5
       0x7C0C0200,  //  000C  CALL	R3	1
       0x5C080600,  //  000D  MOVE	R2	R3
-      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x880C010A,  //  000E  GETMBR	R3	R0	K10
       0x4C100000,  //  000F  LDNIL	R4
       0x1C0C0604,  //  0010  EQ	R3	R3	R4
       0x780E000D,  //  0011  JMPF	R3	#0020
-      0x90020300,  //  0012  SETMBR	R0	K1	K0
-      0x880C0102,  //  0013  GETMBR	R3	R0	K2
+      0x90021515,  //  0012  SETMBR	R0	K10	K21
+      0x880C0116,  //  0013  GETMBR	R3	R0	K22
       0x780E0003,  //  0014  JMPF	R3	#0019
-      0x880C0101,  //  0015  GETMBR	R3	R0	K1
+      0x880C010A,  //  0015  GETMBR	R3	R0	K10
       0x54120003,  //  0016  LDINT	R4	4
       0x300C0604,  //  0017  OR	R3	R3	R4
-      0x90020203,  //  0018  SETMBR	R0	K1	R3
-      0x880C0103,  //  0019  GETMBR	R3	R0	K3
+      0x90021403,  //  0018  SETMBR	R0	K10	R3
+      0x880C0117,  //  0019  GETMBR	R3	R0	K23
       0x780E0004,  //  001A  JMPF	R3	#0020
-      0x880C0101,  //  001B  GETMBR	R3	R0	K1
-      0x88100103,  //  001C  GETMBR	R4	R0	K3
-      0x2C100904,  //  001D  AND	R4	R4	K4
+      0x880C010A,  //  001B  GETMBR	R3	R0	K10
+      0x88100117,  //  001C  GETMBR	R4	R0	K23
+      0x2C100918,  //  001D  AND	R4	R4	K24
       0x300C0604,  //  001E  OR	R3	R3	R4
-      0x90020203,  //  001F  SETMBR	R0	K1	R3
-      0x8C0C0505,  //  0020  GETMET	R3	R2	K5
-      0x88140101,  //  0021  GETMBR	R5	R0	K1
-      0x58180006,  //  0022  LDCONST	R6	K6
+      0x90021403,  //  001F  SETMBR	R0	K10	R3
+      0x8C0C0509,  //  0020  GETMET	R3	R2	K9
+      0x8814010A,  //  0021  GETMBR	R5	R0	K10
+      0x5818000B,  //  0022  LDCONST	R6	K11
       0x7C0C0600,  //  0023  CALL	R3	3
-      0x8C0C0505,  //  0024  GETMET	R3	R2	K5
-      0x88140107,  //  0025  GETMBR	R5	R0	K7
+      0x8C0C0509,  //  0024  GETMET	R3	R2	K9
+      0x88140119,  //  0025  GETMBR	R5	R0	K25
       0x78160001,  //  0026  JMPF	R5	#0029
-      0x88140107,  //  0027  GETMBR	R5	R0	K7
+      0x88140119,  //  0027  GETMBR	R5	R0	K25
       0x70020000,  //  0028  JMP		#002A
-      0x58140000,  //  0029  LDCONST	R5	K0
-      0x58180008,  //  002A  LDCONST	R6	K8
+      0x58140015,  //  0029  LDCONST	R5	K21
+      0x5818001A,  //  002A  LDCONST	R6	K26
       0x7C0C0600,  //  002B  CALL	R3	3
-      0x880C0109,  //  002C  GETMBR	R3	R0	K9
+      0x880C011B,  //  002C  GETMBR	R3	R0	K27
       0x4C100000,  //  002D  LDNIL	R4
       0x1C0C0604,  //  002E  EQ	R3	R3	R4
       0x780E0013,  //  002F  JMPF	R3	#0044
-      0x90021300,  //  0030  SETMBR	R0	K9	K0
-      0x880C010A,  //  0031  GETMBR	R3	R0	K10
+      0x90023715,  //  0030  SETMBR	R0	K27	K21
+      0x880C011C,  //  0031  GETMBR	R3	R0	K28
       0x780E0003,  //  0032  JMPF	R3	#0037
-      0x880C0109,  //  0033  GETMBR	R3	R0	K9
+      0x880C011B,  //  0033  GETMBR	R3	R0	K27
       0x5412007F,  //  0034  LDINT	R4	128
       0x300C0604,  //  0035  OR	R3	R3	R4
-      0x90021203,  //  0036  SETMBR	R0	K9	R3
-      0x880C010B,  //  0037  GETMBR	R3	R0	K11
+      0x90023603,  //  0036  SETMBR	R0	K27	R3
+      0x880C011D,  //  0037  GETMBR	R3	R0	K29
       0x780E0003,  //  0038  JMPF	R3	#003D
-      0x880C0109,  //  0039  GETMBR	R3	R0	K9
+      0x880C011B,  //  0039  GETMBR	R3	R0	K27
       0x5412003F,  //  003A  LDINT	R4	64
       0x300C0604,  //  003B  OR	R3	R3	R4
-      0x90021203,  //  003C  SETMBR	R0	K9	R3
-      0x880C010C,  //  003D  GETMBR	R3	R0	K12
+      0x90023603,  //  003C  SETMBR	R0	K27	R3
+      0x880C011E,  //  003D  GETMBR	R3	R0	K30
       0x780E0004,  //  003E  JMPF	R3	#0044
-      0x880C0109,  //  003F  GETMBR	R3	R0	K9
-      0x8810010C,  //  0040  GETMBR	R4	R0	K12
-      0x2C100904,  //  0041  AND	R4	R4	K4
+      0x880C011B,  //  003F  GETMBR	R3	R0	K27
+      0x8810011E,  //  0040  GETMBR	R4	R0	K30
+      0x2C100918,  //  0041  AND	R4	R4	K24
       0x300C0604,  //  0042  OR	R3	R3	R4
-      0x90021203,  //  0043  SETMBR	R0	K9	R3
-      0x8C0C0505,  //  0044  GETMET	R3	R2	K5
-      0x88140109,  //  0045  GETMBR	R5	R0	K9
-      0x58180006,  //  0046  LDCONST	R6	K6
+      0x90023603,  //  0043  SETMBR	R0	K27	R3
+      0x8C0C0509,  //  0044  GETMET	R3	R2	K9
+      0x8814011B,  //  0045  GETMBR	R5	R0	K27
+      0x5818000B,  //  0046  LDCONST	R6	K11
       0x7C0C0600,  //  0047  CALL	R3	3
-      0x8C0C0505,  //  0048  GETMET	R3	R2	K5
-      0x8814010D,  //  0049  GETMBR	R5	R0	K13
+      0x8C0C0509,  //  0048  GETMET	R3	R2	K9
+      0x8814010C,  //  0049  GETMBR	R5	R0	K12
       0x541A0003,  //  004A  LDINT	R6	4
       0x7C0C0600,  //  004B  CALL	R3	3
-      0x880C0102,  //  004C  GETMBR	R3	R0	K2
+      0x880C0116,  //  004C  GETMBR	R3	R0	K22
       0x780E0001,  //  004D  JMPF	R3	#0050
-      0x880C010E,  //  004E  GETMBR	R3	R0	K14
+      0x880C011F,  //  004E  GETMBR	R3	R0	K31
       0x400C0403,  //  004F  CONNECT	R3	R2	R3
-      0x880C0103,  //  0050  GETMBR	R3	R0	K3
-      0x1C0C0706,  //  0051  EQ	R3	R3	K6
+      0x880C0117,  //  0050  GETMBR	R3	R0	K23
+      0x1C0C070B,  //  0051  EQ	R3	R3	K11
       0x780E0001,  //  0052  JMPF	R3	#0055
-      0x880C010F,  //  0053  GETMBR	R3	R0	K15
+      0x880C0120,  //  0053  GETMBR	R3	R0	K32
       0x400C0403,  //  0054  CONNECT	R3	R2	R3
-      0x880C0103,  //  0055  GETMBR	R3	R0	K3
-      0x1C0C0708,  //  0056  EQ	R3	R3	K8
+      0x880C0117,  //  0055  GETMBR	R3	R0	K23
+      0x1C0C071A,  //  0056  EQ	R3	R3	K26
       0x780E0003,  //  0057  JMPF	R3	#005C
-      0x8C0C0505,  //  0058  GETMET	R3	R2	K5
-      0x88140110,  //  0059  GETMBR	R5	R0	K16
-      0x58180008,  //  005A  LDCONST	R6	K8
+      0x8C0C0509,  //  0058  GETMET	R3	R2	K9
+      0x88140121,  //  0059  GETMBR	R5	R0	K33
+      0x5818001A,  //  005A  LDCONST	R6	K26
       0x7C0C0600,  //  005B  CALL	R3	3
       0x600C000C,  //  005C  GETGBL	R3	G12
       0x5C100400,  //  005D  MOVE	R4	R2
       0x7C0C0200,  //  005E  CALL	R3	1
-      0x90022203,  //  005F  SETMBR	R0	K17	R3
-      0x880C0112,  //  0060  GETMBR	R3	R0	K18
+      0x90020803,  //  005F  SETMBR	R0	K4	R3
+      0x880C0122,  //  0060  GETMBR	R3	R0	K34
       0x4C100000,  //  0061  LDNIL	R4
       0x1C0C0604,  //  0062  EQ	R3	R3	R4
       0x780E0016,  //  0063  JMPF	R3	#007B
-      0x90022500,  //  0064  SETMBR	R0	K18	K0
-      0x880C0113,  //  0065  GETMBR	R3	R0	K19
+      0x90024515,  //  0064  SETMBR	R0	K34	K21
+      0x880C0123,  //  0065  GETMBR	R3	R0	K35
       0x780E0003,  //  0066  JMPF	R3	#006B
-      0x880C0112,  //  0067  GETMBR	R3	R0	K18
+      0x880C0122,  //  0067  GETMBR	R3	R0	K34
       0x5412000F,  //  0068  LDINT	R4	16
       0x300C0604,  //  0069  OR	R3	R3	R4
-      0x90022403,  //  006A  SETMBR	R0	K18	R3
-      0x880C0114,  //  006B  GETMBR	R3	R0	K20
+      0x90024403,  //  006A  SETMBR	R0	K34	R3
+      0x880C0124,  //  006B  GETMBR	R3	R0	K36
       0x780E0003,  //  006C  JMPF	R3	#0071
-      0x880C0112,  //  006D  GETMBR	R3	R0	K18
+      0x880C0122,  //  006D  GETMBR	R3	R0	K34
       0x54120003,  //  006E  LDINT	R4	4
       0x300C0604,  //  006F  OR	R3	R3	R4
-      0x90022403,  //  0070  SETMBR	R0	K18	R3
-      0x880C0115,  //  0071  GETMBR	R3	R0	K21
+      0x90024403,  //  0070  SETMBR	R0	K34	R3
+      0x880C0125,  //  0071  GETMBR	R3	R0	K37
       0x780E0002,  //  0072  JMPF	R3	#0076
-      0x880C0112,  //  0073  GETMBR	R3	R0	K18
-      0x300C0708,  //  0074  OR	R3	R3	K8
-      0x90022403,  //  0075  SETMBR	R0	K18	R3
-      0x880C0116,  //  0076  GETMBR	R3	R0	K22
+      0x880C0122,  //  0073  GETMBR	R3	R0	K34
+      0x300C071A,  //  0074  OR	R3	R3	K26
+      0x90024403,  //  0075  SETMBR	R0	K34	R3
+      0x880C0126,  //  0076  GETMBR	R3	R0	K38
       0x780E0002,  //  0077  JMPF	R3	#007B
-      0x880C0112,  //  0078  GETMBR	R3	R0	K18
-      0x300C0706,  //  0079  OR	R3	R3	K6
-      0x90022403,  //  007A  SETMBR	R0	K18	R3
-      0x8C0C0505,  //  007B  GETMET	R3	R2	K5
-      0x88140112,  //  007C  GETMBR	R5	R0	K18
-      0x58180006,  //  007D  LDCONST	R6	K6
+      0x880C0122,  //  0078  GETMBR	R3	R0	K34
+      0x300C070B,  //  0079  OR	R3	R3	K11
+      0x90024403,  //  007A  SETMBR	R0	K34	R3
+      0x8C0C0509,  //  007B  GETMET	R3	R2	K9
+      0x88140122,  //  007C  GETMBR	R5	R0	K34
+      0x5818000B,  //  007D  LDCONST	R6	K11
       0x7C0C0600,  //  007E  CALL	R3	3
-      0x8C0C0505,  //  007F  GETMET	R3	R2	K5
-      0x88140117,  //  0080  GETMBR	R5	R0	K23
-      0x58180006,  //  0081  LDCONST	R6	K6
+      0x8C0C0509,  //  007F  GETMET	R3	R2	K9
+      0x88140127,  //  0080  GETMBR	R5	R0	K39
+      0x5818000B,  //  0081  LDCONST	R6	K11
       0x7C0C0600,  //  0082  CALL	R3	3
-      0x8C0C0505,  //  0083  GETMET	R3	R2	K5
-      0x88140118,  //  0084  GETMBR	R5	R0	K24
+      0x8C0C0509,  //  0083  GETMET	R3	R2	K9
+      0x88140128,  //  0084  GETMBR	R5	R0	K40
       0x4C180000,  //  0085  LDNIL	R6
       0x20140A06,  //  0086  NE	R5	R5	R6
       0x78160003,  //  0087  JMPF	R5	#008C
-      0x88140118,  //  0088  GETMBR	R5	R0	K24
+      0x88140128,  //  0088  GETMBR	R5	R0	K40
       0x541AFFFE,  //  0089  LDINT	R6	65535
       0x2C140A06,  //  008A  AND	R5	R5	R6
       0x70020000,  //  008B  JMP		#008D
-      0x58140000,  //  008C  LDCONST	R5	K0
-      0x58180008,  //  008D  LDCONST	R6	K8
+      0x58140015,  //  008C  LDCONST	R5	K21
+      0x5818001A,  //  008D  LDCONST	R6	K26
       0x7C0C0600,  //  008E  CALL	R3	3
-      0x8C0C0505,  //  008F  GETMET	R3	R2	K5
-      0x88140119,  //  0090  GETMBR	R5	R0	K25
-      0x58180008,  //  0091  LDCONST	R6	K8
+      0x8C0C0509,  //  008F  GETMET	R3	R2	K9
+      0x88140129,  //  0090  GETMBR	R5	R0	K41
+      0x5818001A,  //  0091  LDCONST	R6	K26
       0x7C0C0600,  //  0092  CALL	R3	3
-      0x880C0115,  //  0093  GETMBR	R3	R0	K21
+      0x880C0125,  //  0093  GETMBR	R3	R0	K37
       0x780E0003,  //  0094  JMPF	R3	#0099
-      0x8C0C0505,  //  0095  GETMET	R3	R2	K5
-      0x8814011A,  //  0096  GETMBR	R5	R0	K26
+      0x8C0C0509,  //  0095  GETMET	R3	R2	K9
+      0x8814012A,  //  0096  GETMBR	R5	R0	K42
       0x541A0003,  //  0097  LDINT	R6	4
       0x7C0C0600,  //  0098  CALL	R3	3
       0x600C000C,  //  0099  GETGBL	R3	G12
       0x5C100400,  //  009A  MOVE	R4	R2
       0x7C0C0200,  //  009B  CALL	R3	1
-      0x90023603,  //  009C  SETMBR	R0	K27	R3
+      0x90025603,  //  009C  SETMBR	R0	K43	R3
       0x78060000,  //  009D  JMPF	R1	#009F
       0x400C0401,  //  009E  CONNECT	R3	R2	R1
-      0x90023802,  //  009F  SETMBR	R0	K28	R2
+      0x90020602,  //  009F  SETMBR	R0	K3	R2
       0x80040400,  //  00A0  RET	1	R2
     })
   )
@@ -399,157 +424,135 @@ be_local_closure(class_Matter_Frame_decode_header,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(raw),
-    /* K2   */  be_nested_str_weak(flags),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(flag_s),
-    /* K6   */  be_nested_str_weak(getbits),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(flag_dsiz),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(sec_flags),
-    /* K11  */  be_nested_str_weak(sec_p),
-    /* K12  */  be_nested_str_weak(sec_c),
-    /* K13  */  be_nested_str_weak(sec_mx),
-    /* K14  */  be_nested_str_weak(sec_sesstype),
-    /* K15  */  be_nested_str_weak(local_session_id),
-    /* K16  */  be_nested_str_weak(message_counter),
-    /* K17  */  be_nested_str_weak(source_node_id),
-    /* K18  */  be_nested_str_weak(dest_node_id_8),
-    /* K19  */  be_nested_str_weak(dest_node_id_2),
-    /* K20  */  be_nested_str_weak(payload_idx),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(decode_header),
     &be_const_str_solidified,
     ( &(const binstruction[121]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C0C0503,  //  0002  GETMET	R3	R2	K3
-      0x58140000,  //  0003  LDCONST	R5	K0
-      0x58180004,  //  0004  LDCONST	R6	K4
+      0x58040015,  //  0000  LDCONST	R1	K21
+      0x88080103,  //  0001  GETMBR	R2	R0	K3
+      0x8C0C052C,  //  0002  GETMET	R3	R2	K44
+      0x58140015,  //  0003  LDCONST	R5	K21
+      0x5818000B,  //  0004  LDCONST	R6	K11
       0x7C0C0600,  //  0005  CALL	R3	3
-      0x90020403,  //  0006  SETMBR	R0	K2	R3
-      0x880C0102,  //  0007  GETMBR	R3	R0	K2
+      0x90021403,  //  0006  SETMBR	R0	K10	R3
+      0x880C010A,  //  0007  GETMBR	R3	R0	K10
       0x541200F7,  //  0008  LDINT	R4	248
       0x2C0C0604,  //  0009  AND	R3	R3	R4
-      0x200C0700,  //  000A  NE	R3	R3	K0
+      0x200C0715,  //  000A  NE	R3	R3	K21
       0x780E0001,  //  000B  JMPF	R3	#000E
       0x500C0000,  //  000C  LDBOOL	R3	0	0
       0x80040600,  //  000D  RET	1	R3
-      0x8C0C0506,  //  000E  GETMET	R3	R2	K6
-      0x58140007,  //  000F  LDCONST	R5	K7
-      0x58180004,  //  0010  LDCONST	R6	K4
+      0x8C0C052D,  //  000E  GETMET	R3	R2	K45
+      0x5814001A,  //  000F  LDCONST	R5	K26
+      0x5818000B,  //  0010  LDCONST	R6	K11
       0x7C0C0600,  //  0011  CALL	R3	3
-      0x90020A03,  //  0012  SETMBR	R0	K5	R3
-      0x8C0C0506,  //  0013  GETMET	R3	R2	K6
-      0x58140000,  //  0014  LDCONST	R5	K0
-      0x58180007,  //  0015  LDCONST	R6	K7
+      0x90022C03,  //  0012  SETMBR	R0	K22	R3
+      0x8C0C052D,  //  0013  GETMET	R3	R2	K45
+      0x58140015,  //  0014  LDCONST	R5	K21
+      0x5818001A,  //  0015  LDCONST	R6	K26
       0x7C0C0600,  //  0016  CALL	R3	3
-      0x90021003,  //  0017  SETMBR	R0	K8	R3
-      0x880C0108,  //  0018  GETMBR	R3	R0	K8
-      0x1C0C0709,  //  0019  EQ	R3	R3	K9
+      0x90022E03,  //  0017  SETMBR	R0	K23	R3
+      0x880C0117,  //  0018  GETMBR	R3	R0	K23
+      0x1C0C0718,  //  0019  EQ	R3	R3	K24
       0x780E0001,  //  001A  JMPF	R3	#001D
       0x500C0000,  //  001B  LDBOOL	R3	0	0
       0x80040600,  //  001C  RET	1	R3
-      0x8C0C0503,  //  001D  GETMET	R3	R2	K3
-      0x58140009,  //  001E  LDCONST	R5	K9
-      0x58180004,  //  001F  LDCONST	R6	K4
+      0x8C0C052C,  //  001D  GETMET	R3	R2	K44
+      0x58140018,  //  001E  LDCONST	R5	K24
+      0x5818000B,  //  001F  LDCONST	R6	K11
       0x7C0C0600,  //  0020  CALL	R3	3
-      0x90021403,  //  0021  SETMBR	R0	K10	R3
-      0x8C0C0506,  //  0022  GETMET	R3	R2	K6
+      0x90023603,  //  0021  SETMBR	R0	K27	R3
+      0x8C0C052D,  //  0022  GETMET	R3	R2	K45
       0x54160007,  //  0023  LDINT	R5	8
-      0x08161205,  //  0024  MUL	R5	K9	R5
+      0x08163005,  //  0024  MUL	R5	K24	R5
       0x541A0006,  //  0025  LDINT	R6	7
       0x00140A06,  //  0026  ADD	R5	R5	R6
-      0x58180004,  //  0027  LDCONST	R6	K4
+      0x5818000B,  //  0027  LDCONST	R6	K11
       0x7C0C0600,  //  0028  CALL	R3	3
-      0x90021603,  //  0029  SETMBR	R0	K11	R3
-      0x8C0C0506,  //  002A  GETMET	R3	R2	K6
+      0x90023803,  //  0029  SETMBR	R0	K28	R3
+      0x8C0C052D,  //  002A  GETMET	R3	R2	K45
       0x54160007,  //  002B  LDINT	R5	8
-      0x08161205,  //  002C  MUL	R5	K9	R5
+      0x08163005,  //  002C  MUL	R5	K24	R5
       0x541A0005,  //  002D  LDINT	R6	6
       0x00140A06,  //  002E  ADD	R5	R5	R6
-      0x58180004,  //  002F  LDCONST	R6	K4
+      0x5818000B,  //  002F  LDCONST	R6	K11
       0x7C0C0600,  //  0030  CALL	R3	3
-      0x90021803,  //  0031  SETMBR	R0	K12	R3
-      0x8C0C0506,  //  0032  GETMET	R3	R2	K6
+      0x90023A03,  //  0031  SETMBR	R0	K29	R3
+      0x8C0C052D,  //  0032  GETMET	R3	R2	K45
       0x54160007,  //  0033  LDINT	R5	8
-      0x08161205,  //  0034  MUL	R5	K9	R5
+      0x08163005,  //  0034  MUL	R5	K24	R5
       0x541A0004,  //  0035  LDINT	R6	5
       0x00140A06,  //  0036  ADD	R5	R5	R6
-      0x58180004,  //  0037  LDCONST	R6	K4
+      0x5818000B,  //  0037  LDCONST	R6	K11
       0x7C0C0600,  //  0038  CALL	R3	3
-      0x90021A03,  //  0039  SETMBR	R0	K13	R3
-      0x8C0C0506,  //  003A  GETMET	R3	R2	K6
+      0x90025C03,  //  0039  SETMBR	R0	K46	R3
+      0x8C0C052D,  //  003A  GETMET	R3	R2	K45
       0x54160007,  //  003B  LDINT	R5	8
-      0x08161205,  //  003C  MUL	R5	K9	R5
-      0x58180007,  //  003D  LDCONST	R6	K7
+      0x08163005,  //  003C  MUL	R5	K24	R5
+      0x5818001A,  //  003D  LDCONST	R6	K26
       0x7C0C0600,  //  003E  CALL	R3	3
-      0x90021C03,  //  003F  SETMBR	R0	K14	R3
-      0x880C010E,  //  0040  GETMBR	R3	R0	K14
-      0x240C0704,  //  0041  GT	R3	R3	K4
+      0x90023C03,  //  003F  SETMBR	R0	K30	R3
+      0x880C011E,  //  0040  GETMBR	R3	R0	K30
+      0x240C070B,  //  0041  GT	R3	R3	K11
       0x780E0001,  //  0042  JMPF	R3	#0045
       0x500C0000,  //  0043  LDBOOL	R3	0	0
       0x80040600,  //  0044  RET	1	R3
-      0x8C0C0503,  //  0045  GETMET	R3	R2	K3
-      0x58140004,  //  0046  LDCONST	R5	K4
-      0x58180007,  //  0047  LDCONST	R6	K7
+      0x8C0C052C,  //  0045  GETMET	R3	R2	K44
+      0x5814000B,  //  0046  LDCONST	R5	K11
+      0x5818001A,  //  0047  LDCONST	R6	K26
       0x7C0C0600,  //  0048  CALL	R3	3
-      0x90021E03,  //  0049  SETMBR	R0	K15	R3
-      0x8C0C0503,  //  004A  GETMET	R3	R2	K3
+      0x90023203,  //  0049  SETMBR	R0	K25	R3
+      0x8C0C052C,  //  004A  GETMET	R3	R2	K44
       0x54160003,  //  004B  LDINT	R5	4
       0x541A0003,  //  004C  LDINT	R6	4
       0x7C0C0600,  //  004D  CALL	R3	3
-      0x90022003,  //  004E  SETMBR	R0	K16	R3
+      0x90021803,  //  004E  SETMBR	R0	K12	R3
       0x540E0007,  //  004F  LDINT	R3	8
       0x00040203,  //  0050  ADD	R1	R1	R3
-      0x880C0105,  //  0051  GETMBR	R3	R0	K5
+      0x880C0116,  //  0051  GETMBR	R3	R0	K22
       0x780E0006,  //  0052  JMPF	R3	#005A
       0x540E0006,  //  0053  LDINT	R3	7
       0x000C0203,  //  0054  ADD	R3	R1	R3
       0x400C0203,  //  0055  CONNECT	R3	R1	R3
       0x940C0403,  //  0056  GETIDX	R3	R2	R3
-      0x90022203,  //  0057  SETMBR	R0	K17	R3
+      0x90023E03,  //  0057  SETMBR	R0	K31	R3
       0x540E0007,  //  0058  LDINT	R3	8
       0x00040203,  //  0059  ADD	R1	R1	R3
-      0x880C0108,  //  005A  GETMBR	R3	R0	K8
-      0x1C0C0704,  //  005B  EQ	R3	R3	K4
+      0x880C0117,  //  005A  GETMBR	R3	R0	K23
+      0x1C0C070B,  //  005B  EQ	R3	R3	K11
       0x780E0007,  //  005C  JMPF	R3	#0065
       0x540E0006,  //  005D  LDINT	R3	7
       0x000C0203,  //  005E  ADD	R3	R1	R3
       0x400C0203,  //  005F  CONNECT	R3	R1	R3
       0x940C0403,  //  0060  GETIDX	R3	R2	R3
-      0x90022403,  //  0061  SETMBR	R0	K18	R3
+      0x90024003,  //  0061  SETMBR	R0	K32	R3
       0x540E0007,  //  0062  LDINT	R3	8
       0x00040203,  //  0063  ADD	R1	R1	R3
       0x70020008,  //  0064  JMP		#006E
-      0x880C0108,  //  0065  GETMBR	R3	R0	K8
-      0x1C0C0707,  //  0066  EQ	R3	R3	K7
+      0x880C0117,  //  0065  GETMBR	R3	R0	K23
+      0x1C0C071A,  //  0066  EQ	R3	R3	K26
       0x780E0005,  //  0067  JMPF	R3	#006E
-      0x8C0C0503,  //  0068  GETMET	R3	R2	K3
+      0x8C0C052C,  //  0068  GETMET	R3	R2	K44
       0x5C140200,  //  0069  MOVE	R5	R1
-      0x58180007,  //  006A  LDCONST	R6	K7
+      0x5818001A,  //  006A  LDCONST	R6	K26
       0x7C0C0600,  //  006B  CALL	R3	3
-      0x90022603,  //  006C  SETMBR	R0	K19	R3
-      0x00040307,  //  006D  ADD	R1	R1	K7
-      0x880C010D,  //  006E  GETMBR	R3	R0	K13
+      0x90024203,  //  006C  SETMBR	R0	K33	R3
+      0x0004031A,  //  006D  ADD	R1	R1	K26
+      0x880C012E,  //  006E  GETMBR	R3	R0	K46
       0x780E0005,  //  006F  JMPF	R3	#0076
-      0x8C0C0503,  //  0070  GETMET	R3	R2	K3
+      0x8C0C052C,  //  0070  GETMET	R3	R2	K44
       0x5C140200,  //  0071  MOVE	R5	R1
-      0x58180007,  //  0072  LDCONST	R6	K7
+      0x5818001A,  //  0072  LDCONST	R6	K26
       0x7C0C0600,  //  0073  CALL	R3	3
-      0x00100707,  //  0074  ADD	R4	R3	K7
+      0x0010071A,  //  0074  ADD	R4	R3	K26
       0x00040204,  //  0075  ADD	R1	R1	R4
-      0x90022801,  //  0076  SETMBR	R0	K20	R1
+      0x90020801,  //  0076  SETMBR	R0	K4	R1
       0x500C0200,  //  0077  LDBOOL	R3	1	0
       0x80040600,  //  0078  RET	1	R3
     })
@@ -565,31 +568,25 @@ be_local_closure(class_Matter_Frame_debug,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Frame),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(decode_header),
-    /* K4   */  be_nested_str_weak(decode_payload),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(debug),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x80000400,  //  0000  RET	0
-      0xB80A0000,  //  0001  GETNGBL	R2	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0xB80A5E00,  //  0001  GETNGBL	R2	K47
+      0x8C080530,  //  0002  GETMET	R2	R2	K48
+      0x88100106,  //  0003  GETMBR	R4	R0	K6
       0x5C140200,  //  0004  MOVE	R5	R1
       0x7C080600,  //  0005  CALL	R2	3
-      0x8C0C0503,  //  0006  GETMET	R3	R2	K3
+      0x8C0C0531,  //  0006  GETMET	R3	R2	K49
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C0504,  //  0008  GETMET	R3	R2	K4
+      0x8C0C0532,  //  0008  GETMET	R3	R2	K50
       0x7C0C0200,  //  0009  CALL	R3	1
     })
   )
@@ -604,43 +601,13 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(remote_ip),
-    /* K2   */  be_nested_str_weak(remote_port),
-    /* K3   */  be_nested_str_weak(flag_s),
-    /* K4   */  be_nested_str_weak(flag_dsiz),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(dest_node_id_8),
-    /* K7   */  be_nested_str_weak(source_node_id),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(local_session_id),
-    /* K11  */  be_nested_str_weak(initiator_session_id),
-    /* K12  */  be_nested_str_weak(message_counter),
-    /* K13  */  be_nested_str_weak(counter_snd_next),
-    /* K14  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K15  */  be_nested_str_weak(next),
-    /* K16  */  be_nested_str_weak(x_flag_i),
-    /* K17  */  be_nested_str_weak(opcode),
-    /* K18  */  be_nested_str_weak(exchange_id),
-    /* K19  */  be_nested_str_weak(protocol_id),
-    /* K20  */  be_nested_str_weak(x_flag_r),
-    /* K21  */  be_nested_str_weak(x_flag_a),
-    /* K22  */  be_nested_str_weak(ack_message_counter),
-    /* K23  */  be_nested_str_weak(matter),
-    /* K24  */  be_nested_str_weak(get_opcode_name),
-    /* K25  */  be_nested_str_weak(0x_X2502X),
-    /* K26  */  be_nested_str_weak(log),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
-    /* K28  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(build_response),
     &be_const_str_solidified,
     ( &(const binstruction[90]) {  /* code */
@@ -650,88 +617,88 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
       0x60100006,  //  0003  GETGBL	R4	G6
       0x5C140000,  //  0004  MOVE	R5	R0
       0x7C100200,  //  0005  CALL	R4	1
-      0x88140100,  //  0006  GETMBR	R5	R0	K0
+      0x88140106,  //  0006  GETMBR	R5	R0	K6
       0x7C100200,  //  0007  CALL	R4	1
       0x5C0C0800,  //  0008  MOVE	R3	R4
-      0x88100101,  //  0009  GETMBR	R4	R0	K1
-      0x900E0204,  //  000A  SETMBR	R3	K1	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x900E0404,  //  000C  SETMBR	R3	K2	R4
-      0x88100103,  //  000D  GETMBR	R4	R0	K3
+      0x88100113,  //  0009  GETMBR	R4	R0	K19
+      0x900E2604,  //  000A  SETMBR	R3	K19	R4
+      0x88100114,  //  000B  GETMBR	R4	R0	K20
+      0x900E2804,  //  000C  SETMBR	R3	K20	R4
+      0x88100116,  //  000D  GETMBR	R4	R0	K22
       0x78120003,  //  000E  JMPF	R4	#0013
-      0x900E0905,  //  000F  SETMBR	R3	K4	K5
-      0x88100107,  //  0010  GETMBR	R4	R0	K7
-      0x900E0C04,  //  0011  SETMBR	R3	K6	R4
+      0x900E2F33,  //  000F  SETMBR	R3	K23	K51
+      0x8810011F,  //  0010  GETMBR	R4	R0	K31
+      0x900E4004,  //  0011  SETMBR	R3	K32	R4
       0x70020000,  //  0012  JMP		#0014
-      0x900E0908,  //  0013  SETMBR	R3	K4	K8
-      0x88100109,  //  0014  GETMBR	R4	R0	K9
-      0x900E1204,  //  0015  SETMBR	R3	K9	R4
-      0x8810010A,  //  0016  GETMBR	R4	R0	K10
-      0x20100908,  //  0017  NE	R4	R4	K8
+      0x900E2F15,  //  0013  SETMBR	R3	K23	K21
+      0x88100100,  //  0014  GETMBR	R4	R0	K0
+      0x900E0004,  //  0015  SETMBR	R3	K0	R4
+      0x88100119,  //  0016  GETMBR	R4	R0	K25
+      0x20100915,  //  0017  NE	R4	R4	K21
       0x7812000D,  //  0018  JMPF	R4	#0027
-      0x88100109,  //  0019  GETMBR	R4	R0	K9
+      0x88100100,  //  0019  GETMBR	R4	R0	K0
       0x7812000B,  //  001A  JMPF	R4	#0027
-      0x88100109,  //  001B  GETMBR	R4	R0	K9
-      0x8810090B,  //  001C  GETMBR	R4	R4	K11
-      0x20100908,  //  001D  NE	R4	R4	K8
+      0x88100100,  //  001B  GETMBR	R4	R0	K0
+      0x88100934,  //  001C  GETMBR	R4	R4	K52
+      0x20100915,  //  001D  NE	R4	R4	K21
       0x78120007,  //  001E  JMPF	R4	#0027
-      0x88100109,  //  001F  GETMBR	R4	R0	K9
-      0x8C10090D,  //  0020  GETMET	R4	R4	K13
+      0x88100100,  //  001F  GETMBR	R4	R0	K0
+      0x8C100935,  //  0020  GETMET	R4	R4	K53
       0x7C100200,  //  0021  CALL	R4	1
       0x900E1804,  //  0022  SETMBR	R3	K12	R4
-      0x88100109,  //  0023  GETMBR	R4	R0	K9
-      0x8810090B,  //  0024  GETMBR	R4	R4	K11
-      0x900E1404,  //  0025  SETMBR	R3	K10	R4
+      0x88100100,  //  0023  GETMBR	R4	R0	K0
+      0x88100934,  //  0024  GETMBR	R4	R4	K52
+      0x900E3204,  //  0025  SETMBR	R3	K25	R4
       0x70020005,  //  0026  JMP		#002D
-      0x88100109,  //  0027  GETMBR	R4	R0	K9
-      0x8810090E,  //  0028  GETMBR	R4	R4	K14
-      0x8C10090F,  //  0029  GETMET	R4	R4	K15
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x88100936,  //  0028  GETMBR	R4	R4	K54
+      0x8C100937,  //  0029  GETMET	R4	R4	K55
       0x7C100200,  //  002A  CALL	R4	1
       0x900E1804,  //  002B  SETMBR	R3	K12	R4
-      0x900E1508,  //  002C  SETMBR	R3	K10	K8
-      0x88100110,  //  002D  GETMBR	R4	R0	K16
+      0x900E3315,  //  002C  SETMBR	R3	K25	K21
+      0x88100126,  //  002D  GETMBR	R4	R0	K38
       0x78120001,  //  002E  JMPF	R4	#0031
-      0x58100008,  //  002F  LDCONST	R4	K8
+      0x58100015,  //  002F  LDCONST	R4	K21
       0x70020000,  //  0030  JMP		#0032
-      0x58100005,  //  0031  LDCONST	R4	K5
-      0x900E2004,  //  0032  SETMBR	R3	K16	R4
-      0x900E2201,  //  0033  SETMBR	R3	K17	R1
-      0x88100112,  //  0034  GETMBR	R4	R0	K18
-      0x900E2404,  //  0035  SETMBR	R3	K18	R4
-      0x88100113,  //  0036  GETMBR	R4	R0	K19
-      0x900E2604,  //  0037  SETMBR	R3	K19	R4
-      0x88100114,  //  0038  GETMBR	R4	R0	K20
+      0x58100033,  //  0031  LDCONST	R4	K51
+      0x900E4C04,  //  0032  SETMBR	R3	K38	R4
+      0x900E4E01,  //  0033  SETMBR	R3	K39	R1
+      0x88100128,  //  0034  GETMBR	R4	R0	K40
+      0x900E5004,  //  0035  SETMBR	R3	K40	R4
+      0x88100129,  //  0036  GETMBR	R4	R0	K41
+      0x900E5204,  //  0037  SETMBR	R3	K41	R4
+      0x88100124,  //  0038  GETMBR	R4	R0	K36
       0x78120002,  //  0039  JMPF	R4	#003D
-      0x900E2B05,  //  003A  SETMBR	R3	K21	K5
+      0x900E4B33,  //  003A  SETMBR	R3	K37	K51
       0x8810010C,  //  003B  GETMBR	R4	R0	K12
-      0x900E2C04,  //  003C  SETMBR	R3	K22	R4
+      0x900E5404,  //  003C  SETMBR	R3	K42	R4
       0x780A0001,  //  003D  JMPF	R2	#0040
-      0x58100005,  //  003E  LDCONST	R4	K5
+      0x58100033,  //  003E  LDCONST	R4	K51
       0x70020000,  //  003F  JMP		#0041
-      0x58100008,  //  0040  LDCONST	R4	K8
-      0x900E2804,  //  0041  SETMBR	R3	K20	R4
-      0x8810070A,  //  0042  GETMBR	R4	R3	K10
-      0x1C100908,  //  0043  EQ	R4	R4	K8
+      0x58100015,  //  0040  LDCONST	R4	K21
+      0x900E4804,  //  0041  SETMBR	R3	K36	R4
+      0x88100719,  //  0042  GETMBR	R4	R3	K25
+      0x1C100915,  //  0043  EQ	R4	R4	K21
       0x78120013,  //  0044  JMPF	R4	#0059
-      0xB8122E00,  //  0045  GETNGBL	R4	K23
-      0x8C100918,  //  0046  GETMET	R4	R4	K24
-      0x88180711,  //  0047  GETMBR	R6	R3	K17
+      0xB8125E00,  //  0045  GETNGBL	R4	K47
+      0x8C100938,  //  0046  GETMET	R4	R4	K56
+      0x88180727,  //  0047  GETMBR	R6	R3	K39
       0x7C100400,  //  0048  CALL	R4	2
       0x5C140800,  //  0049  MOVE	R5	R4
       0x74160004,  //  004A  JMPT	R5	#0050
       0x60140018,  //  004B  GETGBL	R5	G24
-      0x58180019,  //  004C  LDCONST	R6	K25
-      0x881C0711,  //  004D  GETMBR	R7	R3	K17
+      0x58180039,  //  004C  LDCONST	R6	K57
+      0x881C0727,  //  004D  GETMBR	R7	R3	K39
       0x7C140400,  //  004E  CALL	R5	2
       0x5C100A00,  //  004F  MOVE	R4	R5
-      0xB8163400,  //  0050  GETNGBL	R5	K26
+      0xB8167400,  //  0050  GETNGBL	R5	K58
       0x60180018,  //  0051  GETGBL	R6	G24
-      0x581C001B,  //  0052  LDCONST	R7	K27
-      0x88200709,  //  0053  GETMBR	R8	R3	K9
-      0x8820110A,  //  0054  GETMBR	R8	R8	K10
+      0x581C003B,  //  0052  LDCONST	R7	K59
+      0x88200700,  //  0053  GETMBR	R8	R3	K0
+      0x88201119,  //  0054  GETMBR	R8	R8	K25
       0x5C240800,  //  0055  MOVE	R9	R4
       0x7C180600,  //  0056  CALL	R6	3
-      0x581C001C,  //  0057  LDCONST	R7	K28
+      0x581C003C,  //  0057  LDCONST	R7	K60
       0x7C140400,  //  0058  CALL	R5	2
       0x80040600,  //  0059  RET	1	R3
     })
@@ -747,68 +714,38 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
   be_nested_proto(
     23,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(raw),
-    /* K3   */  be_nested_str_weak(payload_idx),
-    /* K4   */  be_nested_str_weak(get_i2r),
-    /* K5   */  be_nested_str_weak(sec_p),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X20Compute_X20Privacy_X20TODO),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(get_i2r_privacy),
-    /* K10  */  be_const_int(2147483647),
-    /* K11  */  be_nested_str_weak(add),
-    /* K12  */  be_nested_str_weak(local_session_id),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(AES_CTR),
-    /* K15  */  be_nested_str_weak(decrypt),
-    /* K16  */  be_const_int(0),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(message_handler),
-    /* K19  */  be_nested_str_weak(_n_bytes),
-    /* K20  */  be_nested_str_weak(clear),
-    /* K21  */  be_nested_str_weak(flags),
-    /* K22  */  be_nested_str_weak(message_counter),
-    /* K23  */  be_nested_str_weak(source_node_id),
-    /* K24  */  be_nested_str_weak(peer_node_id),
-    /* K25  */  be_nested_str_weak(resize),
-    /* K26  */  be_nested_str_weak(AES_CCM),
-    /* K27  */  be_nested_str_weak(decrypt1),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(decrypt),
     &be_const_str_solidified,
     ( &(const binstruction[115]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0xA4060400,  //  0000  IMPORT	R1	K2
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x880C0103,  //  0002  GETMBR	R3	R0	K3
+      0x88100104,  //  0003  GETMBR	R4	R0	K4
       0x5416000F,  //  0004  LDINT	R5	16
-      0x8C180504,  //  0005  GETMET	R6	R2	K4
+      0x8C18053D,  //  0005  GETMET	R6	R2	K61
       0x7C180200,  //  0006  CALL	R6	1
-      0x881C0105,  //  0007  GETMBR	R7	R0	K5
+      0x881C011C,  //  0007  GETMBR	R7	R0	K28
       0x781E002B,  //  0008  JMPF	R7	#0035
-      0xB81E0C00,  //  0009  GETNGBL	R7	K6
-      0x58200007,  //  000A  LDCONST	R8	K7
-      0x58240008,  //  000B  LDCONST	R9	K8
+      0xB81E7400,  //  0009  GETNGBL	R7	K58
+      0x5820003E,  //  000A  LDCONST	R8	K62
+      0x5824003F,  //  000B  LDCONST	R9	K63
       0x7C1C0400,  //  000C  CALL	R7	2
-      0x8C1C0509,  //  000D  GETMET	R7	R2	K9
+      0x8C1C0540,  //  000D  GETMET	R7	R2	K64
       0x7C1C0200,  //  000E  CALL	R7	1
       0x5421FFEF,  //  000F  LDINT	R8	-16
-      0x4020110A,  //  0010  CONNECT	R8	R8	K10
+      0x40201141,  //  0010  CONNECT	R8	R8	K65
       0x94200608,  //  0011  GETIDX	R8	R3	R8
       0x60240015,  //  0012  GETGBL	R9	G21
       0x7C240000,  //  0013  CALL	R9	0
-      0x8C24130B,  //  0014  GETMET	R9	R9	K11
-      0x882C010C,  //  0015  GETMBR	R11	R0	K12
+      0x8C241309,  //  0014  GETMET	R9	R9	K9
+      0x882C0119,  //  0015  GETMBR	R11	R0	K25
       0x5431FFFD,  //  0016  LDINT	R12	-2
       0x7C240600,  //  0017  CALL	R9	3
       0x542A0004,  //  0018  LDINT	R10	5
@@ -817,63 +754,63 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
       0x9428100A,  //  001B  GETIDX	R10	R8	R10
       0x0024120A,  //  001C  ADD	R9	R9	R10
       0x542A0003,  //  001D  LDINT	R10	4
-      0x882C0103,  //  001E  GETMBR	R11	R0	K3
-      0x042C170D,  //  001F  SUB	R11	R11	K13
+      0x882C0104,  //  001E  GETMBR	R11	R0	K4
+      0x042C1733,  //  001F  SUB	R11	R11	K51
       0x4028140B,  //  0020  CONNECT	R10	R10	R11
-      0x882C0102,  //  0021  GETMBR	R11	R0	K2
+      0x882C0103,  //  0021  GETMBR	R11	R0	K3
       0x9428160A,  //  0022  GETIDX	R10	R11	R10
-      0x8C30030E,  //  0023  GETMET	R12	R1	K14
+      0x8C300342,  //  0023  GETMET	R12	R1	K66
       0x5C380E00,  //  0024  MOVE	R14	R7
       0x7C300400,  //  0025  CALL	R12	2
-      0x8C30190F,  //  0026  GETMET	R12	R12	K15
+      0x8C301943,  //  0026  GETMET	R12	R12	K67
       0x5C381400,  //  0027  MOVE	R14	R10
       0x5C3C1200,  //  0028  MOVE	R15	R9
-      0x58400008,  //  0029  LDCONST	R16	K8
+      0x5840003F,  //  0029  LDCONST	R16	K63
       0x7C300800,  //  002A  CALL	R12	4
       0x5C2C1800,  //  002B  MOVE	R11	R12
-      0x40322111,  //  002C  CONNECT	R12	K16	K17
-      0x88340102,  //  002D  GETMBR	R13	R0	K2
+      0x40322518,  //  002C  CONNECT	R12	K18	K24
+      0x88340103,  //  002D  GETMBR	R13	R0	K3
       0x94301A0C,  //  002E  GETIDX	R12	R13	R12
       0x0030180B,  //  002F  ADD	R12	R12	R11
-      0x88340103,  //  0030  GETMBR	R13	R0	K3
-      0x40341B0A,  //  0031  CONNECT	R13	R13	K10
+      0x88340104,  //  0030  GETMBR	R13	R0	K4
+      0x40341B41,  //  0031  CONNECT	R13	R13	K65
       0x9434140D,  //  0032  GETIDX	R13	R10	R13
       0x0030180D,  //  0033  ADD	R12	R12	R13
-      0x9002040C,  //  0034  SETMBR	R0	K2	R12
-      0x881C0112,  //  0035  GETMBR	R7	R0	K18
-      0x881C0F13,  //  0036  GETMBR	R7	R7	K19
-      0x8C200F14,  //  0037  GETMET	R8	R7	K20
+      0x9002060C,  //  0034  SETMBR	R0	K3	R12
+      0x881C0106,  //  0035  GETMBR	R7	R0	K6
+      0x881C0F07,  //  0036  GETMBR	R7	R7	K7
+      0x8C200F08,  //  0037  GETMET	R8	R7	K8
       0x7C200200,  //  0038  CALL	R8	1
-      0x8C200F0B,  //  0039  GETMET	R8	R7	K11
-      0x88280115,  //  003A  GETMBR	R10	R0	K21
-      0x582C000D,  //  003B  LDCONST	R11	K13
+      0x8C200F09,  //  0039  GETMET	R8	R7	K9
+      0x8828010A,  //  003A  GETMBR	R10	R0	K10
+      0x582C0033,  //  003B  LDCONST	R11	K51
       0x7C200600,  //  003C  CALL	R8	3
-      0x8C200F0B,  //  003D  GETMET	R8	R7	K11
-      0x88280116,  //  003E  GETMBR	R10	R0	K22
+      0x8C200F09,  //  003D  GETMET	R8	R7	K9
+      0x8828010C,  //  003E  GETMBR	R10	R0	K12
       0x542E0003,  //  003F  LDINT	R11	4
       0x7C200600,  //  0040  CALL	R8	3
-      0x88200117,  //  0041  GETMBR	R8	R0	K23
+      0x8820011F,  //  0041  GETMBR	R8	R0	K31
       0x78220002,  //  0042  JMPF	R8	#0046
-      0x88200117,  //  0043  GETMBR	R8	R0	K23
+      0x8820011F,  //  0043  GETMBR	R8	R0	K31
       0x40200E08,  //  0044  CONNECT	R8	R7	R8
       0x70020006,  //  0045  JMP		#004D
-      0x88200518,  //  0046  GETMBR	R8	R2	K24
+      0x88200544,  //  0046  GETMBR	R8	R2	K68
       0x78220001,  //  0047  JMPF	R8	#004A
-      0x88200518,  //  0048  GETMBR	R8	R2	K24
+      0x88200544,  //  0048  GETMBR	R8	R2	K68
       0x40200E08,  //  0049  CONNECT	R8	R7	R8
-      0x8C200F19,  //  004A  GETMET	R8	R7	K25
+      0x8C200F0F,  //  004A  GETMET	R8	R7	K15
       0x542A000C,  //  004B  LDINT	R10	13
       0x7C200400,  //  004C  CALL	R8	2
-      0x8820031A,  //  004D  GETMBR	R8	R1	K26
-      0x8C20111B,  //  004E  GETMET	R8	R8	K27
+      0x88200310,  //  004D  GETMBR	R8	R1	K16
+      0x8C201145,  //  004E  GETMET	R8	R8	K69
       0x5C280C00,  //  004F  MOVE	R10	R6
       0x5C2C0E00,  //  0050  MOVE	R11	R7
-      0x58300010,  //  0051  LDCONST	R12	K16
+      0x58300012,  //  0051  LDCONST	R12	K18
       0x6034000C,  //  0052  GETGBL	R13	G12
       0x5C380E00,  //  0053  MOVE	R14	R7
       0x7C340200,  //  0054  CALL	R13	1
       0x5C380600,  //  0055  MOVE	R14	R3
-      0x583C0010,  //  0056  LDCONST	R15	K16
+      0x583C0012,  //  0056  LDCONST	R15	K18
       0x5C400800,  //  0057  MOVE	R16	R4
       0x5C440600,  //  0058  MOVE	R17	R3
       0x5C480800,  //  0059  MOVE	R18	R4
@@ -890,16 +827,16 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
       0x5C580A00,  //  0064  MOVE	R22	R5
       0x7C201C00,  //  0065  CALL	R8	14
       0x78220006,  //  0066  JMPF	R8	#006E
-      0x8C240719,  //  0067  GETMET	R9	R3	K25
+      0x8C24070F,  //  0067  GETMET	R9	R3	K15
       0x602C000C,  //  0068  GETGBL	R11	G12
       0x5C300600,  //  0069  MOVE	R12	R3
       0x7C2C0200,  //  006A  CALL	R11	1
       0x042C1605,  //  006B  SUB	R11	R11	R5
       0x7C240400,  //  006C  CALL	R9	2
       0x70020003,  //  006D  JMP		#0072
-      0xB8260C00,  //  006E  GETNGBL	R9	K6
-      0x5828001C,  //  006F  LDCONST	R10	K28
-      0x582C0011,  //  0070  LDCONST	R11	K17
+      0xB8267400,  //  006E  GETNGBL	R9	K58
+      0x58280046,  //  006F  LDCONST	R10	K70
+      0x582C0018,  //  0070  LDCONST	R11	K24
       0x7C240400,  //  0071  CALL	R9	2
       0x80041000,  //  0072  RET	1	R8
     })
@@ -915,82 +852,60 @@ be_local_closure(class_Matter_Frame_build_standalone_ack,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(remote_ip),
-    /* K2   */  be_nested_str_weak(remote_port),
-    /* K3   */  be_nested_str_weak(flag_s),
-    /* K4   */  be_nested_str_weak(flag_dsiz),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(dest_node_id_8),
-    /* K7   */  be_nested_str_weak(source_node_id),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(message_counter),
-    /* K11  */  be_nested_str_weak(counter_snd_next),
-    /* K12  */  be_nested_str_weak(local_session_id),
-    /* K13  */  be_nested_str_weak(initiator_session_id),
-    /* K14  */  be_nested_str_weak(x_flag_i),
-    /* K15  */  be_nested_str_weak(opcode),
-    /* K16  */  be_nested_str_weak(exchange_id),
-    /* K17  */  be_nested_str_weak(protocol_id),
-    /* K18  */  be_nested_str_weak(x_flag_a),
-    /* K19  */  be_nested_str_weak(ack_message_counter),
-    /* K20  */  be_nested_str_weak(x_flag_r),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(build_standalone_ack),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
       0x60080006,  //  0000  GETGBL	R2	G6
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x880C0106,  //  0003  GETMBR	R3	R0	K6
       0x7C080200,  //  0004  CALL	R2	1
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
-      0x900A0203,  //  0006  SETMBR	R2	K1	R3
-      0x880C0102,  //  0007  GETMBR	R3	R0	K2
-      0x900A0403,  //  0008  SETMBR	R2	K2	R3
-      0x880C0103,  //  0009  GETMBR	R3	R0	K3
+      0x880C0113,  //  0005  GETMBR	R3	R0	K19
+      0x900A2603,  //  0006  SETMBR	R2	K19	R3
+      0x880C0114,  //  0007  GETMBR	R3	R0	K20
+      0x900A2803,  //  0008  SETMBR	R2	K20	R3
+      0x880C0116,  //  0009  GETMBR	R3	R0	K22
       0x780E0003,  //  000A  JMPF	R3	#000F
-      0x900A0905,  //  000B  SETMBR	R2	K4	K5
-      0x880C0107,  //  000C  GETMBR	R3	R0	K7
-      0x900A0C03,  //  000D  SETMBR	R2	K6	R3
+      0x900A2F33,  //  000B  SETMBR	R2	K23	K51
+      0x880C011F,  //  000C  GETMBR	R3	R0	K31
+      0x900A4003,  //  000D  SETMBR	R2	K32	R3
       0x70020000,  //  000E  JMP		#0010
-      0x900A0908,  //  000F  SETMBR	R2	K4	K8
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x900A1203,  //  0011  SETMBR	R2	K9	R3
-      0x880C0109,  //  0012  GETMBR	R3	R0	K9
-      0x8C0C070B,  //  0013  GETMET	R3	R3	K11
+      0x900A2F15,  //  000F  SETMBR	R2	K23	K21
+      0x880C0100,  //  0010  GETMBR	R3	R0	K0
+      0x900A0003,  //  0011  SETMBR	R2	K0	R3
+      0x880C0100,  //  0012  GETMBR	R3	R0	K0
+      0x8C0C0735,  //  0013  GETMET	R3	R3	K53
       0x7C0C0200,  //  0014  CALL	R3	1
-      0x900A1403,  //  0015  SETMBR	R2	K10	R3
-      0x880C0109,  //  0016  GETMBR	R3	R0	K9
-      0x880C070D,  //  0017  GETMBR	R3	R3	K13
-      0x900A1803,  //  0018  SETMBR	R2	K12	R3
-      0x880C010E,  //  0019  GETMBR	R3	R0	K14
+      0x900A1803,  //  0015  SETMBR	R2	K12	R3
+      0x880C0100,  //  0016  GETMBR	R3	R0	K0
+      0x880C0734,  //  0017  GETMBR	R3	R3	K52
+      0x900A3203,  //  0018  SETMBR	R2	K25	R3
+      0x880C0126,  //  0019  GETMBR	R3	R0	K38
       0x780E0001,  //  001A  JMPF	R3	#001D
-      0x580C0008,  //  001B  LDCONST	R3	K8
+      0x580C0015,  //  001B  LDCONST	R3	K21
       0x70020000,  //  001C  JMP		#001E
-      0x580C0005,  //  001D  LDCONST	R3	K5
-      0x900A1C03,  //  001E  SETMBR	R2	K14	R3
+      0x580C0033,  //  001D  LDCONST	R3	K51
+      0x900A4C03,  //  001E  SETMBR	R2	K38	R3
       0x540E000F,  //  001F  LDINT	R3	16
-      0x900A1E03,  //  0020  SETMBR	R2	K15	R3
-      0x880C0110,  //  0021  GETMBR	R3	R0	K16
-      0x900A2003,  //  0022  SETMBR	R2	K16	R3
-      0x900A2308,  //  0023  SETMBR	R2	K17	K8
-      0x900A2505,  //  0024  SETMBR	R2	K18	K5
-      0x880C010A,  //  0025  GETMBR	R3	R0	K10
-      0x900A2603,  //  0026  SETMBR	R2	K19	R3
+      0x900A4E03,  //  0020  SETMBR	R2	K39	R3
+      0x880C0128,  //  0021  GETMBR	R3	R0	K40
+      0x900A5003,  //  0022  SETMBR	R2	K40	R3
+      0x900A5315,  //  0023  SETMBR	R2	K41	K21
+      0x900A4B33,  //  0024  SETMBR	R2	K37	K51
+      0x880C010C,  //  0025  GETMBR	R3	R0	K12
+      0x900A5403,  //  0026  SETMBR	R2	K42	R3
       0x78060001,  //  0027  JMPF	R1	#002A
-      0x580C0005,  //  0028  LDCONST	R3	K5
+      0x580C0033,  //  0028  LDCONST	R3	K51
       0x70020000,  //  0029  JMP		#002B
-      0x580C0008,  //  002A  LDCONST	R3	K8
-      0x900A2803,  //  002B  SETMBR	R2	K20	R3
+      0x580C0015,  //  002A  LDCONST	R3	K21
+      0x900A4803,  //  002B  SETMBR	R2	K36	R3
       0x80040400,  //  002C  RET	1	R2
     })
   )
@@ -1005,85 +920,61 @@ be_local_closure(class_Matter_Frame_initiate_response,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     5,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Frame),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Frame),
-    /* K3   */  be_nested_str_weak(remote_ip),
-    /* K4   */  be_nested_str_weak(_ip),
-    /* K5   */  be_nested_str_weak(remote_port),
-    /* K6   */  be_nested_str_weak(_port),
-    /* K7   */  be_nested_str_weak(flag_dsiz),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(initiator_session_id),
-    /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(counter_snd_next),
-    /* K13  */  be_nested_str_weak(local_session_id),
-    /* K14  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K15  */  be_nested_str_weak(next),
-    /* K16  */  be_nested_str_weak(x_flag_i),
-    /* K17  */  be_const_int(1),
-    /* K18  */  be_nested_str_weak(opcode),
-    /* K19  */  be_nested_str_weak(_exchange_id),
-    /* K20  */  be_nested_str_weak(exchange_id),
-    /* K21  */  be_nested_str_weak(protocol_id),
-    /* K22  */  be_nested_str_weak(x_flag_r),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(initiate_response),
     &be_const_str_solidified,
     ( &(const binstruction[46]) {  /* code */
-      0x58140000,  //  0000  LDCONST	R5	K0
+      0x58140047,  //  0000  LDCONST	R5	K71
       0x4C180000,  //  0001  LDNIL	R6
       0x1C180806,  //  0002  EQ	R6	R4	R6
       0x781A0004,  //  0003  JMPF	R6	#0009
-      0xB81A0200,  //  0004  GETNGBL	R6	K1
-      0x8C180D02,  //  0005  GETMET	R6	R6	K2
+      0xB81A5E00,  //  0004  GETNGBL	R6	K47
+      0x8C180D30,  //  0005  GETMET	R6	R6	K48
       0x5C200000,  //  0006  MOVE	R8	R0
       0x7C180400,  //  0007  CALL	R6	2
       0x5C100C00,  //  0008  MOVE	R4	R6
-      0x88180304,  //  0009  GETMBR	R6	R1	K4
-      0x90120606,  //  000A  SETMBR	R4	K3	R6
-      0x88180306,  //  000B  GETMBR	R6	R1	K6
-      0x90120A06,  //  000C  SETMBR	R4	K5	R6
-      0x90120F08,  //  000D  SETMBR	R4	K7	K8
-      0x90121201,  //  000E  SETMBR	R4	K9	R1
+      0x88180348,  //  0009  GETMBR	R6	R1	K72
+      0x90122606,  //  000A  SETMBR	R4	K19	R6
+      0x88180349,  //  000B  GETMBR	R6	R1	K73
+      0x90122806,  //  000C  SETMBR	R4	K20	R6
+      0x90122F12,  //  000D  SETMBR	R4	K23	K18
+      0x90120001,  //  000E  SETMBR	R4	K0	R1
       0x78060008,  //  000F  JMPF	R1	#0019
-      0x8818030A,  //  0010  GETMBR	R6	R1	K10
-      0x20180D08,  //  0011  NE	R6	R6	K8
+      0x88180334,  //  0010  GETMBR	R6	R1	K52
+      0x20180D12,  //  0011  NE	R6	R6	K18
       0x781A0005,  //  0012  JMPF	R6	#0019
-      0x8C18030C,  //  0013  GETMET	R6	R1	K12
+      0x8C180335,  //  0013  GETMET	R6	R1	K53
       0x7C180200,  //  0014  CALL	R6	1
-      0x90121606,  //  0015  SETMBR	R4	K11	R6
-      0x8818030A,  //  0016  GETMBR	R6	R1	K10
-      0x90121A06,  //  0017  SETMBR	R4	K13	R6
+      0x90121806,  //  0015  SETMBR	R4	K12	R6
+      0x88180334,  //  0016  GETMBR	R6	R1	K52
+      0x90123206,  //  0017  SETMBR	R4	K25	R6
       0x70020004,  //  0018  JMP		#001E
-      0x8818030E,  //  0019  GETMBR	R6	R1	K14
-      0x8C180D0F,  //  001A  GETMET	R6	R6	K15
+      0x88180336,  //  0019  GETMBR	R6	R1	K54
+      0x8C180D37,  //  001A  GETMET	R6	R6	K55
       0x7C180200,  //  001B  CALL	R6	1
-      0x90121606,  //  001C  SETMBR	R4	K11	R6
-      0x90121B08,  //  001D  SETMBR	R4	K13	K8
-      0x90122111,  //  001E  SETMBR	R4	K16	K17
-      0x90122402,  //  001F  SETMBR	R4	K18	R2
-      0x88180313,  //  0020  GETMBR	R6	R1	K19
-      0x00180D11,  //  0021  ADD	R6	R6	K17
-      0x90062606,  //  0022  SETMBR	R1	K19	R6
-      0x88180313,  //  0023  GETMBR	R6	R1	K19
+      0x90121806,  //  001C  SETMBR	R4	K12	R6
+      0x90123312,  //  001D  SETMBR	R4	K25	K18
+      0x90124D0B,  //  001E  SETMBR	R4	K38	K11
+      0x90124E02,  //  001F  SETMBR	R4	K39	R2
+      0x8818034A,  //  0020  GETMBR	R6	R1	K74
+      0x00180D0B,  //  0021  ADD	R6	R6	K11
+      0x90069406,  //  0022  SETMBR	R1	K74	R6
+      0x8818034A,  //  0023  GETMBR	R6	R1	K74
       0x541EFFFF,  //  0024  LDINT	R7	65536
       0x30180C07,  //  0025  OR	R6	R6	R7
-      0x90122806,  //  0026  SETMBR	R4	K20	R6
-      0x90122B11,  //  0027  SETMBR	R4	K21	K17
+      0x90125006,  //  0026  SETMBR	R4	K40	R6
+      0x9012530B,  //  0027  SETMBR	R4	K41	K11
       0x780E0001,  //  0028  JMPF	R3	#002B
-      0x58180011,  //  0029  LDCONST	R6	K17
+      0x5818000B,  //  0029  LDCONST	R6	K11
       0x70020000,  //  002A  JMP		#002C
-      0x58180008,  //  002B  LDCONST	R6	K8
-      0x90122C06,  //  002C  SETMBR	R4	K22	R6
+      0x58180012,  //  002B  LDCONST	R6	K18
+      0x90124806,  //  002C  SETMBR	R4	K36	R6
       0x80040800,  //  002D  RET	1	R4
     })
   )
@@ -1098,128 +989,108 @@ be_local_closure(class_Matter_Frame_decode_payload,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(payload_idx),
-    /* K1   */  be_nested_str_weak(raw),
-    /* K2   */  be_nested_str_weak(x_flags),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(x_flag_v),
-    /* K6   */  be_nested_str_weak(getbits),
-    /* K7   */  be_nested_str_weak(x_flag_sx),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(x_flag_r),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(x_flag_a),
-    /* K12  */  be_nested_str_weak(x_flag_i),
-    /* K13  */  be_nested_str_weak(opcode),
-    /* K14  */  be_nested_str_weak(exchange_id),
-    /* K15  */  be_nested_str_weak(protocol_id),
-    /* K16  */  be_nested_str_weak(vendor_id),
-    /* K17  */  be_nested_str_weak(ack_message_counter),
-    /* K18  */  be_nested_str_weak(app_payload_idx),
-    }),
+    &be_ktab_class_Matter_Frame,     /* shared constants */
     be_str_weak(decode_payload),
     &be_const_str_solidified,
     ( &(const binstruction[93]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C0C0503,  //  0002  GETMET	R3	R2	K3
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x88080103,  //  0001  GETMBR	R2	R0	K3
+      0x8C0C052C,  //  0002  GETMET	R3	R2	K44
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180004,  //  0004  LDCONST	R6	K4
+      0x5818000B,  //  0004  LDCONST	R6	K11
       0x7C0C0600,  //  0005  CALL	R3	3
-      0x90020403,  //  0006  SETMBR	R0	K2	R3
-      0x8C0C0506,  //  0007  GETMET	R3	R2	K6
+      0x90024403,  //  0006  SETMBR	R0	K34	R3
+      0x8C0C052D,  //  0007  GETMET	R3	R2	K45
       0x54160007,  //  0008  LDINT	R5	8
       0x08140205,  //  0009  MUL	R5	R1	R5
       0x541A0003,  //  000A  LDINT	R6	4
       0x00140A06,  //  000B  ADD	R5	R5	R6
-      0x58180004,  //  000C  LDCONST	R6	K4
+      0x5818000B,  //  000C  LDCONST	R6	K11
       0x7C0C0600,  //  000D  CALL	R3	3
-      0x90020A03,  //  000E  SETMBR	R0	K5	R3
-      0x8C0C0506,  //  000F  GETMET	R3	R2	K6
+      0x90024603,  //  000E  SETMBR	R0	K35	R3
+      0x8C0C052D,  //  000F  GETMET	R3	R2	K45
       0x54160007,  //  0010  LDINT	R5	8
       0x08140205,  //  0011  MUL	R5	R1	R5
-      0x00140B08,  //  0012  ADD	R5	R5	K8
-      0x58180004,  //  0013  LDCONST	R6	K4
+      0x00140B3C,  //  0012  ADD	R5	R5	K60
+      0x5818000B,  //  0013  LDCONST	R6	K11
       0x7C0C0600,  //  0014  CALL	R3	3
-      0x90020E03,  //  0015  SETMBR	R0	K7	R3
-      0x8C0C0506,  //  0016  GETMET	R3	R2	K6
+      0x90029603,  //  0015  SETMBR	R0	K75	R3
+      0x8C0C052D,  //  0016  GETMET	R3	R2	K45
       0x54160007,  //  0017  LDINT	R5	8
       0x08140205,  //  0018  MUL	R5	R1	R5
-      0x00140B0A,  //  0019  ADD	R5	R5	K10
-      0x58180004,  //  001A  LDCONST	R6	K4
+      0x00140B3F,  //  0019  ADD	R5	R5	K63
+      0x5818000B,  //  001A  LDCONST	R6	K11
       0x7C0C0600,  //  001B  CALL	R3	3
-      0x90021203,  //  001C  SETMBR	R0	K9	R3
-      0x8C0C0506,  //  001D  GETMET	R3	R2	K6
+      0x90024803,  //  001C  SETMBR	R0	K36	R3
+      0x8C0C052D,  //  001D  GETMET	R3	R2	K45
       0x54160007,  //  001E  LDINT	R5	8
       0x08140205,  //  001F  MUL	R5	R1	R5
-      0x00140B04,  //  0020  ADD	R5	R5	K4
-      0x58180004,  //  0021  LDCONST	R6	K4
+      0x00140B0B,  //  0020  ADD	R5	R5	K11
+      0x5818000B,  //  0021  LDCONST	R6	K11
       0x7C0C0600,  //  0022  CALL	R3	3
-      0x90021603,  //  0023  SETMBR	R0	K11	R3
-      0x8C0C0506,  //  0024  GETMET	R3	R2	K6
+      0x90024A03,  //  0023  SETMBR	R0	K37	R3
+      0x8C0C052D,  //  0024  GETMET	R3	R2	K45
       0x54160007,  //  0025  LDINT	R5	8
       0x08140205,  //  0026  MUL	R5	R1	R5
-      0x58180004,  //  0027  LDCONST	R6	K4
+      0x5818000B,  //  0027  LDCONST	R6	K11
       0x7C0C0600,  //  0028  CALL	R3	3
-      0x90021803,  //  0029  SETMBR	R0	K12	R3
-      0x8C0C0503,  //  002A  GETMET	R3	R2	K3
-      0x00140304,  //  002B  ADD	R5	R1	K4
-      0x58180004,  //  002C  LDCONST	R6	K4
+      0x90024C03,  //  0029  SETMBR	R0	K38	R3
+      0x8C0C052C,  //  002A  GETMET	R3	R2	K44
+      0x0014030B,  //  002B  ADD	R5	R1	K11
+      0x5818000B,  //  002C  LDCONST	R6	K11
       0x7C0C0600,  //  002D  CALL	R3	3
-      0x90021A03,  //  002E  SETMBR	R0	K13	R3
-      0x8C0C0503,  //  002F  GETMET	R3	R2	K3
-      0x0014030A,  //  0030  ADD	R5	R1	K10
-      0x5818000A,  //  0031  LDCONST	R6	K10
+      0x90024E03,  //  002E  SETMBR	R0	K39	R3
+      0x8C0C052C,  //  002F  GETMET	R3	R2	K44
+      0x0014033F,  //  0030  ADD	R5	R1	K63
+      0x5818003F,  //  0031  LDCONST	R6	K63
       0x7C0C0600,  //  0032  CALL	R3	3
-      0x90021C03,  //  0033  SETMBR	R0	K14	R3
-      0x880C010C,  //  0034  GETMBR	R3	R0	K12
+      0x90025003,  //  0033  SETMBR	R0	K40	R3
+      0x880C0126,  //  0034  GETMBR	R3	R0	K38
       0x740E0003,  //  0035  JMPT	R3	#003A
-      0x880C010E,  //  0036  GETMBR	R3	R0	K14
+      0x880C0128,  //  0036  GETMBR	R3	R0	K40
       0x5412FFFF,  //  0037  LDINT	R4	65536
       0x300C0604,  //  0038  OR	R3	R3	R4
-      0x90021C03,  //  0039  SETMBR	R0	K14	R3
-      0x8C0C0503,  //  003A  GETMET	R3	R2	K3
+      0x90025003,  //  0039  SETMBR	R0	K40	R3
+      0x8C0C052C,  //  003A  GETMET	R3	R2	K44
       0x54160003,  //  003B  LDINT	R5	4
       0x00140205,  //  003C  ADD	R5	R1	R5
-      0x5818000A,  //  003D  LDCONST	R6	K10
+      0x5818003F,  //  003D  LDCONST	R6	K63
       0x7C0C0600,  //  003E  CALL	R3	3
-      0x90021E03,  //  003F  SETMBR	R0	K15	R3
+      0x90025203,  //  003F  SETMBR	R0	K41	R3
       0x540E0005,  //  0040  LDINT	R3	6
       0x00040203,  //  0041  ADD	R1	R1	R3
-      0x880C0105,  //  0042  GETMBR	R3	R0	K5
+      0x880C0123,  //  0042  GETMBR	R3	R0	K35
       0x780E0005,  //  0043  JMPF	R3	#004A
-      0x8C0C0503,  //  0044  GETMET	R3	R2	K3
+      0x8C0C052C,  //  0044  GETMET	R3	R2	K44
       0x5C140200,  //  0045  MOVE	R5	R1
-      0x5818000A,  //  0046  LDCONST	R6	K10
+      0x5818003F,  //  0046  LDCONST	R6	K63
       0x7C0C0600,  //  0047  CALL	R3	3
-      0x90022003,  //  0048  SETMBR	R0	K16	R3
-      0x0004030A,  //  0049  ADD	R1	R1	K10
-      0x880C010B,  //  004A  GETMBR	R3	R0	K11
+      0x90029803,  //  0048  SETMBR	R0	K76	R3
+      0x0004033F,  //  0049  ADD	R1	R1	K63
+      0x880C0125,  //  004A  GETMBR	R3	R0	K37
       0x780E0006,  //  004B  JMPF	R3	#0053
-      0x8C0C0503,  //  004C  GETMET	R3	R2	K3
+      0x8C0C052C,  //  004C  GETMET	R3	R2	K44
       0x5C140200,  //  004D  MOVE	R5	R1
       0x541A0003,  //  004E  LDINT	R6	4
       0x7C0C0600,  //  004F  CALL	R3	3
-      0x90022203,  //  0050  SETMBR	R0	K17	R3
+      0x90025403,  //  0050  SETMBR	R0	K42	R3
       0x540E0003,  //  0051  LDINT	R3	4
       0x00040203,  //  0052  ADD	R1	R1	R3
-      0x880C0107,  //  0053  GETMBR	R3	R0	K7
+      0x880C014B,  //  0053  GETMBR	R3	R0	K75
       0x780E0005,  //  0054  JMPF	R3	#005B
-      0x8C0C0503,  //  0055  GETMET	R3	R2	K3
+      0x8C0C052C,  //  0055  GETMET	R3	R2	K44
       0x5C140200,  //  0056  MOVE	R5	R1
-      0x5818000A,  //  0057  LDCONST	R6	K10
+      0x5818003F,  //  0057  LDCONST	R6	K63
       0x7C0C0600,  //  0058  CALL	R3	3
-      0x0010070A,  //  0059  ADD	R4	R3	K10
+      0x0010073F,  //  0059  ADD	R4	R3	K63
       0x00040204,  //  005A  ADD	R1	R1	R4
-      0x90022401,  //  005B  SETMBR	R0	K18	R1
+      0x90025601,  //  005B  SETMBR	R0	K43	R1
       0x80040000,  //  005C  RET	1	R0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -3,6 +3,89 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_MessageHandler' ktab size: 79, total: 110 (saved 248 bytes)
+static const bvalue be_ktab_class_Matter_MessageHandler[79] = {
+  /* K0   */  be_nested_str_weak(device),
+  /* K1   */  be_nested_str_weak(commissioning),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(Commisioning_Context),
+  /* K4   */  be_nested_str_weak(im),
+  /* K5   */  be_nested_str_weak(IM),
+  /* K6   */  be_nested_str_weak(control_message),
+  /* K7   */  be_nested_str_weak(Control_Message),
+  /* K8   */  be_nested_str_weak(_n_bytes),
+  /* K9   */  be_nested_str_weak(x_flag_r),
+  /* K10  */  be_nested_str_weak(build_standalone_ack),
+  /* K11  */  be_nested_str_weak(encode_frame),
+  /* K12  */  be_nested_str_weak(encrypt),
+  /* K13  */  be_nested_str_weak(tasmota),
+  /* K14  */  be_nested_str_weak(loglevel),
+  /* K15  */  be_nested_str_weak(log),
+  /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X2A_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
+  /* K17  */  be_nested_str_weak(session),
+  /* K18  */  be_nested_str_weak(local_session_id),
+  /* K19  */  be_nested_str_weak(ack_message_counter),
+  /* K20  */  be_nested_str_weak(message_counter),
+  /* K21  */  be_nested_str_weak(_X7Breliable_X7D),
+  /* K22  */  be_nested_str_weak(),
+  /* K23  */  be_nested_str_weak(send_response_frame),
+  /* K24  */  be_nested_str_weak(Frame),
+  /* K25  */  be_nested_str_weak(decode_header),
+  /* K26  */  be_nested_str_weak(sec_p),
+  /* K27  */  be_nested_str_weak(sessions),
+  /* K28  */  be_nested_str_weak(find_session_source_id_unsecure),
+  /* K29  */  be_nested_str_weak(source_node_id),
+  /* K30  */  be_nested_str_weak(process_incoming_control_message),
+  /* K31  */  be_const_int(0),
+  /* K32  */  be_nested_str_weak(sec_sesstype),
+  /* K33  */  be_nested_str_weak(_ip),
+  /* K34  */  be_nested_str_weak(_port),
+  /* K35  */  be_nested_str_weak(_message_handler),
+  /* K36  */  be_nested_str_weak(_counter_insecure_rcv),
+  /* K37  */  be_nested_str_weak(validate),
+  /* K38  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
+  /* K39  */  be_nested_str_weak(val),
+  /* K40  */  be_nested_str_weak(send_simple_ack),
+  /* K41  */  be_nested_str_weak(decode_payload),
+  /* K42  */  be_nested_str_weak(received_ack),
+  /* K43  */  be_nested_str_weak(opcode),
+  /* K44  */  be_nested_str_weak(get_opcode_name),
+  /* K45  */  be_nested_str_weak(0x_X2502X),
+  /* K46  */  be_const_int(3),
+  /* K47  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K49  */  be_nested_str_weak(_X7Breliable_X7D_X20),
+  /* K50  */  be_nested_str_weak(exchange_id),
+  /* K51  */  be_nested_str_weak(process_incoming),
+  /* K52  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
+  /* K53  */  be_nested_str_weak(get_session_by_local_session_id),
+  /* K54  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
+  /* K55  */  be_nested_str_weak(counter_rcv_validate),
+  /* K56  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20encrypted_X20message_X20_X3D_X20),
+  /* K57  */  be_nested_str_weak(_X20counter_X3D),
+  /* K58  */  be_nested_str_weak(counter_rcv),
+  /* K59  */  be_nested_str_weak(send_encrypted_ack),
+  /* K60  */  be_nested_str_weak(decrypt),
+  /* K61  */  be_nested_str_weak(MTR_X3A_X20_X3E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Decrypted_X20message_X3A_X20protocol_id_X3A),
+  /* K62  */  be_nested_str_weak(protocol_id),
+  /* K63  */  be_nested_str_weak(_X20opcode_X3D),
+  /* K64  */  be_nested_str_weak(_X20exchange_id_X3D),
+  /* K65  */  be_nested_str_weak(process_incoming_ack),
+  /* K66  */  be_nested_str_weak(send_enqueued),
+  /* K67  */  be_const_int(1),
+  /* K68  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+  /* K69  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+  /* K70  */  be_nested_str_weak(_X3B),
+  /* K71  */  be_const_int(2),
+  /* K72  */  be_nested_str_weak(_debug_present),
+  /* K73  */  be_nested_str_weak(debug),
+  /* K74  */  be_nested_str_weak(traceback),
+  /* K75  */  be_nested_str_weak(msg_send),
+  /* K76  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
+  /* K77  */  be_nested_str_weak(every_50ms),
+  /* K78  */  be_nested_str_weak(every_second),
+};
+
 
 extern const bclass be_class_Matter_MessageHandler;
 
@@ -13,23 +96,13 @@ be_local_closure(class_Matter_MessageHandler_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(commissioning),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Commisioning_Context),
-    /* K4   */  be_nested_str_weak(im),
-    /* K5   */  be_nested_str_weak(IM),
-    /* K6   */  be_nested_str_weak(control_message),
-    /* K7   */  be_nested_str_weak(Control_Message),
-    /* K8   */  be_nested_str_weak(_n_bytes),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
@@ -67,61 +140,45 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(x_flag_r),
-    /* K1   */  be_nested_str_weak(build_standalone_ack),
-    /* K2   */  be_nested_str_weak(encode_frame),
-    /* K3   */  be_nested_str_weak(encrypt),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(loglevel),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X2A_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(local_session_id),
-    /* K10  */  be_nested_str_weak(ack_message_counter),
-    /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(_X7Breliable_X7D),
-    /* K13  */  be_nested_str_weak(),
-    /* K14  */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(send_encrypted_ack),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x880C0309,  //  0000  GETMBR	R3	R1	K9
       0x780E001C,  //  0001  JMPF	R3	#001F
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x8C0C030A,  //  0002  GETMET	R3	R1	K10
       0x5C140400,  //  0003  MOVE	R5	R2
       0x7C0C0400,  //  0004  CALL	R3	2
-      0x8C100702,  //  0005  GETMET	R4	R3	K2
+      0x8C10070B,  //  0005  GETMET	R4	R3	K11
       0x7C100200,  //  0006  CALL	R4	1
-      0x8C100703,  //  0007  GETMET	R4	R3	K3
+      0x8C10070C,  //  0007  GETMET	R4	R3	K12
       0x7C100200,  //  0008  CALL	R4	1
-      0xB8120800,  //  0009  GETNGBL	R4	K4
-      0x8C100905,  //  000A  GETMET	R4	R4	K5
+      0xB8121A00,  //  0009  GETNGBL	R4	K13
+      0x8C10090E,  //  000A  GETMET	R4	R4	K14
       0x541A0003,  //  000B  LDINT	R6	4
       0x7C100400,  //  000C  CALL	R4	2
       0x7812000D,  //  000D  JMPF	R4	#001C
-      0xB8120C00,  //  000E  GETNGBL	R4	K6
+      0xB8121E00,  //  000E  GETNGBL	R4	K15
       0x60140018,  //  000F  GETGBL	R5	G24
-      0x58180007,  //  0010  LDCONST	R6	K7
-      0x881C0708,  //  0011  GETMBR	R7	R3	K8
-      0x881C0F09,  //  0012  GETMBR	R7	R7	K9
-      0x8820070A,  //  0013  GETMBR	R8	R3	K10
-      0x8824070B,  //  0014  GETMBR	R9	R3	K11
+      0x58180010,  //  0010  LDCONST	R6	K16
+      0x881C0711,  //  0011  GETMBR	R7	R3	K17
+      0x881C0F12,  //  0012  GETMBR	R7	R7	K18
+      0x88200713,  //  0013  GETMBR	R8	R3	K19
+      0x88240714,  //  0014  GETMBR	R9	R3	K20
       0x780A0001,  //  0015  JMPF	R2	#0018
-      0x5828000C,  //  0016  LDCONST	R10	K12
+      0x58280015,  //  0016  LDCONST	R10	K21
       0x70020000,  //  0017  JMP		#0019
-      0x5828000D,  //  0018  LDCONST	R10	K13
+      0x58280016,  //  0018  LDCONST	R10	K22
       0x7C140A00,  //  0019  CALL	R5	5
       0x541A0003,  //  001A  LDINT	R6	4
       0x7C100400,  //  001B  CALL	R4	2
-      0x8C10010E,  //  001C  GETMET	R4	R0	K14
+      0x8C100117,  //  001C  GETMET	R4	R0	K23
       0x5C180600,  //  001D  MOVE	R6	R3
       0x7C100400,  //  001E  CALL	R4	2
       0x80000000,  //  001F  RET	0
@@ -138,232 +195,166 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[65]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Frame),
-    /* K2   */  be_nested_str_weak(decode_header),
-    /* K3   */  be_nested_str_weak(sec_p),
-    /* K4   */  be_nested_str_weak(device),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(find_session_source_id_unsecure),
-    /* K7   */  be_nested_str_weak(source_node_id),
-    /* K8   */  be_nested_str_weak(control_message),
-    /* K9   */  be_nested_str_weak(process_incoming_control_message),
-    /* K10  */  be_nested_str_weak(local_session_id),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(sec_sesstype),
-    /* K13  */  be_nested_str_weak(_ip),
-    /* K14  */  be_nested_str_weak(_port),
-    /* K15  */  be_nested_str_weak(_message_handler),
-    /* K16  */  be_nested_str_weak(session),
-    /* K17  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K18  */  be_nested_str_weak(validate),
-    /* K19  */  be_nested_str_weak(message_counter),
-    /* K20  */  be_nested_str_weak(tasmota),
-    /* K21  */  be_nested_str_weak(loglevel),
-    /* K22  */  be_nested_str_weak(log),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
-    /* K24  */  be_nested_str_weak(val),
-    /* K25  */  be_nested_str_weak(send_simple_ack),
-    /* K26  */  be_nested_str_weak(decode_payload),
-    /* K27  */  be_nested_str_weak(received_ack),
-    /* K28  */  be_nested_str_weak(opcode),
-    /* K29  */  be_nested_str_weak(get_opcode_name),
-    /* K30  */  be_nested_str_weak(0x_X2502X),
-    /* K31  */  be_const_int(3),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K34  */  be_nested_str_weak(x_flag_r),
-    /* K35  */  be_nested_str_weak(_X7Breliable_X7D_X20),
-    /* K36  */  be_nested_str_weak(),
-    /* K37  */  be_nested_str_weak(exchange_id),
-    /* K38  */  be_nested_str_weak(ack_message_counter),
-    /* K39  */  be_nested_str_weak(commissioning),
-    /* K40  */  be_nested_str_weak(process_incoming),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
-    /* K42  */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
-    /* K44  */  be_nested_str_weak(counter_rcv_validate),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20encrypted_X20message_X20_X3D_X20),
-    /* K46  */  be_nested_str_weak(_X20counter_X3D),
-    /* K47  */  be_nested_str_weak(counter_rcv),
-    /* K48  */  be_nested_str_weak(send_encrypted_ack),
-    /* K49  */  be_nested_str_weak(decrypt),
-    /* K50  */  be_nested_str_weak(MTR_X3A_X20_X3E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Decrypted_X20message_X3A_X20protocol_id_X3A),
-    /* K51  */  be_nested_str_weak(protocol_id),
-    /* K52  */  be_nested_str_weak(_X20opcode_X3D),
-    /* K53  */  be_nested_str_weak(_X20exchange_id_X3D),
-    /* K54  */  be_nested_str_weak(im),
-    /* K55  */  be_nested_str_weak(process_incoming_ack),
-    /* K56  */  be_nested_str_weak(send_enqueued),
-    /* K57  */  be_const_int(1),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K59  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K60  */  be_nested_str_weak(_X3B),
-    /* K61  */  be_const_int(2),
-    /* K62  */  be_nested_str_weak(_debug_present),
-    /* K63  */  be_nested_str_weak(debug),
-    /* K64  */  be_nested_str_weak(traceback),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(msg_received),
     &be_const_str_solidified,
     ( &(const binstruction[334]) {  /* code */
       0x50100000,  //  0000  LDBOOL	R4	0	0
       0xA8020132,  //  0001  EXBLK	0	#0135
-      0xB8160000,  //  0002  GETNGBL	R5	K0
-      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B18,  //  0003  GETMET	R5	R5	K24
       0x5C1C0000,  //  0004  MOVE	R7	R0
       0x5C200200,  //  0005  MOVE	R8	R1
       0x5C240400,  //  0006  MOVE	R9	R2
       0x5C280600,  //  0007  MOVE	R10	R3
       0x7C140A00,  //  0008  CALL	R5	5
-      0x8C180B02,  //  0009  GETMET	R6	R5	K2
+      0x8C180B19,  //  0009  GETMET	R6	R5	K25
       0x7C180200,  //  000A  CALL	R6	1
       0x5C1C0C00,  //  000B  MOVE	R7	R6
       0x741E0002,  //  000C  JMPT	R7	#0010
       0x501C0000,  //  000D  LDBOOL	R7	0	0
       0xA8040001,  //  000E  EXBLK	1	1
       0x80040E00,  //  000F  RET	1	R7
-      0x881C0B03,  //  0010  GETMBR	R7	R5	K3
+      0x881C0B1A,  //  0010  GETMBR	R7	R5	K26
       0x781E000C,  //  0011  JMPF	R7	#001F
-      0x881C0104,  //  0012  GETMBR	R7	R0	K4
-      0x881C0F05,  //  0013  GETMBR	R7	R7	K5
-      0x8C1C0F06,  //  0014  GETMET	R7	R7	K6
-      0x88240B07,  //  0015  GETMBR	R9	R5	K7
+      0x881C0100,  //  0012  GETMBR	R7	R0	K0
+      0x881C0F1B,  //  0013  GETMBR	R7	R7	K27
+      0x8C1C0F1C,  //  0014  GETMET	R7	R7	K28
+      0x88240B1D,  //  0015  GETMBR	R9	R5	K29
       0x542A0059,  //  0016  LDINT	R10	90
       0x7C1C0600,  //  0017  CALL	R7	3
-      0x88200108,  //  0018  GETMBR	R8	R0	K8
-      0x8C201109,  //  0019  GETMET	R8	R8	K9
+      0x88200106,  //  0018  GETMBR	R8	R0	K6
+      0x8C20111E,  //  0019  GETMET	R8	R8	K30
       0x5C280A00,  //  001A  MOVE	R10	R5
       0x7C200400,  //  001B  CALL	R8	2
       0xA8040001,  //  001C  EXBLK	1	1
       0x80041000,  //  001D  RET	1	R8
       0x70020111,  //  001E  JMP		#0131
-      0x881C0B0A,  //  001F  GETMBR	R7	R5	K10
-      0x1C1C0F0B,  //  0020  EQ	R7	R7	K11
+      0x881C0B12,  //  001F  GETMBR	R7	R5	K18
+      0x1C1C0F1F,  //  0020  EQ	R7	R7	K31
       0x781E007A,  //  0021  JMPF	R7	#009D
-      0x881C0B0C,  //  0022  GETMBR	R7	R5	K12
-      0x1C1C0F0B,  //  0023  EQ	R7	R7	K11
+      0x881C0B20,  //  0022  GETMBR	R7	R5	K32
+      0x1C1C0F1F,  //  0023  EQ	R7	R7	K31
       0x781E0077,  //  0024  JMPF	R7	#009D
-      0x881C0104,  //  0025  GETMBR	R7	R0	K4
-      0x881C0F05,  //  0026  GETMBR	R7	R7	K5
-      0x8C1C0F06,  //  0027  GETMET	R7	R7	K6
-      0x88240B07,  //  0028  GETMBR	R9	R5	K7
+      0x881C0100,  //  0025  GETMBR	R7	R0	K0
+      0x881C0F1B,  //  0026  GETMBR	R7	R7	K27
+      0x8C1C0F1C,  //  0027  GETMET	R7	R7	K28
+      0x88240B1D,  //  0028  GETMBR	R9	R5	K29
       0x542A0059,  //  0029  LDINT	R10	90
       0x7C1C0600,  //  002A  CALL	R7	3
       0x780A0000,  //  002B  JMPF	R2	#002D
-      0x901E1A02,  //  002C  SETMBR	R7	K13	R2
+      0x901E4202,  //  002C  SETMBR	R7	K33	R2
       0x780E0000,  //  002D  JMPF	R3	#002F
-      0x901E1C03,  //  002E  SETMBR	R7	K14	R3
-      0x901E1E00,  //  002F  SETMBR	R7	K15	R0
-      0x90162007,  //  0030  SETMBR	R5	K16	R7
-      0x88200F11,  //  0031  GETMBR	R8	R7	K17
-      0x8C201112,  //  0032  GETMET	R8	R8	K18
-      0x88280B13,  //  0033  GETMBR	R10	R5	K19
+      0x901E4403,  //  002E  SETMBR	R7	K34	R3
+      0x901E4600,  //  002F  SETMBR	R7	K35	R0
+      0x90162207,  //  0030  SETMBR	R5	K17	R7
+      0x88200F24,  //  0031  GETMBR	R8	R7	K36
+      0x8C201125,  //  0032  GETMET	R8	R8	K37
+      0x88280B14,  //  0033  GETMBR	R10	R5	K20
       0x502C0000,  //  0034  LDBOOL	R11	0	0
       0x7C200600,  //  0035  CALL	R8	3
       0x74220015,  //  0036  JMPT	R8	#004D
-      0xB8222800,  //  0037  GETNGBL	R8	K20
-      0x8C201115,  //  0038  GETMET	R8	R8	K21
+      0xB8221A00,  //  0037  GETNGBL	R8	K13
+      0x8C20110E,  //  0038  GETMET	R8	R8	K14
       0x542A0003,  //  0039  LDINT	R10	4
       0x7C200400,  //  003A  CALL	R8	2
       0x78220009,  //  003B  JMPF	R8	#0046
-      0xB8222C00,  //  003C  GETNGBL	R8	K22
+      0xB8221E00,  //  003C  GETNGBL	R8	K15
       0x60240018,  //  003D  GETGBL	R9	G24
-      0x58280017,  //  003E  LDCONST	R10	K23
-      0x882C0B13,  //  003F  GETMBR	R11	R5	K19
-      0x88300F11,  //  0040  GETMBR	R12	R7	K17
-      0x8C301918,  //  0041  GETMET	R12	R12	K24
+      0x58280026,  //  003E  LDCONST	R10	K38
+      0x882C0B14,  //  003F  GETMBR	R11	R5	K20
+      0x88300F24,  //  0040  GETMBR	R12	R7	K36
+      0x8C301927,  //  0041  GETMET	R12	R12	K39
       0x7C300200,  //  0042  CALL	R12	1
       0x7C240600,  //  0043  CALL	R9	3
       0x542A0003,  //  0044  LDINT	R10	4
       0x7C200400,  //  0045  CALL	R8	2
-      0x8C200119,  //  0046  GETMET	R8	R0	K25
+      0x8C200128,  //  0046  GETMET	R8	R0	K40
       0x5C280A00,  //  0047  MOVE	R10	R5
       0x502C0000,  //  0048  LDBOOL	R11	0	0
       0x7C200600,  //  0049  CALL	R8	3
       0x50200000,  //  004A  LDBOOL	R8	0	0
       0xA8040001,  //  004B  EXBLK	1	1
       0x80041000,  //  004C  RET	1	R8
-      0x8C200B1A,  //  004D  GETMET	R8	R5	K26
+      0x8C200B29,  //  004D  GETMET	R8	R5	K41
       0x7C200200,  //  004E  CALL	R8	1
       0x74220002,  //  004F  JMPT	R8	#0053
       0x50200000,  //  0050  LDBOOL	R8	0	0
       0xA8040001,  //  0051  EXBLK	1	1
       0x80041000,  //  0052  RET	1	R8
-      0x88200104,  //  0053  GETMBR	R8	R0	K4
-      0x8C20111B,  //  0054  GETMET	R8	R8	K27
+      0x88200100,  //  0053  GETMBR	R8	R0	K0
+      0x8C20112A,  //  0054  GETMET	R8	R8	K42
       0x5C280A00,  //  0055  MOVE	R10	R5
       0x7C200400,  //  0056  CALL	R8	2
-      0x88200B1C,  //  0057  GETMBR	R8	R5	K28
+      0x88200B2B,  //  0057  GETMBR	R8	R5	K43
       0x5426000F,  //  0058  LDINT	R9	16
       0x20201009,  //  0059  NE	R8	R8	R9
       0x7822001A,  //  005A  JMPF	R8	#0076
-      0xB8220000,  //  005B  GETNGBL	R8	K0
-      0x8C20111D,  //  005C  GETMET	R8	R8	K29
-      0x88280B1C,  //  005D  GETMBR	R10	R5	K28
+      0xB8220400,  //  005B  GETNGBL	R8	K2
+      0x8C20112C,  //  005C  GETMET	R8	R8	K44
+      0x88280B2B,  //  005D  GETMBR	R10	R5	K43
       0x7C200400,  //  005E  CALL	R8	2
       0x5C241000,  //  005F  MOVE	R9	R8
       0x74260004,  //  0060  JMPT	R9	#0066
       0x60240018,  //  0061  GETGBL	R9	G24
-      0x5828001E,  //  0062  LDCONST	R10	K30
-      0x882C0B1C,  //  0063  GETMBR	R11	R5	K28
+      0x5828002D,  //  0062  LDCONST	R10	K45
+      0x882C0B2B,  //  0063  GETMBR	R11	R5	K43
       0x7C240400,  //  0064  CALL	R9	2
       0x5C201200,  //  0065  MOVE	R8	R9
-      0xB8262800,  //  0066  GETNGBL	R9	K20
-      0x8C241315,  //  0067  GETMET	R9	R9	K21
-      0x582C001F,  //  0068  LDCONST	R11	K31
+      0xB8261A00,  //  0066  GETNGBL	R9	K13
+      0x8C24130E,  //  0067  GETMET	R9	R9	K14
+      0x582C002E,  //  0068  LDCONST	R11	K46
       0x7C240400,  //  0069  CALL	R9	2
       0x78260009,  //  006A  JMPF	R9	#0075
-      0xB8262C00,  //  006B  GETNGBL	R9	K22
+      0xB8261E00,  //  006B  GETNGBL	R9	K15
       0x60280018,  //  006C  GETGBL	R10	G24
-      0x582C0020,  //  006D  LDCONST	R11	K32
-      0x88300F0A,  //  006E  GETMBR	R12	R7	K10
+      0x582C002F,  //  006D  LDCONST	R11	K47
+      0x88300F12,  //  006E  GETMBR	R12	R7	K18
       0x5C341000,  //  006F  MOVE	R13	R8
       0x5C380400,  //  0070  MOVE	R14	R2
       0x5C3C0600,  //  0071  MOVE	R15	R3
       0x7C280A00,  //  0072  CALL	R10	5
-      0x582C001F,  //  0073  LDCONST	R11	K31
+      0x582C002E,  //  0073  LDCONST	R11	K46
       0x7C240400,  //  0074  CALL	R9	2
       0x70020017,  //  0075  JMP		#008E
-      0xB8222800,  //  0076  GETNGBL	R8	K20
-      0x8C201115,  //  0077  GETMET	R8	R8	K21
+      0xB8221A00,  //  0076  GETNGBL	R8	K13
+      0x8C20110E,  //  0077  GETMET	R8	R8	K14
       0x542A0003,  //  0078  LDINT	R10	4
       0x7C200400,  //  0079  CALL	R8	2
       0x78220012,  //  007A  JMPF	R8	#008E
-      0xB8222C00,  //  007B  GETNGBL	R8	K22
+      0xB8221E00,  //  007B  GETNGBL	R8	K15
       0x60240018,  //  007C  GETGBL	R9	G24
-      0x58280021,  //  007D  LDCONST	R10	K33
-      0x882C0F0A,  //  007E  GETMBR	R11	R7	K10
-      0x88300B13,  //  007F  GETMBR	R12	R5	K19
-      0x88340B22,  //  0080  GETMBR	R13	R5	K34
+      0x58280030,  //  007D  LDCONST	R10	K48
+      0x882C0F12,  //  007E  GETMBR	R11	R7	K18
+      0x88300B14,  //  007F  GETMBR	R12	R5	K20
+      0x88340B09,  //  0080  GETMBR	R13	R5	K9
       0x78360001,  //  0081  JMPF	R13	#0084
-      0x58340023,  //  0082  LDCONST	R13	K35
+      0x58340031,  //  0082  LDCONST	R13	K49
       0x70020000,  //  0083  JMP		#0085
-      0x58340024,  //  0084  LDCONST	R13	K36
-      0x88380B25,  //  0085  GETMBR	R14	R5	K37
+      0x58340016,  //  0084  LDCONST	R13	K22
+      0x88380B32,  //  0085  GETMBR	R14	R5	K50
       0x603C0008,  //  0086  GETGBL	R15	G8
-      0x88400B26,  //  0087  GETMBR	R16	R5	K38
+      0x88400B13,  //  0087  GETMBR	R16	R5	K19
       0x7C3C0200,  //  0088  CALL	R15	1
       0x5C400400,  //  0089  MOVE	R16	R2
       0x5C440600,  //  008A  MOVE	R17	R3
       0x7C241000,  //  008B  CALL	R9	8
       0x542A0003,  //  008C  LDINT	R10	4
       0x7C200400,  //  008D  CALL	R8	2
-      0x88200127,  //  008E  GETMBR	R8	R0	K39
-      0x8C201128,  //  008F  GETMET	R8	R8	K40
+      0x88200101,  //  008E  GETMBR	R8	R0	K1
+      0x8C201133,  //  008F  GETMET	R8	R8	K51
       0x5C280A00,  //  0090  MOVE	R10	R5
       0x7C200400,  //  0091  CALL	R8	2
       0x5C101000,  //  0092  MOVE	R4	R8
       0x5C200800,  //  0093  MOVE	R8	R4
       0x74220003,  //  0094  JMPT	R8	#0099
-      0x8C200119,  //  0095  GETMET	R8	R0	K25
+      0x8C200128,  //  0095  GETMET	R8	R0	K40
       0x5C280A00,  //  0096  MOVE	R10	R5
       0x502C0000,  //  0097  LDBOOL	R11	0	0
       0x7C200600,  //  0098  CALL	R8	3
@@ -371,153 +362,153 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
       0xA8040001,  //  009A  EXBLK	1	1
       0x80041000,  //  009B  RET	1	R8
       0x70020093,  //  009C  JMP		#0131
-      0xB81E2800,  //  009D  GETNGBL	R7	K20
-      0x8C1C0F15,  //  009E  GETMET	R7	R7	K21
+      0xB81E1A00,  //  009D  GETNGBL	R7	K13
+      0x8C1C0F0E,  //  009E  GETMET	R7	R7	K14
       0x54260003,  //  009F  LDINT	R9	4
       0x7C1C0400,  //  00A0  CALL	R7	2
       0x781E0007,  //  00A1  JMPF	R7	#00AA
-      0xB81E2C00,  //  00A2  GETNGBL	R7	K22
+      0xB81E1E00,  //  00A2  GETNGBL	R7	K15
       0x60200018,  //  00A3  GETGBL	R8	G24
-      0x58240029,  //  00A4  LDCONST	R9	K41
-      0x88280B0A,  //  00A5  GETMBR	R10	R5	K10
-      0x882C0B13,  //  00A6  GETMBR	R11	R5	K19
+      0x58240034,  //  00A4  LDCONST	R9	K52
+      0x88280B12,  //  00A5  GETMBR	R10	R5	K18
+      0x882C0B14,  //  00A6  GETMBR	R11	R5	K20
       0x7C200600,  //  00A7  CALL	R8	3
       0x54260003,  //  00A8  LDINT	R9	4
       0x7C1C0400,  //  00A9  CALL	R7	2
-      0x881C0104,  //  00AA  GETMBR	R7	R0	K4
-      0x881C0F05,  //  00AB  GETMBR	R7	R7	K5
-      0x8C1C0F2A,  //  00AC  GETMET	R7	R7	K42
-      0x88240B0A,  //  00AD  GETMBR	R9	R5	K10
+      0x881C0100,  //  00AA  GETMBR	R7	R0	K0
+      0x881C0F1B,  //  00AB  GETMBR	R7	R7	K27
+      0x8C1C0F35,  //  00AC  GETMET	R7	R7	K53
+      0x88240B12,  //  00AD  GETMBR	R9	R5	K18
       0x7C1C0400,  //  00AE  CALL	R7	2
       0x4C200000,  //  00AF  LDNIL	R8
       0x1C200E08,  //  00B0  EQ	R8	R7	R8
       0x78220009,  //  00B1  JMPF	R8	#00BC
-      0xB8222C00,  //  00B2  GETNGBL	R8	K22
+      0xB8221E00,  //  00B2  GETNGBL	R8	K15
       0x60240008,  //  00B3  GETGBL	R9	G8
-      0x88280B0A,  //  00B4  GETMBR	R10	R5	K10
+      0x88280B12,  //  00B4  GETMBR	R10	R5	K18
       0x7C240200,  //  00B5  CALL	R9	1
-      0x00265609,  //  00B6  ADD	R9	K43	R9
-      0x5828001F,  //  00B7  LDCONST	R10	K31
+      0x00266C09,  //  00B6  ADD	R9	K54	R9
+      0x5828002E,  //  00B7  LDCONST	R10	K46
       0x7C200400,  //  00B8  CALL	R8	2
       0x50200000,  //  00B9  LDBOOL	R8	0	0
       0xA8040001,  //  00BA  EXBLK	1	1
       0x80041000,  //  00BB  RET	1	R8
       0x780A0000,  //  00BC  JMPF	R2	#00BE
-      0x901E1A02,  //  00BD  SETMBR	R7	K13	R2
+      0x901E4202,  //  00BD  SETMBR	R7	K33	R2
       0x780E0000,  //  00BE  JMPF	R3	#00C0
-      0x901E1C03,  //  00BF  SETMBR	R7	K14	R3
-      0x901E1E00,  //  00C0  SETMBR	R7	K15	R0
-      0x90162007,  //  00C1  SETMBR	R5	K16	R7
-      0x8C200F2C,  //  00C2  GETMET	R8	R7	K44
-      0x88280B13,  //  00C3  GETMBR	R10	R5	K19
+      0x901E4403,  //  00BF  SETMBR	R7	K34	R3
+      0x901E4600,  //  00C0  SETMBR	R7	K35	R0
+      0x90162207,  //  00C1  SETMBR	R5	K17	R7
+      0x8C200F37,  //  00C2  GETMET	R8	R7	K55
+      0x88280B14,  //  00C3  GETMBR	R10	R5	K20
       0x502C0200,  //  00C4  LDBOOL	R11	1	0
       0x7C200600,  //  00C5  CALL	R8	3
       0x74220017,  //  00C6  JMPT	R8	#00DF
-      0xB8222800,  //  00C7  GETNGBL	R8	K20
-      0x8C201115,  //  00C8  GETMET	R8	R8	K21
-      0x5828001F,  //  00C9  LDCONST	R10	K31
+      0xB8221A00,  //  00C7  GETNGBL	R8	K13
+      0x8C20110E,  //  00C8  GETMET	R8	R8	K14
+      0x5828002E,  //  00C9  LDCONST	R10	K46
       0x7C200400,  //  00CA  CALL	R8	2
       0x7822000B,  //  00CB  JMPF	R8	#00D8
-      0xB8222C00,  //  00CC  GETNGBL	R8	K22
+      0xB8221E00,  //  00CC  GETNGBL	R8	K15
       0x60240008,  //  00CD  GETGBL	R9	G8
-      0x88280B13,  //  00CE  GETMBR	R10	R5	K19
+      0x88280B14,  //  00CE  GETMBR	R10	R5	K20
       0x7C240200,  //  00CF  CALL	R9	1
-      0x00265A09,  //  00D0  ADD	R9	K45	R9
-      0x0024132E,  //  00D1  ADD	R9	R9	K46
+      0x00267009,  //  00D0  ADD	R9	K56	R9
+      0x00241339,  //  00D1  ADD	R9	R9	K57
       0x60280008,  //  00D2  GETGBL	R10	G8
-      0x882C0F2F,  //  00D3  GETMBR	R11	R7	K47
+      0x882C0F3A,  //  00D3  GETMBR	R11	R7	K58
       0x7C280200,  //  00D4  CALL	R10	1
       0x0024120A,  //  00D5  ADD	R9	R9	R10
-      0x5828001F,  //  00D6  LDCONST	R10	K31
+      0x5828002E,  //  00D6  LDCONST	R10	K46
       0x7C200400,  //  00D7  CALL	R8	2
-      0x8C200130,  //  00D8  GETMET	R8	R0	K48
+      0x8C20013B,  //  00D8  GETMET	R8	R0	K59
       0x5C280A00,  //  00D9  MOVE	R10	R5
       0x502C0000,  //  00DA  LDBOOL	R11	0	0
       0x7C200600,  //  00DB  CALL	R8	3
       0x50200000,  //  00DC  LDBOOL	R8	0	0
       0xA8040001,  //  00DD  EXBLK	1	1
       0x80041000,  //  00DE  RET	1	R8
-      0x8C200B31,  //  00DF  GETMET	R8	R5	K49
+      0x8C200B3C,  //  00DF  GETMET	R8	R5	K60
       0x7C200200,  //  00E0  CALL	R8	1
       0x5C241000,  //  00E1  MOVE	R9	R8
       0x74260002,  //  00E2  JMPT	R9	#00E6
       0x50240000,  //  00E3  LDBOOL	R9	0	0
       0xA8040001,  //  00E4  EXBLK	1	1
       0x80041200,  //  00E5  RET	1	R9
-      0x8C240B1A,  //  00E6  GETMET	R9	R5	K26
+      0x8C240B29,  //  00E6  GETMET	R9	R5	K41
       0x7C240200,  //  00E7  CALL	R9	1
-      0xB8262800,  //  00E8  GETNGBL	R9	K20
-      0x8C241315,  //  00E9  GETMET	R9	R9	K21
+      0xB8261A00,  //  00E8  GETNGBL	R9	K13
+      0x8C24130E,  //  00E9  GETMET	R9	R9	K14
       0x542E0003,  //  00EA  LDINT	R11	4
       0x7C240400,  //  00EB  CALL	R9	2
       0x78260012,  //  00EC  JMPF	R9	#0100
-      0xB8262C00,  //  00ED  GETNGBL	R9	K22
+      0xB8261E00,  //  00ED  GETNGBL	R9	K15
       0x60280008,  //  00EE  GETGBL	R10	G8
-      0x882C0B33,  //  00EF  GETMBR	R11	R5	K51
+      0x882C0B3E,  //  00EF  GETMBR	R11	R5	K62
       0x7C280200,  //  00F0  CALL	R10	1
-      0x002A640A,  //  00F1  ADD	R10	K50	R10
-      0x00281534,  //  00F2  ADD	R10	R10	K52
+      0x002A7A0A,  //  00F1  ADD	R10	K61	R10
+      0x0028153F,  //  00F2  ADD	R10	R10	K63
       0x602C0008,  //  00F3  GETGBL	R11	G8
-      0x88300B1C,  //  00F4  GETMBR	R12	R5	K28
+      0x88300B2B,  //  00F4  GETMBR	R12	R5	K43
       0x7C2C0200,  //  00F5  CALL	R11	1
       0x0028140B,  //  00F6  ADD	R10	R10	R11
-      0x00281535,  //  00F7  ADD	R10	R10	K53
+      0x00281540,  //  00F7  ADD	R10	R10	K64
       0x602C0008,  //  00F8  GETGBL	R11	G8
-      0x88300B25,  //  00F9  GETMBR	R12	R5	K37
+      0x88300B32,  //  00F9  GETMBR	R12	R5	K50
       0x5436FFFE,  //  00FA  LDINT	R13	65535
       0x2C30180D,  //  00FB  AND	R12	R12	R13
       0x7C2C0200,  //  00FC  CALL	R11	1
       0x0028140B,  //  00FD  ADD	R10	R10	R11
       0x542E0003,  //  00FE  LDINT	R11	4
       0x7C240400,  //  00FF  CALL	R9	2
-      0x88240104,  //  0100  GETMBR	R9	R0	K4
-      0x8C24131B,  //  0101  GETMET	R9	R9	K27
+      0x88240100,  //  0100  GETMBR	R9	R0	K0
+      0x8C24132A,  //  0101  GETMET	R9	R9	K42
       0x5C2C0A00,  //  0102  MOVE	R11	R5
       0x7C240400,  //  0103  CALL	R9	2
-      0x88240B33,  //  0104  GETMBR	R9	R5	K51
-      0x1C28130B,  //  0105  EQ	R10	R9	K11
+      0x88240B3E,  //  0104  GETMBR	R9	R5	K62
+      0x1C28131F,  //  0105  EQ	R10	R9	K31
       0x782A000F,  //  0106  JMPF	R10	#0117
-      0x88280B1C,  //  0107  GETMBR	R10	R5	K28
+      0x88280B2B,  //  0107  GETMBR	R10	R5	K43
       0x542E000F,  //  0108  LDINT	R11	16
       0x1C28140B,  //  0109  EQ	R10	R10	R11
       0x782A0009,  //  010A  JMPF	R10	#0115
-      0x88280136,  //  010B  GETMBR	R10	R0	K54
-      0x8C281537,  //  010C  GETMET	R10	R10	K55
+      0x88280104,  //  010B  GETMBR	R10	R0	K4
+      0x8C281541,  //  010C  GETMET	R10	R10	K65
       0x5C300A00,  //  010D  MOVE	R12	R5
       0x7C280400,  //  010E  CALL	R10	2
       0x5C101400,  //  010F  MOVE	R4	R10
       0x78120003,  //  0110  JMPF	R4	#0115
-      0x88280136,  //  0111  GETMBR	R10	R0	K54
-      0x8C281538,  //  0112  GETMET	R10	R10	K56
+      0x88280104,  //  0111  GETMBR	R10	R0	K4
+      0x8C281542,  //  0112  GETMET	R10	R10	K66
       0x5C300000,  //  0113  MOVE	R12	R0
       0x7C280400,  //  0114  CALL	R10	2
       0x50100200,  //  0115  LDBOOL	R4	1	0
       0x70020019,  //  0116  JMP		#0131
-      0x1C281339,  //  0117  EQ	R10	R9	K57
+      0x1C281343,  //  0117  EQ	R10	R9	K67
       0x782A0010,  //  0118  JMPF	R10	#012A
-      0x88280136,  //  0119  GETMBR	R10	R0	K54
-      0x8C281528,  //  011A  GETMET	R10	R10	K40
+      0x88280104,  //  0119  GETMBR	R10	R0	K4
+      0x8C281533,  //  011A  GETMET	R10	R10	K51
       0x5C300A00,  //  011B  MOVE	R12	R5
       0x7C280400,  //  011C  CALL	R10	2
       0x5C101400,  //  011D  MOVE	R4	R10
       0x78120004,  //  011E  JMPF	R4	#0124
-      0x88280136,  //  011F  GETMBR	R10	R0	K54
-      0x8C281538,  //  0120  GETMET	R10	R10	K56
+      0x88280104,  //  011F  GETMBR	R10	R0	K4
+      0x8C281542,  //  0120  GETMET	R10	R10	K66
       0x5C300000,  //  0121  MOVE	R12	R0
       0x7C280400,  //  0122  CALL	R10	2
       0x70020003,  //  0123  JMP		#0128
-      0x8C280130,  //  0124  GETMET	R10	R0	K48
+      0x8C28013B,  //  0124  GETMET	R10	R0	K59
       0x5C300A00,  //  0125  MOVE	R12	R5
       0x50340200,  //  0126  LDBOOL	R13	1	0
       0x7C280600,  //  0127  CALL	R10	3
       0x50100200,  //  0128  LDBOOL	R4	1	0
       0x70020006,  //  0129  JMP		#0131
-      0xB82A2C00,  //  012A  GETNGBL	R10	K22
+      0xB82A1E00,  //  012A  GETNGBL	R10	K15
       0x602C0008,  //  012B  GETGBL	R11	G8
       0x5C301200,  //  012C  MOVE	R12	R9
       0x7C2C0200,  //  012D  CALL	R11	1
-      0x002E740B,  //  012E  ADD	R11	K58	R11
-      0x5830001F,  //  012F  LDCONST	R12	K31
+      0x002E880B,  //  012E  ADD	R11	K68	R11
+      0x5830002E,  //  012F  LDCONST	R12	K46
       0x7C280400,  //  0130  CALL	R10	2
       0xA8040001,  //  0131  EXBLK	1	1
       0x80040800,  //  0132  RET	1	R4
@@ -525,23 +516,23 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
       0x70020017,  //  0134  JMP		#014D
       0xAC140002,  //  0135  CATCH	R5	0	2
       0x70020014,  //  0136  JMP		#014C
-      0xB81E2C00,  //  0137  GETNGBL	R7	K22
+      0xB81E1E00,  //  0137  GETNGBL	R7	K15
       0x60200008,  //  0138  GETGBL	R8	G8
       0x5C240A00,  //  0139  MOVE	R9	R5
       0x7C200200,  //  013A  CALL	R8	1
-      0x00227608,  //  013B  ADD	R8	K59	R8
-      0x0020113C,  //  013C  ADD	R8	R8	K60
+      0x00228A08,  //  013B  ADD	R8	K69	R8
+      0x00201146,  //  013C  ADD	R8	R8	K70
       0x60240008,  //  013D  GETGBL	R9	G8
       0x5C280C00,  //  013E  MOVE	R10	R6
       0x7C240200,  //  013F  CALL	R9	1
       0x00201009,  //  0140  ADD	R8	R8	R9
-      0x5824003D,  //  0141  LDCONST	R9	K61
+      0x58240047,  //  0141  LDCONST	R9	K71
       0x7C1C0400,  //  0142  CALL	R7	2
-      0xB81E2800,  //  0143  GETNGBL	R7	K20
-      0x881C0F3E,  //  0144  GETMBR	R7	R7	K62
+      0xB81E1A00,  //  0143  GETNGBL	R7	K13
+      0x881C0F48,  //  0144  GETMBR	R7	R7	K72
       0x781E0002,  //  0145  JMPF	R7	#0149
-      0xA41E7E00,  //  0146  IMPORT	R7	K63
-      0x8C200F40,  //  0147  GETMET	R8	R7	K64
+      0xA41E9200,  //  0146  IMPORT	R7	K73
+      0x8C200F4A,  //  0147  GETMET	R8	R7	K74
       0x7C200200,  //  0148  CALL	R8	1
       0x501C0000,  //  0149  LDBOOL	R7	0	0
       0x80040E00,  //  014A  RET	1	R7
@@ -561,21 +552,18 @@ be_local_closure(class_Matter_MessageHandler_send_response_frame,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(msg_send),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(send_response_frame),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C08054B,  //  0001  GETMET	R2	R2	K75
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
@@ -592,60 +580,45 @@ be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(x_flag_r),
-    /* K1   */  be_nested_str_weak(build_standalone_ack),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(encode_frame),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(loglevel),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(ack_message_counter),
-    /* K10  */  be_nested_str_weak(message_counter),
-    /* K11  */  be_nested_str_weak(_X7Breliable_X7D),
-    /* K12  */  be_nested_str_weak(),
-    /* K13  */  be_nested_str_weak(send_response_frame),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(send_simple_ack),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x880C0309,  //  0000  GETMBR	R3	R1	K9
       0x780E001C,  //  0001  JMPF	R3	#001F
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x8C0C030A,  //  0002  GETMET	R3	R1	K10
       0x5C140400,  //  0003  MOVE	R5	R2
       0x7C0C0400,  //  0004  CALL	R3	2
-      0x88100302,  //  0005  GETMBR	R4	R1	K2
-      0x900E0404,  //  0006  SETMBR	R3	K2	R4
-      0x8C100703,  //  0007  GETMET	R4	R3	K3
+      0x88100312,  //  0005  GETMBR	R4	R1	K18
+      0x900E2404,  //  0006  SETMBR	R3	K18	R4
+      0x8C10070B,  //  0007  GETMET	R4	R3	K11
       0x7C100200,  //  0008  CALL	R4	1
-      0xB8120800,  //  0009  GETNGBL	R4	K4
-      0x8C100905,  //  000A  GETMET	R4	R4	K5
+      0xB8121A00,  //  0009  GETNGBL	R4	K13
+      0x8C10090E,  //  000A  GETMET	R4	R4	K14
       0x541A0003,  //  000B  LDINT	R6	4
       0x7C100400,  //  000C  CALL	R4	2
       0x7812000D,  //  000D  JMPF	R4	#001C
-      0xB8120C00,  //  000E  GETNGBL	R4	K6
+      0xB8121E00,  //  000E  GETNGBL	R4	K15
       0x60140018,  //  000F  GETGBL	R5	G24
-      0x58180007,  //  0010  LDCONST	R6	K7
-      0x881C0708,  //  0011  GETMBR	R7	R3	K8
-      0x881C0F02,  //  0012  GETMBR	R7	R7	K2
-      0x88200709,  //  0013  GETMBR	R8	R3	K9
-      0x8824070A,  //  0014  GETMBR	R9	R3	K10
+      0x5818004C,  //  0010  LDCONST	R6	K76
+      0x881C0711,  //  0011  GETMBR	R7	R3	K17
+      0x881C0F12,  //  0012  GETMBR	R7	R7	K18
+      0x88200713,  //  0013  GETMBR	R8	R3	K19
+      0x88240714,  //  0014  GETMBR	R9	R3	K20
       0x780A0001,  //  0015  JMPF	R2	#0018
-      0x5828000B,  //  0016  LDCONST	R10	K11
+      0x58280015,  //  0016  LDCONST	R10	K21
       0x70020000,  //  0017  JMP		#0019
-      0x5828000C,  //  0018  LDCONST	R10	K12
+      0x58280016,  //  0018  LDCONST	R10	K22
       0x7C140A00,  //  0019  CALL	R5	5
       0x541A0003,  //  001A  LDINT	R6	4
       0x7C100400,  //  001B  CALL	R4	2
-      0x8C10010D,  //  001C  GETMET	R4	R0	K13
+      0x8C100117,  //  001C  GETMET	R4	R0	K23
       0x5C180600,  //  001D  MOVE	R6	R3
       0x7C100400,  //  001E  CALL	R4	2
       0x80000000,  //  001F  RET	0
@@ -662,21 +635,18 @@ be_local_closure(class_Matter_MessageHandler_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(im),
-    /* K1   */  be_nested_str_weak(every_50ms),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x8C04034D,  //  0001  GETMET	R1	R1	K77
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -692,25 +662,21 @@ be_local_closure(class_Matter_MessageHandler_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(im),
-    }),
+    &be_ktab_class_Matter_MessageHandler,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04034E,  //  0001  GETMET	R1	R1	K78
       0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x88040104,  //  0003  GETMBR	R1	R0	K4
+      0x8C04034E,  //  0004  GETMET	R1	R1	K78
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
@@ -3,6 +3,29 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Path' ktab size: 19, total: 30 (saved 88 bytes)
+static const bvalue be_ktab_class_Matter_Path[19] = {
+  /* K0   */  be_nested_str_weak(endpoint),
+  /* K1   */  be_nested_str_weak(cluster),
+  /* K2   */  be_nested_str_weak(attribute),
+  /* K3   */  be_nested_str_weak(fabric_filtered),
+  /* K4   */  be_nested_str_weak(command),
+  /* K5   */  be_nested_str_weak(status),
+  /* K6   */  be_nested_str_weak(log),
+  /* K7   */  be_nested_str_weak(msg),
+  /* K8   */  be_nested_str_weak(),
+  /* K9   */  be_nested_str_weak(_X5B_X2502X_X5D),
+  /* K10  */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
+  /* K11  */  be_nested_str_weak(_X2504X_X2F),
+  /* K12  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
+  /* K13  */  be_nested_str_weak(_X2504X),
+  /* K14  */  be_nested_str_weak(_X21),
+  /* K15  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+  /* K16  */  be_nested_str_weak(Exception_X3E_X20),
+  /* K17  */  be_nested_str_weak(_X2C_X20),
+  /* K18  */  be_nested_str_weak(reset),
+};
+
 
 extern const bclass be_class_Matter_Path;
 
@@ -13,22 +36,13 @@ be_local_closure(class_Matter_Path_reset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    /* K1   */  be_nested_str_weak(cluster),
-    /* K2   */  be_nested_str_weak(attribute),
-    /* K3   */  be_nested_str_weak(fabric_filtered),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(msg),
-    }),
+    &be_ktab_class_Matter_Path,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -55,17 +69,13 @@ be_local_closure(class_Matter_Path_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    /* K1   */  be_nested_str_weak(cluster),
-    /* K2   */  be_nested_str_weak(attribute),
-    }),
+    &be_ktab_class_Matter_Path,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -86,90 +96,74 @@ be_local_closure(class_Matter_Path_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(_X5B_X2502X_X5D),
-    /* K3   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(_X2504X_X2F),
-    /* K6   */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
-    /* K7   */  be_nested_str_weak(attribute),
-    /* K8   */  be_nested_str_weak(_X2504X),
-    /* K9   */  be_nested_str_weak(command),
-    /* K10  */  be_nested_str_weak(fabric_filtered),
-    /* K11  */  be_nested_str_weak(_X21),
-    /* K12  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K13  */  be_nested_str_weak(Exception_X3E_X20),
-    /* K14  */  be_nested_str_weak(_X2C_X20),
-    }),
+    &be_ktab_class_Matter_Path,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[77]) {  /* code */
       0xA802003C,  //  0000  EXBLK	0	#003E
-      0x58040000,  //  0001  LDCONST	R1	K0
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x58040008,  //  0001  LDCONST	R1	K8
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
       0x4C0C0000,  //  0003  LDNIL	R3
       0x20080403,  //  0004  NE	R2	R2	R3
       0x780A0004,  //  0005  JMPF	R2	#000B
       0x60080018,  //  0006  GETGBL	R2	G24
-      0x580C0002,  //  0007  LDCONST	R3	K2
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x580C0009,  //  0007  LDCONST	R3	K9
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
       0x7C080400,  //  0009  CALL	R2	2
       0x70020000,  //  000A  JMP		#000C
-      0x58080003,  //  000B  LDCONST	R2	K3
+      0x5808000A,  //  000B  LDCONST	R2	K10
       0x00040202,  //  000C  ADD	R1	R1	R2
-      0x88080104,  //  000D  GETMBR	R2	R0	K4
+      0x88080101,  //  000D  GETMBR	R2	R0	K1
       0x4C0C0000,  //  000E  LDNIL	R3
       0x20080403,  //  000F  NE	R2	R2	R3
       0x780A0004,  //  0010  JMPF	R2	#0016
       0x60080018,  //  0011  GETGBL	R2	G24
-      0x580C0005,  //  0012  LDCONST	R3	K5
-      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x580C000B,  //  0012  LDCONST	R3	K11
+      0x88100101,  //  0013  GETMBR	R4	R0	K1
       0x7C080400,  //  0014  CALL	R2	2
       0x70020000,  //  0015  JMP		#0017
-      0x58080006,  //  0016  LDCONST	R2	K6
+      0x5808000C,  //  0016  LDCONST	R2	K12
       0x00040202,  //  0017  ADD	R1	R1	R2
-      0x88080107,  //  0018  GETMBR	R2	R0	K7
+      0x88080102,  //  0018  GETMBR	R2	R0	K2
       0x4C0C0000,  //  0019  LDNIL	R3
       0x20080403,  //  001A  NE	R2	R2	R3
       0x780A0004,  //  001B  JMPF	R2	#0021
       0x60080018,  //  001C  GETGBL	R2	G24
-      0x580C0008,  //  001D  LDCONST	R3	K8
-      0x88100107,  //  001E  GETMBR	R4	R0	K7
+      0x580C000D,  //  001D  LDCONST	R3	K13
+      0x88100102,  //  001E  GETMBR	R4	R0	K2
       0x7C080400,  //  001F  CALL	R2	2
       0x70020000,  //  0020  JMP		#0022
-      0x58080000,  //  0021  LDCONST	R2	K0
+      0x58080008,  //  0021  LDCONST	R2	K8
       0x00040202,  //  0022  ADD	R1	R1	R2
-      0x88080109,  //  0023  GETMBR	R2	R0	K9
+      0x88080104,  //  0023  GETMBR	R2	R0	K4
       0x4C0C0000,  //  0024  LDNIL	R3
       0x20080403,  //  0025  NE	R2	R2	R3
       0x780A0004,  //  0026  JMPF	R2	#002C
       0x60080018,  //  0027  GETGBL	R2	G24
-      0x580C0008,  //  0028  LDCONST	R3	K8
-      0x88100109,  //  0029  GETMBR	R4	R0	K9
+      0x580C000D,  //  0028  LDCONST	R3	K13
+      0x88100104,  //  0029  GETMBR	R4	R0	K4
       0x7C080400,  //  002A  CALL	R2	2
       0x70020000,  //  002B  JMP		#002D
-      0x58080000,  //  002C  LDCONST	R2	K0
+      0x58080008,  //  002C  LDCONST	R2	K8
       0x00040202,  //  002D  ADD	R1	R1	R2
-      0x8808010A,  //  002E  GETMBR	R2	R0	K10
+      0x88080103,  //  002E  GETMBR	R2	R0	K3
       0x780A0000,  //  002F  JMPF	R2	#0031
-      0x0004030B,  //  0030  ADD	R1	R1	K11
-      0x88080107,  //  0031  GETMBR	R2	R0	K7
+      0x0004030E,  //  0030  ADD	R1	R1	K14
+      0x88080102,  //  0031  GETMBR	R2	R0	K2
       0x4C0C0000,  //  0032  LDNIL	R3
       0x1C080403,  //  0033  EQ	R2	R2	R3
       0x780A0004,  //  0034  JMPF	R2	#003A
-      0x88080109,  //  0035  GETMBR	R2	R0	K9
+      0x88080104,  //  0035  GETMBR	R2	R0	K4
       0x4C0C0000,  //  0036  LDNIL	R3
       0x1C080403,  //  0037  EQ	R2	R2	R3
       0x780A0000,  //  0038  JMPF	R2	#003A
-      0x0004030C,  //  0039  ADD	R1	R1	K12
+      0x0004030F,  //  0039  ADD	R1	R1	K15
       0xA8040001,  //  003A  EXBLK	1	1
       0x80040200,  //  003B  RET	1	R1
       0xA8040001,  //  003C  EXBLK	1	1
@@ -179,8 +173,8 @@ be_local_closure(class_Matter_Path_tostring,   /* name */
       0x600C0008,  //  0040  GETGBL	R3	G8
       0x5C100200,  //  0041  MOVE	R4	R1
       0x7C0C0200,  //  0042  CALL	R3	1
-      0x000E1A03,  //  0043  ADD	R3	K13	R3
-      0x000C070E,  //  0044  ADD	R3	R3	K14
+      0x000E2003,  //  0043  ADD	R3	K16	R3
+      0x000C0711,  //  0044  ADD	R3	R3	K17
       0x60100008,  //  0045  GETGBL	R4	G8
       0x5C140400,  //  0046  MOVE	R5	R2
       0x7C100200,  //  0047  CALL	R4	1
@@ -202,29 +196,24 @@ be_local_closure(class_Matter_Path_copy,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    }),
+    &be_ktab_class_Matter_Path,     /* shared constants */
     be_str_weak(copy),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080112,  //  0000  GETMET	R2	R0	K18
       0x7C080200,  //  0001  CALL	R2	1
-      0x88080301,  //  0002  GETMBR	R2	R1	K1
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0x88080302,  //  0004  GETMBR	R2	R1	K2
-      0x90020402,  //  0005  SETMBR	R0	K2	R2
-      0x88080303,  //  0006  GETMBR	R2	R1	K3
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x88080300,  //  0002  GETMBR	R2	R1	K0
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080301,  //  0004  GETMBR	R2	R1	K1
+      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x88080302,  //  0006  GETMBR	R2	R1	K2
+      0x90020402,  //  0007  SETMBR	R0	K2	R2
       0x80000000,  //  0008  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_EventGenerator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_EventGenerator.h
@@ -3,6 +3,24 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_EventGenerator' ktab size: 14, total: 26 (saved 96 bytes)
+static const bvalue be_ktab_class_Matter_EventGenerator[14] = {
+  /* K0   */  be_nested_str_weak(device),
+  /* K1   */  be_nested_str_weak(reset),
+  /* K2   */  be_nested_str_weak(path_in_endpoint),
+  /* K3   */  be_nested_str_weak(path_in_cluster),
+  /* K4   */  be_nested_str_weak(path_in_event),
+  /* K5   */  be_nested_str_weak(path_in_event_min),
+  /* K6   */  be_nested_str_weak(event_no),
+  /* K7   */  be_nested_str_weak(finished),
+  /* K8   */  be_nested_str_weak(endpoint),
+  /* K9   */  be_nested_str_weak(cluster),
+  /* K10  */  be_nested_str_weak(event_id),
+  /* K11  */  be_nested_str_weak(events),
+  /* K12  */  be_nested_str_weak(find_min_no),
+  /* K13  */  be_nested_str_weak(event_is_match),
+};
+
 
 extern const bclass be_class_Matter_EventGenerator;
 
@@ -13,15 +31,13 @@ be_local_closure(class_Matter_EventGenerator_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -40,13 +56,13 @@ be_local_closure(class_Matter_EventGenerator_get_pi,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(get_pi),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -65,33 +81,25 @@ be_local_closure(class_Matter_EventGenerator_start,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(path_in_endpoint),
-    /* K2   */  be_nested_str_weak(path_in_cluster),
-    /* K3   */  be_nested_str_weak(path_in_event),
-    /* K4   */  be_nested_str_weak(path_in_event_min),
-    /* K5   */  be_nested_str_weak(event_no),
-    /* K6   */  be_nested_str_weak(finished),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x8C140100,  //  0000  GETMET	R5	R0	K0
+      0x8C140101,  //  0000  GETMET	R5	R0	K1
       0x7C140200,  //  0001  CALL	R5	1
-      0x90020201,  //  0002  SETMBR	R0	K1	R1
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020603,  //  0004  SETMBR	R0	K3	R3
-      0x90020804,  //  0005  SETMBR	R0	K4	R4
-      0x90020A04,  //  0006  SETMBR	R0	K5	R4
+      0x90020401,  //  0002  SETMBR	R0	K2	R1
+      0x90020602,  //  0003  SETMBR	R0	K3	R2
+      0x90020803,  //  0004  SETMBR	R0	K4	R3
+      0x90020A04,  //  0005  SETMBR	R0	K5	R4
+      0x90020C04,  //  0006  SETMBR	R0	K6	R4
       0x50140000,  //  0007  LDBOOL	R5	0	0
-      0x90020C05,  //  0008  SETMBR	R0	K6	R5
+      0x90020E05,  //  0008  SETMBR	R0	K7	R5
       0x80000000,  //  0009  RET	0
     })
   )
@@ -106,23 +114,20 @@ be_local_closure(class_Matter_EventGenerator_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_no),
-    /* K1   */  be_nested_str_weak(finished),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020C01,  //  0001  SETMBR	R0	K6	R1
       0x50080200,  //  0002  LDBOOL	R2	1	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0x90020E02,  //  0003  SETMBR	R0	K7	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -137,19 +142,17 @@ be_local_closure(class_Matter_EventGenerator_is_finished,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(finished),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(is_finished),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -164,43 +167,36 @@ be_local_closure(class_Matter_EventGenerator_event_is_match,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path_in_endpoint),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(path_in_cluster),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(path_in_event),
-    /* K5   */  be_nested_str_weak(event_id),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(event_is_match),
     &be_const_str_solidified,
     ( &(const binstruction[38]) {  /* code */
       0x50080200,  //  0000  LDBOOL	R2	1	0
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x880C0102,  //  0001  GETMBR	R3	R0	K2
       0x4C100000,  //  0002  LDNIL	R4
       0x200C0604,  //  0003  NE	R3	R3	R4
       0x780E0007,  //  0004  JMPF	R3	#000D
       0x780A0003,  //  0005  JMPF	R2	#000A
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x88100301,  //  0007  GETMBR	R4	R1	K1
+      0x880C0102,  //  0006  GETMBR	R3	R0	K2
+      0x88100308,  //  0007  GETMBR	R4	R1	K8
       0x1C0C0604,  //  0008  EQ	R3	R3	R4
       0x740E0000,  //  0009  JMPT	R3	#000B
       0x500C0001,  //  000A  LDBOOL	R3	0	1
       0x500C0200,  //  000B  LDBOOL	R3	1	0
       0x5C080600,  //  000C  MOVE	R2	R3
-      0x880C0102,  //  000D  GETMBR	R3	R0	K2
+      0x880C0103,  //  000D  GETMBR	R3	R0	K3
       0x4C100000,  //  000E  LDNIL	R4
       0x200C0604,  //  000F  NE	R3	R3	R4
       0x780E0007,  //  0010  JMPF	R3	#0019
       0x780A0003,  //  0011  JMPF	R2	#0016
-      0x880C0102,  //  0012  GETMBR	R3	R0	K2
-      0x88100303,  //  0013  GETMBR	R4	R1	K3
+      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x88100309,  //  0013  GETMBR	R4	R1	K9
       0x1C0C0604,  //  0014  EQ	R3	R3	R4
       0x740E0000,  //  0015  JMPT	R3	#0017
       0x500C0001,  //  0016  LDBOOL	R3	0	1
@@ -212,7 +208,7 @@ be_local_closure(class_Matter_EventGenerator_event_is_match,   /* name */
       0x780E0007,  //  001C  JMPF	R3	#0025
       0x780A0003,  //  001D  JMPF	R2	#0022
       0x880C0104,  //  001E  GETMBR	R3	R0	K4
-      0x88100305,  //  001F  GETMBR	R4	R1	K5
+      0x8810030A,  //  001F  GETMBR	R4	R1	K10
       0x1C0C0604,  //  0020  EQ	R3	R3	R4
       0x740E0000,  //  0021  JMPT	R3	#0023
       0x500C0001,  //  0022  LDBOOL	R3	0	1
@@ -232,45 +228,37 @@ be_local_closure(class_Matter_EventGenerator_next_event,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(finished),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(events),
-    /* K3   */  be_nested_str_weak(find_min_no),
-    /* K4   */  be_nested_str_weak(event_no),
-    /* K5   */  be_nested_str_weak(reset),
-    /* K6   */  be_nested_str_weak(event_is_match),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(next_event),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
       0x78060001,  //  0001  JMPF	R1	#0004
       0x4C040000,  //  0002  LDNIL	R1
       0x80040200,  //  0003  RET	1	R1
       0x50040200,  //  0004  LDBOOL	R1	1	0
       0x78060013,  //  0005  JMPF	R1	#001A
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x88040302,  //  0007  GETMBR	R1	R1	K2
-      0x8C040303,  //  0008  GETMET	R1	R1	K3
-      0x880C0104,  //  0009  GETMBR	R3	R0	K4
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x8804030B,  //  0007  GETMBR	R1	R1	K11
+      0x8C04030C,  //  0008  GETMET	R1	R1	K12
+      0x880C0106,  //  0009  GETMBR	R3	R0	K6
       0x7C040400,  //  000A  CALL	R1	2
       0x4C080000,  //  000B  LDNIL	R2
       0x1C080202,  //  000C  EQ	R2	R1	R2
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C080105,  //  000E  GETMET	R2	R0	K5
+      0x8C080101,  //  000E  GETMET	R2	R0	K1
       0x7C080200,  //  000F  CALL	R2	1
       0x4C080000,  //  0010  LDNIL	R2
       0x80040400,  //  0011  RET	1	R2
-      0x88080304,  //  0012  GETMBR	R2	R1	K4
-      0x90020802,  //  0013  SETMBR	R0	K4	R2
-      0x8C080106,  //  0014  GETMET	R2	R0	K6
+      0x88080306,  //  0012  GETMBR	R2	R1	K6
+      0x90020C02,  //  0013  SETMBR	R0	K6	R2
+      0x8C08010D,  //  0014  GETMET	R2	R0	K13
       0x5C100200,  //  0015  MOVE	R4	R1
       0x7C080400,  //  0016  CALL	R2	2
       0x780A0000,  //  0017  JMPF	R2	#0019
@@ -290,22 +278,19 @@ be_local_closure(class_Matter_EventGenerator_restart_from,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(finished),
-    /* K1   */  be_nested_str_weak(event_no),
-    }),
+    &be_ktab_class_Matter_EventGenerator,     /* shared constants */
     be_str_weak(restart_from),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x50080000,  //  0000  LDBOOL	R2	0	0
-      0x90020002,  //  0001  SETMBR	R0	K0	R2
-      0x90020201,  //  0002  SETMBR	R0	K1	R1
+      0x90020E02,  //  0001  SETMBR	R0	K7	R2
+      0x90020C01,  //  0002  SETMBR	R0	K6	R1
       0x80000000,  //  0003  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_PathGenerator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_PathGenerator.h
@@ -3,6 +3,45 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_PathGenerator' ktab size: 35, total: 78 (saved 344 bytes)
+static const bvalue be_ktab_class_Matter_PathGenerator[35] = {
+  /* K0   */  be_nested_str_weak(path_concrete),
+  /* K1   */  be_nested_str_weak(reset),
+  /* K2   */  be_nested_str_weak(pi),
+  /* K3   */  be_nested_str_weak(cluster),
+  /* K4   */  be_nested_str_weak(attribute),
+  /* K5   */  be_nested_str_weak(clusters),
+  /* K6   */  be_nested_str_weak(device),
+  /* K7   */  be_nested_str_weak(path_in_endpoint),
+  /* K8   */  be_nested_str_weak(path_in_cluster),
+  /* K9   */  be_nested_str_weak(path_in_attribute),
+  /* K10  */  be_nested_str_weak(is_direct),
+  /* K11  */  be_nested_str_weak(_next_endpoint),
+  /* K12  */  be_nested_str_weak(endpoint_found),
+  /* K13  */  be_nested_str_weak(_next_cluster),
+  /* K14  */  be_nested_str_weak(cluster_found),
+  /* K15  */  be_nested_str_weak(_next_attribute),
+  /* K16  */  be_nested_str_weak(attribute_found),
+  /* K17  */  be_nested_str_weak(endpoint),
+  /* K18  */  be_nested_str_weak(get_endpoint),
+  /* K19  */  be_nested_str_weak(fabric_filtered),
+  /* K20  */  be_nested_str_weak(path_in_fabric_filtered),
+  /* K21  */  be_nested_str_weak(status),
+  /* K22  */  be_nested_str_weak(_default_status_error),
+  /* K23  */  be_nested_str_weak(find),
+  /* K24  */  be_const_int(1),
+  /* K25  */  be_nested_str_weak(matter),
+  /* K26  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+  /* K27  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+  /* K28  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+  /* K29  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
+  /* K30  */  be_nested_str_weak(get_attribute_list),
+  /* K31  */  be_const_int(1),
+  /* K32  */  be_nested_str_weak(plugins),
+  /* K33  */  be_nested_str_weak(get_cluster_list_sorted),
+  /* K34  */  be_nested_str_weak(Path),
+};
+
 
 extern const bclass be_class_Matter_PathGenerator;
 
@@ -13,20 +52,13 @@ be_local_closure(class_Matter_PathGenerator_reset,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path_concrete),
-    /* K1   */  be_nested_str_weak(reset),
-    /* K2   */  be_nested_str_weak(pi),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(clusters),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -53,19 +85,17 @@ be_local_closure(class_Matter_PathGenerator_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020C01,  //  0000  SETMBR	R0	K6	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -80,29 +110,25 @@ be_local_closure(class_Matter_PathGenerator_is_direct,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path_in_endpoint),
-    /* K1   */  be_nested_str_weak(path_in_cluster),
-    /* K2   */  be_nested_str_weak(path_in_attribute),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(is_direct),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x88040108,  //  0004  GETMBR	R1	R0	K8
       0x4C080000,  //  0005  LDNIL	R2
       0x20040202,  //  0006  NE	R1	R1	R2
       0x78060003,  //  0007  JMPF	R1	#000C
-      0x88040102,  //  0008  GETMBR	R1	R0	K2
+      0x88040109,  //  0008  GETMBR	R1	R0	K9
       0x4C080000,  //  0009  LDNIL	R2
       0x20040202,  //  000A  NE	R1	R1	R2
       0x74060000,  //  000B  JMPT	R1	#000D
@@ -122,19 +148,17 @@ be_local_closure(class_Matter_PathGenerator_is_finished,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pi),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(is_finished),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0x20040202,  //  0002  NE	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
@@ -151,58 +175,36 @@ be_local_closure(class_Matter_PathGenerator_next_attribute,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pi),
-    /* K1   */  be_nested_str_weak(is_direct),
-    /* K2   */  be_nested_str_weak(reset),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(_next_endpoint),
-    /* K5   */  be_nested_str_weak(endpoint_found),
-    /* K6   */  be_nested_str_weak(attribute),
-    /* K7   */  be_nested_str_weak(_next_cluster),
-    /* K8   */  be_nested_str_weak(cluster_found),
-    /* K9   */  be_nested_str_weak(_next_attribute),
-    /* K10  */  be_nested_str_weak(attribute_found),
-    /* K11  */  be_nested_str_weak(path_concrete),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_nested_str_weak(get_endpoint),
-    /* K14  */  be_nested_str_weak(fabric_filtered),
-    /* K15  */  be_nested_str_weak(path_in_fabric_filtered),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(path_in_endpoint),
-    /* K18  */  be_nested_str_weak(path_in_cluster),
-    /* K19  */  be_nested_str_weak(path_in_attribute),
-    /* K20  */  be_nested_str_weak(_default_status_error),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(next_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[95]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
       0x50080200,  //  0001  LDBOOL	R2	1	0
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x74060006,  //  0003  JMPT	R1	#000B
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
       0x4C080000,  //  0005  LDNIL	R2
       0x20040202,  //  0006  NE	R1	R1	R2
       0x78060006,  //  0007  JMPF	R1	#000F
-      0x8C040101,  //  0008  GETMET	R1	R0	K1
+      0x8C04010A,  //  0008  GETMET	R1	R0	K10
       0x7C040200,  //  0009  CALL	R1	1
       0x78060003,  //  000A  JMPF	R1	#000F
-      0x8C040102,  //  000B  GETMET	R1	R0	K2
+      0x8C040101,  //  000B  GETMET	R1	R0	K1
       0x7C040200,  //  000C  CALL	R1	1
       0x4C040000,  //  000D  LDNIL	R1
       0x80040200,  //  000E  RET	1	R1
-      0x88040100,  //  000F  GETMBR	R1	R0	K0
+      0x88040102,  //  000F  GETMBR	R1	R0	K2
       0x50080000,  //  0010  LDBOOL	R2	0	0
       0x20040202,  //  0011  NE	R1	R1	R2
       0x78060033,  //  0012  JMPF	R1	#0047
-      0x88040100,  //  0013  GETMBR	R1	R0	K0
+      0x88040102,  //  0013  GETMBR	R1	R0	K2
       0x4C080000,  //  0014  LDNIL	R2
       0x1C040202,  //  0015  EQ	R1	R1	R2
       0x74060003,  //  0016  JMPT	R1	#001B
@@ -210,71 +212,71 @@ be_local_closure(class_Matter_PathGenerator_next_attribute,   /* name */
       0x50080000,  //  0018  LDBOOL	R2	0	0
       0x1C040202,  //  0019  EQ	R1	R1	R2
       0x78060002,  //  001A  JMPF	R1	#001E
-      0x8C040104,  //  001B  GETMET	R1	R0	K4
+      0x8C04010B,  //  001B  GETMET	R1	R0	K11
       0x7C040200,  //  001C  CALL	R1	1
       0x7001FFF0,  //  001D  JMP		#000F
       0x50040200,  //  001E  LDBOOL	R1	1	0
-      0x90020A01,  //  001F  SETMBR	R0	K5	R1
+      0x90021801,  //  001F  SETMBR	R0	K12	R1
       0x88040103,  //  0020  GETMBR	R1	R0	K3
       0x4C080000,  //  0021  LDNIL	R2
       0x1C040202,  //  0022  EQ	R1	R1	R2
       0x74060003,  //  0023  JMPT	R1	#0028
-      0x88040106,  //  0024  GETMBR	R1	R0	K6
+      0x88040104,  //  0024  GETMBR	R1	R0	K4
       0x50080000,  //  0025  LDBOOL	R2	0	0
       0x1C040202,  //  0026  EQ	R1	R1	R2
       0x78060002,  //  0027  JMPF	R1	#002B
-      0x8C040107,  //  0028  GETMET	R1	R0	K7
+      0x8C04010D,  //  0028  GETMET	R1	R0	K13
       0x7C040200,  //  0029  CALL	R1	1
       0x7001FFE3,  //  002A  JMP		#000F
       0x50040200,  //  002B  LDBOOL	R1	1	0
-      0x90021001,  //  002C  SETMBR	R0	K8	R1
-      0x8C040109,  //  002D  GETMET	R1	R0	K9
+      0x90021C01,  //  002C  SETMBR	R0	K14	R1
+      0x8C04010F,  //  002D  GETMET	R1	R0	K15
       0x7C040200,  //  002E  CALL	R1	1
-      0x88040106,  //  002F  GETMBR	R1	R0	K6
+      0x88040104,  //  002F  GETMBR	R1	R0	K4
       0x50080000,  //  0030  LDBOOL	R2	0	0
       0x1C040202,  //  0031  EQ	R1	R1	R2
       0x78060000,  //  0032  JMPF	R1	#0034
       0x7001FFDA,  //  0033  JMP		#000F
       0x50040200,  //  0034  LDBOOL	R1	1	0
-      0x90021401,  //  0035  SETMBR	R0	K10	R1
-      0x8804010B,  //  0036  GETMBR	R1	R0	K11
-      0x8C080302,  //  0037  GETMET	R2	R1	K2
+      0x90022001,  //  0035  SETMBR	R0	K16	R1
+      0x88040100,  //  0036  GETMBR	R1	R0	K0
+      0x8C080301,  //  0037  GETMET	R2	R1	K1
       0x7C080200,  //  0038  CALL	R2	1
-      0x88080100,  //  0039  GETMBR	R2	R0	K0
-      0x8C08050D,  //  003A  GETMET	R2	R2	K13
+      0x88080102,  //  0039  GETMBR	R2	R0	K2
+      0x8C080512,  //  003A  GETMET	R2	R2	K18
       0x7C080200,  //  003B  CALL	R2	1
-      0x90061802,  //  003C  SETMBR	R1	K12	R2
+      0x90062202,  //  003C  SETMBR	R1	K17	R2
       0x88080103,  //  003D  GETMBR	R2	R0	K3
       0x90060602,  //  003E  SETMBR	R1	K3	R2
-      0x88080106,  //  003F  GETMBR	R2	R0	K6
-      0x90060C02,  //  0040  SETMBR	R1	K6	R2
-      0x8808010F,  //  0041  GETMBR	R2	R0	K15
-      0x90061C02,  //  0042  SETMBR	R1	K14	R2
+      0x88080104,  //  003F  GETMBR	R2	R0	K4
+      0x90060802,  //  0040  SETMBR	R1	K4	R2
+      0x88080114,  //  0041  GETMBR	R2	R0	K20
+      0x90062602,  //  0042  SETMBR	R1	K19	R2
       0x4C080000,  //  0043  LDNIL	R2
-      0x90062002,  //  0044  SETMBR	R1	K16	R2
+      0x90062A02,  //  0044  SETMBR	R1	K21	R2
       0x80040200,  //  0045  RET	1	R1
       0x7001FFC7,  //  0046  JMP		#000F
-      0x8C040101,  //  0047  GETMET	R1	R0	K1
+      0x8C04010A,  //  0047  GETMET	R1	R0	K10
       0x7C040200,  //  0048  CALL	R1	1
       0x78060010,  //  0049  JMPF	R1	#005B
-      0x8804010B,  //  004A  GETMBR	R1	R0	K11
-      0x8C080302,  //  004B  GETMET	R2	R1	K2
+      0x88040100,  //  004A  GETMBR	R1	R0	K0
+      0x8C080301,  //  004B  GETMET	R2	R1	K1
       0x7C080200,  //  004C  CALL	R2	1
-      0x88080111,  //  004D  GETMBR	R2	R0	K17
-      0x90061802,  //  004E  SETMBR	R1	K12	R2
-      0x88080112,  //  004F  GETMBR	R2	R0	K18
+      0x88080107,  //  004D  GETMBR	R2	R0	K7
+      0x90062202,  //  004E  SETMBR	R1	K17	R2
+      0x88080108,  //  004F  GETMBR	R2	R0	K8
       0x90060602,  //  0050  SETMBR	R1	K3	R2
-      0x88080113,  //  0051  GETMBR	R2	R0	K19
-      0x90060C02,  //  0052  SETMBR	R1	K6	R2
-      0x8808010F,  //  0053  GETMBR	R2	R0	K15
-      0x90061C02,  //  0054  SETMBR	R1	K14	R2
-      0x8C080114,  //  0055  GETMET	R2	R0	K20
+      0x88080109,  //  0051  GETMBR	R2	R0	K9
+      0x90060802,  //  0052  SETMBR	R1	K4	R2
+      0x88080114,  //  0053  GETMBR	R2	R0	K20
+      0x90062602,  //  0054  SETMBR	R1	K19	R2
+      0x8C080116,  //  0055  GETMET	R2	R0	K22
       0x7C080200,  //  0056  CALL	R2	1
-      0x90062002,  //  0057  SETMBR	R1	K16	R2
+      0x90062A02,  //  0057  SETMBR	R1	K21	R2
       0x50080200,  //  0058  LDBOOL	R2	1	0
-      0x90020002,  //  0059  SETMBR	R0	K0	R2
+      0x90020402,  //  0059  SETMBR	R0	K2	R2
       0x80040200,  //  005A  RET	1	R1
-      0x8C040102,  //  005B  GETMET	R1	R0	K2
+      0x8C040101,  //  005B  GETMET	R1	R0	K1
       0x7C040200,  //  005C  CALL	R1	1
       0x4C040000,  //  005D  LDNIL	R1
       0x80040200,  //  005E  RET	1	R1
@@ -291,65 +293,58 @@ be_local_closure(class_Matter_PathGenerator__next_cluster,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cluster),
-    /* K1   */  be_nested_str_weak(clusters),
-    /* K2   */  be_nested_str_weak(path_in_cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(_next_cluster),
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060001,  //  0003  JMPF	R1	#0006
       0x50040000,  //  0004  LDBOOL	R1	0	0
       0x80040200,  //  0005  RET	1	R1
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x88080102,  //  0007  GETMBR	R2	R0	K2
+      0x88040105,  //  0006  GETMBR	R1	R0	K5
+      0x88080108,  //  0007  GETMBR	R2	R0	K8
       0x4C0C0000,  //  0008  LDNIL	R3
-      0x90020603,  //  0009  SETMBR	R0	K3	R3
+      0x90020803,  //  0009  SETMBR	R0	K4	R3
       0x540DFFFE,  //  000A  LDINT	R3	-1
-      0x88100100,  //  000B  GETMBR	R4	R0	K0
+      0x88100103,  //  000B  GETMBR	R4	R0	K3
       0x4C140000,  //  000C  LDNIL	R5
       0x20100805,  //  000D  NE	R4	R4	R5
       0x78120003,  //  000E  JMPF	R4	#0013
-      0x8C100304,  //  000F  GETMET	R4	R1	K4
-      0x88180100,  //  0010  GETMBR	R6	R0	K0
+      0x8C100317,  //  000F  GETMET	R4	R1	K23
+      0x88180103,  //  0010  GETMBR	R6	R0	K3
       0x7C100400,  //  0011  CALL	R4	2
       0x5C0C0800,  //  0012  MOVE	R3	R4
       0x4C100000,  //  0013  LDNIL	R4
       0x20100604,  //  0014  NE	R4	R3	R4
       0x78120011,  //  0015  JMPF	R4	#0028
-      0x00100705,  //  0016  ADD	R4	R3	K5
+      0x00100718,  //  0016  ADD	R4	R3	K24
       0x6014000C,  //  0017  GETGBL	R5	G12
       0x5C180200,  //  0018  MOVE	R6	R1
       0x7C140200,  //  0019  CALL	R5	1
       0x14100805,  //  001A  LT	R4	R4	R5
       0x7812000B,  //  001B  JMPF	R4	#0028
-      0x000C0705,  //  001C  ADD	R3	R3	K5
+      0x000C0718,  //  001C  ADD	R3	R3	K24
       0x94100203,  //  001D  GETIDX	R4	R1	R3
-      0x90020004,  //  001E  SETMBR	R0	K0	R4
+      0x90020604,  //  001E  SETMBR	R0	K3	R4
       0x4C100000,  //  001F  LDNIL	R4
       0x1C100404,  //  0020  EQ	R4	R2	R4
       0x74120002,  //  0021  JMPT	R4	#0025
-      0x88100100,  //  0022  GETMBR	R4	R0	K0
+      0x88100103,  //  0022  GETMBR	R4	R0	K3
       0x1C100404,  //  0023  EQ	R4	R2	R4
       0x78120001,  //  0024  JMPF	R4	#0027
-      0x88100100,  //  0025  GETMBR	R4	R0	K0
+      0x88100103,  //  0025  GETMBR	R4	R0	K3
       0x80040800,  //  0026  RET	1	R4
       0x7001FFED,  //  0027  JMP		#0016
       0x50100000,  //  0028  LDBOOL	R4	0	0
-      0x90020004,  //  0029  SETMBR	R0	K0	R4
+      0x90020604,  //  0029  SETMBR	R0	K3	R4
       0x50100000,  //  002A  LDBOOL	R4	0	0
       0x80040800,  //  002B  RET	1	R4
     })
@@ -365,46 +360,36 @@ be_local_closure(class_Matter_PathGenerator__default_status_error,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(is_direct),
-    /* K1   */  be_nested_str_weak(endpoint_found),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    /* K4   */  be_nested_str_weak(cluster_found),
-    /* K5   */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-    /* K6   */  be_nested_str_weak(attribute_found),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K8   */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(_default_status_error),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
       0x7C040200,  //  0001  CALL	R1	1
       0x78060011,  //  0002  JMPF	R1	#0015
-      0x88040101,  //  0003  GETMBR	R1	R0	K1
+      0x8804010C,  //  0003  GETMBR	R1	R0	K12
       0x74060002,  //  0004  JMPT	R1	#0008
-      0xB8060400,  //  0005  GETNGBL	R1	K2
-      0x88040303,  //  0006  GETMBR	R1	R1	K3
+      0xB8063200,  //  0005  GETNGBL	R1	K25
+      0x8804031A,  //  0006  GETMBR	R1	R1	K26
       0x80040200,  //  0007  RET	1	R1
-      0x88040104,  //  0008  GETMBR	R1	R0	K4
+      0x8804010E,  //  0008  GETMBR	R1	R0	K14
       0x74060002,  //  0009  JMPT	R1	#000D
-      0xB8060400,  //  000A  GETNGBL	R1	K2
-      0x88040305,  //  000B  GETMBR	R1	R1	K5
+      0xB8063200,  //  000A  GETNGBL	R1	K25
+      0x8804031B,  //  000B  GETMBR	R1	R1	K27
       0x80040200,  //  000C  RET	1	R1
-      0x88040106,  //  000D  GETMBR	R1	R0	K6
+      0x88040110,  //  000D  GETMBR	R1	R0	K16
       0x74060002,  //  000E  JMPT	R1	#0012
-      0xB8060400,  //  000F  GETNGBL	R1	K2
-      0x88040307,  //  0010  GETMBR	R1	R1	K7
+      0xB8063200,  //  000F  GETNGBL	R1	K25
+      0x8804031C,  //  0010  GETMBR	R1	R1	K28
       0x80040200,  //  0011  RET	1	R1
-      0xB8060400,  //  0012  GETNGBL	R1	K2
-      0x88040308,  //  0013  GETMBR	R1	R1	K8
+      0xB8063200,  //  0012  GETNGBL	R1	K25
+      0x8804031D,  //  0013  GETMBR	R1	R1	K29
       0x80040200,  //  0014  RET	1	R1
       0x4C040000,  //  0015  LDNIL	R1
       0x80040200,  //  0016  RET	1	R1
@@ -421,67 +406,59 @@ be_local_closure(class_Matter_PathGenerator__next_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute),
-    /* K1   */  be_nested_str_weak(pi),
-    /* K2   */  be_nested_str_weak(get_attribute_list),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(path_in_attribute),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(_next_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060001,  //  0003  JMPF	R1	#0006
       0x50040000,  //  0004  LDBOOL	R1	0	0
       0x80040200,  //  0005  RET	1	R1
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C04031E,  //  0007  GETMET	R1	R1	K30
       0x880C0103,  //  0008  GETMBR	R3	R0	K3
       0x7C040400,  //  0009  CALL	R1	2
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x88080109,  //  000A  GETMBR	R2	R0	K9
       0x540DFFFE,  //  000B  LDINT	R3	-1
-      0x88100100,  //  000C  GETMBR	R4	R0	K0
+      0x88100104,  //  000C  GETMBR	R4	R0	K4
       0x4C140000,  //  000D  LDNIL	R5
       0x20100805,  //  000E  NE	R4	R4	R5
       0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C100305,  //  0010  GETMET	R4	R1	K5
-      0x88180100,  //  0011  GETMBR	R6	R0	K0
+      0x8C100317,  //  0010  GETMET	R4	R1	K23
+      0x88180104,  //  0011  GETMBR	R6	R0	K4
       0x7C100400,  //  0012  CALL	R4	2
       0x5C0C0800,  //  0013  MOVE	R3	R4
       0x4C100000,  //  0014  LDNIL	R4
       0x20100604,  //  0015  NE	R4	R3	R4
       0x78120011,  //  0016  JMPF	R4	#0029
-      0x00100706,  //  0017  ADD	R4	R3	K6
+      0x0010071F,  //  0017  ADD	R4	R3	K31
       0x6014000C,  //  0018  GETGBL	R5	G12
       0x5C180200,  //  0019  MOVE	R6	R1
       0x7C140200,  //  001A  CALL	R5	1
       0x14100805,  //  001B  LT	R4	R4	R5
       0x7812000B,  //  001C  JMPF	R4	#0029
-      0x000C0706,  //  001D  ADD	R3	R3	K6
+      0x000C071F,  //  001D  ADD	R3	R3	K31
       0x94100203,  //  001E  GETIDX	R4	R1	R3
-      0x90020004,  //  001F  SETMBR	R0	K0	R4
+      0x90020804,  //  001F  SETMBR	R0	K4	R4
       0x4C100000,  //  0020  LDNIL	R4
       0x1C100404,  //  0021  EQ	R4	R2	R4
       0x74120002,  //  0022  JMPT	R4	#0026
-      0x88100100,  //  0023  GETMBR	R4	R0	K0
+      0x88100104,  //  0023  GETMBR	R4	R0	K4
       0x1C100404,  //  0024  EQ	R4	R2	R4
       0x78120001,  //  0025  JMPF	R4	#0028
-      0x88100100,  //  0026  GETMBR	R4	R0	K0
+      0x88100104,  //  0026  GETMBR	R4	R0	K4
       0x80040800,  //  0027  RET	1	R4
       0x7001FFED,  //  0028  JMP		#0017
       0x50100000,  //  0029  LDBOOL	R4	0	0
-      0x90020004,  //  002A  SETMBR	R0	K0	R4
+      0x90020804,  //  002A  SETMBR	R0	K4	R4
       0x50100000,  //  002B  LDBOOL	R4	0	0
       0x80040800,  //  002C  RET	1	R4
     })
@@ -497,79 +474,67 @@ be_local_closure(class_Matter_PathGenerator__next_endpoint,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pi),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(path_in_endpoint),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(attribute),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(get_endpoint),
-    /* K9   */  be_nested_str_weak(clusters),
-    /* K10  */  be_nested_str_weak(get_cluster_list_sorted),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(_next_endpoint),
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060001,  //  0003  JMPF	R1	#0006
       0x50040000,  //  0004  LDBOOL	R1	0	0
       0x80040200,  //  0005  RET	1	R1
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x88040302,  //  0007  GETMBR	R1	R1	K2
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x88040106,  //  0006  GETMBR	R1	R0	K6
+      0x88040320,  //  0007  GETMBR	R1	R1	K32
+      0x88080107,  //  0008  GETMBR	R2	R0	K7
       0x4C0C0000,  //  0009  LDNIL	R3
-      0x90020803,  //  000A  SETMBR	R0	K4	R3
+      0x90020603,  //  000A  SETMBR	R0	K3	R3
       0x4C0C0000,  //  000B  LDNIL	R3
-      0x90020A03,  //  000C  SETMBR	R0	K5	R3
+      0x90020803,  //  000C  SETMBR	R0	K4	R3
       0x540DFFFE,  //  000D  LDINT	R3	-1
-      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x88100102,  //  000E  GETMBR	R4	R0	K2
       0x4C140000,  //  000F  LDNIL	R5
       0x20100805,  //  0010  NE	R4	R4	R5
       0x78120003,  //  0011  JMPF	R4	#0016
-      0x8C100306,  //  0012  GETMET	R4	R1	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
+      0x8C100317,  //  0012  GETMET	R4	R1	K23
+      0x88180102,  //  0013  GETMBR	R6	R0	K2
       0x7C100400,  //  0014  CALL	R4	2
       0x5C0C0800,  //  0015  MOVE	R3	R4
       0x4C100000,  //  0016  LDNIL	R4
       0x20100604,  //  0017  NE	R4	R3	R4
       0x78120017,  //  0018  JMPF	R4	#0031
-      0x00100707,  //  0019  ADD	R4	R3	K7
+      0x0010071F,  //  0019  ADD	R4	R3	K31
       0x6014000C,  //  001A  GETGBL	R5	G12
       0x5C180200,  //  001B  MOVE	R6	R1
       0x7C140200,  //  001C  CALL	R5	1
       0x14100805,  //  001D  LT	R4	R4	R5
       0x78120011,  //  001E  JMPF	R4	#0031
-      0x000C0707,  //  001F  ADD	R3	R3	K7
+      0x000C071F,  //  001F  ADD	R3	R3	K31
       0x94100203,  //  0020  GETIDX	R4	R1	R3
-      0x90020004,  //  0021  SETMBR	R0	K0	R4
+      0x90020404,  //  0021  SETMBR	R0	K2	R4
       0x4C100000,  //  0022  LDNIL	R4
       0x1C100404,  //  0023  EQ	R4	R2	R4
       0x74120004,  //  0024  JMPT	R4	#002A
-      0x88100100,  //  0025  GETMBR	R4	R0	K0
-      0x8C100908,  //  0026  GETMET	R4	R4	K8
+      0x88100102,  //  0025  GETMBR	R4	R0	K2
+      0x8C100912,  //  0026  GETMET	R4	R4	K18
       0x7C100200,  //  0027  CALL	R4	1
       0x1C100404,  //  0028  EQ	R4	R2	R4
       0x78120005,  //  0029  JMPF	R4	#0030
-      0x88100100,  //  002A  GETMBR	R4	R0	K0
-      0x8C10090A,  //  002B  GETMET	R4	R4	K10
+      0x88100102,  //  002A  GETMBR	R4	R0	K2
+      0x8C100921,  //  002B  GETMET	R4	R4	K33
       0x7C100200,  //  002C  CALL	R4	1
-      0x90021204,  //  002D  SETMBR	R0	K9	R4
-      0x88100100,  //  002E  GETMBR	R4	R0	K0
+      0x90020A04,  //  002D  SETMBR	R0	K5	R4
+      0x88100102,  //  002E  GETMBR	R4	R0	K2
       0x80040800,  //  002F  RET	1	R4
       0x7001FFE7,  //  0030  JMP		#0019
       0x50100000,  //  0031  LDBOOL	R4	0	0
-      0x90020004,  //  0032  SETMBR	R0	K0	R4
+      0x90020404,  //  0032  SETMBR	R0	K2	R4
       0x50100000,  //  0033  LDBOOL	R4	0	0
       0x80040800,  //  0034  RET	1	R4
     })
@@ -585,29 +550,27 @@ be_local_closure(class_Matter_PathGenerator_get_pi,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pi),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(get_pi),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
       0x50080200,  //  0005  LDBOOL	R2	1	0
       0x1C040202,  //  0006  EQ	R1	R1	R2
       0x78060001,  //  0007  JMPF	R1	#000A
       0x4C040000,  //  0008  LDNIL	R1
       0x70020000,  //  0009  JMP		#000B
-      0x88040100,  //  000A  GETMBR	R1	R0	K0
+      0x88040102,  //  000A  GETMBR	R1	R0	K2
       0x80040200,  //  000B  RET	1	R1
     })
   )
@@ -622,50 +585,37 @@ be_local_closure(class_Matter_PathGenerator_start,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path_concrete),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Path),
-    /* K3   */  be_nested_str_weak(reset),
-    /* K4   */  be_nested_str_weak(path_in_endpoint),
-    /* K5   */  be_nested_str_weak(path_in_cluster),
-    /* K6   */  be_nested_str_weak(path_in_attribute),
-    /* K7   */  be_nested_str_weak(path_in_fabric_filtered),
-    /* K8   */  be_nested_str_weak(pi),
-    /* K9   */  be_nested_str_weak(endpoint_found),
-    /* K10  */  be_nested_str_weak(cluster_found),
-    /* K11  */  be_nested_str_weak(attribute_found),
-    }),
+    &be_ktab_class_Matter_PathGenerator,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xB8160200,  //  0000  GETNGBL	R5	K1
-      0x8C140B02,  //  0001  GETMET	R5	R5	K2
+      0xB8163200,  //  0000  GETNGBL	R5	K25
+      0x8C140B22,  //  0001  GETMET	R5	R5	K34
       0x7C140200,  //  0002  CALL	R5	1
       0x90020005,  //  0003  SETMBR	R0	K0	R5
-      0x8C140103,  //  0004  GETMET	R5	R0	K3
+      0x8C140101,  //  0004  GETMET	R5	R0	K1
       0x7C140200,  //  0005  CALL	R5	1
-      0x90020801,  //  0006  SETMBR	R0	K4	R1
-      0x90020A02,  //  0007  SETMBR	R0	K5	R2
-      0x90020C03,  //  0008  SETMBR	R0	K6	R3
+      0x90020E01,  //  0006  SETMBR	R0	K7	R1
+      0x90021002,  //  0007  SETMBR	R0	K8	R2
+      0x90021203,  //  0008  SETMBR	R0	K9	R3
       0x60140017,  //  0009  GETGBL	R5	G23
       0x5C180800,  //  000A  MOVE	R6	R4
       0x7C140200,  //  000B  CALL	R5	1
-      0x90020E05,  //  000C  SETMBR	R0	K7	R5
+      0x90022805,  //  000C  SETMBR	R0	K20	R5
       0x4C140000,  //  000D  LDNIL	R5
-      0x90021005,  //  000E  SETMBR	R0	K8	R5
+      0x90020405,  //  000E  SETMBR	R0	K2	R5
       0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x90021205,  //  0010  SETMBR	R0	K9	R5
+      0x90021805,  //  0010  SETMBR	R0	K12	R5
       0x50140000,  //  0011  LDBOOL	R5	0	0
-      0x90021405,  //  0012  SETMBR	R0	K10	R5
+      0x90021C05,  //  0012  SETMBR	R0	K14	R5
       0x50140000,  //  0013  LDBOOL	R5	0	0
-      0x90021605,  //  0014  SETMBR	R0	K11	R5
+      0x90022005,  //  0014  SETMBR	R0	K16	R5
       0x80000000,  //  0015  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -3,6 +3,75 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_Plugin;
+// compact class 'Matter_Plugin' ktab size: 64, total: 103 (saved 312 bytes)
+static const bvalue be_ktab_class_Matter_Plugin[64] = {
+  /* K0   */  be_nested_str_weak(tick),
+  /* K1   */  be_nested_str_weak(device),
+  /* K2   */  be_nested_str_weak(json),
+  /* K3   */  be_nested_str_weak(node_label),
+  /* K4   */  be_nested_str_weak(_X2C_X22Name_X22_X3A_X25s),
+  /* K5   */  be_nested_str_weak(dump),
+  /* K6   */  be_nested_str_weak(),
+  /* K7   */  be_nested_str_weak(append_state_json),
+  /* K8   */  be_nested_str_weak(_X7B_X22Ep_X22_X3A_X25i_X25s_X25s_X7D),
+  /* K9   */  be_nested_str_weak(endpoint),
+  /* K10  */  be_nested_str_weak(msg),
+  /* K11  */  be_nested_str_weak(message_handler),
+  /* K12  */  be_nested_str_weak(im),
+  /* K13  */  be_nested_str_weak(send_ack_now),
+  /* K14  */  be_nested_str_weak(update_next),
+  /* K15  */  be_nested_str_weak(matter),
+  /* K16  */  be_nested_str_weak(jitter),
+  /* K17  */  be_nested_str_weak(UPDATE_TIME),
+  /* K18  */  be_nested_str_weak(tasmota),
+  /* K19  */  be_nested_str_weak(time_reached),
+  /* K20  */  be_nested_str_weak(update_shadow),
+  /* K21  */  be_nested_str_weak(millis),
+  /* K22  */  be_nested_str_weak(events),
+  /* K23  */  be_nested_str_weak(publish_event),
+  /* K24  */  be_nested_str_weak(attribute_updated),
+  /* K25  */  be_const_class(be_class_Matter_Plugin),
+  /* K26  */  be_nested_str_weak(ARG),
+  /* K27  */  be_nested_str_weak(ARG_TYPE),
+  /* K28  */  be_nested_str_weak(clusters),
+  /* K29  */  be_nested_str_weak(get_clusters),
+  /* K30  */  be_nested_str_weak(parse_configuration),
+  /* K31  */  be_nested_str_weak(find),
+  /* K32  */  be_nested_str_weak(name),
+  /* K33  */  be_nested_str_weak(BRIDGE),
+  /* K34  */  be_nested_str_weak(UPDATE_COMMANDS),
+  /* K35  */  be_nested_str_weak(k2l),
+  /* K36  */  be_const_int(0),
+  /* K37  */  be_const_int(1),
+  /* K38  */  be_nested_str_weak(_X25s_X3A_X25s),
+  /* K39  */  be_nested_str_weak(_X25s_X2C_X25s_X3A_X25s),
+  /* K40  */  be_nested_str_weak(publish_command),
+  /* K41  */  be_nested_str_weak(MtrReceived),
+  /* K42  */  be_nested_str_weak(CLUSTERS),
+  /* K43  */  be_nested_str_weak(contains),
+  /* K44  */  be_nested_str_weak(TLV),
+  /* K45  */  be_nested_str_weak(cluster),
+  /* K46  */  be_nested_str_weak(attribute),
+  /* K47  */  be_const_int(0),
+  /* K48  */  be_nested_str_weak(Matter_TLV_array),
+  /* K49  */  be_nested_str_weak(TYPES),
+  /* K50  */  be_nested_str_weak(keys),
+  /* K51  */  be_nested_str_weak(add_struct),
+  /* K52  */  be_nested_str_weak(add_TLV),
+  /* K53  */  be_nested_str_weak(U2),
+  /* K54  */  be_const_int(1),
+  /* K55  */  be_nested_str_weak(stop_iteration),
+  /* K56  */  be_nested_str_weak(get_cluster_list_sorted),
+  /* K57  */  be_nested_str_weak(U4),
+  /* K58  */  be_const_int(2),
+  /* K59  */  be_const_int(3),
+  /* K60  */  be_nested_str_weak(set),
+  /* K61  */  be_nested_str_weak(get_attribute_list),
+  /* K62  */  be_nested_str_weak(FEATURE_MAPS),
+  /* K63  */  be_nested_str_weak(CLUSTER_REVISIONS),
+};
+
 
 extern const bclass be_class_Matter_Plugin;
 
@@ -13,16 +82,13 @@ be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -43,42 +109,33 @@ be_local_closure(class_Matter_Plugin_state_json,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(node_label),
-    /* K2   */  be_nested_str_weak(_X2C_X22Name_X22_X3A_X25s),
-    /* K3   */  be_nested_str_weak(dump),
-    /* K4   */  be_nested_str_weak(),
-    /* K5   */  be_nested_str_weak(append_state_json),
-    /* K6   */  be_nested_str_weak(_X7B_X22Ep_X22_X3A_X25i_X25s_X25s_X7D),
-    /* K7   */  be_nested_str_weak(endpoint),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(state_json),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0xA4060400,  //  0000  IMPORT	R1	K2
+      0x88080103,  //  0001  GETMBR	R2	R0	K3
       0x780A0006,  //  0002  JMPF	R2	#000A
       0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0002,  //  0004  LDCONST	R3	K2
-      0x8C100303,  //  0005  GETMET	R4	R1	K3
-      0x88180101,  //  0006  GETMBR	R6	R0	K1
+      0x580C0004,  //  0004  LDCONST	R3	K4
+      0x8C100305,  //  0005  GETMET	R4	R1	K5
+      0x88180103,  //  0006  GETMBR	R6	R0	K3
       0x7C100400,  //  0007  CALL	R4	2
       0x7C080400,  //  0008  CALL	R2	2
       0x70020000,  //  0009  JMP		#000B
-      0x58080004,  //  000A  LDCONST	R2	K4
-      0x8C0C0105,  //  000B  GETMET	R3	R0	K5
+      0x58080006,  //  000A  LDCONST	R2	K6
+      0x8C0C0107,  //  000B  GETMET	R3	R0	K7
       0x7C0C0200,  //  000C  CALL	R3	1
       0x780E0007,  //  000D  JMPF	R3	#0016
       0x60100018,  //  000E  GETGBL	R4	G24
-      0x58140006,  //  000F  LDCONST	R5	K6
-      0x88180107,  //  0010  GETMBR	R6	R0	K7
+      0x58140008,  //  000F  LDCONST	R5	K8
+      0x88180109,  //  0010  GETMBR	R6	R0	K9
       0x5C1C0400,  //  0011  MOVE	R7	R2
       0x5C200600,  //  0012  MOVE	R8	R3
       0x7C100800,  //  0013  CALL	R4	4
@@ -100,34 +157,28 @@ be_local_closure(class_Matter_Plugin_ack_request,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(msg),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(im),
-    /* K4   */  be_nested_str_weak(send_ack_now),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(ack_request),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x8808030A,  //  0000  GETMBR	R2	R1	K10
       0x4C0C0000,  //  0001  LDNIL	R3
       0x200C0403,  //  0002  NE	R3	R2	R3
       0x780E0005,  //  0003  JMPF	R3	#000A
       0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x880C0702,  //  0005  GETMBR	R3	R3	K2
-      0x880C0703,  //  0006  GETMBR	R3	R3	K3
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
+      0x880C070B,  //  0005  GETMBR	R3	R3	K11
+      0x880C070C,  //  0006  GETMBR	R3	R3	K12
+      0x8C0C070D,  //  0007  GETMET	R3	R3	K13
       0x5C140400,  //  0008  MOVE	R5	R2
       0x7C0C0400,  //  0009  CALL	R3	2
       0x4C0C0000,  //  000A  LDNIL	R3
-      0x90060003,  //  000B  SETMBR	R1	K0	R3
+      0x90061403,  //  000B  SETMBR	R1	K10	R3
       0x80000000,  //  000C  RET	0
     })
   )
@@ -142,13 +193,13 @@ be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(write_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -167,13 +218,13 @@ be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -192,19 +243,17 @@ be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(append_state_json),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
-      0x80060000,  //  0000  RET	1	K0
+      0x80060C00,  //  0000  RET	1	K6
     })
   )
 );
@@ -218,54 +267,43 @@ be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_next),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(jitter),
-    /* K3   */  be_nested_str_weak(UPDATE_TIME),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    /* K6   */  be_nested_str_weak(tick),
-    /* K7   */  be_nested_str_weak(device),
-    /* K8   */  be_nested_str_weak(update_shadow),
-    /* K9   */  be_nested_str_weak(millis),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(every_250ms),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010E,  //  0000  GETMBR	R1	R0	K14
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060005,  //  0003  JMPF	R1	#000A
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0103,  //  0006  GETMBR	R3	R0	K3
+      0xB8061E00,  //  0004  GETNGBL	R1	K15
+      0x8C040310,  //  0005  GETMET	R1	R1	K16
+      0x880C0111,  //  0006  GETMBR	R3	R0	K17
       0x7C040400,  //  0007  CALL	R1	2
-      0x90020001,  //  0008  SETMBR	R0	K0	R1
+      0x90021C01,  //  0008  SETMBR	R0	K14	R1
       0x70020010,  //  0009  JMP		#001B
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0xB8062400,  //  000A  GETNGBL	R1	K18
+      0x8C040313,  //  000B  GETMET	R1	R1	K19
+      0x880C010E,  //  000C  GETMBR	R3	R0	K14
       0x7C040400,  //  000D  CALL	R1	2
       0x7806000B,  //  000E  JMPF	R1	#001B
-      0x88040106,  //  000F  GETMBR	R1	R0	K6
-      0x88080107,  //  0010  GETMBR	R2	R0	K7
-      0x88080506,  //  0011  GETMBR	R2	R2	K6
+      0x88040100,  //  000F  GETMBR	R1	R0	K0
+      0x88080101,  //  0010  GETMBR	R2	R0	K1
+      0x88080500,  //  0011  GETMBR	R2	R2	K0
       0x20040202,  //  0012  NE	R1	R1	R2
       0x78060001,  //  0013  JMPF	R1	#0016
-      0x8C040108,  //  0014  GETMET	R1	R0	K8
+      0x8C040114,  //  0014  GETMET	R1	R0	K20
       0x7C040200,  //  0015  CALL	R1	1
-      0xB8060800,  //  0016  GETNGBL	R1	K4
-      0x8C040309,  //  0017  GETMET	R1	R1	K9
-      0x880C0103,  //  0018  GETMBR	R3	R0	K3
+      0xB8062400,  //  0016  GETNGBL	R1	K18
+      0x8C040315,  //  0017  GETMET	R1	R1	K21
+      0x880C0111,  //  0018  GETMBR	R3	R0	K17
       0x7C040400,  //  0019  CALL	R1	2
-      0x90020001,  //  001A  SETMBR	R0	K0	R1
+      0x90021C01,  //  001A  SETMBR	R0	K14	R1
       0x80000000,  //  001B  RET	0
     })
   )
@@ -280,25 +318,20 @@ be_local_closure(class_Matter_Plugin_publish_event,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     7,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(events),
-    /* K2   */  be_nested_str_weak(publish_event),
-    /* K3   */  be_nested_str_weak(endpoint),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(publish_event),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x881C0100,  //  0000  GETMBR	R7	R0	K0
-      0x881C0F01,  //  0001  GETMBR	R7	R7	K1
-      0x8C1C0F02,  //  0002  GETMET	R7	R7	K2
-      0x88240103,  //  0003  GETMBR	R9	R0	K3
+      0x881C0101,  //  0000  GETMBR	R7	R0	K1
+      0x881C0F16,  //  0001  GETMBR	R7	R7	K22
+      0x8C1C0F17,  //  0002  GETMET	R7	R7	K23
+      0x88240109,  //  0003  GETMBR	R9	R0	K9
       0x5C280200,  //  0004  MOVE	R10	R1
       0x5C2C0400,  //  0005  MOVE	R11	R2
       0x50300200,  //  0006  LDBOOL	R12	1	0
@@ -321,27 +354,24 @@ be_local_closure(class_Matter_Plugin_set_name,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node_label),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(set_name),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080103,  //  0000  GETMBR	R2	R0	K3
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0003,  //  0002  JMPF	R2	#0007
-      0x8C080101,  //  0003  GETMET	R2	R0	K1
+      0x8C080118,  //  0003  GETMET	R2	R0	K24
       0x54120038,  //  0004  LDINT	R4	57
       0x54160004,  //  0005  LDINT	R5	5
       0x7C080600,  //  0006  CALL	R2	3
-      0x90020001,  //  0007  SETMBR	R0	K0	R1
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
       0x80000000,  //  0008  RET	0
     })
   )
@@ -356,13 +386,13 @@ be_local_closure(class_Matter_Plugin__X3Clambda_X3E,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -383,23 +413,19 @@ be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin),
-    /* K1   */  be_nested_str_weak(ARG),
-    /* K2   */  be_nested_str_weak(ARG_TYPE),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(ui_string_to_conf),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x580C0019,  //  0000  LDCONST	R3	K25
+      0x8810011A,  //  0001  GETMBR	R4	R0	K26
+      0x8814011B,  //  0002  GETMBR	R5	R0	K27
       0x780A0004,  //  0003  JMPF	R2	#0009
       0x78120003,  //  0004  JMPF	R4	#0009
       0x5C180A00,  //  0005  MOVE	R6	R5
@@ -420,13 +446,13 @@ be_local_closure(class_Matter_Plugin_timed_request,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(timed_request),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -445,39 +471,29 @@ be_local_closure(class_Matter_Plugin_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(clusters),
-    /* K3   */  be_nested_str_weak(get_clusters),
-    /* K4   */  be_nested_str_weak(parse_configuration),
-    /* K5   */  be_nested_str_weak(node_label),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(name),
-    /* K8   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x8C100103,  //  0002  GETMET	R4	R0	K3
+      0x90020201,  //  0000  SETMBR	R0	K1	R1
+      0x90021202,  //  0001  SETMBR	R0	K9	R2
+      0x8C10011D,  //  0002  GETMET	R4	R0	K29
       0x7C100200,  //  0003  CALL	R4	1
-      0x90020404,  //  0004  SETMBR	R0	K2	R4
-      0x8C100104,  //  0005  GETMET	R4	R0	K4
+      0x90023804,  //  0004  SETMBR	R0	K28	R4
+      0x8C10011E,  //  0005  GETMET	R4	R0	K30
       0x5C180600,  //  0006  MOVE	R6	R3
       0x7C100400,  //  0007  CALL	R4	2
-      0x8C100706,  //  0008  GETMET	R4	R3	K6
-      0x58180007,  //  0009  LDCONST	R6	K7
-      0x581C0008,  //  000A  LDCONST	R7	K8
+      0x8C10071F,  //  0008  GETMET	R4	R3	K31
+      0x58180020,  //  0009  LDCONST	R6	K32
+      0x581C0006,  //  000A  LDCONST	R7	K6
       0x7C100600,  //  000B  CALL	R4	3
-      0x90020A04,  //  000C  SETMBR	R0	K5	R4
+      0x90020604,  //  000C  SETMBR	R0	K3	R4
       0x80000000,  //  000D  RET	0
     })
   )
@@ -492,19 +508,17 @@ be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(is_local_device),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040121,  //  0000  GETMBR	R1	R0	K33
       0x78060000,  //  0001  JMPF	R1	#0003
       0x50040001,  //  0002  LDBOOL	R1	0	1
       0x50040200,  //  0003  LDBOOL	R1	1	0
@@ -522,19 +536,17 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(UPDATE_COMMANDS),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(consolidate_update_commands),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040122,  //  0000  GETMBR	R1	R0	K34
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -549,17 +561,13 @@ be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(update_shadow_lazy),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
@@ -568,7 +576,7 @@ be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
       0x88080500,  //  0002  GETMBR	R2	R2	K0
       0x20040202,  //  0003  NE	R1	R1	R2
       0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x8C040114,  //  0005  GETMET	R1	R0	K20
       0x7C040200,  //  0006  CALL	R1	1
       0x88040101,  //  0007  GETMBR	R1	R0	K1
       0x88040300,  //  0008  GETMBR	R1	R1	K0
@@ -587,23 +595,19 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(k2l),
-    /* K2   */  be_nested_str_weak(clusters),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_cluster_list_sorted),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040323,  //  0001  GETMET	R1	R1	K35
+      0x880C011C,  //  0002  GETMBR	R3	R0	K28
       0x7C040400,  //  0003  CALL	R1	2
       0x80040200,  //  0004  RET	1	R1
     })
@@ -619,32 +623,27 @@ be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin),
-    /* K1   */  be_nested_str_weak(ARG),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(ui_conf_to_string),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x58080019,  //  0000  LDCONST	R2	K25
+      0x880C011A,  //  0001  GETMBR	R3	R0	K26
       0x780E0006,  //  0002  JMPF	R3	#000A
       0x60100008,  //  0003  GETGBL	R4	G8
-      0x8C140302,  //  0004  GETMET	R5	R1	K2
+      0x8C14031F,  //  0004  GETMET	R5	R1	K31
       0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200003,  //  0006  LDCONST	R8	K3
+      0x58200006,  //  0006  LDCONST	R8	K6
       0x7C140600,  //  0007  CALL	R5	3
       0x7C100200,  //  0008  CALL	R4	1
       0x70020000,  //  0009  JMP		#000B
-      0x58100003,  //  000A  LDCONST	R4	K3
+      0x58100006,  //  000A  LDCONST	R4	K6
       0x80040800,  //  000B  RET	1	R4
     })
   )
@@ -659,23 +658,19 @@ be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    /* K2   */  be_nested_str_weak(endpoint),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(attribute_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x88180102,  //  0002  GETMBR	R6	R0	K2
+      0x88100101,  //  0000  GETMBR	R4	R0	K1
+      0x8C100918,  //  0001  GETMET	R4	R4	K24
+      0x88180109,  //  0002  GETMBR	R6	R0	K9
       0x5C1C0200,  //  0003  MOVE	R7	R1
       0x5C200400,  //  0004  MOVE	R8	R2
       0x5C240600,  //  0005  MOVE	R9	R3
@@ -694,13 +689,13 @@ be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -718,20 +713,17 @@ be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     7,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(_parse_update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8C1C0300,  //  0000  GETMET	R7	R1	K0
+      0x8C1C031F,  //  0000  GETMET	R7	R1	K31
       0x5C240400,  //  0001  MOVE	R9	R2
       0x7C1C0400,  //  0002  CALL	R7	2
       0x4C200000,  //  0003  LDNIL	R8
@@ -743,7 +735,7 @@ be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
       0x5C1C1000,  //  0009  MOVE	R7	R8
       0x20200E03,  //  000A  NE	R8	R7	R3
       0x78220003,  //  000B  JMPF	R8	#0010
-      0x8C200101,  //  000C  GETMET	R8	R0	K1
+      0x8C200118,  //  000C  GETMET	R8	R0	K24
       0x5C280A00,  //  000D  MOVE	R10	R5
       0x5C2C0C00,  //  000E  MOVE	R11	R6
       0x7C200600,  //  000F  CALL	R8	3
@@ -762,13 +754,13 @@ be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -786,19 +778,17 @@ be_local_closure(class_Matter_Plugin_get_name,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node_label),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_name),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -813,19 +803,17 @@ be_local_closure(class_Matter_Plugin_get_endpoint,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_endpoint),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -840,29 +828,24 @@ be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(contains_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x880C011C,  //  0000  GETMBR	R3	R0	K28
+      0x8C0C071F,  //  0001  GETMET	R3	R3	K31
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x4C100000,  //  0004  LDNIL	R4
       0x20100604,  //  0005  NE	R4	R3	R4
       0x7812000C,  //  0006  JMPF	R4	#0014
-      0x58100002,  //  0007  LDCONST	R4	K2
+      0x58100024,  //  0007  LDCONST	R4	K36
       0x6014000C,  //  0008  GETGBL	R5	G12
       0x5C180600,  //  0009  MOVE	R6	R3
       0x7C140200,  //  000A  CALL	R5	1
@@ -873,7 +856,7 @@ be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
       0x78160001,  //  000F  JMPF	R5	#0012
       0x50140200,  //  0010  LDBOOL	R5	1	0
       0x80040A00,  //  0011  RET	1	R5
-      0x00100903,  //  0012  ADD	R4	R4	K3
+      0x00100925,  //  0012  ADD	R4	R4	K37
       0x7001FFF3,  //  0013  JMP		#0008
       0x50100000,  //  0014  LDBOOL	R4	0	0
       0x80040800,  //  0015  RET	1	R4
@@ -890,13 +873,13 @@ be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(subscribe_event),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -915,13 +898,13 @@ be_local_closure(class_Matter_Plugin_read_event,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(read_event),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -940,13 +923,13 @@ be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -964,21 +947,18 @@ be_local_closure(class_Matter_Plugin_get_attribute_list,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(find),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_attribute_list),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808011C,  //  0000  GETMBR	R2	R0	K28
+      0x8C08051F,  //  0001  GETMET	R2	R2	K31
       0x5C100200,  //  0002  MOVE	R4	R1
       0x60140012,  //  0003  GETGBL	R5	G18
       0x7C140000,  //  0004  CALL	R5	0
@@ -997,33 +977,23 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     7,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K2   */  be_nested_str_weak(dump),
-    /* K3   */  be_nested_str_weak(_X25s_X2C_X25s_X3A_X25s),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(publish_command),
-    /* K6   */  be_nested_str_weak(MtrReceived),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(node_label),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(publish_command),
     &be_const_str_solidified,
     ( &(const binstruction[46]) {  /* code */
-      0xA41E0000,  //  0000  IMPORT	R7	K0
+      0xA41E0400,  //  0000  IMPORT	R7	K2
       0x60200018,  //  0001  GETGBL	R8	G24
-      0x58240001,  //  0002  LDCONST	R9	K1
-      0x8C280F02,  //  0003  GETMET	R10	R7	K2
+      0x58240026,  //  0002  LDCONST	R9	K38
+      0x8C280F05,  //  0003  GETMET	R10	R7	K5
       0x5C300200,  //  0004  MOVE	R12	R1
       0x7C280400,  //  0005  CALL	R10	2
-      0x8C2C0F02,  //  0006  GETMET	R11	R7	K2
+      0x8C2C0F05,  //  0006  GETMET	R11	R7	K5
       0x5C340400,  //  0007  MOVE	R13	R2
       0x7C2C0400,  //  0008  CALL	R11	2
       0x7C200600,  //  0009  CALL	R8	3
@@ -1031,12 +1001,12 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
       0x20240609,  //  000B  NE	R9	R3	R9
       0x7826000A,  //  000C  JMPF	R9	#0018
       0x60240018,  //  000D  GETGBL	R9	G24
-      0x58280003,  //  000E  LDCONST	R10	K3
+      0x58280027,  //  000E  LDCONST	R10	K39
       0x5C2C1000,  //  000F  MOVE	R11	R8
-      0x8C300F02,  //  0010  GETMET	R12	R7	K2
+      0x8C300F05,  //  0010  GETMET	R12	R7	K5
       0x5C380600,  //  0011  MOVE	R14	R3
       0x7C300400,  //  0012  CALL	R12	2
-      0x8C340F02,  //  0013  GETMET	R13	R7	K2
+      0x8C340F05,  //  0013  GETMET	R13	R7	K5
       0x5C3C0800,  //  0014  MOVE	R15	R4
       0x7C340400,  //  0015  CALL	R13	2
       0x7C240800,  //  0016  CALL	R9	4
@@ -1045,21 +1015,21 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
       0x20240A09,  //  0019  NE	R9	R5	R9
       0x7826000A,  //  001A  JMPF	R9	#0026
       0x60240018,  //  001B  GETGBL	R9	G24
-      0x58280003,  //  001C  LDCONST	R10	K3
+      0x58280027,  //  001C  LDCONST	R10	K39
       0x5C2C1000,  //  001D  MOVE	R11	R8
-      0x8C300F02,  //  001E  GETMET	R12	R7	K2
+      0x8C300F05,  //  001E  GETMET	R12	R7	K5
       0x5C380A00,  //  001F  MOVE	R14	R5
       0x7C300400,  //  0020  CALL	R12	2
-      0x8C340F02,  //  0021  GETMET	R13	R7	K2
+      0x8C340F05,  //  0021  GETMET	R13	R7	K5
       0x5C3C0C00,  //  0022  MOVE	R15	R6
       0x7C340400,  //  0023  CALL	R13	2
       0x7C240800,  //  0024  CALL	R9	4
       0x5C201200,  //  0025  MOVE	R8	R9
-      0xB8260800,  //  0026  GETNGBL	R9	K4
-      0x8C241305,  //  0027  GETMET	R9	R9	K5
-      0x582C0006,  //  0028  LDCONST	R11	K6
-      0x88300107,  //  0029  GETMBR	R12	R0	K7
-      0x88340108,  //  002A  GETMBR	R13	R0	K8
+      0xB8261E00,  //  0026  GETNGBL	R9	K15
+      0x8C241328,  //  0027  GETMET	R9	R9	K40
+      0x582C0029,  //  0028  LDCONST	R11	K41
+      0x88300109,  //  0029  GETMBR	R12	R0	K9
+      0x88340103,  //  002A  GETMBR	R13	R0	K3
       0x5C381000,  //  002B  MOVE	R14	R8
       0x7C240A00,  //  002C  CALL	R9	5
       0x80000000,  //  002D  RET	0
@@ -1076,19 +1046,17 @@ be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(CLUSTERS),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_clusters),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804012A,  //  0000  GETMBR	R1	R0	K42
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1103,21 +1071,18 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(contains),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(contains_cluster),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808011C,  //  0000  GETMBR	R2	R0	K28
+      0x8C08052B,  //  0001  GETMET	R2	R2	K43
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -1134,181 +1099,158 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(Matter_TLV_array),
-    /* K6   */  be_nested_str_weak(TYPES),
-    /* K7   */  be_nested_str_weak(keys),
-    /* K8   */  be_nested_str_weak(add_struct),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(get_cluster_list_sorted),
-    /* K14  */  be_nested_str_weak(U4),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(set),
-    /* K18  */  be_nested_str_weak(get_attribute_list),
-    /* K19  */  be_nested_str_weak(FEATURE_MAPS),
-    /* K20  */  be_nested_str_weak(find),
-    /* K21  */  be_nested_str_weak(CLUSTER_REVISIONS),
-    }),
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[161]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8121E00,  //  0000  GETNGBL	R4	K15
+      0x8810092C,  //  0001  GETMBR	R4	R4	K44
+      0x8814052D,  //  0002  GETMBR	R5	R2	K45
+      0x8818052E,  //  0003  GETMBR	R6	R2	K46
       0x541E001C,  //  0004  LDINT	R7	29
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0050,  //  0006  JMPF	R7	#0058
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D2F,  //  0007  EQ	R7	R6	K47
       0x781E001B,  //  0008  JMPF	R7	#0025
-      0x8C1C0905,  //  0009  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0009  GETMET	R7	R4	K48
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200106,  //  000B  GETMBR	R8	R0	K6
+      0x88200131,  //  000B  GETMBR	R8	R0	K49
       0x60240010,  //  000C  GETGBL	R9	G16
-      0x8C281107,  //  000D  GETMET	R10	R8	K7
+      0x8C281132,  //  000D  GETMET	R10	R8	K50
       0x7C280200,  //  000E  CALL	R10	1
       0x7C240200,  //  000F  CALL	R9	1
       0xA802000E,  //  0010  EXBLK	0	#0020
       0x5C281200,  //  0011  MOVE	R10	R9
       0x7C280000,  //  0012  CALL	R10	0
-      0x8C2C0F08,  //  0013  GETMET	R11	R7	K8
+      0x8C2C0F33,  //  0013  GETMET	R11	R7	K51
       0x7C2C0200,  //  0014  CALL	R11	1
-      0x8C301709,  //  0015  GETMET	R12	R11	K9
-      0x58380004,  //  0016  LDCONST	R14	K4
-      0x883C090A,  //  0017  GETMBR	R15	R4	K10
+      0x8C301734,  //  0015  GETMET	R12	R11	K52
+      0x5838002F,  //  0016  LDCONST	R14	K47
+      0x883C0935,  //  0017  GETMBR	R15	R4	K53
       0x5C401400,  //  0018  MOVE	R16	R10
       0x7C300800,  //  0019  CALL	R12	4
-      0x8C301709,  //  001A  GETMET	R12	R11	K9
-      0x5838000B,  //  001B  LDCONST	R14	K11
-      0x883C090A,  //  001C  GETMBR	R15	R4	K10
+      0x8C301734,  //  001A  GETMET	R12	R11	K52
+      0x58380036,  //  001B  LDCONST	R14	K54
+      0x883C0935,  //  001C  GETMBR	R15	R4	K53
       0x9440100A,  //  001D  GETIDX	R16	R8	R10
       0x7C300800,  //  001E  CALL	R12	4
       0x7001FFF0,  //  001F  JMP		#0011
-      0x5824000C,  //  0020  LDCONST	R9	K12
+      0x58240037,  //  0020  LDCONST	R9	K55
       0xAC240200,  //  0021  CATCH	R9	1	0
       0xB0080000,  //  0022  RAISE	2	R0	R0
       0x80040E00,  //  0023  RET	1	R7
       0x70020032,  //  0024  JMP		#0058
-      0x1C1C0D0B,  //  0025  EQ	R7	R6	K11
+      0x1C1C0D36,  //  0025  EQ	R7	R6	K54
       0x781E0013,  //  0026  JMPF	R7	#003B
-      0x8C1C0905,  //  0027  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0027  GETMET	R7	R4	K48
       0x7C1C0200,  //  0028  CALL	R7	1
       0x60200010,  //  0029  GETGBL	R8	G16
-      0x8C24010D,  //  002A  GETMET	R9	R0	K13
+      0x8C240138,  //  002A  GETMET	R9	R0	K56
       0x7C240200,  //  002B  CALL	R9	1
       0x7C200200,  //  002C  CALL	R8	1
       0xA8020007,  //  002D  EXBLK	0	#0036
       0x5C241000,  //  002E  MOVE	R9	R8
       0x7C240000,  //  002F  CALL	R9	0
-      0x8C280F09,  //  0030  GETMET	R10	R7	K9
+      0x8C280F34,  //  0030  GETMET	R10	R7	K52
       0x4C300000,  //  0031  LDNIL	R12
-      0x8834090E,  //  0032  GETMBR	R13	R4	K14
+      0x88340939,  //  0032  GETMBR	R13	R4	K57
       0x5C381200,  //  0033  MOVE	R14	R9
       0x7C280800,  //  0034  CALL	R10	4
       0x7001FFF7,  //  0035  JMP		#002E
-      0x5820000C,  //  0036  LDCONST	R8	K12
+      0x58200037,  //  0036  LDCONST	R8	K55
       0xAC200200,  //  0037  CATCH	R8	1	0
       0xB0080000,  //  0038  RAISE	2	R0	R0
       0x80040E00,  //  0039  RET	1	R7
       0x7002001C,  //  003A  JMP		#0058
-      0x1C1C0D0F,  //  003B  EQ	R7	R6	K15
+      0x1C1C0D3A,  //  003B  EQ	R7	R6	K58
       0x781E0003,  //  003C  JMPF	R7	#0041
-      0x8C1C0905,  //  003D  GETMET	R7	R4	K5
+      0x8C1C0930,  //  003D  GETMET	R7	R4	K48
       0x7C1C0200,  //  003E  CALL	R7	1
       0x80040E00,  //  003F  RET	1	R7
       0x70020016,  //  0040  JMP		#0058
-      0x1C1C0D10,  //  0041  EQ	R7	R6	K16
+      0x1C1C0D3B,  //  0041  EQ	R7	R6	K59
       0x781E0003,  //  0042  JMPF	R7	#0047
-      0x8C1C0905,  //  0043  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0043  GETMET	R7	R4	K48
       0x7C1C0200,  //  0044  CALL	R7	1
       0x80040E00,  //  0045  RET	1	R7
       0x70020010,  //  0046  JMP		#0058
       0x541EFFFB,  //  0047  LDINT	R7	65532
       0x1C1C0C07,  //  0048  EQ	R7	R6	R7
       0x781E0005,  //  0049  JMPF	R7	#0050
-      0x8C1C0711,  //  004A  GETMET	R7	R3	K17
-      0x8824090E,  //  004B  GETMBR	R9	R4	K14
-      0x58280004,  //  004C  LDCONST	R10	K4
+      0x8C1C073C,  //  004A  GETMET	R7	R3	K60
+      0x88240939,  //  004B  GETMBR	R9	R4	K57
+      0x5828002F,  //  004C  LDCONST	R10	K47
       0x7C1C0600,  //  004D  CALL	R7	3
       0x80040E00,  //  004E  RET	1	R7
       0x70020007,  //  004F  JMP		#0058
       0x541EFFFC,  //  0050  LDINT	R7	65533
       0x1C1C0C07,  //  0051  EQ	R7	R6	R7
       0x781E0004,  //  0052  JMPF	R7	#0058
-      0x8C1C0711,  //  0053  GETMET	R7	R3	K17
-      0x8824090E,  //  0054  GETMBR	R9	R4	K14
-      0x5828000B,  //  0055  LDCONST	R10	K11
+      0x8C1C073C,  //  0053  GETMET	R7	R3	K60
+      0x88240939,  //  0054  GETMBR	R9	R4	K57
+      0x58280036,  //  0055  LDCONST	R10	K54
       0x7C1C0600,  //  0056  CALL	R7	3
       0x80040E00,  //  0057  RET	1	R7
       0x541EFFF7,  //  0058  LDINT	R7	65528
       0x1C1C0C07,  //  0059  EQ	R7	R6	R7
       0x781E0003,  //  005A  JMPF	R7	#005F
-      0x8C1C0905,  //  005B  GETMET	R7	R4	K5
+      0x8C1C0930,  //  005B  GETMET	R7	R4	K48
       0x7C1C0200,  //  005C  CALL	R7	1
       0x80040E00,  //  005D  RET	1	R7
       0x7002003F,  //  005E  JMP		#009F
       0x541EFFFA,  //  005F  LDINT	R7	65531
       0x1C1C0C07,  //  0060  EQ	R7	R6	R7
       0x781E0013,  //  0061  JMPF	R7	#0076
-      0x8C1C0905,  //  0062  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0062  GETMET	R7	R4	K48
       0x7C1C0200,  //  0063  CALL	R7	1
-      0x8C200112,  //  0064  GETMET	R8	R0	K18
+      0x8C20013D,  //  0064  GETMET	R8	R0	K61
       0x5C280A00,  //  0065  MOVE	R10	R5
       0x7C200400,  //  0066  CALL	R8	2
-      0x58240004,  //  0067  LDCONST	R9	K4
+      0x5824002F,  //  0067  LDCONST	R9	K47
       0x6028000C,  //  0068  GETGBL	R10	G12
       0x5C2C1000,  //  0069  MOVE	R11	R8
       0x7C280200,  //  006A  CALL	R10	1
       0x1428120A,  //  006B  LT	R10	R9	R10
       0x782A0006,  //  006C  JMPF	R10	#0074
-      0x8C280F09,  //  006D  GETMET	R10	R7	K9
+      0x8C280F34,  //  006D  GETMET	R10	R7	K52
       0x4C300000,  //  006E  LDNIL	R12
-      0x8834090A,  //  006F  GETMBR	R13	R4	K10
+      0x88340935,  //  006F  GETMBR	R13	R4	K53
       0x94381009,  //  0070  GETIDX	R14	R8	R9
       0x7C280800,  //  0071  CALL	R10	4
-      0x0024130B,  //  0072  ADD	R9	R9	K11
+      0x00241336,  //  0072  ADD	R9	R9	K54
       0x7001FFF3,  //  0073  JMP		#0068
       0x80040E00,  //  0074  RET	1	R7
       0x70020028,  //  0075  JMP		#009F
       0x541EFFF9,  //  0076  LDINT	R7	65530
       0x1C1C0C07,  //  0077  EQ	R7	R6	R7
       0x781E0003,  //  0078  JMPF	R7	#007D
-      0x8C1C0905,  //  0079  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0079  GETMET	R7	R4	K48
       0x7C1C0200,  //  007A  CALL	R7	1
       0x80040E00,  //  007B  RET	1	R7
       0x70020021,  //  007C  JMP		#009F
       0x541EFFF8,  //  007D  LDINT	R7	65529
       0x1C1C0C07,  //  007E  EQ	R7	R6	R7
       0x781E0003,  //  007F  JMPF	R7	#0084
-      0x8C1C0905,  //  0080  GETMET	R7	R4	K5
+      0x8C1C0930,  //  0080  GETMET	R7	R4	K48
       0x7C1C0200,  //  0081  CALL	R7	1
       0x80040E00,  //  0082  RET	1	R7
       0x7002001A,  //  0083  JMP		#009F
       0x541EFFFB,  //  0084  LDINT	R7	65532
       0x1C1C0C07,  //  0085  EQ	R7	R6	R7
       0x781E000A,  //  0086  JMPF	R7	#0092
-      0x881C0113,  //  0087  GETMBR	R7	R0	K19
-      0x8C1C0F14,  //  0088  GETMET	R7	R7	K20
+      0x881C013E,  //  0087  GETMBR	R7	R0	K62
+      0x8C1C0F1F,  //  0088  GETMET	R7	R7	K31
       0x5C240A00,  //  0089  MOVE	R9	R5
-      0x58280004,  //  008A  LDCONST	R10	K4
+      0x5828002F,  //  008A  LDCONST	R10	K47
       0x7C1C0600,  //  008B  CALL	R7	3
-      0x8C200711,  //  008C  GETMET	R8	R3	K17
-      0x8828090E,  //  008D  GETMBR	R10	R4	K14
+      0x8C20073C,  //  008C  GETMET	R8	R3	K60
+      0x88280939,  //  008D  GETMBR	R10	R4	K57
       0x5C2C0E00,  //  008E  MOVE	R11	R7
       0x7C200600,  //  008F  CALL	R8	3
       0x80041000,  //  0090  RET	1	R8
@@ -1316,13 +1258,13 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x541EFFFC,  //  0092  LDINT	R7	65533
       0x1C1C0C07,  //  0093  EQ	R7	R6	R7
       0x781E0009,  //  0094  JMPF	R7	#009F
-      0x881C0115,  //  0095  GETMBR	R7	R0	K21
-      0x8C1C0F14,  //  0096  GETMET	R7	R7	K20
+      0x881C013F,  //  0095  GETMBR	R7	R0	K63
+      0x8C1C0F1F,  //  0096  GETMET	R7	R7	K31
       0x5C240A00,  //  0097  MOVE	R9	R5
-      0x5828000B,  //  0098  LDCONST	R10	K11
+      0x58280036,  //  0098  LDCONST	R10	K54
       0x7C1C0600,  //  0099  CALL	R7	3
-      0x8C200711,  //  009A  GETMET	R8	R3	K17
-      0x8828090E,  //  009B  GETMBR	R10	R4	K14
+      0x8C20073C,  //  009A  GETMET	R8	R3	K60
+      0x88280939,  //  009B  GETMBR	R10	R4	K57
       0x5C2C0E00,  //  009C  MOVE	R11	R7
       0x7C200600,  //  009D  CALL	R8	3
       0x80041000,  //  009E  RET	1	R8
@@ -1341,13 +1283,13 @@ be_local_closure(class_Matter_Plugin_subscribe_attribute,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(subscribe_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
@@ -3,6 +3,32 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Aggregator' ktab size: 22, total: 29 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Aggregator[22] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(cluster),
+  /* K3   */  be_nested_str_weak(attribute),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(set),
+  /* K7   */  be_nested_str_weak(U2),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(U1),
+  /* K10  */  be_const_int(2),
+  /* K11  */  be_nested_str_weak(Matter_TLV_array),
+  /* K12  */  be_nested_str_weak(add_TLV),
+  /* K13  */  be_nested_str_weak(device),
+  /* K14  */  be_nested_str_weak(get_active_endpoints),
+  /* K15  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K16  */  be_nested_str_weak(stop_iteration),
+  /* K17  */  be_nested_str_weak(read_attribute),
+  /* K18  */  be_nested_str_weak(command),
+  /* K19  */  be_const_int(1),
+  /* K20  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K21  */  be_nested_str_weak(invoke_request),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Aggregator;
 
@@ -13,32 +39,13 @@ be_local_closure(class_Matter_Plugin_Aggregator_read_attribute,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U2),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(Matter_TLV_array),
-    /* K12  */  be_nested_str_weak(add_TLV),
-    /* K13  */  be_nested_str_weak(device),
-    /* K14  */  be_nested_str_weak(get_active_endpoints),
-    /* K15  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K16  */  be_nested_str_weak(stop_iteration),
-    /* K17  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Aggregator,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[73]) {  /* code */
@@ -128,32 +135,20 @@ be_local_closure(class_Matter_Plugin_Aggregator_invoke_request,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K8   */  be_nested_str_weak(add_TLV),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Aggregator,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x88180712,  //  0003  GETMBR	R6	R3	K18
       0x1C1C0B04,  //  0004  EQ	R7	R5	K4
       0x781E0016,  //  0005  JMPF	R7	#001D
       0x1C1C0D05,  //  0006  EQ	R7	R6	K5
@@ -161,16 +156,16 @@ be_local_closure(class_Matter_Plugin_Aggregator_invoke_request,   /* name */
       0x501C0200,  //  0008  LDBOOL	R7	1	0
       0x80040E00,  //  0009  RET	1	R7
       0x70020010,  //  000A  JMP		#001C
-      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
+      0x1C1C0D13,  //  000B  EQ	R7	R6	K19
       0x781E0009,  //  000C  JMPF	R7	#0017
-      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
+      0x8C1C0914,  //  000D  GETMET	R7	R4	K20
       0x7C1C0200,  //  000E  CALL	R7	1
-      0x8C200F08,  //  000F  GETMET	R8	R7	K8
+      0x8C200F0C,  //  000F  GETMET	R8	R7	K12
       0x58280005,  //  0010  LDCONST	R10	K5
-      0x882C0909,  //  0011  GETMBR	R11	R4	K9
+      0x882C0907,  //  0011  GETMBR	R11	R4	K7
       0x58300005,  //  0012  LDCONST	R12	K5
       0x7C200800,  //  0013  CALL	R8	4
-      0x900E0705,  //  0014  SETMBR	R3	K3	K5
+      0x900E2505,  //  0014  SETMBR	R3	K18	K5
       0x80040E00,  //  0015  RET	1	R7
       0x70020004,  //  0016  JMP		#001C
       0x541E003F,  //  0017  LDINT	R7	64
@@ -182,7 +177,7 @@ be_local_closure(class_Matter_Plugin_Aggregator_invoke_request,   /* name */
       0x601C0003,  //  001D  GETGBL	R7	G3
       0x5C200000,  //  001E  MOVE	R8	R0
       0x7C1C0200,  //  001F  CALL	R7	1
-      0x8C1C0F0A,  //  0020  GETMET	R7	R7	K10
+      0x8C1C0F15,  //  0020  GETMET	R7	R7	K21
       0x5C240200,  //  0021  MOVE	R9	R1
       0x5C280400,  //  0022  MOVE	R10	R2
       0x5C2C0600,  //  0023  MOVE	R11	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
@@ -3,6 +3,28 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'GetOptionReader' ktab size: 18, total: 24 (saved 48 bytes)
+static const bvalue be_ktab_class_GetOptionReader[18] = {
+  /* K0   */  be_nested_str_weak(flag),
+  /* K1   */  be_nested_str_weak(getbits),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_nested_str_weak(flag2),
+  /* K4   */  be_nested_str_weak(get),
+  /* K5   */  be_nested_str_weak(flag3),
+  /* K6   */  be_nested_str_weak(flag4),
+  /* K7   */  be_nested_str_weak(flag5),
+  /* K8   */  be_nested_str_weak(flag6),
+  /* K9   */  be_nested_str_weak(value_error),
+  /* K10  */  be_nested_str_weak(invalid_X20json),
+  /* K11  */  be_nested_str_weak(SetOption),
+  /* K12  */  be_nested_str_weak(fromhex),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_nested_str_weak(reverse),
+  /* K15  */  be_const_int(1),
+  /* K16  */  be_const_int(2),
+  /* K17  */  be_const_int(3),
+};
+
 
 extern const bclass be_class_GetOptionReader;
 
@@ -13,23 +35,13 @@ be_local_closure(class_GetOptionReader_getoption,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(flag),
-    /* K1   */  be_nested_str_weak(getbits),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(flag2),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(flag3),
-    /* K6   */  be_nested_str_weak(flag4),
-    /* K7   */  be_nested_str_weak(flag5),
-    /* K8   */  be_nested_str_weak(flag6),
-    }),
+    &be_ktab_class_GetOptionReader,     /* shared constants */
     be_str_weak(getoption),
     &be_const_str_solidified,
     ( &(const binstruction[65]) {  /* code */
@@ -111,85 +123,69 @@ be_local_closure(class_GetOptionReader_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(value_error),
-    /* K1   */  be_nested_str_weak(invalid_X20json),
-    /* K2   */  be_nested_str_weak(SetOption),
-    /* K3   */  be_nested_str_weak(flag),
-    /* K4   */  be_nested_str_weak(fromhex),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(reverse),
-    /* K7   */  be_nested_str_weak(flag2),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(flag3),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(flag4),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(flag5),
-    /* K14  */  be_nested_str_weak(flag6),
-    }),
+    &be_ktab_class_GetOptionReader,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
-      0xB0060101,  //  0003  RAISE	1	K0	K1
-      0x94080302,  //  0004  GETIDX	R2	R1	K2
+      0xB006130A,  //  0003  RAISE	1	K9	K10
+      0x9408030B,  //  0004  GETIDX	R2	R1	K11
       0x600C0015,  //  0005  GETGBL	R3	G21
       0x7C0C0000,  //  0006  CALL	R3	0
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
-      0x94140505,  //  0008  GETIDX	R5	R2	K5
+      0x8C0C070C,  //  0007  GETMET	R3	R3	K12
+      0x9414050D,  //  0008  GETIDX	R5	R2	K13
       0x7C0C0400,  //  0009  CALL	R3	2
-      0x8C0C0706,  //  000A  GETMET	R3	R3	K6
+      0x8C0C070E,  //  000A  GETMET	R3	R3	K14
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x90020603,  //  000C  SETMBR	R0	K3	R3
+      0x90020003,  //  000C  SETMBR	R0	K0	R3
       0x600C0015,  //  000D  GETGBL	R3	G21
       0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x94140508,  //  0010  GETIDX	R5	R2	K8
+      0x8C0C070C,  //  000F  GETMET	R3	R3	K12
+      0x9414050F,  //  0010  GETIDX	R5	R2	K15
       0x7C0C0400,  //  0011  CALL	R3	2
-      0x90020E03,  //  0012  SETMBR	R0	K7	R3
+      0x90020603,  //  0012  SETMBR	R0	K3	R3
       0x600C0015,  //  0013  GETGBL	R3	G21
       0x7C0C0000,  //  0014  CALL	R3	0
-      0x8C0C0704,  //  0015  GETMET	R3	R3	K4
-      0x9414050A,  //  0016  GETIDX	R5	R2	K10
+      0x8C0C070C,  //  0015  GETMET	R3	R3	K12
+      0x94140510,  //  0016  GETIDX	R5	R2	K16
       0x7C0C0400,  //  0017  CALL	R3	2
-      0x8C0C0706,  //  0018  GETMET	R3	R3	K6
+      0x8C0C070E,  //  0018  GETMET	R3	R3	K14
       0x7C0C0200,  //  0019  CALL	R3	1
-      0x90021203,  //  001A  SETMBR	R0	K9	R3
+      0x90020A03,  //  001A  SETMBR	R0	K5	R3
       0x600C0015,  //  001B  GETGBL	R3	G21
       0x7C0C0000,  //  001C  CALL	R3	0
-      0x8C0C0704,  //  001D  GETMET	R3	R3	K4
-      0x9414050C,  //  001E  GETIDX	R5	R2	K12
+      0x8C0C070C,  //  001D  GETMET	R3	R3	K12
+      0x94140511,  //  001E  GETIDX	R5	R2	K17
       0x7C0C0400,  //  001F  CALL	R3	2
-      0x8C0C0706,  //  0020  GETMET	R3	R3	K6
+      0x8C0C070E,  //  0020  GETMET	R3	R3	K14
       0x7C0C0200,  //  0021  CALL	R3	1
-      0x90021603,  //  0022  SETMBR	R0	K11	R3
+      0x90020C03,  //  0022  SETMBR	R0	K6	R3
       0x600C0015,  //  0023  GETGBL	R3	G21
       0x7C0C0000,  //  0024  CALL	R3	0
-      0x8C0C0704,  //  0025  GETMET	R3	R3	K4
+      0x8C0C070C,  //  0025  GETMET	R3	R3	K12
       0x54160003,  //  0026  LDINT	R5	4
       0x94140405,  //  0027  GETIDX	R5	R2	R5
       0x7C0C0400,  //  0028  CALL	R3	2
-      0x8C0C0706,  //  0029  GETMET	R3	R3	K6
+      0x8C0C070E,  //  0029  GETMET	R3	R3	K14
       0x7C0C0200,  //  002A  CALL	R3	1
-      0x90021A03,  //  002B  SETMBR	R0	K13	R3
+      0x90020E03,  //  002B  SETMBR	R0	K7	R3
       0x600C0015,  //  002C  GETGBL	R3	G21
       0x7C0C0000,  //  002D  CALL	R3	0
-      0x8C0C0704,  //  002E  GETMET	R3	R3	K4
+      0x8C0C070C,  //  002E  GETMET	R3	R3	K12
       0x54160004,  //  002F  LDINT	R5	5
       0x94140405,  //  0030  GETIDX	R5	R2	R5
       0x7C0C0400,  //  0031  CALL	R3	2
-      0x8C0C0706,  //  0032  GETMET	R3	R3	K6
+      0x8C0C070E,  //  0032  GETMET	R3	R3	K14
       0x7C0C0200,  //  0033  CALL	R3	1
-      0x90021C03,  //  0034  SETMBR	R0	K14	R3
+      0x90021003,  //  0034  SETMBR	R0	K8	R3
       0x80000000,  //  0035  RET	0
     })
   )
@@ -216,6 +212,136 @@ be_local_class(GetOptionReader,
     })),
     be_str_weak(GetOptionReader)
 );
+// compact class 'Matter_Plugin_Device' ktab size: 126, total: 158 (saved 256 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Device[126] = {
+  /* K0   */  be_nested_str_weak(http_remote),
+  /* K1   */  be_nested_str_weak(add_schedule),
+  /* K2   */  be_nested_str_weak(UPDATE_CMD),
+  /* K3   */  be_nested_str_weak(UPDATE_TIME),
+  /* K4   */  be_nested_str_weak(webserver),
+  /* K5   */  be_nested_str_weak(web_values_prefix),
+  /* K6   */  be_nested_str_weak(content_send),
+  /* K7   */  be_nested_str_weak(_X26lt_X3B_X2D_X2D_X20_X28),
+  /* K8   */  be_nested_str_weak(DISPLAY_NAME),
+  /* K9   */  be_nested_str_weak(_X29_X20_X2D_X2D_X26gt_X3B),
+  /* K10  */  be_nested_str_weak(BRIDGE),
+  /* K11  */  be_nested_str_weak(scheduler),
+  /* K12  */  be_nested_str_weak(every_250ms),
+  /* K13  */  be_nested_str_weak(_X3Cb_X3EOn_X3C_X2Fb_X3E),
+  /* K14  */  be_nested_str_weak(Off),
+  /* K15  */  be_nested_str_weak(),
+  /* K16  */  be_nested_str_weak(matter),
+  /* K17  */  be_nested_str_weak(TLV),
+  /* K18  */  be_nested_str_weak(cluster),
+  /* K19  */  be_nested_str_weak(command),
+  /* K20  */  be_const_int(3),
+  /* K21  */  be_const_int(0),
+  /* K22  */  be_const_int(1),
+  /* K23  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K24  */  be_nested_str_weak(add_TLV),
+  /* K25  */  be_nested_str_weak(U2),
+  /* K26  */  be_nested_str_weak(invoke_request),
+  /* K27  */  be_nested_str_weak(tick),
+  /* K28  */  be_nested_str_weak(device),
+  /* K29  */  be_nested_str_weak(call_remote_sync),
+  /* K30  */  be_nested_str_weak(parse_http_response),
+  /* K31  */  be_const_int(1),
+  /* K32  */  be_nested_str_weak(json),
+  /* K33  */  be_const_int(2),
+  /* K34  */  be_nested_str_weak(_X20),
+  /* K35  */  be_const_int(0),
+  /* K36  */  be_nested_str_weak(call_sync),
+  /* K37  */  be_nested_str_weak(SYNC_TIMEOUT),
+  /* K38  */  be_nested_str_weak(device_is_alive),
+  /* K39  */  be_nested_str_weak(load),
+  /* K40  */  be_const_int(1),
+  /* K41  */  be_nested_str_weak(log),
+  /* K42  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+  /* K43  */  be_const_int(3),
+  /* K44  */  be_nested_str_weak(parse_status_response_and_call_method),
+  /* K45  */  be_nested_str_weak(parse_status),
+  /* K46  */  be_nested_str_weak(get_name),
+  /* K47  */  be_nested_str_weak(PREFIX),
+  /* K48  */  be_nested_str_weak(html_escape),
+  /* K49  */  be_nested_str_weak(attribute),
+  /* K50  */  be_nested_str_weak(set),
+  /* K51  */  be_nested_str_weak(U1),
+  /* K52  */  be_nested_str_weak(Matter_TLV_array),
+  /* K53  */  be_nested_str_weak(TYPES),
+  /* K54  */  be_nested_str_weak(keys),
+  /* K55  */  be_nested_str_weak(add_struct),
+  /* K56  */  be_nested_str_weak(stop_iteration),
+  /* K57  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
+  /* K58  */  be_nested_str_weak(find),
+  /* K59  */  be_nested_str_weak(get_admin_vendor),
+  /* K60  */  be_nested_str_weak(disable_bridge_mode),
+  /* K61  */  be_nested_str_weak(string),
+  /* K62  */  be_nested_str_weak(get_info),
+  /* K63  */  be_nested_str_weak(name),
+  /* K64  */  be_nested_str_weak(set_or_nil),
+  /* K65  */  be_nested_str_weak(UTF1),
+  /* K66  */  be_nested_str_weak(tasmota),
+  /* K67  */  be_nested_str_weak(cmd),
+  /* K68  */  be_nested_str_weak(DeviceName),
+  /* K69  */  be_nested_str_weak(version),
+  /* K70  */  be_nested_str_weak(_X28),
+  /* K71  */  be_nested_str_weak(NULL),
+  /* K72  */  be_nested_str_weak(Status_X202),
+  /* K73  */  be_nested_str_weak(StatusFWR),
+  /* K74  */  be_nested_str_weak(Version),
+  /* K75  */  be_nested_str_weak(mac),
+  /* K76  */  be_nested_str_weak(wifi),
+  /* K77  */  be_nested_str_weak(BOOL),
+  /* K78  */  be_nested_str_weak(reachable),
+  /* K79  */  be_nested_str_weak(read_attribute),
+  /* K80  */  be_nested_str_weak(init),
+  /* K81  */  be_nested_str_weak(ARG_HTTP),
+  /* K82  */  be_nested_str_weak(register_http_remote),
+  /* K83  */  be_nested_str_weak(PROBE_TIMEOUT),
+  /* K84  */  be_nested_str_weak(register_cmd_cb),
+  /* K85  */  be_nested_str_weak(introspect),
+  /* K86  */  be_nested_str_weak(get),
+  /* K87  */  be_nested_str_weak(JSON_NAME),
+  /* K88  */  be_nested_str_weak(contains),
+  /* K89  */  be_nested_str_weak(shadow_value),
+  /* K90  */  be_nested_str_weak(dump),
+  /* K91  */  be_nested_str_weak(null),
+  /* K92  */  be_nested_str_weak(_X2C_X22_X25s_X22_X3A_X25s),
+  /* K93  */  be_nested_str_weak(shadow_onoff),
+  /* K94  */  be_nested_str_weak(Power),
+  /* K95  */  be_nested_str_weak(shadow_bri),
+  /* K96  */  be_nested_str_weak(Bri),
+  /* K97  */  be_nested_str_weak(shadow_ct),
+  /* K98  */  be_nested_str_weak(CT),
+  /* K99  */  be_nested_str_weak(shadow_hue),
+  /* K100 */  be_nested_str_weak(Hue),
+  /* K101 */  be_nested_str_weak(shadow_sat),
+  /* K102 */  be_nested_str_weak(Sat),
+  /* K103 */  be_nested_str_weak(shadow_shutter_pos),
+  /* K104 */  be_nested_str_weak(ShutterPos),
+  /* K105 */  be_nested_str_weak(shadow_shutter_target),
+  /* K106 */  be_nested_str_weak(ShutterTarget),
+  /* K107 */  be_nested_str_weak(shadow_shutter_tilt),
+  /* K108 */  be_nested_str_weak(ShutterTilt),
+  /* K109 */  be_nested_str_weak(shadow_contact),
+  /* K110 */  be_nested_str_weak(Contact),
+  /* K111 */  be_nested_str_weak(shadow_occupancy),
+  /* K112 */  be_nested_str_weak(Occupancy),
+  /* K113 */  be_nested_str_weak(shadow_air_quality),
+  /* K114 */  be_nested_str_weak(AirQuality),
+  /* K115 */  be_nested_str_weak(shadow_co2),
+  /* K116 */  be_nested_str_weak(CO2),
+  /* K117 */  be_nested_str_weak(shadow_pm1),
+  /* K118 */  be_nested_str_weak(PM1),
+  /* K119 */  be_nested_str_weak(shadow_pm2_5),
+  /* K120 */  be_nested_str_weak(PM2_X2E5),
+  /* K121 */  be_nested_str_weak(shadow_pm10),
+  /* K122 */  be_nested_str_weak(PM10),
+  /* K123 */  be_nested_str_weak(shadow_tvoc),
+  /* K124 */  be_nested_str_weak(TVOC),
+  /* K125 */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Device;
 
@@ -226,13 +352,13 @@ be_local_closure(class_Matter_Plugin_Device_parse_status,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -250,7 +376,7 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -283,12 +409,7 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remote),
-    /* K1   */  be_nested_str_weak(add_schedule),
-    /* K2   */  be_nested_str_weak(UPDATE_CMD),
-    /* K3   */  be_nested_str_weak(UPDATE_TIME),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(register_cmd_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
@@ -313,30 +434,23 @@ be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26lt_X3B_X2D_X2D_X20_X28),
-    /* K4   */  be_nested_str_weak(DISPLAY_NAME),
-    /* K5   */  be_nested_str_weak(_X29_X20_X2D_X2D_X26gt_X3B),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4060800,  //  0000  IMPORT	R1	K4
+      0x8C080105,  //  0001  GETMET	R2	R0	K5
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x88100104,  //  0004  GETMBR	R4	R0	K4
-      0x00120604,  //  0005  ADD	R4	K3	R4
-      0x00100905,  //  0006  ADD	R4	R4	K5
+      0x8C080306,  //  0003  GETMET	R2	R1	K6
+      0x88100108,  //  0004  GETMBR	R4	R0	K8
+      0x00120E04,  //  0005  ADD	R4	K7	R4
+      0x00100909,  //  0006  ADD	R4	R4	K9
       0x7C080400,  //  0007  CALL	R2	2
       0x80000000,  //  0008  RET	0
     })
@@ -352,31 +466,26 @@ be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(http_remote),
-    /* K2   */  be_nested_str_weak(scheduler),
-    /* K3   */  be_nested_str_weak(every_250ms),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(every_250ms),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010A,  //  0000  GETMBR	R1	R0	K10
       0x78060003,  //  0001  JMPF	R1	#0006
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x8C04030B,  //  0003  GETMET	R1	R1	K11
       0x7C040200,  //  0004  CALL	R1	1
       0x70020004,  //  0005  JMP		#000B
       0x60040003,  //  0006  GETGBL	R1	G3
       0x5C080000,  //  0007  MOVE	R2	R0
       0x7C040200,  //  0008  CALL	R1	1
-      0x8C040303,  //  0009  GETMET	R1	R1	K3
+      0x8C04030C,  //  0009  GETMET	R1	R1	K12
       0x7C040200,  //  000A  CALL	R1	1
       0x80000000,  //  000B  RET	0
     })
@@ -392,17 +501,13 @@ be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_X3Cb_X3EOn_X3C_X2Fb_X3E),
-    /* K1   */  be_nested_str_weak(Off),
-    /* K2   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(web_value_onoff),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -410,11 +515,11 @@ be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0004,  //  0002  JMPF	R2	#0008
       0x78060001,  //  0003  JMPF	R1	#0006
-      0x58080000,  //  0004  LDCONST	R2	K0
+      0x5808000D,  //  0004  LDCONST	R2	K13
       0x70020000,  //  0005  JMP		#0007
-      0x58080001,  //  0006  LDCONST	R2	K1
+      0x5808000E,  //  0006  LDCONST	R2	K14
       0x70020000,  //  0007  JMP		#0009
-      0x58080002,  //  0008  LDCONST	R2	K2
+      0x5808000F,  //  0008  LDCONST	R2	K15
       0x80040400,  //  0009  RET	1	R2
     })
   )
@@ -429,49 +534,37 @@ be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K8   */  be_nested_str_weak(add_TLV),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[51]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0xB8122000,  //  0000  GETNGBL	R4	K16
+      0x88100911,  //  0001  GETMBR	R4	R4	K17
+      0x88140712,  //  0002  GETMBR	R5	R3	K18
+      0x88180713,  //  0003  GETMBR	R6	R3	K19
+      0x1C1C0B14,  //  0004  EQ	R7	R5	K20
       0x781E0016,  //  0005  JMPF	R7	#001D
-      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x1C1C0D15,  //  0006  EQ	R7	R6	K21
       0x781E0002,  //  0007  JMPF	R7	#000B
       0x501C0200,  //  0008  LDBOOL	R7	1	0
       0x80040E00,  //  0009  RET	1	R7
       0x70020010,  //  000A  JMP		#001C
-      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
+      0x1C1C0D16,  //  000B  EQ	R7	R6	K22
       0x781E0009,  //  000C  JMPF	R7	#0017
-      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
+      0x8C1C0917,  //  000D  GETMET	R7	R4	K23
       0x7C1C0200,  //  000E  CALL	R7	1
-      0x8C200F08,  //  000F  GETMET	R8	R7	K8
-      0x58280005,  //  0010  LDCONST	R10	K5
-      0x882C0909,  //  0011  GETMBR	R11	R4	K9
-      0x58300005,  //  0012  LDCONST	R12	K5
+      0x8C200F18,  //  000F  GETMET	R8	R7	K24
+      0x58280015,  //  0010  LDCONST	R10	K21
+      0x882C0919,  //  0011  GETMBR	R11	R4	K25
+      0x58300015,  //  0012  LDCONST	R12	K21
       0x7C200800,  //  0013  CALL	R8	4
-      0x900E0705,  //  0014  SETMBR	R3	K3	K5
+      0x900E2715,  //  0014  SETMBR	R3	K19	K21
       0x80040E00,  //  0015  RET	1	R7
       0x70020004,  //  0016  JMP		#001C
       0x541E003F,  //  0017  LDINT	R7	64
@@ -495,7 +588,7 @@ be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
       0x601C0003,  //  0029  GETGBL	R7	G3
       0x5C200000,  //  002A  MOVE	R8	R0
       0x7C1C0200,  //  002B  CALL	R7	1
-      0x8C1C0F0A,  //  002C  GETMET	R7	R7	K10
+      0x8C1C0F1A,  //  002C  GETMET	R7	R7	K26
       0x5C240200,  //  002D  MOVE	R9	R1
       0x5C280400,  //  002E  MOVE	R10	R2
       0x5C2C0600,  //  002F  MOVE	R11	R3
@@ -515,43 +608,35 @@ be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(tick),
-    /* K2   */  be_nested_str_weak(device),
-    /* K3   */  be_nested_str_weak(call_remote_sync),
-    /* K4   */  be_nested_str_weak(UPDATE_CMD),
-    /* K5   */  be_nested_str_weak(parse_http_response),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010A,  //  0000  GETMBR	R1	R0	K10
       0x7806000D,  //  0001  JMPF	R1	#0010
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x88080102,  //  0003  GETMBR	R2	R0	K2
-      0x88080501,  //  0004  GETMBR	R2	R2	K1
+      0x8804011B,  //  0002  GETMBR	R1	R0	K27
+      0x8808011C,  //  0003  GETMBR	R2	R0	K28
+      0x8808051B,  //  0004  GETMBR	R2	R2	K27
       0x20040202,  //  0005  NE	R1	R1	R2
       0x78060008,  //  0006  JMPF	R1	#0010
-      0x8C040103,  //  0007  GETMET	R1	R0	K3
-      0x880C0104,  //  0008  GETMBR	R3	R0	K4
+      0x8C04011D,  //  0007  GETMET	R1	R0	K29
+      0x880C0102,  //  0008  GETMBR	R3	R0	K2
       0x7C040400,  //  0009  CALL	R1	2
       0x78060004,  //  000A  JMPF	R1	#0010
-      0x8C080105,  //  000B  GETMET	R2	R0	K5
-      0x58100006,  //  000C  LDCONST	R4	K6
+      0x8C08011E,  //  000B  GETMET	R2	R0	K30
+      0x5810001F,  //  000C  LDCONST	R4	K31
       0x5C140200,  //  000D  MOVE	R5	R1
-      0x88180104,  //  000E  GETMBR	R6	R0	K4
+      0x88180102,  //  000E  GETMBR	R6	R0	K2
       0x7C080800,  //  000F  CALL	R2	4
-      0x88040102,  //  0010  GETMBR	R1	R0	K2
-      0x88040301,  //  0011  GETMBR	R1	R1	K1
-      0x90020201,  //  0012  SETMBR	R0	K1	R1
+      0x8804011C,  //  0010  GETMBR	R1	R0	K28
+      0x8804031B,  //  0011  GETMBR	R1	R1	K27
+      0x90023601,  //  0012  SETMBR	R0	K27	R1
       0x80000000,  //  0013  RET	0
     })
   )
@@ -566,70 +651,55 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(_X20),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(http_remote),
-    /* K6   */  be_nested_str_weak(call_sync),
-    /* K7   */  be_nested_str_weak(SYNC_TIMEOUT),
-    /* K8   */  be_nested_str_weak(device_is_alive),
-    /* K9   */  be_nested_str_weak(load),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
-    /* K13  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(call_remote_sync),
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C010A,  //  0000  GETMBR	R3	R0	K10
       0x780E0028,  //  0001  JMPF	R3	#002B
-      0xA40E0200,  //  0002  IMPORT	R3	K1
-      0x58100002,  //  0003  LDCONST	R4	K2
+      0xA40E4000,  //  0002  IMPORT	R3	K32
+      0x58100021,  //  0003  LDCONST	R4	K33
       0x4C140000,  //  0004  LDNIL	R5
       0x20140405,  //  0005  NE	R5	R2	R5
       0x78160005,  //  0006  JMPF	R5	#000D
-      0x00140303,  //  0007  ADD	R5	R1	K3
+      0x00140322,  //  0007  ADD	R5	R1	K34
       0x60180008,  //  0008  GETGBL	R6	G8
       0x5C1C0400,  //  0009  MOVE	R7	R2
       0x7C180200,  //  000A  CALL	R6	1
       0x00140A06,  //  000B  ADD	R5	R5	R6
       0x5C040A00,  //  000C  MOVE	R1	R5
-      0x24140904,  //  000D  GT	R5	R4	K4
+      0x24140923,  //  000D  GT	R5	R4	K35
       0x78160015,  //  000E  JMPF	R5	#0025
-      0x88140105,  //  000F  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0010  GETMET	R5	R5	K6
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x8C140B24,  //  0010  GETMET	R5	R5	K36
       0x5C1C0200,  //  0011  MOVE	R7	R1
-      0x88200107,  //  0012  GETMBR	R8	R0	K7
+      0x88200125,  //  0012  GETMBR	R8	R0	K37
       0x7C140600,  //  0013  CALL	R5	3
       0x4C180000,  //  0014  LDNIL	R6
       0x20180A06,  //  0015  NE	R6	R5	R6
       0x781A0007,  //  0016  JMPF	R6	#001F
-      0x88180105,  //  0017  GETMBR	R6	R0	K5
-      0x8C180D08,  //  0018  GETMET	R6	R6	K8
+      0x88180100,  //  0017  GETMBR	R6	R0	K0
+      0x8C180D26,  //  0018  GETMET	R6	R6	K38
       0x50200200,  //  0019  LDBOOL	R8	1	0
       0x7C180400,  //  001A  CALL	R6	2
-      0x8C180709,  //  001B  GETMET	R6	R3	K9
+      0x8C180727,  //  001B  GETMET	R6	R3	K39
       0x5C200A00,  //  001C  MOVE	R8	R5
       0x7C180400,  //  001D  CALL	R6	2
       0x80040C00,  //  001E  RET	1	R6
-      0x0410090A,  //  001F  SUB	R4	R4	K10
-      0xB81A1600,  //  0020  GETNGBL	R6	K11
-      0x581C000C,  //  0021  LDCONST	R7	K12
-      0x5820000D,  //  0022  LDCONST	R8	K13
+      0x04100928,  //  001F  SUB	R4	R4	K40
+      0xB81A5200,  //  0020  GETNGBL	R6	K41
+      0x581C002A,  //  0021  LDCONST	R7	K42
+      0x5820002B,  //  0022  LDCONST	R8	K43
       0x7C180400,  //  0023  CALL	R6	2
       0x7001FFE7,  //  0024  JMP		#000D
-      0x88140105,  //  0025  GETMBR	R5	R0	K5
-      0x8C140B08,  //  0026  GETMET	R5	R5	K8
+      0x88140100,  //  0025  GETMBR	R5	R0	K0
+      0x8C140B26,  //  0026  GETMET	R5	R5	K38
       0x501C0000,  //  0027  LDBOOL	R7	0	0
       0x7C140400,  //  0028  CALL	R5	2
       0x4C140000,  //  0029  LDNIL	R5
@@ -648,35 +718,28 @@ be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(tick),
-    /* K2   */  be_nested_str_weak(device),
-    /* K3   */  be_nested_str_weak(http_remote),
-    /* K4   */  be_nested_str_weak(parse_status_response_and_call_method),
-    /* K5   */  be_nested_str_weak(parse_status),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(parse_http_response),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8810010A,  //  0000  GETMBR	R4	R0	K10
       0x7812000A,  //  0001  JMPF	R4	#000D
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x90020204,  //  0004  SETMBR	R0	K1	R4
-      0x88100103,  //  0005  GETMBR	R4	R0	K3
-      0x8C100904,  //  0006  GETMET	R4	R4	K4
+      0x8810011C,  //  0002  GETMBR	R4	R0	K28
+      0x8810091B,  //  0003  GETMBR	R4	R4	K27
+      0x90023604,  //  0004  SETMBR	R0	K27	R4
+      0x88100100,  //  0005  GETMBR	R4	R0	K0
+      0x8C10092C,  //  0006  GETMET	R4	R4	K44
       0x5C180200,  //  0007  MOVE	R6	R1
       0x5C1C0400,  //  0008  MOVE	R7	R2
       0x5C200600,  //  0009  MOVE	R8	R3
       0x5C240000,  //  000A  MOVE	R9	R0
-      0x88280105,  //  000B  GETMBR	R10	R0	K5
+      0x8828012D,  //  000B  GETMBR	R10	R0	K45
       0x7C100C00,  //  000C  CALL	R4	6
       0x80000000,  //  000D  RET	0
     })
@@ -692,35 +755,28 @@ be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(PREFIX),
-    /* K4   */  be_nested_str_weak(html_escape),
-    /* K5   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4060800,  //  0000  IMPORT	R1	K4
+      0x8C08012E,  //  0001  GETMET	R2	R0	K46
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
+      0x8C0C0306,  //  0003  GETMET	R3	R1	K6
       0x60140018,  //  0004  GETGBL	R5	G24
-      0x88180103,  //  0005  GETMBR	R6	R0	K3
+      0x8818012F,  //  0005  GETMBR	R6	R0	K47
       0x780A0003,  //  0006  JMPF	R2	#000B
-      0x8C1C0304,  //  0007  GETMET	R7	R1	K4
+      0x8C1C0330,  //  0007  GETMET	R7	R1	K48
       0x5C240400,  //  0008  MOVE	R9	R2
       0x7C1C0400,  //  0009  CALL	R7	2
       0x70020000,  //  000A  JMP		#000C
-      0x581C0005,  //  000B  LDCONST	R7	K5
+      0x581C000F,  //  000B  LDCONST	R7	K15
       0x7C140400,  //  000C  CALL	R5	2
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80000000,  //  000E  RET	0
@@ -737,87 +793,42 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U2),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_nested_str_weak(Matter_TLV_array),
-    /* K11  */  be_nested_str_weak(TYPES),
-    /* K12  */  be_nested_str_weak(keys),
-    /* K13  */  be_nested_str_weak(add_struct),
-    /* K14  */  be_nested_str_weak(add_TLV),
-    /* K15  */  be_nested_str_weak(stop_iteration),
-    /* K16  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
-    /* K17  */  be_nested_str_weak(find),
-    /* K18  */  be_nested_str_weak(get_admin_vendor),
-    /* K19  */  be_nested_str_weak(device),
-    /* K20  */  be_nested_str_weak(disable_bridge_mode),
-    /* K21  */  be_nested_str_weak(string),
-    /* K22  */  be_nested_str_weak(BRIDGE),
-    /* K23  */  be_nested_str_weak(http_remote),
-    /* K24  */  be_nested_str_weak(get_info),
-    /* K25  */  be_nested_str_weak(name),
-    /* K26  */  be_nested_str_weak(set_or_nil),
-    /* K27  */  be_nested_str_weak(UTF1),
-    /* K28  */  be_nested_str_weak(tasmota),
-    /* K29  */  be_nested_str_weak(cmd),
-    /* K30  */  be_nested_str_weak(DeviceName),
-    /* K31  */  be_nested_str_weak(get_name),
-    /* K32  */  be_nested_str_weak(version),
-    /* K33  */  be_nested_str_weak(_X28),
-    /* K34  */  be_nested_str_weak(NULL),
-    /* K35  */  be_nested_str_weak(Status_X202),
-    /* K36  */  be_nested_str_weak(StatusFWR),
-    /* K37  */  be_nested_str_weak(Version),
-    /* K38  */  be_nested_str_weak(mac),
-    /* K39  */  be_nested_str_weak(wifi),
-    /* K40  */  be_nested_str_weak(),
-    /* K41  */  be_nested_str_weak(BOOL),
-    /* K42  */  be_nested_str_weak(reachable),
-    /* K43  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[244]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
-      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0xB8122000,  //  0000  GETNGBL	R4	K16
+      0x88100911,  //  0001  GETMBR	R4	R4	K17
+      0x88140512,  //  0002  GETMBR	R5	R2	K18
+      0x88180531,  //  0003  GETMBR	R6	R2	K49
+      0x1C1C0B14,  //  0004  EQ	R7	R5	K20
       0x781E000F,  //  0005  JMPF	R7	#0016
-      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x1C1C0D15,  //  0006  EQ	R7	R6	K21
       0x781E0005,  //  0007  JMPF	R7	#000E
-      0x8C1C0706,  //  0008  GETMET	R7	R3	K6
-      0x88240907,  //  0009  GETMBR	R9	R4	K7
-      0x58280005,  //  000A  LDCONST	R10	K5
+      0x8C1C0732,  //  0008  GETMET	R7	R3	K50
+      0x88240919,  //  0009  GETMBR	R9	R4	K25
+      0x58280015,  //  000A  LDCONST	R10	K21
       0x7C1C0600,  //  000B  CALL	R7	3
       0x80040E00,  //  000C  RET	1	R7
       0x70020006,  //  000D  JMP		#0015
-      0x1C1C0D08,  //  000E  EQ	R7	R6	K8
+      0x1C1C0D28,  //  000E  EQ	R7	R6	K40
       0x781E0004,  //  000F  JMPF	R7	#0015
-      0x8C1C0706,  //  0010  GETMET	R7	R3	K6
-      0x88240909,  //  0011  GETMBR	R9	R4	K9
-      0x58280005,  //  0012  LDCONST	R10	K5
+      0x8C1C0732,  //  0010  GETMET	R7	R3	K50
+      0x88240933,  //  0011  GETMBR	R9	R4	K51
+      0x58280015,  //  0012  LDCONST	R10	K21
       0x7C1C0600,  //  0013  CALL	R7	3
       0x80040E00,  //  0014  RET	1	R7
       0x700200D4,  //  0015  JMP		#00EB
       0x541E0003,  //  0016  LDINT	R7	4
       0x1C1C0A07,  //  0017  EQ	R7	R5	R7
       0x781E0004,  //  0018  JMPF	R7	#001E
-      0x1C1C0D05,  //  0019  EQ	R7	R6	K5
+      0x1C1C0D15,  //  0019  EQ	R7	R6	K21
       0x781E0001,  //  001A  JMPF	R7	#001D
       0x4C1C0000,  //  001B  LDNIL	R7
       0x80040E00,  //  001C  RET	1	R7
@@ -829,96 +840,96 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x541E001C,  //  0022  LDINT	R7	29
       0x1C1C0A07,  //  0023  EQ	R7	R5	R7
       0x781E0034,  //  0024  JMPF	R7	#005A
-      0x1C1C0D05,  //  0025  EQ	R7	R6	K5
+      0x1C1C0D15,  //  0025  EQ	R7	R6	K21
       0x781E0031,  //  0026  JMPF	R7	#0059
-      0x8C1C090A,  //  0027  GETMET	R7	R4	K10
+      0x8C1C0934,  //  0027  GETMET	R7	R4	K52
       0x7C1C0200,  //  0028  CALL	R7	1
-      0x8820010B,  //  0029  GETMBR	R8	R0	K11
+      0x88200135,  //  0029  GETMBR	R8	R0	K53
       0x60240010,  //  002A  GETGBL	R9	G16
-      0x8C28110C,  //  002B  GETMET	R10	R8	K12
+      0x8C281136,  //  002B  GETMET	R10	R8	K54
       0x7C280200,  //  002C  CALL	R10	1
       0x7C240200,  //  002D  CALL	R9	1
       0xA802000E,  //  002E  EXBLK	0	#003E
       0x5C281200,  //  002F  MOVE	R10	R9
       0x7C280000,  //  0030  CALL	R10	0
-      0x8C2C0F0D,  //  0031  GETMET	R11	R7	K13
+      0x8C2C0F37,  //  0031  GETMET	R11	R7	K55
       0x7C2C0200,  //  0032  CALL	R11	1
-      0x8C30170E,  //  0033  GETMET	R12	R11	K14
-      0x58380005,  //  0034  LDCONST	R14	K5
-      0x883C0907,  //  0035  GETMBR	R15	R4	K7
+      0x8C301718,  //  0033  GETMET	R12	R11	K24
+      0x58380015,  //  0034  LDCONST	R14	K21
+      0x883C0919,  //  0035  GETMBR	R15	R4	K25
       0x5C401400,  //  0036  MOVE	R16	R10
       0x7C300800,  //  0037  CALL	R12	4
-      0x8C30170E,  //  0038  GETMET	R12	R11	K14
-      0x58380008,  //  0039  LDCONST	R14	K8
-      0x883C0907,  //  003A  GETMBR	R15	R4	K7
+      0x8C301718,  //  0038  GETMET	R12	R11	K24
+      0x58380028,  //  0039  LDCONST	R14	K40
+      0x883C0919,  //  003A  GETMBR	R15	R4	K25
       0x9440100A,  //  003B  GETIDX	R16	R8	R10
       0x7C300800,  //  003C  CALL	R12	4
       0x7001FFF0,  //  003D  JMP		#002F
-      0x5824000F,  //  003E  LDCONST	R9	K15
+      0x58240038,  //  003E  LDCONST	R9	K56
       0xAC240200,  //  003F  CATCH	R9	1	0
       0xB0080000,  //  0040  RAISE	2	R0	R0
-      0x88240110,  //  0041  GETMBR	R9	R0	K16
-      0x8C241311,  //  0042  GETMET	R9	R9	K17
-      0x8C2C0312,  //  0043  GETMET	R11	R1	K18
+      0x88240139,  //  0041  GETMBR	R9	R0	K57
+      0x8C24133A,  //  0042  GETMET	R9	R9	K58
+      0x8C2C033B,  //  0043  GETMET	R11	R1	K59
       0x7C2C0200,  //  0044  CALL	R11	1
       0x7C240400,  //  0045  CALL	R9	2
       0x4C280000,  //  0046  LDNIL	R10
       0x1C24120A,  //  0047  EQ	R9	R9	R10
       0x7826000E,  //  0048  JMPF	R9	#0058
-      0x88240113,  //  0049  GETMBR	R9	R0	K19
-      0x88241314,  //  004A  GETMBR	R9	R9	K20
+      0x8824011C,  //  0049  GETMBR	R9	R0	K28
+      0x8824133C,  //  004A  GETMBR	R9	R9	K60
       0x7426000B,  //  004B  JMPT	R9	#0058
-      0x8C240F0D,  //  004C  GETMET	R9	R7	K13
+      0x8C240F37,  //  004C  GETMET	R9	R7	K55
       0x7C240200,  //  004D  CALL	R9	1
-      0x8C28130E,  //  004E  GETMET	R10	R9	K14
-      0x58300005,  //  004F  LDCONST	R12	K5
-      0x88340907,  //  0050  GETMBR	R13	R4	K7
+      0x8C281318,  //  004E  GETMET	R10	R9	K24
+      0x58300015,  //  004F  LDCONST	R12	K21
+      0x88340919,  //  0050  GETMBR	R13	R4	K25
       0x543A0012,  //  0051  LDINT	R14	19
       0x7C280800,  //  0052  CALL	R10	4
-      0x8C28130E,  //  0053  GETMET	R10	R9	K14
-      0x58300008,  //  0054  LDCONST	R12	K8
-      0x88340907,  //  0055  GETMBR	R13	R4	K7
-      0x58380008,  //  0056  LDCONST	R14	K8
+      0x8C281318,  //  0053  GETMET	R10	R9	K24
+      0x58300028,  //  0054  LDCONST	R12	K40
+      0x88340919,  //  0055  GETMBR	R13	R4	K25
+      0x58380028,  //  0056  LDCONST	R14	K40
       0x7C280800,  //  0057  CALL	R10	4
       0x80040E00,  //  0058  RET	1	R7
       0x70020090,  //  0059  JMP		#00EB
       0x541E0038,  //  005A  LDINT	R7	57
       0x1C1C0A07,  //  005B  EQ	R7	R5	R7
       0x781E008D,  //  005C  JMPF	R7	#00EB
-      0xA41E2A00,  //  005D  IMPORT	R7	K21
-      0x1C200D04,  //  005E  EQ	R8	R6	K4
+      0xA41E7A00,  //  005D  IMPORT	R7	K61
+      0x1C200D14,  //  005E  EQ	R8	R6	K20
       0x78220018,  //  005F  JMPF	R8	#0079
-      0x88200116,  //  0060  GETMBR	R8	R0	K22
+      0x8820010A,  //  0060  GETMBR	R8	R0	K10
       0x7822000B,  //  0061  JMPF	R8	#006E
-      0x88200117,  //  0062  GETMBR	R8	R0	K23
-      0x8C201118,  //  0063  GETMET	R8	R8	K24
+      0x88200100,  //  0062  GETMBR	R8	R0	K0
+      0x8C20113E,  //  0063  GETMET	R8	R8	K62
       0x7C200200,  //  0064  CALL	R8	1
-      0x8C201111,  //  0065  GETMET	R8	R8	K17
-      0x58280019,  //  0066  LDCONST	R10	K25
+      0x8C20113A,  //  0065  GETMET	R8	R8	K58
+      0x5828003F,  //  0066  LDCONST	R10	K63
       0x7C200400,  //  0067  CALL	R8	2
-      0x8C24071A,  //  0068  GETMET	R9	R3	K26
-      0x882C091B,  //  0069  GETMBR	R11	R4	K27
+      0x8C240740,  //  0068  GETMET	R9	R3	K64
+      0x882C0941,  //  0069  GETMBR	R11	R4	K65
       0x5C301000,  //  006A  MOVE	R12	R8
       0x7C240600,  //  006B  CALL	R9	3
       0x80041200,  //  006C  RET	1	R9
       0x70020009,  //  006D  JMP		#0078
-      0x8C200706,  //  006E  GETMET	R8	R3	K6
-      0x8828091B,  //  006F  GETMBR	R10	R4	K27
-      0xB82E3800,  //  0070  GETNGBL	R11	K28
-      0x8C2C171D,  //  0071  GETMET	R11	R11	K29
-      0x5834001E,  //  0072  LDCONST	R13	K30
+      0x8C200732,  //  006E  GETMET	R8	R3	K50
+      0x88280941,  //  006F  GETMBR	R10	R4	K65
+      0xB82E8400,  //  0070  GETNGBL	R11	K66
+      0x8C2C1743,  //  0071  GETMET	R11	R11	K67
+      0x58340044,  //  0072  LDCONST	R13	K68
       0x50380200,  //  0073  LDBOOL	R14	1	0
       0x7C2C0600,  //  0074  CALL	R11	3
-      0x942C171E,  //  0075  GETIDX	R11	R11	K30
+      0x942C1744,  //  0075  GETIDX	R11	R11	K68
       0x7C200600,  //  0076  CALL	R8	3
       0x80041000,  //  0077  RET	1	R8
       0x70020071,  //  0078  JMP		#00EB
       0x54220004,  //  0079  LDINT	R8	5
       0x1C200C08,  //  007A  EQ	R8	R6	R8
       0x78220006,  //  007B  JMPF	R8	#0083
-      0x8C200706,  //  007C  GETMET	R8	R3	K6
-      0x8828091B,  //  007D  GETMBR	R10	R4	K27
-      0x8C2C011F,  //  007E  GETMET	R11	R0	K31
+      0x8C200732,  //  007C  GETMET	R8	R3	K50
+      0x88280941,  //  007D  GETMBR	R10	R4	K65
+      0x8C2C012E,  //  007E  GETMET	R11	R0	K46
       0x7C2C0200,  //  007F  CALL	R11	1
       0x7C200600,  //  0080  CALL	R8	3
       0x80041000,  //  0081  RET	1	R8
@@ -926,54 +937,54 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x54220009,  //  0083  LDINT	R8	10
       0x1C200C08,  //  0084  EQ	R8	R6	R8
       0x78220033,  //  0085  JMPF	R8	#00BA
-      0x88200116,  //  0086  GETMBR	R8	R0	K22
+      0x8820010A,  //  0086  GETMBR	R8	R0	K10
       0x7822001B,  //  0087  JMPF	R8	#00A4
-      0x88200117,  //  0088  GETMBR	R8	R0	K23
-      0x8C201118,  //  0089  GETMET	R8	R8	K24
+      0x88200100,  //  0088  GETMBR	R8	R0	K0
+      0x8C20113E,  //  0089  GETMET	R8	R8	K62
       0x7C200200,  //  008A  CALL	R8	1
-      0x8C201111,  //  008B  GETMET	R8	R8	K17
-      0x58280020,  //  008C  LDCONST	R10	K32
+      0x8C20113A,  //  008B  GETMET	R8	R8	K58
+      0x58280045,  //  008C  LDCONST	R10	K69
       0x7C200400,  //  008D  CALL	R8	2
       0x7822000E,  //  008E  JMPF	R8	#009E
-      0x8C240F11,  //  008F  GETMET	R9	R7	K17
+      0x8C240F3A,  //  008F  GETMET	R9	R7	K58
       0x5C2C1000,  //  0090  MOVE	R11	R8
-      0x58300021,  //  0091  LDCONST	R12	K33
+      0x58300046,  //  0091  LDCONST	R12	K70
       0x7C240600,  //  0092  CALL	R9	3
-      0x24281305,  //  0093  GT	R10	R9	K5
+      0x24281315,  //  0093  GT	R10	R9	K21
       0x782A0002,  //  0094  JMPF	R10	#0098
-      0x04281308,  //  0095  SUB	R10	R9	K8
-      0x402A0A0A,  //  0096  CONNECT	R10	K5	R10
+      0x04281328,  //  0095  SUB	R10	R9	K40
+      0x402A2A0A,  //  0096  CONNECT	R10	K21	R10
       0x9420100A,  //  0097  GETIDX	R8	R8	R10
-      0x8C280706,  //  0098  GETMET	R10	R3	K6
-      0x8830091B,  //  0099  GETMBR	R12	R4	K27
+      0x8C280732,  //  0098  GETMET	R10	R3	K50
+      0x88300941,  //  0099  GETMBR	R12	R4	K65
       0x5C341000,  //  009A  MOVE	R13	R8
       0x7C280600,  //  009B  CALL	R10	3
       0x80041400,  //  009C  RET	1	R10
       0x70020004,  //  009D  JMP		#00A3
-      0x8C240706,  //  009E  GETMET	R9	R3	K6
-      0x882C0922,  //  009F  GETMBR	R11	R4	K34
+      0x8C240732,  //  009E  GETMET	R9	R3	K50
+      0x882C0947,  //  009F  GETMBR	R11	R4	K71
       0x4C300000,  //  00A0  LDNIL	R12
       0x7C240600,  //  00A1  CALL	R9	3
       0x80041200,  //  00A2  RET	1	R9
       0x70020014,  //  00A3  JMP		#00B9
-      0xB8223800,  //  00A4  GETNGBL	R8	K28
-      0x8C20111D,  //  00A5  GETMET	R8	R8	K29
-      0x58280023,  //  00A6  LDCONST	R10	K35
+      0xB8228400,  //  00A4  GETNGBL	R8	K66
+      0x8C201143,  //  00A5  GETMET	R8	R8	K67
+      0x58280048,  //  00A6  LDCONST	R10	K72
       0x502C0200,  //  00A7  LDBOOL	R11	1	0
       0x7C200600,  //  00A8  CALL	R8	3
-      0x94201124,  //  00A9  GETIDX	R8	R8	K36
-      0x94201125,  //  00AA  GETIDX	R8	R8	K37
-      0x8C240F11,  //  00AB  GETMET	R9	R7	K17
+      0x94201149,  //  00A9  GETIDX	R8	R8	K73
+      0x9420114A,  //  00AA  GETIDX	R8	R8	K74
+      0x8C240F3A,  //  00AB  GETMET	R9	R7	K58
       0x5C2C1000,  //  00AC  MOVE	R11	R8
-      0x58300021,  //  00AD  LDCONST	R12	K33
+      0x58300046,  //  00AD  LDCONST	R12	K70
       0x7C240600,  //  00AE  CALL	R9	3
-      0x24281305,  //  00AF  GT	R10	R9	K5
+      0x24281315,  //  00AF  GT	R10	R9	K21
       0x782A0002,  //  00B0  JMPF	R10	#00B4
-      0x04281308,  //  00B1  SUB	R10	R9	K8
-      0x402A0A0A,  //  00B2  CONNECT	R10	K5	R10
+      0x04281328,  //  00B1  SUB	R10	R9	K40
+      0x402A2A0A,  //  00B2  CONNECT	R10	K21	R10
       0x9420100A,  //  00B3  GETIDX	R8	R8	R10
-      0x8C280706,  //  00B4  GETMET	R10	R3	K6
-      0x8830091B,  //  00B5  GETMBR	R12	R4	K27
+      0x8C280732,  //  00B4  GETMET	R10	R3	K50
+      0x88300941,  //  00B5  GETMBR	R12	R4	K65
       0x5C341000,  //  00B6  MOVE	R13	R8
       0x7C280600,  //  00B7  CALL	R10	3
       0x80041400,  //  00B8  RET	1	R10
@@ -984,28 +995,28 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x54220011,  //  00BD  LDINT	R8	18
       0x1C200C08,  //  00BE  EQ	R8	R6	R8
       0x78220019,  //  00BF  JMPF	R8	#00DA
-      0x88200116,  //  00C0  GETMBR	R8	R0	K22
+      0x8820010A,  //  00C0  GETMBR	R8	R0	K10
       0x7822000B,  //  00C1  JMPF	R8	#00CE
-      0x88200117,  //  00C2  GETMBR	R8	R0	K23
-      0x8C201118,  //  00C3  GETMET	R8	R8	K24
+      0x88200100,  //  00C2  GETMBR	R8	R0	K0
+      0x8C20113E,  //  00C3  GETMET	R8	R8	K62
       0x7C200200,  //  00C4  CALL	R8	1
-      0x8C201111,  //  00C5  GETMET	R8	R8	K17
-      0x58280026,  //  00C6  LDCONST	R10	K38
+      0x8C20113A,  //  00C5  GETMET	R8	R8	K58
+      0x5828004B,  //  00C6  LDCONST	R10	K75
       0x7C200400,  //  00C7  CALL	R8	2
-      0x8C24071A,  //  00C8  GETMET	R9	R3	K26
-      0x882C091B,  //  00C9  GETMBR	R11	R4	K27
+      0x8C240740,  //  00C8  GETMET	R9	R3	K64
+      0x882C0941,  //  00C9  GETMBR	R11	R4	K65
       0x5C301000,  //  00CA  MOVE	R12	R8
       0x7C240600,  //  00CB  CALL	R9	3
       0x80041200,  //  00CC  RET	1	R9
       0x7002000A,  //  00CD  JMP		#00D9
-      0x8C200706,  //  00CE  GETMET	R8	R3	K6
-      0x8828091B,  //  00CF  GETMBR	R10	R4	K27
-      0xB82E3800,  //  00D0  GETNGBL	R11	K28
-      0x8C2C1727,  //  00D1  GETMET	R11	R11	K39
+      0x8C200732,  //  00CE  GETMET	R8	R3	K50
+      0x88280941,  //  00CF  GETMBR	R10	R4	K65
+      0xB82E8400,  //  00D0  GETNGBL	R11	K66
+      0x8C2C174C,  //  00D1  GETMET	R11	R11	K76
       0x7C2C0200,  //  00D2  CALL	R11	1
-      0x8C2C1711,  //  00D3  GETMET	R11	R11	K17
-      0x58340026,  //  00D4  LDCONST	R13	K38
-      0x58380028,  //  00D5  LDCONST	R14	K40
+      0x8C2C173A,  //  00D3  GETMET	R11	R11	K58
+      0x5834004B,  //  00D4  LDCONST	R13	K75
+      0x5838000F,  //  00D5  LDCONST	R14	K15
       0x7C2C0600,  //  00D6  CALL	R11	3
       0x7C200600,  //  00D7  CALL	R8	3
       0x80041000,  //  00D8  RET	1	R8
@@ -1013,24 +1024,24 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x54220010,  //  00DA  LDINT	R8	17
       0x1C200C08,  //  00DB  EQ	R8	R6	R8
       0x7822000D,  //  00DC  JMPF	R8	#00EB
-      0x88200116,  //  00DD  GETMBR	R8	R0	K22
+      0x8820010A,  //  00DD  GETMBR	R8	R0	K10
       0x78220006,  //  00DE  JMPF	R8	#00E6
-      0x8C200706,  //  00DF  GETMET	R8	R3	K6
-      0x88280929,  //  00E0  GETMBR	R10	R4	K41
-      0x882C0117,  //  00E1  GETMBR	R11	R0	K23
-      0x882C172A,  //  00E2  GETMBR	R11	R11	K42
+      0x8C200732,  //  00DF  GETMET	R8	R3	K50
+      0x8828094D,  //  00E0  GETMBR	R10	R4	K77
+      0x882C0100,  //  00E1  GETMBR	R11	R0	K0
+      0x882C174E,  //  00E2  GETMBR	R11	R11	K78
       0x7C200600,  //  00E3  CALL	R8	3
       0x80041000,  //  00E4  RET	1	R8
       0x70020004,  //  00E5  JMP		#00EB
-      0x8C200706,  //  00E6  GETMET	R8	R3	K6
-      0x88280929,  //  00E7  GETMBR	R10	R4	K41
-      0x582C0008,  //  00E8  LDCONST	R11	K8
+      0x8C200732,  //  00E6  GETMET	R8	R3	K50
+      0x8828094D,  //  00E7  GETMBR	R10	R4	K77
+      0x582C0028,  //  00E8  LDCONST	R11	K40
       0x7C200600,  //  00E9  CALL	R8	3
       0x80041000,  //  00EA  RET	1	R8
       0x601C0003,  //  00EB  GETGBL	R7	G3
       0x5C200000,  //  00EC  MOVE	R8	R0
       0x7C1C0200,  //  00ED  CALL	R7	1
-      0x8C1C0F2B,  //  00EE  GETMET	R7	R7	K43
+      0x8C1C0F4F,  //  00EE  GETMET	R7	R7	K79
       0x5C240200,  //  00EF  MOVE	R9	R1
       0x5C280400,  //  00F0  MOVE	R10	R2
       0x5C2C0600,  //  00F1  MOVE	R11	R3
@@ -1049,46 +1060,36 @@ be_local_closure(class_Matter_Plugin_Device_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG_HTTP),
-    /* K4   */  be_nested_str_weak(http_remote),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(register_http_remote),
-    /* K7   */  be_nested_str_weak(PROBE_TIMEOUT),
-    /* K8   */  be_nested_str_weak(register_cmd_cb),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100950,  //  0003  GETMET	R4	R4	K80
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x8810010A,  //  0008  GETMBR	R4	R0	K10
       0x7812000A,  //  0009  JMPF	R4	#0015
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x88180103,  //  000B  GETMBR	R6	R0	K3
+      0x8C10073A,  //  000A  GETMET	R4	R3	K58
+      0x88180151,  //  000B  GETMBR	R6	R0	K81
       0x7C100400,  //  000C  CALL	R4	2
-      0x88140105,  //  000D  GETMBR	R5	R0	K5
-      0x8C140B06,  //  000E  GETMET	R5	R5	K6
+      0x8814011C,  //  000D  GETMBR	R5	R0	K28
+      0x8C140B52,  //  000E  GETMET	R5	R5	K82
       0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x88200107,  //  0010  GETMBR	R8	R0	K7
+      0x88200153,  //  0010  GETMBR	R8	R0	K83
       0x7C140600,  //  0011  CALL	R5	3
-      0x90020805,  //  0012  SETMBR	R0	K4	R5
-      0x8C140108,  //  0013  GETMET	R5	R0	K8
+      0x90020005,  //  0012  SETMBR	R0	K0	R5
+      0x8C140154,  //  0013  GETMET	R5	R0	K84
       0x7C140200,  //  0014  CALL	R5	1
       0x80000000,  //  0015  RET	0
     })
@@ -1104,7 +1105,7 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1167,145 +1168,102 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[42]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_nested_str_weak(JSON_NAME),
-    /* K5   */  be_nested_str_weak(contains),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(dump),
-    /* K8   */  be_nested_str_weak(null),
-    /* K9   */  be_nested_str_weak(_X2C_X22_X25s_X22_X3A_X25s),
-    /* K10  */  be_nested_str_weak(shadow_onoff),
-    /* K11  */  be_nested_str_weak(Power),
-    /* K12  */  be_nested_str_weak(shadow_bri),
-    /* K13  */  be_nested_str_weak(Bri),
-    /* K14  */  be_nested_str_weak(shadow_ct),
-    /* K15  */  be_nested_str_weak(CT),
-    /* K16  */  be_nested_str_weak(shadow_hue),
-    /* K17  */  be_nested_str_weak(Hue),
-    /* K18  */  be_nested_str_weak(shadow_sat),
-    /* K19  */  be_nested_str_weak(Sat),
-    /* K20  */  be_nested_str_weak(shadow_shutter_pos),
-    /* K21  */  be_nested_str_weak(ShutterPos),
-    /* K22  */  be_nested_str_weak(shadow_shutter_target),
-    /* K23  */  be_nested_str_weak(ShutterTarget),
-    /* K24  */  be_nested_str_weak(shadow_shutter_tilt),
-    /* K25  */  be_nested_str_weak(ShutterTilt),
-    /* K26  */  be_nested_str_weak(shadow_contact),
-    /* K27  */  be_nested_str_weak(Contact),
-    /* K28  */  be_nested_str_weak(shadow_occupancy),
-    /* K29  */  be_nested_str_weak(Occupancy),
-    /* K30  */  be_nested_str_weak(shadow_air_quality),
-    /* K31  */  be_nested_str_weak(AirQuality),
-    /* K32  */  be_nested_str_weak(shadow_co2),
-    /* K33  */  be_nested_str_weak(CO2),
-    /* K34  */  be_nested_str_weak(shadow_pm1),
-    /* K35  */  be_nested_str_weak(PM1),
-    /* K36  */  be_nested_str_weak(shadow_pm2_5),
-    /* K37  */  be_nested_str_weak(PM2_X2E5),
-    /* K38  */  be_nested_str_weak(shadow_pm10),
-    /* K39  */  be_nested_str_weak(PM10),
-    /* K40  */  be_nested_str_weak(shadow_tvoc),
-    /* K41  */  be_nested_str_weak(TVOC),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(append_state_json),
     &be_const_str_solidified,
     ( &(const binstruction[95]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
+      0xA406AA00,  //  0000  IMPORT	R1	K85
+      0xA40A4000,  //  0001  IMPORT	R2	K32
+      0x580C000F,  //  0002  LDCONST	R3	K15
       0x84100000,  //  0003  CLOSURE	R4	P0
-      0x8C140303,  //  0004  GETMET	R5	R1	K3
+      0x8C140356,  //  0004  GETMET	R5	R1	K86
       0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x58200004,  //  0006  LDCONST	R8	K4
+      0x58200057,  //  0006  LDCONST	R8	K87
       0x7C140600,  //  0007  CALL	R5	3
       0x78160013,  //  0008  JMPF	R5	#001D
-      0x8C180305,  //  0009  GETMET	R6	R1	K5
+      0x8C180358,  //  0009  GETMET	R6	R1	K88
       0x5C200000,  //  000A  MOVE	R8	R0
-      0x58240006,  //  000B  LDCONST	R9	K6
+      0x58240059,  //  000B  LDCONST	R9	K89
       0x7C180600,  //  000C  CALL	R6	3
       0x781A000E,  //  000D  JMPF	R6	#001D
-      0x88180106,  //  000E  GETMBR	R6	R0	K6
+      0x88180159,  //  000E  GETMBR	R6	R0	K89
       0x4C1C0000,  //  000F  LDNIL	R7
       0x20180C07,  //  0010  NE	R6	R6	R7
       0x781A0003,  //  0011  JMPF	R6	#0016
-      0x8C180507,  //  0012  GETMET	R6	R2	K7
-      0x88200106,  //  0013  GETMBR	R8	R0	K6
+      0x8C18055A,  //  0012  GETMET	R6	R2	K90
+      0x88200159,  //  0013  GETMBR	R8	R0	K89
       0x7C180400,  //  0014  CALL	R6	2
       0x70020000,  //  0015  JMP		#0017
-      0x58180008,  //  0016  LDCONST	R6	K8
+      0x5818005B,  //  0016  LDCONST	R6	K91
       0x601C0018,  //  0017  GETGBL	R7	G24
-      0x58200009,  //  0018  LDCONST	R8	K9
+      0x5820005C,  //  0018  LDCONST	R8	K92
       0x5C240A00,  //  0019  MOVE	R9	R5
       0x5C280C00,  //  001A  MOVE	R10	R6
       0x7C1C0600,  //  001B  CALL	R7	3
       0x000C0607,  //  001C  ADD	R3	R3	R7
       0x5C180800,  //  001D  MOVE	R6	R4
-      0x581C000A,  //  001E  LDCONST	R7	K10
-      0x5820000B,  //  001F  LDCONST	R8	K11
+      0x581C005D,  //  001E  LDCONST	R7	K93
+      0x5820005E,  //  001F  LDCONST	R8	K94
       0x7C180400,  //  0020  CALL	R6	2
       0x5C180800,  //  0021  MOVE	R6	R4
-      0x581C000C,  //  0022  LDCONST	R7	K12
-      0x5820000D,  //  0023  LDCONST	R8	K13
+      0x581C005F,  //  0022  LDCONST	R7	K95
+      0x58200060,  //  0023  LDCONST	R8	K96
       0x7C180400,  //  0024  CALL	R6	2
       0x5C180800,  //  0025  MOVE	R6	R4
-      0x581C000E,  //  0026  LDCONST	R7	K14
-      0x5820000F,  //  0027  LDCONST	R8	K15
+      0x581C0061,  //  0026  LDCONST	R7	K97
+      0x58200062,  //  0027  LDCONST	R8	K98
       0x7C180400,  //  0028  CALL	R6	2
       0x5C180800,  //  0029  MOVE	R6	R4
-      0x581C0010,  //  002A  LDCONST	R7	K16
-      0x58200011,  //  002B  LDCONST	R8	K17
+      0x581C0063,  //  002A  LDCONST	R7	K99
+      0x58200064,  //  002B  LDCONST	R8	K100
       0x7C180400,  //  002C  CALL	R6	2
       0x5C180800,  //  002D  MOVE	R6	R4
-      0x581C0012,  //  002E  LDCONST	R7	K18
-      0x58200013,  //  002F  LDCONST	R8	K19
+      0x581C0065,  //  002E  LDCONST	R7	K101
+      0x58200066,  //  002F  LDCONST	R8	K102
       0x7C180400,  //  0030  CALL	R6	2
       0x5C180800,  //  0031  MOVE	R6	R4
-      0x581C0014,  //  0032  LDCONST	R7	K20
-      0x58200015,  //  0033  LDCONST	R8	K21
+      0x581C0067,  //  0032  LDCONST	R7	K103
+      0x58200068,  //  0033  LDCONST	R8	K104
       0x7C180400,  //  0034  CALL	R6	2
       0x5C180800,  //  0035  MOVE	R6	R4
-      0x581C0016,  //  0036  LDCONST	R7	K22
-      0x58200017,  //  0037  LDCONST	R8	K23
+      0x581C0069,  //  0036  LDCONST	R7	K105
+      0x5820006A,  //  0037  LDCONST	R8	K106
       0x7C180400,  //  0038  CALL	R6	2
       0x5C180800,  //  0039  MOVE	R6	R4
-      0x581C0018,  //  003A  LDCONST	R7	K24
-      0x58200019,  //  003B  LDCONST	R8	K25
+      0x581C006B,  //  003A  LDCONST	R7	K107
+      0x5820006C,  //  003B  LDCONST	R8	K108
       0x7C180400,  //  003C  CALL	R6	2
       0x5C180800,  //  003D  MOVE	R6	R4
-      0x581C001A,  //  003E  LDCONST	R7	K26
-      0x5820001B,  //  003F  LDCONST	R8	K27
+      0x581C006D,  //  003E  LDCONST	R7	K109
+      0x5820006E,  //  003F  LDCONST	R8	K110
       0x7C180400,  //  0040  CALL	R6	2
       0x5C180800,  //  0041  MOVE	R6	R4
-      0x581C001C,  //  0042  LDCONST	R7	K28
-      0x5820001D,  //  0043  LDCONST	R8	K29
+      0x581C006F,  //  0042  LDCONST	R7	K111
+      0x58200070,  //  0043  LDCONST	R8	K112
       0x7C180400,  //  0044  CALL	R6	2
       0x5C180800,  //  0045  MOVE	R6	R4
-      0x581C001E,  //  0046  LDCONST	R7	K30
-      0x5820001F,  //  0047  LDCONST	R8	K31
+      0x581C0071,  //  0046  LDCONST	R7	K113
+      0x58200072,  //  0047  LDCONST	R8	K114
       0x7C180400,  //  0048  CALL	R6	2
       0x5C180800,  //  0049  MOVE	R6	R4
-      0x581C0020,  //  004A  LDCONST	R7	K32
-      0x58200021,  //  004B  LDCONST	R8	K33
+      0x581C0073,  //  004A  LDCONST	R7	K115
+      0x58200074,  //  004B  LDCONST	R8	K116
       0x7C180400,  //  004C  CALL	R6	2
       0x5C180800,  //  004D  MOVE	R6	R4
-      0x581C0022,  //  004E  LDCONST	R7	K34
-      0x58200023,  //  004F  LDCONST	R8	K35
+      0x581C0075,  //  004E  LDCONST	R7	K117
+      0x58200076,  //  004F  LDCONST	R8	K118
       0x7C180400,  //  0050  CALL	R6	2
       0x5C180800,  //  0051  MOVE	R6	R4
-      0x581C0024,  //  0052  LDCONST	R7	K36
-      0x58200025,  //  0053  LDCONST	R8	K37
+      0x581C0077,  //  0052  LDCONST	R7	K119
+      0x58200078,  //  0053  LDCONST	R8	K120
       0x7C180400,  //  0054  CALL	R6	2
       0x5C180800,  //  0055  MOVE	R6	R4
-      0x581C0026,  //  0056  LDCONST	R7	K38
-      0x58200027,  //  0057  LDCONST	R8	K39
+      0x581C0079,  //  0056  LDCONST	R7	K121
+      0x5820007A,  //  0057  LDCONST	R8	K122
       0x7C180400,  //  0058  CALL	R6	2
       0x5C180800,  //  0059  MOVE	R6	R4
-      0x581C0028,  //  005A  LDCONST	R7	K40
-      0x58200029,  //  005B  LDCONST	R8	K41
+      0x581C007B,  //  005A  LDCONST	R7	K123
+      0x5820007C,  //  005B  LDCONST	R8	K124
       0x7C180400,  //  005C  CALL	R6	2
       0xA0000000,  //  005D  CLOSE	R0
       0x80040600,  //  005E  RET	1	R3
@@ -1322,20 +1280,17 @@ be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     7,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
     be_str_weak(_parse_sensor_entry),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8C1C0300,  //  0000  GETMET	R7	R1	K0
+      0x8C1C033A,  //  0000  GETMET	R7	R1	K58
       0x5C240400,  //  0001  MOVE	R9	R2
       0x7C1C0400,  //  0002  CALL	R7	2
       0x4C200000,  //  0003  LDNIL	R8
@@ -1347,7 +1302,7 @@ be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
       0x5C1C1000,  //  0009  MOVE	R7	R8
       0x20200E03,  //  000A  NE	R8	R7	R3
       0x78220003,  //  000B  JMPF	R8	#0010
-      0x8C200101,  //  000C  GETMET	R8	R0	K1
+      0x8C20017D,  //  000C  GETMET	R8	R0	K125
       0x5C280A00,  //  000D  MOVE	R10	R5
       0x5C2C0C00,  //  000E  MOVE	R11	R6
       0x7C200600,  //  000F  CALL	R8	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -3,6 +3,183 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Root' ktab size: 173, total: 225 (saved 416 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Root[173] = {
+  /* K0   */  be_nested_str_weak(string),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(TLV),
+  /* K3   */  be_nested_str_weak(cluster),
+  /* K4   */  be_nested_str_weak(attribute),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(set),
+  /* K7   */  be_nested_str_weak(U8),
+  /* K8   */  be_nested_str_weak(_breadcrumb),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K11  */  be_nested_str_weak(add_TLV),
+  /* K12  */  be_nested_str_weak(U2),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_nested_str_weak(U1),
+  /* K15  */  be_const_int(3),
+  /* K16  */  be_nested_str_weak(BOOL),
+  /* K17  */  be_nested_str_weak(Matter_TLV_array),
+  /* K18  */  be_nested_str_weak(tasmota),
+  /* K19  */  be_nested_str_weak(eth),
+  /* K20  */  be_nested_str_weak(up),
+  /* K21  */  be_nested_str_weak(add_struct),
+  /* K22  */  be_nested_str_weak(UTF1),
+  /* K23  */  be_nested_str_weak(ethernet),
+  /* K24  */  be_nested_str_weak(NULL),
+  /* K25  */  be_nested_str_weak(fromhex),
+  /* K26  */  be_nested_str_weak(replace),
+  /* K27  */  be_nested_str_weak(find),
+  /* K28  */  be_nested_str_weak(mac),
+  /* K29  */  be_nested_str_weak(),
+  /* K30  */  be_nested_str_weak(_X3A),
+  /* K31  */  be_nested_str_weak(B1),
+  /* K32  */  be_nested_str_weak(add_array),
+  /* K33  */  be_nested_str_weak(get_ip_bytes),
+  /* K34  */  be_nested_str_weak(ip),
+  /* K35  */  be_nested_str_weak(ip6local),
+  /* K36  */  be_nested_str_weak(ip6),
+  /* K37  */  be_nested_str_weak(wifi),
+  /* K38  */  be_nested_str_weak(cmd),
+  /* K39  */  be_nested_str_weak(Status_X201),
+  /* K40  */  be_nested_str_weak(StatusPRM),
+  /* K41  */  be_nested_str_weak(BootCount),
+  /* K42  */  be_nested_str_weak(U4),
+  /* K43  */  be_nested_str_weak(Status_X2011),
+  /* K44  */  be_nested_str_weak(StatusSTS),
+  /* K45  */  be_nested_str_weak(UptimeSec),
+  /* K46  */  be_nested_str_weak(int64),
+  /* K47  */  be_nested_str_weak(rtc_utc),
+  /* K48  */  be_const_int(1000000),
+  /* K49  */  be_nested_str_weak(rtc),
+  /* K50  */  be_nested_str_weak(local),
+  /* K51  */  be_nested_str_weak(ack_request),
+  /* K52  */  be_nested_str_weak(fabric_filtered),
+  /* K53  */  be_nested_str_weak(get_fabric),
+  /* K54  */  be_nested_str_weak(device),
+  /* K55  */  be_nested_str_weak(sessions),
+  /* K56  */  be_nested_str_weak(active_fabrics),
+  /* K57  */  be_nested_str_weak(is_marked_for_deletion),
+  /* K58  */  be_nested_str_weak(B2),
+  /* K59  */  be_nested_str_weak(get_noc),
+  /* K60  */  be_nested_str_weak(get_icac),
+  /* K61  */  be_nested_str_weak(get_fabric_index),
+  /* K62  */  be_nested_str_weak(stop_iteration),
+  /* K63  */  be_nested_str_weak(parse),
+  /* K64  */  be_nested_str_weak(get_ca),
+  /* K65  */  be_nested_str_weak(findsubval),
+  /* K66  */  be_nested_str_weak(get_admin_vendor),
+  /* K67  */  be_nested_str_weak(get_fabric_id_as_int64),
+  /* K68  */  be_nested_str_weak(get_device_id_as_int64),
+  /* K69  */  be_nested_str_weak(get_fabric_label),
+  /* K70  */  be_nested_str_weak(Fabric),
+  /* K71  */  be_nested_str_weak(_MAX_CASE),
+  /* K72  */  be_nested_str_weak(count_active_fabrics),
+  /* K73  */  be_nested_str_weak(_fabric),
+  /* K74  */  be_nested_str_weak(is_commissioning_open),
+  /* K75  */  be_nested_str_weak(is_root_commissioning_open),
+  /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
+  /* K77  */  be_nested_str_weak(set_or_nil),
+  /* K78  */  be_nested_str_weak(Tasmota),
+  /* K79  */  be_nested_str_weak(VENDOR_ID),
+  /* K80  */  be_nested_str_weak(DeviceName),
+  /* K81  */  be_nested_str_weak(FriendlyName),
+  /* K82  */  be_nested_str_weak(FriendlyName1),
+  /* K83  */  be_nested_str_weak(XX),
+  /* K84  */  be_nested_str_weak(Status_X202),
+  /* K85  */  be_nested_str_weak(StatusFWR),
+  /* K86  */  be_nested_str_weak(Hardware),
+  /* K87  */  be_nested_str_weak(version),
+  /* K88  */  be_nested_str_weak(Version),
+  /* K89  */  be_nested_str_weak(_X28),
+  /* K90  */  be_nested_str_weak(locale),
+  /* K91  */  be_nested_str_weak(create_TLV),
+  /* K92  */  be_nested_str_weak(get_active_endpoints),
+  /* K93  */  be_nested_str_weak(disable_bridge_mode),
+  /* K94  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K95  */  be_nested_str_weak(read_attribute),
+  /* K96  */  be_nested_str_weak(int),
+  /* K97  */  be_nested_str_weak(attribute_updated),
+  /* K98  */  be_nested_str_weak(status),
+  /* K99  */  be_nested_str_weak(CONSTRAINT_ERROR),
+  /* K100 */  be_nested_str_weak(INVALID_ACTION),
+  /* K101 */  be_nested_str_weak(init),
+  /* K102 */  be_nested_str_weak(publish_event),
+  /* K103 */  be_nested_str_weak(EVENT_CRITICAL),
+  /* K104 */  be_nested_str_weak(Matter_TLV_item),
+  /* K105 */  be_nested_str_weak(crypto),
+  /* K106 */  be_nested_str_weak(command),
+  /* K107 */  be_const_int(3),
+  /* K108 */  be_nested_str_weak(fabric_completed),
+  /* K109 */  be_nested_str_weak(set_no_expiration),
+  /* K110 */  be_nested_str_weak(save),
+  /* K111 */  be_nested_str_weak(start_commissioning_complete_deferred),
+  /* K112 */  be_nested_str_weak(context_error),
+  /* K113 */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
+  /* K114 */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+  /* K115 */  be_nested_str_weak(DAC_Cert_FFF1_8000),
+  /* K116 */  be_nested_str_weak(PAI_Cert_FFF1),
+  /* K117 */  be_nested_str_weak(CD_FFF1_8000),
+  /* K118 */  be_nested_str_weak(tlv2raw),
+  /* K119 */  be_nested_str_weak(get_ac),
+  /* K120 */  be_nested_str_weak(EC_P256),
+  /* K121 */  be_nested_str_weak(ecdsa_sign_sha256),
+  /* K122 */  be_nested_str_weak(DAC_Priv_FFF1_8000),
+  /* K123 */  be_nested_str_weak(gen_CSR),
+  /* K124 */  be_nested_str_weak(set_temp_ca),
+  /* K125 */  be_nested_str_weak(SUCCESS),
+  /* K126 */  be_nested_str_weak(log),
+  /* K127 */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
+  /* K128 */  be_nested_str_weak(get_temp_ca),
+  /* K129 */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
+  /* K130 */  be_nested_str_weak(create_fabric),
+  /* K131 */  be_nested_str_weak(set_ca),
+  /* K132 */  be_nested_str_weak(set_noc_icac),
+  /* K133 */  be_nested_str_weak(set_ipk_epoch_key),
+  /* K134 */  be_nested_str_weak(set_admin_subject_vendor),
+  /* K135 */  be_nested_str_weak(set_pk),
+  /* K136 */  be_nested_str_weak(get_pk),
+  /* K137 */  be_nested_str_weak(findsub),
+  /* K138 */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
+  /* K139 */  be_nested_str_weak(fromu32),
+  /* K140 */  be_nested_str_weak(tobytes),
+  /* K141 */  be_nested_str_weak(get_temp_ca_pub),
+  /* K142 */  be_const_int(2147483647),
+  /* K143 */  be_nested_str_weak(fromstring),
+  /* K144 */  be_nested_str_weak(CompressedFabric),
+  /* K145 */  be_nested_str_weak(HKDF_SHA256),
+  /* K146 */  be_nested_str_weak(copy),
+  /* K147 */  be_nested_str_weak(reverse),
+  /* K148 */  be_nested_str_weak(derive),
+  /* K149 */  be_nested_str_weak(set_fabric_device),
+  /* K150 */  be_nested_str_weak(fabric_candidate),
+  /* K151 */  be_nested_str_weak(start_operational_discovery_deferred),
+  /* K152 */  be_nested_str_weak(is_PASE),
+  /* K153 */  be_nested_str_weak(set_expire_in_seconds),
+  /* K154 */  be_nested_str_weak(log_new_fabric),
+  /* K155 */  be_nested_str_weak(assign_fabric_index),
+  /* K156 */  be_nested_str_weak(set_fabric_label),
+  /* K157 */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+  /* K158 */  be_nested_str_weak(get_fabric_id),
+  /* K159 */  be_nested_str_weak(tohex),
+  /* K160 */  be_nested_str_weak(fabric_index_X3A),
+  /* K161 */  be_nested_str_weak(mark_for_deletion),
+  /* K162 */  be_nested_str_weak(set_timer),
+  /* K163 */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+  /* K164 */  be_nested_str_weak(_X29_X20not_X20found),
+  /* K165 */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+  /* K166 */  be_nested_str_weak(INVALID_DATA_TYPE),
+  /* K167 */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+  /* K168 */  be_nested_str_weak(start_basic_commissioning),
+  /* K169 */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+  /* K170 */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K171 */  be_nested_str_weak(stop_basic_commissioning),
+  /* K172 */  be_nested_str_weak(invoke_request),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Root;
 
@@ -13,110 +190,13 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
   be_nested_proto(
     25,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[96]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U8),
-    /* K8   */  be_nested_str_weak(_breadcrumb),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K11  */  be_nested_str_weak(add_TLV),
-    /* K12  */  be_nested_str_weak(U2),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(U1),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(BOOL),
-    /* K17  */  be_nested_str_weak(Matter_TLV_array),
-    /* K18  */  be_nested_str_weak(tasmota),
-    /* K19  */  be_nested_str_weak(eth),
-    /* K20  */  be_nested_str_weak(up),
-    /* K21  */  be_nested_str_weak(add_struct),
-    /* K22  */  be_nested_str_weak(UTF1),
-    /* K23  */  be_nested_str_weak(ethernet),
-    /* K24  */  be_nested_str_weak(NULL),
-    /* K25  */  be_nested_str_weak(fromhex),
-    /* K26  */  be_nested_str_weak(replace),
-    /* K27  */  be_nested_str_weak(find),
-    /* K28  */  be_nested_str_weak(mac),
-    /* K29  */  be_nested_str_weak(),
-    /* K30  */  be_nested_str_weak(_X3A),
-    /* K31  */  be_nested_str_weak(B1),
-    /* K32  */  be_nested_str_weak(add_array),
-    /* K33  */  be_nested_str_weak(get_ip_bytes),
-    /* K34  */  be_nested_str_weak(ip),
-    /* K35  */  be_nested_str_weak(ip6local),
-    /* K36  */  be_nested_str_weak(ip6),
-    /* K37  */  be_nested_str_weak(wifi),
-    /* K38  */  be_nested_str_weak(cmd),
-    /* K39  */  be_nested_str_weak(Status_X201),
-    /* K40  */  be_nested_str_weak(StatusPRM),
-    /* K41  */  be_nested_str_weak(BootCount),
-    /* K42  */  be_nested_str_weak(U4),
-    /* K43  */  be_nested_str_weak(Status_X2011),
-    /* K44  */  be_nested_str_weak(StatusSTS),
-    /* K45  */  be_nested_str_weak(UptimeSec),
-    /* K46  */  be_nested_str_weak(int64),
-    /* K47  */  be_nested_str_weak(rtc_utc),
-    /* K48  */  be_const_int(1000000),
-    /* K49  */  be_nested_str_weak(rtc),
-    /* K50  */  be_nested_str_weak(local),
-    /* K51  */  be_nested_str_weak(ack_request),
-    /* K52  */  be_nested_str_weak(fabric_filtered),
-    /* K53  */  be_nested_str_weak(get_fabric),
-    /* K54  */  be_nested_str_weak(device),
-    /* K55  */  be_nested_str_weak(sessions),
-    /* K56  */  be_nested_str_weak(active_fabrics),
-    /* K57  */  be_nested_str_weak(is_marked_for_deletion),
-    /* K58  */  be_nested_str_weak(B2),
-    /* K59  */  be_nested_str_weak(get_noc),
-    /* K60  */  be_nested_str_weak(get_icac),
-    /* K61  */  be_nested_str_weak(get_fabric_index),
-    /* K62  */  be_nested_str_weak(stop_iteration),
-    /* K63  */  be_nested_str_weak(parse),
-    /* K64  */  be_nested_str_weak(get_ca),
-    /* K65  */  be_nested_str_weak(findsubval),
-    /* K66  */  be_nested_str_weak(get_admin_vendor),
-    /* K67  */  be_nested_str_weak(get_fabric_id_as_int64),
-    /* K68  */  be_nested_str_weak(get_device_id_as_int64),
-    /* K69  */  be_nested_str_weak(get_fabric_label),
-    /* K70  */  be_nested_str_weak(Fabric),
-    /* K71  */  be_nested_str_weak(_MAX_CASE),
-    /* K72  */  be_nested_str_weak(count_active_fabrics),
-    /* K73  */  be_nested_str_weak(_fabric),
-    /* K74  */  be_nested_str_weak(is_commissioning_open),
-    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K77  */  be_nested_str_weak(set_or_nil),
-    /* K78  */  be_nested_str_weak(Tasmota),
-    /* K79  */  be_nested_str_weak(VENDOR_ID),
-    /* K80  */  be_nested_str_weak(DeviceName),
-    /* K81  */  be_nested_str_weak(FriendlyName),
-    /* K82  */  be_nested_str_weak(FriendlyName1),
-    /* K83  */  be_nested_str_weak(XX),
-    /* K84  */  be_nested_str_weak(Status_X202),
-    /* K85  */  be_nested_str_weak(StatusFWR),
-    /* K86  */  be_nested_str_weak(Hardware),
-    /* K87  */  be_nested_str_weak(version),
-    /* K88  */  be_nested_str_weak(Version),
-    /* K89  */  be_nested_str_weak(_X28),
-    /* K90  */  be_nested_str_weak(locale),
-    /* K91  */  be_nested_str_weak(create_TLV),
-    /* K92  */  be_nested_str_weak(get_active_endpoints),
-    /* K93  */  be_nested_str_weak(disable_bridge_mode),
-    /* K94  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K95  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Root,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[926]) {  /* code */
@@ -1059,67 +1139,53 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(int),
-    /* K6   */  be_nested_str_weak(int64),
-    /* K7   */  be_nested_str_weak(_breadcrumb),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_nested_str_weak(status),
-    /* K10  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(INVALID_ACTION),
-    }),
+    &be_ktab_class_Matter_Plugin_Root,     /* shared constants */
     be_str_weak(write_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[100]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120200,  //  0000  GETNGBL	R4	K1
+      0x88100902,  //  0001  GETMBR	R4	R4	K2
+      0x88140503,  //  0002  GETMBR	R5	R2	K3
+      0x88180504,  //  0003  GETMBR	R6	R2	K4
       0x541E002F,  //  0004  LDINT	R7	48
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0019,  //  0006  JMPF	R7	#0021
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D05,  //  0007  EQ	R7	R6	K5
       0x781E0016,  //  0008  JMPF	R7	#0020
       0x601C0004,  //  0009  GETGBL	R7	G4
       0x5C200600,  //  000A  MOVE	R8	R3
       0x7C1C0200,  //  000B  CALL	R7	1
-      0x1C1C0F05,  //  000C  EQ	R7	R7	K5
+      0x1C1C0F60,  //  000C  EQ	R7	R7	K96
       0x741E0004,  //  000D  JMPT	R7	#0013
       0x601C000F,  //  000E  GETGBL	R7	G15
       0x5C200600,  //  000F  MOVE	R8	R3
-      0xB8260C00,  //  0010  GETNGBL	R9	K6
+      0xB8265C00,  //  0010  GETNGBL	R9	K46
       0x7C1C0400,  //  0011  CALL	R7	2
       0x781E0007,  //  0012  JMPF	R7	#001B
-      0x90060E03,  //  0013  SETMBR	R1	K7	R3
-      0x8C1C0108,  //  0014  GETMET	R7	R0	K8
-      0x88240502,  //  0015  GETMBR	R9	R2	K2
-      0x88280503,  //  0016  GETMBR	R10	R2	K3
+      0x90061003,  //  0013  SETMBR	R1	K8	R3
+      0x8C1C0161,  //  0014  GETMET	R7	R0	K97
+      0x88240503,  //  0015  GETMBR	R9	R2	K3
+      0x88280504,  //  0016  GETMBR	R10	R2	K4
       0x7C1C0600,  //  0017  CALL	R7	3
       0x501C0200,  //  0018  LDBOOL	R7	1	0
       0x80040E00,  //  0019  RET	1	R7
       0x70020004,  //  001A  JMP		#0020
-      0xB81E0000,  //  001B  GETNGBL	R7	K0
-      0x881C0F0A,  //  001C  GETMBR	R7	R7	K10
-      0x900A1207,  //  001D  SETMBR	R2	K9	R7
+      0xB81E0200,  //  001B  GETNGBL	R7	K1
+      0x881C0F63,  //  001C  GETMBR	R7	R7	K99
+      0x900AC407,  //  001D  SETMBR	R2	K98	R7
       0x501C0000,  //  001E  LDBOOL	R7	0	0
       0x80040E00,  //  001F  RET	1	R7
       0x70020041,  //  0020  JMP		#0063
       0x541E001E,  //  0021  LDINT	R7	31
       0x1C1C0A07,  //  0022  EQ	R7	R5	R7
       0x781E0004,  //  0023  JMPF	R7	#0029
-      0x1C1C0D04,  //  0024  EQ	R7	R6	K4
+      0x1C1C0D05,  //  0024  EQ	R7	R6	K5
       0x781E0001,  //  0025  JMPF	R7	#0028
       0x501C0200,  //  0026  LDBOOL	R7	1	0
       0x80040E00,  //  0027  RET	1	R7
@@ -1142,7 +1208,7 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
       0x541E0029,  //  0038  LDINT	R7	42
       0x1C1C0A07,  //  0039  EQ	R7	R5	R7
       0x781E0004,  //  003A  JMPF	R7	#0040
-      0x1C1C0D04,  //  003B  EQ	R7	R6	K4
+      0x1C1C0D05,  //  003B  EQ	R7	R6	K5
       0x781E0001,  //  003C  JMPF	R7	#003F
       0x501C0200,  //  003D  LDBOOL	R7	1	0
       0x80040E00,  //  003E  RET	1	R7
@@ -1150,23 +1216,23 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
       0x541E002A,  //  0040  LDINT	R7	43
       0x1C1C0A07,  //  0041  EQ	R7	R5	R7
       0x781E0007,  //  0042  JMPF	R7	#004B
-      0x1C1C0D04,  //  0043  EQ	R7	R6	K4
+      0x1C1C0D05,  //  0043  EQ	R7	R6	K5
       0x781E0004,  //  0044  JMPF	R7	#004A
-      0xB81E0000,  //  0045  GETNGBL	R7	K0
-      0x881C0F0A,  //  0046  GETMBR	R7	R7	K10
-      0x900A1207,  //  0047  SETMBR	R2	K9	R7
+      0xB81E0200,  //  0045  GETNGBL	R7	K1
+      0x881C0F63,  //  0046  GETMBR	R7	R7	K99
+      0x900AC407,  //  0047  SETMBR	R2	K98	R7
       0x501C0000,  //  0048  LDBOOL	R7	0	0
       0x80040E00,  //  0049  RET	1	R7
       0x70020017,  //  004A  JMP		#0063
       0x541E002B,  //  004B  LDINT	R7	44
       0x1C1C0A07,  //  004C  EQ	R7	R5	R7
       0x781E0009,  //  004D  JMPF	R7	#0058
-      0x1C1C0D04,  //  004E  EQ	R7	R6	K4
+      0x1C1C0D05,  //  004E  EQ	R7	R6	K5
       0x781E0002,  //  004F  JMPF	R7	#0053
       0x501C0200,  //  0050  LDBOOL	R7	1	0
       0x80040E00,  //  0051  RET	1	R7
       0x70020003,  //  0052  JMP		#0057
-      0x1C1C0D0B,  //  0053  EQ	R7	R6	K11
+      0x1C1C0D09,  //  0053  EQ	R7	R6	K9
       0x781E0001,  //  0054  JMPF	R7	#0057
       0x501C0200,  //  0055  LDBOOL	R7	1	0
       0x80040E00,  //  0056  RET	1	R7
@@ -1177,9 +1243,9 @@ be_local_closure(class_Matter_Plugin_Root_write_attribute,   /* name */
       0x541E0003,  //  005B  LDINT	R7	4
       0x1C1C0C07,  //  005C  EQ	R7	R6	R7
       0x781E0004,  //  005D  JMPF	R7	#0063
-      0xB81E0000,  //  005E  GETNGBL	R7	K0
-      0x881C0F0C,  //  005F  GETMBR	R7	R7	K12
-      0x900A1207,  //  0060  SETMBR	R2	K9	R7
+      0xB81E0200,  //  005E  GETNGBL	R7	K1
+      0x881C0F64,  //  005F  GETMBR	R7	R7	K100
+      0x900AC407,  //  0060  SETMBR	R2	K98	R7
       0x501C0000,  //  0061  LDBOOL	R7	0	0
       0x80040E00,  //  0062  RET	1	R7
       0x80000000,  //  0063  RET	0
@@ -1196,71 +1262,56 @@ be_local_closure(class_Matter_Plugin_Root_init,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(publish_event),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(EVENT_CRITICAL),
-    /* K5   */  be_nested_str_weak(TLV),
-    /* K6   */  be_nested_str_weak(Matter_TLV_item),
-    /* K7   */  be_nested_str_weak(set),
-    /* K8   */  be_nested_str_weak(U4),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(version),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Root,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100965,  //  0003  GETMET	R4	R4	K101
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x8C100166,  //  0008  GETMET	R4	R0	K102
       0x541A0027,  //  0009  LDINT	R6	40
-      0x581C0002,  //  000A  LDCONST	R7	K2
-      0xB8220600,  //  000B  GETNGBL	R8	K3
-      0x88201104,  //  000C  GETMBR	R8	R8	K4
-      0xB8260600,  //  000D  GETNGBL	R9	K3
-      0x88241305,  //  000E  GETMBR	R9	R9	K5
-      0x8C241306,  //  000F  GETMET	R9	R9	K6
+      0x581C0005,  //  000A  LDCONST	R7	K5
+      0xB8220200,  //  000B  GETNGBL	R8	K1
+      0x88201167,  //  000C  GETMBR	R8	R8	K103
+      0xB8260200,  //  000D  GETNGBL	R9	K1
+      0x88241302,  //  000E  GETMBR	R9	R9	K2
+      0x8C241368,  //  000F  GETMET	R9	R9	K104
       0x7C240200,  //  0010  CALL	R9	1
-      0x8C241307,  //  0011  GETMET	R9	R9	K7
-      0xB82E0600,  //  0012  GETNGBL	R11	K3
-      0x882C1705,  //  0013  GETMBR	R11	R11	K5
-      0x882C1708,  //  0014  GETMBR	R11	R11	K8
-      0xB8321200,  //  0015  GETNGBL	R12	K9
-      0x8C30190A,  //  0016  GETMET	R12	R12	K10
+      0x8C241306,  //  0011  GETMET	R9	R9	K6
+      0xB82E0200,  //  0012  GETNGBL	R11	K1
+      0x882C1702,  //  0013  GETMBR	R11	R11	K2
+      0x882C172A,  //  0014  GETMBR	R11	R11	K42
+      0xB8322400,  //  0015  GETNGBL	R12	K18
+      0x8C301957,  //  0016  GETMET	R12	R12	K87
       0x7C300200,  //  0017  CALL	R12	1
       0x7C240600,  //  0018  CALL	R9	3
       0x7C100A00,  //  0019  CALL	R4	5
-      0x8C100101,  //  001A  GETMET	R4	R0	K1
+      0x8C100166,  //  001A  GETMET	R4	R0	K102
       0x541A0032,  //  001B  LDINT	R6	51
-      0x581C000B,  //  001C  LDCONST	R7	K11
-      0xB8220600,  //  001D  GETNGBL	R8	K3
-      0x88201104,  //  001E  GETMBR	R8	R8	K4
-      0xB8260600,  //  001F  GETNGBL	R9	K3
-      0x88241305,  //  0020  GETMBR	R9	R9	K5
-      0x8C241306,  //  0021  GETMET	R9	R9	K6
+      0x581C000F,  //  001C  LDCONST	R7	K15
+      0xB8220200,  //  001D  GETNGBL	R8	K1
+      0x88201167,  //  001E  GETMBR	R8	R8	K103
+      0xB8260200,  //  001F  GETNGBL	R9	K1
+      0x88241302,  //  0020  GETMBR	R9	R9	K2
+      0x8C241368,  //  0021  GETMET	R9	R9	K104
       0x7C240200,  //  0022  CALL	R9	1
-      0x8C241307,  //  0023  GETMET	R9	R9	K7
-      0xB82E0600,  //  0024  GETNGBL	R11	K3
-      0x882C1705,  //  0025  GETMBR	R11	R11	K5
-      0x882C170C,  //  0026  GETMBR	R11	R11	K12
-      0x5830000D,  //  0027  LDCONST	R12	K13
+      0x8C241306,  //  0023  GETMET	R9	R9	K6
+      0xB82E0200,  //  0024  GETNGBL	R11	K1
+      0x882C1702,  //  0025  GETMBR	R11	R11	K2
+      0x882C170E,  //  0026  GETMBR	R11	R11	K14
+      0x58300009,  //  0027  LDCONST	R12	K9
       0x7C240600,  //  0028  CALL	R9	3
       0x7C100A00,  //  0029  CALL	R4	5
       0x80000000,  //  002A  RET	0
@@ -1277,7 +1328,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
   be_nested_proto(
     31,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1311,252 +1362,149 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[102]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(findsubval),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(_breadcrumb),
-    /* K9   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K10  */  be_nested_str_weak(add_TLV),
-    /* K11  */  be_nested_str_weak(U1),
-    /* K12  */  be_nested_str_weak(UTF1),
-    /* K13  */  be_nested_str_weak(),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(XX),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(ack_request),
-    /* K18  */  be_nested_str_weak(_fabric),
-    /* K19  */  be_nested_str_weak(fabric_completed),
-    /* K20  */  be_nested_str_weak(set_no_expiration),
-    /* K21  */  be_nested_str_weak(save),
-    /* K22  */  be_nested_str_weak(device),
-    /* K23  */  be_nested_str_weak(start_commissioning_complete_deferred),
-    /* K24  */  be_nested_str_weak(context_error),
-    /* K25  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
-    /* K26  */  be_nested_str_weak(status),
-    /* K27  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K28  */  be_nested_str_weak(B2),
-    /* K29  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
-    /* K30  */  be_nested_str_weak(PAI_Cert_FFF1),
-    /* K31  */  be_nested_str_weak(CD_FFF1_8000),
-    /* K32  */  be_nested_str_weak(B1),
-    /* K33  */  be_nested_str_weak(U4),
-    /* K34  */  be_nested_str_weak(tasmota),
-    /* K35  */  be_nested_str_weak(rtc_utc),
-    /* K36  */  be_nested_str_weak(tlv2raw),
-    /* K37  */  be_nested_str_weak(get_ac),
-    /* K38  */  be_nested_str_weak(EC_P256),
-    /* K39  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K40  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
-    /* K41  */  be_nested_str_weak(gen_CSR),
-    /* K42  */  be_nested_str_weak(set_temp_ca),
-    /* K43  */  be_nested_str_weak(SUCCESS),
-    /* K44  */  be_nested_str_weak(log),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
-    /* K46  */  be_nested_str_weak(get_temp_ca),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
-    /* K48  */  be_nested_str_weak(sessions),
-    /* K49  */  be_nested_str_weak(create_fabric),
-    /* K50  */  be_nested_str_weak(set_ca),
-    /* K51  */  be_nested_str_weak(set_noc_icac),
-    /* K52  */  be_nested_str_weak(set_ipk_epoch_key),
-    /* K53  */  be_nested_str_weak(set_admin_subject_vendor),
-    /* K54  */  be_nested_str_weak(set_pk),
-    /* K55  */  be_nested_str_weak(get_pk),
-    /* K56  */  be_nested_str_weak(parse),
-    /* K57  */  be_nested_str_weak(findsub),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
-    /* K59  */  be_nested_str_weak(int),
-    /* K60  */  be_nested_str_weak(int64),
-    /* K61  */  be_nested_str_weak(fromu32),
-    /* K62  */  be_nested_str_weak(tobytes),
-    /* K63  */  be_nested_str_weak(get_temp_ca_pub),
-    /* K64  */  be_const_int(2147483647),
-    /* K65  */  be_nested_str_weak(fromstring),
-    /* K66  */  be_nested_str_weak(CompressedFabric),
-    /* K67  */  be_nested_str_weak(HKDF_SHA256),
-    /* K68  */  be_nested_str_weak(copy),
-    /* K69  */  be_nested_str_weak(reverse),
-    /* K70  */  be_nested_str_weak(derive),
-    /* K71  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K72  */  be_nested_str_weak(set_fabric_device),
-    /* K73  */  be_nested_str_weak(fabric_candidate),
-    /* K74  */  be_nested_str_weak(start_operational_discovery_deferred),
-    /* K75  */  be_nested_str_weak(is_PASE),
-    /* K76  */  be_nested_str_weak(set_expire_in_seconds),
-    /* K77  */  be_nested_str_weak(log_new_fabric),
-    /* K78  */  be_nested_str_weak(assign_fabric_index),
-    /* K79  */  be_nested_str_weak(get_fabric_index),
-    /* K80  */  be_nested_str_weak(set_fabric_label),
-    /* K81  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
-    /* K82  */  be_nested_str_weak(get_fabric_id),
-    /* K83  */  be_nested_str_weak(tohex),
-    /* K84  */  be_nested_str_weak(get_fabric),
-    /* K85  */  be_nested_str_weak(fabric_index_X3A),
-    /* K86  */  be_nested_str_weak(active_fabrics),
-    /* K87  */  be_nested_str_weak(mark_for_deletion),
-    /* K88  */  be_nested_str_weak(set_timer),
-    /* K89  */  be_nested_str_weak(stop_iteration),
-    /* K90  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K91  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K92  */  be_nested_str_weak(INVALID_ACTION),
-    /* K93  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K94  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K95  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K96  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K97  */  be_nested_str_weak(start_basic_commissioning),
-    /* K98  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K99  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K100 */  be_nested_str_weak(stop_basic_commissioning),
-    /* K101 */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Root,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[737]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xA412D200,  //  0000  IMPORT	R4	K105
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0x881C076A,  //  0004  GETMBR	R7	R3	K106
       0x5422002F,  //  0005  LDINT	R8	48
       0x1C200C08,  //  0006  EQ	R8	R6	R8
       0x7822005C,  //  0007  JMPF	R8	#0065
       0x1C200F05,  //  0008  EQ	R8	R7	K5
       0x78220017,  //  0009  JMPF	R8	#0022
-      0x8C200506,  //  000A  GETMET	R8	R2	K6
+      0x8C200541,  //  000A  GETMET	R8	R2	K65
       0x58280005,  //  000B  LDCONST	R10	K5
       0x542E0383,  //  000C  LDINT	R11	900
       0x7C200600,  //  000D  CALL	R8	3
-      0x8C240506,  //  000E  GETMET	R9	R2	K6
-      0x582C0007,  //  000F  LDCONST	R11	K7
+      0x8C240541,  //  000E  GETMET	R9	R2	K65
+      0x582C0009,  //  000F  LDCONST	R11	K9
       0x58300005,  //  0010  LDCONST	R12	K5
       0x7C240600,  //  0011  CALL	R9	3
       0x90061009,  //  0012  SETMBR	R1	K8	R9
-      0x8C280B09,  //  0013  GETMET	R10	R5	K9
+      0x8C280B0A,  //  0013  GETMET	R10	R5	K10
       0x7C280200,  //  0014  CALL	R10	1
-      0x8C2C150A,  //  0015  GETMET	R11	R10	K10
+      0x8C2C150B,  //  0015  GETMET	R11	R10	K11
       0x58340005,  //  0016  LDCONST	R13	K5
-      0x88380B0B,  //  0017  GETMBR	R14	R5	K11
+      0x88380B0E,  //  0017  GETMBR	R14	R5	K14
       0x583C0005,  //  0018  LDCONST	R15	K5
       0x7C2C0800,  //  0019  CALL	R11	4
-      0x8C2C150A,  //  001A  GETMET	R11	R10	K10
-      0x58340007,  //  001B  LDCONST	R13	K7
-      0x88380B0C,  //  001C  GETMBR	R14	R5	K12
-      0x583C000D,  //  001D  LDCONST	R15	K13
+      0x8C2C150B,  //  001A  GETMET	R11	R10	K11
+      0x58340009,  //  001B  LDCONST	R13	K9
+      0x88380B16,  //  001C  GETMBR	R14	R5	K22
+      0x583C001D,  //  001D  LDCONST	R15	K29
       0x7C2C0800,  //  001E  CALL	R11	4
-      0x900E0907,  //  001F  SETMBR	R3	K4	K7
+      0x900ED509,  //  001F  SETMBR	R3	K106	K9
       0x80041400,  //  0020  RET	1	R10
       0x70020041,  //  0021  JMP		#0064
-      0x1C200F0E,  //  0022  EQ	R8	R7	K14
+      0x1C200F0D,  //  0022  EQ	R8	R7	K13
       0x7822001A,  //  0023  JMPF	R8	#003F
-      0x8C200506,  //  0024  GETMET	R8	R2	K6
+      0x8C200541,  //  0024  GETMET	R8	R2	K65
       0x58280005,  //  0025  LDCONST	R10	K5
       0x7C200400,  //  0026  CALL	R8	2
-      0x8C240506,  //  0027  GETMET	R9	R2	K6
-      0x582C0007,  //  0028  LDCONST	R11	K7
-      0x5830000F,  //  0029  LDCONST	R12	K15
+      0x8C240541,  //  0027  GETMET	R9	R2	K65
+      0x582C0009,  //  0028  LDCONST	R11	K9
+      0x58300053,  //  0029  LDCONST	R12	K83
       0x7C240600,  //  002A  CALL	R9	3
-      0x8C280506,  //  002B  GETMET	R10	R2	K6
-      0x5830000E,  //  002C  LDCONST	R12	K14
+      0x8C280541,  //  002B  GETMET	R10	R2	K65
+      0x5830000D,  //  002C  LDCONST	R12	K13
       0x58340005,  //  002D  LDCONST	R13	K5
       0x7C280600,  //  002E  CALL	R10	3
       0x9006100A,  //  002F  SETMBR	R1	K8	R10
-      0x8C2C0B09,  //  0030  GETMET	R11	R5	K9
+      0x8C2C0B0A,  //  0030  GETMET	R11	R5	K10
       0x7C2C0200,  //  0031  CALL	R11	1
-      0x8C30170A,  //  0032  GETMET	R12	R11	K10
+      0x8C30170B,  //  0032  GETMET	R12	R11	K11
       0x58380005,  //  0033  LDCONST	R14	K5
-      0x883C0B0B,  //  0034  GETMBR	R15	R5	K11
+      0x883C0B0E,  //  0034  GETMBR	R15	R5	K14
       0x58400005,  //  0035  LDCONST	R16	K5
       0x7C300800,  //  0036  CALL	R12	4
-      0x8C30170A,  //  0037  GETMET	R12	R11	K10
-      0x58380007,  //  0038  LDCONST	R14	K7
-      0x883C0B0C,  //  0039  GETMBR	R15	R5	K12
-      0x5840000D,  //  003A  LDCONST	R16	K13
+      0x8C30170B,  //  0037  GETMET	R12	R11	K11
+      0x58380009,  //  0038  LDCONST	R14	K9
+      0x883C0B16,  //  0039  GETMBR	R15	R5	K22
+      0x5840001D,  //  003A  LDCONST	R16	K29
       0x7C300800,  //  003B  CALL	R12	4
-      0x900E0910,  //  003C  SETMBR	R3	K4	K16
+      0x900ED56B,  //  003C  SETMBR	R3	K106	K107
       0x80041600,  //  003D  RET	1	R11
       0x70020024,  //  003E  JMP		#0064
       0x54220003,  //  003F  LDINT	R8	4
       0x1C200E08,  //  0040  EQ	R8	R7	R8
       0x78220021,  //  0041  JMPF	R8	#0064
-      0x8C200111,  //  0042  GETMET	R8	R0	K17
+      0x8C200133,  //  0042  GETMET	R8	R0	K51
       0x5C280600,  //  0043  MOVE	R10	R3
       0x7C200400,  //  0044  CALL	R8	2
-      0x88200312,  //  0045  GETMBR	R8	R1	K18
+      0x88200349,  //  0045  GETMBR	R8	R1	K73
       0x7822001B,  //  0046  JMPF	R8	#0063
       0x90061105,  //  0047  SETMBR	R1	K8	K5
-      0x88200312,  //  0048  GETMBR	R8	R1	K18
-      0x8C201113,  //  0049  GETMET	R8	R8	K19
+      0x88200349,  //  0048  GETMBR	R8	R1	K73
+      0x8C20116C,  //  0049  GETMET	R8	R8	K108
       0x7C200200,  //  004A  CALL	R8	1
-      0x8C200314,  //  004B  GETMET	R8	R1	K20
+      0x8C20036D,  //  004B  GETMET	R8	R1	K109
       0x7C200200,  //  004C  CALL	R8	1
-      0x8C200315,  //  004D  GETMET	R8	R1	K21
+      0x8C20036E,  //  004D  GETMET	R8	R1	K110
       0x7C200200,  //  004E  CALL	R8	1
-      0x8C200B09,  //  004F  GETMET	R8	R5	K9
+      0x8C200B0A,  //  004F  GETMET	R8	R5	K10
       0x7C200200,  //  0050  CALL	R8	1
-      0x8C24110A,  //  0051  GETMET	R9	R8	K10
+      0x8C24110B,  //  0051  GETMET	R9	R8	K11
       0x582C0005,  //  0052  LDCONST	R11	K5
-      0x88300B0B,  //  0053  GETMBR	R12	R5	K11
+      0x88300B0E,  //  0053  GETMBR	R12	R5	K14
       0x58340005,  //  0054  LDCONST	R13	K5
       0x7C240800,  //  0055  CALL	R9	4
-      0x8C24110A,  //  0056  GETMET	R9	R8	K10
-      0x582C0007,  //  0057  LDCONST	R11	K7
-      0x88300B0C,  //  0058  GETMBR	R12	R5	K12
-      0x5834000D,  //  0059  LDCONST	R13	K13
+      0x8C24110B,  //  0056  GETMET	R9	R8	K11
+      0x582C0009,  //  0057  LDCONST	R11	K9
+      0x88300B16,  //  0058  GETMBR	R12	R5	K22
+      0x5834001D,  //  0059  LDCONST	R13	K29
       0x7C240800,  //  005A  CALL	R9	4
       0x54260004,  //  005B  LDINT	R9	5
-      0x900E0809,  //  005C  SETMBR	R3	K4	R9
-      0x88240116,  //  005D  GETMBR	R9	R0	K22
-      0x8C241317,  //  005E  GETMET	R9	R9	K23
+      0x900ED409,  //  005C  SETMBR	R3	K106	R9
+      0x88240136,  //  005D  GETMBR	R9	R0	K54
+      0x8C24136F,  //  005E  GETMET	R9	R9	K111
       0x5C2C0200,  //  005F  MOVE	R11	R1
       0x7C240400,  //  0060  CALL	R9	2
       0x80041000,  //  0061  RET	1	R8
       0x70020000,  //  0062  JMP		#0064
-      0xB0063119,  //  0063  RAISE	1	K24	K25
+      0xB006E171,  //  0063  RAISE	1	K112	K113
       0x70020279,  //  0064  JMP		#02DF
       0x5422003D,  //  0065  LDINT	R8	62
       0x1C200C08,  //  0066  EQ	R8	R6	R8
       0x782201DD,  //  0067  JMPF	R8	#0246
-      0x1C200F0E,  //  0068  EQ	R8	R7	K14
+      0x1C200F0D,  //  0068  EQ	R8	R7	K13
       0x7822001D,  //  0069  JMPF	R8	#0088
-      0x8C200506,  //  006A  GETMET	R8	R2	K6
+      0x8C200541,  //  006A  GETMET	R8	R2	K65
       0x58280005,  //  006B  LDCONST	R10	K5
       0x7C200400,  //  006C  CALL	R8	2
-      0x20241107,  //  006D  NE	R9	R8	K7
+      0x20241109,  //  006D  NE	R9	R8	K9
       0x78260006,  //  006E  JMPF	R9	#0076
-      0x2024110E,  //  006F  NE	R9	R8	K14
+      0x2024110D,  //  006F  NE	R9	R8	K13
       0x78260004,  //  0070  JMPF	R9	#0076
       0xB8260200,  //  0071  GETNGBL	R9	K1
-      0x8824131B,  //  0072  GETMBR	R9	R9	K27
-      0x900E3409,  //  0073  SETMBR	R3	K26	R9
+      0x88241372,  //  0072  GETMBR	R9	R9	K114
+      0x900EC409,  //  0073  SETMBR	R3	K98	R9
       0x4C240000,  //  0074  LDNIL	R9
       0x80041200,  //  0075  RET	1	R9
-      0x8C240B09,  //  0076  GETMET	R9	R5	K9
+      0x8C240B0A,  //  0076  GETMET	R9	R5	K10
       0x7C240200,  //  0077  CALL	R9	1
-      0x8C28130A,  //  0078  GETMET	R10	R9	K10
+      0x8C28130B,  //  0078  GETMET	R10	R9	K11
       0x58300005,  //  0079  LDCONST	R12	K5
-      0x88340B1C,  //  007A  GETMBR	R13	R5	K28
-      0x1C381107,  //  007B  EQ	R14	R8	K7
+      0x88340B3A,  //  007A  GETMBR	R13	R5	K58
+      0x1C381109,  //  007B  EQ	R14	R8	K9
       0x783A0003,  //  007C  JMPF	R14	#0081
       0xB83A0200,  //  007D  GETNGBL	R14	K1
-      0x8C381D1D,  //  007E  GETMET	R14	R14	K29
+      0x8C381D73,  //  007E  GETMET	R14	R14	K115
       0x7C380200,  //  007F  CALL	R14	1
       0x70020002,  //  0080  JMP		#0084
       0xB83A0200,  //  0081  GETNGBL	R14	K1
-      0x8C381D1E,  //  0082  GETMET	R14	R14	K30
+      0x8C381D74,  //  0082  GETMET	R14	R14	K116
       0x7C380200,  //  0083  CALL	R14	1
       0x7C280800,  //  0084  CALL	R10	4
-      0x900E0910,  //  0085  SETMBR	R3	K4	K16
+      0x900ED56B,  //  0085  SETMBR	R3	K106	K107
       0x80041200,  //  0086  RET	1	R9
       0x700201BC,  //  0087  JMP		#0245
       0x1C200F05,  //  0088  EQ	R8	R7	K5
       0x7822003C,  //  0089  JMPF	R8	#00C7
-      0x8C200506,  //  008A  GETMET	R8	R2	K6
+      0x8C200541,  //  008A  GETMET	R8	R2	K65
       0x58280005,  //  008B  LDCONST	R10	K5
       0x7C200400,  //  008C  CALL	R8	2
       0x6024000C,  //  008D  GETGBL	R9	G12
@@ -1567,63 +1515,63 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x78260001,  //  0092  JMPF	R9	#0095
       0x4C240000,  //  0093  LDNIL	R9
       0x80041200,  //  0094  RET	1	R9
-      0x900E0907,  //  0095  SETMBR	R3	K4	K7
-      0x8C240B09,  //  0096  GETMET	R9	R5	K9
+      0x900ED509,  //  0095  SETMBR	R3	K106	K9
+      0x8C240B0A,  //  0096  GETMET	R9	R5	K10
       0x7C240200,  //  0097  CALL	R9	1
-      0x8C28130A,  //  0098  GETMET	R10	R9	K10
-      0x58300007,  //  0099  LDCONST	R12	K7
-      0x88340B1C,  //  009A  GETMBR	R13	R5	K28
+      0x8C28130B,  //  0098  GETMET	R10	R9	K11
+      0x58300009,  //  0099  LDCONST	R12	K9
+      0x88340B3A,  //  009A  GETMBR	R13	R5	K58
       0xB83A0200,  //  009B  GETNGBL	R14	K1
-      0x8C381D1F,  //  009C  GETMET	R14	R14	K31
+      0x8C381D75,  //  009C  GETMET	R14	R14	K117
       0x7C380200,  //  009D  CALL	R14	1
       0x7C280800,  //  009E  CALL	R10	4
-      0x8C28130A,  //  009F  GETMET	R10	R9	K10
-      0x5830000E,  //  00A0  LDCONST	R12	K14
-      0x88340B20,  //  00A1  GETMBR	R13	R5	K32
+      0x8C28130B,  //  009F  GETMET	R10	R9	K11
+      0x5830000D,  //  00A0  LDCONST	R12	K13
+      0x88340B1F,  //  00A1  GETMBR	R13	R5	K31
       0x5C381000,  //  00A2  MOVE	R14	R8
       0x7C280800,  //  00A3  CALL	R10	4
-      0x8C28130A,  //  00A4  GETMET	R10	R9	K10
-      0x58300010,  //  00A5  LDCONST	R12	K16
-      0x88340B21,  //  00A6  GETMBR	R13	R5	K33
-      0xB83A4400,  //  00A7  GETNGBL	R14	K34
-      0x8C381D23,  //  00A8  GETMET	R14	R14	K35
+      0x8C28130B,  //  00A4  GETMET	R10	R9	K11
+      0x5830006B,  //  00A5  LDCONST	R12	K107
+      0x88340B2A,  //  00A6  GETMBR	R13	R5	K42
+      0xB83A2400,  //  00A7  GETNGBL	R14	K18
+      0x8C381D2F,  //  00A8  GETMET	R14	R14	K47
       0x7C380200,  //  00A9  CALL	R14	1
       0x7C280800,  //  00AA  CALL	R10	4
-      0x8C281324,  //  00AB  GETMET	R10	R9	K36
+      0x8C281376,  //  00AB  GETMET	R10	R9	K118
       0x7C280200,  //  00AC  CALL	R10	1
-      0x8C2C0325,  //  00AD  GETMET	R11	R1	K37
+      0x8C2C0377,  //  00AD  GETMET	R11	R1	K119
       0x7C2C0200,  //  00AE  CALL	R11	1
       0x0030140B,  //  00AF  ADD	R12	R10	R11
-      0x8C340926,  //  00B0  GETMET	R13	R4	K38
+      0x8C340978,  //  00B0  GETMET	R13	R4	K120
       0x7C340200,  //  00B1  CALL	R13	1
-      0x8C341B27,  //  00B2  GETMET	R13	R13	K39
+      0x8C341B79,  //  00B2  GETMET	R13	R13	K121
       0xB83E0200,  //  00B3  GETNGBL	R15	K1
-      0x8C3C1F28,  //  00B4  GETMET	R15	R15	K40
+      0x8C3C1F7A,  //  00B4  GETMET	R15	R15	K122
       0x7C3C0200,  //  00B5  CALL	R15	1
       0x5C401800,  //  00B6  MOVE	R16	R12
       0x7C340600,  //  00B7  CALL	R13	3
-      0x8C380B09,  //  00B8  GETMET	R14	R5	K9
+      0x8C380B0A,  //  00B8  GETMET	R14	R5	K10
       0x7C380200,  //  00B9  CALL	R14	1
-      0x8C3C1D0A,  //  00BA  GETMET	R15	R14	K10
+      0x8C3C1D0B,  //  00BA  GETMET	R15	R14	K11
       0x58440005,  //  00BB  LDCONST	R17	K5
-      0x88480B1C,  //  00BC  GETMBR	R18	R5	K28
+      0x88480B3A,  //  00BC  GETMBR	R18	R5	K58
       0x5C4C1400,  //  00BD  MOVE	R19	R10
       0x7C3C0800,  //  00BE  CALL	R15	4
-      0x8C3C1D0A,  //  00BF  GETMET	R15	R14	K10
-      0x58440007,  //  00C0  LDCONST	R17	K7
-      0x88480B20,  //  00C1  GETMBR	R18	R5	K32
+      0x8C3C1D0B,  //  00BF  GETMET	R15	R14	K11
+      0x58440009,  //  00C0  LDCONST	R17	K9
+      0x88480B1F,  //  00C1  GETMBR	R18	R5	K31
       0x5C4C1A00,  //  00C2  MOVE	R19	R13
       0x7C3C0800,  //  00C3  CALL	R15	4
-      0x900E0907,  //  00C4  SETMBR	R3	K4	K7
+      0x900ED509,  //  00C4  SETMBR	R3	K106	K9
       0x80041C00,  //  00C5  RET	1	R14
       0x7002017D,  //  00C6  JMP		#0245
       0x54220003,  //  00C7  LDINT	R8	4
       0x1C200E08,  //  00C8  EQ	R8	R7	R8
       0x7822003C,  //  00C9  JMPF	R8	#0107
-      0x8C200111,  //  00CA  GETMET	R8	R0	K17
+      0x8C200133,  //  00CA  GETMET	R8	R0	K51
       0x5C280600,  //  00CB  MOVE	R10	R3
       0x7C200400,  //  00CC  CALL	R8	2
-      0x8C200506,  //  00CD  GETMET	R8	R2	K6
+      0x8C200541,  //  00CD  GETMET	R8	R2	K65
       0x58280005,  //  00CE  LDCONST	R10	K5
       0x7C200400,  //  00CF  CALL	R8	2
       0x6024000C,  //  00D0  GETGBL	R9	G12
@@ -1634,83 +1582,83 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x78260001,  //  00D5  JMPF	R9	#00D8
       0x4C240000,  //  00D6  LDNIL	R9
       0x80041200,  //  00D7  RET	1	R9
-      0x8C240506,  //  00D8  GETMET	R9	R2	K6
-      0x582C0007,  //  00D9  LDCONST	R11	K7
+      0x8C240541,  //  00D8  GETMET	R9	R2	K65
+      0x582C0009,  //  00D9  LDCONST	R11	K9
       0x50300000,  //  00DA  LDBOOL	R12	0	0
       0x7C240600,  //  00DB  CALL	R9	3
-      0x8C280329,  //  00DC  GETMET	R10	R1	K41
+      0x8C28037B,  //  00DC  GETMET	R10	R1	K123
       0x7C280200,  //  00DD  CALL	R10	1
-      0x8C2C0B09,  //  00DE  GETMET	R11	R5	K9
+      0x8C2C0B0A,  //  00DE  GETMET	R11	R5	K10
       0x7C2C0200,  //  00DF  CALL	R11	1
-      0x8C30170A,  //  00E0  GETMET	R12	R11	K10
-      0x58380007,  //  00E1  LDCONST	R14	K7
-      0x883C0B1C,  //  00E2  GETMBR	R15	R5	K28
+      0x8C30170B,  //  00E0  GETMET	R12	R11	K11
+      0x58380009,  //  00E1  LDCONST	R14	K9
+      0x883C0B3A,  //  00E2  GETMBR	R15	R5	K58
       0x5C401400,  //  00E3  MOVE	R16	R10
       0x7C300800,  //  00E4  CALL	R12	4
-      0x8C30170A,  //  00E5  GETMET	R12	R11	K10
-      0x5838000E,  //  00E6  LDCONST	R14	K14
-      0x883C0B20,  //  00E7  GETMBR	R15	R5	K32
+      0x8C30170B,  //  00E5  GETMET	R12	R11	K11
+      0x5838000D,  //  00E6  LDCONST	R14	K13
+      0x883C0B1F,  //  00E7  GETMBR	R15	R5	K31
       0x5C401000,  //  00E8  MOVE	R16	R8
       0x7C300800,  //  00E9  CALL	R12	4
-      0x8C301724,  //  00EA  GETMET	R12	R11	K36
+      0x8C301776,  //  00EA  GETMET	R12	R11	K118
       0x7C300200,  //  00EB  CALL	R12	1
-      0x8C340325,  //  00EC  GETMET	R13	R1	K37
+      0x8C340377,  //  00EC  GETMET	R13	R1	K119
       0x7C340200,  //  00ED  CALL	R13	1
       0x0034180D,  //  00EE  ADD	R13	R12	R13
-      0x8C380926,  //  00EF  GETMET	R14	R4	K38
+      0x8C380978,  //  00EF  GETMET	R14	R4	K120
       0x7C380200,  //  00F0  CALL	R14	1
-      0x8C381D27,  //  00F1  GETMET	R14	R14	K39
+      0x8C381D79,  //  00F1  GETMET	R14	R14	K121
       0xB8420200,  //  00F2  GETNGBL	R16	K1
-      0x8C402128,  //  00F3  GETMET	R16	R16	K40
+      0x8C40217A,  //  00F3  GETMET	R16	R16	K122
       0x7C400200,  //  00F4  CALL	R16	1
       0x5C441A00,  //  00F5  MOVE	R17	R13
       0x7C380600,  //  00F6  CALL	R14	3
-      0x8C3C0B09,  //  00F7  GETMET	R15	R5	K9
+      0x8C3C0B0A,  //  00F7  GETMET	R15	R5	K10
       0x7C3C0200,  //  00F8  CALL	R15	1
-      0x8C401F0A,  //  00F9  GETMET	R16	R15	K10
+      0x8C401F0B,  //  00F9  GETMET	R16	R15	K11
       0x58480005,  //  00FA  LDCONST	R18	K5
-      0x884C0B1C,  //  00FB  GETMBR	R19	R5	K28
+      0x884C0B3A,  //  00FB  GETMBR	R19	R5	K58
       0x5C501800,  //  00FC  MOVE	R20	R12
       0x7C400800,  //  00FD  CALL	R16	4
-      0x8C401F0A,  //  00FE  GETMET	R16	R15	K10
-      0x58480007,  //  00FF  LDCONST	R18	K7
-      0x884C0B20,  //  0100  GETMBR	R19	R5	K32
+      0x8C401F0B,  //  00FE  GETMET	R16	R15	K11
+      0x58480009,  //  00FF  LDCONST	R18	K9
+      0x884C0B1F,  //  0100  GETMBR	R19	R5	K31
       0x5C501C00,  //  0101  MOVE	R20	R14
       0x7C400800,  //  0102  CALL	R16	4
       0x54420004,  //  0103  LDINT	R16	5
-      0x900E0810,  //  0104  SETMBR	R3	K4	R16
+      0x900ED410,  //  0104  SETMBR	R3	K106	R16
       0x80041E00,  //  0105  RET	1	R15
       0x7002013D,  //  0106  JMP		#0245
       0x5422000A,  //  0107  LDINT	R8	11
       0x1C200E08,  //  0108  EQ	R8	R7	R8
       0x7822000B,  //  0109  JMPF	R8	#0116
-      0x8C200506,  //  010A  GETMET	R8	R2	K6
+      0x8C200541,  //  010A  GETMET	R8	R2	K65
       0x58280005,  //  010B  LDCONST	R10	K5
       0x7C200400,  //  010C  CALL	R8	2
-      0x8C24032A,  //  010D  GETMET	R9	R1	K42
+      0x8C24037C,  //  010D  GETMET	R9	R1	K124
       0x5C2C1000,  //  010E  MOVE	R11	R8
       0x7C240400,  //  010F  CALL	R9	2
       0xB8260200,  //  0110  GETNGBL	R9	K1
-      0x8824132B,  //  0111  GETMBR	R9	R9	K43
-      0x900E3409,  //  0112  SETMBR	R3	K26	R9
+      0x8824137D,  //  0111  GETMBR	R9	R9	K125
+      0x900EC409,  //  0112  SETMBR	R3	K98	R9
       0x4C240000,  //  0113  LDNIL	R9
       0x80041200,  //  0114  RET	1	R9
       0x7002012E,  //  0115  JMP		#0245
       0x54220005,  //  0116  LDINT	R8	6
       0x1C200E08,  //  0117  EQ	R8	R7	R8
       0x782200B8,  //  0118  JMPF	R8	#01D2
-      0xB8225800,  //  0119  GETNGBL	R8	K44
+      0xB822FC00,  //  0119  GETNGBL	R8	K126
       0x60240008,  //  011A  GETGBL	R9	G8
       0x5C280400,  //  011B  MOVE	R10	R2
       0x7C240200,  //  011C  CALL	R9	1
-      0x00265A09,  //  011D  ADD	R9	K45	R9
+      0x0026FE09,  //  011D  ADD	R9	K127	R9
       0x542A0003,  //  011E  LDINT	R10	4
       0x7C200400,  //  011F  CALL	R8	2
-      0x8C200506,  //  0120  GETMET	R8	R2	K6
+      0x8C200541,  //  0120  GETMET	R8	R2	K65
       0x58280005,  //  0121  LDCONST	R10	K5
       0x7C200400,  //  0122  CALL	R8	2
-      0x8C240506,  //  0123  GETMET	R9	R2	K6
-      0x582C0007,  //  0124  LDCONST	R11	K7
+      0x8C240541,  //  0123  GETMET	R9	R2	K65
+      0x582C0009,  //  0124  LDCONST	R11	K9
       0x7C240400,  //  0125  CALL	R9	2
       0x6028000C,  //  0126  GETGBL	R10	G12
       0x5C2C1200,  //  0127  MOVE	R11	R9
@@ -1718,284 +1666,284 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x1C281505,  //  0129  EQ	R10	R10	K5
       0x782A0000,  //  012A  JMPF	R10	#012C
       0x4C240000,  //  012B  LDNIL	R9
-      0x8C280506,  //  012C  GETMET	R10	R2	K6
-      0x5830000E,  //  012D  LDCONST	R12	K14
+      0x8C280541,  //  012C  GETMET	R10	R2	K65
+      0x5830000D,  //  012D  LDCONST	R12	K13
       0x7C280400,  //  012E  CALL	R10	2
-      0x8C2C0506,  //  012F  GETMET	R11	R2	K6
-      0x58340010,  //  0130  LDCONST	R13	K16
+      0x8C2C0541,  //  012F  GETMET	R11	R2	K65
+      0x5834006B,  //  0130  LDCONST	R13	K107
       0x7C2C0400,  //  0131  CALL	R11	2
-      0x8C300506,  //  0132  GETMET	R12	R2	K6
+      0x8C300541,  //  0132  GETMET	R12	R2	K65
       0x543A0003,  //  0133  LDINT	R14	4
       0x7C300400,  //  0134  CALL	R12	2
-      0x8C34032E,  //  0135  GETMET	R13	R1	K46
+      0x8C340380,  //  0135  GETMET	R13	R1	K128
       0x7C340200,  //  0136  CALL	R13	1
       0x4C380000,  //  0137  LDNIL	R14
       0x1C341A0E,  //  0138  EQ	R13	R13	R14
       0x78360005,  //  0139  JMPF	R13	#0140
-      0xB8365800,  //  013A  GETNGBL	R13	K44
-      0x5838002F,  //  013B  LDCONST	R14	K47
-      0x583C000E,  //  013C  LDCONST	R15	K14
+      0xB836FC00,  //  013A  GETNGBL	R13	K126
+      0x58380081,  //  013B  LDCONST	R14	K129
+      0x583C000D,  //  013C  LDCONST	R15	K13
       0x7C340400,  //  013D  CALL	R13	2
       0x4C340000,  //  013E  LDNIL	R13
       0x80041A00,  //  013F  RET	1	R13
-      0x88340116,  //  0140  GETMBR	R13	R0	K22
-      0x88341B30,  //  0141  GETMBR	R13	R13	K48
-      0x8C341B31,  //  0142  GETMET	R13	R13	K49
+      0x88340136,  //  0140  GETMBR	R13	R0	K54
+      0x88341B37,  //  0141  GETMBR	R13	R13	K55
+      0x8C341B82,  //  0142  GETMET	R13	R13	K130
       0x7C340200,  //  0143  CALL	R13	1
-      0x8C381B32,  //  0144  GETMET	R14	R13	K50
-      0x8C40032E,  //  0145  GETMET	R16	R1	K46
+      0x8C381B83,  //  0144  GETMET	R14	R13	K131
+      0x8C400380,  //  0145  GETMET	R16	R1	K128
       0x7C400200,  //  0146  CALL	R16	1
       0x7C380400,  //  0147  CALL	R14	2
-      0x8C381B33,  //  0148  GETMET	R14	R13	K51
+      0x8C381B84,  //  0148  GETMET	R14	R13	K132
       0x5C401000,  //  0149  MOVE	R16	R8
       0x5C441200,  //  014A  MOVE	R17	R9
       0x7C380600,  //  014B  CALL	R14	3
-      0x8C381B34,  //  014C  GETMET	R14	R13	K52
+      0x8C381B85,  //  014C  GETMET	R14	R13	K133
       0x5C401400,  //  014D  MOVE	R16	R10
       0x7C380400,  //  014E  CALL	R14	2
-      0x8C381B35,  //  014F  GETMET	R14	R13	K53
+      0x8C381B86,  //  014F  GETMET	R14	R13	K134
       0x5C401600,  //  0150  MOVE	R16	R11
       0x5C441800,  //  0151  MOVE	R17	R12
       0x7C380600,  //  0152  CALL	R14	3
-      0x8C381B36,  //  0153  GETMET	R14	R13	K54
-      0x8C400337,  //  0154  GETMET	R16	R1	K55
+      0x8C381B87,  //  0153  GETMET	R14	R13	K135
+      0x8C400388,  //  0154  GETMET	R16	R1	K136
       0x7C400200,  //  0155  CALL	R16	1
       0x7C380400,  //  0156  CALL	R14	2
       0xB83A0200,  //  0157  GETNGBL	R14	K1
       0x88381D02,  //  0158  GETMBR	R14	R14	K2
-      0x8C381D38,  //  0159  GETMET	R14	R14	K56
+      0x8C381D3F,  //  0159  GETMET	R14	R14	K63
       0x5C401000,  //  015A  MOVE	R16	R8
       0x7C380400,  //  015B  CALL	R14	2
-      0x8C3C1D39,  //  015C  GETMET	R15	R14	K57
+      0x8C3C1D89,  //  015C  GETMET	R15	R14	K137
       0x54460005,  //  015D  LDINT	R17	6
       0x7C3C0400,  //  015E  CALL	R15	2
-      0x8C401F06,  //  015F  GETMET	R16	R15	K6
+      0x8C401F41,  //  015F  GETMET	R16	R15	K65
       0x544A0014,  //  0160  LDINT	R18	21
       0x7C400400,  //  0161  CALL	R16	2
-      0x8C441F06,  //  0162  GETMET	R17	R15	K6
+      0x8C441F41,  //  0162  GETMET	R17	R15	K65
       0x544E0010,  //  0163  LDINT	R19	17
       0x7C440400,  //  0164  CALL	R17	2
       0x5C482000,  //  0165  MOVE	R18	R16
       0x784A0001,  //  0166  JMPF	R18	#0169
       0x5C482200,  //  0167  MOVE	R18	R17
       0x744A0005,  //  0168  JMPT	R18	#016F
-      0xB84A5800,  //  0169  GETNGBL	R18	K44
-      0x584C003A,  //  016A  LDCONST	R19	K58
-      0x5850000E,  //  016B  LDCONST	R20	K14
+      0xB84AFC00,  //  0169  GETNGBL	R18	K126
+      0x584C008A,  //  016A  LDCONST	R19	K138
+      0x5850000D,  //  016B  LDCONST	R20	K13
       0x7C480400,  //  016C  CALL	R18	2
       0x50480000,  //  016D  LDBOOL	R18	0	0
       0x80042400,  //  016E  RET	1	R18
       0x60480004,  //  016F  GETGBL	R18	G4
       0x5C4C2000,  //  0170  MOVE	R19	R16
       0x7C480200,  //  0171  CALL	R18	1
-      0x1C48253B,  //  0172  EQ	R18	R18	K59
+      0x1C482560,  //  0172  EQ	R18	R18	K96
       0x784A0007,  //  0173  JMPF	R18	#017C
-      0xB84A7800,  //  0174  GETNGBL	R18	K60
-      0x8C48253D,  //  0175  GETMET	R18	R18	K61
+      0xB84A5C00,  //  0174  GETNGBL	R18	K46
+      0x8C48258B,  //  0175  GETMET	R18	R18	K139
       0x5C502000,  //  0176  MOVE	R20	R16
       0x7C480400,  //  0177  CALL	R18	2
-      0x8C48253E,  //  0178  GETMET	R18	R18	K62
+      0x8C48258C,  //  0178  GETMET	R18	R18	K140
       0x7C480200,  //  0179  CALL	R18	1
       0x5C402400,  //  017A  MOVE	R16	R18
       0x70020002,  //  017B  JMP		#017F
-      0x8C48213E,  //  017C  GETMET	R18	R16	K62
+      0x8C48218C,  //  017C  GETMET	R18	R16	K140
       0x7C480200,  //  017D  CALL	R18	1
       0x5C402400,  //  017E  MOVE	R16	R18
       0x60480004,  //  017F  GETGBL	R18	G4
       0x5C4C2200,  //  0180  MOVE	R19	R17
       0x7C480200,  //  0181  CALL	R18	1
-      0x1C48253B,  //  0182  EQ	R18	R18	K59
+      0x1C482560,  //  0182  EQ	R18	R18	K96
       0x784A0007,  //  0183  JMPF	R18	#018C
-      0xB84A7800,  //  0184  GETNGBL	R18	K60
-      0x8C48253D,  //  0185  GETMET	R18	R18	K61
+      0xB84A5C00,  //  0184  GETNGBL	R18	K46
+      0x8C48258B,  //  0185  GETMET	R18	R18	K139
       0x5C502200,  //  0186  MOVE	R20	R17
       0x7C480400,  //  0187  CALL	R18	2
-      0x8C48253E,  //  0188  GETMET	R18	R18	K62
+      0x8C48258C,  //  0188  GETMET	R18	R18	K140
       0x7C480200,  //  0189  CALL	R18	1
       0x5C442400,  //  018A  MOVE	R17	R18
       0x70020002,  //  018B  JMP		#018F
-      0x8C48233E,  //  018C  GETMET	R18	R17	K62
+      0x8C48238C,  //  018C  GETMET	R18	R17	K140
       0x7C480200,  //  018D  CALL	R18	1
       0x5C442400,  //  018E  MOVE	R17	R18
-      0x8C48033F,  //  018F  GETMET	R18	R1	K63
+      0x8C48038D,  //  018F  GETMET	R18	R1	K141
       0x7C480200,  //  0190  CALL	R18	1
-      0x404E0F40,  //  0191  CONNECT	R19	K7	K64
+      0x404E138E,  //  0191  CONNECT	R19	K9	K142
       0x94482413,  //  0192  GETIDX	R18	R18	R19
       0x604C0015,  //  0193  GETGBL	R19	G21
       0x7C4C0000,  //  0194  CALL	R19	0
-      0x8C4C2741,  //  0195  GETMET	R19	R19	K65
-      0x58540042,  //  0196  LDCONST	R21	K66
+      0x8C4C278F,  //  0195  GETMET	R19	R19	K143
+      0x58540090,  //  0196  LDCONST	R21	K144
       0x7C4C0400,  //  0197  CALL	R19	2
-      0x8C500943,  //  0198  GETMET	R20	R4	K67
+      0x8C500991,  //  0198  GETMET	R20	R4	K145
       0x7C500200,  //  0199  CALL	R20	1
-      0x8C542144,  //  019A  GETMET	R21	R16	K68
+      0x8C542192,  //  019A  GETMET	R21	R16	K146
       0x7C540200,  //  019B  CALL	R21	1
-      0x8C542B45,  //  019C  GETMET	R21	R21	K69
+      0x8C542B93,  //  019C  GETMET	R21	R21	K147
       0x7C540200,  //  019D  CALL	R21	1
-      0x8C582946,  //  019E  GETMET	R22	R20	K70
+      0x8C582994,  //  019E  GETMET	R22	R20	K148
       0x5C602400,  //  019F  MOVE	R24	R18
       0x5C642A00,  //  01A0  MOVE	R25	R21
       0x5C682600,  //  01A1  MOVE	R26	R19
       0x546E0007,  //  01A2  LDINT	R27	8
       0x7C580A00,  //  01A3  CALL	R22	5
-      0x885C0312,  //  01A4  GETMBR	R23	R1	K18
+      0x885C0349,  //  01A4  GETMBR	R23	R1	K73
       0x785E0001,  //  01A5  JMPF	R23	#01A8
-      0x885C0312,  //  01A6  GETMBR	R23	R1	K18
+      0x885C0349,  //  01A6  GETMBR	R23	R1	K73
       0x70020001,  //  01A7  JMP		#01AA
-      0x885C0116,  //  01A8  GETMBR	R23	R0	K22
-      0x885C2F47,  //  01A9  GETMBR	R23	R23	K71
-      0x8C601B48,  //  01AA  GETMET	R24	R13	K72
+      0x885C0136,  //  01A8  GETMBR	R23	R0	K54
+      0x885C2F4C,  //  01A9  GETMBR	R23	R23	K76
+      0x8C601B95,  //  01AA  GETMET	R24	R13	K149
       0x5C682000,  //  01AB  MOVE	R26	R16
       0x5C6C2200,  //  01AC  MOVE	R27	R17
       0x5C702C00,  //  01AD  MOVE	R28	R22
       0x5C742E00,  //  01AE  MOVE	R29	R23
       0x7C600A00,  //  01AF  CALL	R24	5
-      0x8C601B49,  //  01B0  GETMET	R24	R13	K73
+      0x8C601B96,  //  01B0  GETMET	R24	R13	K150
       0x7C600200,  //  01B1  CALL	R24	1
-      0x88600116,  //  01B2  GETMBR	R24	R0	K22
-      0x8C60314A,  //  01B3  GETMET	R24	R24	K74
+      0x88600136,  //  01B2  GETMBR	R24	R0	K54
+      0x8C603197,  //  01B3  GETMET	R24	R24	K151
       0x5C681A00,  //  01B4  MOVE	R26	R13
       0x7C600400,  //  01B5  CALL	R24	2
-      0x8C60034B,  //  01B6  GETMET	R24	R1	K75
+      0x8C600398,  //  01B6  GETMET	R24	R1	K152
       0x7C600200,  //  01B7  CALL	R24	1
       0x78620002,  //  01B8  JMPF	R24	#01BC
-      0x8C60034C,  //  01B9  GETMET	R24	R1	K76
+      0x8C600399,  //  01B9  GETMET	R24	R1	K153
       0x546A003B,  //  01BA  LDINT	R26	60
       0x7C600400,  //  01BB  CALL	R24	2
-      0x8C601B4D,  //  01BC  GETMET	R24	R13	K77
+      0x8C601B9A,  //  01BC  GETMET	R24	R13	K154
       0x7C600200,  //  01BD  CALL	R24	1
-      0x8C601B4E,  //  01BE  GETMET	R24	R13	K78
+      0x8C601B9B,  //  01BE  GETMET	R24	R13	K155
       0x7C600200,  //  01BF  CALL	R24	1
-      0x8C600B09,  //  01C0  GETMET	R24	R5	K9
+      0x8C600B0A,  //  01C0  GETMET	R24	R5	K10
       0x7C600200,  //  01C1  CALL	R24	1
-      0x8C64310A,  //  01C2  GETMET	R25	R24	K10
+      0x8C64310B,  //  01C2  GETMET	R25	R24	K11
       0x586C0005,  //  01C3  LDCONST	R27	K5
-      0x88700B0B,  //  01C4  GETMBR	R28	R5	K11
+      0x88700B0E,  //  01C4  GETMBR	R28	R5	K14
       0xB8760200,  //  01C5  GETNGBL	R29	K1
-      0x88743B2B,  //  01C6  GETMBR	R29	R29	K43
+      0x88743B7D,  //  01C6  GETMBR	R29	R29	K125
       0x7C640800,  //  01C7  CALL	R25	4
-      0x8C64310A,  //  01C8  GETMET	R25	R24	K10
-      0x586C0007,  //  01C9  LDCONST	R27	K7
-      0x88700B0B,  //  01CA  GETMBR	R28	R5	K11
-      0x8C741B4F,  //  01CB  GETMET	R29	R13	K79
+      0x8C64310B,  //  01C8  GETMET	R25	R24	K11
+      0x586C0009,  //  01C9  LDCONST	R27	K9
+      0x88700B0E,  //  01CA  GETMBR	R28	R5	K14
+      0x8C741B3D,  //  01CB  GETMET	R29	R13	K61
       0x7C740200,  //  01CC  CALL	R29	1
       0x7C640800,  //  01CD  CALL	R25	4
       0x54660007,  //  01CE  LDINT	R25	8
-      0x900E0819,  //  01CF  SETMBR	R3	K4	R25
+      0x900ED419,  //  01CF  SETMBR	R3	K106	R25
       0x80043000,  //  01D0  RET	1	R24
       0x70020072,  //  01D1  JMP		#0245
       0x54220008,  //  01D2  LDINT	R8	9
       0x1C200E08,  //  01D3  EQ	R8	R7	R8
       0x7822002B,  //  01D4  JMPF	R8	#0201
-      0x8C200506,  //  01D5  GETMET	R8	R2	K6
+      0x8C200541,  //  01D5  GETMET	R8	R2	K65
       0x58280005,  //  01D6  LDCONST	R10	K5
       0x7C200400,  //  01D7  CALL	R8	2
-      0x8C240350,  //  01D8  GETMET	R9	R1	K80
+      0x8C24039C,  //  01D8  GETMET	R9	R1	K156
       0x5C2C1000,  //  01D9  MOVE	R11	R8
       0x7C240400,  //  01DA  CALL	R9	2
-      0xB8265800,  //  01DB  GETNGBL	R9	K44
+      0xB826FC00,  //  01DB  GETNGBL	R9	K126
       0x60280018,  //  01DC  GETGBL	R10	G24
-      0x582C0051,  //  01DD  LDCONST	R11	K81
-      0x88300312,  //  01DE  GETMBR	R12	R1	K18
-      0x8C301952,  //  01DF  GETMET	R12	R12	K82
+      0x582C009D,  //  01DD  LDCONST	R11	K157
+      0x88300349,  //  01DE  GETMBR	R12	R1	K73
+      0x8C30199E,  //  01DF  GETMET	R12	R12	K158
       0x7C300200,  //  01E0  CALL	R12	1
-      0x8C301944,  //  01E1  GETMET	R12	R12	K68
+      0x8C301992,  //  01E1  GETMET	R12	R12	K146
       0x7C300200,  //  01E2  CALL	R12	1
-      0x8C301945,  //  01E3  GETMET	R12	R12	K69
+      0x8C301993,  //  01E3  GETMET	R12	R12	K147
       0x7C300200,  //  01E4  CALL	R12	1
-      0x8C301953,  //  01E5  GETMET	R12	R12	K83
+      0x8C30199F,  //  01E5  GETMET	R12	R12	K159
       0x7C300200,  //  01E6  CALL	R12	1
       0x60340008,  //  01E7  GETGBL	R13	G8
       0x5C381000,  //  01E8  MOVE	R14	R8
       0x7C340200,  //  01E9  CALL	R13	1
       0x7C280600,  //  01EA  CALL	R10	3
-      0x582C0010,  //  01EB  LDCONST	R11	K16
+      0x582C006B,  //  01EB  LDCONST	R11	K107
       0x7C240400,  //  01EC  CALL	R9	2
-      0x8C240B09,  //  01ED  GETMET	R9	R5	K9
+      0x8C240B0A,  //  01ED  GETMET	R9	R5	K10
       0x7C240200,  //  01EE  CALL	R9	1
-      0x8C28130A,  //  01EF  GETMET	R10	R9	K10
+      0x8C28130B,  //  01EF  GETMET	R10	R9	K11
       0x58300005,  //  01F0  LDCONST	R12	K5
-      0x88340B0B,  //  01F1  GETMBR	R13	R5	K11
+      0x88340B0E,  //  01F1  GETMBR	R13	R5	K14
       0xB83A0200,  //  01F2  GETNGBL	R14	K1
-      0x88381D2B,  //  01F3  GETMBR	R14	R14	K43
+      0x88381D7D,  //  01F3  GETMBR	R14	R14	K125
       0x7C280800,  //  01F4  CALL	R10	4
-      0x8C28130A,  //  01F5  GETMET	R10	R9	K10
-      0x58300007,  //  01F6  LDCONST	R12	K7
-      0x88340B0B,  //  01F7  GETMBR	R13	R5	K11
-      0x8C380354,  //  01F8  GETMET	R14	R1	K84
+      0x8C28130B,  //  01F5  GETMET	R10	R9	K11
+      0x58300009,  //  01F6  LDCONST	R12	K9
+      0x88340B0E,  //  01F7  GETMBR	R13	R5	K14
+      0x8C380335,  //  01F8  GETMET	R14	R1	K53
       0x7C380200,  //  01F9  CALL	R14	1
-      0x8C381D4F,  //  01FA  GETMET	R14	R14	K79
+      0x8C381D3D,  //  01FA  GETMET	R14	R14	K61
       0x7C380200,  //  01FB  CALL	R14	1
       0x7C280800,  //  01FC  CALL	R10	4
       0x542A0007,  //  01FD  LDINT	R10	8
-      0x900E080A,  //  01FE  SETMBR	R3	K4	R10
+      0x900ED40A,  //  01FE  SETMBR	R3	K106	R10
       0x80041200,  //  01FF  RET	1	R9
       0x70020043,  //  0200  JMP		#0245
       0x54220009,  //  0201  LDINT	R8	10
       0x1C200E08,  //  0202  EQ	R8	R7	R8
       0x78220040,  //  0203  JMPF	R8	#0245
-      0x8C200506,  //  0204  GETMET	R8	R2	K6
+      0x8C200541,  //  0204  GETMET	R8	R2	K65
       0x58280005,  //  0205  LDCONST	R10	K5
       0x7C200400,  //  0206  CALL	R8	2
       0x60240008,  //  0207  GETGBL	R9	G8
       0x5C281000,  //  0208  MOVE	R10	R8
       0x7C240200,  //  0209  CALL	R9	1
-      0x0026AA09,  //  020A  ADD	R9	K85	R9
-      0x900E5809,  //  020B  SETMBR	R3	K44	R9
+      0x00274009,  //  020A  ADD	R9	K160	R9
+      0x900EFC09,  //  020B  SETMBR	R3	K126	R9
       0x60240010,  //  020C  GETGBL	R9	G16
-      0x88280116,  //  020D  GETMBR	R10	R0	K22
-      0x88281530,  //  020E  GETMBR	R10	R10	K48
-      0x8C281556,  //  020F  GETMET	R10	R10	K86
+      0x88280136,  //  020D  GETMBR	R10	R0	K54
+      0x88281537,  //  020E  GETMBR	R10	R10	K55
+      0x8C281538,  //  020F  GETMET	R10	R10	K56
       0x7C280200,  //  0210  CALL	R10	1
       0x7C240200,  //  0211  CALL	R9	1
       0xA8020020,  //  0212  EXBLK	0	#0234
       0x5C281200,  //  0213  MOVE	R10	R9
       0x7C280000,  //  0214  CALL	R10	0
-      0x8C2C154F,  //  0215  GETMET	R11	R10	K79
+      0x8C2C153D,  //  0215  GETMET	R11	R10	K61
       0x7C2C0200,  //  0216  CALL	R11	1
       0x1C2C1608,  //  0217  EQ	R11	R11	R8
       0x782E0018,  //  0218  JMPF	R11	#0232
-      0x8C2C1557,  //  0219  GETMET	R11	R10	K87
+      0x8C2C15A1,  //  0219  GETMET	R11	R10	K161
       0x7C2C0200,  //  021A  CALL	R11	1
-      0xB82E4400,  //  021B  GETNGBL	R11	K34
-      0x8C2C1758,  //  021C  GETMET	R11	R11	K88
+      0xB82E2400,  //  021B  GETNGBL	R11	K18
+      0x8C2C17A2,  //  021C  GETMET	R11	R11	K162
       0x543607CF,  //  021D  LDINT	R13	2000
       0x84380000,  //  021E  CLOSURE	R14	P0
       0x7C2C0600,  //  021F  CALL	R11	3
-      0x8C2C0B09,  //  0220  GETMET	R11	R5	K9
+      0x8C2C0B0A,  //  0220  GETMET	R11	R5	K10
       0x7C2C0200,  //  0221  CALL	R11	1
-      0x8C30170A,  //  0222  GETMET	R12	R11	K10
+      0x8C30170B,  //  0222  GETMET	R12	R11	K11
       0x58380005,  //  0223  LDCONST	R14	K5
-      0x883C0B0B,  //  0224  GETMBR	R15	R5	K11
+      0x883C0B0E,  //  0224  GETMBR	R15	R5	K14
       0xB8420200,  //  0225  GETNGBL	R16	K1
-      0x8840212B,  //  0226  GETMBR	R16	R16	K43
+      0x8840217D,  //  0226  GETMBR	R16	R16	K125
       0x7C300800,  //  0227  CALL	R12	4
-      0x8C30170A,  //  0228  GETMET	R12	R11	K10
-      0x58380007,  //  0229  LDCONST	R14	K7
-      0x883C0B0B,  //  022A  GETMBR	R15	R5	K11
+      0x8C30170B,  //  0228  GETMET	R12	R11	K11
+      0x58380009,  //  0229  LDCONST	R14	K9
+      0x883C0B0E,  //  022A  GETMBR	R15	R5	K14
       0x5C401000,  //  022B  MOVE	R16	R8
       0x7C300800,  //  022C  CALL	R12	4
       0x54320007,  //  022D  LDINT	R12	8
-      0x900E080C,  //  022E  SETMBR	R3	K4	R12
+      0x900ED40C,  //  022E  SETMBR	R3	K106	R12
       0xA0000000,  //  022F  CLOSE	R0
       0xA8040001,  //  0230  EXBLK	1	1
       0x80041600,  //  0231  RET	1	R11
       0xA0240000,  //  0232  CLOSE	R9
       0x7001FFDE,  //  0233  JMP		#0213
-      0x58240059,  //  0234  LDCONST	R9	K89
+      0x5824003E,  //  0234  LDCONST	R9	K62
       0xAC240200,  //  0235  CATCH	R9	1	0
       0xB0080000,  //  0236  RAISE	2	R0	R0
-      0xB8265800,  //  0237  GETNGBL	R9	K44
+      0xB826FC00,  //  0237  GETNGBL	R9	K126
       0x60280008,  //  0238  GETGBL	R10	G8
       0x5C2C1000,  //  0239  MOVE	R11	R8
       0x7C280200,  //  023A  CALL	R10	1
-      0x002AB40A,  //  023B  ADD	R10	K90	R10
-      0x0028155B,  //  023C  ADD	R10	R10	K91
-      0x582C000E,  //  023D  LDCONST	R11	K14
+      0x002B460A,  //  023B  ADD	R10	K163	R10
+      0x002815A4,  //  023C  ADD	R10	R10	K164
+      0x582C000D,  //  023D  LDCONST	R11	K13
       0x7C240400,  //  023E  CALL	R9	2
       0xB8260200,  //  023F  GETNGBL	R9	K1
-      0x8824135C,  //  0240  GETMBR	R9	R9	K92
-      0x900E3409,  //  0241  SETMBR	R3	K26	R9
+      0x88241364,  //  0240  GETMBR	R9	R9	K100
+      0x900EC409,  //  0241  SETMBR	R3	K98	R9
       0x4C240000,  //  0242  LDNIL	R9
       0xA0000000,  //  0243  CLOSE	R0
       0x80041200,  //  0244  RET	1	R9
@@ -2005,30 +1953,30 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x78220082,  //  0248  JMPF	R8	#02CC
       0x1C200F05,  //  0249  EQ	R8	R7	K5
       0x78220063,  //  024A  JMPF	R8	#02AF
-      0x8C200506,  //  024B  GETMET	R8	R2	K6
+      0x8C200541,  //  024B  GETMET	R8	R2	K65
       0x58280005,  //  024C  LDCONST	R10	K5
       0x7C200400,  //  024D  CALL	R8	2
-      0x8C240506,  //  024E  GETMET	R9	R2	K6
-      0x582C0007,  //  024F  LDCONST	R11	K7
+      0x8C240541,  //  024E  GETMET	R9	R2	K65
+      0x582C0009,  //  024F  LDCONST	R11	K9
       0x7C240400,  //  0250  CALL	R9	2
-      0x8C280506,  //  0251  GETMET	R10	R2	K6
-      0x5830000E,  //  0252  LDCONST	R12	K14
+      0x8C280541,  //  0251  GETMET	R10	R2	K65
+      0x5830000D,  //  0252  LDCONST	R12	K13
       0x7C280400,  //  0253  CALL	R10	2
-      0x8C2C0506,  //  0254  GETMET	R11	R2	K6
-      0x58340010,  //  0255  LDCONST	R13	K16
+      0x8C2C0541,  //  0254  GETMET	R11	R2	K65
+      0x5834006B,  //  0255  LDCONST	R13	K107
       0x7C2C0400,  //  0256  CALL	R11	2
-      0x8C300506,  //  0257  GETMET	R12	R2	K6
+      0x8C300541,  //  0257  GETMET	R12	R2	K65
       0x543A0003,  //  0258  LDINT	R14	4
       0x7C300400,  //  0259  CALL	R12	2
-      0xB8365800,  //  025A  GETNGBL	R13	K44
+      0xB836FC00,  //  025A  GETNGBL	R13	K126
       0x60380018,  //  025B  GETGBL	R14	G24
-      0x583C005D,  //  025C  LDCONST	R15	K93
+      0x583C00A5,  //  025C  LDCONST	R15	K165
       0x5C401000,  //  025D  MOVE	R16	R8
-      0x8C441353,  //  025E  GETMET	R17	R9	K83
+      0x8C44139F,  //  025E  GETMET	R17	R9	K159
       0x7C440200,  //  025F  CALL	R17	1
       0x5C481400,  //  0260  MOVE	R18	R10
       0x5C4C1600,  //  0261  MOVE	R19	R11
-      0x8C501953,  //  0262  GETMET	R20	R12	K83
+      0x8C50199F,  //  0262  GETMET	R20	R12	K159
       0x7C500200,  //  0263  CALL	R20	1
       0x7C380C00,  //  0264  CALL	R14	6
       0x543E0003,  //  0265  LDINT	R15	4
@@ -2049,8 +1997,8 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x1C34180D,  //  0274  EQ	R13	R12	R13
       0x78360005,  //  0275  JMPF	R13	#027C
       0xB8360200,  //  0276  GETNGBL	R13	K1
-      0x88341B5E,  //  0277  GETMBR	R13	R13	K94
-      0x900E340D,  //  0278  SETMBR	R3	K26	R13
+      0x88341BA6,  //  0277  GETMBR	R13	R13	K166
+      0x900EC40D,  //  0278  SETMBR	R3	K98	R13
       0x4C340000,  //  0279  LDNIL	R13
       0xA0000000,  //  027A  CLOSE	R0
       0x80041A00,  //  027B  RET	1	R13
@@ -2074,13 +2022,13 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x543A001F,  //  028D  LDINT	R14	32
       0x24341A0E,  //  028E  GT	R13	R13	R14
       0x78360009,  //  028F  JMPF	R13	#029A
-      0xB8365800,  //  0290  GETNGBL	R13	K44
-      0x5838005F,  //  0291  LDCONST	R14	K95
-      0x583C000E,  //  0292  LDCONST	R15	K14
+      0xB836FC00,  //  0290  GETNGBL	R13	K126
+      0x583800A7,  //  0291  LDCONST	R14	K167
+      0x583C000D,  //  0292  LDCONST	R15	K13
       0x7C340400,  //  0293  CALL	R13	2
       0xB8360200,  //  0294  GETNGBL	R13	K1
-      0x88341B60,  //  0295  GETMBR	R13	R13	K96
-      0x900E340D,  //  0296  SETMBR	R3	K26	R13
+      0x88341B63,  //  0295  GETMBR	R13	R13	K99
+      0x900EC40D,  //  0296  SETMBR	R3	K98	R13
       0x4C340000,  //  0297  LDNIL	R13
       0xA0000000,  //  0298  CLOSE	R0
       0x80041A00,  //  0299  RET	1	R13
@@ -2088,47 +2036,47 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x40360A0D,  //  029B  CONNECT	R13	K5	R13
       0x9434120D,  //  029C  GETIDX	R13	R9	R13
       0x543A001F,  //  029D  LDINT	R14	32
-      0x40381D40,  //  029E  CONNECT	R14	R14	K64
+      0x40381D8E,  //  029E  CONNECT	R14	R14	K142
       0x9438120E,  //  029F  GETIDX	R14	R9	R14
-      0x883C0116,  //  02A0  GETMBR	R15	R0	K22
-      0x8C3C1F61,  //  02A1  GETMET	R15	R15	K97
+      0x883C0136,  //  02A0  GETMBR	R15	R0	K54
+      0x8C3C1FA8,  //  02A1  GETMET	R15	R15	K168
       0x5C441000,  //  02A2  MOVE	R17	R8
       0x5C481600,  //  02A3  MOVE	R18	R11
       0x5C4C1400,  //  02A4  MOVE	R19	R10
       0x5C501800,  //  02A5  MOVE	R20	R12
       0x5C541A00,  //  02A6  MOVE	R21	R13
       0x5C581C00,  //  02A7  MOVE	R22	R14
-      0x8C5C0354,  //  02A8  GETMET	R23	R1	K84
+      0x8C5C0335,  //  02A8  GETMET	R23	R1	K53
       0x7C5C0200,  //  02A9  CALL	R23	1
       0x7C3C1000,  //  02AA  CALL	R15	8
       0x503C0200,  //  02AB  LDBOOL	R15	1	0
       0xA0000000,  //  02AC  CLOSE	R0
       0x80041E00,  //  02AD  RET	1	R15
       0x7002001B,  //  02AE  JMP		#02CB
-      0x1C200F07,  //  02AF  EQ	R8	R7	K7
+      0x1C200F09,  //  02AF  EQ	R8	R7	K9
       0x78220011,  //  02B0  JMPF	R8	#02C3
-      0x8C200506,  //  02B1  GETMET	R8	R2	K6
+      0x8C200541,  //  02B1  GETMET	R8	R2	K65
       0x58280005,  //  02B2  LDCONST	R10	K5
       0x7C200400,  //  02B3  CALL	R8	2
-      0xB8265800,  //  02B4  GETNGBL	R9	K44
+      0xB826FC00,  //  02B4  GETNGBL	R9	K126
       0x60280008,  //  02B5  GETGBL	R10	G8
       0x5C2C1000,  //  02B6  MOVE	R11	R8
       0x7C280200,  //  02B7  CALL	R10	1
-      0x002AC40A,  //  02B8  ADD	R10	K98	R10
-      0x582C0010,  //  02B9  LDCONST	R11	K16
+      0x002B520A,  //  02B8  ADD	R10	K169	R10
+      0x582C006B,  //  02B9  LDCONST	R11	K107
       0x7C240400,  //  02BA  CALL	R9	2
-      0x88240116,  //  02BB  GETMBR	R9	R0	K22
-      0x8C241363,  //  02BC  GETMET	R9	R9	K99
+      0x88240136,  //  02BB  GETMBR	R9	R0	K54
+      0x8C2413AA,  //  02BC  GETMET	R9	R9	K170
       0x5C2C1000,  //  02BD  MOVE	R11	R8
       0x7C240400,  //  02BE  CALL	R9	2
       0x50240200,  //  02BF  LDBOOL	R9	1	0
       0xA0000000,  //  02C0  CLOSE	R0
       0x80041200,  //  02C1  RET	1	R9
       0x70020007,  //  02C2  JMP		#02CB
-      0x1C200F0E,  //  02C3  EQ	R8	R7	K14
+      0x1C200F0D,  //  02C3  EQ	R8	R7	K13
       0x78220005,  //  02C4  JMPF	R8	#02CB
-      0x88200116,  //  02C5  GETMBR	R8	R0	K22
-      0x8C201164,  //  02C6  GETMET	R8	R8	K100
+      0x88200136,  //  02C5  GETMBR	R8	R0	K54
+      0x8C2011AB,  //  02C6  GETMET	R8	R8	K171
       0x7C200200,  //  02C7  CALL	R8	1
       0x50200200,  //  02C8  LDBOOL	R8	1	0
       0xA0000000,  //  02C9  CLOSE	R0
@@ -2146,7 +2094,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x60200003,  //  02D5  GETGBL	R8	G3
       0x5C240000,  //  02D6  MOVE	R9	R0
       0x7C200200,  //  02D7  CALL	R8	1
-      0x8C201165,  //  02D8  GETMET	R8	R8	K101
+      0x8C2011AC,  //  02D8  GETMET	R8	R8	K172
       0x5C280200,  //  02D9  MOVE	R10	R1
       0x5C2C0400,  //  02DA  MOVE	R11	R2
       0x5C300600,  //  02DB  MOVE	R12	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Fan.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Fan.h
@@ -3,6 +3,40 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Fan' ktab size: 30, total: 64 (saved 272 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Fan[30] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(shadow_fan_mode),
+  /* K2   */  be_nested_str_weak(attribute_updated),
+  /* K3   */  be_nested_str_weak(shadow_fan_speed_pct),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_nested_str_weak(tasmota),
+  /* K6   */  be_nested_str_weak(scale_uint),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_nested_str_weak(find),
+  /* K9   */  be_nested_str_weak(FanMode),
+  /* K10  */  be_nested_str_weak(set_fan_mode),
+  /* K11  */  be_nested_str_weak(FanSpeed255),
+  /* K12  */  be_nested_str_weak(set_fan_speed_pct),
+  /* K13  */  be_nested_str_weak(FanSpeed),
+  /* K14  */  be_const_int(0),
+  /* K15  */  be_const_int(1),
+  /* K16  */  be_const_int(3),
+  /* K17  */  be_nested_str_weak(matter),
+  /* K18  */  be_nested_str_weak(TLV),
+  /* K19  */  be_nested_str_weak(cluster),
+  /* K20  */  be_nested_str_weak(attribute),
+  /* K21  */  be_nested_str_weak(update_shadow_lazy),
+  /* K22  */  be_nested_str_weak(int),
+  /* K23  */  be_nested_str_weak(publish_command),
+  /* K24  */  be_nested_str_weak(status),
+  /* K25  */  be_nested_str_weak(CONSTRAINT_ERROR),
+  /* K26  */  be_nested_str_weak(init),
+  /* K27  */  be_nested_str_weak(set),
+  /* K28  */  be_nested_str_weak(U1),
+  /* K29  */  be_nested_str_weak(read_attribute),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Fan;
 
@@ -13,22 +47,13 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_mode,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(shadow_fan_mode),
-    /* K2   */  be_nested_str_weak(attribute_updated),
-    /* K3   */  be_nested_str_weak(shadow_fan_speed_pct),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(scale_uint),
-    /* K7   */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(set_fan_mode),
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
@@ -93,62 +118,52 @@ be_local_closure(class_Matter_Plugin_Fan_update_virtual,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(FanMode),
-    /* K2   */  be_nested_str_weak(set_fan_mode),
-    /* K3   */  be_nested_str_weak(FanSpeed255),
-    /* K4   */  be_nested_str_weak(set_fan_speed_pct),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(scale_uint),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(FanSpeed),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
+      0x8C080308,  //  0000  GETMET	R2	R1	K8
+      0x58100009,  //  0001  LDCONST	R4	K9
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0004,  //  0005  JMPF	R3	#000B
-      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
+      0x8C0C010A,  //  0006  GETMET	R3	R0	K10
       0x60140009,  //  0007  GETGBL	R5	G9
       0x5C180400,  //  0008  MOVE	R6	R2
       0x7C140200,  //  0009  CALL	R5	1
       0x7C0C0400,  //  000A  CALL	R3	2
-      0x8C0C0300,  //  000B  GETMET	R3	R1	K0
-      0x58140003,  //  000C  LDCONST	R5	K3
+      0x8C0C0308,  //  000B  GETMET	R3	R1	K8
+      0x5814000B,  //  000C  LDCONST	R5	K11
       0x7C0C0400,  //  000D  CALL	R3	2
       0x4C100000,  //  000E  LDNIL	R4
       0x20100604,  //  000F  NE	R4	R3	R4
       0x7812000B,  //  0010  JMPF	R4	#001D
-      0x8C100104,  //  0011  GETMET	R4	R0	K4
+      0x8C10010C,  //  0011  GETMET	R4	R0	K12
       0xB81A0A00,  //  0012  GETNGBL	R6	K5
       0x8C180D06,  //  0013  GETMET	R6	R6	K6
       0x60200009,  //  0014  GETGBL	R8	G9
       0x5C240600,  //  0015  MOVE	R9	R3
       0x7C200200,  //  0016  CALL	R8	1
-      0x58240007,  //  0017  LDCONST	R9	K7
+      0x58240000,  //  0017  LDCONST	R9	K0
       0x542A00FE,  //  0018  LDINT	R10	255
-      0x582C0007,  //  0019  LDCONST	R11	K7
+      0x582C0000,  //  0019  LDCONST	R11	K0
       0x54320063,  //  001A  LDINT	R12	100
       0x7C180C00,  //  001B  CALL	R6	6
       0x7C100400,  //  001C  CALL	R4	2
-      0x8C100300,  //  001D  GETMET	R4	R1	K0
-      0x58180008,  //  001E  LDCONST	R6	K8
+      0x8C100308,  //  001D  GETMET	R4	R1	K8
+      0x5818000D,  //  001E  LDCONST	R6	K13
       0x7C100400,  //  001F  CALL	R4	2
       0x4C140000,  //  0020  LDNIL	R5
       0x20140805,  //  0021  NE	R5	R4	R5
       0x78160004,  //  0022  JMPF	R5	#0028
-      0x8C140104,  //  0023  GETMET	R5	R0	K4
+      0x8C14010C,  //  0023  GETMET	R5	R0	K12
       0x601C0009,  //  0024  GETGBL	R7	G9
       0x5C200800,  //  0025  MOVE	R8	R4
       0x7C1C0200,  //  0026  CALL	R7	1
@@ -167,23 +182,13 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_speed_pct,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(shadow_fan_speed_pct),
-    /* K2   */  be_nested_str_weak(attribute_updated),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(shadow_fan_mode),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(scale_uint),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(set_fan_speed_pct),
     &be_const_str_solidified,
     ( &(const binstruction[42]) {  /* code */
@@ -191,42 +196,42 @@ be_local_closure(class_Matter_Plugin_Fan_set_fan_speed_pct,   /* name */
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x5C040400,  //  0003  MOVE	R1	R2
-      0x14080300,  //  0004  LT	R2	R1	K0
+      0x1408030E,  //  0004  LT	R2	R1	K14
       0x780A0000,  //  0005  JMPF	R2	#0007
-      0x58040000,  //  0006  LDCONST	R1	K0
+      0x5804000E,  //  0006  LDCONST	R1	K14
       0x540A0063,  //  0007  LDINT	R2	100
       0x24080202,  //  0008  GT	R2	R1	R2
       0x780A0000,  //  0009  JMPF	R2	#000B
       0x54060063,  //  000A  LDINT	R1	100
-      0x88080101,  //  000B  GETMBR	R2	R0	K1
+      0x88080103,  //  000B  GETMBR	R2	R0	K3
       0x20080202,  //  000C  NE	R2	R1	R2
       0x780A001A,  //  000D  JMPF	R2	#0029
       0x8C080102,  //  000E  GETMET	R2	R0	K2
       0x54120201,  //  000F  LDINT	R4	514
-      0x58140003,  //  0010  LDCONST	R5	K3
+      0x58140007,  //  0010  LDCONST	R5	K7
       0x7C080600,  //  0011  CALL	R2	3
-      0x90020201,  //  0012  SETMBR	R0	K1	R1
-      0x88080104,  //  0013  GETMBR	R2	R0	K4
-      0x1C0C0300,  //  0014  EQ	R3	R1	K0
+      0x90020601,  //  0012  SETMBR	R0	K3	R1
+      0x88080101,  //  0013  GETMBR	R2	R0	K1
+      0x1C0C030E,  //  0014  EQ	R3	R1	K14
       0x780E0001,  //  0015  JMPF	R3	#0018
-      0x58080000,  //  0016  LDCONST	R2	K0
+      0x5808000E,  //  0016  LDCONST	R2	K14
       0x70020008,  //  0017  JMP		#0021
       0xB80E0A00,  //  0018  GETNGBL	R3	K5
       0x8C0C0706,  //  0019  GETMET	R3	R3	K6
       0x5C140200,  //  001A  MOVE	R5	R1
-      0x58180007,  //  001B  LDCONST	R6	K7
+      0x5818000F,  //  001B  LDCONST	R6	K15
       0x541E0063,  //  001C  LDINT	R7	100
-      0x58200007,  //  001D  LDCONST	R8	K7
-      0x58240008,  //  001E  LDCONST	R9	K8
+      0x5820000F,  //  001D  LDCONST	R8	K15
+      0x58240010,  //  001E  LDCONST	R9	K16
       0x7C0C0C00,  //  001F  CALL	R3	6
       0x5C080600,  //  0020  MOVE	R2	R3
-      0x880C0104,  //  0021  GETMBR	R3	R0	K4
+      0x880C0101,  //  0021  GETMBR	R3	R0	K1
       0x200C0403,  //  0022  NE	R3	R2	R3
       0x780E0004,  //  0023  JMPF	R3	#0029
-      0x90020802,  //  0024  SETMBR	R0	K4	R2
+      0x90020202,  //  0024  SETMBR	R0	K1	R2
       0x8C0C0102,  //  0025  GETMET	R3	R0	K2
       0x54160201,  //  0026  LDINT	R5	514
-      0x58180000,  //  0027  LDCONST	R6	K0
+      0x5818000E,  //  0027  LDCONST	R6	K14
       0x7C0C0600,  //  0028  CALL	R3	3
       0x80000000,  //  0029  RET	0
     })
@@ -242,111 +247,90 @@ be_local_closure(class_Matter_Plugin_Fan_write_attribute,   /* name */
   be_nested_proto(
     21,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(int),
-    /* K7   */  be_nested_str_weak(set_fan_mode),
-    /* K8   */  be_nested_str_weak(publish_command),
-    /* K9   */  be_nested_str_weak(FanMode),
-    /* K10  */  be_nested_str_weak(shadow_fan_mode),
-    /* K11  */  be_nested_str_weak(FanSpeed),
-    /* K12  */  be_nested_str_weak(shadow_fan_speed_pct),
-    /* K13  */  be_nested_str_weak(FanSpeed255),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(scale_uint),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K18  */  be_const_int(2),
-    /* K19  */  be_nested_str_weak(set_fan_speed_pct),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(write_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[78]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8122200,  //  0000  GETNGBL	R4	K17
+      0x88100912,  //  0001  GETMBR	R4	R4	K18
+      0x88140513,  //  0002  GETMBR	R5	R2	K19
+      0x88180514,  //  0003  GETMBR	R6	R2	K20
       0x541E0201,  //  0004  LDINT	R7	514
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0044,  //  0006  JMPF	R7	#004C
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0115,  //  0007  GETMET	R7	R0	K21
       0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x1C1C0D00,  //  0009  EQ	R7	R6	K0
       0x781E001F,  //  000A  JMPF	R7	#002B
       0x601C0004,  //  000B  GETGBL	R7	G4
       0x5C200600,  //  000C  MOVE	R8	R3
       0x7C1C0200,  //  000D  CALL	R7	1
-      0x1C1C0F06,  //  000E  EQ	R7	R7	K6
+      0x1C1C0F16,  //  000E  EQ	R7	R7	K22
       0x781E0014,  //  000F  JMPF	R7	#0025
-      0x8C1C0107,  //  0010  GETMET	R7	R0	K7
+      0x8C1C010A,  //  0010  GETMET	R7	R0	K10
       0x5C240600,  //  0011  MOVE	R9	R3
       0x7C1C0400,  //  0012  CALL	R7	2
-      0x8C1C0108,  //  0013  GETMET	R7	R0	K8
+      0x8C1C0117,  //  0013  GETMET	R7	R0	K23
       0x58240009,  //  0014  LDCONST	R9	K9
-      0x8828010A,  //  0015  GETMBR	R10	R0	K10
-      0x582C000B,  //  0016  LDCONST	R11	K11
-      0x8830010C,  //  0017  GETMBR	R12	R0	K12
-      0x5834000D,  //  0018  LDCONST	R13	K13
-      0xB83A1C00,  //  0019  GETNGBL	R14	K14
-      0x8C381D0F,  //  001A  GETMET	R14	R14	K15
-      0x8840010C,  //  001B  GETMBR	R16	R0	K12
-      0x58440005,  //  001C  LDCONST	R17	K5
+      0x88280101,  //  0015  GETMBR	R10	R0	K1
+      0x582C000D,  //  0016  LDCONST	R11	K13
+      0x88300103,  //  0017  GETMBR	R12	R0	K3
+      0x5834000B,  //  0018  LDCONST	R13	K11
+      0xB83A0A00,  //  0019  GETNGBL	R14	K5
+      0x8C381D06,  //  001A  GETMET	R14	R14	K6
+      0x88400103,  //  001B  GETMBR	R16	R0	K3
+      0x58440000,  //  001C  LDCONST	R17	K0
       0x544A0063,  //  001D  LDINT	R18	100
-      0x584C0005,  //  001E  LDCONST	R19	K5
+      0x584C0000,  //  001E  LDCONST	R19	K0
       0x545200FE,  //  001F  LDINT	R20	255
       0x7C380C00,  //  0020  CALL	R14	6
       0x7C1C0E00,  //  0021  CALL	R7	7
       0x501C0200,  //  0022  LDBOOL	R7	1	0
       0x80040E00,  //  0023  RET	1	R7
       0x70020004,  //  0024  JMP		#002A
-      0xB81E0000,  //  0025  GETNGBL	R7	K0
-      0x881C0F11,  //  0026  GETMBR	R7	R7	K17
-      0x900A2007,  //  0027  SETMBR	R2	K16	R7
+      0xB81E2200,  //  0025  GETNGBL	R7	K17
+      0x881C0F19,  //  0026  GETMBR	R7	R7	K25
+      0x900A3007,  //  0027  SETMBR	R2	K24	R7
       0x501C0000,  //  0028  LDBOOL	R7	0	0
       0x80040E00,  //  0029  RET	1	R7
       0x70020020,  //  002A  JMP		#004C
-      0x1C1C0D12,  //  002B  EQ	R7	R6	K18
+      0x1C1C0D07,  //  002B  EQ	R7	R6	K7
       0x781E001E,  //  002C  JMPF	R7	#004C
       0x601C0004,  //  002D  GETGBL	R7	G4
       0x5C200600,  //  002E  MOVE	R8	R3
       0x7C1C0200,  //  002F  CALL	R7	1
-      0x1C1C0F06,  //  0030  EQ	R7	R7	K6
+      0x1C1C0F16,  //  0030  EQ	R7	R7	K22
       0x781E0014,  //  0031  JMPF	R7	#0047
-      0x8C1C0113,  //  0032  GETMET	R7	R0	K19
+      0x8C1C010C,  //  0032  GETMET	R7	R0	K12
       0x5C240600,  //  0033  MOVE	R9	R3
       0x7C1C0400,  //  0034  CALL	R7	2
-      0x8C1C0108,  //  0035  GETMET	R7	R0	K8
+      0x8C1C0117,  //  0035  GETMET	R7	R0	K23
       0x58240009,  //  0036  LDCONST	R9	K9
-      0x8828010A,  //  0037  GETMBR	R10	R0	K10
-      0x582C000B,  //  0038  LDCONST	R11	K11
-      0x8830010C,  //  0039  GETMBR	R12	R0	K12
-      0x5834000D,  //  003A  LDCONST	R13	K13
-      0xB83A1C00,  //  003B  GETNGBL	R14	K14
-      0x8C381D0F,  //  003C  GETMET	R14	R14	K15
-      0x8840010C,  //  003D  GETMBR	R16	R0	K12
-      0x58440005,  //  003E  LDCONST	R17	K5
+      0x88280101,  //  0037  GETMBR	R10	R0	K1
+      0x582C000D,  //  0038  LDCONST	R11	K13
+      0x88300103,  //  0039  GETMBR	R12	R0	K3
+      0x5834000B,  //  003A  LDCONST	R13	K11
+      0xB83A0A00,  //  003B  GETNGBL	R14	K5
+      0x8C381D06,  //  003C  GETMET	R14	R14	K6
+      0x88400103,  //  003D  GETMBR	R16	R0	K3
+      0x58440000,  //  003E  LDCONST	R17	K0
       0x544A0063,  //  003F  LDINT	R18	100
-      0x584C0005,  //  0040  LDCONST	R19	K5
+      0x584C0000,  //  0040  LDCONST	R19	K0
       0x545200FE,  //  0041  LDINT	R20	255
       0x7C380C00,  //  0042  CALL	R14	6
       0x7C1C0E00,  //  0043  CALL	R7	7
       0x501C0200,  //  0044  LDBOOL	R7	1	0
       0x80040E00,  //  0045  RET	1	R7
       0x70020004,  //  0046  JMP		#004C
-      0xB81E0000,  //  0047  GETNGBL	R7	K0
-      0x881C0F11,  //  0048  GETMBR	R7	R7	K17
-      0x900A2007,  //  0049  SETMBR	R2	K16	R7
+      0xB81E2200,  //  0047  GETNGBL	R7	K17
+      0x881C0F19,  //  0048  GETMBR	R7	R7	K25
+      0x900A3007,  //  0049  SETMBR	R2	K24	R7
       0x501C0000,  //  004A  LDBOOL	R7	0	0
       0x80040E00,  //  004B  RET	1	R7
       0x4C1C0000,  //  004C  LDNIL	R7
@@ -364,31 +348,26 @@ be_local_closure(class_Matter_Plugin_Fan_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_fan_mode),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(shadow_fan_speed_pct),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C10091A,  //  0003  GETMET	R4	R4	K26
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x90020302,  //  0008  SETMBR	R0	K1	K2
-      0x90020702,  //  0009  SETMBR	R0	K3	K2
+      0x90020300,  //  0008  SETMBR	R0	K1	K0
+      0x90020700,  //  0009  SETMBR	R0	K3	K0
       0x80000000,  //  000A  RET	0
     })
   )
@@ -403,75 +382,60 @@ be_local_closure(class_Matter_Plugin_Fan_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_fan_mode),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(shadow_fan_speed_pct),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Fan,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[49]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8122200,  //  0000  GETNGBL	R4	K17
+      0x88100912,  //  0001  GETMBR	R4	R4	K18
+      0x88140513,  //  0002  GETMBR	R5	R2	K19
+      0x88180514,  //  0003  GETMBR	R6	R2	K20
       0x541E0201,  //  0004  LDINT	R7	514
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0020,  //  0006  JMPF	R7	#0028
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0115,  //  0007  GETMET	R7	R0	K21
       0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x1C1C0D00,  //  0009  EQ	R7	R6	K0
       0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
-      0x88240907,  //  000C  GETMBR	R9	R4	K7
-      0x88280108,  //  000D  GETMBR	R10	R0	K8
+      0x8C1C071B,  //  000B  GETMET	R7	R3	K27
+      0x8824091C,  //  000C  GETMBR	R9	R4	K28
+      0x88280101,  //  000D  GETMBR	R10	R0	K1
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x70020016,  //  0010  JMP		#0028
-      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
+      0x1C1C0D0F,  //  0011  EQ	R7	R6	K15
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240907,  //  0014  GETMBR	R9	R4	K7
-      0x5828000A,  //  0015  LDCONST	R10	K10
+      0x8C1C071B,  //  0013  GETMET	R7	R3	K27
+      0x8824091C,  //  0014  GETMBR	R9	R4	K28
+      0x58280007,  //  0015  LDCONST	R10	K7
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x7002000E,  //  0018  JMP		#0028
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D07,  //  0019  EQ	R7	R6	K7
       0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
-      0x8828010B,  //  001D  GETMBR	R10	R0	K11
+      0x8C1C071B,  //  001B  GETMET	R7	R3	K27
+      0x8824091C,  //  001C  GETMBR	R9	R4	K28
+      0x88280103,  //  001D  GETMBR	R10	R0	K3
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
       0x70020006,  //  0020  JMP		#0028
-      0x1C1C0D0C,  //  0021  EQ	R7	R6	K12
+      0x1C1C0D10,  //  0021  EQ	R7	R6	K16
       0x781E0004,  //  0022  JMPF	R7	#0028
-      0x8C1C0706,  //  0023  GETMET	R7	R3	K6
-      0x88240907,  //  0024  GETMBR	R9	R4	K7
-      0x8828010B,  //  0025  GETMBR	R10	R0	K11
+      0x8C1C071B,  //  0023  GETMET	R7	R3	K27
+      0x8824091C,  //  0024  GETMBR	R9	R4	K28
+      0x88280103,  //  0025  GETMBR	R10	R0	K3
       0x7C1C0600,  //  0026  CALL	R7	3
       0x80040E00,  //  0027  RET	1	R7
       0x601C0003,  //  0028  GETGBL	R7	G3
       0x5C200000,  //  0029  MOVE	R8	R0
       0x7C1C0200,  //  002A  CALL	R7	1
-      0x8C1C0F0D,  //  002B  GETMET	R7	R7	K13
+      0x8C1C0F1D,  //  002B  GETMET	R7	R7	K29
       0x5C240200,  //  002C  MOVE	R9	R1
       0x5C280400,  //  002D  MOVE	R10	R2
       0x5C2C0600,  //  002E  MOVE	R11	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light0.h
@@ -3,6 +3,59 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Light0' ktab size: 49, total: 87 (saved 304 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Light0[49] = {
+  /* K0   */  be_nested_str_weak(BRIDGE),
+  /* K1   */  be_nested_str_weak(call_remote_sync),
+  /* K2   */  be_nested_str_weak(Power),
+  /* K3   */  be_nested_str_weak(tasmota_relay_index),
+  /* K4   */  be_nested_str_weak(1),
+  /* K5   */  be_nested_str_weak(0),
+  /* K6   */  be_nested_str_weak(parse_status),
+  /* K7   */  be_nested_str_weak(VIRTUAL),
+  /* K8   */  be_nested_str_weak(shadow_onoff),
+  /* K9   */  be_nested_str_weak(attribute_updated),
+  /* K10  */  be_const_int(0),
+  /* K11  */  be_nested_str_weak(tasmota),
+  /* K12  */  be_nested_str_weak(set_power),
+  /* K13  */  be_const_int(1),
+  /* K14  */  be_nested_str_weak(update_shadow),
+  /* K15  */  be_nested_str_weak(light),
+  /* K16  */  be_nested_str_weak(set),
+  /* K17  */  be_nested_str_weak(power),
+  /* K18  */  be_nested_str_weak(light_index),
+  /* K19  */  be_nested_str_weak(webserver),
+  /* K20  */  be_nested_str_weak(web_values_prefix),
+  /* K21  */  be_nested_str_weak(content_send),
+  /* K22  */  be_nested_str_weak(_X25s),
+  /* K23  */  be_nested_str_weak(web_value_onoff),
+  /* K24  */  be_nested_str_weak(init),
+  /* K25  */  be_nested_str_weak(find),
+  /* K26  */  be_nested_str_weak(ARG),
+  /* K27  */  be_const_int(0),
+  /* K28  */  be_const_int(1),
+  /* K29  */  be_nested_str_weak(set_onoff),
+  /* K30  */  be_nested_str_weak(update_virtual),
+  /* K31  */  be_nested_str_weak(matter),
+  /* K32  */  be_nested_str_weak(TLV),
+  /* K33  */  be_nested_str_weak(cluster),
+  /* K34  */  be_nested_str_weak(attribute),
+  /* K35  */  be_nested_str_weak(update_shadow_lazy),
+  /* K36  */  be_nested_str_weak(BOOL),
+  /* K37  */  be_nested_str_weak(read_attribute),
+  /* K38  */  be_nested_str_weak(get_name),
+  /* K39  */  be_nested_str_weak(PREFIX),
+  /* K40  */  be_nested_str_weak(html_escape),
+  /* K41  */  be_nested_str_weak(),
+  /* K42  */  be_nested_str_weak(get_power),
+  /* K43  */  be_nested_str_weak(command),
+  /* K44  */  be_nested_str_weak(publish_command),
+  /* K45  */  be_const_int(2),
+  /* K46  */  be_nested_str_weak(contains),
+  /* K47  */  be_nested_str_weak(POWER),
+  /* K48  */  be_nested_str_weak(ON),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Light0;
 
@@ -13,33 +66,13 @@ be_local_closure(class_Matter_Plugin_Light0_set_onoff,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(call_remote_sync),
-    /* K2   */  be_nested_str_weak(Power),
-    /* K3   */  be_nested_str_weak(tasmota_relay_index),
-    /* K4   */  be_nested_str_weak(1),
-    /* K5   */  be_nested_str_weak(0),
-    /* K6   */  be_nested_str_weak(parse_status),
-    /* K7   */  be_nested_str_weak(VIRTUAL),
-    /* K8   */  be_nested_str_weak(shadow_onoff),
-    /* K9   */  be_nested_str_weak(attribute_updated),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(set_power),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(update_shadow),
-    /* K15  */  be_nested_str_weak(light),
-    /* K16  */  be_nested_str_weak(set),
-    /* K17  */  be_nested_str_weak(power),
-    /* K18  */  be_nested_str_weak(light_index),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(set_onoff),
     &be_const_str_solidified,
     ( &(const binstruction[56]) {  /* code */
@@ -112,31 +145,24 @@ be_local_closure(class_Matter_Plugin_Light0_web_values,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062600,  //  0000  IMPORT	R1	K19
+      0x8C080114,  //  0001  GETMET	R2	R0	K20
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080315,  //  0003  GETMET	R2	R1	K21
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x58140016,  //  0005  LDCONST	R5	K22
+      0x8C180117,  //  0006  GETMET	R6	R0	K23
+      0x88200108,  //  0007  GETMBR	R8	R0	K8
       0x7C180400,  //  0008  CALL	R6	2
       0x7C100400,  //  0009  CALL	R4	2
       0x7C080400,  //  000A  CALL	R2	2
@@ -154,28 +180,23 @@ be_local_closure(class_Matter_Plugin_Light0_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_onoff),
-    /* K1   */  be_nested_str_weak(light_index),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(init),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x50100000,  //  0000  LDBOOL	R4	0	0
-      0x90020004,  //  0001  SETMBR	R0	K0	R4
-      0x90020302,  //  0002  SETMBR	R0	K1	K2
+      0x90021004,  //  0001  SETMBR	R0	K8	R4
+      0x9002250A,  //  0002  SETMBR	R0	K18	K10
       0x60100003,  //  0003  GETGBL	R4	G3
       0x5C140000,  //  0004  MOVE	R5	R0
       0x7C100200,  //  0005  CALL	R4	1
-      0x8C100903,  //  0006  GETMET	R4	R4	K3
+      0x8C100918,  //  0006  GETMET	R4	R4	K24
       0x5C180200,  //  0007  MOVE	R6	R1
       0x5C1C0400,  //  0008  MOVE	R7	R2
       0x5C200600,  //  0009  MOVE	R8	R3
@@ -194,37 +215,31 @@ be_local_closure(class_Matter_Plugin_Light0_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_relay_index),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x8C0C0319,  //  0001  GETMET	R3	R1	K25
+      0x8814011A,  //  0002  GETMBR	R5	R0	K26
       0x4C180000,  //  0003  LDNIL	R6
       0x7C0C0600,  //  0004  CALL	R3	3
       0x7C080200,  //  0005  CALL	R2	1
-      0x90020002,  //  0006  SETMBR	R0	K0	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x90020602,  //  0006  SETMBR	R0	K3	R2
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
       0x4C0C0000,  //  0008  LDNIL	R3
       0x20080403,  //  0009  NE	R2	R2	R3
       0x780A0003,  //  000A  JMPF	R2	#000F
-      0x88080100,  //  000B  GETMBR	R2	R0	K0
-      0x18080503,  //  000C  LE	R2	R2	K3
+      0x88080103,  //  000B  GETMBR	R2	R0	K3
+      0x1808051B,  //  000C  LE	R2	R2	K27
       0x780A0000,  //  000D  JMPF	R2	#000F
-      0x90020104,  //  000E  SETMBR	R0	K0	K4
+      0x9002071C,  //  000E  SETMBR	R0	K3	K28
       0x80000000,  //  000F  RET	0
     })
   )
@@ -239,28 +254,23 @@ be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Power),
-    /* K2   */  be_nested_str_weak(set_onoff),
-    /* K3   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
+      0x8C080319,  //  0000  GETMET	R2	R1	K25
+      0x58100002,  //  0001  LDCONST	R4	K2
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0004,  //  0005  JMPF	R3	#000B
-      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
+      0x8C0C011D,  //  0006  GETMET	R3	R0	K29
       0x60140017,  //  0007  GETGBL	R5	G23
       0x5C180400,  //  0008  MOVE	R6	R2
       0x7C140200,  //  0009  CALL	R5	1
@@ -268,7 +278,7 @@ be_local_closure(class_Matter_Plugin_Light0_update_virtual,   /* name */
       0x600C0003,  //  000B  GETGBL	R3	G3
       0x5C100000,  //  000C  MOVE	R4	R0
       0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
+      0x8C0C071E,  //  000E  GETMET	R3	R3	K30
       0x5C140200,  //  000F  MOVE	R5	R1
       0x7C0C0400,  //  0010  CALL	R3	2
       0x80000000,  //  0011  RET	0
@@ -285,47 +295,36 @@ be_local_closure(class_Matter_Plugin_Light0_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(BOOL),
-    /* K8   */  be_nested_str_weak(shadow_onoff),
-    /* K9   */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8123E00,  //  0000  GETNGBL	R4	K31
+      0x88100920,  //  0001  GETMBR	R4	R4	K32
+      0x88140521,  //  0002  GETMBR	R5	R2	K33
+      0x88180522,  //  0003  GETMBR	R6	R2	K34
       0x541E0005,  //  0004  LDINT	R7	6
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0008,  //  0006  JMPF	R7	#0010
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0123,  //  0007  GETMET	R7	R0	K35
       0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x1C1C0D0A,  //  0009  EQ	R7	R6	K10
       0x781E0004,  //  000A  JMPF	R7	#0010
-      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
-      0x88240907,  //  000C  GETMBR	R9	R4	K7
+      0x8C1C0710,  //  000B  GETMET	R7	R3	K16
+      0x88240924,  //  000C  GETMBR	R9	R4	K36
       0x88280108,  //  000D  GETMBR	R10	R0	K8
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x601C0003,  //  0010  GETGBL	R7	G3
       0x5C200000,  //  0011  MOVE	R8	R0
       0x7C1C0200,  //  0012  CALL	R7	1
-      0x8C1C0F09,  //  0013  GETMET	R7	R7	K9
+      0x8C1C0F25,  //  0013  GETMET	R7	R7	K37
       0x5C240200,  //  0014  MOVE	R9	R1
       0x5C280400,  //  0015  MOVE	R10	R2
       0x5C2C0600,  //  0016  MOVE	R11	R3
@@ -344,27 +343,18 @@ be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Power),
-    /* K3   */  be_nested_str_weak(tasmota_relay_index),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062600,  //  0000  IMPORT	R1	K19
+      0x8C080126,  //  0001  GETMET	R2	R0	K38
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0004,  //  0004  JMPT	R3	#000A
@@ -373,15 +363,15 @@ be_local_closure(class_Matter_Plugin_Light0_web_values_prefix,   /* name */
       0x7C0C0200,  //  0007  CALL	R3	1
       0x000E0403,  //  0008  ADD	R3	K2	R3
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x8C0C0315,  //  000A  GETMET	R3	R1	K21
       0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x88180127,  //  000C  GETMBR	R6	R0	K39
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x8C1C0328,  //  000E  GETMET	R7	R1	K40
       0x5C240400,  //  000F  MOVE	R9	R2
       0x7C1C0400,  //  0010  CALL	R7	2
       0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x581C0029,  //  0012  LDCONST	R7	K41
       0x7C140400,  //  0013  CALL	R5	2
       0x7C0C0400,  //  0014  CALL	R3	2
       0x80000000,  //  0015  RET	0
@@ -398,13 +388,13 @@ be_local_closure(class_Matter_Plugin_Light0__X3Clambda_X3E,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -425,58 +415,47 @@ be_local_closure(class_Matter_Plugin_Light0_update_shadow,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(tasmota_relay_index),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(get_power),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(shadow_onoff),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
       0x74060018,  //  0001  JMPT	R1	#001B
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
       0x74060016,  //  0003  JMPT	R1	#001B
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x88040103,  //  0004  GETMBR	R1	R0	K3
       0x4C080000,  //  0005  LDNIL	R2
       0x20040202,  //  0006  NE	R1	R1	R2
       0x78060012,  //  0007  JMPF	R1	#001B
-      0xB8060600,  //  0008  GETNGBL	R1	K3
-      0x8C040304,  //  0009  GETMET	R1	R1	K4
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x040C0705,  //  000B  SUB	R3	R3	K5
+      0xB8061600,  //  0008  GETNGBL	R1	K11
+      0x8C04032A,  //  0009  GETMET	R1	R1	K42
+      0x880C0103,  //  000A  GETMBR	R3	R0	K3
+      0x040C070D,  //  000B  SUB	R3	R3	K13
       0x7C040400,  //  000C  CALL	R1	2
       0x4C080000,  //  000D  LDNIL	R2
       0x20080202,  //  000E  NE	R2	R1	R2
       0x780A000A,  //  000F  JMPF	R2	#001B
-      0x88080106,  //  0010  GETMBR	R2	R0	K6
+      0x88080108,  //  0010  GETMBR	R2	R0	K8
       0x600C0017,  //  0011  GETGBL	R3	G23
       0x5C100200,  //  0012  MOVE	R4	R1
       0x7C0C0200,  //  0013  CALL	R3	1
       0x20080403,  //  0014  NE	R2	R2	R3
       0x780A0003,  //  0015  JMPF	R2	#001A
-      0x8C080107,  //  0016  GETMET	R2	R0	K7
+      0x8C080109,  //  0016  GETMET	R2	R0	K9
       0x54120005,  //  0017  LDINT	R4	6
-      0x58140008,  //  0018  LDCONST	R5	K8
+      0x5814000A,  //  0018  LDCONST	R5	K10
       0x7C080600,  //  0019  CALL	R2	3
-      0x90020C01,  //  001A  SETMBR	R0	K6	R1
+      0x90021001,  //  001A  SETMBR	R0	K8	R1
       0x60040003,  //  001B  GETGBL	R1	G3
       0x5C080000,  //  001C  MOVE	R2	R0
       0x7C040200,  //  001D  CALL	R1	1
-      0x8C040309,  //  001E  GETMET	R1	R1	K9
+      0x8C04030E,  //  001E  GETMET	R1	R1	K14
       0x7C040200,  //  001F  CALL	R1	1
       0x80000000,  //  0020  RET	0
     })
@@ -492,77 +471,64 @@ be_local_closure(class_Matter_Plugin_Light0_invoke_request,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set_onoff),
-    /* K7   */  be_nested_str_weak(publish_command),
-    /* K8   */  be_nested_str_weak(Power),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(shadow_onoff),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[52]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0xB8123E00,  //  0000  GETNGBL	R4	K31
+      0x88100920,  //  0001  GETMBR	R4	R4	K32
+      0x88140721,  //  0002  GETMBR	R5	R3	K33
+      0x8818072B,  //  0003  GETMBR	R6	R3	K43
       0x541E0005,  //  0004  LDINT	R7	6
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E002B,  //  0006  JMPF	R7	#0033
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0123,  //  0007  GETMET	R7	R0	K35
       0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x1C1C0D0A,  //  0009  EQ	R7	R6	K10
       0x781E0009,  //  000A  JMPF	R7	#0015
-      0x8C1C0106,  //  000B  GETMET	R7	R0	K6
+      0x8C1C011D,  //  000B  GETMET	R7	R0	K29
       0x50240000,  //  000C  LDBOOL	R9	0	0
       0x7C1C0400,  //  000D  CALL	R7	2
-      0x8C1C0107,  //  000E  GETMET	R7	R0	K7
-      0x58240008,  //  000F  LDCONST	R9	K8
-      0x58280005,  //  0010  LDCONST	R10	K5
+      0x8C1C012C,  //  000E  GETMET	R7	R0	K44
+      0x58240002,  //  000F  LDCONST	R9	K2
+      0x5828000A,  //  0010  LDCONST	R10	K10
       0x7C1C0600,  //  0011  CALL	R7	3
       0x501C0200,  //  0012  LDBOOL	R7	1	0
       0x80040E00,  //  0013  RET	1	R7
       0x7002001D,  //  0014  JMP		#0033
-      0x1C1C0D09,  //  0015  EQ	R7	R6	K9
+      0x1C1C0D1C,  //  0015  EQ	R7	R6	K28
       0x781E0009,  //  0016  JMPF	R7	#0021
-      0x8C1C0106,  //  0017  GETMET	R7	R0	K6
+      0x8C1C011D,  //  0017  GETMET	R7	R0	K29
       0x50240200,  //  0018  LDBOOL	R9	1	0
       0x7C1C0400,  //  0019  CALL	R7	2
-      0x8C1C0107,  //  001A  GETMET	R7	R0	K7
-      0x58240008,  //  001B  LDCONST	R9	K8
-      0x58280009,  //  001C  LDCONST	R10	K9
+      0x8C1C012C,  //  001A  GETMET	R7	R0	K44
+      0x58240002,  //  001B  LDCONST	R9	K2
+      0x5828001C,  //  001C  LDCONST	R10	K28
       0x7C1C0600,  //  001D  CALL	R7	3
       0x501C0200,  //  001E  LDBOOL	R7	1	0
       0x80040E00,  //  001F  RET	1	R7
       0x70020011,  //  0020  JMP		#0033
-      0x1C1C0D0A,  //  0021  EQ	R7	R6	K10
+      0x1C1C0D2D,  //  0021  EQ	R7	R6	K45
       0x781E000F,  //  0022  JMPF	R7	#0033
-      0x8C1C0106,  //  0023  GETMET	R7	R0	K6
-      0x8824010B,  //  0024  GETMBR	R9	R0	K11
+      0x8C1C011D,  //  0023  GETMET	R7	R0	K29
+      0x88240108,  //  0024  GETMBR	R9	R0	K8
       0x78260000,  //  0025  JMPF	R9	#0027
       0x50240001,  //  0026  LDBOOL	R9	0	1
       0x50240200,  //  0027  LDBOOL	R9	1	0
       0x7C1C0400,  //  0028  CALL	R7	2
-      0x8C1C0107,  //  0029  GETMET	R7	R0	K7
-      0x58240008,  //  002A  LDCONST	R9	K8
-      0x8828010B,  //  002B  GETMBR	R10	R0	K11
+      0x8C1C012C,  //  0029  GETMET	R7	R0	K44
+      0x58240002,  //  002A  LDCONST	R9	K2
+      0x88280108,  //  002B  GETMBR	R10	R0	K8
       0x782A0001,  //  002C  JMPF	R10	#002F
-      0x58280009,  //  002D  LDCONST	R10	K9
+      0x5828001C,  //  002D  LDCONST	R10	K28
       0x70020000,  //  002E  JMP		#0030
-      0x58280005,  //  002F  LDCONST	R10	K5
+      0x5828000A,  //  002F  LDCONST	R10	K10
       0x7C1C0600,  //  0030  CALL	R7	3
       0x501C0200,  //  0031  LDBOOL	R7	1	0
       0x80040E00,  //  0032  RET	1	R7
@@ -580,23 +546,13 @@ be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_relay_index),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(POWER),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(ON),
-    /* K6   */  be_nested_str_weak(shadow_onoff),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Light0,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
@@ -604,38 +560,38 @@ be_local_closure(class_Matter_Plugin_Light0_parse_status,   /* name */
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0020,  //  0002  JMPF	R3	#0024
       0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x1C100901,  //  0005  EQ	R4	R4	K1
+      0x88100103,  //  0004  GETMBR	R4	R0	K3
+      0x1C10090D,  //  0005  EQ	R4	R4	K13
       0x78120009,  //  0006  JMPF	R4	#0011
-      0x8C100302,  //  0007  GETMET	R4	R1	K2
-      0x58180003,  //  0008  LDCONST	R6	K3
+      0x8C10032E,  //  0007  GETMET	R4	R1	K46
+      0x5818002F,  //  0008  LDCONST	R6	K47
       0x7C100400,  //  0009  CALL	R4	2
       0x78120005,  //  000A  JMPF	R4	#0011
-      0x8C100304,  //  000B  GETMET	R4	R1	K4
-      0x58180003,  //  000C  LDCONST	R6	K3
+      0x8C100319,  //  000B  GETMET	R4	R1	K25
+      0x5818002F,  //  000C  LDCONST	R6	K47
       0x7C100400,  //  000D  CALL	R4	2
-      0x1C100905,  //  000E  EQ	R4	R4	K5
+      0x1C100930,  //  000E  EQ	R4	R4	K48
       0x5C0C0800,  //  000F  MOVE	R3	R4
       0x70020007,  //  0010  JMP		#0019
-      0x8C100304,  //  0011  GETMET	R4	R1	K4
+      0x8C100319,  //  0011  GETMET	R4	R1	K25
       0x60180008,  //  0012  GETGBL	R6	G8
-      0x881C0100,  //  0013  GETMBR	R7	R0	K0
+      0x881C0103,  //  0013  GETMBR	R7	R0	K3
       0x7C180200,  //  0014  CALL	R6	1
-      0x001A0606,  //  0015  ADD	R6	K3	R6
+      0x001A5E06,  //  0015  ADD	R6	K47	R6
       0x7C100400,  //  0016  CALL	R4	2
-      0x1C100905,  //  0017  EQ	R4	R4	K5
+      0x1C100930,  //  0017  EQ	R4	R4	K48
       0x5C0C0800,  //  0018  MOVE	R3	R4
-      0x88100106,  //  0019  GETMBR	R4	R0	K6
+      0x88100108,  //  0019  GETMBR	R4	R0	K8
       0x60140017,  //  001A  GETGBL	R5	G23
       0x5C180600,  //  001B  MOVE	R6	R3
       0x7C140200,  //  001C  CALL	R5	1
       0x20100805,  //  001D  NE	R4	R4	R5
       0x78120004,  //  001E  JMPF	R4	#0024
-      0x8C100107,  //  001F  GETMET	R4	R0	K7
+      0x8C100109,  //  001F  GETMET	R4	R0	K9
       0x541A0005,  //  0020  LDINT	R6	6
-      0x581C0008,  //  0021  LDCONST	R7	K8
+      0x581C000A,  //  0021  LDCONST	R7	K10
       0x7C100600,  //  0022  CALL	R4	3
-      0x90020C03,  //  0023  SETMBR	R0	K6	R3
+      0x90021003,  //  0023  SETMBR	R0	K8	R3
       0x80000000,  //  0024  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
@@ -3,6 +3,46 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor' ktab size: 36, total: 53 (saved 136 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor[36] = {
+  /* K0   */  be_nested_str_weak(contains),
+  /* K1   */  be_nested_str_weak(TempUnit),
+  /* K2   */  be_nested_str_weak(temp_unit),
+  /* K3   */  be_nested_str_weak(PressureUnit),
+  /* K4   */  be_nested_str_weak(pressure_unit),
+  /* K5   */  be_nested_str_weak(tasmota_sensor_matcher),
+  /* K6   */  be_nested_str_weak(pre_value),
+  /* K7   */  be_nested_str_weak(match),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_nested_str_weak(value_changed),
+  /* K10  */  be_nested_str_weak(tasmota_sensor_filter),
+  /* K11  */  be_nested_str_weak(find),
+  /* K12  */  be_nested_str_weak(ARG),
+  /* K13  */  be_nested_str_weak(tasmota),
+  /* K14  */  be_nested_str_weak(Rule_Matcher),
+  /* K15  */  be_nested_str_weak(parse),
+  /* K16  */  be_nested_str_weak(TEMP_C),
+  /* K17  */  be_nested_str_weak(PRESSURE_HPA),
+  /* K18  */  be_nested_str_weak(VIRTUAL),
+  /* K19  */  be_nested_str_weak(JSON_NAME),
+  /* K20  */  be_nested_str_weak(init),
+  /* K21  */  be_nested_str_weak(add_read_sensors_schedule),
+  /* K22  */  be_nested_str_weak(UPDATE_TIME),
+  /* K23  */  be_nested_str_weak(string),
+  /* K24  */  be_nested_str_weak(webserver),
+  /* K25  */  be_nested_str_weak(html_escape),
+  /* K26  */  be_nested_str_weak(split),
+  /* K27  */  be_nested_str_weak(_X23),
+  /* K28  */  be_const_int(0),
+  /* K29  */  be_nested_str_weak(),
+  /* K30  */  be_nested_str_weak(get_name),
+  /* K31  */  be_nested_str_weak(filter_name_html),
+  /* K32  */  be_nested_str_weak(content_send),
+  /* K33  */  be_nested_str_weak(PREFIX),
+  /* K34  */  be_nested_str_weak(bool),
+  /* K35  */  be_nested_str_weak(update_virtual),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor;
 
@@ -13,24 +53,13 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(contains),
-    /* K1   */  be_nested_str_weak(TempUnit),
-    /* K2   */  be_nested_str_weak(temp_unit),
-    /* K3   */  be_nested_str_weak(PressureUnit),
-    /* K4   */  be_nested_str_weak(pressure_unit),
-    /* K5   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K6   */  be_nested_str_weak(pre_value),
-    /* K7   */  be_nested_str_weak(match),
-    /* K8   */  be_nested_str_weak(shadow_value),
-    /* K9   */  be_nested_str_weak(value_changed),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
@@ -82,44 +111,32 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(Rule_Matcher),
-    /* K6   */  be_nested_str_weak(parse),
-    /* K7   */  be_nested_str_weak(temp_unit),
-    /* K8   */  be_nested_str_weak(TEMP_C),
-    /* K9   */  be_nested_str_weak(pressure_unit),
-    /* K10  */  be_nested_str_weak(PRESSURE_HPA),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x8C080301,  //  0000  GETMET	R2	R1	K1
-      0x88100102,  //  0001  GETMBR	R4	R0	K2
+      0x8C08030B,  //  0000  GETMET	R2	R1	K11
+      0x8810010C,  //  0001  GETMBR	R4	R0	K12
       0x7C080400,  //  0002  CALL	R2	2
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x90021402,  //  0003  SETMBR	R0	K10	R2
+      0x8808010A,  //  0004  GETMBR	R2	R0	K10
       0x780A0005,  //  0005  JMPF	R2	#000C
-      0xB80A0800,  //  0006  GETNGBL	R2	K4
-      0x88080505,  //  0007  GETMBR	R2	R2	K5
-      0x8C080506,  //  0008  GETMET	R2	R2	K6
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0xB80A1A00,  //  0006  GETNGBL	R2	K13
+      0x8808050E,  //  0007  GETMBR	R2	R2	K14
+      0x8C08050F,  //  0008  GETMET	R2	R2	K15
+      0x8810010A,  //  0009  GETMBR	R4	R0	K10
       0x7C080400,  //  000A  CALL	R2	2
-      0x90020602,  //  000B  SETMBR	R0	K3	R2
-      0x88080108,  //  000C  GETMBR	R2	R0	K8
-      0x90020E02,  //  000D  SETMBR	R0	K7	R2
-      0x8808010A,  //  000E  GETMBR	R2	R0	K10
-      0x90021202,  //  000F  SETMBR	R0	K9	R2
+      0x90020A02,  //  000B  SETMBR	R0	K5	R2
+      0x88080110,  //  000C  GETMBR	R2	R0	K16
+      0x90020402,  //  000D  SETMBR	R0	K2	R2
+      0x88080111,  //  000E  GETMBR	R2	R0	K17
+      0x90020802,  //  000F  SETMBR	R0	K4	R2
       0x80000000,  //  0010  RET	0
     })
   )
@@ -134,13 +151,13 @@ be_local_closure(class_Matter_Plugin_Sensor_pre_value,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -158,31 +175,22 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K2   */  be_nested_str_weak(match),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(JSON_NAME),
-    /* K5   */  be_nested_str_weak(pre_value),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(value_changed),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080112,  //  0000  GETMBR	R2	R0	K18
       0x740A001D,  //  0001  JMPT	R2	#0020
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x88080105,  //  0002  GETMBR	R2	R0	K5
       0x780A001B,  //  0003  JMPF	R2	#0020
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x88080105,  //  0004  GETMBR	R2	R0	K5
+      0x8C080507,  //  0005  GETMET	R2	R2	K7
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
       0x600C000F,  //  0008  GETGBL	R3	G15
@@ -190,11 +198,11 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
       0x60140013,  //  000A  GETGBL	R5	G19
       0x7C0C0400,  //  000B  CALL	R3	2
       0x780E0003,  //  000C  JMPF	R3	#0011
-      0x8C0C0503,  //  000D  GETMET	R3	R2	K3
-      0x88140104,  //  000E  GETMBR	R5	R0	K4
+      0x8C0C050B,  //  000D  GETMET	R3	R2	K11
+      0x88140113,  //  000E  GETMBR	R5	R0	K19
       0x7C0C0400,  //  000F  CALL	R3	2
       0x5C080600,  //  0010  MOVE	R2	R3
-      0x8C0C0105,  //  0011  GETMET	R3	R0	K5
+      0x8C0C0106,  //  0011  GETMET	R3	R0	K6
       0x6014000A,  //  0012  GETGBL	R5	G10
       0x5C180400,  //  0013  MOVE	R6	R2
       0x7C140200,  //  0014  CALL	R5	1
@@ -203,12 +211,12 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
       0x4C0C0000,  //  0017  LDNIL	R3
       0x200C0403,  //  0018  NE	R3	R2	R3
       0x780E0005,  //  0019  JMPF	R3	#0020
-      0x880C0106,  //  001A  GETMBR	R3	R0	K6
+      0x880C0108,  //  001A  GETMBR	R3	R0	K8
       0x200C0403,  //  001B  NE	R3	R2	R3
       0x780E0002,  //  001C  JMPF	R3	#0020
-      0x8C0C0107,  //  001D  GETMET	R3	R0	K7
+      0x8C0C0109,  //  001D  GETMET	R3	R0	K9
       0x7C0C0200,  //  001E  CALL	R3	1
-      0x90020C02,  //  001F  SETMBR	R0	K6	R2
+      0x90021002,  //  001F  SETMBR	R0	K8	R2
       0x80000000,  //  0020  RET	0
     })
   )
@@ -223,13 +231,13 @@ be_local_closure(class_Matter_Plugin_Sensor_value_changed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -247,30 +255,26 @@ be_local_closure(class_Matter_Plugin_Sensor_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(add_read_sensors_schedule),
-    /* K2   */  be_nested_str_weak(UPDATE_TIME),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100914,  //  0003  GETMET	R4	R4	K20
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x8C100301,  //  0008  GETMET	R4	R1	K1
-      0x88180102,  //  0009  GETMBR	R6	R0	K2
+      0x8C100315,  //  0008  GETMET	R4	R1	K21
+      0x88180116,  //  0009  GETMBR	R6	R0	K22
       0x7C100400,  //  000A  CALL	R4	2
       0x80000000,  //  000B  RET	0
     })
@@ -286,38 +290,29 @@ be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(webserver),
-    /* K3   */  be_nested_str_weak(html_escape),
-    /* K4   */  be_nested_str_weak(split),
-    /* K5   */  be_nested_str_weak(_X23),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(filter_name_html),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010A,  //  0000  GETMBR	R1	R0	K10
       0x78060009,  //  0001  JMPF	R1	#000C
-      0xA4060200,  //  0002  IMPORT	R1	K1
-      0xA40A0400,  //  0003  IMPORT	R2	K2
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x8C140304,  //  0005  GETMET	R5	R1	K4
-      0x881C0100,  //  0006  GETMBR	R7	R0	K0
-      0x58200005,  //  0007  LDCONST	R8	K5
+      0xA4062E00,  //  0002  IMPORT	R1	K23
+      0xA40A3000,  //  0003  IMPORT	R2	K24
+      0x8C0C0519,  //  0004  GETMET	R3	R2	K25
+      0x8C14031A,  //  0005  GETMET	R5	R1	K26
+      0x881C010A,  //  0006  GETMBR	R7	R0	K10
+      0x5820001B,  //  0007  LDCONST	R8	K27
       0x7C140600,  //  0008  CALL	R5	3
-      0x94140B06,  //  0009  GETIDX	R5	R5	K6
+      0x94140B1C,  //  0009  GETIDX	R5	R5	K28
       0x7C0C0400,  //  000A  CALL	R3	2
       0x80040600,  //  000B  RET	1	R3
-      0x80060E00,  //  000C  RET	1	K7
+      0x80063A00,  //  000C  RET	1	K29
     })
   )
 );
@@ -331,41 +326,33 @@ be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(filter_name_html),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(PREFIX),
-    /* K5   */  be_nested_str_weak(html_escape),
-    /* K6   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4063000,  //  0000  IMPORT	R1	K24
+      0x8C08011E,  //  0001  GETMET	R2	R0	K30
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0002,  //  0004  JMPT	R3	#0008
-      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
+      0x8C0C011F,  //  0005  GETMET	R3	R0	K31
       0x7C0C0200,  //  0006  CALL	R3	1
       0x5C080600,  //  0007  MOVE	R2	R3
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x8C0C0320,  //  0008  GETMET	R3	R1	K32
       0x60140018,  //  0009  GETGBL	R5	G24
-      0x88180104,  //  000A  GETMBR	R6	R0	K4
+      0x88180121,  //  000A  GETMBR	R6	R0	K33
       0x780A0003,  //  000B  JMPF	R2	#0010
-      0x8C1C0305,  //  000C  GETMET	R7	R1	K5
+      0x8C1C0319,  //  000C  GETMET	R7	R1	K25
       0x5C240400,  //  000D  MOVE	R9	R2
       0x7C1C0400,  //  000E  CALL	R7	2
       0x70020000,  //  000F  JMP		#0011
-      0x581C0006,  //  0010  LDCONST	R7	K6
+      0x581C001D,  //  0010  LDCONST	R7	K29
       0x7C140400,  //  0011  CALL	R5	2
       0x7C0C0400,  //  0012  CALL	R3	2
       0x80000000,  //  0013  RET	0
@@ -382,25 +369,18 @@ be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(JSON_NAME),
-    /* K2   */  be_nested_str_weak(bool),
-    /* K3   */  be_nested_str_weak(shadow_value),
-    /* K4   */  be_nested_str_weak(value_changed),
-    /* K5   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x8C08030B,  //  0000  GETMET	R2	R1	K11
+      0x88100113,  //  0001  GETMBR	R4	R0	K19
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
@@ -408,22 +388,22 @@ be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
       0x600C0004,  //  0006  GETGBL	R3	G4
       0x5C100400,  //  0007  MOVE	R4	R2
       0x7C0C0200,  //  0008  CALL	R3	1
-      0x1C0C0702,  //  0009  EQ	R3	R3	K2
+      0x1C0C0722,  //  0009  EQ	R3	R3	K34
       0x780E0003,  //  000A  JMPF	R3	#000F
       0x600C0009,  //  000B  GETGBL	R3	G9
       0x5C100400,  //  000C  MOVE	R4	R2
       0x7C0C0200,  //  000D  CALL	R3	1
       0x5C080600,  //  000E  MOVE	R2	R3
-      0x880C0103,  //  000F  GETMBR	R3	R0	K3
+      0x880C0108,  //  000F  GETMBR	R3	R0	K8
       0x200C0602,  //  0010  NE	R3	R3	R2
       0x780E0002,  //  0011  JMPF	R3	#0015
-      0x8C0C0104,  //  0012  GETMET	R3	R0	K4
+      0x8C0C0109,  //  0012  GETMET	R3	R0	K9
       0x7C0C0200,  //  0013  CALL	R3	1
-      0x90020602,  //  0014  SETMBR	R0	K3	R2
+      0x90021002,  //  0014  SETMBR	R0	K8	R2
       0x600C0003,  //  0015  GETGBL	R3	G3
       0x5C100000,  //  0016  MOVE	R4	R0
       0x7C0C0200,  //  0017  CALL	R3	1
-      0x8C0C0705,  //  0018  GETMET	R3	R3	K5
+      0x8C0C0723,  //  0018  GETMET	R3	R3	K35
       0x5C140200,  //  0019  MOVE	R5	R1
       0x7C0C0400,  //  001A  CALL	R3	2
       0x80000000,  //  001B  RET	0

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
@@ -3,6 +3,46 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Air_Quality' ktab size: 36, total: 73 (saved 296 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Air_Quality[36] = {
+  /* K0   */  be_nested_str_weak(web_values_prefix),
+  /* K1   */  be_nested_str_weak(Air),
+  /* K2   */  be_nested_str_weak(shadow_air_quality),
+  /* K3   */  be_nested_str_weak(PM1),
+  /* K4   */  be_nested_str_weak(shadow_pm1),
+  /* K5   */  be_nested_str_weak(PM2_X2E5),
+  /* K6   */  be_nested_str_weak(shadow_pm2_5),
+  /* K7   */  be_nested_str_weak(PM10),
+  /* K8   */  be_nested_str_weak(shadow_pm10),
+  /* K9   */  be_nested_str_weak(CO2),
+  /* K10  */  be_nested_str_weak(shadow_co2),
+  /* K11  */  be_nested_str_weak(NO2),
+  /* K12  */  be_nested_str_weak(shadow_no2),
+  /* K13  */  be_nested_str_weak(TVOC),
+  /* K14  */  be_nested_str_weak(shadow_tvoc),
+  /* K15  */  be_nested_str_weak(find),
+  /* K16  */  be_nested_str_weak(prefix),
+  /* K17  */  be_nested_str_weak(_parse_update_virtual),
+  /* K18  */  be_nested_str_weak(AirQuality),
+  /* K19  */  be_const_int(0),
+  /* K20  */  be_nested_str_weak(update_virtual),
+  /* K21  */  be_nested_str_weak(init),
+  /* K22  */  be_nested_str_weak(add_read_sensors_schedule),
+  /* K23  */  be_nested_str_weak(UPDATE_TIME),
+  /* K24  */  be_nested_str_weak(matter),
+  /* K25  */  be_nested_str_weak(TLV),
+  /* K26  */  be_nested_str_weak(cluster),
+  /* K27  */  be_nested_str_weak(attribute),
+  /* K28  */  be_nested_str_weak(set_or_nil),
+  /* K29  */  be_nested_str_weak(U1),
+  /* K30  */  be_nested_str_weak(read_attribute),
+  /* K31  */  be_nested_str_weak(ARG),
+  /* K32  */  be_nested_str_weak(_parse_sensor_entry),
+  /* K33  */  be_nested_str_weak(CarbonDioxide),
+  /* K34  */  be_nested_str_weak(parse_sensors),
+  /* K35  */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Air_Quality;
 
@@ -13,7 +53,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -51,23 +91,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_web_values,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(web_values_prefix),
-    /* K1   */  be_nested_str_weak(Air),
-    /* K2   */  be_nested_str_weak(shadow_air_quality),
-    /* K3   */  be_nested_str_weak(PM1),
-    /* K4   */  be_nested_str_weak(shadow_pm1),
-    /* K5   */  be_nested_str_weak(PM2_X2E5),
-    /* K6   */  be_nested_str_weak(shadow_pm2_5),
-    /* K7   */  be_nested_str_weak(PM10),
-    /* K8   */  be_nested_str_weak(shadow_pm10),
-    /* K9   */  be_nested_str_weak(CO2),
-    /* K10  */  be_nested_str_weak(shadow_co2),
-    /* K11  */  be_nested_str_weak(NO2),
-    /* K12  */  be_nested_str_weak(shadow_no2),
-    /* K13  */  be_nested_str_weak(TVOC),
-    /* K14  */  be_nested_str_weak(shadow_tvoc),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
@@ -116,24 +140,21 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_status,   /* name 
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(prefix),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x540E0009,  //  0000  LDINT	R3	10
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
+      0x8C0C030F,  //  0003  GETMET	R3	R1	K15
+      0x88140110,  //  0004  GETMBR	R5	R0	K16
       0x7C0C0400,  //  0005  CALL	R3	2
       0x80000000,  //  0006  RET	0
     })
@@ -149,90 +170,74 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_update_virtual,   /* nam
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_air_quality),
-    /* K1   */  be_nested_str_weak(_parse_update_virtual),
-    /* K2   */  be_nested_str_weak(AirQuality),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(shadow_co2),
-    /* K5   */  be_nested_str_weak(CO2),
-    /* K6   */  be_nested_str_weak(shadow_pm1),
-    /* K7   */  be_nested_str_weak(PM1),
-    /* K8   */  be_nested_str_weak(shadow_pm2_5),
-    /* K9   */  be_nested_str_weak(PM2_X2E5),
-    /* K10  */  be_nested_str_weak(shadow_pm10),
-    /* K11  */  be_nested_str_weak(PM10),
-    /* K12  */  be_nested_str_weak(shadow_tvoc),
-    /* K13  */  be_nested_str_weak(TVOC),
-    /* K14  */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[61]) {  /* code */
-      0x8C080101,  //  0000  GETMET	R2	R0	K1
+      0x8C080111,  //  0000  GETMET	R2	R0	K17
       0x5C100200,  //  0001  MOVE	R4	R1
-      0x58140002,  //  0002  LDCONST	R5	K2
+      0x58140012,  //  0002  LDCONST	R5	K18
       0x60180007,  //  0003  GETGBL	R6	G7
-      0x881C0100,  //  0004  GETMBR	R7	R0	K0
+      0x881C0102,  //  0004  GETMBR	R7	R0	K2
       0x5422005A,  //  0005  LDINT	R8	91
-      0x58240003,  //  0006  LDCONST	R9	K3
+      0x58240013,  //  0006  LDCONST	R9	K19
       0x7C080E00,  //  0007  CALL	R2	7
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x8C080101,  //  0009  GETMET	R2	R0	K1
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x8C080111,  //  0009  GETMET	R2	R0	K17
       0x5C100200,  //  000A  MOVE	R4	R1
-      0x58140005,  //  000B  LDCONST	R5	K5
-      0x88180104,  //  000C  GETMBR	R6	R0	K4
+      0x58140009,  //  000B  LDCONST	R5	K9
+      0x8818010A,  //  000C  GETMBR	R6	R0	K10
       0x601C0007,  //  000D  GETGBL	R7	G7
       0x5422040C,  //  000E  LDINT	R8	1037
-      0x58240003,  //  000F  LDCONST	R9	K3
+      0x58240013,  //  000F  LDCONST	R9	K19
       0x7C080E00,  //  0010  CALL	R2	7
-      0x90020802,  //  0011  SETMBR	R0	K4	R2
-      0x8C080101,  //  0012  GETMET	R2	R0	K1
+      0x90021402,  //  0011  SETMBR	R0	K10	R2
+      0x8C080111,  //  0012  GETMET	R2	R0	K17
       0x5C100200,  //  0013  MOVE	R4	R1
-      0x58140007,  //  0014  LDCONST	R5	K7
-      0x88180106,  //  0015  GETMBR	R6	R0	K6
+      0x58140003,  //  0014  LDCONST	R5	K3
+      0x88180104,  //  0015  GETMBR	R6	R0	K4
       0x601C0007,  //  0016  GETGBL	R7	G7
       0x5422042B,  //  0017  LDINT	R8	1068
-      0x58240003,  //  0018  LDCONST	R9	K3
+      0x58240013,  //  0018  LDCONST	R9	K19
       0x7C080E00,  //  0019  CALL	R2	7
-      0x90020C02,  //  001A  SETMBR	R0	K6	R2
-      0x8C080101,  //  001B  GETMET	R2	R0	K1
+      0x90020802,  //  001A  SETMBR	R0	K4	R2
+      0x8C080111,  //  001B  GETMET	R2	R0	K17
       0x5C100200,  //  001C  MOVE	R4	R1
-      0x58140009,  //  001D  LDCONST	R5	K9
-      0x88180108,  //  001E  GETMBR	R6	R0	K8
+      0x58140005,  //  001D  LDCONST	R5	K5
+      0x88180106,  //  001E  GETMBR	R6	R0	K6
       0x601C0007,  //  001F  GETGBL	R7	G7
       0x54220429,  //  0020  LDINT	R8	1066
-      0x58240003,  //  0021  LDCONST	R9	K3
+      0x58240013,  //  0021  LDCONST	R9	K19
       0x7C080E00,  //  0022  CALL	R2	7
-      0x90021002,  //  0023  SETMBR	R0	K8	R2
-      0x8C080101,  //  0024  GETMET	R2	R0	K1
+      0x90020C02,  //  0023  SETMBR	R0	K6	R2
+      0x8C080111,  //  0024  GETMET	R2	R0	K17
       0x5C100200,  //  0025  MOVE	R4	R1
-      0x5814000B,  //  0026  LDCONST	R5	K11
-      0x8818010A,  //  0027  GETMBR	R6	R0	K10
+      0x58140007,  //  0026  LDCONST	R5	K7
+      0x88180108,  //  0027  GETMBR	R6	R0	K8
       0x601C0007,  //  0028  GETGBL	R7	G7
       0x5422042C,  //  0029  LDINT	R8	1069
-      0x58240003,  //  002A  LDCONST	R9	K3
+      0x58240013,  //  002A  LDCONST	R9	K19
       0x7C080E00,  //  002B  CALL	R2	7
-      0x90021402,  //  002C  SETMBR	R0	K10	R2
-      0x8C080101,  //  002D  GETMET	R2	R0	K1
+      0x90021002,  //  002C  SETMBR	R0	K8	R2
+      0x8C080111,  //  002D  GETMET	R2	R0	K17
       0x5C100200,  //  002E  MOVE	R4	R1
       0x5814000D,  //  002F  LDCONST	R5	K13
-      0x8818010C,  //  0030  GETMBR	R6	R0	K12
+      0x8818010E,  //  0030  GETMBR	R6	R0	K14
       0x601C0007,  //  0031  GETGBL	R7	G7
       0x5422042D,  //  0032  LDINT	R8	1070
-      0x58240003,  //  0033  LDCONST	R9	K3
+      0x58240013,  //  0033  LDCONST	R9	K19
       0x7C080E00,  //  0034  CALL	R2	7
-      0x90021802,  //  0035  SETMBR	R0	K12	R2
+      0x90021C02,  //  0035  SETMBR	R0	K14	R2
       0x60080003,  //  0036  GETGBL	R2	G3
       0x5C0C0000,  //  0037  MOVE	R3	R0
       0x7C080200,  //  0038  CALL	R2	1
-      0x8C08050E,  //  0039  GETMET	R2	R2	K14
+      0x8C080514,  //  0039  GETMET	R2	R2	K20
       0x5C100200,  //  003A  MOVE	R4	R1
       0x7C080400,  //  003B  CALL	R2	2
       0x80000000,  //  003C  RET	0
@@ -249,33 +254,28 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_air_quality),
-    /* K2   */  be_nested_str_weak(add_read_sensors_schedule),
-    /* K3   */  be_nested_str_weak(UPDATE_TIME),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100915,  //  0003  GETMET	R4	R4	K21
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
       0x50100000,  //  0008  LDBOOL	R4	0	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
-      0x8C100302,  //  000A  GETMET	R4	R1	K2
-      0x88180103,  //  000B  GETMBR	R6	R0	K3
+      0x90020404,  //  0009  SETMBR	R0	K2	R4
+      0x8C100316,  //  000A  GETMET	R4	R1	K22
+      0x88180117,  //  000B  GETMBR	R6	R0	K23
       0x7C100400,  //  000C  CALL	R4	2
       0x80000000,  //  000D  RET	0
     })
@@ -291,7 +291,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
   be_nested_proto(
     14,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -401,40 +401,24 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_nested_str_weak(shadow_air_quality),
-    /* K8   */  be_nested_str_weak(shadow_co2),
-    /* K9   */  be_nested_str_weak(shadow_pm1),
-    /* K10  */  be_nested_str_weak(shadow_pm2_5),
-    /* K11  */  be_nested_str_weak(shadow_pm10),
-    /* K12  */  be_nested_str_weak(shadow_tvoc),
-    /* K13  */  be_nested_str_weak(shadow_no2),
-    /* K14  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[93]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8123000,  //  0000  GETNGBL	R4	K24
+      0x88100919,  //  0001  GETMBR	R4	R4	K25
+      0x8814051A,  //  0002  GETMBR	R5	R2	K26
+      0x8818051B,  //  0003  GETMBR	R6	R2	K27
       0x4C1C0000,  //  0004  LDNIL	R7
       0x84200000,  //  0005  CLOSURE	R8	P0
       0x5426005A,  //  0006  LDINT	R9	91
       0x1C240A09,  //  0007  EQ	R9	R5	R9
       0x78260008,  //  0008  JMPF	R9	#0012
-      0x1C240D04,  //  0009  EQ	R9	R6	K4
+      0x1C240D13,  //  0009  EQ	R9	R6	K19
       0x78260005,  //  000A  JMPF	R9	#0011
-      0x8C240705,  //  000B  GETMET	R9	R3	K5
-      0x882C0906,  //  000C  GETMBR	R11	R4	K6
-      0x88300107,  //  000D  GETMBR	R12	R0	K7
+      0x8C24071C,  //  000B  GETMET	R9	R3	K28
+      0x882C091D,  //  000C  GETMBR	R11	R4	K29
+      0x88300102,  //  000D  GETMBR	R12	R0	K2
       0x7C240600,  //  000E  CALL	R9	3
       0xA0000000,  //  000F  CLOSE	R0
       0x80041200,  //  0010  RET	1	R9
@@ -443,7 +427,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  0013  EQ	R9	R5	R9
       0x78260007,  //  0014  JMPF	R9	#001D
       0x5C241000,  //  0015  MOVE	R9	R8
-      0x88280108,  //  0016  GETMBR	R10	R0	K8
+      0x8828010A,  //  0016  GETMBR	R10	R0	K10
       0x7C240200,  //  0017  CALL	R9	1
       0x5C1C1200,  //  0018  MOVE	R7	R9
       0x78260001,  //  0019  JMPF	R9	#001C
@@ -454,7 +438,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  001E  EQ	R9	R5	R9
       0x78260007,  //  001F  JMPF	R9	#0028
       0x5C241000,  //  0020  MOVE	R9	R8
-      0x88280109,  //  0021  GETMBR	R10	R0	K9
+      0x88280104,  //  0021  GETMBR	R10	R0	K4
       0x7C240200,  //  0022  CALL	R9	1
       0x5C1C1200,  //  0023  MOVE	R7	R9
       0x78260001,  //  0024  JMPF	R9	#0027
@@ -465,7 +449,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  0029  EQ	R9	R5	R9
       0x78260007,  //  002A  JMPF	R9	#0033
       0x5C241000,  //  002B  MOVE	R9	R8
-      0x8828010A,  //  002C  GETMBR	R10	R0	K10
+      0x88280106,  //  002C  GETMBR	R10	R0	K6
       0x7C240200,  //  002D  CALL	R9	1
       0x5C1C1200,  //  002E  MOVE	R7	R9
       0x78260001,  //  002F  JMPF	R9	#0032
@@ -476,7 +460,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  0034  EQ	R9	R5	R9
       0x78260007,  //  0035  JMPF	R9	#003E
       0x5C241000,  //  0036  MOVE	R9	R8
-      0x8828010B,  //  0037  GETMBR	R10	R0	K11
+      0x88280108,  //  0037  GETMBR	R10	R0	K8
       0x7C240200,  //  0038  CALL	R9	1
       0x5C1C1200,  //  0039  MOVE	R7	R9
       0x78260001,  //  003A  JMPF	R9	#003D
@@ -487,7 +471,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  003F  EQ	R9	R5	R9
       0x78260007,  //  0040  JMPF	R9	#0049
       0x5C241000,  //  0041  MOVE	R9	R8
-      0x8828010C,  //  0042  GETMBR	R10	R0	K12
+      0x8828010E,  //  0042  GETMBR	R10	R0	K14
       0x7C240200,  //  0043  CALL	R9	1
       0x5C1C1200,  //  0044  MOVE	R7	R9
       0x78260001,  //  0045  JMPF	R9	#0048
@@ -498,7 +482,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x1C240A09,  //  004A  EQ	R9	R5	R9
       0x78260006,  //  004B  JMPF	R9	#0053
       0x5C241000,  //  004C  MOVE	R9	R8
-      0x8828010D,  //  004D  GETMBR	R10	R0	K13
+      0x8828010C,  //  004D  GETMBR	R10	R0	K12
       0x7C240200,  //  004E  CALL	R9	1
       0x5C1C1200,  //  004F  MOVE	R7	R9
       0x78260001,  //  0050  JMPF	R9	#0053
@@ -507,7 +491,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x60240003,  //  0053  GETGBL	R9	G3
       0x5C280000,  //  0054  MOVE	R10	R0
       0x7C240200,  //  0055  CALL	R9	1
-      0x8C24130E,  //  0056  GETMET	R9	R9	K14
+      0x8C24131E,  //  0056  GETMET	R9	R9	K30
       0x5C2C0200,  //  0057  MOVE	R11	R1
       0x5C300400,  //  0058  MOVE	R12	R2
       0x5C340600,  //  0059  MOVE	R13	R3
@@ -527,26 +511,22 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_configuration,   /
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(prefix),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
-      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x8C0C030F,  //  0001  GETMET	R3	R1	K15
+      0x8814011F,  //  0002  GETMBR	R5	R0	K31
       0x7C0C0400,  //  0003  CALL	R3	2
       0x7C080200,  //  0004  CALL	R2	1
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x90022002,  //  0005  SETMBR	R0	K16	R2
       0x80000000,  //  0006  RET	0
     })
   )
@@ -561,98 +541,80 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_parse_sensors,   /* name
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(prefix),
-    /* K2   */  be_nested_str_weak(shadow_co2),
-    /* K3   */  be_nested_str_weak(_parse_sensor_entry),
-    /* K4   */  be_nested_str_weak(CarbonDioxide),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_pm1),
-    /* K7   */  be_nested_str_weak(PM1),
-    /* K8   */  be_nested_str_weak(shadow_pm2_5),
-    /* K9   */  be_nested_str_weak(PM2_X2E5),
-    /* K10  */  be_nested_str_weak(shadow_pm10),
-    /* K11  */  be_nested_str_weak(PM10),
-    /* K12  */  be_nested_str_weak(shadow_tvoc),
-    /* K13  */  be_nested_str_weak(TVOC),
-    /* K14  */  be_nested_str_weak(shadow_no2),
-    /* K15  */  be_nested_str_weak(NO2),
-    /* K16  */  be_nested_str_weak(parse_sensors),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
     ( &(const binstruction[67]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x8C08030F,  //  0000  GETMET	R2	R1	K15
+      0x88100110,  //  0001  GETMBR	R4	R0	K16
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0035,  //  0005  JMPF	R3	#003C
-      0x8C0C0103,  //  0006  GETMET	R3	R0	K3
+      0x8C0C0120,  //  0006  GETMET	R3	R0	K32
       0x5C140400,  //  0007  MOVE	R5	R2
-      0x58180004,  //  0008  LDCONST	R6	K4
-      0x881C0102,  //  0009  GETMBR	R7	R0	K2
+      0x58180021,  //  0008  LDCONST	R6	K33
+      0x881C010A,  //  0009  GETMBR	R7	R0	K10
       0x60200007,  //  000A  GETGBL	R8	G7
       0x5426040C,  //  000B  LDINT	R9	1037
-      0x58280005,  //  000C  LDCONST	R10	K5
+      0x58280013,  //  000C  LDCONST	R10	K19
       0x7C0C0E00,  //  000D  CALL	R3	7
-      0x90020403,  //  000E  SETMBR	R0	K2	R3
-      0x8C0C0103,  //  000F  GETMET	R3	R0	K3
+      0x90021403,  //  000E  SETMBR	R0	K10	R3
+      0x8C0C0120,  //  000F  GETMET	R3	R0	K32
       0x5C140400,  //  0010  MOVE	R5	R2
-      0x58180007,  //  0011  LDCONST	R6	K7
-      0x881C0106,  //  0012  GETMBR	R7	R0	K6
+      0x58180003,  //  0011  LDCONST	R6	K3
+      0x881C0104,  //  0012  GETMBR	R7	R0	K4
       0x60200007,  //  0013  GETGBL	R8	G7
       0x5426042B,  //  0014  LDINT	R9	1068
-      0x58280005,  //  0015  LDCONST	R10	K5
+      0x58280013,  //  0015  LDCONST	R10	K19
       0x7C0C0E00,  //  0016  CALL	R3	7
-      0x90020C03,  //  0017  SETMBR	R0	K6	R3
-      0x8C0C0103,  //  0018  GETMET	R3	R0	K3
+      0x90020803,  //  0017  SETMBR	R0	K4	R3
+      0x8C0C0120,  //  0018  GETMET	R3	R0	K32
       0x5C140400,  //  0019  MOVE	R5	R2
-      0x58180009,  //  001A  LDCONST	R6	K9
-      0x881C0108,  //  001B  GETMBR	R7	R0	K8
+      0x58180005,  //  001A  LDCONST	R6	K5
+      0x881C0106,  //  001B  GETMBR	R7	R0	K6
       0x60200007,  //  001C  GETGBL	R8	G7
       0x54260429,  //  001D  LDINT	R9	1066
-      0x58280005,  //  001E  LDCONST	R10	K5
+      0x58280013,  //  001E  LDCONST	R10	K19
       0x7C0C0E00,  //  001F  CALL	R3	7
-      0x90021003,  //  0020  SETMBR	R0	K8	R3
-      0x8C0C0103,  //  0021  GETMET	R3	R0	K3
+      0x90020C03,  //  0020  SETMBR	R0	K6	R3
+      0x8C0C0120,  //  0021  GETMET	R3	R0	K32
       0x5C140400,  //  0022  MOVE	R5	R2
-      0x5818000B,  //  0023  LDCONST	R6	K11
-      0x881C010A,  //  0024  GETMBR	R7	R0	K10
+      0x58180007,  //  0023  LDCONST	R6	K7
+      0x881C0108,  //  0024  GETMBR	R7	R0	K8
       0x60200007,  //  0025  GETGBL	R8	G7
       0x5426042C,  //  0026  LDINT	R9	1069
-      0x58280005,  //  0027  LDCONST	R10	K5
+      0x58280013,  //  0027  LDCONST	R10	K19
       0x7C0C0E00,  //  0028  CALL	R3	7
-      0x90021403,  //  0029  SETMBR	R0	K10	R3
-      0x8C0C0103,  //  002A  GETMET	R3	R0	K3
+      0x90021003,  //  0029  SETMBR	R0	K8	R3
+      0x8C0C0120,  //  002A  GETMET	R3	R0	K32
       0x5C140400,  //  002B  MOVE	R5	R2
       0x5818000D,  //  002C  LDCONST	R6	K13
-      0x881C010C,  //  002D  GETMBR	R7	R0	K12
+      0x881C010E,  //  002D  GETMBR	R7	R0	K14
       0x60200007,  //  002E  GETGBL	R8	G7
       0x5426042D,  //  002F  LDINT	R9	1070
-      0x58280005,  //  0030  LDCONST	R10	K5
+      0x58280013,  //  0030  LDCONST	R10	K19
       0x7C0C0E00,  //  0031  CALL	R3	7
-      0x90021803,  //  0032  SETMBR	R0	K12	R3
-      0x8C0C0103,  //  0033  GETMET	R3	R0	K3
+      0x90021C03,  //  0032  SETMBR	R0	K14	R3
+      0x8C0C0120,  //  0033  GETMET	R3	R0	K32
       0x5C140400,  //  0034  MOVE	R5	R2
-      0x5818000F,  //  0035  LDCONST	R6	K15
-      0x881C010E,  //  0036  GETMBR	R7	R0	K14
+      0x5818000B,  //  0035  LDCONST	R6	K11
+      0x881C010C,  //  0036  GETMBR	R7	R0	K12
       0x60200007,  //  0037  GETGBL	R8	G7
       0x54260412,  //  0038  LDINT	R9	1043
-      0x58280005,  //  0039  LDCONST	R10	K5
+      0x58280013,  //  0039  LDCONST	R10	K19
       0x7C0C0E00,  //  003A  CALL	R3	7
-      0x90021C03,  //  003B  SETMBR	R0	K14	R3
+      0x90021803,  //  003B  SETMBR	R0	K12	R3
       0x600C0003,  //  003C  GETGBL	R3	G3
       0x5C100000,  //  003D  MOVE	R4	R0
       0x7C0C0200,  //  003E  CALL	R3	1
-      0x8C0C0710,  //  003F  GETMET	R3	R3	K16
+      0x8C0C0722,  //  003F  GETMET	R3	R3	K34
       0x5C140200,  //  0040  MOVE	R5	R1
       0x7C0C0400,  //  0041  CALL	R3	2
       0x80000000,  //  0042  RET	0
@@ -669,20 +631,17 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality__parse_sensor_entry,   /
   be_nested_proto(
     12,                          /* nstack */
     7,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Air_Quality,     /* shared constants */
     be_str_weak(_parse_sensor_entry),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C1C0300,  //  0000  GETMET	R7	R1	K0
+      0x8C1C030F,  //  0000  GETMET	R7	R1	K15
       0x5C240400,  //  0001  MOVE	R9	R2
       0x7C1C0400,  //  0002  CALL	R7	2
       0x4C200000,  //  0003  LDNIL	R8
@@ -697,7 +656,7 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality__parse_sensor_entry,   /
       0x78220005,  //  000C  JMPF	R8	#0013
       0x20200E03,  //  000D  NE	R8	R7	R3
       0x78220003,  //  000E  JMPF	R8	#0013
-      0x8C200101,  //  000F  GETMET	R8	R0	K1
+      0x8C200123,  //  000F  GETMET	R8	R0	K35
       0x5C280A00,  //  0010  MOVE	R10	R5
       0x5C2C0C00,  //  0011  MOVE	R11	R6
       0x7C200600,  //  0012  CALL	R8	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Boolean.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Boolean.h
@@ -3,6 +3,27 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Boolean' ktab size: 17, total: 26 (saved 72 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Boolean[17] = {
+  /* K0   */  be_nested_str_weak(tasmota_switch_index),
+  /* K1   */  be_nested_str_weak(find),
+  /* K2   */  be_nested_str_weak(ARG),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(update_shadow),
+  /* K6   */  be_nested_str_weak(VIRTUAL),
+  /* K7   */  be_nested_str_weak(Switch),
+  /* K8   */  be_nested_str_weak(tasmota),
+  /* K9   */  be_nested_str_weak(cmd),
+  /* K10  */  be_nested_str_weak(Status_X2010),
+  /* K11  */  be_nested_str_weak(StatusSNS),
+  /* K12  */  be_nested_str_weak(contains),
+  /* K13  */  be_nested_str_weak(ON),
+  /* K14  */  be_nested_str_weak(shadow_bool_value),
+  /* K15  */  be_nested_str_weak(value_updated),
+  /* K16  */  be_nested_str_weak(init),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Boolean;
 
@@ -13,19 +34,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_configuration,   /* na
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_switch_index),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
@@ -54,13 +69,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_value_updated,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -78,13 +93,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean__X3Clambda_X3E,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -105,70 +120,56 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_update_shadow,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_shadow),
-    /* K1   */  be_nested_str_weak(VIRTUAL),
-    /* K2   */  be_nested_str_weak(Switch),
-    /* K3   */  be_nested_str_weak(tasmota_switch_index),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(cmd),
-    /* K6   */  be_nested_str_weak(Status_X2010),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(StatusSNS),
-    /* K9   */  be_nested_str_weak(contains),
-    /* K10  */  be_nested_str_weak(ON),
-    /* K11  */  be_nested_str_weak(shadow_bool_value),
-    /* K12  */  be_nested_str_weak(value_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040305,  //  0003  GETMET	R1	R1	K5
       0x7C040200,  //  0004  CALL	R1	1
-      0x88040101,  //  0005  GETMBR	R1	R0	K1
+      0x88040106,  //  0005  GETMBR	R1	R0	K6
       0x74060020,  //  0006  JMPT	R1	#0028
       0x60040008,  //  0007  GETGBL	R1	G8
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x88080100,  //  0008  GETMBR	R2	R0	K0
       0x7C040200,  //  0009  CALL	R1	1
-      0x00060401,  //  000A  ADD	R1	K2	R1
-      0xB80A0800,  //  000B  GETNGBL	R2	K4
-      0x8C080505,  //  000C  GETMET	R2	R2	K5
-      0x58100006,  //  000D  LDCONST	R4	K6
+      0x00060E01,  //  000A  ADD	R1	K7	R1
+      0xB80A1000,  //  000B  GETNGBL	R2	K8
+      0x8C080509,  //  000C  GETMET	R2	R2	K9
+      0x5810000A,  //  000D  LDCONST	R4	K10
       0x50140200,  //  000E  LDBOOL	R5	1	0
       0x7C080600,  //  000F  CALL	R2	3
       0x4C0C0000,  //  0010  LDNIL	R3
       0x200C0403,  //  0011  NE	R3	R2	R3
       0x780E0003,  //  0012  JMPF	R3	#0017
-      0x8C0C0507,  //  0013  GETMET	R3	R2	K7
-      0x58140008,  //  0014  LDCONST	R5	K8
+      0x8C0C0501,  //  0013  GETMET	R3	R2	K1
+      0x5814000B,  //  0014  LDCONST	R5	K11
       0x7C0C0400,  //  0015  CALL	R3	2
       0x5C080600,  //  0016  MOVE	R2	R3
       0x4C0C0000,  //  0017  LDNIL	R3
       0x200C0403,  //  0018  NE	R3	R2	R3
       0x780E000D,  //  0019  JMPF	R3	#0028
-      0x8C0C0509,  //  001A  GETMET	R3	R2	K9
+      0x8C0C050C,  //  001A  GETMET	R3	R2	K12
       0x5C140200,  //  001B  MOVE	R5	R1
       0x7C0C0400,  //  001C  CALL	R3	2
       0x780E0009,  //  001D  JMPF	R3	#0028
-      0x8C0C0507,  //  001E  GETMET	R3	R2	K7
+      0x8C0C0501,  //  001E  GETMET	R3	R2	K1
       0x5C140200,  //  001F  MOVE	R5	R1
       0x7C0C0400,  //  0020  CALL	R3	2
-      0x1C0C070A,  //  0021  EQ	R3	R3	K10
-      0x8810010B,  //  0022  GETMBR	R4	R0	K11
+      0x1C0C070D,  //  0021  EQ	R3	R3	K13
+      0x8810010E,  //  0022  GETMBR	R4	R0	K14
       0x20100803,  //  0023  NE	R4	R4	R3
       0x78120001,  //  0024  JMPF	R4	#0027
-      0x8C10010C,  //  0025  GETMET	R4	R0	K12
+      0x8C10010F,  //  0025  GETMET	R4	R0	K15
       0x7C100200,  //  0026  CALL	R4	1
-      0x90021603,  //  0027  SETMBR	R0	K11	R3
+      0x90021C03,  //  0027  SETMBR	R0	K14	R3
       0x80000000,  //  0028  RET	0
     })
   )
@@ -183,29 +184,26 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_bool_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C100910,  //  0003  GETMET	R4	R4	K16
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
       0x50100000,  //  0008  LDBOOL	R4	0	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x90021C04,  //  0009  SETMBR	R0	K14	R4
       0x80000000,  //  000A  RET	0
     })
   )
@@ -220,20 +218,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Switch),
-    /* K2   */  be_nested_str_weak(tasmota_switch_index),
-    /* K3   */  be_nested_str_weak(ON),
-    /* K4   */  be_nested_str_weak(shadow_bool_value),
-    /* K5   */  be_nested_str_weak(value_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Boolean,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
@@ -241,27 +232,27 @@ be_local_closure(class_Matter_Plugin_Sensor_Boolean_parse_status,   /* name */
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0015,  //  0002  JMPF	R3	#0019
       0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x8C100300,  //  0004  GETMET	R4	R1	K0
+      0x8C100301,  //  0004  GETMET	R4	R1	K1
       0x60180008,  //  0005  GETGBL	R6	G8
-      0x881C0102,  //  0006  GETMBR	R7	R0	K2
+      0x881C0100,  //  0006  GETMBR	R7	R0	K0
       0x7C180200,  //  0007  CALL	R6	1
-      0x001A0206,  //  0008  ADD	R6	K1	R6
+      0x001A0E06,  //  0008  ADD	R6	K7	R6
       0x7C100400,  //  0009  CALL	R4	2
-      0x1C100903,  //  000A  EQ	R4	R4	K3
+      0x1C10090D,  //  000A  EQ	R4	R4	K13
       0x5C0C0800,  //  000B  MOVE	R3	R4
-      0x88100104,  //  000C  GETMBR	R4	R0	K4
+      0x8810010E,  //  000C  GETMBR	R4	R0	K14
       0x4C140000,  //  000D  LDNIL	R5
       0x20100805,  //  000E  NE	R4	R4	R5
       0x78120007,  //  000F  JMPF	R4	#0018
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
+      0x8810010E,  //  0010  GETMBR	R4	R0	K14
       0x60140017,  //  0011  GETGBL	R5	G23
       0x5C180600,  //  0012  MOVE	R6	R3
       0x7C140200,  //  0013  CALL	R5	1
       0x20100805,  //  0014  NE	R4	R4	R5
       0x78120001,  //  0015  JMPF	R4	#0018
-      0x8C100105,  //  0016  GETMET	R4	R0	K5
+      0x8C10010F,  //  0016  GETMET	R4	R0	K15
       0x7C100200,  //  0017  CALL	R4	1
-      0x90020803,  //  0018  SETMBR	R0	K4	R3
+      0x90021C03,  //  0018  SETMBR	R0	K14	R3
       0x80000000,  //  0019  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_GenericSwitch_Btn.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_GenericSwitch_Btn.h
@@ -3,6 +3,36 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_GenericSwitch_Btn' ktab size: 26, total: 35 (saved 72 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn[26] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(cluster),
+  /* K3   */  be_nested_str_weak(attribute),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(set),
+  /* K6   */  be_nested_str_weak(U1),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(set_or_nil),
+  /* K10  */  be_nested_str_weak(shadow_position),
+  /* K11  */  be_nested_str_weak(U4),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(attribute_updated),
+  /* K14  */  be_nested_str_weak(tasmota_switch_index),
+  /* K15  */  be_nested_str_weak(find),
+  /* K16  */  be_nested_str_weak(ARG),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(_X2C_X22Switch_X22_X3A_X25s),
+  /* K19  */  be_nested_str_weak(shadow_onoff),
+  /* K20  */  be_nested_str_weak(set_position),
+  /* K21  */  be_nested_str_weak(publish_event),
+  /* K22  */  be_nested_str_weak(EVENT_INFO),
+  /* K23  */  be_nested_str_weak(Matter_TLV_item),
+  /* K24  */  be_const_int(3),
+  /* K25  */  be_const_int(2),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_GenericSwitch_Btn;
 
@@ -13,27 +43,13 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_read_attribute,   
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set_or_nil),
-    /* K10  */  be_nested_str_weak(shadow_position),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
@@ -98,13 +114,13 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn__X3Clambda_X3E,   
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -125,28 +141,24 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_set_position,   /*
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_position),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    /* K2   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(set_position),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808010A,  //  0000  GETMBR	R2	R0	K10
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0004,  //  0002  JMPF	R2	#0008
-      0x8C080101,  //  0003  GETMET	R2	R0	K1
+      0x8C08010D,  //  0003  GETMET	R2	R0	K13
       0x5412003A,  //  0004  LDINT	R4	59
-      0x58140002,  //  0005  LDCONST	R5	K2
+      0x58140008,  //  0005  LDCONST	R5	K8
       0x7C080600,  //  0006  CALL	R2	3
-      0x90020001,  //  0007  SETMBR	R0	K0	R1
+      0x90021401,  //  0007  SETMBR	R0	K10	R1
       0x80000000,  //  0008  RET	0
     })
   )
@@ -161,33 +173,27 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_parse_configuratio
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_switch_index),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
-      0x58180003,  //  0003  LDCONST	R6	K3
+      0x8C0C030F,  //  0001  GETMET	R3	R1	K15
+      0x88140110,  //  0002  GETMBR	R5	R0	K16
+      0x58180008,  //  0003  LDCONST	R6	K8
       0x7C0C0600,  //  0004  CALL	R3	3
       0x7C080200,  //  0005  CALL	R2	1
-      0x90020002,  //  0006  SETMBR	R0	K0	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x18080504,  //  0008  LE	R2	R2	K4
+      0x90021C02,  //  0006  SETMBR	R0	K14	R2
+      0x8808010E,  //  0007  GETMBR	R2	R0	K14
+      0x18080511,  //  0008  LE	R2	R2	K17
       0x780A0000,  //  0009  JMPF	R2	#000B
-      0x90020103,  //  000A  SETMBR	R0	K0	K3
+      0x90021D08,  //  000A  SETMBR	R0	K14	K8
       0x80000000,  //  000B  RET	0
     })
   )
@@ -202,23 +208,20 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_append_state_json,
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_X2C_X22Switch_X22_X3A_X25s),
-    /* K1   */  be_nested_str_weak(shadow_onoff),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(append_state_json),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
+      0x58080012,  //  0001  LDCONST	R2	K18
       0x600C0009,  //  0002  GETGBL	R3	G9
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x88100113,  //  0003  GETMBR	R4	R0	K19
       0x7C0C0200,  //  0004  CALL	R3	1
       0x7C040400,  //  0005  CALL	R1	2
       0x80040200,  //  0006  RET	1	R1
@@ -235,130 +238,117 @@ be_local_closure(class_Matter_Plugin_Sensor_GenericSwitch_Btn_button_handler,   
   be_nested_proto(
     15,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(set_position),
-    /* K3   */  be_nested_str_weak(publish_event),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(EVENT_INFO),
-    /* K6   */  be_nested_str_weak(TLV),
-    /* K7   */  be_nested_str_weak(Matter_TLV_item),
-    /* K8   */  be_nested_str_weak(set),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_const_int(2),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_GenericSwitch_Btn,     /* shared constants */
     be_str_weak(button_handler),
     &be_const_str_solidified,
     ( &(const binstruction[105]) {  /* code */
-      0x1C140500,  //  0000  EQ	R5	R2	K0
+      0x1C140511,  //  0000  EQ	R5	R2	K17
       0x74160001,  //  0001  JMPT	R5	#0004
-      0x1C140501,  //  0002  EQ	R5	R2	K1
+      0x1C140508,  //  0002  EQ	R5	R2	K8
       0x78160002,  //  0003  JMPF	R5	#0007
-      0x8C140102,  //  0004  GETMET	R5	R0	K2
+      0x8C140114,  //  0004  GETMET	R5	R0	K20
       0x5C1C0600,  //  0005  MOVE	R7	R3
       0x7C140400,  //  0006  CALL	R5	2
-      0x1C140501,  //  0007  EQ	R5	R2	K1
+      0x1C140508,  //  0007  EQ	R5	R2	K8
       0x78160040,  //  0008  JMPF	R5	#004A
       0x780E0010,  //  0009  JMPF	R3	#001B
-      0x8C140103,  //  000A  GETMET	R5	R0	K3
+      0x8C140115,  //  000A  GETMET	R5	R0	K21
       0x541E003A,  //  000B  LDINT	R7	59
-      0x58200001,  //  000C  LDCONST	R8	K1
-      0xB8260800,  //  000D  GETNGBL	R9	K4
-      0x88241305,  //  000E  GETMBR	R9	R9	K5
-      0xB82A0800,  //  000F  GETNGBL	R10	K4
-      0x88281506,  //  0010  GETMBR	R10	R10	K6
-      0x8C281507,  //  0011  GETMET	R10	R10	K7
+      0x58200008,  //  000C  LDCONST	R8	K8
+      0xB8260000,  //  000D  GETNGBL	R9	K0
+      0x88241316,  //  000E  GETMBR	R9	R9	K22
+      0xB82A0000,  //  000F  GETNGBL	R10	K0
+      0x88281501,  //  0010  GETMBR	R10	R10	K1
+      0x8C281517,  //  0011  GETMET	R10	R10	K23
       0x7C280200,  //  0012  CALL	R10	1
-      0x8C281508,  //  0013  GETMET	R10	R10	K8
-      0xB8320800,  //  0014  GETNGBL	R12	K4
-      0x88301906,  //  0015  GETMBR	R12	R12	K6
-      0x88301909,  //  0016  GETMBR	R12	R12	K9
-      0x58340001,  //  0017  LDCONST	R13	K1
+      0x8C281505,  //  0013  GETMET	R10	R10	K5
+      0xB8320000,  //  0014  GETNGBL	R12	K0
+      0x88301901,  //  0015  GETMBR	R12	R12	K1
+      0x88301906,  //  0016  GETMBR	R12	R12	K6
+      0x58340008,  //  0017  LDCONST	R13	K8
       0x7C280600,  //  0018  CALL	R10	3
       0x7C140A00,  //  0019  CALL	R5	5
       0x7002000F,  //  001A  JMP		#002B
-      0x8C140103,  //  001B  GETMET	R5	R0	K3
+      0x8C140115,  //  001B  GETMET	R5	R0	K21
       0x541E003A,  //  001C  LDINT	R7	59
-      0x5820000A,  //  001D  LDCONST	R8	K10
-      0xB8260800,  //  001E  GETNGBL	R9	K4
-      0x88241305,  //  001F  GETMBR	R9	R9	K5
-      0xB82A0800,  //  0020  GETNGBL	R10	K4
-      0x88281506,  //  0021  GETMBR	R10	R10	K6
-      0x8C281507,  //  0022  GETMET	R10	R10	K7
+      0x58200018,  //  001D  LDCONST	R8	K24
+      0xB8260000,  //  001E  GETNGBL	R9	K0
+      0x88241316,  //  001F  GETMBR	R9	R9	K22
+      0xB82A0000,  //  0020  GETNGBL	R10	K0
+      0x88281501,  //  0021  GETMBR	R10	R10	K1
+      0x8C281517,  //  0022  GETMET	R10	R10	K23
       0x7C280200,  //  0023  CALL	R10	1
-      0x8C281508,  //  0024  GETMET	R10	R10	K8
-      0xB8320800,  //  0025  GETNGBL	R12	K4
-      0x88301906,  //  0026  GETMBR	R12	R12	K6
-      0x88301909,  //  0027  GETMBR	R12	R12	K9
-      0x58340001,  //  0028  LDCONST	R13	K1
+      0x8C281505,  //  0024  GETMET	R10	R10	K5
+      0xB8320000,  //  0025  GETNGBL	R12	K0
+      0x88301901,  //  0026  GETMBR	R12	R12	K1
+      0x88301906,  //  0027  GETMBR	R12	R12	K6
+      0x58340008,  //  0028  LDCONST	R13	K8
       0x7C280600,  //  0029  CALL	R10	3
       0x7C140A00,  //  002A  CALL	R5	5
-      0x1C140701,  //  002B  EQ	R5	R3	K1
+      0x1C140708,  //  002B  EQ	R5	R3	K8
       0x7816001B,  //  002C  JMPF	R5	#0049
-      0x24140900,  //  002D  GT	R5	R4	K0
+      0x24140911,  //  002D  GT	R5	R4	K17
       0x78160019,  //  002E  JMPF	R5	#0049
-      0x8C140103,  //  002F  GETMET	R5	R0	K3
+      0x8C140115,  //  002F  GETMET	R5	R0	K21
       0x541E003A,  //  0030  LDINT	R7	59
       0x54220004,  //  0031  LDINT	R8	5
-      0xB8260800,  //  0032  GETNGBL	R9	K4
-      0x88241305,  //  0033  GETMBR	R9	R9	K5
-      0xB82A0800,  //  0034  GETNGBL	R10	K4
-      0x88281506,  //  0035  GETMBR	R10	R10	K6
-      0x8C281507,  //  0036  GETMET	R10	R10	K7
+      0xB8260000,  //  0032  GETNGBL	R9	K0
+      0x88241316,  //  0033  GETMBR	R9	R9	K22
+      0xB82A0000,  //  0034  GETNGBL	R10	K0
+      0x88281501,  //  0035  GETMBR	R10	R10	K1
+      0x8C281517,  //  0036  GETMET	R10	R10	K23
       0x7C280200,  //  0037  CALL	R10	1
-      0x8C281508,  //  0038  GETMET	R10	R10	K8
-      0xB8320800,  //  0039  GETNGBL	R12	K4
-      0x88301906,  //  003A  GETMBR	R12	R12	K6
-      0x88301909,  //  003B  GETMBR	R12	R12	K9
-      0x58340001,  //  003C  LDCONST	R13	K1
+      0x8C281505,  //  0038  GETMET	R10	R10	K5
+      0xB8320000,  //  0039  GETNGBL	R12	K0
+      0x88301901,  //  003A  GETMBR	R12	R12	K1
+      0x88301906,  //  003B  GETMBR	R12	R12	K6
+      0x58340008,  //  003C  LDCONST	R13	K8
       0x7C280600,  //  003D  CALL	R10	3
-      0xB82E0800,  //  003E  GETNGBL	R11	K4
-      0x882C1706,  //  003F  GETMBR	R11	R11	K6
-      0x8C2C1707,  //  0040  GETMET	R11	R11	K7
+      0xB82E0000,  //  003E  GETNGBL	R11	K0
+      0x882C1701,  //  003F  GETMBR	R11	R11	K1
+      0x8C2C1717,  //  0040  GETMET	R11	R11	K23
       0x7C2C0200,  //  0041  CALL	R11	1
-      0x8C2C1708,  //  0042  GETMET	R11	R11	K8
-      0xB8360800,  //  0043  GETNGBL	R13	K4
-      0x88341B06,  //  0044  GETMBR	R13	R13	K6
-      0x88341B09,  //  0045  GETMBR	R13	R13	K9
-      0x00380901,  //  0046  ADD	R14	R4	K1
+      0x8C2C1705,  //  0042  GETMET	R11	R11	K5
+      0xB8360000,  //  0043  GETNGBL	R13	K0
+      0x88341B01,  //  0044  GETMBR	R13	R13	K1
+      0x88341B06,  //  0045  GETMBR	R13	R13	K6
+      0x00380908,  //  0046  ADD	R14	R4	K8
       0x7C2C0600,  //  0047  CALL	R11	3
       0x7C140C00,  //  0048  CALL	R5	6
       0x7002001D,  //  0049  JMP		#0068
-      0x1C14050B,  //  004A  EQ	R5	R2	K11
+      0x1C140519,  //  004A  EQ	R5	R2	K25
       0x7816001B,  //  004B  JMPF	R5	#0068
-      0x24140900,  //  004C  GT	R5	R4	K0
+      0x24140911,  //  004C  GT	R5	R4	K17
       0x78160019,  //  004D  JMPF	R5	#0068
-      0x8C140103,  //  004E  GETMET	R5	R0	K3
+      0x8C140115,  //  004E  GETMET	R5	R0	K21
       0x541E003A,  //  004F  LDINT	R7	59
       0x54220005,  //  0050  LDINT	R8	6
-      0xB8260800,  //  0051  GETNGBL	R9	K4
-      0x88241305,  //  0052  GETMBR	R9	R9	K5
-      0xB82A0800,  //  0053  GETNGBL	R10	K4
-      0x88281506,  //  0054  GETMBR	R10	R10	K6
-      0x8C281507,  //  0055  GETMET	R10	R10	K7
+      0xB8260000,  //  0051  GETNGBL	R9	K0
+      0x88241316,  //  0052  GETMBR	R9	R9	K22
+      0xB82A0000,  //  0053  GETNGBL	R10	K0
+      0x88281501,  //  0054  GETMBR	R10	R10	K1
+      0x8C281517,  //  0055  GETMET	R10	R10	K23
       0x7C280200,  //  0056  CALL	R10	1
-      0x8C281508,  //  0057  GETMET	R10	R10	K8
-      0xB8320800,  //  0058  GETNGBL	R12	K4
-      0x88301906,  //  0059  GETMBR	R12	R12	K6
-      0x88301909,  //  005A  GETMBR	R12	R12	K9
-      0x58340001,  //  005B  LDCONST	R13	K1
+      0x8C281505,  //  0057  GETMET	R10	R10	K5
+      0xB8320000,  //  0058  GETNGBL	R12	K0
+      0x88301901,  //  0059  GETMBR	R12	R12	K1
+      0x88301906,  //  005A  GETMBR	R12	R12	K6
+      0x58340008,  //  005B  LDCONST	R13	K8
       0x7C280600,  //  005C  CALL	R10	3
-      0xB82E0800,  //  005D  GETNGBL	R11	K4
-      0x882C1706,  //  005E  GETMBR	R11	R11	K6
-      0x8C2C1707,  //  005F  GETMET	R11	R11	K7
+      0xB82E0000,  //  005D  GETNGBL	R11	K0
+      0x882C1701,  //  005E  GETMBR	R11	R11	K1
+      0x8C2C1717,  //  005F  GETMET	R11	R11	K23
       0x7C2C0200,  //  0060  CALL	R11	1
-      0x8C2C1708,  //  0061  GETMET	R11	R11	K8
-      0xB8360800,  //  0062  GETNGBL	R13	K4
-      0x88341B06,  //  0063  GETMBR	R13	R13	K6
-      0x88341B09,  //  0064  GETMBR	R13	R13	K9
+      0x8C2C1705,  //  0061  GETMET	R11	R11	K5
+      0xB8360000,  //  0062  GETNGBL	R13	K0
+      0x88341B01,  //  0063  GETMBR	R13	R13	K1
+      0x88341B06,  //  0064  GETMBR	R13	R13	K6
       0x5C380800,  //  0065  MOVE	R14	R4
       0x7C2C0600,  //  0066  CALL	R11	3
       0x7C140C00,  //  0067  CALL	R5	6

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
@@ -3,6 +3,58 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Shutter' ktab size: 48, total: 78 (saved 240 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Shutter[48] = {
+  /* K0   */  be_nested_str_weak(tasmota_shutter_index),
+  /* K1   */  be_nested_str_weak(find),
+  /* K2   */  be_nested_str_weak(ARG),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(shadow_shutter_inverted),
+  /* K5   */  be_nested_str_weak(light),
+  /* K6   */  be_nested_str_weak(matter),
+  /* K7   */  be_nested_str_weak(TLV),
+  /* K8   */  be_nested_str_weak(cluster),
+  /* K9   */  be_nested_str_weak(command),
+  /* K10  */  be_nested_str_weak(update_shadow_lazy),
+  /* K11  */  be_nested_str_weak(tasmota),
+  /* K12  */  be_nested_str_weak(cmd),
+  /* K13  */  be_nested_str_weak(ShutterStopOpen),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str_weak(update_shadow),
+  /* K16  */  be_nested_str_weak(ShutterStopClose),
+  /* K17  */  be_const_int(2),
+  /* K18  */  be_nested_str_weak(ShutterStop),
+  /* K19  */  be_nested_str_weak(log),
+  /* K20  */  be_nested_str_weak(MTR_X3A_X20Tilt_X20_X3D_X20),
+  /* K21  */  be_nested_str_weak(findsubval),
+  /* K22  */  be_nested_str_weak(ShutterPosition),
+  /* K23  */  be_nested_str_weak(_X20),
+  /* K24  */  be_nested_str_weak(pos_X25_X3A),
+  /* K25  */  be_nested_str_weak(invoke_request),
+  /* K26  */  be_nested_str_weak(attribute),
+  /* K27  */  be_nested_str_weak(update_inverted),
+  /* K28  */  be_nested_str_weak(set),
+  /* K29  */  be_nested_str_weak(U1),
+  /* K30  */  be_nested_str_weak(U2),
+  /* K31  */  be_nested_str_weak(shadow_shutter_pos),
+  /* K32  */  be_nested_str_weak(shadow_shutter_direction),
+  /* K33  */  be_nested_str_weak(shadow_shutter_target),
+  /* K34  */  be_nested_str_weak(read_attribute),
+  /* K35  */  be_nested_str_weak(Shutter),
+  /* K36  */  be_nested_str_weak(contains),
+  /* K37  */  be_nested_str_weak(Position),
+  /* K38  */  be_nested_str_weak(attribute_updated),
+  /* K39  */  be_nested_str_weak(Direction),
+  /* K40  */  be_nested_str_weak(Target),
+  /* K41  */  be_nested_str_weak(Status_X2013),
+  /* K42  */  be_nested_str_weak(StatusSHT),
+  /* K43  */  be_nested_str_weak(SHT),
+  /* K44  */  be_nested_str_weak(Opt),
+  /* K45  */  be_const_int(1),
+  /* K46  */  be_nested_str_weak(VIRTUAL),
+  /* K47  */  be_nested_str_weak(parse_sensors),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Shutter;
 
@@ -13,19 +65,13 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_configuration,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(shadow_shutter_inverted),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
@@ -54,95 +100,70 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(cmd),
-    /* K9   */  be_nested_str_weak(ShutterStopOpen),
-    /* K10  */  be_nested_str_weak(tasmota_shutter_index),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(update_shadow),
-    /* K13  */  be_nested_str_weak(ShutterStopClose),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(ShutterStop),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20Tilt_X20_X3D_X20),
-    /* K18  */  be_nested_str_weak(findsubval),
-    /* K19  */  be_nested_str_weak(shadow_shutter_inverted),
-    /* K20  */  be_nested_str_weak(ShutterPosition),
-    /* K21  */  be_nested_str_weak(_X20),
-    /* K22  */  be_nested_str_weak(pos_X25_X3A),
-    /* K23  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[115]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0xA4120A00,  //  0000  IMPORT	R4	K5
+      0xB8160C00,  //  0001  GETNGBL	R5	K6
+      0x88140B07,  //  0002  GETMBR	R5	R5	K7
+      0x88180708,  //  0003  GETMBR	R6	R3	K8
+      0x881C0709,  //  0004  GETMBR	R7	R3	K9
       0x54220101,  //  0005  LDINT	R8	258
       0x1C200C08,  //  0006  EQ	R8	R6	R8
       0x78220060,  //  0007  JMPF	R8	#0069
-      0x8C200105,  //  0008  GETMET	R8	R0	K5
+      0x8C20010A,  //  0008  GETMET	R8	R0	K10
       0x7C200200,  //  0009  CALL	R8	1
-      0x1C200F06,  //  000A  EQ	R8	R7	K6
+      0x1C200F03,  //  000A  EQ	R8	R7	K3
       0x7822000D,  //  000B  JMPF	R8	#001A
-      0xB8220E00,  //  000C  GETNGBL	R8	K7
-      0x8C201108,  //  000D  GETMET	R8	R8	K8
+      0xB8221600,  //  000C  GETNGBL	R8	K11
+      0x8C20110C,  //  000D  GETMET	R8	R8	K12
       0x60280008,  //  000E  GETGBL	R10	G8
-      0x882C010A,  //  000F  GETMBR	R11	R0	K10
-      0x002C170B,  //  0010  ADD	R11	R11	K11
+      0x882C0100,  //  000F  GETMBR	R11	R0	K0
+      0x002C170E,  //  0010  ADD	R11	R11	K14
       0x7C280200,  //  0011  CALL	R10	1
-      0x002A120A,  //  0012  ADD	R10	K9	R10
+      0x002A1A0A,  //  0012  ADD	R10	K13	R10
       0x502C0200,  //  0013  LDBOOL	R11	1	0
       0x7C200600,  //  0014  CALL	R8	3
-      0x8C20010C,  //  0015  GETMET	R8	R0	K12
+      0x8C20010F,  //  0015  GETMET	R8	R0	K15
       0x7C200200,  //  0016  CALL	R8	1
       0x50200200,  //  0017  LDBOOL	R8	1	0
       0x80041000,  //  0018  RET	1	R8
       0x7002004D,  //  0019  JMP		#0068
-      0x1C200F0B,  //  001A  EQ	R8	R7	K11
+      0x1C200F0E,  //  001A  EQ	R8	R7	K14
       0x7822000D,  //  001B  JMPF	R8	#002A
-      0xB8220E00,  //  001C  GETNGBL	R8	K7
-      0x8C201108,  //  001D  GETMET	R8	R8	K8
+      0xB8221600,  //  001C  GETNGBL	R8	K11
+      0x8C20110C,  //  001D  GETMET	R8	R8	K12
       0x60280008,  //  001E  GETGBL	R10	G8
-      0x882C010A,  //  001F  GETMBR	R11	R0	K10
-      0x002C170B,  //  0020  ADD	R11	R11	K11
+      0x882C0100,  //  001F  GETMBR	R11	R0	K0
+      0x002C170E,  //  0020  ADD	R11	R11	K14
       0x7C280200,  //  0021  CALL	R10	1
-      0x002A1A0A,  //  0022  ADD	R10	K13	R10
+      0x002A200A,  //  0022  ADD	R10	K16	R10
       0x502C0200,  //  0023  LDBOOL	R11	1	0
       0x7C200600,  //  0024  CALL	R8	3
-      0x8C20010C,  //  0025  GETMET	R8	R0	K12
+      0x8C20010F,  //  0025  GETMET	R8	R0	K15
       0x7C200200,  //  0026  CALL	R8	1
       0x50200200,  //  0027  LDBOOL	R8	1	0
       0x80041000,  //  0028  RET	1	R8
       0x7002003D,  //  0029  JMP		#0068
-      0x1C200F0E,  //  002A  EQ	R8	R7	K14
+      0x1C200F11,  //  002A  EQ	R8	R7	K17
       0x7822000D,  //  002B  JMPF	R8	#003A
-      0xB8220E00,  //  002C  GETNGBL	R8	K7
-      0x8C201108,  //  002D  GETMET	R8	R8	K8
+      0xB8221600,  //  002C  GETNGBL	R8	K11
+      0x8C20110C,  //  002D  GETMET	R8	R8	K12
       0x60280008,  //  002E  GETGBL	R10	G8
-      0x882C010A,  //  002F  GETMBR	R11	R0	K10
-      0x002C170B,  //  0030  ADD	R11	R11	K11
+      0x882C0100,  //  002F  GETMBR	R11	R0	K0
+      0x002C170E,  //  0030  ADD	R11	R11	K14
       0x7C280200,  //  0031  CALL	R10	1
-      0x002A1E0A,  //  0032  ADD	R10	K15	R10
+      0x002A240A,  //  0032  ADD	R10	K18	R10
       0x502C0200,  //  0033  LDBOOL	R11	1	0
       0x7C200600,  //  0034  CALL	R8	3
-      0x8C20010C,  //  0035  GETMET	R8	R0	K12
+      0x8C20010F,  //  0035  GETMET	R8	R0	K15
       0x7C200200,  //  0036  CALL	R8	1
       0x50200200,  //  0037  LDBOOL	R8	1	0
       0x80041000,  //  0038  RET	1	R8
@@ -150,34 +171,34 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x54220004,  //  003A  LDINT	R8	5
       0x1C200E08,  //  003B  EQ	R8	R7	R8
       0x7822002A,  //  003C  JMPF	R8	#0068
-      0xB8222000,  //  003D  GETNGBL	R8	K16
+      0xB8222600,  //  003D  GETNGBL	R8	K19
       0x60240008,  //  003E  GETGBL	R9	G8
       0x5C280400,  //  003F  MOVE	R10	R2
       0x7C240200,  //  0040  CALL	R9	1
-      0x00262209,  //  0041  ADD	R9	K17	R9
-      0x5828000E,  //  0042  LDCONST	R10	K14
+      0x00262809,  //  0041  ADD	R9	K20	R9
+      0x58280011,  //  0042  LDCONST	R10	K17
       0x7C200400,  //  0043  CALL	R8	2
-      0x8C200512,  //  0044  GETMET	R8	R2	K18
-      0x58280006,  //  0045  LDCONST	R10	K6
+      0x8C200515,  //  0044  GETMET	R8	R2	K21
+      0x58280003,  //  0045  LDCONST	R10	K3
       0x7C200400,  //  0046  CALL	R8	2
       0x4C240000,  //  0047  LDNIL	R9
       0x20241009,  //  0048  NE	R9	R8	R9
       0x7826001B,  //  0049  JMPF	R9	#0066
       0x54260063,  //  004A  LDINT	R9	100
       0x0C201009,  //  004B  DIV	R8	R8	R9
-      0x88240113,  //  004C  GETMBR	R9	R0	K19
-      0x1C241306,  //  004D  EQ	R9	R9	K6
+      0x88240104,  //  004C  GETMBR	R9	R0	K4
+      0x1C241303,  //  004D  EQ	R9	R9	K3
       0x78260001,  //  004E  JMPF	R9	#0051
       0x54260063,  //  004F  LDINT	R9	100
       0x04201208,  //  0050  SUB	R8	R9	R8
-      0xB8260E00,  //  0051  GETNGBL	R9	K7
-      0x8C241308,  //  0052  GETMET	R9	R9	K8
+      0xB8261600,  //  0051  GETNGBL	R9	K11
+      0x8C24130C,  //  0052  GETMET	R9	R9	K12
       0x602C0008,  //  0053  GETGBL	R11	G8
-      0x8830010A,  //  0054  GETMBR	R12	R0	K10
-      0x0030190B,  //  0055  ADD	R12	R12	K11
+      0x88300100,  //  0054  GETMBR	R12	R0	K0
+      0x0030190E,  //  0055  ADD	R12	R12	K14
       0x7C2C0200,  //  0056  CALL	R11	1
-      0x002E280B,  //  0057  ADD	R11	K20	R11
-      0x002C1715,  //  0058  ADD	R11	R11	K21
+      0x002E2C0B,  //  0057  ADD	R11	K22	R11
+      0x002C1717,  //  0058  ADD	R11	R11	K23
       0x60300008,  //  0059  GETGBL	R12	G8
       0x5C341000,  //  005A  MOVE	R13	R8
       0x7C300200,  //  005B  CALL	R12	1
@@ -187,9 +208,9 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x60240008,  //  005F  GETGBL	R9	G8
       0x5C281000,  //  0060  MOVE	R10	R8
       0x7C240200,  //  0061  CALL	R9	1
-      0x00262C09,  //  0062  ADD	R9	K22	R9
-      0x900E2009,  //  0063  SETMBR	R3	K16	R9
-      0x8C24010C,  //  0064  GETMET	R9	R0	K12
+      0x00263009,  //  0062  ADD	R9	K24	R9
+      0x900E2609,  //  0063  SETMBR	R3	K19	R9
+      0x8C24010F,  //  0064  GETMET	R9	R0	K15
       0x7C240200,  //  0065  CALL	R9	1
       0x50240200,  //  0066  LDBOOL	R9	1	0
       0x80041200,  //  0067  RET	1	R9
@@ -197,7 +218,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x60200003,  //  0069  GETGBL	R8	G3
       0x5C240000,  //  006A  MOVE	R9	R0
       0x7C200200,  //  006B  CALL	R8	1
-      0x8C201117,  //  006C  GETMET	R8	R8	K23
+      0x8C201119,  //  006C  GETMET	R8	R8	K25
       0x5C280200,  //  006D  MOVE	R10	R1
       0x5C2C0400,  //  006E  MOVE	R11	R2
       0x5C300600,  //  006F  MOVE	R12	R3
@@ -217,50 +238,32 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(update_inverted),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(set),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(shadow_shutter_inverted),
-    /* K12  */  be_nested_str_weak(shadow_shutter_pos),
-    /* K13  */  be_nested_str_weak(shadow_shutter_direction),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(shadow_shutter_target),
-    /* K16  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[131]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120C00,  //  0000  GETNGBL	R4	K6
+      0x88100907,  //  0001  GETMBR	R4	R4	K7
+      0x88140508,  //  0002  GETMBR	R5	R2	K8
+      0x8818051A,  //  0003  GETMBR	R6	R2	K26
       0x4C1C0000,  //  0004  LDNIL	R7
       0x54220101,  //  0005  LDINT	R8	258
       0x1C200A08,  //  0006  EQ	R8	R5	R8
       0x78220071,  //  0007  JMPF	R8	#007A
-      0x8C200104,  //  0008  GETMET	R8	R0	K4
+      0x8C20010A,  //  0008  GETMET	R8	R0	K10
       0x7C200200,  //  0009  CALL	R8	1
-      0x8C200105,  //  000A  GETMET	R8	R0	K5
+      0x8C20011B,  //  000A  GETMET	R8	R0	K27
       0x7C200200,  //  000B  CALL	R8	1
-      0x1C200D06,  //  000C  EQ	R8	R6	K6
+      0x1C200D03,  //  000C  EQ	R8	R6	K3
       0x78220005,  //  000D  JMPF	R8	#0014
-      0x8C200707,  //  000E  GETMET	R8	R3	K7
-      0x88280908,  //  000F  GETMBR	R10	R4	K8
+      0x8C20071C,  //  000E  GETMET	R8	R3	K28
+      0x8828091D,  //  000F  GETMBR	R10	R4	K29
       0x542E00FE,  //  0010  LDINT	R11	255
       0x7C200600,  //  0011  CALL	R8	3
       0x80041000,  //  0012  RET	1	R8
@@ -268,27 +271,27 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
       0x54220004,  //  0014  LDINT	R8	5
       0x1C200C08,  //  0015  EQ	R8	R6	R8
       0x78220005,  //  0016  JMPF	R8	#001D
-      0x8C200707,  //  0017  GETMET	R8	R3	K7
-      0x88280909,  //  0018  GETMBR	R10	R4	K9
-      0x582C0006,  //  0019  LDCONST	R11	K6
+      0x8C20071C,  //  0017  GETMET	R8	R3	K28
+      0x8828091E,  //  0018  GETMBR	R10	R4	K30
+      0x582C0003,  //  0019  LDCONST	R11	K3
       0x7C200600,  //  001A  CALL	R8	3
       0x80041000,  //  001B  RET	1	R8
       0x7002005C,  //  001C  JMP		#007A
       0x54220006,  //  001D  LDINT	R8	7
       0x1C200C08,  //  001E  EQ	R8	R6	R8
       0x78220006,  //  001F  JMPF	R8	#0027
-      0x8C200707,  //  0020  GETMET	R8	R3	K7
-      0x88280908,  //  0021  GETMBR	R10	R4	K8
+      0x8C20071C,  //  0020  GETMET	R8	R3	K28
+      0x8828091D,  //  0021  GETMBR	R10	R4	K29
       0x542E0007,  //  0022  LDINT	R11	8
-      0x002E140B,  //  0023  ADD	R11	K10	R11
+      0x002E1C0B,  //  0023  ADD	R11	K14	R11
       0x7C200600,  //  0024  CALL	R8	3
       0x80041000,  //  0025  RET	1	R8
       0x70020052,  //  0026  JMP		#007A
       0x5422000C,  //  0027  LDINT	R8	13
       0x1C200C08,  //  0028  EQ	R8	R6	R8
       0x78220005,  //  0029  JMPF	R8	#0030
-      0x8C200707,  //  002A  GETMET	R8	R3	K7
-      0x88280908,  //  002B  GETMBR	R10	R4	K8
+      0x8C20071C,  //  002A  GETMET	R8	R3	K28
+      0x8828091D,  //  002B  GETMBR	R10	R4	K29
       0x542E00FE,  //  002C  LDINT	R11	255
       0x7C200600,  //  002D  CALL	R8	3
       0x80041000,  //  002E  RET	1	R8
@@ -296,22 +299,22 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
       0x5422000D,  //  0030  LDINT	R8	14
       0x1C200C08,  //  0031  EQ	R8	R6	R8
       0x78220013,  //  0032  JMPF	R8	#0047
-      0x8820010B,  //  0033  GETMBR	R8	R0	K11
-      0x1C201106,  //  0034  EQ	R8	R8	K6
+      0x88200104,  //  0033  GETMBR	R8	R0	K4
+      0x1C201103,  //  0034  EQ	R8	R8	K3
       0x78220006,  //  0035  JMPF	R8	#003D
       0x54220063,  //  0036  LDINT	R8	100
-      0x8824010C,  //  0037  GETMBR	R9	R0	K12
+      0x8824011F,  //  0037  GETMBR	R9	R0	K31
       0x04201009,  //  0038  SUB	R8	R8	R9
       0x54260063,  //  0039  LDINT	R9	100
       0x08201009,  //  003A  MUL	R8	R8	R9
       0x5C1C1000,  //  003B  MOVE	R7	R8
       0x70020003,  //  003C  JMP		#0041
-      0x8820010C,  //  003D  GETMBR	R8	R0	K12
+      0x8820011F,  //  003D  GETMBR	R8	R0	K31
       0x54260063,  //  003E  LDINT	R9	100
       0x08201009,  //  003F  MUL	R8	R8	R9
       0x5C1C1000,  //  0040  MOVE	R7	R8
-      0x8C200707,  //  0041  GETMET	R8	R3	K7
-      0x88280909,  //  0042  GETMBR	R10	R4	K9
+      0x8C20071C,  //  0041  GETMET	R8	R3	K28
+      0x8828091E,  //  0042  GETMBR	R10	R4	K30
       0x5C2C0E00,  //  0043  MOVE	R11	R7
       0x7C200600,  //  0044  CALL	R8	3
       0x80041000,  //  0045  RET	1	R8
@@ -319,19 +322,19 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
       0x54220009,  //  0047  LDINT	R8	10
       0x1C200C08,  //  0048  EQ	R8	R6	R8
       0x78220010,  //  0049  JMPF	R8	#005B
-      0x8820010D,  //  004A  GETMBR	R8	R0	K13
-      0x1C201106,  //  004B  EQ	R8	R8	K6
+      0x88200120,  //  004A  GETMBR	R8	R0	K32
+      0x1C201103,  //  004B  EQ	R8	R8	K3
       0x78220001,  //  004C  JMPF	R8	#004F
-      0x58200006,  //  004D  LDCONST	R8	K6
+      0x58200003,  //  004D  LDCONST	R8	K3
       0x70020005,  //  004E  JMP		#0055
-      0x8820010D,  //  004F  GETMBR	R8	R0	K13
-      0x24201106,  //  0050  GT	R8	R8	K6
+      0x88200120,  //  004F  GETMBR	R8	R0	K32
+      0x24201103,  //  0050  GT	R8	R8	K3
       0x78220001,  //  0051  JMPF	R8	#0054
-      0x5820000A,  //  0052  LDCONST	R8	K10
+      0x5820000E,  //  0052  LDCONST	R8	K14
       0x70020000,  //  0053  JMP		#0055
-      0x5820000E,  //  0054  LDCONST	R8	K14
-      0x8C240707,  //  0055  GETMET	R9	R3	K7
-      0x882C0908,  //  0056  GETMBR	R11	R4	K8
+      0x58200011,  //  0054  LDCONST	R8	K17
+      0x8C24071C,  //  0055  GETMET	R9	R3	K28
+      0x882C091D,  //  0056  GETMBR	R11	R4	K29
       0x5C301000,  //  0057  MOVE	R12	R8
       0x7C240600,  //  0058  CALL	R9	3
       0x80041200,  //  0059  RET	1	R9
@@ -339,22 +342,22 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
       0x5422000A,  //  005B  LDINT	R8	11
       0x1C200C08,  //  005C  EQ	R8	R6	R8
       0x78220013,  //  005D  JMPF	R8	#0072
-      0x8820010B,  //  005E  GETMBR	R8	R0	K11
-      0x1C201106,  //  005F  EQ	R8	R8	K6
+      0x88200104,  //  005E  GETMBR	R8	R0	K4
+      0x1C201103,  //  005F  EQ	R8	R8	K3
       0x78220006,  //  0060  JMPF	R8	#0068
       0x54220063,  //  0061  LDINT	R8	100
-      0x8824010F,  //  0062  GETMBR	R9	R0	K15
+      0x88240121,  //  0062  GETMBR	R9	R0	K33
       0x04201009,  //  0063  SUB	R8	R8	R9
       0x54260063,  //  0064  LDINT	R9	100
       0x08201009,  //  0065  MUL	R8	R8	R9
       0x5C1C1000,  //  0066  MOVE	R7	R8
       0x70020003,  //  0067  JMP		#006C
-      0x8820010F,  //  0068  GETMBR	R8	R0	K15
+      0x88200121,  //  0068  GETMBR	R8	R0	K33
       0x54260063,  //  0069  LDINT	R9	100
       0x08201009,  //  006A  MUL	R8	R8	R9
       0x5C1C1000,  //  006B  MOVE	R7	R8
-      0x8C200707,  //  006C  GETMET	R8	R3	K7
-      0x88280909,  //  006D  GETMBR	R10	R4	K9
+      0x8C20071C,  //  006C  GETMET	R8	R3	K28
+      0x8828091E,  //  006D  GETMBR	R10	R4	K30
       0x5C2C0E00,  //  006E  MOVE	R11	R7
       0x7C200600,  //  006F  CALL	R8	3
       0x80041000,  //  0070  RET	1	R8
@@ -362,15 +365,15 @@ be_local_closure(class_Matter_Plugin_Shutter_read_attribute,   /* name */
       0x54220016,  //  0072  LDINT	R8	23
       0x1C200C08,  //  0073  EQ	R8	R6	R8
       0x78220004,  //  0074  JMPF	R8	#007A
-      0x8C200707,  //  0075  GETMET	R8	R3	K7
-      0x88280908,  //  0076  GETMBR	R10	R4	K8
-      0x582C0006,  //  0077  LDCONST	R11	K6
+      0x8C20071C,  //  0075  GETMET	R8	R3	K28
+      0x8828091D,  //  0076  GETMBR	R10	R4	K29
+      0x582C0003,  //  0077  LDCONST	R11	K3
       0x7C200600,  //  0078  CALL	R8	3
       0x80041000,  //  0079  RET	1	R8
       0x60200003,  //  007A  GETGBL	R8	G3
       0x5C240000,  //  007B  MOVE	R9	R0
       0x7C200200,  //  007C  CALL	R8	1
-      0x8C201110,  //  007D  GETMET	R8	R8	K16
+      0x8C201122,  //  007D  GETMET	R8	R8	K34
       0x5C280200,  //  007E  MOVE	R10	R1
       0x5C2C0400,  //  007F  MOVE	R11	R2
       0x5C300600,  //  0080  MOVE	R12	R3
@@ -389,13 +392,13 @@ be_local_closure(class_Matter_Plugin_Shutter__X3Clambda_X3E,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -416,81 +419,68 @@ be_local_closure(class_Matter_Plugin_Shutter_parse_sensors,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(Shutter),
-    /* K1   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(contains),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(Position),
-    /* K6   */  be_nested_str_weak(shadow_shutter_pos),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_nested_str_weak(Direction),
-    /* K9   */  be_nested_str_weak(shadow_shutter_direction),
-    /* K10  */  be_nested_str_weak(Target),
-    /* K11  */  be_nested_str_weak(shadow_shutter_target),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x000C0702,  //  0002  ADD	R3	R3	K2
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x000C070E,  //  0002  ADD	R3	R3	K14
       0x7C080200,  //  0003  CALL	R2	1
-      0x000A0002,  //  0004  ADD	R2	K0	R2
-      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
+      0x000A4602,  //  0004  ADD	R2	K35	R2
+      0x8C0C0324,  //  0005  GETMET	R3	R1	K36
       0x5C140400,  //  0006  MOVE	R5	R2
       0x7C0C0400,  //  0007  CALL	R3	2
       0x780E002A,  //  0008  JMPF	R3	#0034
       0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C100704,  //  000A  GETMET	R4	R3	K4
-      0x58180005,  //  000B  LDCONST	R6	K5
+      0x8C100701,  //  000A  GETMET	R4	R3	K1
+      0x58180025,  //  000B  LDCONST	R6	K37
       0x7C100400,  //  000C  CALL	R4	2
       0x4C140000,  //  000D  LDNIL	R5
       0x20140805,  //  000E  NE	R5	R4	R5
       0x78160007,  //  000F  JMPF	R5	#0018
-      0x88140106,  //  0010  GETMBR	R5	R0	K6
+      0x8814011F,  //  0010  GETMBR	R5	R0	K31
       0x20140805,  //  0011  NE	R5	R4	R5
       0x78160003,  //  0012  JMPF	R5	#0017
-      0x8C140107,  //  0013  GETMET	R5	R0	K7
+      0x8C140126,  //  0013  GETMET	R5	R0	K38
       0x541E0101,  //  0014  LDINT	R7	258
       0x5422000D,  //  0015  LDINT	R8	14
       0x7C140600,  //  0016  CALL	R5	3
-      0x90020C04,  //  0017  SETMBR	R0	K6	R4
-      0x8C140704,  //  0018  GETMET	R5	R3	K4
-      0x581C0008,  //  0019  LDCONST	R7	K8
+      0x90023E04,  //  0017  SETMBR	R0	K31	R4
+      0x8C140701,  //  0018  GETMET	R5	R3	K1
+      0x581C0027,  //  0019  LDCONST	R7	K39
       0x7C140400,  //  001A  CALL	R5	2
       0x4C180000,  //  001B  LDNIL	R6
       0x20180A06,  //  001C  NE	R6	R5	R6
       0x781A0007,  //  001D  JMPF	R6	#0026
-      0x88180109,  //  001E  GETMBR	R6	R0	K9
+      0x88180120,  //  001E  GETMBR	R6	R0	K32
       0x20180A06,  //  001F  NE	R6	R5	R6
       0x781A0003,  //  0020  JMPF	R6	#0025
-      0x8C180107,  //  0021  GETMET	R6	R0	K7
+      0x8C180126,  //  0021  GETMET	R6	R0	K38
       0x54220101,  //  0022  LDINT	R8	258
       0x54260009,  //  0023  LDINT	R9	10
       0x7C180600,  //  0024  CALL	R6	3
-      0x90021205,  //  0025  SETMBR	R0	K9	R5
-      0x8C180704,  //  0026  GETMET	R6	R3	K4
-      0x5820000A,  //  0027  LDCONST	R8	K10
+      0x90024005,  //  0025  SETMBR	R0	K32	R5
+      0x8C180701,  //  0026  GETMET	R6	R3	K1
+      0x58200028,  //  0027  LDCONST	R8	K40
       0x7C180400,  //  0028  CALL	R6	2
       0x4C1C0000,  //  0029  LDNIL	R7
       0x201C0C07,  //  002A  NE	R7	R6	R7
       0x781E0007,  //  002B  JMPF	R7	#0034
-      0x881C010B,  //  002C  GETMBR	R7	R0	K11
+      0x881C0121,  //  002C  GETMBR	R7	R0	K33
       0x201C0C07,  //  002D  NE	R7	R6	R7
       0x781E0003,  //  002E  JMPF	R7	#0033
-      0x8C1C0107,  //  002F  GETMET	R7	R0	K7
+      0x8C1C0126,  //  002F  GETMET	R7	R0	K38
       0x54260101,  //  0030  LDINT	R9	258
       0x542A000A,  //  0031  LDINT	R10	11
       0x7C1C0600,  //  0032  CALL	R7	3
-      0x90021606,  //  0033  SETMBR	R0	K11	R6
+      0x90024206,  //  0033  SETMBR	R0	K33	R6
       0x80000000,  //  0034  RET	0
     })
   )
@@ -505,52 +495,40 @@ be_local_closure(class_Matter_Plugin_Shutter_update_inverted,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_shutter_inverted),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(cmd),
-    /* K3   */  be_nested_str_weak(Status_X2013),
-    /* K4   */  be_nested_str_weak(contains),
-    /* K5   */  be_nested_str_weak(StatusSHT),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(SHT),
-    /* K8   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K9   */  be_nested_str_weak(Opt),
-    /* K10  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(update_inverted),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x5409FFFE,  //  0001  LDINT	R2	-1
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x7806001F,  //  0003  JMPF	R1	#0024
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x580C0003,  //  0006  LDCONST	R3	K3
+      0xB8061600,  //  0004  GETNGBL	R1	K11
+      0x8C04030C,  //  0005  GETMET	R1	R1	K12
+      0x580C0029,  //  0006  LDCONST	R3	K41
       0x50100200,  //  0007  LDBOOL	R4	1	0
       0x7C040600,  //  0008  CALL	R1	3
-      0x8C080304,  //  0009  GETMET	R2	R1	K4
-      0x58100005,  //  000A  LDCONST	R4	K5
+      0x8C080324,  //  0009  GETMET	R2	R1	K36
+      0x5810002A,  //  000A  LDCONST	R4	K42
       0x7C080400,  //  000B  CALL	R2	2
       0x780A0016,  //  000C  JMPF	R2	#0024
-      0x94040305,  //  000D  GETIDX	R1	R1	K5
-      0x8C080306,  //  000E  GETMET	R2	R1	K6
+      0x9404032A,  //  000D  GETIDX	R1	R1	K42
+      0x8C080301,  //  000E  GETMET	R2	R1	K1
       0x60100008,  //  000F  GETGBL	R4	G8
-      0x88140108,  //  0010  GETMBR	R5	R0	K8
+      0x88140100,  //  0010  GETMBR	R5	R0	K0
       0x7C100200,  //  0011  CALL	R4	1
-      0x00120E04,  //  0012  ADD	R4	K7	R4
+      0x00125604,  //  0012  ADD	R4	K43	R4
       0x60140013,  //  0013  GETGBL	R5	G19
       0x7C140000,  //  0014  CALL	R5	0
       0x7C080600,  //  0015  CALL	R2	3
-      0x8C080506,  //  0016  GETMET	R2	R2	K6
-      0x58100009,  //  0017  LDCONST	R4	K9
+      0x8C080501,  //  0016  GETMET	R2	R2	K1
+      0x5810002C,  //  0017  LDCONST	R4	K44
       0x7C080400,  //  0018  CALL	R2	2
       0x4C0C0000,  //  0019  LDNIL	R3
       0x200C0403,  //  001A  NE	R3	R2	R3
@@ -559,10 +537,10 @@ be_local_closure(class_Matter_Plugin_Shutter_update_inverted,   /* name */
       0x6010000C,  //  001D  GETGBL	R4	G12
       0x5C140400,  //  001E  MOVE	R5	R2
       0x7C100200,  //  001F  CALL	R4	1
-      0x0410090A,  //  0020  SUB	R4	R4	K10
+      0x0410092D,  //  0020  SUB	R4	R4	K45
       0x94100404,  //  0021  GETIDX	R4	R2	R4
       0x7C0C0200,  //  0022  CALL	R3	1
-      0x90020003,  //  0023  SETMBR	R0	K0	R3
+      0x90020803,  //  0023  SETMBR	R0	K4	R3
       0x80000000,  //  0024  RET	0
     })
   )
@@ -577,47 +555,37 @@ be_local_closure(class_Matter_Plugin_Shutter_update_shadow,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(update_inverted),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(cmd),
-    /* K4   */  be_nested_str_weak(ShutterPosition),
-    /* K5   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(parse_sensors),
-    /* K8   */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Shutter,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804012E,  //  0000  GETMBR	R1	R0	K46
       0x7406000E,  //  0001  JMPT	R1	#0011
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x8C04011B,  //  0002  GETMET	R1	R0	K27
       0x7C040200,  //  0003  CALL	R1	1
-      0xB8060400,  //  0004  GETNGBL	R1	K2
-      0x8C040303,  //  0005  GETMET	R1	R1	K3
+      0xB8061600,  //  0004  GETNGBL	R1	K11
+      0x8C04030C,  //  0005  GETMET	R1	R1	K12
       0x600C0008,  //  0006  GETGBL	R3	G8
-      0x88100105,  //  0007  GETMBR	R4	R0	K5
-      0x00100906,  //  0008  ADD	R4	R4	K6
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x0010090E,  //  0008  ADD	R4	R4	K14
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x000E0803,  //  000A  ADD	R3	K4	R3
+      0x000E2C03,  //  000A  ADD	R3	K22	R3
       0x50100200,  //  000B  LDBOOL	R4	1	0
       0x7C040600,  //  000C  CALL	R1	3
       0x78060002,  //  000D  JMPF	R1	#0011
-      0x8C080107,  //  000E  GETMET	R2	R0	K7
+      0x8C08012F,  //  000E  GETMET	R2	R0	K47
       0x5C100200,  //  000F  MOVE	R4	R1
       0x7C080400,  //  0010  CALL	R2	2
       0x60040003,  //  0011  GETGBL	R1	G3
       0x5C080000,  //  0012  MOVE	R2	R0
       0x7C040200,  //  0013  CALL	R1	1
-      0x8C040308,  //  0014  GETMET	R1	R1	K8
+      0x8C04030F,  //  0014  GETMET	R1	R1	K15
       0x7C040200,  //  0015  CALL	R1	1
       0x80000000,  //  0016  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light1.h
@@ -3,6 +3,65 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Light1' ktab size: 55, total: 108 (saved 424 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Light1[55] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(BRIDGE),
+  /* K2   */  be_nested_str_weak(tasmota),
+  /* K3   */  be_nested_str_weak(scale_uint),
+  /* K4   */  be_nested_str_weak(call_remote_sync),
+  /* K5   */  be_nested_str_weak(Dimmer),
+  /* K6   */  be_nested_str_weak(parse_status),
+  /* K7   */  be_nested_str_weak(VIRTUAL),
+  /* K8   */  be_nested_str_weak(shadow_onoff),
+  /* K9   */  be_nested_str_weak(attribute_updated),
+  /* K10  */  be_nested_str_weak(shadow_bri),
+  /* K11  */  be_nested_str_weak(light),
+  /* K12  */  be_nested_str_weak(set),
+  /* K13  */  be_nested_str_weak(bri),
+  /* K14  */  be_nested_str_weak(light_index),
+  /* K15  */  be_nested_str_weak(power),
+  /* K16  */  be_nested_str_weak(update_shadow),
+  /* K17  */  be_nested_str_weak(),
+  /* K18  */  be_nested_str_weak(_X25i_X25_X25),
+  /* K19  */  be_nested_str_weak(_X26_X23128261_X3B_X20),
+  /* K20  */  be_nested_str_weak(matter),
+  /* K21  */  be_nested_str_weak(TLV),
+  /* K22  */  be_nested_str_weak(cluster),
+  /* K23  */  be_nested_str_weak(command),
+  /* K24  */  be_nested_str_weak(update_shadow_lazy),
+  /* K25  */  be_nested_str_weak(findsubval),
+  /* K26  */  be_nested_str_weak(set_bri),
+  /* K27  */  be_nested_str_weak(log),
+  /* K28  */  be_nested_str_weak(bri_X3A),
+  /* K29  */  be_nested_str_weak(publish_command),
+  /* K30  */  be_nested_str_weak(Bri),
+  /* K31  */  be_const_int(1),
+  /* K32  */  be_const_int(2),
+  /* K33  */  be_const_int(3),
+  /* K34  */  be_nested_str_weak(Power),
+  /* K35  */  be_nested_str_weak(invoke_request),
+  /* K36  */  be_nested_str_weak(attribute),
+  /* K37  */  be_nested_str_weak(U1),
+  /* K38  */  be_nested_str_weak(read_attribute),
+  /* K39  */  be_nested_str_weak(tasmota_relay_index),
+  /* K40  */  be_nested_str_weak(find),
+  /* K41  */  be_nested_str_weak(ARG),
+  /* K42  */  be_const_int(0),
+  /* K43  */  be_nested_str_weak(TYPE),
+  /* K44  */  be_nested_str_weak(light1),
+  /* K45  */  be_nested_str_weak(get_option),
+  /* K46  */  be_nested_str_weak(get),
+  /* K47  */  be_nested_str_weak(update_virtual),
+  /* K48  */  be_nested_str_weak(init),
+  /* K49  */  be_nested_str_weak(webserver),
+  /* K50  */  be_nested_str_weak(web_values_prefix),
+  /* K51  */  be_nested_str_weak(content_send),
+  /* K52  */  be_nested_str_weak(_X25s_X20_X25s),
+  /* K53  */  be_nested_str_weak(web_value_onoff),
+  /* K54  */  be_nested_str_weak(web_value_dimmer),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Light1;
 
@@ -13,31 +72,13 @@ be_local_closure(class_Matter_Plugin_Light1_set_bri,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_nested_str_weak(call_remote_sync),
-    /* K5   */  be_nested_str_weak(Dimmer),
-    /* K6   */  be_nested_str_weak(parse_status),
-    /* K7   */  be_nested_str_weak(VIRTUAL),
-    /* K8   */  be_nested_str_weak(shadow_onoff),
-    /* K9   */  be_nested_str_weak(attribute_updated),
-    /* K10  */  be_nested_str_weak(shadow_bri),
-    /* K11  */  be_nested_str_weak(light),
-    /* K12  */  be_nested_str_weak(set),
-    /* K13  */  be_nested_str_weak(bri),
-    /* K14  */  be_nested_str_weak(light_index),
-    /* K15  */  be_nested_str_weak(power),
-    /* K16  */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(set_bri),
     &be_const_str_solidified,
     ( &(const binstruction[91]) {  /* code */
@@ -145,43 +186,35 @@ be_local_closure(class_Matter_Plugin_Light1_web_value_dimmer,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(shadow_bri),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(_X25i_X25_X25),
-    /* K6   */  be_nested_str_weak(_X26_X23128261_X3B_X20),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(web_value_dimmer),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x58040011,  //  0000  LDCONST	R1	K17
+      0x8808010A,  //  0001  GETMBR	R2	R0	K10
       0x4C0C0000,  //  0002  LDNIL	R3
       0x20080403,  //  0003  NE	R2	R2	R3
       0x780A000C,  //  0004  JMPF	R2	#0012
       0xB80A0400,  //  0005  GETNGBL	R2	K2
       0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x88100101,  //  0007  GETMBR	R4	R0	K1
-      0x58140004,  //  0008  LDCONST	R5	K4
+      0x8810010A,  //  0007  GETMBR	R4	R0	K10
+      0x58140000,  //  0008  LDCONST	R5	K0
       0x541A00FD,  //  0009  LDINT	R6	254
-      0x581C0004,  //  000A  LDCONST	R7	K4
+      0x581C0000,  //  000A  LDCONST	R7	K0
       0x54220063,  //  000B  LDINT	R8	100
       0x7C080C00,  //  000C  CALL	R2	6
       0x600C0018,  //  000D  GETGBL	R3	G24
-      0x58100005,  //  000E  LDCONST	R4	K5
+      0x58100012,  //  000E  LDCONST	R4	K18
       0x5C140400,  //  000F  MOVE	R5	R2
       0x7C0C0400,  //  0010  CALL	R3	2
       0x5C040600,  //  0011  MOVE	R1	R3
-      0x000A0C01,  //  0012  ADD	R2	K6	R1
+      0x000A2601,  //  0012  ADD	R2	K19	R1
       0x80040400,  //  0013  RET	1	R2
     })
   )
@@ -196,88 +229,66 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
   be_nested_proto(
     22,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_nested_str_weak(set_bri),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(bri_X3A),
-    /* K11  */  be_nested_str_weak(publish_command),
-    /* K12  */  be_nested_str_weak(Bri),
-    /* K13  */  be_nested_str_weak(Dimmer),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(scale_uint),
-    /* K16  */  be_const_int(1),
-    /* K17  */  be_const_int(2),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(Power),
-    /* K20  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[119]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0xA4121600,  //  0000  IMPORT	R4	K11
+      0xB8162800,  //  0001  GETNGBL	R5	K20
+      0x88140B15,  //  0002  GETMBR	R5	R5	K21
+      0x88180716,  //  0003  GETMBR	R6	R3	K22
+      0x881C0717,  //  0004  GETMBR	R7	R3	K23
       0x54220007,  //  0005  LDINT	R8	8
       0x1C200C08,  //  0006  EQ	R8	R6	R8
       0x78220064,  //  0007  JMPF	R8	#006D
-      0x8C200105,  //  0008  GETMET	R8	R0	K5
+      0x8C200118,  //  0008  GETMET	R8	R0	K24
       0x7C200200,  //  0009  CALL	R8	1
-      0x1C200F06,  //  000A  EQ	R8	R7	K6
+      0x1C200F00,  //  000A  EQ	R8	R7	K0
       0x7822001A,  //  000B  JMPF	R8	#0027
-      0x8C200507,  //  000C  GETMET	R8	R2	K7
-      0x58280006,  //  000D  LDCONST	R10	K6
+      0x8C200519,  //  000C  GETMET	R8	R2	K25
+      0x58280000,  //  000D  LDCONST	R10	K0
       0x7C200400,  //  000E  CALL	R8	2
-      0x8C240108,  //  000F  GETMET	R9	R0	K8
+      0x8C24011A,  //  000F  GETMET	R9	R0	K26
       0x5C2C1000,  //  0010  MOVE	R11	R8
       0x7C240400,  //  0011  CALL	R9	2
       0x60240008,  //  0012  GETGBL	R9	G8
       0x5C281000,  //  0013  MOVE	R10	R8
       0x7C240200,  //  0014  CALL	R9	1
-      0x00261409,  //  0015  ADD	R9	K10	R9
-      0x900E1209,  //  0016  SETMBR	R3	K9	R9
-      0x8C24010B,  //  0017  GETMET	R9	R0	K11
-      0x582C000C,  //  0018  LDCONST	R11	K12
+      0x00263809,  //  0015  ADD	R9	K28	R9
+      0x900E3609,  //  0016  SETMBR	R3	K27	R9
+      0x8C24011D,  //  0017  GETMET	R9	R0	K29
+      0x582C001E,  //  0018  LDCONST	R11	K30
       0x5C301000,  //  0019  MOVE	R12	R8
-      0x5834000D,  //  001A  LDCONST	R13	K13
-      0xB83A1C00,  //  001B  GETNGBL	R14	K14
-      0x8C381D0F,  //  001C  GETMET	R14	R14	K15
+      0x58340005,  //  001A  LDCONST	R13	K5
+      0xB83A0400,  //  001B  GETNGBL	R14	K2
+      0x8C381D03,  //  001C  GETMET	R14	R14	K3
       0x5C401000,  //  001D  MOVE	R16	R8
-      0x58440006,  //  001E  LDCONST	R17	K6
+      0x58440000,  //  001E  LDCONST	R17	K0
       0x544A00FD,  //  001F  LDINT	R18	254
-      0x584C0006,  //  0020  LDCONST	R19	K6
+      0x584C0000,  //  0020  LDCONST	R19	K0
       0x54520063,  //  0021  LDINT	R20	100
       0x7C380C00,  //  0022  CALL	R14	6
       0x7C240A00,  //  0023  CALL	R9	5
       0x50240200,  //  0024  LDBOOL	R9	1	0
       0x80041200,  //  0025  RET	1	R9
       0x70020044,  //  0026  JMP		#006C
-      0x1C200F10,  //  0027  EQ	R8	R7	K16
+      0x1C200F1F,  //  0027  EQ	R8	R7	K31
       0x78220002,  //  0028  JMPF	R8	#002C
       0x50200200,  //  0029  LDBOOL	R8	1	0
       0x80041000,  //  002A  RET	1	R8
       0x7002003F,  //  002B  JMP		#006C
-      0x1C200F11,  //  002C  EQ	R8	R7	K17
+      0x1C200F20,  //  002C  EQ	R8	R7	K32
       0x78220002,  //  002D  JMPF	R8	#0031
       0x50200200,  //  002E  LDBOOL	R8	1	0
       0x80041000,  //  002F  RET	1	R8
       0x7002003A,  //  0030  JMP		#006C
-      0x1C200F12,  //  0031  EQ	R8	R7	K18
+      0x1C200F21,  //  0031  EQ	R8	R7	K33
       0x78220002,  //  0032  JMPF	R8	#0036
       0x50200200,  //  0033  LDBOOL	R8	1	0
       0x80041000,  //  0034  RET	1	R8
@@ -285,36 +296,36 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
       0x54220003,  //  0036  LDINT	R8	4
       0x1C200E08,  //  0037  EQ	R8	R7	R8
       0x78220021,  //  0038  JMPF	R8	#005B
-      0x8C200507,  //  0039  GETMET	R8	R2	K7
-      0x58280006,  //  003A  LDCONST	R10	K6
+      0x8C200519,  //  0039  GETMET	R8	R2	K25
+      0x58280000,  //  003A  LDCONST	R10	K0
       0x7C200400,  //  003B  CALL	R8	2
-      0x24241106,  //  003C  GT	R9	R8	K6
-      0x8C280108,  //  003D  GETMET	R10	R0	K8
+      0x24241100,  //  003C  GT	R9	R8	K0
+      0x8C28011A,  //  003D  GETMET	R10	R0	K26
       0x5C301000,  //  003E  MOVE	R12	R8
       0x5C341200,  //  003F  MOVE	R13	R9
       0x7C280600,  //  0040  CALL	R10	3
       0x60280008,  //  0041  GETGBL	R10	G8
       0x5C2C1000,  //  0042  MOVE	R11	R8
       0x7C280200,  //  0043  CALL	R10	1
-      0x002A140A,  //  0044  ADD	R10	K10	R10
-      0x900E120A,  //  0045  SETMBR	R3	K9	R10
-      0x8C28010B,  //  0046  GETMET	R10	R0	K11
-      0x5830000C,  //  0047  LDCONST	R12	K12
+      0x002A380A,  //  0044  ADD	R10	K28	R10
+      0x900E360A,  //  0045  SETMBR	R3	K27	R10
+      0x8C28011D,  //  0046  GETMET	R10	R0	K29
+      0x5830001E,  //  0047  LDCONST	R12	K30
       0x5C341000,  //  0048  MOVE	R13	R8
-      0x5838000D,  //  0049  LDCONST	R14	K13
-      0xB83E1C00,  //  004A  GETNGBL	R15	K14
-      0x8C3C1F0F,  //  004B  GETMET	R15	R15	K15
+      0x58380005,  //  0049  LDCONST	R14	K5
+      0xB83E0400,  //  004A  GETNGBL	R15	K2
+      0x8C3C1F03,  //  004B  GETMET	R15	R15	K3
       0x5C441000,  //  004C  MOVE	R17	R8
-      0x58480006,  //  004D  LDCONST	R18	K6
+      0x58480000,  //  004D  LDCONST	R18	K0
       0x544E00FD,  //  004E  LDINT	R19	254
-      0x58500006,  //  004F  LDCONST	R20	K6
+      0x58500000,  //  004F  LDCONST	R20	K0
       0x54560063,  //  0050  LDINT	R21	100
       0x7C3C0C00,  //  0051  CALL	R15	6
-      0x58400013,  //  0052  LDCONST	R16	K19
+      0x58400022,  //  0052  LDCONST	R16	K34
       0x78260001,  //  0053  JMPF	R9	#0056
-      0x58440010,  //  0054  LDCONST	R17	K16
+      0x5844001F,  //  0054  LDCONST	R17	K31
       0x70020000,  //  0055  JMP		#0057
-      0x58440006,  //  0056  LDCONST	R17	K6
+      0x58440000,  //  0056  LDCONST	R17	K0
       0x7C280E00,  //  0057  CALL	R10	7
       0x50280200,  //  0058  LDBOOL	R10	1	0
       0x80041400,  //  0059  RET	1	R10
@@ -340,7 +351,7 @@ be_local_closure(class_Matter_Plugin_Light1_invoke_request,   /* name */
       0x60200003,  //  006D  GETGBL	R8	G3
       0x5C240000,  //  006E  MOVE	R9	R0
       0x7C200200,  //  006F  CALL	R8	1
-      0x8C201114,  //  0070  GETMET	R8	R8	K20
+      0x8C201123,  //  0070  GETMET	R8	R8	K35
       0x5C280200,  //  0071  MOVE	R10	R1
       0x5C2C0400,  //  0072  MOVE	R11	R2
       0x5C300600,  //  0073  MOVE	R12	R3
@@ -360,58 +371,45 @@ be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_bri),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[59]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8122800,  //  0000  GETNGBL	R4	K20
+      0x88100915,  //  0001  GETMBR	R4	R4	K21
+      0x88140516,  //  0002  GETMBR	R5	R2	K22
+      0x88180524,  //  0003  GETMBR	R6	R2	K36
       0x541E0007,  //  0004  LDINT	R7	8
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E002A,  //  0006  JMPF	R7	#0032
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0118,  //  0007  GETMET	R7	R0	K24
       0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
+      0x1C1C0D00,  //  0009  EQ	R7	R6	K0
       0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
-      0x88240907,  //  000C  GETMBR	R9	R4	K7
-      0x88280108,  //  000D  GETMBR	R10	R0	K8
+      0x8C1C070C,  //  000B  GETMET	R7	R3	K12
+      0x88240925,  //  000C  GETMBR	R9	R4	K37
+      0x8828010A,  //  000D  GETMBR	R10	R0	K10
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x70020020,  //  0010  JMP		#0032
-      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
+      0x1C1C0D20,  //  0011  EQ	R7	R6	K32
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240907,  //  0014  GETMBR	R9	R4	K7
-      0x58280005,  //  0015  LDCONST	R10	K5
+      0x8C1C070C,  //  0013  GETMET	R7	R3	K12
+      0x88240925,  //  0014  GETMBR	R9	R4	K37
+      0x58280000,  //  0015  LDCONST	R10	K0
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x70020018,  //  0018  JMP		#0032
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D21,  //  0019  EQ	R7	R6	K33
       0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
+      0x8C1C070C,  //  001B  GETMET	R7	R3	K12
+      0x88240925,  //  001C  GETMBR	R9	R4	K37
       0x542A00FD,  //  001D  LDINT	R10	254
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
@@ -419,24 +417,24 @@ be_local_closure(class_Matter_Plugin_Light1_read_attribute,   /* name */
       0x541E000E,  //  0021  LDINT	R7	15
       0x1C1C0C07,  //  0022  EQ	R7	R6	R7
       0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0706,  //  0024  GETMET	R7	R3	K6
-      0x88240907,  //  0025  GETMBR	R9	R4	K7
-      0x58280005,  //  0026  LDCONST	R10	K5
+      0x8C1C070C,  //  0024  GETMET	R7	R3	K12
+      0x88240925,  //  0025  GETMBR	R9	R4	K37
+      0x58280000,  //  0026  LDCONST	R10	K0
       0x7C1C0600,  //  0027  CALL	R7	3
       0x80040E00,  //  0028  RET	1	R7
       0x70020007,  //  0029  JMP		#0032
       0x541E0010,  //  002A  LDINT	R7	17
       0x1C1C0C07,  //  002B  EQ	R7	R6	R7
       0x781E0004,  //  002C  JMPF	R7	#0032
-      0x8C1C0706,  //  002D  GETMET	R7	R3	K6
-      0x88240907,  //  002E  GETMBR	R9	R4	K7
-      0x88280108,  //  002F  GETMBR	R10	R0	K8
+      0x8C1C070C,  //  002D  GETMET	R7	R3	K12
+      0x88240925,  //  002E  GETMBR	R9	R4	K37
+      0x8828010A,  //  002F  GETMBR	R10	R0	K10
       0x7C1C0600,  //  0030  CALL	R7	3
       0x80040E00,  //  0031  RET	1	R7
       0x601C0003,  //  0032  GETGBL	R7	G3
       0x5C200000,  //  0033  MOVE	R8	R0
       0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0F0B,  //  0035  GETMET	R7	R7	K11
+      0x8C1C0F26,  //  0035  GETMET	R7	R7	K38
       0x5C240200,  //  0036  MOVE	R9	R1
       0x5C280400,  //  0037  MOVE	R10	R2
       0x5C2C0600,  //  0038  MOVE	R11	R3
@@ -455,81 +453,67 @@ be_local_closure(class_Matter_Plugin_Light1_parse_configuration,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(tasmota_relay_index),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(TYPE),
-    /* K7   */  be_nested_str_weak(light1),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(get_option),
-    /* K10  */  be_nested_str_weak(light),
-    /* K11  */  be_nested_str_weak(get),
-    /* K12  */  be_nested_str_weak(light_index),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(parse_configuration),
     &be_const_str_solidified,
     ( &(const binstruction[52]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
       0x780A000F,  //  0001  JMPF	R2	#0012
       0x60080009,  //  0002  GETGBL	R2	G9
-      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x8C0C0328,  //  0003  GETMET	R3	R1	K40
+      0x88140129,  //  0004  GETMBR	R5	R0	K41
       0x4C180000,  //  0005  LDNIL	R6
       0x7C0C0600,  //  0006  CALL	R3	3
       0x7C080200,  //  0007  CALL	R2	1
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x90024E02,  //  0008  SETMBR	R0	K39	R2
+      0x88080127,  //  0009  GETMBR	R2	R0	K39
       0x4C0C0000,  //  000A  LDNIL	R3
       0x20080403,  //  000B  NE	R2	R2	R3
       0x780A0003,  //  000C  JMPF	R2	#0011
-      0x88080101,  //  000D  GETMBR	R2	R0	K1
-      0x18080504,  //  000E  LE	R2	R2	K4
+      0x88080127,  //  000D  GETMBR	R2	R0	K39
+      0x1808052A,  //  000E  LE	R2	R2	K42
       0x780A0000,  //  000F  JMPF	R2	#0011
-      0x90020305,  //  0010  SETMBR	R0	K1	K5
+      0x90024F1F,  //  0010  SETMBR	R0	K39	K31
       0x70020020,  //  0011  JMP		#0033
-      0x88080101,  //  0012  GETMBR	R2	R0	K1
+      0x88080127,  //  0012  GETMBR	R2	R0	K39
       0x4C0C0000,  //  0013  LDNIL	R3
       0x1C080403,  //  0014  EQ	R2	R2	R3
       0x780A001C,  //  0015  JMPF	R2	#0033
-      0x88080106,  //  0016  GETMBR	R2	R0	K6
-      0x1C080507,  //  0017  EQ	R2	R2	K7
+      0x8808012B,  //  0016  GETMBR	R2	R0	K43
+      0x1C08052C,  //  0017  EQ	R2	R2	K44
       0x780A0019,  //  0018  JMPF	R2	#0033
-      0x8C080302,  //  0019  GETMET	R2	R1	K2
-      0x88100103,  //  001A  GETMBR	R4	R0	K3
+      0x8C080328,  //  0019  GETMET	R2	R1	K40
+      0x88100129,  //  001A  GETMBR	R4	R0	K41
       0x7C080400,  //  001B  CALL	R2	2
       0x4C0C0000,  //  001C  LDNIL	R3
       0x1C0C0403,  //  001D  EQ	R3	R2	R3
       0x780E000E,  //  001E  JMPF	R3	#002E
-      0xB80E1000,  //  001F  GETNGBL	R3	K8
-      0x8C0C0709,  //  0020  GETMET	R3	R3	K9
+      0xB80E0400,  //  001F  GETNGBL	R3	K2
+      0x8C0C072D,  //  0020  GETMET	R3	R3	K45
       0x54160043,  //  0021  LDINT	R5	68
       0x7C0C0400,  //  0022  CALL	R3	2
-      0x1C0C0704,  //  0023  EQ	R3	R3	K4
+      0x1C0C072A,  //  0023  EQ	R3	R3	K42
       0x780E0007,  //  0024  JMPF	R3	#002D
-      0xA40E1400,  //  0025  IMPORT	R3	K10
-      0x8C10070B,  //  0026  GETMET	R4	R3	K11
-      0x58180005,  //  0027  LDCONST	R6	K5
+      0xA40E1600,  //  0025  IMPORT	R3	K11
+      0x8C10072E,  //  0026  GETMET	R4	R3	K46
+      0x5818001F,  //  0027  LDCONST	R6	K31
       0x7C100400,  //  0028  CALL	R4	2
       0x4C140000,  //  0029  LDNIL	R5
       0x20100805,  //  002A  NE	R4	R4	R5
       0x78120000,  //  002B  JMPF	R4	#002D
-      0x90021905,  //  002C  SETMBR	R0	K12	K5
+      0x90021D1F,  //  002C  SETMBR	R0	K14	K31
       0x70020004,  //  002D  JMP		#0033
       0x600C0009,  //  002E  GETGBL	R3	G9
       0x5C100400,  //  002F  MOVE	R4	R2
       0x7C0C0200,  //  0030  CALL	R3	1
-      0x040C0705,  //  0031  SUB	R3	R3	K5
-      0x90021803,  //  0032  SETMBR	R0	K12	R3
+      0x040C071F,  //  0031  SUB	R3	R3	K31
+      0x90021C03,  //  0032  SETMBR	R0	K14	R3
       0x80000000,  //  0033  RET	0
     })
   )
@@ -544,32 +528,26 @@ be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Power),
-    /* K2   */  be_nested_str_weak(Bri),
-    /* K3   */  be_nested_str_weak(set_bri),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
+      0x8C080328,  //  0000  GETMET	R2	R1	K40
+      0x58100022,  //  0001  LDCONST	R4	K34
       0x7C080400,  //  0002  CALL	R2	2
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x58140002,  //  0004  LDCONST	R5	K2
+      0x8C0C0328,  //  0003  GETMET	R3	R1	K40
+      0x5814001E,  //  0004  LDCONST	R5	K30
       0x7C0C0400,  //  0005  CALL	R3	2
       0x4C100000,  //  0006  LDNIL	R4
       0x20100604,  //  0007  NE	R4	R3	R4
       0x78120006,  //  0008  JMPF	R4	#0010
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x8C10011A,  //  0009  GETMET	R4	R0	K26
       0x60180009,  //  000A  GETGBL	R6	G9
       0x5C1C0600,  //  000B  MOVE	R7	R3
       0x7C180200,  //  000C  CALL	R6	1
@@ -579,7 +557,7 @@ be_local_closure(class_Matter_Plugin_Light1_update_virtual,   /* name */
       0x60100003,  //  0010  GETGBL	R4	G3
       0x5C140000,  //  0011  MOVE	R5	R0
       0x7C100200,  //  0012  CALL	R4	1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x8C10092F,  //  0013  GETMET	R4	R4	K47
       0x5C180200,  //  0014  MOVE	R6	R1
       0x7C100400,  //  0015  CALL	R4	2
       0x80000000,  //  0016  RET	0
@@ -596,25 +574,21 @@ be_local_closure(class_Matter_Plugin_Light1_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_bri),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(init),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x90020101,  //  0000  SETMBR	R0	K0	K1
+      0x90021500,  //  0000  SETMBR	R0	K10	K0
       0x60100003,  //  0001  GETGBL	R4	G3
       0x5C140000,  //  0002  MOVE	R5	R0
       0x7C100200,  //  0003  CALL	R4	1
-      0x8C100902,  //  0004  GETMET	R4	R4	K2
+      0x8C100930,  //  0004  GETMET	R4	R4	K48
       0x5C180200,  //  0005  MOVE	R6	R1
       0x5C1C0400,  //  0006  MOVE	R7	R2
       0x5C200600,  //  0007  MOVE	R8	R3
@@ -633,34 +607,26 @@ be_local_closure(class_Matter_Plugin_Light1_web_values,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s_X20_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    /* K6   */  be_nested_str_weak(web_value_dimmer),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4066200,  //  0000  IMPORT	R1	K49
+      0x8C080132,  //  0001  GETMET	R2	R0	K50
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080333,  //  0003  GETMET	R2	R1	K51
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x58140034,  //  0005  LDCONST	R5	K52
+      0x8C180135,  //  0006  GETMET	R6	R0	K53
+      0x88200108,  //  0007  GETMBR	R8	R0	K8
       0x7C180400,  //  0008  CALL	R6	2
-      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x8C1C0136,  //  0009  GETMET	R7	R0	K54
       0x7C1C0200,  //  000A  CALL	R7	1
       0x7C100600,  //  000B  CALL	R4	3
       0x7C080400,  //  000C  CALL	R2	2
@@ -678,29 +644,20 @@ be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_status),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(Dimmer),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(scale_uint),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_bri),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x8C0C0706,  //  0003  GETMET	R3	R3	K6
       0x5C140200,  //  0004  MOVE	R5	R1
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C0C0600,  //  0006  CALL	R3	3
@@ -708,29 +665,29 @@ be_local_closure(class_Matter_Plugin_Light1_parse_status,   /* name */
       0x1C0C0403,  //  0008  EQ	R3	R2	R3
       0x780E0017,  //  0009  JMPF	R3	#0022
       0x600C0009,  //  000A  GETGBL	R3	G9
-      0x8C100301,  //  000B  GETMET	R4	R1	K1
-      0x58180002,  //  000C  LDCONST	R6	K2
+      0x8C100328,  //  000B  GETMET	R4	R1	K40
+      0x58180005,  //  000C  LDCONST	R6	K5
       0x7C100400,  //  000D  CALL	R4	2
       0x7C0C0200,  //  000E  CALL	R3	1
       0x4C100000,  //  000F  LDNIL	R4
       0x20100604,  //  0010  NE	R4	R3	R4
       0x7812000F,  //  0011  JMPF	R4	#0022
-      0xB8120600,  //  0012  GETNGBL	R4	K3
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0xB8120400,  //  0012  GETNGBL	R4	K2
+      0x8C100903,  //  0013  GETMET	R4	R4	K3
       0x5C180600,  //  0014  MOVE	R6	R3
-      0x581C0005,  //  0015  LDCONST	R7	K5
+      0x581C002A,  //  0015  LDCONST	R7	K42
       0x54220063,  //  0016  LDINT	R8	100
-      0x58240005,  //  0017  LDCONST	R9	K5
+      0x5824002A,  //  0017  LDCONST	R9	K42
       0x542A00FD,  //  0018  LDINT	R10	254
       0x7C100C00,  //  0019  CALL	R4	6
-      0x88140106,  //  001A  GETMBR	R5	R0	K6
+      0x8814010A,  //  001A  GETMBR	R5	R0	K10
       0x20140805,  //  001B  NE	R5	R4	R5
       0x78160004,  //  001C  JMPF	R5	#0022
-      0x8C140107,  //  001D  GETMET	R5	R0	K7
+      0x8C140109,  //  001D  GETMET	R5	R0	K9
       0x541E0007,  //  001E  LDINT	R7	8
-      0x58200005,  //  001F  LDCONST	R8	K5
+      0x5820002A,  //  001F  LDCONST	R8	K42
       0x7C140600,  //  0020  CALL	R5	3
-      0x90020C04,  //  0021  SETMBR	R0	K6	R4
+      0x90021404,  //  0021  SETMBR	R0	K10	R4
       0x80000000,  //  0022  RET	0
     })
   )
@@ -745,83 +702,67 @@ be_local_closure(class_Matter_Plugin_Light1_update_shadow,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_nested_str_weak(light_index),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(power),
-    /* K7   */  be_nested_str_weak(shadow_onoff),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(bri),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(scale_uint),
-    /* K13  */  be_nested_str_weak(shadow_bri),
-    /* K14  */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Light1,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
       0x7406002C,  //  0001  JMPT	R1	#002F
       0x88040101,  //  0002  GETMBR	R1	R0	K1
       0x7406002A,  //  0003  JMPT	R1	#002F
-      0xA4060400,  //  0004  IMPORT	R1	K2
-      0x8C080303,  //  0005  GETMET	R2	R1	K3
-      0x88100104,  //  0006  GETMBR	R4	R0	K4
+      0xA4061600,  //  0004  IMPORT	R1	K11
+      0x8C08032E,  //  0005  GETMET	R2	R1	K46
+      0x8810010E,  //  0006  GETMBR	R4	R0	K14
       0x7C080400,  //  0007  CALL	R2	2
       0x4C0C0000,  //  0008  LDNIL	R3
       0x200C0403,  //  0009  NE	R3	R2	R3
       0x780E0023,  //  000A  JMPF	R3	#002F
-      0x8C0C0505,  //  000B  GETMET	R3	R2	K5
-      0x58140006,  //  000C  LDCONST	R5	K6
+      0x8C0C0528,  //  000B  GETMET	R3	R2	K40
+      0x5814000F,  //  000C  LDCONST	R5	K15
       0x4C180000,  //  000D  LDNIL	R6
       0x7C0C0600,  //  000E  CALL	R3	3
-      0x88100107,  //  000F  GETMBR	R4	R0	K7
+      0x88100108,  //  000F  GETMBR	R4	R0	K8
       0x20100604,  //  0010  NE	R4	R3	R4
       0x78120004,  //  0011  JMPF	R4	#0017
-      0x8C100108,  //  0012  GETMET	R4	R0	K8
+      0x8C100109,  //  0012  GETMET	R4	R0	K9
       0x541A0005,  //  0013  LDINT	R6	6
-      0x581C0009,  //  0014  LDCONST	R7	K9
+      0x581C0000,  //  0014  LDCONST	R7	K0
       0x7C100600,  //  0015  CALL	R4	3
-      0x90020E03,  //  0016  SETMBR	R0	K7	R3
-      0x8C100505,  //  0017  GETMET	R4	R2	K5
-      0x5818000A,  //  0018  LDCONST	R6	K10
+      0x90021003,  //  0016  SETMBR	R0	K8	R3
+      0x8C100528,  //  0017  GETMET	R4	R2	K40
+      0x5818000D,  //  0018  LDCONST	R6	K13
       0x4C1C0000,  //  0019  LDNIL	R7
       0x7C100600,  //  001A  CALL	R4	3
       0x4C140000,  //  001B  LDNIL	R5
       0x20140805,  //  001C  NE	R5	R4	R5
       0x78160010,  //  001D  JMPF	R5	#002F
-      0xB8161600,  //  001E  GETNGBL	R5	K11
-      0x8C140B0C,  //  001F  GETMET	R5	R5	K12
+      0xB8160400,  //  001E  GETNGBL	R5	K2
+      0x8C140B03,  //  001F  GETMET	R5	R5	K3
       0x5C1C0800,  //  0020  MOVE	R7	R4
-      0x58200009,  //  0021  LDCONST	R8	K9
+      0x58200000,  //  0021  LDCONST	R8	K0
       0x542600FE,  //  0022  LDINT	R9	255
-      0x58280009,  //  0023  LDCONST	R10	K9
+      0x58280000,  //  0023  LDCONST	R10	K0
       0x542E00FD,  //  0024  LDINT	R11	254
       0x7C140C00,  //  0025  CALL	R5	6
       0x5C100A00,  //  0026  MOVE	R4	R5
-      0x8814010D,  //  0027  GETMBR	R5	R0	K13
+      0x8814010A,  //  0027  GETMBR	R5	R0	K10
       0x20140805,  //  0028  NE	R5	R4	R5
       0x78160004,  //  0029  JMPF	R5	#002F
-      0x8C140108,  //  002A  GETMET	R5	R0	K8
+      0x8C140109,  //  002A  GETMET	R5	R0	K9
       0x541E0007,  //  002B  LDINT	R7	8
-      0x58200009,  //  002C  LDCONST	R8	K9
+      0x58200000,  //  002C  LDCONST	R8	K0
       0x7C140600,  //  002D  CALL	R5	3
-      0x90021A04,  //  002E  SETMBR	R0	K13	R4
+      0x90021404,  //  002E  SETMBR	R0	K10	R4
       0x60040003,  //  002F  GETGBL	R1	G3
       0x5C080000,  //  0030  MOVE	R2	R0
       0x7C040200,  //  0031  CALL	R1	1
-      0x8C04030E,  //  0032  GETMET	R1	R1	K14
+      0x8C040310,  //  0032  GETMET	R1	R1	K16
       0x7C040200,  //  0033  CALL	R1	1
       0x80000000,  //  0034  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Contact.h
@@ -3,6 +3,34 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Contact' ktab size: 24, total: 31 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Contact[24] = {
+  /* K0   */  be_nested_str_weak(shadow_bool_value),
+  /* K1   */  be_nested_str_weak(_parse_update_virtual),
+  /* K2   */  be_nested_str_weak(Contact),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(update_virtual),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(TLV),
+  /* K7   */  be_nested_str_weak(cluster),
+  /* K8   */  be_nested_str_weak(attribute),
+  /* K9   */  be_nested_str_weak(set_or_nil),
+  /* K10  */  be_nested_str_weak(BOOL),
+  /* K11  */  be_nested_str_weak(read_attribute),
+  /* K12  */  be_nested_str_weak(webserver),
+  /* K13  */  be_nested_str_weak(web_values_prefix),
+  /* K14  */  be_nested_str_weak(content_send),
+  /* K15  */  be_nested_str_weak(Contact_X25i_X20_X25s),
+  /* K16  */  be_nested_str_weak(tasmota_switch_index),
+  /* K17  */  be_nested_str_weak(web_value_onoff),
+  /* K18  */  be_nested_str_weak(get_name),
+  /* K19  */  be_nested_str_weak(Switch),
+  /* K20  */  be_nested_str_weak(PREFIX),
+  /* K21  */  be_nested_str_weak(html_escape),
+  /* K22  */  be_nested_str_weak(),
+  /* K23  */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Contact;
 
@@ -13,19 +41,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_bool_value),
-    /* K1   */  be_nested_str_weak(_parse_update_virtual),
-    /* K2   */  be_nested_str_weak(Contact),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Contact,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -58,44 +80,34 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(BOOL),
-    /* K7   */  be_nested_str_weak(shadow_bool_value),
-    /* K8   */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Contact,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120A00,  //  0000  GETNGBL	R4	K5
+      0x88100906,  //  0001  GETMBR	R4	R4	K6
+      0x88140507,  //  0002  GETMBR	R5	R2	K7
+      0x88180508,  //  0003  GETMBR	R6	R2	K8
       0x541E0044,  //  0004  LDINT	R7	69
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0006,  //  0006  JMPF	R7	#000E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D03,  //  0007  EQ	R7	R6	K3
       0x781E0004,  //  0008  JMPF	R7	#000E
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
-      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x8C1C0709,  //  0009  GETMET	R7	R3	K9
+      0x8824090A,  //  000A  GETMBR	R9	R4	K10
+      0x88280100,  //  000B  GETMBR	R10	R0	K0
       0x7C1C0600,  //  000C  CALL	R7	3
       0x80040E00,  //  000D  RET	1	R7
       0x601C0003,  //  000E  GETGBL	R7	G3
       0x5C200000,  //  000F  MOVE	R8	R0
       0x7C1C0200,  //  0010  CALL	R7	1
-      0x8C1C0F08,  //  0011  GETMET	R7	R7	K8
+      0x8C1C0F0B,  //  0011  GETMET	R7	R7	K11
       0x5C240200,  //  0012  MOVE	R9	R1
       0x5C280400,  //  0013  MOVE	R10	R2
       0x5C2C0600,  //  0014  MOVE	R11	R3
@@ -114,33 +126,25 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(Contact_X25i_X20_X25s),
-    /* K4   */  be_nested_str_weak(tasmota_switch_index),
-    /* K5   */  be_nested_str_weak(web_value_onoff),
-    /* K6   */  be_nested_str_weak(shadow_bool_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Contact,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061800,  //  0000  IMPORT	R1	K12
+      0x8C08010D,  //  0001  GETMET	R2	R0	K13
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08030E,  //  0003  GETMET	R2	R1	K14
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x5814000F,  //  0005  LDCONST	R5	K15
+      0x88180110,  //  0006  GETMBR	R6	R0	K16
+      0x8C1C0111,  //  0007  GETMET	R7	R0	K17
+      0x88240100,  //  0008  GETMBR	R9	R0	K0
       0x7C1C0400,  //  0009  CALL	R7	2
       0x7C100600,  //  000A  CALL	R4	3
       0x7C080400,  //  000B  CALL	R2	2
@@ -158,44 +162,35 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_web_values_prefix,   /* name
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Switch),
-    /* K3   */  be_nested_str_weak(tasmota_switch_index),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Contact,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061800,  //  0000  IMPORT	R1	K12
+      0x8C080112,  //  0001  GETMET	R2	R0	K18
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0004,  //  0004  JMPT	R3	#000A
       0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88100110,  //  0006  GETMBR	R4	R0	K16
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x000E2603,  //  0008  ADD	R3	K19	R3
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x8C0C030E,  //  000A  GETMET	R3	R1	K14
       0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x88180114,  //  000C  GETMBR	R6	R0	K20
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x8C1C0315,  //  000E  GETMET	R7	R1	K21
       0x5C240400,  //  000F  MOVE	R9	R2
       0x7C1C0400,  //  0010  CALL	R7	2
       0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x581C0016,  //  0012  LDCONST	R7	K22
       0x7C140400,  //  0013  CALL	R5	2
       0x7C0C0400,  //  0014  CALL	R3	2
       0x80000000,  //  0015  RET	0
@@ -212,22 +207,19 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Contact,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040117,  //  0000  GETMET	R1	R0	K23
       0x540E0044,  //  0001  LDINT	R3	69
-      0x58100001,  //  0002  LDCONST	R4	K1
+      0x58100003,  //  0002  LDCONST	R4	K3
       0x7C040600,  //  0003  CALL	R1	3
       0x80000000,  //  0004  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
@@ -3,6 +3,27 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Flow' ktab size: 17, total: 19 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Flow[17] = {
+  /* K0   */  be_nested_str_weak(attribute_updated),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(TLV),
+  /* K4   */  be_nested_str_weak(cluster),
+  /* K5   */  be_nested_str_weak(attribute),
+  /* K6   */  be_nested_str_weak(set_or_nil),
+  /* K7   */  be_nested_str_weak(U2),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(set),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(webserver),
+  /* K14  */  be_nested_str_weak(web_values_prefix),
+  /* K15  */  be_nested_str_weak(content_send),
+  /* K16  */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20m_X26sup3_X3B_X2Fh),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Flow;
 
@@ -13,16 +34,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Flow,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,65 +62,52 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U2),
-    /* K7   */  be_nested_str_weak(shadow_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Flow,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120400,  //  0000  GETNGBL	R4	K2
+      0x88100903,  //  0001  GETMBR	R4	R4	K3
+      0x88140504,  //  0002  GETMBR	R5	R2	K4
+      0x88180505,  //  0003  GETMBR	R6	R2	K5
       0x541E0403,  //  0004  LDINT	R7	1028
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0018,  //  0006  JMPF	R7	#0020
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D01,  //  0007  EQ	R7	R6	K1
       0x781E0007,  //  0008  JMPF	R7	#0011
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x88240907,  //  000A  GETMBR	R9	R4	K7
       0x60280009,  //  000B  GETGBL	R10	G9
-      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x882C0108,  //  000C  GETMBR	R11	R0	K8
       0x7C280200,  //  000D  CALL	R10	1
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x7002000E,  //  0010  JMP		#0020
-      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
-      0x88240906,  //  0014  GETMBR	R9	R4	K6
-      0x58280004,  //  0015  LDCONST	R10	K4
+      0x8C1C070A,  //  0013  GETMET	R7	R3	K10
+      0x88240907,  //  0014  GETMBR	R9	R4	K7
+      0x58280001,  //  0015  LDCONST	R10	K1
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x70020006,  //  0018  JMP		#0020
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D0B,  //  0019  EQ	R7	R6	K11
       0x781E0004,  //  001A  JMPF	R7	#0020
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  001B  GETMET	R7	R3	K10
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
       0x542AFFFD,  //  001D  LDINT	R10	65534
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
       0x601C0003,  //  0020  GETGBL	R7	G3
       0x5C200000,  //  0021  MOVE	R8	R0
       0x7C1C0200,  //  0022  CALL	R7	1
-      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
       0x5C240200,  //  0024  MOVE	R9	R1
       0x5C280400,  //  0025  MOVE	R10	R2
       0x5C2C0600,  //  0026  MOVE	R11	R3
@@ -121,13 +126,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_Flow,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -154,30 +159,24 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20m_X26sup3_X3B_X2Fh),
-    /* K4   */  be_nested_str_weak(shadow_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Flow,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061A00,  //  0000  IMPORT	R1	K13
+      0x8C08010E,  //  0001  GETMET	R2	R0	K14
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08030F,  //  0003  GETMET	R2	R1	K15
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
+      0x58140010,  //  0005  LDCONST	R5	K16
       0x60180009,  //  0006  GETGBL	R6	G9
-      0x881C0104,  //  0007  GETMBR	R7	R0	K4
+      0x881C0108,  //  0007  GETMBR	R7	R0	K8
       0x7C180200,  //  0008  CALL	R6	1
       0x7C100400,  //  0009  CALL	R4	2
       0x7C080400,  //  000A  CALL	R2	2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
@@ -3,6 +3,27 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Humidity' ktab size: 17, total: 19 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Humidity[17] = {
+  /* K0   */  be_nested_str_weak(attribute_updated),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(TLV),
+  /* K4   */  be_nested_str_weak(cluster),
+  /* K5   */  be_nested_str_weak(attribute),
+  /* K6   */  be_nested_str_weak(set_or_nil),
+  /* K7   */  be_nested_str_weak(U2),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(set),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(webserver),
+  /* K14  */  be_nested_str_weak(web_values_prefix),
+  /* K15  */  be_nested_str_weak(content_send),
+  /* K16  */  be_nested_str_weak(_X26_X23x1F4A7_X3B_X20_X252_X2E0f_X25_X25),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 
@@ -13,16 +34,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Humidity,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,65 +62,52 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_read_attribute,   /* name *
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U2),
-    /* K7   */  be_nested_str_weak(shadow_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Humidity,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120400,  //  0000  GETNGBL	R4	K2
+      0x88100903,  //  0001  GETMBR	R4	R4	K3
+      0x88140504,  //  0002  GETMBR	R5	R2	K4
+      0x88180505,  //  0003  GETMBR	R6	R2	K5
       0x541E0404,  //  0004  LDINT	R7	1029
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0018,  //  0006  JMPF	R7	#0020
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D01,  //  0007  EQ	R7	R6	K1
       0x781E0007,  //  0008  JMPF	R7	#0011
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x88240907,  //  000A  GETMBR	R9	R4	K7
       0x60280009,  //  000B  GETGBL	R10	G9
-      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x882C0108,  //  000C  GETMBR	R11	R0	K8
       0x7C280200,  //  000D  CALL	R10	1
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x7002000E,  //  0010  JMP		#0020
-      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
-      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  0013  GETMET	R7	R3	K10
+      0x88240907,  //  0014  GETMBR	R9	R4	K7
       0x542A01F3,  //  0015  LDINT	R10	500
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x70020006,  //  0018  JMP		#0020
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D0B,  //  0019  EQ	R7	R6	K11
       0x781E0004,  //  001A  JMPF	R7	#0020
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  001B  GETMET	R7	R3	K10
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
       0x542A270F,  //  001D  LDINT	R10	10000
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
       0x601C0003,  //  0020  GETGBL	R7	G3
       0x5C200000,  //  0021  MOVE	R8	R0
       0x7C1C0200,  //  0022  CALL	R7	1
-      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
       0x5C240200,  //  0024  MOVE	R9	R1
       0x5C280400,  //  0025  MOVE	R10	R2
       0x5C2C0600,  //  0026  MOVE	R11	R3
@@ -121,13 +126,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_Humidity,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -154,34 +159,28 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26_X23x1F4A7_X3B_X20_X252_X2E0f_X25_X25),
-    /* K4   */  be_nested_str_weak(shadow_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Humidity,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061A00,  //  0000  IMPORT	R1	K13
+      0x8C08010E,  //  0001  GETMET	R2	R0	K14
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08030F,  //  0003  GETMET	R2	R1	K15
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x58140010,  //  0005  LDCONST	R5	K16
+      0x88180108,  //  0006  GETMBR	R6	R0	K8
       0x4C1C0000,  //  0007  LDNIL	R7
       0x20180C07,  //  0008  NE	R6	R6	R7
       0x781A0005,  //  0009  JMPF	R6	#0010
       0x6018000A,  //  000A  GETGBL	R6	G10
-      0x881C0104,  //  000B  GETMBR	R7	R0	K4
+      0x881C0108,  //  000B  GETMBR	R7	R0	K8
       0x7C180200,  //  000C  CALL	R6	1
       0x541E0063,  //  000D  LDINT	R7	100
       0x0C180C07,  //  000E  DIV	R6	R6	R7

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
@@ -3,6 +3,30 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Illuminance' ktab size: 20, total: 23 (saved 24 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Illuminance[20] = {
+  /* K0   */  be_nested_str_weak(attribute_updated),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(TLV),
+  /* K4   */  be_nested_str_weak(cluster),
+  /* K5   */  be_nested_str_weak(attribute),
+  /* K6   */  be_nested_str_weak(set_or_nil),
+  /* K7   */  be_nested_str_weak(U2),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(set),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(math),
+  /* K14  */  be_const_int(0),
+  /* K15  */  be_nested_str_weak(log10),
+  /* K16  */  be_nested_str_weak(webserver),
+  /* K17  */  be_nested_str_weak(web_values_prefix),
+  /* K18  */  be_nested_str_weak(content_send),
+  /* K19  */  be_nested_str_weak(_X26_X23128261_X3B_X20_X25i_X20lux),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 
@@ -13,16 +37,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_value_changed,   /* name
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Illuminance,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,65 +65,52 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_read_attribute,   /* nam
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U2),
-    /* K7   */  be_nested_str_weak(shadow_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Illuminance,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120400,  //  0000  GETNGBL	R4	K2
+      0x88100903,  //  0001  GETMBR	R4	R4	K3
+      0x88140504,  //  0002  GETMBR	R5	R2	K4
+      0x88180505,  //  0003  GETMBR	R6	R2	K5
       0x541E03FF,  //  0004  LDINT	R7	1024
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0018,  //  0006  JMPF	R7	#0020
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D01,  //  0007  EQ	R7	R6	K1
       0x781E0007,  //  0008  JMPF	R7	#0011
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x88240907,  //  000A  GETMBR	R9	R4	K7
       0x60280009,  //  000B  GETGBL	R10	G9
-      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x882C0108,  //  000C  GETMBR	R11	R0	K8
       0x7C280200,  //  000D  CALL	R10	1
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x7002000E,  //  0010  JMP		#0020
-      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
-      0x88240906,  //  0014  GETMBR	R9	R4	K6
-      0x58280008,  //  0015  LDCONST	R10	K8
+      0x8C1C070A,  //  0013  GETMET	R7	R3	K10
+      0x88240907,  //  0014  GETMBR	R9	R4	K7
+      0x58280009,  //  0015  LDCONST	R10	K9
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x70020006,  //  0018  JMP		#0020
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D0B,  //  0019  EQ	R7	R6	K11
       0x781E0004,  //  001A  JMPF	R7	#0020
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  001B  GETMET	R7	R3	K10
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
       0x542AFFFD,  //  001D  LDINT	R10	65534
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
       0x601C0003,  //  0020  GETGBL	R7	G3
       0x5C200000,  //  0021  MOVE	R8	R0
       0x7C1C0200,  //  0022  CALL	R7	1
-      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
       0x5C240200,  //  0024  MOVE	R9	R1
       0x5C280400,  //  0025  MOVE	R10	R2
       0x5C2C0600,  //  0026  MOVE	R11	R3
@@ -121,18 +129,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(math),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(log10),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Illuminance,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
@@ -141,13 +144,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
       0x780A0001,  //  0002  JMPF	R2	#0005
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
-      0xA40A0000,  //  0005  IMPORT	R2	K0
-      0x140C0301,  //  0006  LT	R3	R1	K1
+      0xA40A1A00,  //  0005  IMPORT	R2	K13
+      0x140C030E,  //  0006  LT	R3	R1	K14
       0x780E0001,  //  0007  JMPF	R3	#000A
-      0x80060200,  //  0008  RET	1	K1
+      0x80061C00,  //  0008  RET	1	K14
       0x70020005,  //  0009  JMP		#0010
-      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
-      0x00140303,  //  000B  ADD	R5	R1	K3
+      0x8C0C050F,  //  000A  GETMET	R3	R2	K15
+      0x00140309,  //  000B  ADD	R5	R1	K9
       0x7C0C0400,  //  000C  CALL	R3	2
       0x5412270F,  //  000D  LDINT	R4	10000
       0x080C0604,  //  000E  MUL	R3	R3	R4
@@ -166,30 +169,24 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26_X23128261_X3B_X20_X25i_X20lux),
-    /* K4   */  be_nested_str_weak(shadow_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Illuminance,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0x8C080111,  //  0001  GETMET	R2	R0	K17
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080312,  //  0003  GETMET	R2	R1	K18
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
+      0x58140013,  //  0005  LDCONST	R5	K19
       0x60180009,  //  0006  GETGBL	R6	G9
-      0x881C0104,  //  0007  GETMBR	R7	R0	K4
+      0x881C0108,  //  0007  GETMBR	R7	R0	K8
       0x7C180200,  //  0008  CALL	R6	1
       0x7C100400,  //  0009  CALL	R4	2
       0x7C080400,  //  000A  CALL	R2	2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Occupancy.h
@@ -3,6 +3,38 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Occupancy' ktab size: 28, total: 35 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Occupancy[28] = {
+  /* K0   */  be_nested_str_weak(shadow_bool_value),
+  /* K1   */  be_nested_str_weak(_parse_update_virtual),
+  /* K2   */  be_nested_str_weak(Occupancy),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(update_virtual),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(TLV),
+  /* K7   */  be_nested_str_weak(cluster),
+  /* K8   */  be_nested_str_weak(attribute),
+  /* K9   */  be_nested_str_weak(set_or_nil),
+  /* K10  */  be_nested_str_weak(U1),
+  /* K11  */  be_const_int(1),
+  /* K12  */  be_nested_str_weak(set),
+  /* K13  */  be_const_int(3),
+  /* K14  */  be_const_int(2),
+  /* K15  */  be_nested_str_weak(read_attribute),
+  /* K16  */  be_nested_str_weak(webserver),
+  /* K17  */  be_nested_str_weak(web_values_prefix),
+  /* K18  */  be_nested_str_weak(content_send),
+  /* K19  */  be_nested_str_weak(Occupancy_X25i_X20_X25s),
+  /* K20  */  be_nested_str_weak(web_value_onoff),
+  /* K21  */  be_nested_str_weak(shadow_occupancy),
+  /* K22  */  be_nested_str_weak(get_name),
+  /* K23  */  be_nested_str_weak(Switch),
+  /* K24  */  be_nested_str_weak(PREFIX),
+  /* K25  */  be_nested_str_weak(html_escape),
+  /* K26  */  be_nested_str_weak(),
+  /* K27  */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Occupancy;
 
@@ -13,19 +45,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_update_virtual,   /* name 
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_bool_value),
-    /* K1   */  be_nested_str_weak(_parse_update_virtual),
-    /* K2   */  be_nested_str_weak(Occupancy),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Occupancy,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -58,64 +84,50 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name 
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_nested_str_weak(shadow_bool_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Occupancy,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120A00,  //  0000  GETNGBL	R4	K5
+      0x88100906,  //  0001  GETMBR	R4	R4	K6
+      0x88140507,  //  0002  GETMBR	R5	R2	K7
+      0x88180508,  //  0003  GETMBR	R6	R2	K8
       0x541E0405,  //  0004  LDINT	R7	1030
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0016,  //  0006  JMPF	R7	#001E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D03,  //  0007  EQ	R7	R6	K3
       0x781E0005,  //  0008  JMPF	R7	#000F
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
-      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x8C1C0709,  //  0009  GETMET	R7	R3	K9
+      0x8824090A,  //  000A  GETMBR	R9	R4	K10
+      0x88280100,  //  000B  GETMBR	R10	R0	K0
       0x7C1C0600,  //  000C  CALL	R7	3
       0x80040E00,  //  000D  RET	1	R7
       0x7002000E,  //  000E  JMP		#001E
-      0x1C1C0D08,  //  000F  EQ	R7	R6	K8
+      0x1C1C0D0B,  //  000F  EQ	R7	R6	K11
       0x781E0005,  //  0010  JMPF	R7	#0017
-      0x8C1C0709,  //  0011  GETMET	R7	R3	K9
-      0x88240906,  //  0012  GETMBR	R9	R4	K6
-      0x5828000A,  //  0013  LDCONST	R10	K10
+      0x8C1C070C,  //  0011  GETMET	R7	R3	K12
+      0x8824090A,  //  0012  GETMBR	R9	R4	K10
+      0x5828000D,  //  0013  LDCONST	R10	K13
       0x7C1C0600,  //  0014  CALL	R7	3
       0x80040E00,  //  0015  RET	1	R7
       0x70020006,  //  0016  JMP		#001E
-      0x1C1C0D0B,  //  0017  EQ	R7	R6	K11
+      0x1C1C0D0E,  //  0017  EQ	R7	R6	K14
       0x781E0004,  //  0018  JMPF	R7	#001E
-      0x8C1C0709,  //  0019  GETMET	R7	R3	K9
-      0x88240906,  //  001A  GETMBR	R9	R4	K6
-      0x58280004,  //  001B  LDCONST	R10	K4
+      0x8C1C070C,  //  0019  GETMET	R7	R3	K12
+      0x8824090A,  //  001A  GETMBR	R9	R4	K10
+      0x58280003,  //  001B  LDCONST	R10	K3
       0x7C1C0600,  //  001C  CALL	R7	3
       0x80040E00,  //  001D  RET	1	R7
       0x601C0003,  //  001E  GETGBL	R7	G3
       0x5C200000,  //  001F  MOVE	R8	R0
       0x7C1C0200,  //  0020  CALL	R7	1
-      0x8C1C0F0C,  //  0021  GETMET	R7	R7	K12
+      0x8C1C0F0F,  //  0021  GETMET	R7	R7	K15
       0x5C240200,  //  0022  MOVE	R9	R1
       0x5C280400,  //  0023  MOVE	R10	R2
       0x5C2C0600,  //  0024  MOVE	R11	R3
@@ -134,33 +146,25 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(Occupancy_X25i_X20_X25s),
-    /* K4   */  be_nested_str_weak(shadow_bool_value),
-    /* K5   */  be_nested_str_weak(web_value_onoff),
-    /* K6   */  be_nested_str_weak(shadow_occupancy),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Occupancy,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0x8C080111,  //  0001  GETMET	R2	R0	K17
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080312,  //  0003  GETMET	R2	R1	K18
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x58140013,  //  0005  LDCONST	R5	K19
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
+      0x8C1C0114,  //  0007  GETMET	R7	R0	K20
+      0x88240115,  //  0008  GETMBR	R9	R0	K21
       0x7C1C0400,  //  0009  CALL	R7	2
       0x7C100600,  //  000A  CALL	R4	3
       0x7C080400,  //  000B  CALL	R2	2
@@ -178,44 +182,35 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_web_values_prefix,   /* na
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Switch),
-    /* K3   */  be_nested_str_weak(shadow_bool_value),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Occupancy,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0x8C080116,  //  0001  GETMET	R2	R0	K22
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0004,  //  0004  JMPT	R3	#000A
       0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x000E2E03,  //  0008  ADD	R3	K23	R3
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x8C0C0312,  //  000A  GETMET	R3	R1	K18
       0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x88180118,  //  000C  GETMBR	R6	R0	K24
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x8C1C0319,  //  000E  GETMET	R7	R1	K25
       0x5C240400,  //  000F  MOVE	R9	R2
       0x7C1C0400,  //  0010  CALL	R7	2
       0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x581C001A,  //  0012  LDCONST	R7	K26
       0x7C140400,  //  0013  CALL	R5	2
       0x7C0C0400,  //  0014  CALL	R3	2
       0x80000000,  //  0015  RET	0
@@ -232,22 +227,19 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_value_updated,   /* name *
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Occupancy,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04011B,  //  0000  GETMET	R1	R0	K27
       0x540E0405,  //  0001  LDINT	R3	1030
-      0x58100001,  //  0002  LDCONST	R4	K1
+      0x58100003,  //  0002  LDCONST	R4	K3
       0x7C040600,  //  0003  CALL	R1	3
       0x80000000,  //  0004  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_OnOff.h
@@ -3,6 +3,22 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_OnOff' ktab size: 12, total: 14 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_OnOff[12] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(cluster),
+  /* K3   */  be_nested_str_weak(attribute),
+  /* K4   */  be_nested_str_weak(update_shadow_lazy),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(set),
+  /* K7   */  be_nested_str_weak(BOOL),
+  /* K8   */  be_nested_str_weak(shadow_bool_value),
+  /* K9   */  be_nested_str_weak(read_attribute),
+  /* K10  */  be_nested_str_weak(_X2C_X22OnOff_X22_X3A_X25s),
+  /* K11  */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
 
@@ -13,24 +29,13 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(BOOL),
-    /* K8   */  be_nested_str_weak(shadow_bool_value),
-    /* K9   */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_OnOff,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
@@ -72,23 +77,20 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_append_state_json,   /* name *
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_X2C_X22OnOff_X22_X3A_X25s),
-    /* K1   */  be_nested_str_weak(shadow_bool_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_OnOff,     /* shared constants */
     be_str_weak(append_state_json),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
+      0x5808000A,  //  0001  LDCONST	R2	K10
       0x600C0009,  //  0002  GETGBL	R3	G9
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x88100108,  //  0003  GETMBR	R4	R0	K8
       0x7C0C0200,  //  0004  CALL	R3	1
       0x7C040400,  //  0005  CALL	R1	2
       0x80040200,  //  0006  RET	1	R1
@@ -105,22 +107,19 @@ be_local_closure(class_Matter_Plugin_Sensor_OnOff_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_OnOff,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010B,  //  0000  GETMET	R1	R0	K11
       0x540E0005,  //  0001  LDINT	R3	6
-      0x58100001,  //  0002  LDCONST	R4	K1
+      0x58100005,  //  0002  LDCONST	R4	K5
       0x7C040600,  //  0003  CALL	R1	3
       0x80000000,  //  0004  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
@@ -3,6 +3,27 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Pressure' ktab size: 17, total: 19 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Pressure[17] = {
+  /* K0   */  be_nested_str_weak(attribute_updated),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(TLV),
+  /* K4   */  be_nested_str_weak(cluster),
+  /* K5   */  be_nested_str_weak(attribute),
+  /* K6   */  be_nested_str_weak(set_or_nil),
+  /* K7   */  be_nested_str_weak(I2),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(set),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(webserver),
+  /* K14  */  be_nested_str_weak(web_values_prefix),
+  /* K15  */  be_nested_str_weak(content_send),
+  /* K16  */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20hPa),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 
@@ -13,16 +34,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Pressure,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,65 +62,52 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_read_attribute,   /* name *
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(I2),
-    /* K7   */  be_nested_str_weak(shadow_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Pressure,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120400,  //  0000  GETNGBL	R4	K2
+      0x88100903,  //  0001  GETMBR	R4	R4	K3
+      0x88140504,  //  0002  GETMBR	R5	R2	K4
+      0x88180505,  //  0003  GETMBR	R6	R2	K5
       0x541E0402,  //  0004  LDINT	R7	1027
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0018,  //  0006  JMPF	R7	#0020
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D01,  //  0007  EQ	R7	R6	K1
       0x781E0007,  //  0008  JMPF	R7	#0011
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x88240907,  //  000A  GETMBR	R9	R4	K7
       0x60280009,  //  000B  GETGBL	R10	G9
-      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x882C0108,  //  000C  GETMBR	R11	R0	K8
       0x7C280200,  //  000D  CALL	R10	1
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x7002000E,  //  0010  JMP		#0020
-      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
-      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  0013  GETMET	R7	R3	K10
+      0x88240907,  //  0014  GETMBR	R9	R4	K7
       0x542A01F3,  //  0015  LDINT	R10	500
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x70020006,  //  0018  JMP		#0020
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x1C1C0D0B,  //  0019  EQ	R7	R6	K11
       0x781E0004,  //  001A  JMPF	R7	#0020
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  001B  GETMET	R7	R3	K10
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
       0x542A05DB,  //  001D  LDINT	R10	1500
       0x7C1C0600,  //  001E  CALL	R7	3
       0x80040E00,  //  001F  RET	1	R7
       0x601C0003,  //  0020  GETGBL	R7	G3
       0x5C200000,  //  0021  MOVE	R8	R0
       0x7C1C0200,  //  0022  CALL	R7	1
-      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
       0x5C240200,  //  0024  MOVE	R9	R1
       0x5C280400,  //  0025  MOVE	R10	R2
       0x5C2C0600,  //  0026  MOVE	R11	R3
@@ -121,13 +126,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor_Pressure,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -153,30 +158,24 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20hPa),
-    /* K4   */  be_nested_str_weak(shadow_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Pressure,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061A00,  //  0000  IMPORT	R1	K13
+      0x8C08010E,  //  0001  GETMET	R2	R0	K14
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08030F,  //  0003  GETMET	R2	R1	K15
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
+      0x58140010,  //  0005  LDCONST	R5	K16
       0x60180009,  //  0006  GETGBL	R6	G9
-      0x881C0104,  //  0007  GETMBR	R7	R0	K4
+      0x881C0108,  //  0007  GETMBR	R7	R0	K8
       0x7C180200,  //  0008  CALL	R6	1
       0x7C100400,  //  0009  CALL	R4	2
       0x7C080400,  //  000A  CALL	R2	2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Rain.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Rain.h
@@ -3,6 +3,34 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Rain' ktab size: 24, total: 31 (saved 56 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Rain[24] = {
+  /* K0   */  be_nested_str_weak(shadow_bool_value),
+  /* K1   */  be_nested_str_weak(_parse_update_virtual),
+  /* K2   */  be_nested_str_weak(Rain),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(update_virtual),
+  /* K5   */  be_nested_str_weak(matter),
+  /* K6   */  be_nested_str_weak(TLV),
+  /* K7   */  be_nested_str_weak(cluster),
+  /* K8   */  be_nested_str_weak(attribute),
+  /* K9   */  be_nested_str_weak(set),
+  /* K10  */  be_nested_str_weak(BOOL),
+  /* K11  */  be_nested_str_weak(read_attribute),
+  /* K12  */  be_nested_str_weak(webserver),
+  /* K13  */  be_nested_str_weak(web_values_prefix),
+  /* K14  */  be_nested_str_weak(content_send),
+  /* K15  */  be_nested_str_weak(Rain_X25i_X20_X25s),
+  /* K16  */  be_nested_str_weak(tasmota_switch_index),
+  /* K17  */  be_nested_str_weak(web_value_onoff),
+  /* K18  */  be_nested_str_weak(get_name),
+  /* K19  */  be_nested_str_weak(Switch),
+  /* K20  */  be_nested_str_weak(PREFIX),
+  /* K21  */  be_nested_str_weak(html_escape),
+  /* K22  */  be_nested_str_weak(),
+  /* K23  */  be_nested_str_weak(attribute_updated),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Rain;
 
@@ -13,19 +41,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_update_virtual,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_bool_value),
-    /* K1   */  be_nested_str_weak(_parse_update_virtual),
-    /* K2   */  be_nested_str_weak(Rain),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Rain,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -58,44 +80,34 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set),
-    /* K6   */  be_nested_str_weak(BOOL),
-    /* K7   */  be_nested_str_weak(shadow_bool_value),
-    /* K8   */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Rain,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120A00,  //  0000  GETNGBL	R4	K5
+      0x88100906,  //  0001  GETMBR	R4	R4	K6
+      0x88140507,  //  0002  GETMBR	R5	R2	K7
+      0x88180508,  //  0003  GETMBR	R6	R2	K8
       0x541E0044,  //  0004  LDINT	R7	69
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0006,  //  0006  JMPF	R7	#000E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D03,  //  0007  EQ	R7	R6	K3
       0x781E0004,  //  0008  JMPF	R7	#000E
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
-      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x8C1C0709,  //  0009  GETMET	R7	R3	K9
+      0x8824090A,  //  000A  GETMBR	R9	R4	K10
+      0x88280100,  //  000B  GETMBR	R10	R0	K0
       0x7C1C0600,  //  000C  CALL	R7	3
       0x80040E00,  //  000D  RET	1	R7
       0x601C0003,  //  000E  GETGBL	R7	G3
       0x5C200000,  //  000F  MOVE	R8	R0
       0x7C1C0200,  //  0010  CALL	R7	1
-      0x8C1C0F08,  //  0011  GETMET	R7	R7	K8
+      0x8C1C0F0B,  //  0011  GETMET	R7	R7	K11
       0x5C240200,  //  0012  MOVE	R9	R1
       0x5C280400,  //  0013  MOVE	R10	R2
       0x5C2C0600,  //  0014  MOVE	R11	R3
@@ -114,33 +126,25 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(Rain_X25i_X20_X25s),
-    /* K4   */  be_nested_str_weak(tasmota_switch_index),
-    /* K5   */  be_nested_str_weak(web_value_onoff),
-    /* K6   */  be_nested_str_weak(shadow_bool_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Rain,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061800,  //  0000  IMPORT	R1	K12
+      0x8C08010D,  //  0001  GETMET	R2	R0	K13
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08030E,  //  0003  GETMET	R2	R1	K14
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x5814000F,  //  0005  LDCONST	R5	K15
+      0x88180110,  //  0006  GETMBR	R6	R0	K16
+      0x8C1C0111,  //  0007  GETMET	R7	R0	K17
+      0x88240100,  //  0008  GETMBR	R9	R0	K0
       0x7C1C0400,  //  0009  CALL	R7	2
       0x7C100600,  //  000A  CALL	R4	3
       0x7C080400,  //  000B  CALL	R2	2
@@ -158,44 +162,35 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_web_values_prefix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Switch),
-    /* K3   */  be_nested_str_weak(tasmota_switch_index),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Rain,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4061800,  //  0000  IMPORT	R1	K12
+      0x8C080112,  //  0001  GETMET	R2	R0	K18
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0004,  //  0004  JMPT	R3	#000A
       0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88100110,  //  0006  GETMBR	R4	R0	K16
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x000E2603,  //  0008  ADD	R3	K19	R3
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x8C0C030E,  //  000A  GETMET	R3	R1	K14
       0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x88180114,  //  000C  GETMBR	R6	R0	K20
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x8C1C0315,  //  000E  GETMET	R7	R1	K21
       0x5C240400,  //  000F  MOVE	R9	R2
       0x7C1C0400,  //  0010  CALL	R7	2
       0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x581C0016,  //  0012  LDCONST	R7	K22
       0x7C140400,  //  0013  CALL	R5	2
       0x7C0C0400,  //  0014  CALL	R3	2
       0x80000000,  //  0015  RET	0
@@ -212,22 +207,19 @@ be_local_closure(class_Matter_Plugin_Sensor_Rain_value_updated,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Rain,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040117,  //  0000  GETMET	R1	R0	K23
       0x540E0044,  //  0001  LDINT	R3	69
-      0x58100001,  //  0002  LDCONST	R4	K1
+      0x58100003,  //  0002  LDCONST	R4	K3
       0x7C040600,  //  0003  CALL	R1	3
       0x80000000,  //  0004  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
@@ -3,6 +3,33 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Temp' ktab size: 23, total: 26 (saved 24 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Temp[23] = {
+  /* K0   */  be_nested_str_weak(attribute_updated),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(matter),
+  /* K3   */  be_nested_str_weak(TLV),
+  /* K4   */  be_nested_str_weak(cluster),
+  /* K5   */  be_nested_str_weak(attribute),
+  /* K6   */  be_nested_str_weak(set_or_nil),
+  /* K7   */  be_nested_str_weak(I2),
+  /* K8   */  be_nested_str_weak(shadow_value),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(set),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(read_attribute),
+  /* K13  */  be_nested_str_weak(BRIDGE),
+  /* K14  */  be_nested_str_weak(temp_unit),
+  /* K15  */  be_nested_str_weak(TEMP_F),
+  /* K16  */  be_const_real_hex(0x3FE66666),
+  /* K17  */  be_nested_str_weak(tasmota),
+  /* K18  */  be_nested_str_weak(get_option),
+  /* K19  */  be_nested_str_weak(webserver),
+  /* K20  */  be_nested_str_weak(web_values_prefix),
+  /* K21  */  be_nested_str_weak(content_send),
+  /* K22  */  be_nested_str_weak(_X26_X23x2600_X3B_X26_X23xFE0F_X3B_X20_X25_X2E1f_X20_XC2_XB0C),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 
@@ -13,16 +40,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_value_changed,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Temp,     /* shared constants */
     be_str_weak(value_changed),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,63 +68,50 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(I2),
-    /* K7   */  be_nested_str_weak(shadow_value),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Temp,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120400,  //  0000  GETNGBL	R4	K2
+      0x88100903,  //  0001  GETMBR	R4	R4	K3
+      0x88140504,  //  0002  GETMBR	R5	R2	K4
+      0x88180505,  //  0003  GETMBR	R6	R2	K5
       0x541E0401,  //  0004  LDINT	R7	1026
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0016,  //  0006  JMPF	R7	#001E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D01,  //  0007  EQ	R7	R6	K1
       0x781E0005,  //  0008  JMPF	R7	#000F
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
-      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x88240907,  //  000A  GETMBR	R9	R4	K7
+      0x88280108,  //  000B  GETMBR	R10	R0	K8
       0x7C1C0600,  //  000C  CALL	R7	3
       0x80040E00,  //  000D  RET	1	R7
       0x7002000E,  //  000E  JMP		#001E
-      0x1C1C0D08,  //  000F  EQ	R7	R6	K8
+      0x1C1C0D09,  //  000F  EQ	R7	R6	K9
       0x781E0005,  //  0010  JMPF	R7	#0017
-      0x8C1C0709,  //  0011  GETMET	R7	R3	K9
-      0x88240906,  //  0012  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  0011  GETMET	R7	R3	K10
+      0x88240907,  //  0012  GETMBR	R9	R4	K7
       0x5429EC77,  //  0013  LDINT	R10	-5000
       0x7C1C0600,  //  0014  CALL	R7	3
       0x80040E00,  //  0015  RET	1	R7
       0x70020006,  //  0016  JMP		#001E
-      0x1C1C0D0A,  //  0017  EQ	R7	R6	K10
+      0x1C1C0D0B,  //  0017  EQ	R7	R6	K11
       0x781E0004,  //  0018  JMPF	R7	#001E
-      0x8C1C0709,  //  0019  GETMET	R7	R3	K9
-      0x88240906,  //  001A  GETMBR	R9	R4	K6
+      0x8C1C070A,  //  0019  GETMET	R7	R3	K10
+      0x88240907,  //  001A  GETMBR	R9	R4	K7
       0x542A3A97,  //  001B  LDINT	R10	15000
       0x7C1C0600,  //  001C  CALL	R7	3
       0x80040E00,  //  001D  RET	1	R7
       0x601C0003,  //  001E  GETGBL	R7	G3
       0x5C200000,  //  001F  MOVE	R8	R0
       0x7C1C0200,  //  0020  CALL	R7	1
-      0x8C1C0F0B,  //  0021  GETMET	R7	R7	K11
+      0x8C1C0F0C,  //  0021  GETMET	R7	R7	K12
       0x5C240200,  //  0022  MOVE	R9	R1
       0x5C280400,  //  0023  MOVE	R10	R2
       0x5C2C0600,  //  0024  MOVE	R11	R3
@@ -119,33 +130,25 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_pre_value,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(BRIDGE),
-    /* K1   */  be_nested_str_weak(temp_unit),
-    /* K2   */  be_nested_str_weak(TEMP_F),
-    /* K3   */  be_const_real_hex(0x3FE66666),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(get_option),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Temp,     /* shared constants */
     be_str_weak(pre_value),
     &be_const_str_solidified,
     ( &(const binstruction[42]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808010D,  //  0000  GETMBR	R2	R0	K13
       0x780A0012,  //  0001  JMPF	R2	#0015
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x8808010E,  //  0002  GETMBR	R2	R0	K14
+      0x880C010F,  //  0003  GETMBR	R3	R0	K15
       0x1C080403,  //  0004  EQ	R2	R2	R3
       0x780A0003,  //  0005  JMPF	R2	#000A
       0x540A001F,  //  0006  LDINT	R2	32
       0x04080202,  //  0007  SUB	R2	R1	R2
-      0x0C080503,  //  0008  DIV	R2	R2	K3
+      0x0C080510,  //  0008  DIV	R2	R2	K16
       0x5C040400,  //  0009  MOVE	R1	R2
       0x4C080000,  //  000A  LDNIL	R2
       0x20080202,  //  000B  NE	R2	R1	R2
@@ -158,15 +161,15 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_pre_value,   /* name */
       0x4C080000,  //  0012  LDNIL	R2
       0x80040400,  //  0013  RET	1	R2
       0x70020013,  //  0014  JMP		#0029
-      0xB80A0800,  //  0015  GETNGBL	R2	K4
-      0x8C080505,  //  0016  GETMET	R2	R2	K5
+      0xB80A2200,  //  0015  GETNGBL	R2	K17
+      0x8C080512,  //  0016  GETMET	R2	R2	K18
       0x54120007,  //  0017  LDINT	R4	8
       0x7C080400,  //  0018  CALL	R2	2
-      0x1C080506,  //  0019  EQ	R2	R2	K6
+      0x1C080509,  //  0019  EQ	R2	R2	K9
       0x780A0003,  //  001A  JMPF	R2	#001F
       0x540A001F,  //  001B  LDINT	R2	32
       0x04080202,  //  001C  SUB	R2	R1	R2
-      0x0C080503,  //  001D  DIV	R2	R2	K3
+      0x0C080510,  //  001D  DIV	R2	R2	K16
       0x5C040400,  //  001E  MOVE	R1	R2
       0x4C080000,  //  001F  LDNIL	R2
       0x20080202,  //  0020  NE	R2	R1	R2
@@ -192,34 +195,28 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_web_values,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X26_X23x2600_X3B_X26_X23xFE0F_X3B_X20_X25_X2E1f_X20_XC2_XB0C),
-    /* K4   */  be_nested_str_weak(shadow_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Temp,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4062600,  //  0000  IMPORT	R1	K19
+      0x8C080114,  //  0001  GETMET	R2	R0	K20
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080315,  //  0003  GETMET	R2	R1	K21
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x58140016,  //  0005  LDCONST	R5	K22
+      0x88180108,  //  0006  GETMBR	R6	R0	K8
       0x4C1C0000,  //  0007  LDNIL	R7
       0x20180C07,  //  0008  NE	R6	R6	R7
       0x781A0005,  //  0009  JMPF	R6	#0010
       0x6018000A,  //  000A  GETGBL	R6	G10
-      0x881C0104,  //  000B  GETMBR	R7	R0	K4
+      0x881C0108,  //  000B  GETMBR	R7	R0	K8
       0x7C180200,  //  000C  CALL	R6	1
       0x541E0063,  //  000D  LDINT	R7	100
       0x0C180C07,  //  000E  DIV	R6	R6	R7

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Waterleak.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Waterleak.h
@@ -3,6 +3,26 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Sensor_Waterleak' ktab size: 16, total: 20 (saved 32 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor_Waterleak[16] = {
+  /* K0   */  be_nested_str_weak(shadow_bool_value),
+  /* K1   */  be_nested_str_weak(_parse_update_virtual),
+  /* K2   */  be_nested_str_weak(Waterleak),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(update_virtual),
+  /* K5   */  be_nested_str_weak(webserver),
+  /* K6   */  be_nested_str_weak(web_values_prefix),
+  /* K7   */  be_nested_str_weak(content_send),
+  /* K8   */  be_nested_str_weak(Waterleak_X25i_X20_X25s),
+  /* K9   */  be_nested_str_weak(tasmota_switch_index),
+  /* K10  */  be_nested_str_weak(web_value_onoff),
+  /* K11  */  be_nested_str_weak(get_name),
+  /* K12  */  be_nested_str_weak(Switch),
+  /* K13  */  be_nested_str_weak(PREFIX),
+  /* K14  */  be_nested_str_weak(html_escape),
+  /* K15  */  be_nested_str_weak(),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Sensor_Waterleak;
 
@@ -13,19 +33,13 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_update_virtual,   /* name 
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_bool_value),
-    /* K1   */  be_nested_str_weak(_parse_update_virtual),
-    /* K2   */  be_nested_str_weak(Waterleak),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Waterleak,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -58,44 +72,34 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_read_attribute,   /* name 
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(set),
-    /* K6   */  be_nested_str_weak(BOOL),
-    /* K7   */  be_nested_str_weak(shadow_bool_value),
-    /* K8   */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Waterleak,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120A00,  //  0000  GETNGBL	R4	K5
+      0x88100906,  //  0001  GETMBR	R4	R4	K6
+      0x88140507,  //  0002  GETMBR	R5	R2	K7
+      0x88180508,  //  0003  GETMBR	R6	R2	K8
       0x541E0044,  //  0004  LDINT	R7	69
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0006,  //  0006  JMPF	R7	#000E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x1C1C0D03,  //  0007  EQ	R7	R6	K3
       0x781E0004,  //  0008  JMPF	R7	#000E
-      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
-      0x88240906,  //  000A  GETMBR	R9	R4	K6
-      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x8C1C0709,  //  0009  GETMET	R7	R3	K9
+      0x8824090A,  //  000A  GETMBR	R9	R4	K10
+      0x88280100,  //  000B  GETMBR	R10	R0	K0
       0x7C1C0600,  //  000C  CALL	R7	3
       0x80040E00,  //  000D  RET	1	R7
       0x601C0003,  //  000E  GETGBL	R7	G3
       0x5C200000,  //  000F  MOVE	R8	R0
       0x7C1C0200,  //  0010  CALL	R7	1
-      0x8C1C0F08,  //  0011  GETMET	R7	R7	K8
+      0x8C1C0F0B,  //  0011  GETMET	R7	R7	K11
       0x5C240200,  //  0012  MOVE	R9	R1
       0x5C280400,  //  0013  MOVE	R10	R2
       0x5C2C0600,  //  0014  MOVE	R11	R3
@@ -114,33 +118,25 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(Waterleak_X25i_X20_X25s),
-    /* K4   */  be_nested_str_weak(tasmota_switch_index),
-    /* K5   */  be_nested_str_weak(web_value_onoff),
-    /* K6   */  be_nested_str_weak(shadow_bool_value),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Waterleak,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4060A00,  //  0000  IMPORT	R1	K5
+      0x8C080106,  //  0001  GETMET	R2	R0	K6
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080307,  //  0003  GETMET	R2	R1	K7
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x58140008,  //  0005  LDCONST	R5	K8
+      0x88180109,  //  0006  GETMBR	R6	R0	K9
+      0x8C1C010A,  //  0007  GETMET	R7	R0	K10
+      0x88240100,  //  0008  GETMBR	R9	R0	K0
       0x7C1C0400,  //  0009  CALL	R7	2
       0x7C100600,  //  000A  CALL	R4	3
       0x7C080400,  //  000B  CALL	R2	2
@@ -158,44 +154,35 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_web_values_prefix,   /* na
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(get_name),
-    /* K2   */  be_nested_str_weak(Switch),
-    /* K3   */  be_nested_str_weak(tasmota_switch_index),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Waterleak,     /* shared constants */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4060A00,  //  0000  IMPORT	R1	K5
+      0x8C08010B,  //  0001  GETMET	R2	R0	K11
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0004,  //  0004  JMPT	R3	#000A
       0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88100109,  //  0006  GETMBR	R4	R0	K9
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x000E1803,  //  0008  ADD	R3	K12	R3
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x8C0C0307,  //  000A  GETMET	R3	R1	K7
       0x60140018,  //  000B  GETGBL	R5	G24
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x8818010D,  //  000C  GETMBR	R6	R0	K13
       0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x8C1C030E,  //  000E  GETMET	R7	R1	K14
       0x5C240400,  //  000F  MOVE	R9	R2
       0x7C1C0400,  //  0010  CALL	R7	2
       0x70020000,  //  0011  JMP		#0013
-      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x581C000F,  //  0012  LDCONST	R7	K15
       0x7C140400,  //  0013  CALL	R5	2
       0x7C0C0400,  //  0014  CALL	R3	2
       0x80000000,  //  0015  RET	0
@@ -212,22 +199,19 @@ be_local_closure(class_Matter_Plugin_Sensor_Waterleak_value_updated,   /* name *
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Plugin_Sensor_Waterleak,     /* shared constants */
     be_str_weak(value_updated),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040117,  //  0000  GETMET	R1	R0	K23
       0x540E0044,  //  0001  LDINT	R3	69
-      0x58100001,  //  0002  LDCONST	R4	K1
+      0x58100003,  //  0002  LDCONST	R4	K3
       0x7C040600,  //  0003  CALL	R1	3
       0x80000000,  //  0004  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
@@ -3,6 +3,53 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_ShutterTilt' ktab size: 43, total: 65 (saved 176 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_ShutterTilt[43] = {
+  /* K0   */  be_nested_str_weak(tasmota),
+  /* K1   */  be_nested_str_weak(cmd),
+  /* K2   */  be_nested_str_weak(Status_X2013),
+  /* K3   */  be_nested_str_weak(contains),
+  /* K4   */  be_nested_str_weak(StatusSHT),
+  /* K5   */  be_nested_str_weak(find),
+  /* K6   */  be_nested_str_weak(SHT),
+  /* K7   */  be_nested_str_weak(tasmota_shutter_index),
+  /* K8   */  be_nested_str_weak(TiltConfig),
+  /* K9   */  be_nested_str_weak(tilt_min),
+  /* K10  */  be_const_int(0),
+  /* K11  */  be_nested_str_weak(tilt_max),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_nested_str_weak(matter),
+  /* K14  */  be_nested_str_weak(TLV),
+  /* K15  */  be_nested_str_weak(cluster),
+  /* K16  */  be_nested_str_weak(attribute),
+  /* K17  */  be_nested_str_weak(update_shadow_lazy),
+  /* K18  */  be_nested_str_weak(set),
+  /* K19  */  be_nested_str_weak(U1),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_nested_str_weak(update_tilt_min_max),
+  /* K22  */  be_nested_str_weak(scale_uint),
+  /* K23  */  be_nested_str_weak(shadow_shutter_tilt),
+  /* K24  */  be_nested_str_weak(U2),
+  /* K25  */  be_nested_str_weak(NULL),
+  /* K26  */  be_nested_str_weak(U4),
+  /* K27  */  be_const_int(3),
+  /* K28  */  be_nested_str_weak(read_attribute),
+  /* K29  */  be_nested_str_weak(Shutter),
+  /* K30  */  be_nested_str_weak(Tilt),
+  /* K31  */  be_nested_str_weak(attribute_updated),
+  /* K32  */  be_nested_str_weak(parse_sensors),
+  /* K33  */  be_nested_str_weak(light),
+  /* K34  */  be_nested_str_weak(command),
+  /* K35  */  be_nested_str_weak(findsubval),
+  /* K36  */  be_nested_str_weak(ShutterTilt),
+  /* K37  */  be_nested_str_weak(_X20),
+  /* K38  */  be_nested_str_weak(update_shadow),
+  /* K39  */  be_nested_str_weak(log),
+  /* K40  */  be_nested_str_weak(tilt_X25_X3A),
+  /* K41  */  be_nested_str_weak(tilt_X25_X28no_tilt_support_X29_X3A),
+  /* K42  */  be_nested_str_weak(invoke_request),
+};
+
 
 extern const bclass be_class_Matter_Plugin_ShutterTilt;
 
@@ -13,27 +60,13 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_update_tilt_min_max,   /* name 
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(cmd),
-    /* K2   */  be_nested_str_weak(Status_X2013),
-    /* K3   */  be_nested_str_weak(contains),
-    /* K4   */  be_nested_str_weak(StatusSHT),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(SHT),
-    /* K7   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K8   */  be_nested_str_weak(TiltConfig),
-    /* K9   */  be_nested_str_weak(tilt_min),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(tilt_max),
-    /* K12  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_ShutterTilt,     /* shared constants */
     be_str_weak(update_tilt_min_max),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
@@ -83,53 +116,32 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(set),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(update_tilt_min_max),
-    /* K9   */  be_nested_str_weak(tilt_min),
-    /* K10  */  be_nested_str_weak(tilt_max),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(scale_uint),
-    /* K13  */  be_nested_str_weak(shadow_shutter_tilt),
-    /* K14  */  be_const_int(0),
-    /* K15  */  be_nested_str_weak(U2),
-    /* K16  */  be_nested_str_weak(NULL),
-    /* K17  */  be_nested_str_weak(U4),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_ShutterTilt,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[113]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8121A00,  //  0000  GETNGBL	R4	K13
+      0x8810090E,  //  0001  GETMBR	R4	R4	K14
+      0x8814050F,  //  0002  GETMBR	R5	R2	K15
+      0x88180510,  //  0003  GETMBR	R6	R2	K16
       0x541E0101,  //  0004  LDINT	R7	258
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0060,  //  0006  JMPF	R7	#0068
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0111,  //  0007  GETMET	R7	R0	K17
       0x7C1C0200,  //  0008  CALL	R7	1
       0x541E0006,  //  0009  LDINT	R7	7
       0x1C1C0C07,  //  000A  EQ	R7	R6	R7
       0x781E0008,  //  000B  JMPF	R7	#0015
-      0x8C1C0705,  //  000C  GETMET	R7	R3	K5
-      0x88240906,  //  000D  GETMBR	R9	R4	K6
+      0x8C1C0712,  //  000C  GETMET	R7	R3	K18
+      0x88240913,  //  000D  GETMBR	R9	R4	K19
       0x542A0007,  //  000E  LDINT	R10	8
-      0x002A0E0A,  //  000F  ADD	R10	K7	R10
+      0x002A280A,  //  000F  ADD	R10	K20	R10
       0x542E000F,  //  0010  LDINT	R11	16
       0x0028140B,  //  0011  ADD	R10	R10	R11
       0x7C1C0600,  //  0012  CALL	R7	3
@@ -138,36 +150,36 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
       0x541E000E,  //  0015  LDINT	R7	15
       0x1C1C0C07,  //  0016  EQ	R7	R6	R7
       0x781E0021,  //  0017  JMPF	R7	#003A
-      0x8C1C0108,  //  0018  GETMET	R7	R0	K8
+      0x8C1C0115,  //  0018  GETMET	R7	R0	K21
       0x7C1C0200,  //  0019  CALL	R7	1
       0x881C0109,  //  001A  GETMBR	R7	R0	K9
       0x4C200000,  //  001B  LDNIL	R8
       0x201C0E08,  //  001C  NE	R7	R7	R8
       0x781E0015,  //  001D  JMPF	R7	#0034
-      0x881C010A,  //  001E  GETMBR	R7	R0	K10
+      0x881C010B,  //  001E  GETMBR	R7	R0	K11
       0x4C200000,  //  001F  LDNIL	R8
       0x201C0E08,  //  0020  NE	R7	R7	R8
       0x781E0011,  //  0021  JMPF	R7	#0034
-      0xB81E1600,  //  0022  GETNGBL	R7	K11
-      0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
-      0x8824010D,  //  0024  GETMBR	R9	R0	K13
+      0xB81E0000,  //  0022  GETNGBL	R7	K0
+      0x8C1C0F16,  //  0023  GETMET	R7	R7	K22
+      0x88240117,  //  0024  GETMBR	R9	R0	K23
       0x88280109,  //  0025  GETMBR	R10	R0	K9
       0x0424120A,  //  0026  SUB	R9	R9	R10
-      0x5828000E,  //  0027  LDCONST	R10	K14
-      0x882C010A,  //  0028  GETMBR	R11	R0	K10
+      0x5828000A,  //  0027  LDCONST	R10	K10
+      0x882C010B,  //  0028  GETMBR	R11	R0	K11
       0x88300109,  //  0029  GETMBR	R12	R0	K9
       0x042C160C,  //  002A  SUB	R11	R11	R12
-      0x5830000E,  //  002B  LDCONST	R12	K14
+      0x5830000A,  //  002B  LDCONST	R12	K10
       0x5436270F,  //  002C  LDINT	R13	10000
       0x7C1C0C00,  //  002D  CALL	R7	6
-      0x8C200705,  //  002E  GETMET	R8	R3	K5
-      0x8828090F,  //  002F  GETMBR	R10	R4	K15
+      0x8C200712,  //  002E  GETMET	R8	R3	K18
+      0x88280918,  //  002F  GETMBR	R10	R4	K24
       0x5C2C0E00,  //  0030  MOVE	R11	R7
       0x7C200600,  //  0031  CALL	R8	3
       0x80041000,  //  0032  RET	1	R8
       0x70020004,  //  0033  JMP		#0039
-      0x8C1C0705,  //  0034  GETMET	R7	R3	K5
-      0x88240910,  //  0035  GETMBR	R9	R4	K16
+      0x8C1C0712,  //  0034  GETMET	R7	R3	K18
+      0x88240919,  //  0035  GETMBR	R9	R4	K25
       0x4C280000,  //  0036  LDNIL	R10
       0x7C1C0600,  //  0037  CALL	R7	3
       0x80040E00,  //  0038  RET	1	R7
@@ -179,30 +191,30 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
       0x4C200000,  //  003E  LDNIL	R8
       0x201C0E08,  //  003F  NE	R7	R7	R8
       0x781E0015,  //  0040  JMPF	R7	#0057
-      0x881C010A,  //  0041  GETMBR	R7	R0	K10
+      0x881C010B,  //  0041  GETMBR	R7	R0	K11
       0x4C200000,  //  0042  LDNIL	R8
       0x201C0E08,  //  0043  NE	R7	R7	R8
       0x781E0011,  //  0044  JMPF	R7	#0057
-      0xB81E1600,  //  0045  GETNGBL	R7	K11
-      0x8C1C0F0C,  //  0046  GETMET	R7	R7	K12
-      0x8824010D,  //  0047  GETMBR	R9	R0	K13
+      0xB81E0000,  //  0045  GETNGBL	R7	K0
+      0x8C1C0F16,  //  0046  GETMET	R7	R7	K22
+      0x88240117,  //  0047  GETMBR	R9	R0	K23
       0x88280109,  //  0048  GETMBR	R10	R0	K9
       0x0424120A,  //  0049  SUB	R9	R9	R10
-      0x5828000E,  //  004A  LDCONST	R10	K14
-      0x882C010A,  //  004B  GETMBR	R11	R0	K10
+      0x5828000A,  //  004A  LDCONST	R10	K10
+      0x882C010B,  //  004B  GETMBR	R11	R0	K11
       0x88300109,  //  004C  GETMBR	R12	R0	K9
       0x042C160C,  //  004D  SUB	R11	R11	R12
-      0x5830000E,  //  004E  LDCONST	R12	K14
+      0x5830000A,  //  004E  LDCONST	R12	K10
       0x5436270F,  //  004F  LDINT	R13	10000
       0x7C1C0C00,  //  0050  CALL	R7	6
-      0x8C200705,  //  0051  GETMET	R8	R3	K5
-      0x8828090F,  //  0052  GETMBR	R10	R4	K15
+      0x8C200712,  //  0051  GETMET	R8	R3	K18
+      0x88280918,  //  0052  GETMBR	R10	R4	K24
       0x5C2C0E00,  //  0053  MOVE	R11	R7
       0x7C200600,  //  0054  CALL	R8	3
       0x80041000,  //  0055  RET	1	R8
       0x70020004,  //  0056  JMP		#005C
-      0x8C1C0705,  //  0057  GETMET	R7	R3	K5
-      0x88240910,  //  0058  GETMBR	R9	R4	K16
+      0x8C1C0712,  //  0057  GETMET	R7	R3	K18
+      0x88240919,  //  0058  GETMBR	R9	R4	K25
       0x4C280000,  //  0059  LDNIL	R10
       0x7C1C0600,  //  005A  CALL	R7	3
       0x80040E00,  //  005B  RET	1	R7
@@ -210,10 +222,10 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
       0x541EFFFB,  //  005D  LDINT	R7	65532
       0x1C1C0C07,  //  005E  EQ	R7	R6	R7
       0x781E0007,  //  005F  JMPF	R7	#0068
-      0x8C1C0705,  //  0060  GETMET	R7	R3	K5
-      0x88240911,  //  0061  GETMBR	R9	R4	K17
+      0x8C1C0712,  //  0060  GETMET	R7	R3	K18
+      0x8824091A,  //  0061  GETMBR	R9	R4	K26
       0x542A0003,  //  0062  LDINT	R10	4
-      0x002A240A,  //  0063  ADD	R10	K18	R10
+      0x002A360A,  //  0063  ADD	R10	K27	R10
       0x542E000F,  //  0064  LDINT	R11	16
       0x0028140B,  //  0065  ADD	R10	R10	R11
       0x7C1C0600,  //  0066  CALL	R7	3
@@ -221,7 +233,7 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_read_attribute,   /* name */
       0x601C0003,  //  0068  GETGBL	R7	G3
       0x5C200000,  //  0069  MOVE	R8	R0
       0x7C1C0200,  //  006A  CALL	R7	1
-      0x8C1C0F13,  //  006B  GETMET	R7	R7	K19
+      0x8C1C0F1C,  //  006B  GETMET	R7	R7	K28
       0x5C240200,  //  006C  MOVE	R9	R1
       0x5C280400,  //  006D  MOVE	R10	R2
       0x5C2C0600,  //  006E  MOVE	R11	R3
@@ -240,54 +252,44 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(Shutter),
-    /* K1   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(contains),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(Tilt),
-    /* K6   */  be_nested_str_weak(shadow_shutter_tilt),
-    /* K7   */  be_nested_str_weak(attribute_updated),
-    /* K8   */  be_nested_str_weak(parse_sensors),
-    }),
+    &be_ktab_class_Matter_Plugin_ShutterTilt,     /* shared constants */
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x000C0702,  //  0002  ADD	R3	R3	K2
+      0x880C0107,  //  0001  GETMBR	R3	R0	K7
+      0x000C0714,  //  0002  ADD	R3	R3	K20
       0x7C080200,  //  0003  CALL	R2	1
-      0x000A0002,  //  0004  ADD	R2	K0	R2
+      0x000A3A02,  //  0004  ADD	R2	K29	R2
       0x8C0C0303,  //  0005  GETMET	R3	R1	K3
       0x5C140400,  //  0006  MOVE	R5	R2
       0x7C0C0400,  //  0007  CALL	R3	2
       0x780E000E,  //  0008  JMPF	R3	#0018
       0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C100704,  //  000A  GETMET	R4	R3	K4
-      0x58180005,  //  000B  LDCONST	R6	K5
+      0x8C100705,  //  000A  GETMET	R4	R3	K5
+      0x5818001E,  //  000B  LDCONST	R6	K30
       0x7C100400,  //  000C  CALL	R4	2
       0x4C140000,  //  000D  LDNIL	R5
       0x20140805,  //  000E  NE	R5	R4	R5
       0x78160007,  //  000F  JMPF	R5	#0018
-      0x88140106,  //  0010  GETMBR	R5	R0	K6
+      0x88140117,  //  0010  GETMBR	R5	R0	K23
       0x20140805,  //  0011  NE	R5	R4	R5
       0x78160003,  //  0012  JMPF	R5	#0017
-      0x8C140107,  //  0013  GETMET	R5	R0	K7
+      0x8C14011F,  //  0013  GETMET	R5	R0	K31
       0x541E0101,  //  0014  LDINT	R7	258
       0x5422000E,  //  0015  LDINT	R8	15
       0x7C140600,  //  0016  CALL	R5	3
-      0x90020C04,  //  0017  SETMBR	R0	K6	R4
+      0x90022E04,  //  0017  SETMBR	R0	K23	R4
       0x600C0003,  //  0018  GETGBL	R3	G3
       0x5C100000,  //  0019  MOVE	R4	R0
       0x7C0C0200,  //  001A  CALL	R3	1
-      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
+      0x8C0C0720,  //  001B  GETMET	R3	R3	K32
       0x5C140200,  //  001C  MOVE	R5	R1
       0x7C0C0400,  //  001D  CALL	R3	2
       0x80000000,  //  001E  RET	0
@@ -304,114 +306,90 @@ be_local_closure(class_Matter_Plugin_ShutterTilt_invoke_request,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_nested_str_weak(findsubval),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(update_tilt_min_max),
-    /* K9   */  be_nested_str_weak(tilt_min),
-    /* K10  */  be_nested_str_weak(tilt_max),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(scale_uint),
-    /* K13  */  be_nested_str_weak(cmd),
-    /* K14  */  be_nested_str_weak(ShutterTilt),
-    /* K15  */  be_nested_str_weak(tasmota_shutter_index),
-    /* K16  */  be_const_int(1),
-    /* K17  */  be_nested_str_weak(_X20),
-    /* K18  */  be_nested_str_weak(update_shadow),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(tilt_X25_X3A),
-    /* K21  */  be_nested_str_weak(tilt_X25_X28no_tilt_support_X29_X3A),
-    /* K22  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_ShutterTilt,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[79]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0xA4124200,  //  0000  IMPORT	R4	K33
+      0xB8161A00,  //  0001  GETNGBL	R5	K13
+      0x88140B0E,  //  0002  GETMBR	R5	R5	K14
+      0x8818070F,  //  0003  GETMBR	R6	R3	K15
+      0x881C0722,  //  0004  GETMBR	R7	R3	K34
       0x54220101,  //  0005  LDINT	R8	258
       0x1C200C08,  //  0006  EQ	R8	R6	R8
       0x7822003D,  //  0007  JMPF	R8	#0046
-      0x8C200105,  //  0008  GETMET	R8	R0	K5
+      0x8C200111,  //  0008  GETMET	R8	R0	K17
       0x7C200200,  //  0009  CALL	R8	1
       0x54220007,  //  000A  LDINT	R8	8
       0x1C200E08,  //  000B  EQ	R8	R7	R8
       0x78220038,  //  000C  JMPF	R8	#0046
-      0x8C200506,  //  000D  GETMET	R8	R2	K6
-      0x58280007,  //  000E  LDCONST	R10	K7
+      0x8C200523,  //  000D  GETMET	R8	R2	K35
+      0x5828000A,  //  000E  LDCONST	R10	K10
       0x7C200400,  //  000F  CALL	R8	2
       0x4C240000,  //  0010  LDNIL	R9
       0x20241009,  //  0011  NE	R9	R8	R9
       0x78260030,  //  0012  JMPF	R9	#0044
-      0x8C240108,  //  0013  GETMET	R9	R0	K8
+      0x8C240115,  //  0013  GETMET	R9	R0	K21
       0x7C240200,  //  0014  CALL	R9	1
       0x88240109,  //  0015  GETMBR	R9	R0	K9
       0x4C280000,  //  0016  LDNIL	R10
       0x2024120A,  //  0017  NE	R9	R9	R10
       0x78260025,  //  0018  JMPF	R9	#003F
-      0x8824010A,  //  0019  GETMBR	R9	R0	K10
+      0x8824010B,  //  0019  GETMBR	R9	R0	K11
       0x4C280000,  //  001A  LDNIL	R10
       0x2024120A,  //  001B  NE	R9	R9	R10
       0x78260021,  //  001C  JMPF	R9	#003F
       0x88240109,  //  001D  GETMBR	R9	R0	K9
-      0xB82A1600,  //  001E  GETNGBL	R10	K11
-      0x8C28150C,  //  001F  GETMET	R10	R10	K12
+      0xB82A0000,  //  001E  GETNGBL	R10	K0
+      0x8C281516,  //  001F  GETMET	R10	R10	K22
       0x5C301000,  //  0020  MOVE	R12	R8
-      0x58340007,  //  0021  LDCONST	R13	K7
+      0x5834000A,  //  0021  LDCONST	R13	K10
       0x543A270F,  //  0022  LDINT	R14	10000
-      0x583C0007,  //  0023  LDCONST	R15	K7
-      0x8840010A,  //  0024  GETMBR	R16	R0	K10
+      0x583C000A,  //  0023  LDCONST	R15	K10
+      0x8840010B,  //  0024  GETMBR	R16	R0	K11
       0x88440109,  //  0025  GETMBR	R17	R0	K9
       0x04402011,  //  0026  SUB	R16	R16	R17
       0x7C280C00,  //  0027  CALL	R10	6
       0x0024120A,  //  0028  ADD	R9	R9	R10
-      0xB82A1600,  //  0029  GETNGBL	R10	K11
-      0x8C28150D,  //  002A  GETMET	R10	R10	K13
+      0xB82A0000,  //  0029  GETNGBL	R10	K0
+      0x8C281501,  //  002A  GETMET	R10	R10	K1
       0x60300008,  //  002B  GETGBL	R12	G8
-      0x8834010F,  //  002C  GETMBR	R13	R0	K15
-      0x00341B10,  //  002D  ADD	R13	R13	K16
+      0x88340107,  //  002C  GETMBR	R13	R0	K7
+      0x00341B14,  //  002D  ADD	R13	R13	K20
       0x7C300200,  //  002E  CALL	R12	1
-      0x00321C0C,  //  002F  ADD	R12	K14	R12
-      0x00301911,  //  0030  ADD	R12	R12	K17
+      0x0032480C,  //  002F  ADD	R12	K36	R12
+      0x00301925,  //  0030  ADD	R12	R12	K37
       0x60340008,  //  0031  GETGBL	R13	G8
       0x5C381200,  //  0032  MOVE	R14	R9
       0x7C340200,  //  0033  CALL	R13	1
       0x0030180D,  //  0034  ADD	R12	R12	R13
       0x50340000,  //  0035  LDBOOL	R13	0	0
       0x7C280600,  //  0036  CALL	R10	3
-      0x8C280112,  //  0037  GETMET	R10	R0	K18
+      0x8C280126,  //  0037  GETMET	R10	R0	K38
       0x7C280200,  //  0038  CALL	R10	1
       0x60280008,  //  0039  GETGBL	R10	G8
       0x5C2C1000,  //  003A  MOVE	R11	R8
       0x7C280200,  //  003B  CALL	R10	1
-      0x002A280A,  //  003C  ADD	R10	K20	R10
-      0x900E260A,  //  003D  SETMBR	R3	K19	R10
+      0x002A500A,  //  003C  ADD	R10	K40	R10
+      0x900E4E0A,  //  003D  SETMBR	R3	K39	R10
       0x70020004,  //  003E  JMP		#0044
       0x60240008,  //  003F  GETGBL	R9	G8
       0x5C281000,  //  0040  MOVE	R10	R8
       0x7C240200,  //  0041  CALL	R9	1
-      0x00262A09,  //  0042  ADD	R9	K21	R9
-      0x900E2609,  //  0043  SETMBR	R3	K19	R9
+      0x00265209,  //  0042  ADD	R9	K41	R9
+      0x900E4E09,  //  0043  SETMBR	R3	K39	R9
       0x50240200,  //  0044  LDBOOL	R9	1	0
       0x80041200,  //  0045  RET	1	R9
       0x60200003,  //  0046  GETGBL	R8	G3
       0x5C240000,  //  0047  MOVE	R9	R0
       0x7C200200,  //  0048  CALL	R8	1
-      0x8C201116,  //  0049  GETMET	R8	R8	K22
+      0x8C20112A,  //  0049  GETMET	R8	R8	K42
       0x5C280200,  //  004A  MOVE	R10	R1
       0x5C2C0400,  //  004B  MOVE	R11	R2
       0x5C300600,  //  004C  MOVE	R12	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light2.h
@@ -3,6 +3,62 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Light2' ktab size: 52, total: 91 (saved 312 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Light2[52] = {
+  /* K0   */  be_nested_str_weak(find),
+  /* K1   */  be_nested_str_weak(CT),
+  /* K2   */  be_nested_str_weak(set_ct),
+  /* K3   */  be_nested_str_weak(update_virtual),
+  /* K4   */  be_nested_str_weak(matter),
+  /* K5   */  be_nested_str_weak(TLV),
+  /* K6   */  be_nested_str_weak(cluster),
+  /* K7   */  be_nested_str_weak(attribute),
+  /* K8   */  be_nested_str_weak(update_shadow_lazy),
+  /* K9   */  be_nested_str_weak(set_or_nil),
+  /* K10  */  be_nested_str_weak(U1),
+  /* K11  */  be_nested_str_weak(shadow_ct),
+  /* K12  */  be_nested_str_weak(set),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_const_int(0),
+  /* K15  */  be_nested_str_weak(ct_min),
+  /* K16  */  be_nested_str_weak(ct_max),
+  /* K17  */  be_nested_str_weak(U4),
+  /* K18  */  be_nested_str_weak(read_attribute),
+  /* K19  */  be_nested_str_weak(VIRTUAL),
+  /* K20  */  be_nested_str_weak(BRIDGE),
+  /* K21  */  be_nested_str_weak(light),
+  /* K22  */  be_nested_str_weak(update_ct_minmax),
+  /* K23  */  be_nested_str_weak(update_shadow),
+  /* K24  */  be_nested_str_weak(get),
+  /* K25  */  be_nested_str_weak(light_index),
+  /* K26  */  be_nested_str_weak(ct),
+  /* K27  */  be_nested_str_weak(attribute_updated),
+  /* K28  */  be_nested_str_weak(call_remote_sync),
+  /* K29  */  be_nested_str_weak(parse_status),
+  /* K30  */  be_nested_str_weak(),
+  /* K31  */  be_const_int(1000000),
+  /* K32  */  be_nested_str_weak(_X25iK),
+  /* K33  */  be_nested_str_weak(_X26_X239898_X3B_X20),
+  /* K34  */  be_nested_str_weak(webserver),
+  /* K35  */  be_nested_str_weak(web_values_prefix),
+  /* K36  */  be_nested_str_weak(content_send),
+  /* K37  */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
+  /* K38  */  be_nested_str_weak(web_value_onoff),
+  /* K39  */  be_nested_str_weak(shadow_onoff),
+  /* K40  */  be_nested_str_weak(web_value_dimmer),
+  /* K41  */  be_nested_str_weak(web_value_ct),
+  /* K42  */  be_nested_str_weak(init),
+  /* K43  */  be_const_int(1),
+  /* K44  */  be_nested_str_weak(command),
+  /* K45  */  be_nested_str_weak(findsubval),
+  /* K46  */  be_nested_str_weak(log),
+  /* K47  */  be_nested_str_weak(ct_X3A),
+  /* K48  */  be_nested_str_weak(publish_command),
+  /* K49  */  be_nested_str_weak(invoke_request),
+  /* K50  */  be_nested_str_weak(tasmota),
+  /* K51  */  be_nested_str_weak(get_option),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Light2;
 
@@ -13,18 +69,13 @@ be_local_closure(class_Matter_Plugin_Light2_update_virtual,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(CT),
-    /* K2   */  be_nested_str_weak(set_ct),
-    /* K3   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -59,98 +110,82 @@ be_local_closure(class_Matter_Plugin_Light2_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(set_or_nil),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_nested_str_weak(shadow_ct),
-    /* K8   */  be_nested_str_weak(set),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(ct_min),
-    /* K12  */  be_nested_str_weak(ct_max),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[71]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0xB8120800,  //  0000  GETNGBL	R4	K4
+      0x88100905,  //  0001  GETMBR	R4	R4	K5
+      0x88140506,  //  0002  GETMBR	R5	R2	K6
+      0x88180507,  //  0003  GETMBR	R6	R2	K7
       0x541E02FF,  //  0004  LDINT	R7	768
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0036,  //  0006  JMPF	R7	#003E
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0108,  //  0007  GETMET	R7	R0	K8
       0x7C1C0200,  //  0008  CALL	R7	1
       0x541E0006,  //  0009  LDINT	R7	7
       0x1C1C0C07,  //  000A  EQ	R7	R6	R7
       0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0705,  //  000C  GETMET	R7	R3	K5
-      0x88240906,  //  000D  GETMBR	R9	R4	K6
-      0x88280107,  //  000E  GETMBR	R10	R0	K7
+      0x8C1C0709,  //  000C  GETMET	R7	R3	K9
+      0x8824090A,  //  000D  GETMBR	R9	R4	K10
+      0x8828010B,  //  000E  GETMBR	R10	R0	K11
       0x7C1C0600,  //  000F  CALL	R7	3
       0x80040E00,  //  0010  RET	1	R7
       0x7002002B,  //  0011  JMP		#003E
       0x541E0007,  //  0012  LDINT	R7	8
       0x1C1C0C07,  //  0013  EQ	R7	R6	R7
       0x781E0005,  //  0014  JMPF	R7	#001B
-      0x8C1C0708,  //  0015  GETMET	R7	R3	K8
-      0x88240906,  //  0016  GETMBR	R9	R4	K6
-      0x58280009,  //  0017  LDCONST	R10	K9
+      0x8C1C070C,  //  0015  GETMET	R7	R3	K12
+      0x8824090A,  //  0016  GETMBR	R9	R4	K10
+      0x5828000D,  //  0017  LDCONST	R10	K13
       0x7C1C0600,  //  0018  CALL	R7	3
       0x80040E00,  //  0019  RET	1	R7
       0x70020022,  //  001A  JMP		#003E
       0x541E000E,  //  001B  LDINT	R7	15
       0x1C1C0C07,  //  001C  EQ	R7	R6	R7
       0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0708,  //  001E  GETMET	R7	R3	K8
-      0x88240906,  //  001F  GETMBR	R9	R4	K6
-      0x5828000A,  //  0020  LDCONST	R10	K10
+      0x8C1C070C,  //  001E  GETMET	R7	R3	K12
+      0x8824090A,  //  001F  GETMBR	R9	R4	K10
+      0x5828000E,  //  0020  LDCONST	R10	K14
       0x7C1C0600,  //  0021  CALL	R7	3
       0x80040E00,  //  0022  RET	1	R7
       0x70020019,  //  0023  JMP		#003E
       0x541E400A,  //  0024  LDINT	R7	16395
       0x1C1C0C07,  //  0025  EQ	R7	R6	R7
       0x781E0005,  //  0026  JMPF	R7	#002D
-      0x8C1C0708,  //  0027  GETMET	R7	R3	K8
-      0x88240906,  //  0028  GETMBR	R9	R4	K6
-      0x8828010B,  //  0029  GETMBR	R10	R0	K11
+      0x8C1C070C,  //  0027  GETMET	R7	R3	K12
+      0x8824090A,  //  0028  GETMBR	R9	R4	K10
+      0x8828010F,  //  0029  GETMBR	R10	R0	K15
       0x7C1C0600,  //  002A  CALL	R7	3
       0x80040E00,  //  002B  RET	1	R7
       0x70020010,  //  002C  JMP		#003E
       0x541E400B,  //  002D  LDINT	R7	16396
       0x1C1C0C07,  //  002E  EQ	R7	R6	R7
       0x781E0005,  //  002F  JMPF	R7	#0036
-      0x8C1C0708,  //  0030  GETMET	R7	R3	K8
-      0x88240906,  //  0031  GETMBR	R9	R4	K6
-      0x8828010C,  //  0032  GETMBR	R10	R0	K12
+      0x8C1C070C,  //  0030  GETMET	R7	R3	K12
+      0x8824090A,  //  0031  GETMBR	R9	R4	K10
+      0x88280110,  //  0032  GETMBR	R10	R0	K16
       0x7C1C0600,  //  0033  CALL	R7	3
       0x80040E00,  //  0034  RET	1	R7
       0x70020007,  //  0035  JMP		#003E
       0x541EFFFB,  //  0036  LDINT	R7	65532
       0x1C1C0C07,  //  0037  EQ	R7	R6	R7
       0x781E0004,  //  0038  JMPF	R7	#003E
-      0x8C1C0708,  //  0039  GETMET	R7	R3	K8
-      0x8824090D,  //  003A  GETMBR	R9	R4	K13
+      0x8C1C070C,  //  0039  GETMET	R7	R3	K12
+      0x88240911,  //  003A  GETMBR	R9	R4	K17
       0x542A000F,  //  003B  LDINT	R10	16
       0x7C1C0600,  //  003C  CALL	R7	3
       0x80040E00,  //  003D  RET	1	R7
       0x601C0003,  //  003E  GETGBL	R7	G3
       0x5C200000,  //  003F  MOVE	R8	R0
       0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
+      0x8C1C0F12,  //  0041  GETMET	R7	R7	K18
       0x5C240200,  //  0042  MOVE	R9	R1
       0x5C280400,  //  0043  MOVE	R10	R2
       0x5C2C0600,  //  0044  MOVE	R11	R3
@@ -169,67 +204,55 @@ be_local_closure(class_Matter_Plugin_Light2_update_shadow,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(update_ct_minmax),
-    /* K4   */  be_nested_str_weak(update_shadow),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(light_index),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(ct),
-    /* K9   */  be_nested_str_weak(shadow_ct),
-    /* K10  */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040113,  //  0000  GETMBR	R1	R0	K19
       0x74060020,  //  0001  JMPT	R1	#0023
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x88040114,  //  0002  GETMBR	R1	R0	K20
       0x7406001E,  //  0003  JMPT	R1	#0023
-      0xA4060400,  //  0004  IMPORT	R1	K2
-      0x8C080103,  //  0005  GETMET	R2	R0	K3
+      0xA4062A00,  //  0004  IMPORT	R1	K21
+      0x8C080116,  //  0005  GETMET	R2	R0	K22
       0x7C080200,  //  0006  CALL	R2	1
       0x60080003,  //  0007  GETGBL	R2	G3
       0x5C0C0000,  //  0008  MOVE	R3	R0
       0x7C080200,  //  0009  CALL	R2	1
-      0x8C080504,  //  000A  GETMET	R2	R2	K4
+      0x8C080517,  //  000A  GETMET	R2	R2	K23
       0x7C080200,  //  000B  CALL	R2	1
-      0x8C080305,  //  000C  GETMET	R2	R1	K5
-      0x88100106,  //  000D  GETMBR	R4	R0	K6
+      0x8C080318,  //  000C  GETMET	R2	R1	K24
+      0x88100119,  //  000D  GETMBR	R4	R0	K25
       0x7C080400,  //  000E  CALL	R2	2
       0x4C0C0000,  //  000F  LDNIL	R3
       0x200C0403,  //  0010  NE	R3	R2	R3
       0x780E000F,  //  0011  JMPF	R3	#0022
-      0x8C0C0507,  //  0012  GETMET	R3	R2	K7
-      0x58140008,  //  0013  LDCONST	R5	K8
+      0x8C0C0500,  //  0012  GETMET	R3	R2	K0
+      0x5814001A,  //  0013  LDCONST	R5	K26
       0x4C180000,  //  0014  LDNIL	R6
       0x7C0C0600,  //  0015  CALL	R3	3
       0x4C100000,  //  0016  LDNIL	R4
       0x1C100604,  //  0017  EQ	R4	R3	R4
       0x78120000,  //  0018  JMPF	R4	#001A
-      0x880C0109,  //  0019  GETMBR	R3	R0	K9
-      0x88100109,  //  001A  GETMBR	R4	R0	K9
+      0x880C010B,  //  0019  GETMBR	R3	R0	K11
+      0x8810010B,  //  001A  GETMBR	R4	R0	K11
       0x20100604,  //  001B  NE	R4	R3	R4
       0x78120004,  //  001C  JMPF	R4	#0022
-      0x8C10010A,  //  001D  GETMET	R4	R0	K10
+      0x8C10011B,  //  001D  GETMET	R4	R0	K27
       0x541A02FF,  //  001E  LDINT	R6	768
       0x541E0006,  //  001F  LDINT	R7	7
       0x7C100600,  //  0020  CALL	R4	3
-      0x90021203,  //  0021  SETMBR	R0	K9	R3
+      0x90021603,  //  0021  SETMBR	R0	K11	R3
       0x70020004,  //  0022  JMP		#0028
       0x60040003,  //  0023  GETGBL	R1	G3
       0x5C080000,  //  0024  MOVE	R2	R0
       0x7C040200,  //  0025  CALL	R1	1
-      0x8C040304,  //  0026  GETMET	R1	R1	K4
+      0x8C040317,  //  0026  GETMET	R1	R1	K23
       0x7C040200,  //  0027  CALL	R1	1
       0x80000000,  //  0028  RET	0
     })
@@ -245,43 +268,28 @@ be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ct_min),
-    /* K1   */  be_nested_str_weak(ct_max),
-    /* K2   */  be_nested_str_weak(BRIDGE),
-    /* K3   */  be_nested_str_weak(call_remote_sync),
-    /* K4   */  be_nested_str_weak(CT),
-    /* K5   */  be_nested_str_weak(parse_status),
-    /* K6   */  be_nested_str_weak(VIRTUAL),
-    /* K7   */  be_nested_str_weak(shadow_ct),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_nested_str_weak(light),
-    /* K10  */  be_nested_str_weak(set),
-    /* K11  */  be_nested_str_weak(ct),
-    /* K12  */  be_nested_str_weak(light_index),
-    /* K13  */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(set_ct),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808010F,  //  0000  GETMBR	R2	R0	K15
       0x14080202,  //  0001  LT	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8804010F,  //  0003  GETMBR	R1	R0	K15
+      0x88080110,  //  0004  GETMBR	R2	R0	K16
       0x24080202,  //  0005  GT	R2	R1	R2
       0x780A0000,  //  0006  JMPF	R2	#0008
-      0x88040101,  //  0007  GETMBR	R1	R0	K1
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x88040110,  //  0007  GETMBR	R1	R0	K16
+      0x88080114,  //  0008  GETMBR	R2	R0	K20
       0x780A000D,  //  0009  JMPF	R2	#0018
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100004,  //  000B  LDCONST	R4	K4
+      0x8C08011C,  //  000A  GETMET	R2	R0	K28
+      0x58100001,  //  000B  LDCONST	R4	K1
       0x60140008,  //  000C  GETGBL	R5	G8
       0x5C180200,  //  000D  MOVE	R6	R1
       0x7C140200,  //  000E  CALL	R5	1
@@ -289,30 +297,30 @@ be_local_closure(class_Matter_Plugin_Light2_set_ct,   /* name */
       0x4C0C0000,  //  0010  LDNIL	R3
       0x200C0403,  //  0011  NE	R3	R2	R3
       0x780E0003,  //  0012  JMPF	R3	#0017
-      0x8C0C0105,  //  0013  GETMET	R3	R0	K5
+      0x8C0C011D,  //  0013  GETMET	R3	R0	K29
       0x5C140400,  //  0014  MOVE	R5	R2
       0x541A000A,  //  0015  LDINT	R6	11
       0x7C0C0600,  //  0016  CALL	R3	3
       0x70020013,  //  0017  JMP		#002C
-      0x88080106,  //  0018  GETMBR	R2	R0	K6
+      0x88080113,  //  0018  GETMBR	R2	R0	K19
       0x780A0008,  //  0019  JMPF	R2	#0023
-      0x88080107,  //  001A  GETMBR	R2	R0	K7
+      0x8808010B,  //  001A  GETMBR	R2	R0	K11
       0x20080202,  //  001B  NE	R2	R1	R2
       0x780A0004,  //  001C  JMPF	R2	#0022
-      0x8C080108,  //  001D  GETMET	R2	R0	K8
+      0x8C08011B,  //  001D  GETMET	R2	R0	K27
       0x541202FF,  //  001E  LDINT	R4	768
       0x54160006,  //  001F  LDINT	R5	7
       0x7C080600,  //  0020  CALL	R2	3
-      0x90020E01,  //  0021  SETMBR	R0	K7	R1
+      0x90021601,  //  0021  SETMBR	R0	K11	R1
       0x70020008,  //  0022  JMP		#002C
-      0xA40A1200,  //  0023  IMPORT	R2	K9
-      0x8C0C050A,  //  0024  GETMET	R3	R2	K10
+      0xA40A2A00,  //  0023  IMPORT	R2	K21
+      0x8C0C050C,  //  0024  GETMET	R3	R2	K12
       0x60140013,  //  0025  GETGBL	R5	G19
       0x7C140000,  //  0026  CALL	R5	0
-      0x98161601,  //  0027  SETIDX	R5	K11	R1
-      0x8818010C,  //  0028  GETMBR	R6	R0	K12
+      0x98163401,  //  0027  SETIDX	R5	K26	R1
+      0x88180119,  //  0028  GETMBR	R6	R0	K25
       0x7C0C0600,  //  0029  CALL	R3	3
-      0x8C0C010D,  //  002A  GETMET	R3	R0	K13
+      0x8C0C0117,  //  002A  GETMET	R3	R0	K23
       0x7C0C0200,  //  002B  CALL	R3	1
       0x80000000,  //  002C  RET	0
     })
@@ -328,28 +336,20 @@ be_local_closure(class_Matter_Plugin_Light2_parse_status,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_status),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(CT),
-    /* K3   */  be_nested_str_weak(shadow_ct),
-    /* K4   */  be_nested_str_weak(ct_min),
-    /* K5   */  be_nested_str_weak(ct_max),
-    /* K6   */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x8C0C071D,  //  0003  GETMET	R3	R3	K29
       0x5C140200,  //  0004  MOVE	R5	R1
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C0C0600,  //  0006  CALL	R3	3
@@ -357,29 +357,29 @@ be_local_closure(class_Matter_Plugin_Light2_parse_status,   /* name */
       0x1C0C0403,  //  0008  EQ	R3	R2	R3
       0x780E0017,  //  0009  JMPF	R3	#0022
       0x600C0009,  //  000A  GETGBL	R3	G9
-      0x8C100301,  //  000B  GETMET	R4	R1	K1
-      0x58180002,  //  000C  LDCONST	R6	K2
+      0x8C100300,  //  000B  GETMET	R4	R1	K0
+      0x58180001,  //  000C  LDCONST	R6	K1
       0x7C100400,  //  000D  CALL	R4	2
       0x7C0C0200,  //  000E  CALL	R3	1
       0x4C100000,  //  000F  LDNIL	R4
       0x20100604,  //  0010  NE	R4	R3	R4
       0x7812000F,  //  0011  JMPF	R4	#0022
-      0x88100103,  //  0012  GETMBR	R4	R0	K3
+      0x8810010B,  //  0012  GETMBR	R4	R0	K11
       0x20100604,  //  0013  NE	R4	R3	R4
       0x7812000C,  //  0014  JMPF	R4	#0022
-      0x88100104,  //  0015  GETMBR	R4	R0	K4
+      0x8810010F,  //  0015  GETMBR	R4	R0	K15
       0x14100604,  //  0016  LT	R4	R3	R4
       0x78120000,  //  0017  JMPF	R4	#0019
-      0x880C0104,  //  0018  GETMBR	R3	R0	K4
-      0x88100105,  //  0019  GETMBR	R4	R0	K5
+      0x880C010F,  //  0018  GETMBR	R3	R0	K15
+      0x88100110,  //  0019  GETMBR	R4	R0	K16
       0x24100604,  //  001A  GT	R4	R3	R4
       0x78120000,  //  001B  JMPF	R4	#001D
-      0x880C0105,  //  001C  GETMBR	R3	R0	K5
-      0x8C100106,  //  001D  GETMET	R4	R0	K6
+      0x880C0110,  //  001C  GETMBR	R3	R0	K16
+      0x8C10011B,  //  001D  GETMET	R4	R0	K27
       0x541A02FF,  //  001E  LDINT	R6	768
       0x541E0006,  //  001F  LDINT	R7	7
       0x7C100600,  //  0020  CALL	R4	3
-      0x90020603,  //  0021  SETMBR	R0	K3	R3
+      0x90021603,  //  0021  SETMBR	R0	K11	R3
       0x80000000,  //  0022  RET	0
     })
   )
@@ -394,29 +394,23 @@ be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(shadow_ct),
-    /* K2   */  be_const_int(1000000),
-    /* K3   */  be_nested_str_weak(_X25iK),
-    /* K4   */  be_nested_str_weak(_X26_X239898_X3B_X20),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(web_value_ct),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x5804001E,  //  0000  LDCONST	R1	K30
+      0x8808010B,  //  0001  GETMBR	R2	R0	K11
       0x4C0C0000,  //  0002  LDNIL	R3
       0x20080403,  //  0003  NE	R2	R2	R3
       0x780A000C,  //  0004  JMPF	R2	#0012
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x0C0A0402,  //  0006  DIV	R2	K2	R2
+      0x8808010B,  //  0005  GETMBR	R2	R0	K11
+      0x0C0A3E02,  //  0006  DIV	R2	K31	R2
       0x540E0018,  //  0007  LDINT	R3	25
       0x00080403,  //  0008  ADD	R2	R2	R3
       0x540E0031,  //  0009  LDINT	R3	50
@@ -424,11 +418,11 @@ be_local_closure(class_Matter_Plugin_Light2_web_value_ct,   /* name */
       0x540E0031,  //  000B  LDINT	R3	50
       0x08080403,  //  000C  MUL	R2	R2	R3
       0x600C0018,  //  000D  GETGBL	R3	G24
-      0x58100003,  //  000E  LDCONST	R4	K3
+      0x58100020,  //  000E  LDCONST	R4	K32
       0x5C140400,  //  000F  MOVE	R5	R2
       0x7C0C0400,  //  0010  CALL	R3	2
       0x5C040600,  //  0011  MOVE	R1	R3
-      0x000A0801,  //  0012  ADD	R2	K4	R1
+      0x000A4201,  //  0012  ADD	R2	K33	R1
       0x80040400,  //  0013  RET	1	R2
     })
   )
@@ -443,37 +437,28 @@ be_local_closure(class_Matter_Plugin_Light2_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    /* K6   */  be_nested_str_weak(web_value_dimmer),
-    /* K7   */  be_nested_str_weak(web_value_ct),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4064400,  //  0000  IMPORT	R1	K34
+      0x8C080123,  //  0001  GETMET	R2	R0	K35
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080324,  //  0003  GETMET	R2	R1	K36
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x58140025,  //  0005  LDCONST	R5	K37
+      0x8C180126,  //  0006  GETMET	R6	R0	K38
+      0x88200127,  //  0007  GETMBR	R8	R0	K39
       0x7C180400,  //  0008  CALL	R6	2
-      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x8C1C0128,  //  0009  GETMET	R7	R0	K40
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C200107,  //  000B  GETMET	R8	R0	K7
+      0x8C200129,  //  000B  GETMET	R8	R0	K41
       0x7C200200,  //  000C  CALL	R8	1
       0x7C100800,  //  000D  CALL	R4	4
       0x7C080400,  //  000E  CALL	R2	2
@@ -491,46 +476,37 @@ be_local_closure(class_Matter_Plugin_Light2_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(shadow_ct),
-    /* K3   */  be_nested_str_weak(light),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(light_index),
-    /* K7   */  be_nested_str_weak(update_ct_minmax),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C10092A,  //  0003  GETMET	R4	R4	K42
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x88100114,  //  0008  GETMBR	R4	R0	K20
       0x74120009,  //  0009  JMPT	R4	#0014
       0x54120144,  //  000A  LDINT	R4	325
-      0x90020404,  //  000B  SETMBR	R0	K2	R4
-      0xA4120600,  //  000C  IMPORT	R4	K3
-      0x8C140904,  //  000D  GETMET	R5	R4	K4
-      0x581C0005,  //  000E  LDCONST	R7	K5
+      0x90021604,  //  000B  SETMBR	R0	K11	R4
+      0xA4122A00,  //  000C  IMPORT	R4	K21
+      0x8C140918,  //  000D  GETMET	R5	R4	K24
+      0x581C002B,  //  000E  LDCONST	R7	K43
       0x7C140400,  //  000F  CALL	R5	2
       0x4C180000,  //  0010  LDNIL	R6
       0x20140A06,  //  0011  NE	R5	R5	R6
       0x78160000,  //  0012  JMPF	R5	#0014
-      0x90020D05,  //  0013  SETMBR	R0	K6	K5
-      0x8C100107,  //  0014  GETMET	R4	R0	K7
+      0x9002332B,  //  0013  SETMBR	R0	K25	K43
+      0x8C100116,  //  0014  GETMET	R4	R0	K22
       0x7C100200,  //  0015  CALL	R4	1
       0x80000000,  //  0016  RET	0
     })
@@ -546,65 +522,49 @@ be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(findsubval),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(ct_min),
-    /* K8   */  be_nested_str_weak(ct_max),
-    /* K9   */  be_nested_str_weak(set_ct),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(ct_X3A),
-    /* K12  */  be_nested_str_weak(publish_command),
-    /* K13  */  be_nested_str_weak(CT),
-    /* K14  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[66]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0xB8120800,  //  0000  GETNGBL	R4	K4
+      0x88100905,  //  0001  GETMBR	R4	R4	K5
+      0x88140706,  //  0002  GETMBR	R5	R3	K6
+      0x8818072C,  //  0003  GETMBR	R6	R3	K44
       0x541E02FF,  //  0004  LDINT	R7	768
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0030,  //  0006  JMPF	R7	#0038
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0108,  //  0007  GETMET	R7	R0	K8
       0x7C1C0200,  //  0008  CALL	R7	1
       0x541E0009,  //  0009  LDINT	R7	10
       0x1C1C0C07,  //  000A  EQ	R7	R6	R7
       0x781E0019,  //  000B  JMPF	R7	#0026
-      0x8C1C0505,  //  000C  GETMET	R7	R2	K5
-      0x58240006,  //  000D  LDCONST	R9	K6
+      0x8C1C052D,  //  000C  GETMET	R7	R2	K45
+      0x5824000E,  //  000D  LDCONST	R9	K14
       0x7C1C0400,  //  000E  CALL	R7	2
-      0x88200107,  //  000F  GETMBR	R8	R0	K7
+      0x8820010F,  //  000F  GETMBR	R8	R0	K15
       0x14200E08,  //  0010  LT	R8	R7	R8
       0x78220000,  //  0011  JMPF	R8	#0013
-      0x881C0107,  //  0012  GETMBR	R7	R0	K7
-      0x88200108,  //  0013  GETMBR	R8	R0	K8
+      0x881C010F,  //  0012  GETMBR	R7	R0	K15
+      0x88200110,  //  0013  GETMBR	R8	R0	K16
       0x24200E08,  //  0014  GT	R8	R7	R8
       0x78220000,  //  0015  JMPF	R8	#0017
-      0x881C0108,  //  0016  GETMBR	R7	R0	K8
-      0x8C200109,  //  0017  GETMET	R8	R0	K9
+      0x881C0110,  //  0016  GETMBR	R7	R0	K16
+      0x8C200102,  //  0017  GETMET	R8	R0	K2
       0x5C280E00,  //  0018  MOVE	R10	R7
       0x7C200400,  //  0019  CALL	R8	2
       0x60200008,  //  001A  GETGBL	R8	G8
       0x5C240E00,  //  001B  MOVE	R9	R7
       0x7C200200,  //  001C  CALL	R8	1
-      0x00221608,  //  001D  ADD	R8	K11	R8
-      0x900E1408,  //  001E  SETMBR	R3	K10	R8
-      0x8C20010C,  //  001F  GETMET	R8	R0	K12
-      0x5828000D,  //  0020  LDCONST	R10	K13
+      0x00225E08,  //  001D  ADD	R8	K47	R8
+      0x900E5C08,  //  001E  SETMBR	R3	K46	R8
+      0x8C200130,  //  001F  GETMET	R8	R0	K48
+      0x58280001,  //  0020  LDCONST	R10	K1
       0x5C2C0E00,  //  0021  MOVE	R11	R7
       0x7C200600,  //  0022  CALL	R8	3
       0x50200200,  //  0023  LDBOOL	R8	1	0
@@ -631,7 +591,7 @@ be_local_closure(class_Matter_Plugin_Light2_invoke_request,   /* name */
       0x601C0003,  //  0038  GETGBL	R7	G3
       0x5C200000,  //  0039  MOVE	R8	R0
       0x7C1C0200,  //  003A  CALL	R7	1
-      0x8C1C0F0E,  //  003B  GETMET	R7	R7	K14
+      0x8C1C0F31,  //  003B  GETMET	R7	R7	K49
       0x5C240200,  //  003C  MOVE	R9	R1
       0x5C280400,  //  003D  MOVE	R10	R2
       0x5C2C0600,  //  003E  MOVE	R11	R3
@@ -651,35 +611,30 @@ be_local_closure(class_Matter_Plugin_Light2_update_ct_minmax,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(get_option),
-    /* K2   */  be_nested_str_weak(ct_min),
-    /* K3   */  be_nested_str_weak(ct_max),
-    }),
+    &be_ktab_class_Matter_Plugin_Light2,     /* shared constants */
     be_str_weak(update_ct_minmax),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB8066400,  //  0000  GETNGBL	R1	K50
+      0x8C040333,  //  0001  GETMET	R1	R1	K51
       0x540E0051,  //  0002  LDINT	R3	82
       0x7C040400,  //  0003  CALL	R1	2
       0x78060001,  //  0004  JMPF	R1	#0007
       0x540A00C7,  //  0005  LDINT	R2	200
       0x70020000,  //  0006  JMP		#0008
       0x540A0098,  //  0007  LDINT	R2	153
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x90021E02,  //  0008  SETMBR	R0	K15	R2
       0x78060001,  //  0009  JMPF	R1	#000C
       0x540A017B,  //  000A  LDINT	R2	380
       0x70020000,  //  000B  JMP		#000D
       0x540A01F3,  //  000C  LDINT	R2	500
-      0x90020602,  //  000D  SETMBR	R0	K3	R2
+      0x90022002,  //  000D  SETMBR	R0	K16	R2
       0x80000000,  //  000E  RET	0
     })
   )

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Light3.h
@@ -3,6 +3,78 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Plugin_Light3' ktab size: 68, total: 113 (saved 360 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Light3[68] = {
+  /* K0   */  be_nested_str_weak(matter),
+  /* K1   */  be_nested_str_weak(TLV),
+  /* K2   */  be_nested_str_weak(cluster),
+  /* K3   */  be_nested_str_weak(command),
+  /* K4   */  be_nested_str_weak(update_shadow_lazy),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(findsubval),
+  /* K7   */  be_nested_str_weak(set_hue_sat),
+  /* K8   */  be_nested_str_weak(log),
+  /* K9   */  be_nested_str_weak(hue_X3A),
+  /* K10  */  be_nested_str_weak(publish_command),
+  /* K11  */  be_nested_str_weak(Hue),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_const_int(3),
+  /* K15  */  be_nested_str_weak(sat_X3A),
+  /* K16  */  be_nested_str_weak(Sat),
+  /* K17  */  be_nested_str_weak(_X20sat_X3A),
+  /* K18  */  be_nested_str_weak(invoke_request),
+  /* K19  */  be_nested_str_weak(attribute),
+  /* K20  */  be_nested_str_weak(set_or_nil),
+  /* K21  */  be_nested_str_weak(U1),
+  /* K22  */  be_nested_str_weak(shadow_hue),
+  /* K23  */  be_nested_str_weak(shadow_sat),
+  /* K24  */  be_nested_str_weak(set),
+  /* K25  */  be_nested_str_weak(U4),
+  /* K26  */  be_nested_str_weak(read_attribute),
+  /* K27  */  be_nested_str_weak(VIRTUAL),
+  /* K28  */  be_nested_str_weak(BRIDGE),
+  /* K29  */  be_nested_str_weak(light),
+  /* K30  */  be_nested_str_weak(update_shadow),
+  /* K31  */  be_nested_str_weak(get),
+  /* K32  */  be_nested_str_weak(light_index),
+  /* K33  */  be_nested_str_weak(find),
+  /* K34  */  be_nested_str_weak(hue),
+  /* K35  */  be_nested_str_weak(sat),
+  /* K36  */  be_nested_str_weak(tasmota),
+  /* K37  */  be_nested_str_weak(scale_uint),
+  /* K38  */  be_nested_str_weak(attribute_updated),
+  /* K39  */  be_nested_str_weak(update_virtual),
+  /* K40  */  be_nested_str_weak(call_remote_sync),
+  /* K41  */  be_nested_str_weak(HSBColor1),
+  /* K42  */  be_nested_str_weak(parse_status),
+  /* K43  */  be_nested_str_weak(HSBColor2),
+  /* K44  */  be_nested_str_weak(init),
+  /* K45  */  be_nested_str_weak(webserver),
+  /* K46  */  be_nested_str_weak(web_values_prefix),
+  /* K47  */  be_nested_str_weak(content_send),
+  /* K48  */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
+  /* K49  */  be_nested_str_weak(web_value_onoff),
+  /* K50  */  be_nested_str_weak(shadow_onoff),
+  /* K51  */  be_nested_str_weak(web_value_dimmer),
+  /* K52  */  be_nested_str_weak(web_value_RGB),
+  /* K53  */  be_nested_str_weak(HSBColor),
+  /* K54  */  be_nested_str_weak(string),
+  /* K55  */  be_nested_str_weak(split),
+  /* K56  */  be_nested_str_weak(_X2C),
+  /* K57  */  be_const_int(0),
+  /* K58  */  be_const_int(1),
+  /* K59  */  be_nested_str_weak(light_state),
+  /* K60  */  be_nested_str_weak(set_bri),
+  /* K61  */  be_nested_str_weak(set_huesat),
+  /* K62  */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
+  /* K63  */  be_nested_str_weak(r),
+  /* K64  */  be_nested_str_weak(g),
+  /* K65  */  be_nested_str_weak(b),
+  /* K66  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
+  /* K67  */  be_nested_str_weak(),
+};
+
 
 extern const bclass be_class_Matter_Plugin_Light3;
 
@@ -13,33 +85,13 @@ be_local_closure(class_Matter_Plugin_Light3_invoke_request,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(findsubval),
-    /* K7   */  be_nested_str_weak(set_hue_sat),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(hue_X3A),
-    /* K10  */  be_nested_str_weak(publish_command),
-    /* K11  */  be_nested_str_weak(Hue),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(sat_X3A),
-    /* K16  */  be_nested_str_weak(Sat),
-    /* K17  */  be_nested_str_weak(_X20sat_X3A),
-    /* K18  */  be_nested_str_weak(invoke_request),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[121]) {  /* code */
@@ -177,35 +229,20 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set_or_nil),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_hue),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(shadow_sat),
-    /* K11  */  be_nested_str_weak(set),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_nested_str_weak(read_attribute),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[96]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
-      0x88180503,  //  0003  GETMBR	R6	R2	K3
+      0x88180513,  //  0003  GETMBR	R6	R2	K19
       0x541E02FF,  //  0004  LDINT	R7	768
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E004F,  //  0006  JMPF	R7	#0057
@@ -213,25 +250,25 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x7C1C0200,  //  0008  CALL	R7	1
       0x1C1C0D05,  //  0009  EQ	R7	R6	K5
       0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0706,  //  000B  GETMET	R7	R3	K6
-      0x88240907,  //  000C  GETMBR	R9	R4	K7
-      0x88280108,  //  000D  GETMBR	R10	R0	K8
+      0x8C1C0714,  //  000B  GETMET	R7	R3	K20
+      0x88240915,  //  000C  GETMBR	R9	R4	K21
+      0x88280116,  //  000D  GETMBR	R10	R0	K22
       0x7C1C0600,  //  000E  CALL	R7	3
       0x80040E00,  //  000F  RET	1	R7
       0x70020045,  //  0010  JMP		#0057
-      0x1C1C0D09,  //  0011  EQ	R7	R6	K9
+      0x1C1C0D0C,  //  0011  EQ	R7	R6	K12
       0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240907,  //  0014  GETMBR	R9	R4	K7
-      0x8828010A,  //  0015  GETMBR	R10	R0	K10
+      0x8C1C0714,  //  0013  GETMET	R7	R3	K20
+      0x88240915,  //  0014  GETMBR	R9	R4	K21
+      0x88280117,  //  0015  GETMBR	R10	R0	K23
       0x7C1C0600,  //  0016  CALL	R7	3
       0x80040E00,  //  0017  RET	1	R7
       0x7002003D,  //  0018  JMP		#0057
       0x541E0006,  //  0019  LDINT	R7	7
       0x1C1C0C07,  //  001A  EQ	R7	R6	R7
       0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C070B,  //  001C  GETMET	R7	R3	K11
-      0x88240907,  //  001D  GETMBR	R9	R4	K7
+      0x8C1C0718,  //  001C  GETMET	R7	R3	K24
+      0x88240915,  //  001D  GETMBR	R9	R4	K21
       0x58280005,  //  001E  LDCONST	R10	K5
       0x7C1C0600,  //  001F  CALL	R7	3
       0x80040E00,  //  0020  RET	1	R7
@@ -239,8 +276,8 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x541E0007,  //  0022  LDINT	R7	8
       0x1C1C0C07,  //  0023  EQ	R7	R6	R7
       0x781E0005,  //  0024  JMPF	R7	#002B
-      0x8C1C070B,  //  0025  GETMET	R7	R3	K11
-      0x88240907,  //  0026  GETMBR	R9	R4	K7
+      0x8C1C0718,  //  0025  GETMET	R7	R3	K24
+      0x88240915,  //  0026  GETMBR	R9	R4	K21
       0x58280005,  //  0027  LDCONST	R10	K5
       0x7C1C0600,  //  0028  CALL	R7	3
       0x80040E00,  //  0029  RET	1	R7
@@ -248,8 +285,8 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x541E000E,  //  002B  LDINT	R7	15
       0x1C1C0C07,  //  002C  EQ	R7	R6	R7
       0x781E0005,  //  002D  JMPF	R7	#0034
-      0x8C1C070B,  //  002E  GETMET	R7	R3	K11
-      0x88240907,  //  002F  GETMBR	R9	R4	K7
+      0x8C1C0718,  //  002E  GETMET	R7	R3	K24
+      0x88240915,  //  002F  GETMBR	R9	R4	K21
       0x58280005,  //  0030  LDCONST	R10	K5
       0x7C1C0600,  //  0031  CALL	R7	3
       0x80040E00,  //  0032  RET	1	R7
@@ -257,8 +294,8 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x541E4000,  //  0034  LDINT	R7	16385
       0x1C1C0C07,  //  0035  EQ	R7	R6	R7
       0x781E0005,  //  0036  JMPF	R7	#003D
-      0x8C1C070B,  //  0037  GETMET	R7	R3	K11
-      0x88240907,  //  0038  GETMBR	R9	R4	K7
+      0x8C1C0718,  //  0037  GETMET	R7	R3	K24
+      0x88240915,  //  0038  GETMBR	R9	R4	K21
       0x58280005,  //  0039  LDCONST	R10	K5
       0x7C1C0600,  //  003A  CALL	R7	3
       0x80040E00,  //  003B  RET	1	R7
@@ -266,17 +303,17 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x541E4009,  //  003D  LDINT	R7	16394
       0x1C1C0C07,  //  003E  EQ	R7	R6	R7
       0x781E0005,  //  003F  JMPF	R7	#0046
-      0x8C1C070B,  //  0040  GETMET	R7	R3	K11
-      0x88240907,  //  0041  GETMBR	R9	R4	K7
-      0x58280009,  //  0042  LDCONST	R10	K9
+      0x8C1C0718,  //  0040  GETMET	R7	R3	K24
+      0x88240915,  //  0041  GETMBR	R9	R4	K21
+      0x5828000C,  //  0042  LDCONST	R10	K12
       0x7C1C0600,  //  0043  CALL	R7	3
       0x80040E00,  //  0044  RET	1	R7
       0x70020010,  //  0045  JMP		#0057
       0x541E000F,  //  0046  LDINT	R7	16
       0x1C1C0C07,  //  0047  EQ	R7	R6	R7
       0x781E0005,  //  0048  JMPF	R7	#004F
-      0x8C1C070B,  //  0049  GETMET	R7	R3	K11
-      0x88240907,  //  004A  GETMBR	R9	R4	K7
+      0x8C1C0718,  //  0049  GETMET	R7	R3	K24
+      0x88240915,  //  004A  GETMBR	R9	R4	K21
       0x58280005,  //  004B  LDCONST	R10	K5
       0x7C1C0600,  //  004C  CALL	R7	3
       0x80040E00,  //  004D  RET	1	R7
@@ -284,15 +321,15 @@ be_local_closure(class_Matter_Plugin_Light3_read_attribute,   /* name */
       0x541EFFFB,  //  004F  LDINT	R7	65532
       0x1C1C0C07,  //  0050  EQ	R7	R6	R7
       0x781E0004,  //  0051  JMPF	R7	#0057
-      0x8C1C070B,  //  0052  GETMET	R7	R3	K11
-      0x8824090C,  //  0053  GETMBR	R9	R4	K12
-      0x58280009,  //  0054  LDCONST	R10	K9
+      0x8C1C0718,  //  0052  GETMET	R7	R3	K24
+      0x88240919,  //  0053  GETMBR	R9	R4	K25
+      0x5828000C,  //  0054  LDCONST	R10	K12
       0x7C1C0600,  //  0055  CALL	R7	3
       0x80040E00,  //  0056  RET	1	R7
       0x601C0003,  //  0057  GETGBL	R7	G3
       0x5C200000,  //  0058  MOVE	R8	R0
       0x7C1C0200,  //  0059  CALL	R7	1
-      0x8C1C0F0D,  //  005A  GETMET	R7	R7	K13
+      0x8C1C0F1A,  //  005A  GETMET	R7	R7	K26
       0x5C240200,  //  005B  MOVE	R9	R1
       0x5C280400,  //  005C  MOVE	R10	R2
       0x5C2C0600,  //  005D  MOVE	R11	R3
@@ -311,106 +348,89 @@ be_local_closure(class_Matter_Plugin_Light3_update_shadow,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(VIRTUAL),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(update_shadow),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(light_index),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(hue),
-    /* K8   */  be_nested_str_weak(sat),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(scale_uint),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(shadow_hue),
-    /* K13  */  be_nested_str_weak(shadow_sat),
-    /* K14  */  be_nested_str_weak(attribute_updated),
-    /* K15  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(update_shadow),
     &be_const_str_solidified,
     ( &(const binstruction[75]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011B,  //  0000  GETMBR	R1	R0	K27
       0x74060042,  //  0001  JMPT	R1	#0045
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8804011C,  //  0002  GETMBR	R1	R0	K28
       0x74060040,  //  0003  JMPT	R1	#0045
-      0xA4060400,  //  0004  IMPORT	R1	K2
+      0xA4063A00,  //  0004  IMPORT	R1	K29
       0x60080003,  //  0005  GETGBL	R2	G3
       0x5C0C0000,  //  0006  MOVE	R3	R0
       0x7C080200,  //  0007  CALL	R2	1
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
+      0x8C08051E,  //  0008  GETMET	R2	R2	K30
       0x7C080200,  //  0009  CALL	R2	1
-      0x8C080304,  //  000A  GETMET	R2	R1	K4
-      0x88100105,  //  000B  GETMBR	R4	R0	K5
+      0x8C08031F,  //  000A  GETMET	R2	R1	K31
+      0x88100120,  //  000B  GETMBR	R4	R0	K32
       0x7C080400,  //  000C  CALL	R2	2
       0x4C0C0000,  //  000D  LDNIL	R3
       0x200C0403,  //  000E  NE	R3	R2	R3
       0x780E0033,  //  000F  JMPF	R3	#0044
-      0x8C0C0506,  //  0010  GETMET	R3	R2	K6
-      0x58140007,  //  0011  LDCONST	R5	K7
+      0x8C0C0521,  //  0010  GETMET	R3	R2	K33
+      0x58140022,  //  0011  LDCONST	R5	K34
       0x4C180000,  //  0012  LDNIL	R6
       0x7C0C0600,  //  0013  CALL	R3	3
-      0x8C100506,  //  0014  GETMET	R4	R2	K6
-      0x58180008,  //  0015  LDCONST	R6	K8
+      0x8C100521,  //  0014  GETMET	R4	R2	K33
+      0x58180023,  //  0015  LDCONST	R6	K35
       0x4C1C0000,  //  0016  LDNIL	R7
       0x7C100600,  //  0017  CALL	R4	3
       0x4C140000,  //  0018  LDNIL	R5
       0x20140605,  //  0019  NE	R5	R3	R5
       0x78160009,  //  001A  JMPF	R5	#0025
-      0xB8161200,  //  001B  GETNGBL	R5	K9
-      0x8C140B0A,  //  001C  GETMET	R5	R5	K10
+      0xB8164800,  //  001B  GETNGBL	R5	K36
+      0x8C140B25,  //  001C  GETMET	R5	R5	K37
       0x5C1C0600,  //  001D  MOVE	R7	R3
-      0x5820000B,  //  001E  LDCONST	R8	K11
+      0x58200005,  //  001E  LDCONST	R8	K5
       0x54260167,  //  001F  LDINT	R9	360
-      0x5828000B,  //  0020  LDCONST	R10	K11
+      0x58280005,  //  0020  LDCONST	R10	K5
       0x542E00FD,  //  0021  LDINT	R11	254
       0x7C140C00,  //  0022  CALL	R5	6
       0x5C0C0A00,  //  0023  MOVE	R3	R5
       0x70020000,  //  0024  JMP		#0026
-      0x880C010C,  //  0025  GETMBR	R3	R0	K12
+      0x880C0116,  //  0025  GETMBR	R3	R0	K22
       0x4C140000,  //  0026  LDNIL	R5
       0x20140805,  //  0027  NE	R5	R4	R5
       0x78160009,  //  0028  JMPF	R5	#0033
-      0xB8161200,  //  0029  GETNGBL	R5	K9
-      0x8C140B0A,  //  002A  GETMET	R5	R5	K10
+      0xB8164800,  //  0029  GETNGBL	R5	K36
+      0x8C140B25,  //  002A  GETMET	R5	R5	K37
       0x5C1C0800,  //  002B  MOVE	R7	R4
-      0x5820000B,  //  002C  LDCONST	R8	K11
+      0x58200005,  //  002C  LDCONST	R8	K5
       0x542600FE,  //  002D  LDINT	R9	255
-      0x5828000B,  //  002E  LDCONST	R10	K11
+      0x58280005,  //  002E  LDCONST	R10	K5
       0x542E00FD,  //  002F  LDINT	R11	254
       0x7C140C00,  //  0030  CALL	R5	6
       0x5C100A00,  //  0031  MOVE	R4	R5
       0x70020000,  //  0032  JMP		#0034
-      0x8810010D,  //  0033  GETMBR	R4	R0	K13
-      0x8814010C,  //  0034  GETMBR	R5	R0	K12
+      0x88100117,  //  0033  GETMBR	R4	R0	K23
+      0x88140116,  //  0034  GETMBR	R5	R0	K22
       0x20140605,  //  0035  NE	R5	R3	R5
       0x78160004,  //  0036  JMPF	R5	#003C
-      0x8C14010E,  //  0037  GETMET	R5	R0	K14
+      0x8C140126,  //  0037  GETMET	R5	R0	K38
       0x541E02FF,  //  0038  LDINT	R7	768
-      0x5820000B,  //  0039  LDCONST	R8	K11
+      0x58200005,  //  0039  LDCONST	R8	K5
       0x7C140600,  //  003A  CALL	R5	3
-      0x90021803,  //  003B  SETMBR	R0	K12	R3
-      0x8814010D,  //  003C  GETMBR	R5	R0	K13
+      0x90022C03,  //  003B  SETMBR	R0	K22	R3
+      0x88140117,  //  003C  GETMBR	R5	R0	K23
       0x20140805,  //  003D  NE	R5	R4	R5
       0x78160004,  //  003E  JMPF	R5	#0044
-      0x8C14010E,  //  003F  GETMET	R5	R0	K14
+      0x8C140126,  //  003F  GETMET	R5	R0	K38
       0x541E02FF,  //  0040  LDINT	R7	768
-      0x5820000F,  //  0041  LDCONST	R8	K15
+      0x5820000C,  //  0041  LDCONST	R8	K12
       0x7C140600,  //  0042  CALL	R5	3
-      0x90021A04,  //  0043  SETMBR	R0	K13	R4
+      0x90022E04,  //  0043  SETMBR	R0	K23	R4
       0x70020004,  //  0044  JMP		#004A
       0x60040003,  //  0045  GETGBL	R1	G3
       0x5C080000,  //  0046  MOVE	R2	R0
       0x7C040200,  //  0047  CALL	R1	1
-      0x8C040303,  //  0048  GETMET	R1	R1	K3
+      0x8C04031E,  //  0048  GETMET	R1	R1	K30
       0x7C040200,  //  0049  CALL	R1	1
       0x80000000,  //  004A  RET	0
     })
@@ -426,30 +446,24 @@ be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find),
-    /* K1   */  be_nested_str_weak(Hue),
-    /* K2   */  be_nested_str_weak(Sat),
-    /* K3   */  be_nested_str_weak(set_hue_sat),
-    /* K4   */  be_nested_str_weak(update_virtual),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(update_virtual),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
-      0x8C0C0300,  //  0001  GETMET	R3	R1	K0
-      0x58140001,  //  0002  LDCONST	R5	K1
+      0x8C0C0321,  //  0001  GETMET	R3	R1	K33
+      0x5814000B,  //  0002  LDCONST	R5	K11
       0x7C0C0400,  //  0003  CALL	R3	2
       0x7C080200,  //  0004  CALL	R2	1
       0x600C0009,  //  0005  GETGBL	R3	G9
-      0x8C100300,  //  0006  GETMET	R4	R1	K0
-      0x58180002,  //  0007  LDCONST	R6	K2
+      0x8C100321,  //  0006  GETMET	R4	R1	K33
+      0x58180010,  //  0007  LDCONST	R6	K16
       0x7C100400,  //  0008  CALL	R4	2
       0x7C0C0200,  //  0009  CALL	R3	1
       0x4C100000,  //  000A  LDNIL	R4
@@ -458,14 +472,14 @@ be_local_closure(class_Matter_Plugin_Light3_update_virtual,   /* name */
       0x4C100000,  //  000D  LDNIL	R4
       0x20100604,  //  000E  NE	R4	R3	R4
       0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C100103,  //  0010  GETMET	R4	R0	K3
+      0x8C100107,  //  0010  GETMET	R4	R0	K7
       0x5C180400,  //  0011  MOVE	R6	R2
       0x5C1C0600,  //  0012  MOVE	R7	R3
       0x7C100600,  //  0013  CALL	R4	3
       0x60100003,  //  0014  GETGBL	R4	G3
       0x5C140000,  //  0015  MOVE	R5	R0
       0x7C100200,  //  0016  CALL	R4	1
-      0x8C100904,  //  0017  GETMET	R4	R4	K4
+      0x8C100927,  //  0017  GETMET	R4	R4	K39
       0x5C180200,  //  0018  MOVE	R6	R1
       0x7C100400,  //  0019  CALL	R4	2
       0x80000000,  //  001A  RET	0
@@ -482,42 +496,22 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(BRIDGE),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_nested_str_weak(call_remote_sync),
-    /* K5   */  be_nested_str_weak(HSBColor1),
-    /* K6   */  be_nested_str_weak(parse_status),
-    /* K7   */  be_nested_str_weak(HSBColor2),
-    /* K8   */  be_nested_str_weak(VIRTUAL),
-    /* K9   */  be_nested_str_weak(shadow_hue),
-    /* K10  */  be_nested_str_weak(attribute_updated),
-    /* K11  */  be_nested_str_weak(shadow_sat),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(light),
-    /* K14  */  be_nested_str_weak(set),
-    /* K15  */  be_nested_str_weak(hue),
-    /* K16  */  be_nested_str_weak(sat),
-    /* K17  */  be_nested_str_weak(light_index),
-    /* K18  */  be_nested_str_weak(update_shadow),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(set_hue_sat),
     &be_const_str_solidified,
     ( &(const binstruction[154]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x200C0203,  //  0001  NE	R3	R1	R3
       0x780E0006,  //  0002  JMPF	R3	#000A
-      0x140C0300,  //  0003  LT	R3	R1	K0
+      0x140C0305,  //  0003  LT	R3	R1	K5
       0x780E0000,  //  0004  JMPF	R3	#0006
-      0x58040000,  //  0005  LDCONST	R1	K0
+      0x58040005,  //  0005  LDCONST	R1	K5
       0x540E00FD,  //  0006  LDINT	R3	254
       0x240C0203,  //  0007  GT	R3	R1	R3
       0x780E0000,  //  0008  JMPF	R3	#000A
@@ -525,94 +519,94 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
       0x4C0C0000,  //  000A  LDNIL	R3
       0x200C0403,  //  000B  NE	R3	R2	R3
       0x780E0006,  //  000C  JMPF	R3	#0014
-      0x140C0500,  //  000D  LT	R3	R2	K0
+      0x140C0505,  //  000D  LT	R3	R2	K5
       0x780E0000,  //  000E  JMPF	R3	#0010
-      0x58080000,  //  000F  LDCONST	R2	K0
+      0x58080005,  //  000F  LDCONST	R2	K5
       0x540E00FD,  //  0010  LDINT	R3	254
       0x240C0403,  //  0011  GT	R3	R2	R3
       0x780E0000,  //  0012  JMPF	R3	#0014
       0x540A00FD,  //  0013  LDINT	R2	254
-      0x880C0101,  //  0014  GETMBR	R3	R0	K1
+      0x880C011C,  //  0014  GETMBR	R3	R0	K28
       0x780E002C,  //  0015  JMPF	R3	#0043
       0x4C0C0000,  //  0016  LDNIL	R3
       0x200C0203,  //  0017  NE	R3	R1	R3
       0x780E0012,  //  0018  JMPF	R3	#002C
-      0xB80E0400,  //  0019  GETNGBL	R3	K2
-      0x8C0C0703,  //  001A  GETMET	R3	R3	K3
+      0xB80E4800,  //  0019  GETNGBL	R3	K36
+      0x8C0C0725,  //  001A  GETMET	R3	R3	K37
       0x5C140200,  //  001B  MOVE	R5	R1
-      0x58180000,  //  001C  LDCONST	R6	K0
+      0x58180005,  //  001C  LDCONST	R6	K5
       0x541E00FD,  //  001D  LDINT	R7	254
-      0x58200000,  //  001E  LDCONST	R8	K0
+      0x58200005,  //  001E  LDCONST	R8	K5
       0x54260167,  //  001F  LDINT	R9	360
       0x7C0C0C00,  //  0020  CALL	R3	6
-      0x8C100104,  //  0021  GETMET	R4	R0	K4
-      0x58180005,  //  0022  LDCONST	R6	K5
+      0x8C100128,  //  0021  GETMET	R4	R0	K40
+      0x58180029,  //  0022  LDCONST	R6	K41
       0x5C1C0600,  //  0023  MOVE	R7	R3
       0x7C100600,  //  0024  CALL	R4	3
       0x4C140000,  //  0025  LDNIL	R5
       0x20140805,  //  0026  NE	R5	R4	R5
       0x78160003,  //  0027  JMPF	R5	#002C
-      0x8C140106,  //  0028  GETMET	R5	R0	K6
+      0x8C14012A,  //  0028  GETMET	R5	R0	K42
       0x5C1C0800,  //  0029  MOVE	R7	R4
       0x5422000A,  //  002A  LDINT	R8	11
       0x7C140600,  //  002B  CALL	R5	3
       0x4C0C0000,  //  002C  LDNIL	R3
       0x200C0403,  //  002D  NE	R3	R2	R3
       0x780E0012,  //  002E  JMPF	R3	#0042
-      0xB80E0400,  //  002F  GETNGBL	R3	K2
-      0x8C0C0703,  //  0030  GETMET	R3	R3	K3
+      0xB80E4800,  //  002F  GETNGBL	R3	K36
+      0x8C0C0725,  //  0030  GETMET	R3	R3	K37
       0x5C140400,  //  0031  MOVE	R5	R2
-      0x58180000,  //  0032  LDCONST	R6	K0
+      0x58180005,  //  0032  LDCONST	R6	K5
       0x541E00FD,  //  0033  LDINT	R7	254
-      0x58200000,  //  0034  LDCONST	R8	K0
+      0x58200005,  //  0034  LDCONST	R8	K5
       0x54260063,  //  0035  LDINT	R9	100
       0x7C0C0C00,  //  0036  CALL	R3	6
-      0x8C100104,  //  0037  GETMET	R4	R0	K4
-      0x58180007,  //  0038  LDCONST	R6	K7
+      0x8C100128,  //  0037  GETMET	R4	R0	K40
+      0x5818002B,  //  0038  LDCONST	R6	K43
       0x5C1C0600,  //  0039  MOVE	R7	R3
       0x7C100600,  //  003A  CALL	R4	3
       0x4C140000,  //  003B  LDNIL	R5
       0x20140805,  //  003C  NE	R5	R4	R5
       0x78160003,  //  003D  JMPF	R5	#0042
-      0x8C140106,  //  003E  GETMET	R5	R0	K6
+      0x8C14012A,  //  003E  GETMET	R5	R0	K42
       0x5C1C0800,  //  003F  MOVE	R7	R4
       0x5422000A,  //  0040  LDINT	R8	11
       0x7C140600,  //  0041  CALL	R5	3
       0x70020055,  //  0042  JMP		#0099
-      0x880C0108,  //  0043  GETMBR	R3	R0	K8
+      0x880C011B,  //  0043  GETMBR	R3	R0	K27
       0x780E0016,  //  0044  JMPF	R3	#005C
       0x4C0C0000,  //  0045  LDNIL	R3
       0x200C0203,  //  0046  NE	R3	R1	R3
       0x780E0007,  //  0047  JMPF	R3	#0050
-      0x880C0109,  //  0048  GETMBR	R3	R0	K9
+      0x880C0116,  //  0048  GETMBR	R3	R0	K22
       0x200C0203,  //  0049  NE	R3	R1	R3
       0x780E0004,  //  004A  JMPF	R3	#0050
-      0x8C0C010A,  //  004B  GETMET	R3	R0	K10
+      0x8C0C0126,  //  004B  GETMET	R3	R0	K38
       0x541602FF,  //  004C  LDINT	R5	768
-      0x58180000,  //  004D  LDCONST	R6	K0
+      0x58180005,  //  004D  LDCONST	R6	K5
       0x7C0C0600,  //  004E  CALL	R3	3
-      0x90021201,  //  004F  SETMBR	R0	K9	R1
+      0x90022C01,  //  004F  SETMBR	R0	K22	R1
       0x4C0C0000,  //  0050  LDNIL	R3
       0x200C0403,  //  0051  NE	R3	R2	R3
       0x780E0007,  //  0052  JMPF	R3	#005B
-      0x880C010B,  //  0053  GETMBR	R3	R0	K11
+      0x880C0117,  //  0053  GETMBR	R3	R0	K23
       0x200C0403,  //  0054  NE	R3	R2	R3
       0x780E0004,  //  0055  JMPF	R3	#005B
-      0x8C0C010A,  //  0056  GETMET	R3	R0	K10
+      0x8C0C0126,  //  0056  GETMET	R3	R0	K38
       0x541602FF,  //  0057  LDINT	R5	768
       0x5818000C,  //  0058  LDCONST	R6	K12
       0x7C0C0600,  //  0059  CALL	R3	3
-      0x90021602,  //  005A  SETMBR	R0	K11	R2
+      0x90022E02,  //  005A  SETMBR	R0	K23	R2
       0x7002003C,  //  005B  JMP		#0099
       0x4C0C0000,  //  005C  LDNIL	R3
       0x200C0203,  //  005D  NE	R3	R1	R3
       0x780E0008,  //  005E  JMPF	R3	#0068
-      0xB80E0400,  //  005F  GETNGBL	R3	K2
-      0x8C0C0703,  //  0060  GETMET	R3	R3	K3
+      0xB80E4800,  //  005F  GETNGBL	R3	K36
+      0x8C0C0725,  //  0060  GETMET	R3	R3	K37
       0x5C140200,  //  0061  MOVE	R5	R1
-      0x58180000,  //  0062  LDCONST	R6	K0
+      0x58180005,  //  0062  LDCONST	R6	K5
       0x541E00FD,  //  0063  LDINT	R7	254
-      0x58200000,  //  0064  LDCONST	R8	K0
+      0x58200005,  //  0064  LDCONST	R8	K5
       0x54260167,  //  0065  LDINT	R9	360
       0x7C0C0C00,  //  0066  CALL	R3	6
       0x70020000,  //  0067  JMP		#0069
@@ -620,12 +614,12 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
       0x4C100000,  //  0069  LDNIL	R4
       0x20100404,  //  006A  NE	R4	R2	R4
       0x78120008,  //  006B  JMPF	R4	#0075
-      0xB8120400,  //  006C  GETNGBL	R4	K2
-      0x8C100903,  //  006D  GETMET	R4	R4	K3
+      0xB8124800,  //  006C  GETNGBL	R4	K36
+      0x8C100925,  //  006D  GETMET	R4	R4	K37
       0x5C180400,  //  006E  MOVE	R6	R2
-      0x581C0000,  //  006F  LDCONST	R7	K0
+      0x581C0005,  //  006F  LDCONST	R7	K5
       0x542200FD,  //  0070  LDINT	R8	254
-      0x58240000,  //  0071  LDCONST	R9	K0
+      0x58240005,  //  0071  LDCONST	R9	K5
       0x542A00FE,  //  0072  LDINT	R10	255
       0x7C100C00,  //  0073  CALL	R4	6
       0x70020000,  //  0074  JMP		#0076
@@ -636,34 +630,34 @@ be_local_closure(class_Matter_Plugin_Light3_set_hue_sat,   /* name */
       0x4C140000,  //  0079  LDNIL	R5
       0x20140805,  //  007A  NE	R5	R4	R5
       0x78160008,  //  007B  JMPF	R5	#0085
-      0xB8161A00,  //  007C  GETNGBL	R5	K13
-      0x8C140B0E,  //  007D  GETMET	R5	R5	K14
+      0xB8163A00,  //  007C  GETNGBL	R5	K29
+      0x8C140B18,  //  007D  GETMET	R5	R5	K24
       0x601C0013,  //  007E  GETGBL	R7	G19
       0x7C1C0000,  //  007F  CALL	R7	0
-      0x981E1E03,  //  0080  SETIDX	R7	K15	R3
-      0x981E2004,  //  0081  SETIDX	R7	K16	R4
-      0x88200111,  //  0082  GETMBR	R8	R0	K17
+      0x981E4403,  //  0080  SETIDX	R7	K34	R3
+      0x981E4604,  //  0081  SETIDX	R7	K35	R4
+      0x88200120,  //  0082  GETMBR	R8	R0	K32
       0x7C140600,  //  0083  CALL	R5	3
       0x70020011,  //  0084  JMP		#0097
       0x4C140000,  //  0085  LDNIL	R5
       0x20140605,  //  0086  NE	R5	R3	R5
       0x78160007,  //  0087  JMPF	R5	#0090
-      0xB8161A00,  //  0088  GETNGBL	R5	K13
-      0x8C140B0E,  //  0089  GETMET	R5	R5	K14
+      0xB8163A00,  //  0088  GETNGBL	R5	K29
+      0x8C140B18,  //  0089  GETMET	R5	R5	K24
       0x601C0013,  //  008A  GETGBL	R7	G19
       0x7C1C0000,  //  008B  CALL	R7	0
-      0x981E1E03,  //  008C  SETIDX	R7	K15	R3
-      0x88200111,  //  008D  GETMBR	R8	R0	K17
+      0x981E4403,  //  008C  SETIDX	R7	K34	R3
+      0x88200120,  //  008D  GETMBR	R8	R0	K32
       0x7C140600,  //  008E  CALL	R5	3
       0x70020006,  //  008F  JMP		#0097
-      0xB8161A00,  //  0090  GETNGBL	R5	K13
-      0x8C140B0E,  //  0091  GETMET	R5	R5	K14
+      0xB8163A00,  //  0090  GETNGBL	R5	K29
+      0x8C140B18,  //  0091  GETMET	R5	R5	K24
       0x601C0013,  //  0092  GETGBL	R7	G19
       0x7C1C0000,  //  0093  CALL	R7	0
-      0x981E2004,  //  0094  SETIDX	R7	K16	R4
-      0x88200111,  //  0095  GETMBR	R8	R0	K17
+      0x981E4604,  //  0094  SETIDX	R7	K35	R4
+      0x88200120,  //  0095  GETMBR	R8	R0	K32
       0x7C140600,  //  0096  CALL	R5	3
-      0x8C140112,  //  0097  GETMET	R5	R0	K18
+      0x8C14011E,  //  0097  GETMET	R5	R0	K30
       0x7C140200,  //  0098  CALL	R5	1
       0x80000000,  //  0099  RET	0
     })
@@ -679,31 +673,26 @@ be_local_closure(class_Matter_Plugin_Light3_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_hue),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(shadow_sat),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x8C10092C,  //  0003  GETMET	R4	R4	K44
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x90020302,  //  0008  SETMBR	R0	K1	K2
-      0x90020702,  //  0009  SETMBR	R0	K3	K2
+      0x90022D05,  //  0008  SETMBR	R0	K22	K5
+      0x90022F05,  //  0009  SETMBR	R0	K23	K5
       0x80000000,  //  000A  RET	0
     })
   )
@@ -718,37 +707,28 @@ be_local_closure(class_Matter_Plugin_Light3_web_values,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(web_values_prefix),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
-    /* K4   */  be_nested_str_weak(web_value_onoff),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    /* K6   */  be_nested_str_weak(web_value_dimmer),
-    /* K7   */  be_nested_str_weak(web_value_RGB),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(web_values),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4065A00,  //  0000  IMPORT	R1	K45
+      0x8C08012E,  //  0001  GETMET	R2	R0	K46
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C08032F,  //  0003  GETMET	R2	R1	K47
       0x60100018,  //  0004  GETGBL	R4	G24
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x8C180104,  //  0006  GETMET	R6	R0	K4
-      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x58140030,  //  0005  LDCONST	R5	K48
+      0x8C180131,  //  0006  GETMET	R6	R0	K49
+      0x88200132,  //  0007  GETMBR	R8	R0	K50
       0x7C180400,  //  0008  CALL	R6	2
-      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x8C1C0133,  //  0009  GETMET	R7	R0	K51
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C200107,  //  000B  GETMET	R8	R0	K7
+      0x8C200134,  //  000B  GETMET	R8	R0	K52
       0x7C200200,  //  000C  CALL	R8	1
       0x7C100800,  //  000D  CALL	R4	4
       0x7C080400,  //  000E  CALL	R2	2
@@ -766,99 +746,85 @@ be_local_closure(class_Matter_Plugin_Light3_parse_status,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_status),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(HSBColor),
-    /* K3   */  be_nested_str_weak(string),
-    /* K4   */  be_nested_str_weak(split),
-    /* K5   */  be_nested_str_weak(_X2C),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(scale_uint),
-    /* K10  */  be_nested_str_weak(shadow_hue),
-    /* K11  */  be_nested_str_weak(shadow_sat),
-    /* K12  */  be_nested_str_weak(attribute_updated),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(parse_status),
     &be_const_str_solidified,
     ( &(const binstruction[70]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x8C0C072A,  //  0003  GETMET	R3	R3	K42
       0x5C140200,  //  0004  MOVE	R5	R1
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C0C0600,  //  0006  CALL	R3	3
       0x540E000A,  //  0007  LDINT	R3	11
       0x1C0C0403,  //  0008  EQ	R3	R2	R3
       0x780E003A,  //  0009  JMPF	R3	#0045
-      0x8C0C0301,  //  000A  GETMET	R3	R1	K1
-      0x58140002,  //  000B  LDCONST	R5	K2
+      0x8C0C0321,  //  000A  GETMET	R3	R1	K33
+      0x58140035,  //  000B  LDCONST	R5	K53
       0x7C0C0400,  //  000C  CALL	R3	2
       0x780E0036,  //  000D  JMPF	R3	#0045
-      0xA4120600,  //  000E  IMPORT	R4	K3
-      0x8C140904,  //  000F  GETMET	R5	R4	K4
+      0xA4126C00,  //  000E  IMPORT	R4	K54
+      0x8C140937,  //  000F  GETMET	R5	R4	K55
       0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x58200005,  //  0011  LDCONST	R8	K5
+      0x58200038,  //  0011  LDCONST	R8	K56
       0x7C140600,  //  0012  CALL	R5	3
       0x60180009,  //  0013  GETGBL	R6	G9
-      0x941C0B06,  //  0014  GETIDX	R7	R5	K6
+      0x941C0B39,  //  0014  GETIDX	R7	R5	K57
       0x7C180200,  //  0015  CALL	R6	1
       0x601C0009,  //  0016  GETGBL	R7	G9
-      0x94200B07,  //  0017  GETIDX	R8	R5	K7
+      0x94200B3A,  //  0017  GETIDX	R8	R5	K58
       0x7C1C0200,  //  0018  CALL	R7	1
       0x4C200000,  //  0019  LDNIL	R8
       0x20200C08,  //  001A  NE	R8	R6	R8
       0x78220009,  //  001B  JMPF	R8	#0026
-      0xB8221000,  //  001C  GETNGBL	R8	K8
-      0x8C201109,  //  001D  GETMET	R8	R8	K9
+      0xB8224800,  //  001C  GETNGBL	R8	K36
+      0x8C201125,  //  001D  GETMET	R8	R8	K37
       0x5C280C00,  //  001E  MOVE	R10	R6
-      0x582C0006,  //  001F  LDCONST	R11	K6
+      0x582C0039,  //  001F  LDCONST	R11	K57
       0x54320167,  //  0020  LDINT	R12	360
-      0x58340006,  //  0021  LDCONST	R13	K6
+      0x58340039,  //  0021  LDCONST	R13	K57
       0x543A00FD,  //  0022  LDINT	R14	254
       0x7C200C00,  //  0023  CALL	R8	6
       0x5C181000,  //  0024  MOVE	R6	R8
       0x70020000,  //  0025  JMP		#0027
-      0x8818010A,  //  0026  GETMBR	R6	R0	K10
+      0x88180116,  //  0026  GETMBR	R6	R0	K22
       0x4C200000,  //  0027  LDNIL	R8
       0x20200E08,  //  0028  NE	R8	R7	R8
       0x78220009,  //  0029  JMPF	R8	#0034
-      0xB8221000,  //  002A  GETNGBL	R8	K8
-      0x8C201109,  //  002B  GETMET	R8	R8	K9
+      0xB8224800,  //  002A  GETNGBL	R8	K36
+      0x8C201125,  //  002B  GETMET	R8	R8	K37
       0x5C280E00,  //  002C  MOVE	R10	R7
-      0x582C0006,  //  002D  LDCONST	R11	K6
+      0x582C0039,  //  002D  LDCONST	R11	K57
       0x54320063,  //  002E  LDINT	R12	100
-      0x58340006,  //  002F  LDCONST	R13	K6
+      0x58340039,  //  002F  LDCONST	R13	K57
       0x543A00FD,  //  0030  LDINT	R14	254
       0x7C200C00,  //  0031  CALL	R8	6
       0x5C1C1000,  //  0032  MOVE	R7	R8
       0x70020000,  //  0033  JMP		#0035
-      0x881C010B,  //  0034  GETMBR	R7	R0	K11
-      0x8820010A,  //  0035  GETMBR	R8	R0	K10
+      0x881C0117,  //  0034  GETMBR	R7	R0	K23
+      0x88200116,  //  0035  GETMBR	R8	R0	K22
       0x20200C08,  //  0036  NE	R8	R6	R8
       0x78220004,  //  0037  JMPF	R8	#003D
-      0x8C20010C,  //  0038  GETMET	R8	R0	K12
+      0x8C200126,  //  0038  GETMET	R8	R0	K38
       0x542A02FF,  //  0039  LDINT	R10	768
-      0x582C0006,  //  003A  LDCONST	R11	K6
+      0x582C0039,  //  003A  LDCONST	R11	K57
       0x7C200600,  //  003B  CALL	R8	3
-      0x90021406,  //  003C  SETMBR	R0	K10	R6
-      0x8820010B,  //  003D  GETMBR	R8	R0	K11
+      0x90022C06,  //  003C  SETMBR	R0	K22	R6
+      0x88200117,  //  003D  GETMBR	R8	R0	K23
       0x20200E08,  //  003E  NE	R8	R7	R8
       0x78220004,  //  003F  JMPF	R8	#0045
-      0x8C20010C,  //  0040  GETMET	R8	R0	K12
+      0x8C200126,  //  0040  GETMET	R8	R0	K38
       0x542A02FF,  //  0041  LDINT	R10	768
-      0x582C0007,  //  0042  LDCONST	R11	K7
+      0x582C003A,  //  0042  LDCONST	R11	K58
       0x7C200600,  //  0043  CALL	R8	3
-      0x90021607,  //  0044  SETMBR	R0	K11	R7
+      0x90022E07,  //  0044  SETMBR	R0	K23	R7
       0x80000000,  //  0045  RET	0
     })
   )
@@ -873,77 +839,61 @@ be_local_closure(class_Matter_Plugin_Light3_web_value_RGB,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shadow_hue),
-    /* K1   */  be_nested_str_weak(shadow_sat),
-    /* K2   */  be_nested_str_weak(light_state),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(set_bri),
-    /* K5   */  be_nested_str_weak(set_huesat),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(scale_uint),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
-    /* K10  */  be_nested_str_weak(r),
-    /* K11  */  be_nested_str_weak(g),
-    /* K12  */  be_nested_str_weak(b),
-    /* K13  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
-    /* K14  */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_Matter_Plugin_Light3,     /* shared constants */
     be_str_weak(web_value_RGB),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040116,  //  0000  GETMBR	R1	R0	K22
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060027,  //  0003  JMPF	R1	#002C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x88040117,  //  0004  GETMBR	R1	R0	K23
       0x4C080000,  //  0005  LDNIL	R2
       0x20040202,  //  0006  NE	R1	R1	R2
       0x78060023,  //  0007  JMPF	R1	#002C
-      0xB8060400,  //  0008  GETNGBL	R1	K2
-      0x58080003,  //  0009  LDCONST	R2	K3
+      0xB8067600,  //  0008  GETNGBL	R1	K59
+      0x5808000E,  //  0009  LDCONST	R2	K14
       0x7C040200,  //  000A  CALL	R1	1
-      0x8C080304,  //  000B  GETMET	R2	R1	K4
+      0x8C08033C,  //  000B  GETMET	R2	R1	K60
       0x541200FE,  //  000C  LDINT	R4	255
       0x7C080400,  //  000D  CALL	R2	2
-      0x8C080305,  //  000E  GETMET	R2	R1	K5
-      0xB8120C00,  //  000F  GETNGBL	R4	K6
-      0x8C100907,  //  0010  GETMET	R4	R4	K7
-      0x88180100,  //  0011  GETMBR	R6	R0	K0
-      0x581C0008,  //  0012  LDCONST	R7	K8
+      0x8C08033D,  //  000E  GETMET	R2	R1	K61
+      0xB8124800,  //  000F  GETNGBL	R4	K36
+      0x8C100925,  //  0010  GETMET	R4	R4	K37
+      0x88180116,  //  0011  GETMBR	R6	R0	K22
+      0x581C0005,  //  0012  LDCONST	R7	K5
       0x542200FD,  //  0013  LDINT	R8	254
-      0x58240008,  //  0014  LDCONST	R9	K8
+      0x58240005,  //  0014  LDCONST	R9	K5
       0x542A0167,  //  0015  LDINT	R10	360
       0x7C100C00,  //  0016  CALL	R4	6
-      0xB8160C00,  //  0017  GETNGBL	R5	K6
-      0x8C140B07,  //  0018  GETMET	R5	R5	K7
-      0x881C0101,  //  0019  GETMBR	R7	R0	K1
-      0x58200008,  //  001A  LDCONST	R8	K8
+      0xB8164800,  //  0017  GETNGBL	R5	K36
+      0x8C140B25,  //  0018  GETMET	R5	R5	K37
+      0x881C0117,  //  0019  GETMBR	R7	R0	K23
+      0x58200005,  //  001A  LDCONST	R8	K5
       0x542600FD,  //  001B  LDINT	R9	254
-      0x58280008,  //  001C  LDCONST	R10	K8
+      0x58280005,  //  001C  LDCONST	R10	K5
       0x542E00FE,  //  001D  LDINT	R11	255
       0x7C140C00,  //  001E  CALL	R5	6
       0x7C080600,  //  001F  CALL	R2	3
       0x60080018,  //  0020  GETGBL	R2	G24
-      0x580C0009,  //  0021  LDCONST	R3	K9
-      0x8810030A,  //  0022  GETMBR	R4	R1	K10
-      0x8814030B,  //  0023  GETMBR	R5	R1	K11
-      0x8818030C,  //  0024  GETMBR	R6	R1	K12
+      0x580C003E,  //  0021  LDCONST	R3	K62
+      0x8810033F,  //  0022  GETMBR	R4	R1	K63
+      0x88140340,  //  0023  GETMBR	R5	R1	K64
+      0x88180341,  //  0024  GETMBR	R6	R1	K65
       0x7C080800,  //  0025  CALL	R2	4
       0x600C0018,  //  0026  GETGBL	R3	G24
-      0x5810000D,  //  0027  LDCONST	R4	K13
+      0x58100042,  //  0027  LDCONST	R4	K66
       0x5C140400,  //  0028  MOVE	R5	R2
       0x5C180400,  //  0029  MOVE	R6	R2
       0x7C0C0600,  //  002A  CALL	R3	3
       0x80040600,  //  002B  RET	1	R3
-      0x80061C00,  //  002C  RET	1	K14
+      0x80068600,  //  002C  RET	1	K67
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
@@ -3,6 +3,29 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Profiler' ktab size: 19, total: 43 (saved 192 bytes)
+static const bvalue be_ktab_class_Matter_Profiler[19] = {
+  /* K0   */  be_nested_str_weak(active),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(PREALLOCATED),
+  /* K3   */  be_nested_str_weak(millis),
+  /* K4   */  be_nested_str_weak(names),
+  /* K5   */  be_const_int(1),
+  /* K6   */  be_nested_str_weak(len),
+  /* K7   */  be_nested_str_weak(tasmota),
+  /* K8   */  be_nested_str_weak(gc),
+  /* K9   */  be_nested_str_weak(log),
+  /* K10  */  be_nested_str_weak(start),
+  /* K11  */  be_nested_str_weak(resize),
+  /* K12  */  be_nested_str_weak(allocs),
+  /* K13  */  be_nested_str_weak(reallocs),
+  /* K14  */  be_nested_str_weak(debug),
+  /* K15  */  be_const_int(1),
+  /* K16  */  be_nested_str_weak(_X3C_X2D_X2Dend_X2D_X2D_X3E),
+  /* K17  */  be_nested_str_weak(MTR_X3A_X20Profiler_X20dump_X3A),
+  /* K18  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X254i_X20_X5B_X254i_X5D_X27_X25s_X27),
+};
+
 
 extern const bclass be_class_Matter_Profiler;
 
@@ -13,25 +36,13 @@ be_local_closure(class_Matter_Profiler_start,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(PREALLOCATED),
-    /* K3   */  be_nested_str_weak(millis),
-    /* K4   */  be_nested_str_weak(names),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(len),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(gc),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(start),
-    }),
+    &be_ktab_class_Matter_Profiler,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -71,23 +82,13 @@ be_local_closure(class_Matter_Profiler_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active),
-    /* K1   */  be_nested_str_weak(millis),
-    /* K2   */  be_nested_str_weak(resize),
-    /* K3   */  be_nested_str_weak(PREALLOCATED),
-    /* K4   */  be_nested_str_weak(names),
-    /* K5   */  be_nested_str_weak(allocs),
-    /* K6   */  be_nested_str_weak(reallocs),
-    /* K7   */  be_nested_str_weak(len),
-    /* K8   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Profiler,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
@@ -95,33 +96,33 @@ be_local_closure(class_Matter_Profiler_init,   /* name */
       0x90020001,  //  0001  SETMBR	R0	K0	R1
       0x60040012,  //  0002  GETGBL	R1	G18
       0x7C040000,  //  0003  CALL	R1	0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
-      0x88040101,  //  0005  GETMBR	R1	R0	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
-      0x880C0103,  //  0007  GETMBR	R3	R0	K3
+      0x90020601,  //  0004  SETMBR	R0	K3	R1
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x8C04030B,  //  0006  GETMET	R1	R1	K11
+      0x880C0102,  //  0007  GETMBR	R3	R0	K2
       0x7C040400,  //  0008  CALL	R1	2
       0x60040012,  //  0009  GETGBL	R1	G18
       0x7C040000,  //  000A  CALL	R1	0
       0x90020801,  //  000B  SETMBR	R0	K4	R1
       0x88040104,  //  000C  GETMBR	R1	R0	K4
-      0x8C040302,  //  000D  GETMET	R1	R1	K2
-      0x880C0103,  //  000E  GETMBR	R3	R0	K3
+      0x8C04030B,  //  000D  GETMET	R1	R1	K11
+      0x880C0102,  //  000E  GETMBR	R3	R0	K2
       0x7C040400,  //  000F  CALL	R1	2
       0x60040012,  //  0010  GETGBL	R1	G18
       0x7C040000,  //  0011  CALL	R1	0
-      0x90020A01,  //  0012  SETMBR	R0	K5	R1
-      0x88040105,  //  0013  GETMBR	R1	R0	K5
-      0x8C040302,  //  0014  GETMET	R1	R1	K2
-      0x880C0103,  //  0015  GETMBR	R3	R0	K3
+      0x90021801,  //  0012  SETMBR	R0	K12	R1
+      0x8804010C,  //  0013  GETMBR	R1	R0	K12
+      0x8C04030B,  //  0014  GETMET	R1	R1	K11
+      0x880C0102,  //  0015  GETMBR	R3	R0	K2
       0x7C040400,  //  0016  CALL	R1	2
       0x60040012,  //  0017  GETGBL	R1	G18
       0x7C040000,  //  0018  CALL	R1	0
-      0x90020C01,  //  0019  SETMBR	R0	K6	R1
-      0x88040106,  //  001A  GETMBR	R1	R0	K6
-      0x8C040302,  //  001B  GETMET	R1	R1	K2
-      0x880C0103,  //  001C  GETMBR	R3	R0	K3
+      0x90021A01,  //  0019  SETMBR	R0	K13	R1
+      0x8804010D,  //  001A  GETMBR	R1	R0	K13
+      0x8C04030B,  //  001B  GETMET	R1	R1	K11
+      0x880C0102,  //  001C  GETMBR	R3	R0	K2
       0x7C040400,  //  001D  CALL	R1	2
-      0x90020F08,  //  001E  SETMBR	R0	K7	K8
+      0x90020D01,  //  001E  SETMBR	R0	K6	K1
       0x80000000,  //  001F  RET	0
     })
   )
@@ -136,15 +137,13 @@ be_local_closure(class_Matter_Profiler_set_active,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active),
-    }),
+    &be_ktab_class_Matter_Profiler,     /* shared constants */
     be_str_weak(set_active),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -166,54 +165,43 @@ be_local_closure(class_Matter_Profiler_log,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active),
-    /* K1   */  be_nested_str_weak(debug),
-    /* K2   */  be_nested_str_weak(len),
-    /* K3   */  be_nested_str_weak(PREALLOCATED),
-    /* K4   */  be_nested_str_weak(millis),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(names),
-    /* K7   */  be_nested_str_weak(allocs),
-    /* K8   */  be_nested_str_weak(reallocs),
-    /* K9   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Profiler,     /* shared constants */
     be_str_weak(log),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x740A0000,  //  0001  JMPT	R2	#0003
       0x80000400,  //  0002  RET	0
-      0xA40A0200,  //  0003  IMPORT	R2	K1
-      0x880C0102,  //  0004  GETMBR	R3	R0	K2
-      0x88100103,  //  0005  GETMBR	R4	R0	K3
+      0xA40A1C00,  //  0003  IMPORT	R2	K14
+      0x880C0106,  //  0004  GETMBR	R3	R0	K6
+      0x88100102,  //  0005  GETMBR	R4	R0	K2
       0x28100604,  //  0006  GE	R4	R3	R4
       0x78120000,  //  0007  JMPF	R4	#0009
       0x80000800,  //  0008  RET	0
-      0x88100104,  //  0009  GETMBR	R4	R0	K4
-      0xB8160A00,  //  000A  GETNGBL	R5	K5
-      0x8C140B04,  //  000B  GETMET	R5	R5	K4
+      0x88100103,  //  0009  GETMBR	R4	R0	K3
+      0xB8160E00,  //  000A  GETNGBL	R5	K7
+      0x8C140B03,  //  000B  GETMET	R5	R5	K3
       0x7C140200,  //  000C  CALL	R5	1
       0x98100605,  //  000D  SETIDX	R4	R3	R5
-      0x88100106,  //  000E  GETMBR	R4	R0	K6
+      0x88100104,  //  000E  GETMBR	R4	R0	K4
       0x98100601,  //  000F  SETIDX	R4	R3	R1
-      0x88100107,  //  0010  GETMBR	R4	R0	K7
-      0x8C140507,  //  0011  GETMET	R5	R2	K7
+      0x8810010C,  //  0010  GETMBR	R4	R0	K12
+      0x8C14050C,  //  0011  GETMET	R5	R2	K12
       0x7C140200,  //  0012  CALL	R5	1
       0x98100605,  //  0013  SETIDX	R4	R3	R5
-      0x88100108,  //  0014  GETMBR	R4	R0	K8
-      0x8C140508,  //  0015  GETMET	R5	R2	K8
+      0x8810010D,  //  0014  GETMBR	R4	R0	K13
+      0x8C14050D,  //  0015  GETMET	R5	R2	K13
       0x7C140200,  //  0016  CALL	R5	1
       0x98100605,  //  0017  SETIDX	R4	R3	R5
-      0x88100102,  //  0018  GETMBR	R4	R0	K2
-      0x00100909,  //  0019  ADD	R4	R4	K9
-      0x90020404,  //  001A  SETMBR	R0	K2	R4
+      0x88100106,  //  0018  GETMBR	R4	R0	K6
+      0x0010090F,  //  0019  ADD	R4	R4	K15
+      0x90020C04,  //  001A  SETMBR	R0	K6	R4
       0x80000000,  //  001B  RET	0
     })
   )
@@ -228,64 +216,51 @@ be_local_closure(class_Matter_Profiler_dump,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(_X3C_X2D_X2Dend_X2D_X2D_X3E),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Profiler_X20dump_X3A),
-    /* K4   */  be_nested_str_weak(millis),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(allocs),
-    /* K7   */  be_nested_str_weak(reallocs),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(len),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X254i_X20_X5B_X254i_X5D_X27_X25s_X27),
-    /* K11  */  be_nested_str_weak(names),
-    }),
+    &be_ktab_class_Matter_Profiler,     /* shared constants */
     be_str_weak(dump),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x740A0000,  //  0001  JMPT	R2	#0003
       0x80000400,  //  0002  RET	0
-      0x8C080101,  //  0003  GETMET	R2	R0	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
+      0x8C080109,  //  0003  GETMET	R2	R0	K9
+      0x58100010,  //  0004  LDCONST	R4	K16
       0x7C080400,  //  0005  CALL	R2	2
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x580C0003,  //  0007  LDCONST	R3	K3
+      0xB80A1200,  //  0006  GETNGBL	R2	K9
+      0x580C0011,  //  0007  LDCONST	R3	K17
       0x5C100200,  //  0008  MOVE	R4	R1
       0x7C080400,  //  0009  CALL	R2	2
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
-      0x94080505,  //  000B  GETIDX	R2	R2	K5
-      0x880C0106,  //  000C  GETMBR	R3	R0	K6
-      0x940C0705,  //  000D  GETIDX	R3	R3	K5
-      0x88100107,  //  000E  GETMBR	R4	R0	K7
-      0x94100905,  //  000F  GETIDX	R4	R4	K5
-      0x58140008,  //  0010  LDCONST	R5	K8
-      0x88180109,  //  0011  GETMBR	R6	R0	K9
+      0x88080103,  //  000A  GETMBR	R2	R0	K3
+      0x94080501,  //  000B  GETIDX	R2	R2	K1
+      0x880C010C,  //  000C  GETMBR	R3	R0	K12
+      0x940C0701,  //  000D  GETIDX	R3	R3	K1
+      0x8810010D,  //  000E  GETMBR	R4	R0	K13
+      0x94100901,  //  000F  GETIDX	R4	R4	K1
+      0x5814000F,  //  0010  LDCONST	R5	K15
+      0x88180106,  //  0011  GETMBR	R6	R0	K6
       0x14180A06,  //  0012  LT	R6	R5	R6
       0x781A000F,  //  0013  JMPF	R6	#0024
-      0xB81A0200,  //  0014  GETNGBL	R6	K1
+      0xB81A1200,  //  0014  GETNGBL	R6	K9
       0x601C0018,  //  0015  GETGBL	R7	G24
-      0x5820000A,  //  0016  LDCONST	R8	K10
-      0x88240104,  //  0017  GETMBR	R9	R0	K4
+      0x58200012,  //  0016  LDCONST	R8	K18
+      0x88240103,  //  0017  GETMBR	R9	R0	K3
       0x94241205,  //  0018  GETIDX	R9	R9	R5
       0x04241202,  //  0019  SUB	R9	R9	R2
-      0x88280106,  //  001A  GETMBR	R10	R0	K6
+      0x8828010C,  //  001A  GETMBR	R10	R0	K12
       0x94281405,  //  001B  GETIDX	R10	R10	R5
       0x04281403,  //  001C  SUB	R10	R10	R3
-      0x882C010B,  //  001D  GETMBR	R11	R0	K11
+      0x882C0104,  //  001D  GETMBR	R11	R0	K4
       0x942C1605,  //  001E  GETIDX	R11	R11	R5
       0x7C1C0800,  //  001F  CALL	R7	4
       0x5C200200,  //  0020  MOVE	R8	R1
       0x7C180400,  //  0021  CALL	R6	2
-      0x00140B08,  //  0022  ADD	R5	R5	K8
+      0x00140B0F,  //  0022  ADD	R5	R5	K15
       0x7001FFEC,  //  0023  JMP		#0011
       0x80000000,  //  0024  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -3,6 +3,122 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_Session;
+// compact class 'Matter_Session' ktab size: 111, total: 196 (saved 680 bytes)
+static const bvalue be_ktab_class_Matter_Session[111] = {
+  /* K0   */  be_nested_str_weak(_fabric),
+  /* K1   */  be_nested_str_weak(device_id),
+  /* K2   */  be_nested_str_weak(log),
+  /* K3   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
+  /* K4   */  be_nested_str_weak(local_session_id),
+  /* K5   */  be_const_int(3),
+  /* K6   */  be_nested_str_weak(set_mode),
+  /* K7   */  be_nested_str_weak(_CASE),
+  /* K8   */  be_nested_str_weak(mode),
+  /* K9   */  be_nested_str_weak(add_session),
+  /* K10  */  be_nested_str_weak(noc),
+  /* K11  */  be_nested_str_weak(crypto),
+  /* K12  */  be_nested_str_weak(_store),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_nested_str_weak(initiator_session_id),
+  /* K15  */  be_nested_str_weak(_counter_snd_impl),
+  /* K16  */  be_nested_str_weak(matter),
+  /* K17  */  be_nested_str_weak(Counter),
+  /* K18  */  be_nested_str_weak(_counter_rcv_impl),
+  /* K19  */  be_nested_str_weak(counter_rcv),
+  /* K20  */  be_nested_str_weak(counter_snd),
+  /* K21  */  be_nested_str_weak(next),
+  /* K22  */  be_nested_str_weak(_COUNTER_SND_INCR),
+  /* K23  */  be_nested_str_weak(_counter_insecure_rcv),
+  /* K24  */  be_nested_str_weak(_counter_insecure_snd),
+  /* K25  */  be_nested_str_weak(_breadcrumb),
+  /* K26  */  be_nested_str_weak(_exchange_id),
+  /* K27  */  be_nested_str_weak(random),
+  /* K28  */  be_const_int(2),
+  /* K29  */  be_nested_str_weak(get),
+  /* K30  */  be_nested_str_weak(update),
+  /* K31  */  be_nested_str_weak(admin_vendor),
+  /* K32  */  be_nested_str_weak(i2rkey),
+  /* K33  */  be_nested_str_weak(validate),
+  /* K34  */  be_nested_str_weak(val),
+  /* K35  */  be_nested_str_weak(root_ca_certificate),
+  /* K36  */  be_nested_str_weak(fabric_index),
+  /* K37  */  be_nested_str_weak(r2ikey),
+  /* K38  */  be_nested_str_weak(is_greater),
+  /* K39  */  be_nested_str_weak(does_persist),
+  /* K40  */  be_nested_str_weak(save),
+  /* K41  */  be_nested_str_weak(_temp_root_ca_certificate),
+  /* K42  */  be_nested_str_weak(TLV),
+  /* K43  */  be_nested_str_weak(parse),
+  /* K44  */  be_nested_str_weak(findsubval),
+  /* K45  */  be_nested_str_weak(fabric_id),
+  /* K46  */  be_nested_str_weak(_PASE),
+  /* K47  */  be_nested_str_weak(fabric_label),
+  /* K48  */  be_nested_str_weak(last_used),
+  /* K49  */  be_nested_str_weak(tasmota),
+  /* K50  */  be_nested_str_weak(rtc_utc),
+  /* K51  */  be_nested_str_weak(icac),
+  /* K52  */  be_nested_str_weak(string),
+  /* K53  */  be_nested_str_weak(get_ca_pub),
+  /* K54  */  be_nested_str_weak(get_pk),
+  /* K55  */  be_nested_str_weak(_temp_pk),
+  /* K56  */  be_nested_str_weak(json),
+  /* K57  */  be_nested_str_weak(introspect),
+  /* K58  */  be_nested_str_weak(persist_pre),
+  /* K59  */  be_nested_str_weak(members),
+  /* K60  */  be_nested_str_weak(function),
+  /* K61  */  be_const_int(0),
+  /* K62  */  be_nested_str_weak(_),
+  /* K63  */  be_nested_str_weak(push),
+  /* K64  */  be_nested_str_weak(stop_iteration),
+  /* K65  */  be_nested_str_weak(sort),
+  /* K66  */  be_nested_str_weak(_X24_X24),
+  /* K67  */  be_nested_str_weak(tob64),
+  /* K68  */  be_nested_str_weak(instance),
+  /* K69  */  be_nested_str_weak(_X25s_X3A_X25s),
+  /* K70  */  be_nested_str_weak(dump),
+  /* K71  */  be_nested_str_weak(persist_post),
+  /* K72  */  be_nested_str_weak(_X7B),
+  /* K73  */  be_nested_str_weak(concat),
+  /* K74  */  be_nested_str_weak(_X2C),
+  /* K75  */  be_nested_str_weak(_X7D),
+  /* K76  */  be_nested_str_weak(__future_local_session_id),
+  /* K77  */  be_nested_str_weak(__future_initiator_session_id),
+  /* K78  */  be_nested_str_weak(reset),
+  /* K79  */  be_nested_str_weak(_i2r_privacy),
+  /* K80  */  be_nested_str_weak(attestation_challenge),
+  /* K81  */  be_const_int(1),
+  /* K82  */  be_nested_str_weak(HKDF_SHA256),
+  /* K83  */  be_nested_str_weak(derive),
+  /* K84  */  be_nested_str_weak(get_i2r),
+  /* K85  */  be_nested_str_weak(fromstring),
+  /* K86  */  be_nested_str_weak(PrivacyKey),
+  /* K87  */  be_const_class(be_class_Matter_Session),
+  /* K88  */  be_nested_str_weak(Session),
+  /* K89  */  be_nested_str_weak(keys),
+  /* K90  */  be_nested_str_weak(find),
+  /* K91  */  be_nested_str_weak(0x),
+  /* K92  */  be_nested_str_weak(set),
+  /* K93  */  be_nested_str_weak(fromhex),
+  /* K94  */  be_const_int(2),
+  /* K95  */  be_const_int(2147483647),
+  /* K96  */  be_nested_str_weak(fromb64),
+  /* K97  */  be_nested_str_weak(hydrate_post),
+  /* K98  */  be_nested_str_weak(save_fabrics),
+  /* K99  */  be_nested_str_weak(admin_subject),
+  /* K100 */  be_nested_str_weak(ipk_epoch_key),
+  /* K101 */  be_nested_str_weak(fabric_compressed),
+  /* K102 */  be_nested_str_weak(created),
+  /* K103 */  be_nested_str_weak(EC_P256),
+  /* K104 */  be_nested_str_weak(public_key),
+  /* K105 */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
+  /* K106 */  be_nested_str_weak(A000),
+  /* K107 */  be_nested_str_weak(300C06082A8648CE3D0403020500),
+  /* K108 */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
+  /* K109 */  be_nested_str_weak(add),
+  /* K110 */  be_nested_str_weak(get_ipk_group_key),
+};
+
 
 extern const bclass be_class_Matter_Session;
 
@@ -13,16 +129,13 @@ be_local_closure(class_Matter_Session_get_device_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(device_id),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_device_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -46,27 +159,22 @@ be_local_closure(class_Matter_Session_before_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(log),
-    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(before_remove),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0xB8060400,  //  0000  GETNGBL	R1	K2
       0x60080018,  //  0001  GETGBL	R2	G24
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x580C0003,  //  0002  LDCONST	R3	K3
+      0x88100104,  //  0003  GETMBR	R4	R0	K4
       0x7C080400,  //  0004  CALL	R2	2
-      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x580C0005,  //  0005  LDCONST	R3	K5
       0x7C040400,  //  0006  CALL	R1	2
       0x80000000,  //  0007  RET	0
     })
@@ -82,21 +190,18 @@ be_local_closure(class_Matter_Session_set_mode_CASE,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_mode_CASE),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x880C0107,  //  0001  GETMBR	R3	R0	K7
       0x7C040400,  //  0002  CALL	R1	2
       0x80000000,  //  0003  RET	0
     })
@@ -112,21 +217,18 @@ be_local_closure(class_Matter_Session_is_CASE,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(is_CASE),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
+      0x88080107,  //  0001  GETMBR	R2	R0	K7
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -142,21 +244,18 @@ be_local_closure(class_Matter_Session_persist_to_fabric,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(add_session),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(persist_to_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0x80000000,  //  0004  RET	0
@@ -173,21 +272,18 @@ be_local_closure(class_Matter_Session_get_noc,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(noc),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_noc),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8804030A,  //  0001  GETMBR	R1	R1	K10
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -202,79 +298,55 @@ be_local_closure(class_Matter_Session_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(mode),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_nested_str_weak(initiator_session_id),
-    /* K6   */  be_nested_str_weak(_counter_snd_impl),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Counter),
-    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K10  */  be_nested_str_weak(counter_rcv),
-    /* K11  */  be_nested_str_weak(counter_snd),
-    /* K12  */  be_nested_str_weak(next),
-    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K16  */  be_nested_str_weak(_breadcrumb),
-    /* K17  */  be_nested_str_weak(_exchange_id),
-    /* K18  */  be_nested_str_weak(random),
-    /* K19  */  be_const_int(2),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_nested_str_weak(_fabric),
-    /* K22  */  be_nested_str_weak(update),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x90020503,  //  0002  SETMBR	R0	K2	K3
+      0xA4161600,  //  0000  IMPORT	R5	K11
+      0x90021801,  //  0001  SETMBR	R0	K12	R1
+      0x9002110D,  //  0002  SETMBR	R0	K8	K13
       0x90020802,  //  0003  SETMBR	R0	K4	R2
-      0x90020A03,  //  0004  SETMBR	R0	K5	R3
-      0xB81A0E00,  //  0005  GETNGBL	R6	K7
-      0x8C180D08,  //  0006  GETMET	R6	R6	K8
+      0x90021C03,  //  0004  SETMBR	R0	K14	R3
+      0xB81A2000,  //  0005  GETNGBL	R6	K16
+      0x8C180D11,  //  0006  GETMET	R6	R6	K17
       0x7C180200,  //  0007  CALL	R6	1
-      0x90020C06,  //  0008  SETMBR	R0	K6	R6
-      0xB81A0E00,  //  0009  GETNGBL	R6	K7
-      0x8C180D08,  //  000A  GETMET	R6	R6	K8
+      0x90021E06,  //  0008  SETMBR	R0	K15	R6
+      0xB81A2000,  //  0009  GETNGBL	R6	K16
+      0x8C180D11,  //  000A  GETMET	R6	R6	K17
       0x7C180200,  //  000B  CALL	R6	1
-      0x90021206,  //  000C  SETMBR	R0	K9	R6
-      0x90021503,  //  000D  SETMBR	R0	K10	K3
-      0x88180106,  //  000E  GETMBR	R6	R0	K6
-      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
+      0x90022406,  //  000C  SETMBR	R0	K18	R6
+      0x9002270D,  //  000D  SETMBR	R0	K19	K13
+      0x8818010F,  //  000E  GETMBR	R6	R0	K15
+      0x8C180D15,  //  000F  GETMET	R6	R6	K21
       0x7C180200,  //  0010  CALL	R6	1
-      0x881C010D,  //  0011  GETMBR	R7	R0	K13
+      0x881C0116,  //  0011  GETMBR	R7	R0	K22
       0x00180C07,  //  0012  ADD	R6	R6	R7
-      0x90021606,  //  0013  SETMBR	R0	K11	R6
-      0xB81A0E00,  //  0014  GETNGBL	R6	K7
-      0x8C180D08,  //  0015  GETMET	R6	R6	K8
+      0x90022806,  //  0013  SETMBR	R0	K20	R6
+      0xB81A2000,  //  0014  GETNGBL	R6	K16
+      0x8C180D11,  //  0015  GETMET	R6	R6	K17
       0x7C180200,  //  0016  CALL	R6	1
-      0x90021C06,  //  0017  SETMBR	R0	K14	R6
-      0xB81A0E00,  //  0018  GETNGBL	R6	K7
-      0x8C180D08,  //  0019  GETMET	R6	R6	K8
+      0x90022E06,  //  0017  SETMBR	R0	K23	R6
+      0xB81A2000,  //  0018  GETNGBL	R6	K16
+      0x8C180D11,  //  0019  GETMET	R6	R6	K17
       0x7C180200,  //  001A  CALL	R6	1
-      0x90021E06,  //  001B  SETMBR	R0	K15	R6
-      0x90022103,  //  001C  SETMBR	R0	K16	K3
-      0x8C180B12,  //  001D  GETMET	R6	R5	K18
-      0x58200013,  //  001E  LDCONST	R8	K19
+      0x90023006,  //  001B  SETMBR	R0	K24	R6
+      0x9002330D,  //  001C  SETMBR	R0	K25	K13
+      0x8C180B1B,  //  001D  GETMET	R6	R5	K27
+      0x5820001C,  //  001E  LDCONST	R8	K28
       0x7C180400,  //  001F  CALL	R6	2
-      0x8C180D14,  //  0020  GETMET	R6	R6	K20
-      0x58200003,  //  0021  LDCONST	R8	K3
-      0x58240013,  //  0022  LDCONST	R9	K19
+      0x8C180D1D,  //  0020  GETMET	R6	R6	K29
+      0x5820000D,  //  0021  LDCONST	R8	K13
+      0x5824001C,  //  0022  LDCONST	R9	K28
       0x7C180600,  //  0023  CALL	R6	3
-      0x90022206,  //  0024  SETMBR	R0	K17	R6
-      0x90022A04,  //  0025  SETMBR	R0	K21	R4
-      0x8C180116,  //  0026  GETMET	R6	R0	K22
+      0x90023406,  //  0024  SETMBR	R0	K26	R6
+      0x90020004,  //  0025  SETMBR	R0	K0	R4
+      0x8C18011E,  //  0026  GETMET	R6	R0	K30
       0x7C180200,  //  0027  CALL	R6	1
       0x80000000,  //  0028  RET	0
     })
@@ -290,23 +362,20 @@ be_local_closure(class_Matter_Session_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_admin_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060002,  //  0001  JMPF	R1	#0005
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x8804031F,  //  0003  GETMBR	R1	R1	K31
       0x70020000,  //  0004  JMP		#0006
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
@@ -323,19 +392,17 @@ be_local_closure(class_Matter_Session_get_i2r,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_i2r),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040120,  //  0000  GETMBR	R1	R0	K32
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -350,31 +417,26 @@ be_local_closure(class_Matter_Session_counter_rcv_validate,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K1   */  be_nested_str_weak(validate),
-    /* K2   */  be_nested_str_weak(counter_rcv),
-    /* K3   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(counter_rcv_validate),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x880C0112,  //  0000  GETMBR	R3	R0	K18
+      0x8C0C0721,  //  0001  GETMET	R3	R3	K33
       0x5C140200,  //  0002  MOVE	R5	R1
       0x5C180400,  //  0003  MOVE	R6	R2
       0x7C0C0600,  //  0004  CALL	R3	3
       0x780E0003,  //  0005  JMPF	R3	#000A
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x88100112,  //  0006  GETMBR	R4	R0	K18
+      0x8C100922,  //  0007  GETMET	R4	R4	K34
       0x7C100200,  //  0008  CALL	R4	1
-      0x90020404,  //  0009  SETMBR	R0	K2	R4
+      0x90022604,  //  0009  SETMBR	R0	K19	R4
       0x80040600,  //  000A  RET	1	R3
     })
   )
@@ -389,21 +451,18 @@ be_local_closure(class_Matter_Session_get_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040323,  //  0001  GETMBR	R1	R1	K35
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -418,23 +477,20 @@ be_local_closure(class_Matter_Session_get_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_index),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_fabric_index),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060002,  //  0001  JMPF	R1	#0005
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x88040324,  //  0003  GETMBR	R1	R1	K36
       0x70020000,  //  0004  JMP		#0006
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
@@ -451,19 +507,17 @@ be_local_closure(class_Matter_Session_get_r2i,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(r2ikey),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_r2i),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040125,  //  0000  GETMBR	R1	R0	K37
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -478,43 +532,33 @@ be_local_closure(class_Matter_Session_counter_snd_next,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Counter),
-    /* K4   */  be_nested_str_weak(is_greater),
-    /* K5   */  be_nested_str_weak(counter_snd),
-    /* K6   */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K7   */  be_nested_str_weak(does_persist),
-    /* K8   */  be_nested_str_weak(save),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(counter_snd_next),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8804010F,  //  0000  GETMBR	R1	R0	K15
+      0x8C040315,  //  0001  GETMET	R1	R1	K21
       0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x88080503,  //  0004  GETMBR	R2	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0xB80A2000,  //  0003  GETNGBL	R2	K16
+      0x88080511,  //  0004  GETMBR	R2	R2	K17
+      0x8C080526,  //  0005  GETMET	R2	R2	K38
       0x5C100200,  //  0006  MOVE	R4	R1
-      0x88140105,  //  0007  GETMBR	R5	R0	K5
+      0x88140114,  //  0007  GETMBR	R5	R0	K20
       0x7C080600,  //  0008  CALL	R2	3
       0x780A0007,  //  0009  JMPF	R2	#0012
-      0x88080106,  //  000A  GETMBR	R2	R0	K6
+      0x88080116,  //  000A  GETMBR	R2	R0	K22
       0x00080202,  //  000B  ADD	R2	R1	R2
-      0x90020A02,  //  000C  SETMBR	R0	K5	R2
-      0x8C080107,  //  000D  GETMET	R2	R0	K7
+      0x90022802,  //  000C  SETMBR	R0	K20	R2
+      0x8C080127,  //  000D  GETMET	R2	R0	K39
       0x7C080200,  //  000E  CALL	R2	1
       0x780A0001,  //  000F  JMPF	R2	#0012
-      0x8C080108,  //  0010  GETMET	R2	R0	K8
+      0x8C080128,  //  0010  GETMET	R2	R0	K40
       0x7C080200,  //  0011  CALL	R2	1
       0x80040200,  //  0012  RET	1	R1
     })
@@ -530,30 +574,24 @@ be_local_closure(class_Matter_Session_get_temp_ca_pub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(findsubval),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_temp_ca_pub),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040129,  //  0000  GETMBR	R1	R0	K41
       0x78060008,  //  0001  JMPF	R1	#000B
-      0xB80A0200,  //  0002  GETNGBL	R2	K1
-      0x88080502,  //  0003  GETMBR	R2	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0xB80A2000,  //  0002  GETNGBL	R2	K16
+      0x8808052A,  //  0003  GETMBR	R2	R2	K42
+      0x8C08052B,  //  0004  GETMET	R2	R2	K43
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x8C0C052C,  //  0007  GETMET	R3	R2	K44
       0x54160008,  //  0008  LDINT	R5	9
       0x7C0C0400,  //  0009  CALL	R3	2
       0x80040600,  //  000A  RET	1	R3
@@ -571,19 +609,17 @@ be_local_closure(class_Matter_Session_get_temp_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_temp_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040129,  //  0000  GETMBR	R1	R0	K41
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -598,21 +634,18 @@ be_local_closure(class_Matter_Session_get_fabric_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_id),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_fabric_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8804032D,  //  0001  GETMBR	R1	R1	K45
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -627,21 +660,18 @@ be_local_closure(class_Matter_Session_set_mode_PASE,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_mode_PASE),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x880C012E,  //  0001  GETMBR	R3	R0	K46
       0x7C040400,  //  0002  CALL	R1	2
       0x80000000,  //  0003  RET	0
     })
@@ -657,23 +687,20 @@ be_local_closure(class_Matter_Session_get_fabric_label,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_label),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_fabric_label),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060002,  //  0001  JMPF	R1	#0005
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x8804032F,  //  0003  GETMBR	R1	R1	K47
       0x70020000,  //  0004  JMP		#0006
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
@@ -690,24 +717,20 @@ be_local_closure(class_Matter_Session_update,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(last_used),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(rtc_utc),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(update),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0xB8066200,  //  0000  GETNGBL	R1	K49
+      0x8C040332,  //  0001  GETMET	R1	R1	K50
       0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0x90026001,  //  0003  SETMBR	R0	K48	R1
       0x80000000,  //  0004  RET	0
     })
   )
@@ -722,21 +745,18 @@ be_local_closure(class_Matter_Session_get_icac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(icac),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_icac),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040333,  //  0001  GETMBR	R1	R1	K51
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -751,21 +771,18 @@ be_local_closure(class_Matter_Session_is_PASE,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(is_PASE),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
+      0x8808012E,  //  0001  GETMBR	R2	R0	K46
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -781,27 +798,23 @@ be_local_closure(class_Matter_Session_set_fabric_label,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_fabric),
-    /* K2   */  be_nested_str_weak(fabric_label),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_fabric_label),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x1C080534,  //  0003  EQ	R2	R2	K52
       0x780A0001,  //  0004  JMPF	R2	#0007
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x900A0401,  //  0006  SETMBR	R2	K2	R1
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x900A5E01,  //  0006  SETMBR	R2	K47	R1
       0x80000000,  //  0007  RET	0
     })
   )
@@ -816,16 +829,13 @@ be_local_closure(class_Matter_Session_get_node_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(device_id),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_node_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -849,21 +859,18 @@ be_local_closure(class_Matter_Session_get_ca_pub,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ca_pub),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_ca_pub),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040335,  //  0001  GETMET	R1	R1	K53
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -879,37 +886,31 @@ be_local_closure(class_Matter_Session_get_pk,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_pk),
-    /* K2   */  be_nested_str_weak(_temp_pk),
-    /* K3   */  be_nested_str_weak(crypto),
-    /* K4   */  be_nested_str_weak(random),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_pk),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060004,  //  0001  JMPF	R1	#0007
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C040301,  //  0003  GETMET	R1	R1	K1
+      0x8C040336,  //  0003  GETMET	R1	R1	K54
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
       0x70020008,  //  0006  JMP		#0010
-      0x88040102,  //  0007  GETMBR	R1	R0	K2
+      0x88040137,  //  0007  GETMBR	R1	R0	K55
       0x74060004,  //  0008  JMPT	R1	#000E
-      0xA4060600,  //  0009  IMPORT	R1	K3
-      0x8C080304,  //  000A  GETMET	R2	R1	K4
+      0xA4061600,  //  0009  IMPORT	R1	K11
+      0x8C08031B,  //  000A  GETMET	R2	R1	K27
       0x5412001F,  //  000B  LDINT	R4	32
       0x7C080400,  //  000C  CALL	R2	2
-      0x90020402,  //  000D  SETMBR	R0	K2	R2
-      0x88040102,  //  000E  GETMBR	R1	R0	K2
+      0x90026E02,  //  000D  SETMBR	R0	K55	R2
+      0x88040137,  //  000E  GETMBR	R1	R0	K55
       0x80040200,  //  000F  RET	1	R1
       0x80000000,  //  0010  RET	0
     })
@@ -925,74 +926,51 @@ be_local_closure(class_Matter_Session_tojson,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(persist_pre),
-    /* K3   */  be_nested_str_weak(members),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(function),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(stop_iteration),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(sort),
-    /* K12  */  be_nested_str_weak(_X24_X24),
-    /* K13  */  be_nested_str_weak(tob64),
-    /* K14  */  be_nested_str_weak(instance),
-    /* K15  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K16  */  be_nested_str_weak(dump),
-    /* K17  */  be_nested_str_weak(persist_post),
-    /* K18  */  be_nested_str_weak(_X7B),
-    /* K19  */  be_nested_str_weak(concat),
-    /* K20  */  be_nested_str_weak(_X2C),
-    /* K21  */  be_nested_str_weak(_X7D),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(tojson),
     &be_const_str_solidified,
     ( &(const binstruction[95]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
+      0xA4067000,  //  0000  IMPORT	R1	K56
+      0xA40A7200,  //  0001  IMPORT	R2	K57
+      0x8C0C013A,  //  0002  GETMET	R3	R0	K58
       0x7C0C0200,  //  0003  CALL	R3	1
       0x600C0012,  //  0004  GETGBL	R3	G18
       0x7C0C0000,  //  0005  CALL	R3	0
       0x60100010,  //  0006  GETGBL	R4	G16
-      0x8C140503,  //  0007  GETMET	R5	R2	K3
+      0x8C14053B,  //  0007  GETMET	R5	R2	K59
       0x5C1C0000,  //  0008  MOVE	R7	R0
       0x7C140400,  //  0009  CALL	R5	2
       0x7C100200,  //  000A  CALL	R4	1
       0xA8020011,  //  000B  EXBLK	0	#001E
       0x5C140800,  //  000C  MOVE	R5	R4
       0x7C140000,  //  000D  CALL	R5	0
-      0x8C180504,  //  000E  GETMET	R6	R2	K4
+      0x8C18051D,  //  000E  GETMET	R6	R2	K29
       0x5C200000,  //  000F  MOVE	R8	R0
       0x5C240A00,  //  0010  MOVE	R9	R5
       0x7C180600,  //  0011  CALL	R6	3
       0x601C0004,  //  0012  GETGBL	R7	G4
       0x5C200C00,  //  0013  MOVE	R8	R6
       0x7C1C0200,  //  0014  CALL	R7	1
-      0x201C0F05,  //  0015  NE	R7	R7	K5
+      0x201C0F3C,  //  0015  NE	R7	R7	K60
       0x781E0005,  //  0016  JMPF	R7	#001D
-      0x941C0B06,  //  0017  GETIDX	R7	R5	K6
-      0x201C0F07,  //  0018  NE	R7	R7	K7
+      0x941C0B3D,  //  0017  GETIDX	R7	R5	K61
+      0x201C0F3E,  //  0018  NE	R7	R7	K62
       0x781E0002,  //  0019  JMPF	R7	#001D
-      0x8C1C0708,  //  001A  GETMET	R7	R3	K8
+      0x8C1C073F,  //  001A  GETMET	R7	R3	K63
       0x5C240A00,  //  001B  MOVE	R9	R5
       0x7C1C0400,  //  001C  CALL	R7	2
       0x7001FFED,  //  001D  JMP		#000C
-      0x58100009,  //  001E  LDCONST	R4	K9
+      0x58100040,  //  001E  LDCONST	R4	K64
       0xAC100200,  //  001F  CATCH	R4	1	0
       0xB0080000,  //  0020  RAISE	2	R0	R0
-      0xB8121400,  //  0021  GETNGBL	R4	K10
-      0x8C10090B,  //  0022  GETMET	R4	R4	K11
+      0xB8122000,  //  0021  GETNGBL	R4	K16
+      0x8C100941,  //  0022  GETMET	R4	R4	K65
       0x5C180600,  //  0023  MOVE	R6	R3
       0x7C100400,  //  0024  CALL	R4	2
       0x5C0C0800,  //  0025  MOVE	R3	R4
@@ -1004,7 +982,7 @@ be_local_closure(class_Matter_Session_tojson,   /* name */
       0xA8020027,  //  002B  EXBLK	0	#0054
       0x5C180A00,  //  002C  MOVE	R6	R5
       0x7C180000,  //  002D  CALL	R6	0
-      0x8C1C0504,  //  002E  GETMET	R7	R2	K4
+      0x8C1C051D,  //  002E  GETMET	R7	R2	K29
       0x5C240000,  //  002F  MOVE	R9	R0
       0x5C280C00,  //  0030  MOVE	R10	R6
       0x7C1C0600,  //  0031  CALL	R7	3
@@ -1017,41 +995,41 @@ be_local_closure(class_Matter_Session_tojson,   /* name */
       0x60280015,  //  0038  GETGBL	R10	G21
       0x7C200400,  //  0039  CALL	R8	2
       0x78220004,  //  003A  JMPF	R8	#0040
-      0x8C200F0D,  //  003B  GETMET	R8	R7	K13
+      0x8C200F43,  //  003B  GETMET	R8	R7	K67
       0x7C200200,  //  003C  CALL	R8	1
-      0x00221808,  //  003D  ADD	R8	K12	R8
+      0x00228408,  //  003D  ADD	R8	K66	R8
       0x5C1C1000,  //  003E  MOVE	R7	R8
       0x70020005,  //  003F  JMP		#0046
       0x60200004,  //  0040  GETGBL	R8	G4
       0x5C240E00,  //  0041  MOVE	R9	R7
       0x7C200200,  //  0042  CALL	R8	1
-      0x1C20110E,  //  0043  EQ	R8	R8	K14
+      0x1C201144,  //  0043  EQ	R8	R8	K68
       0x78220000,  //  0044  JMPF	R8	#0046
       0x7001FFE5,  //  0045  JMP		#002C
-      0x8C200908,  //  0046  GETMET	R8	R4	K8
+      0x8C20093F,  //  0046  GETMET	R8	R4	K63
       0x60280018,  //  0047  GETGBL	R10	G24
-      0x582C000F,  //  0048  LDCONST	R11	K15
-      0x8C300310,  //  0049  GETMET	R12	R1	K16
+      0x582C0045,  //  0048  LDCONST	R11	K69
+      0x8C300346,  //  0049  GETMET	R12	R1	K70
       0x60380008,  //  004A  GETGBL	R14	G8
       0x5C3C0C00,  //  004B  MOVE	R15	R6
       0x7C380200,  //  004C  CALL	R14	1
       0x7C300400,  //  004D  CALL	R12	2
-      0x8C340310,  //  004E  GETMET	R13	R1	K16
+      0x8C340346,  //  004E  GETMET	R13	R1	K70
       0x5C3C0E00,  //  004F  MOVE	R15	R7
       0x7C340400,  //  0050  CALL	R13	2
       0x7C280600,  //  0051  CALL	R10	3
       0x7C200400,  //  0052  CALL	R8	2
       0x7001FFD7,  //  0053  JMP		#002C
-      0x58140009,  //  0054  LDCONST	R5	K9
+      0x58140040,  //  0054  LDCONST	R5	K64
       0xAC140200,  //  0055  CATCH	R5	1	0
       0xB0080000,  //  0056  RAISE	2	R0	R0
-      0x8C140111,  //  0057  GETMET	R5	R0	K17
+      0x8C140147,  //  0057  GETMET	R5	R0	K71
       0x7C140200,  //  0058  CALL	R5	1
-      0x8C140913,  //  0059  GETMET	R5	R4	K19
-      0x581C0014,  //  005A  LDCONST	R7	K20
+      0x8C140949,  //  0059  GETMET	R5	R4	K73
+      0x581C004A,  //  005A  LDCONST	R7	K74
       0x7C140400,  //  005B  CALL	R5	2
-      0x00162405,  //  005C  ADD	R5	K18	R5
-      0x00140B15,  //  005D  ADD	R5	R5	K21
+      0x00169005,  //  005C  ADD	R5	K72	R5
+      0x00140B4B,  //  005D  ADD	R5	R5	K75
       0x80040A00,  //  005E  RET	1	R5
     })
   )
@@ -1066,96 +1044,72 @@ be_local_closure(class_Matter_Session_close,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(local_session_id),
-    /* K1   */  be_nested_str_weak(__future_local_session_id),
-    /* K2   */  be_nested_str_weak(initiator_session_id),
-    /* K3   */  be_nested_str_weak(__future_initiator_session_id),
-    /* K4   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K5   */  be_nested_str_weak(reset),
-    /* K6   */  be_nested_str_weak(_counter_snd_impl),
-    /* K7   */  be_nested_str_weak(counter_rcv),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(counter_snd),
-    /* K10  */  be_nested_str_weak(next),
-    /* K11  */  be_nested_str_weak(i2rkey),
-    /* K12  */  be_nested_str_weak(_i2r_privacy),
-    /* K13  */  be_nested_str_weak(r2ikey),
-    /* K14  */  be_nested_str_weak(attestation_challenge),
-    /* K15  */  be_nested_str_weak(introspect),
-    /* K16  */  be_nested_str_weak(members),
-    /* K17  */  be_nested_str_weak(get),
-    /* K18  */  be_nested_str_weak(function),
-    /* K19  */  be_nested_str_weak(instance),
-    /* K20  */  be_nested_str_weak(_),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(close),
     &be_const_str_solidified,
     ( &(const binstruction[59]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040103,  //  0002  GETMBR	R1	R0	K3
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x88040104,  //  0004  GETMBR	R1	R0	K4
-      0x8C040305,  //  0005  GETMET	R1	R1	K5
+      0x8804014C,  //  0000  GETMBR	R1	R0	K76
+      0x90020801,  //  0001  SETMBR	R0	K4	R1
+      0x8804014D,  //  0002  GETMBR	R1	R0	K77
+      0x90021C01,  //  0003  SETMBR	R0	K14	R1
+      0x88040112,  //  0004  GETMBR	R1	R0	K18
+      0x8C04034E,  //  0005  GETMET	R1	R1	K78
       0x7C040200,  //  0006  CALL	R1	1
-      0x88040106,  //  0007  GETMBR	R1	R0	K6
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x8804010F,  //  0007  GETMBR	R1	R0	K15
+      0x8C04034E,  //  0008  GETMET	R1	R1	K78
       0x7C040200,  //  0009  CALL	R1	1
-      0x90020F08,  //  000A  SETMBR	R0	K7	K8
-      0x88040106,  //  000B  GETMBR	R1	R0	K6
-      0x8C04030A,  //  000C  GETMET	R1	R1	K10
+      0x9002270D,  //  000A  SETMBR	R0	K19	K13
+      0x8804010F,  //  000B  GETMBR	R1	R0	K15
+      0x8C040315,  //  000C  GETMET	R1	R1	K21
       0x7C040200,  //  000D  CALL	R1	1
-      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x90022801,  //  000E  SETMBR	R0	K20	R1
       0x4C040000,  //  000F  LDNIL	R1
-      0x90021601,  //  0010  SETMBR	R0	K11	R1
+      0x90024001,  //  0010  SETMBR	R0	K32	R1
       0x4C040000,  //  0011  LDNIL	R1
-      0x90021801,  //  0012  SETMBR	R0	K12	R1
+      0x90029E01,  //  0012  SETMBR	R0	K79	R1
       0x4C040000,  //  0013  LDNIL	R1
-      0x90021A01,  //  0014  SETMBR	R0	K13	R1
+      0x90024A01,  //  0014  SETMBR	R0	K37	R1
       0x4C040000,  //  0015  LDNIL	R1
-      0x90021C01,  //  0016  SETMBR	R0	K14	R1
-      0xA4061E00,  //  0017  IMPORT	R1	K15
+      0x9002A001,  //  0016  SETMBR	R0	K80	R1
+      0xA4067200,  //  0017  IMPORT	R1	K57
       0x60080010,  //  0018  GETGBL	R2	G16
-      0x8C0C0310,  //  0019  GETMET	R3	R1	K16
+      0x8C0C033B,  //  0019  GETMET	R3	R1	K59
       0x5C140000,  //  001A  MOVE	R5	R0
       0x7C0C0400,  //  001B  CALL	R3	2
       0x7C080200,  //  001C  CALL	R2	1
       0xA8020018,  //  001D  EXBLK	0	#0037
       0x5C0C0400,  //  001E  MOVE	R3	R2
       0x7C0C0000,  //  001F  CALL	R3	0
-      0x8C100311,  //  0020  GETMET	R4	R1	K17
+      0x8C10031D,  //  0020  GETMET	R4	R1	K29
       0x5C180000,  //  0021  MOVE	R6	R0
       0x5C1C0600,  //  0022  MOVE	R7	R3
       0x7C100600,  //  0023  CALL	R4	3
       0x60140004,  //  0024  GETGBL	R5	G4
       0x5C180800,  //  0025  MOVE	R6	R4
       0x7C140200,  //  0026  CALL	R5	1
-      0x20140B12,  //  0027  NE	R5	R5	K18
+      0x20140B3C,  //  0027  NE	R5	R5	K60
       0x7816000C,  //  0028  JMPF	R5	#0036
       0x60140004,  //  0029  GETGBL	R5	G4
       0x5C180800,  //  002A  MOVE	R6	R4
       0x7C140200,  //  002B  CALL	R5	1
-      0x20140B13,  //  002C  NE	R5	R5	K19
+      0x20140B44,  //  002C  NE	R5	R5	K68
       0x78160007,  //  002D  JMPF	R5	#0036
-      0x94140708,  //  002E  GETIDX	R5	R3	K8
-      0x1C140B14,  //  002F  EQ	R5	R5	K20
+      0x9414070D,  //  002E  GETIDX	R5	R3	K13
+      0x1C140B3E,  //  002F  EQ	R5	R5	K62
       0x78160004,  //  0030  JMPF	R5	#0036
-      0x94140715,  //  0031  GETIDX	R5	R3	K21
-      0x1C140B14,  //  0032  EQ	R5	R5	K20
+      0x94140751,  //  0031  GETIDX	R5	R3	K81
+      0x1C140B3E,  //  0032  EQ	R5	R5	K62
       0x78160001,  //  0033  JMPF	R5	#0036
       0x4C140000,  //  0034  LDNIL	R5
       0x90000605,  //  0035  SETMBR	R0	R3	R5
       0x7001FFE6,  //  0036  JMP		#001E
-      0x58080016,  //  0037  LDCONST	R2	K22
+      0x58080040,  //  0037  LDCONST	R2	K64
       0xAC080200,  //  0038  CATCH	R2	1	0
       0xB0080000,  //  0039  RAISE	2	R0	R0
       0x80000000,  //  003A  RET	0
@@ -1172,19 +1126,17 @@ be_local_closure(class_Matter_Session_get_ac,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attestation_challenge),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_ac),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040150,  //  0000  GETMBR	R1	R0	K80
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1199,15 +1151,13 @@ be_local_closure(class_Matter_Session_get_fabric,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -1226,45 +1176,37 @@ be_local_closure(class_Matter_Session_get_i2r_privacy,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_i2r_privacy),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(HKDF_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_nested_str_weak(get_i2r),
-    /* K5   */  be_nested_str_weak(fromstring),
-    /* K6   */  be_nested_str_weak(PrivacyKey),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_i2r_privacy),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804014F,  //  0000  GETMBR	R1	R0	K79
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x7806000F,  //  0003  JMPF	R1	#0014
-      0xA4060200,  //  0004  IMPORT	R1	K1
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0xA4061600,  //  0004  IMPORT	R1	K11
+      0x8C080352,  //  0005  GETMET	R2	R1	K82
       0x7C080200,  //  0006  CALL	R2	1
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x8C100104,  //  0008  GETMET	R4	R0	K4
+      0x8C080553,  //  0007  GETMET	R2	R2	K83
+      0x8C100154,  //  0008  GETMET	R4	R0	K84
       0x7C100200,  //  0009  CALL	R4	1
       0x60140015,  //  000A  GETGBL	R5	G21
       0x7C140000,  //  000B  CALL	R5	0
       0x60180015,  //  000C  GETGBL	R6	G21
       0x7C180000,  //  000D  CALL	R6	0
-      0x8C180D05,  //  000E  GETMET	R6	R6	K5
-      0x58200006,  //  000F  LDCONST	R8	K6
+      0x8C180D55,  //  000E  GETMET	R6	R6	K85
+      0x58200056,  //  000F  LDCONST	R8	K86
       0x7C180400,  //  0010  CALL	R6	2
       0x541E000F,  //  0011  LDINT	R7	16
       0x7C080A00,  //  0012  CALL	R2	5
-      0x90020002,  //  0013  SETMBR	R0	K0	R2
-      0x88040100,  //  0014  GETMBR	R1	R0	K0
+      0x90029E02,  //  0013  SETMBR	R0	K79	R2
+      0x8804014F,  //  0014  GETMBR	R1	R0	K79
       0x80040200,  //  0015  RET	1	R1
     })
   )
@@ -1279,46 +1221,28 @@ be_local_closure(class_Matter_Session_fromjson,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     3,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Session),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Session),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(0x),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(set),
-    /* K10  */  be_nested_str_weak(fromhex),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_const_int(2147483647),
-    /* K13  */  be_nested_str_weak(_X24_X24),
-    /* K14  */  be_nested_str_weak(fromb64),
-    /* K15  */  be_nested_str_weak(stop_iteration),
-    /* K16  */  be_nested_str_weak(hydrate_post),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(fromjson),
     &be_const_str_solidified,
     ( &(const binstruction[75]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0xA4160400,  //  0002  IMPORT	R5	K2
-      0xB81A0600,  //  0003  GETNGBL	R6	K3
-      0x8C180D04,  //  0004  GETMET	R6	R6	K4
+      0x580C0057,  //  0000  LDCONST	R3	K87
+      0xA4126800,  //  0001  IMPORT	R4	K52
+      0xA4167200,  //  0002  IMPORT	R5	K57
+      0xB81A2000,  //  0003  GETNGBL	R6	K16
+      0x8C180D58,  //  0004  GETMET	R6	R6	K88
       0x5C200000,  //  0005  MOVE	R8	R0
       0x4C240000,  //  0006  LDNIL	R9
       0x4C280000,  //  0007  LDNIL	R10
       0x5C2C0400,  //  0008  MOVE	R11	R2
       0x7C180A00,  //  0009  CALL	R6	5
       0x601C0010,  //  000A  GETGBL	R7	G16
-      0x8C200305,  //  000B  GETMET	R8	R1	K5
+      0x8C200359,  //  000B  GETMET	R8	R1	K89
       0x7C200200,  //  000C  CALL	R8	1
       0x7C1C0200,  //  000D  CALL	R7	1
       0xA8020035,  //  000E  EXBLK	0	#0045
@@ -1328,58 +1252,58 @@ be_local_closure(class_Matter_Session_fromjson,   /* name */
       0x60280004,  //  0012  GETGBL	R10	G4
       0x5C2C1200,  //  0013  MOVE	R11	R9
       0x7C280200,  //  0014  CALL	R10	1
-      0x1C281501,  //  0015  EQ	R10	R10	K1
+      0x1C281534,  //  0015  EQ	R10	R10	K52
       0x782A0027,  //  0016  JMPF	R10	#003F
-      0x8C280906,  //  0017  GETMET	R10	R4	K6
+      0x8C28095A,  //  0017  GETMET	R10	R4	K90
       0x5C301200,  //  0018  MOVE	R12	R9
-      0x58340007,  //  0019  LDCONST	R13	K7
+      0x5834005B,  //  0019  LDCONST	R13	K91
       0x7C280600,  //  001A  CALL	R10	3
-      0x1C281508,  //  001B  EQ	R10	R10	K8
+      0x1C28150D,  //  001B  EQ	R10	R10	K13
       0x782A000A,  //  001C  JMPF	R10	#0028
-      0x8C280B09,  //  001D  GETMET	R10	R5	K9
+      0x8C280B5C,  //  001D  GETMET	R10	R5	K92
       0x5C300C00,  //  001E  MOVE	R12	R6
       0x5C341000,  //  001F  MOVE	R13	R8
       0x60380015,  //  0020  GETGBL	R14	G21
       0x7C380000,  //  0021  CALL	R14	0
-      0x8C381D0A,  //  0022  GETMET	R14	R14	K10
-      0x4042170C,  //  0023  CONNECT	R16	K11	K12
+      0x8C381D5D,  //  0022  GETMET	R14	R14	K93
+      0x4042BD5F,  //  0023  CONNECT	R16	K94	K95
       0x94401210,  //  0024  GETIDX	R16	R9	R16
       0x7C380400,  //  0025  CALL	R14	2
       0x7C280800,  //  0026  CALL	R10	4
       0x70020015,  //  0027  JMP		#003E
-      0x8C280906,  //  0028  GETMET	R10	R4	K6
+      0x8C28095A,  //  0028  GETMET	R10	R4	K90
       0x5C301200,  //  0029  MOVE	R12	R9
-      0x5834000D,  //  002A  LDCONST	R13	K13
+      0x58340042,  //  002A  LDCONST	R13	K66
       0x7C280600,  //  002B  CALL	R10	3
-      0x1C281508,  //  002C  EQ	R10	R10	K8
+      0x1C28150D,  //  002C  EQ	R10	R10	K13
       0x782A000A,  //  002D  JMPF	R10	#0039
-      0x8C280B09,  //  002E  GETMET	R10	R5	K9
+      0x8C280B5C,  //  002E  GETMET	R10	R5	K92
       0x5C300C00,  //  002F  MOVE	R12	R6
       0x5C341000,  //  0030  MOVE	R13	R8
       0x60380015,  //  0031  GETGBL	R14	G21
       0x7C380000,  //  0032  CALL	R14	0
-      0x8C381D0E,  //  0033  GETMET	R14	R14	K14
-      0x4042170C,  //  0034  CONNECT	R16	K11	K12
+      0x8C381D60,  //  0033  GETMET	R14	R14	K96
+      0x4042BD5F,  //  0034  CONNECT	R16	K94	K95
       0x94401210,  //  0035  GETIDX	R16	R9	R16
       0x7C380400,  //  0036  CALL	R14	2
       0x7C280800,  //  0037  CALL	R10	4
       0x70020004,  //  0038  JMP		#003E
-      0x8C280B09,  //  0039  GETMET	R10	R5	K9
+      0x8C280B5C,  //  0039  GETMET	R10	R5	K92
       0x5C300C00,  //  003A  MOVE	R12	R6
       0x5C341000,  //  003B  MOVE	R13	R8
       0x5C381200,  //  003C  MOVE	R14	R9
       0x7C280800,  //  003D  CALL	R10	4
       0x70020004,  //  003E  JMP		#0044
-      0x8C280B09,  //  003F  GETMET	R10	R5	K9
+      0x8C280B5C,  //  003F  GETMET	R10	R5	K92
       0x5C300C00,  //  0040  MOVE	R12	R6
       0x5C341000,  //  0041  MOVE	R13	R8
       0x5C381200,  //  0042  MOVE	R14	R9
       0x7C280800,  //  0043  CALL	R10	4
       0x7001FFC9,  //  0044  JMP		#000F
-      0x581C000F,  //  0045  LDCONST	R7	K15
+      0x581C0040,  //  0045  LDCONST	R7	K64
       0xAC1C0200,  //  0046  CATCH	R7	1	0
       0xB0080000,  //  0047  RAISE	2	R0	R0
-      0x8C1C0D10,  //  0048  GETMET	R7	R6	K16
+      0x8C1C0D61,  //  0048  GETMET	R7	R6	K97
       0x7C1C0200,  //  0049  CALL	R7	1
       0x80040C00,  //  004A  RET	1	R6
     })
@@ -1395,21 +1319,18 @@ be_local_closure(class_Matter_Session_save,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_store),
-    /* K1   */  be_nested_str_weak(save_fabrics),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(save),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8C040362,  //  0001  GETMET	R1	R1	K98
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -1425,39 +1346,32 @@ be_local_closure(class_Matter_Session_hydrate_post,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(reset),
-    /* K2   */  be_nested_str_weak(counter_snd),
-    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K4   */  be_nested_str_weak(counter_rcv),
-    /* K5   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(hydrate_post),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x8804010F,  //  0000  GETMBR	R1	R0	K15
+      0x8C04034E,  //  0001  GETMET	R1	R1	K78
+      0x880C0114,  //  0002  GETMBR	R3	R0	K20
       0x7C040400,  //  0003  CALL	R1	2
-      0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C040301,  //  0005  GETMET	R1	R1	K1
-      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x88040112,  //  0004  GETMBR	R1	R0	K18
+      0x8C04034E,  //  0005  GETMET	R1	R1	K78
+      0x880C0113,  //  0006  GETMBR	R3	R0	K19
       0x7C040400,  //  0007  CALL	R1	2
-      0x88040100,  //  0008  GETMBR	R1	R0	K0
-      0x8C040305,  //  0009  GETMET	R1	R1	K5
+      0x8804010F,  //  0008  GETMBR	R1	R0	K15
+      0x8C040322,  //  0009  GETMET	R1	R1	K34
       0x7C040200,  //  000A  CALL	R1	1
-      0x90020401,  //  000B  SETMBR	R0	K2	R1
-      0x88040103,  //  000C  GETMBR	R1	R0	K3
-      0x8C040305,  //  000D  GETMET	R1	R1	K5
+      0x90022801,  //  000B  SETMBR	R0	K20	R1
+      0x88040112,  //  000C  GETMBR	R1	R0	K18
+      0x8C040322,  //  000D  GETMET	R1	R1	K34
       0x7C040200,  //  000E  CALL	R1	1
-      0x90020801,  //  000F  SETMBR	R0	K4	R1
+      0x90022601,  //  000F  SETMBR	R0	K19	R1
       0x80000000,  //  0010  RET	0
     })
   )
@@ -1472,23 +1386,20 @@ be_local_closure(class_Matter_Session_get_admin_subject,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_subject),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_admin_subject),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060002,  //  0001  JMPF	R1	#0005
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x88040363,  //  0003  GETMBR	R1	R1	K99
       0x70020000,  //  0004  JMP		#0006
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
@@ -1505,21 +1416,18 @@ be_local_closure(class_Matter_Session_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040364,  //  0001  GETMBR	R1	R1	K100
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -1534,23 +1442,20 @@ be_local_closure(class_Matter_Session_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_fabric_compressed),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060002,  //  0001  JMPF	R1	#0005
       0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x88040365,  //  0003  GETMBR	R1	R1	K101
       0x70020000,  //  0004  JMP		#0006
       0x4C040000,  //  0005  LDNIL	R1
       0x80040200,  //  0006  RET	1	R1
@@ -1567,19 +1472,17 @@ be_local_closure(class_Matter_Session_get_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1594,19 +1497,17 @@ be_local_closure(class_Matter_Session_set_temp_ca,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_temp_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90025201,  //  0000  SETMBR	R0	K41	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1621,19 +1522,17 @@ be_local_closure(class_Matter_Session_set_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021001,  //  0000  SETMBR	R0	K8	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1648,28 +1547,22 @@ be_local_closure(class_Matter_Session_set_keys,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    /* K1   */  be_nested_str_weak(_i2r_privacy),
-    /* K2   */  be_nested_str_weak(r2ikey),
-    /* K3   */  be_nested_str_weak(attestation_challenge),
-    /* K4   */  be_nested_str_weak(created),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(set_keys),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024001,  //  0000  SETMBR	R0	K32	R1
       0x4C140000,  //  0001  LDNIL	R5
-      0x90020205,  //  0002  SETMBR	R0	K1	R5
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020603,  //  0004  SETMBR	R0	K3	R3
-      0x90020804,  //  0005  SETMBR	R0	K4	R4
+      0x90029E05,  //  0002  SETMBR	R0	K79	R5
+      0x90024A02,  //  0003  SETMBR	R0	K37	R2
+      0x9002A003,  //  0004  SETMBR	R0	K80	R3
+      0x9002CC04,  //  0005  SETMBR	R0	K102	R4
       0x80000000,  //  0006  RET	0
     })
   )
@@ -1684,69 +1577,56 @@ be_local_closure(class_Matter_Session_gen_CSR,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_pk),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(public_key),
-    /* K4   */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
-    /* K5   */  be_nested_str_weak(A000),
-    /* K6   */  be_nested_str_weak(300C06082A8648CE3D0403020500),
-    /* K7   */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
-    /* K8   */  be_nested_str_weak(add),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(gen_CSR),
     &be_const_str_solidified,
     ( &(const binstruction[73]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040136,  //  0000  GETMET	R1	R0	K54
       0x7C040200,  //  0001  CALL	R1	1
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0xA40A1600,  //  0002  IMPORT	R2	K11
+      0x8C0C0567,  //  0003  GETMET	R3	R2	K103
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x8C100703,  //  0005  GETMET	R4	R3	K3
+      0x8C100768,  //  0005  GETMET	R4	R3	K104
       0x5C180200,  //  0006  MOVE	R6	R1
       0x7C100400,  //  0007  CALL	R4	2
       0x60140015,  //  0008  GETGBL	R5	G21
-      0x58180004,  //  0009  LDCONST	R6	K4
+      0x58180069,  //  0009  LDCONST	R6	K105
       0x7C140200,  //  000A  CALL	R5	1
       0x40180A04,  //  000B  CONNECT	R6	R5	R4
       0x60180015,  //  000C  GETGBL	R6	G21
-      0x581C0005,  //  000D  LDCONST	R7	K5
+      0x581C006A,  //  000D  LDCONST	R7	K106
       0x7C180200,  //  000E  CALL	R6	1
       0x40180A06,  //  000F  CONNECT	R6	R5	R6
       0x60180015,  //  0010  GETGBL	R6	G21
-      0x581C0006,  //  0011  LDCONST	R7	K6
+      0x581C006B,  //  0011  LDCONST	R7	K107
       0x7C180200,  //  0012  CALL	R6	1
-      0x8C1C0707,  //  0013  GETMET	R7	R3	K7
+      0x8C1C076C,  //  0013  GETMET	R7	R3	K108
       0x5C240200,  //  0014  MOVE	R9	R1
       0x5C280A00,  //  0015  MOVE	R10	R5
       0x7C1C0600,  //  0016  CALL	R7	3
       0x60200015,  //  0017  GETGBL	R8	G21
       0x5426007F,  //  0018  LDINT	R9	128
       0x7C200200,  //  0019  CALL	R8	1
-      0x8C241108,  //  001A  GETMET	R9	R8	K8
-      0x582C0009,  //  001B  LDCONST	R11	K9
-      0x5830000A,  //  001C  LDCONST	R12	K10
+      0x8C24116D,  //  001A  GETMET	R9	R8	K109
+      0x582C0005,  //  001B  LDCONST	R11	K5
+      0x58300051,  //  001C  LDCONST	R12	K81
       0x7C240600,  //  001D  CALL	R9	3
-      0x8C241108,  //  001E  GETMET	R9	R8	K8
+      0x8C24116D,  //  001E  GETMET	R9	R8	K109
       0x602C000C,  //  001F  GETGBL	R11	G12
       0x5C300E00,  //  0020  MOVE	R12	R7
       0x7C2C0200,  //  0021  CALL	R11	1
-      0x002C170A,  //  0022  ADD	R11	R11	K10
-      0x5830000A,  //  0023  LDCONST	R12	K10
+      0x002C1751,  //  0022  ADD	R11	R11	K81
+      0x58300051,  //  0023  LDCONST	R12	K81
       0x7C240600,  //  0024  CALL	R9	3
-      0x8C241108,  //  0025  GETMET	R9	R8	K8
-      0x582C000B,  //  0026  LDCONST	R11	K11
-      0x5830000A,  //  0027  LDCONST	R12	K10
+      0x8C24116D,  //  0025  GETMET	R9	R8	K109
+      0x582C003D,  //  0026  LDCONST	R11	K61
+      0x58300051,  //  0027  LDCONST	R12	K81
       0x7C240600,  //  0028  CALL	R9	3
       0x40241007,  //  0029  CONNECT	R9	R8	R7
       0x6024000C,  //  002A  GETGBL	R9	G12
@@ -1763,18 +1643,18 @@ be_local_closure(class_Matter_Session_gen_CSR,   /* name */
       0x60280015,  //  0035  GETGBL	R10	G21
       0x542E00CF,  //  0036  LDINT	R11	208
       0x7C280200,  //  0037  CALL	R10	1
-      0x8C2C1508,  //  0038  GETMET	R11	R10	K8
+      0x8C2C156D,  //  0038  GETMET	R11	R10	K109
       0x5436002F,  //  0039  LDINT	R13	48
-      0x5838000A,  //  003A  LDCONST	R14	K10
+      0x58380051,  //  003A  LDCONST	R14	K81
       0x7C2C0600,  //  003B  CALL	R11	3
-      0x8C2C1508,  //  003C  GETMET	R11	R10	K8
+      0x8C2C156D,  //  003C  GETMET	R11	R10	K109
       0x54360080,  //  003D  LDINT	R13	129
-      0x5838000A,  //  003E  LDCONST	R14	K10
+      0x58380051,  //  003E  LDCONST	R14	K81
       0x7C2C0600,  //  003F  CALL	R11	3
-      0x8C2C1508,  //  0040  GETMET	R11	R10	K8
+      0x8C2C156D,  //  0040  GETMET	R11	R10	K109
       0x543600FE,  //  0041  LDINT	R13	255
       0x2C34120D,  //  0042  AND	R13	R9	R13
-      0x5838000A,  //  0043  LDCONST	R14	K10
+      0x58380051,  //  0043  LDCONST	R14	K81
       0x7C2C0600,  //  0044  CALL	R11	3
       0x402C1405,  //  0045  CONNECT	R11	R10	R5
       0x402C1406,  //  0046  CONNECT	R11	R10	R6
@@ -1793,21 +1673,18 @@ be_local_closure(class_Matter_Session_get_ipk_group_key,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ipk_group_key),
-    }),
+    &be_ktab_class_Matter_Session,     /* shared constants */
     be_str_weak(get_ipk_group_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C04036E,  //  0001  GETMET	R1	R1	K110
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -3,6 +3,84 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_Session_Store' ktab size: 74, total: 155 (saved 648 bytes)
+static const bvalue be_ktab_class_Matter_Session_Store[74] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(sessions),
+  /* K2   */  be_nested_str_weak(remove),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_nested_str_weak(crypto),
+  /* K5   */  be_nested_str_weak(random),
+  /* K6   */  be_const_int(2),
+  /* K7   */  be_nested_str_weak(get),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(get_session_by_local_session_id),
+  /* K10  */  be_nested_str_weak(matter),
+  /* K11  */  be_nested_str_weak(Expirable_list),
+  /* K12  */  be_nested_str_weak(fabrics),
+  /* K13  */  be_nested_str_weak(_FABRICS),
+  /* K14  */  be_nested_str_weak(read),
+  /* K15  */  be_nested_str_weak(close),
+  /* K16  */  be_nested_str_weak(json),
+  /* K17  */  be_nested_str_weak(load),
+  /* K18  */  be_nested_str_weak(tasmota),
+  /* K19  */  be_nested_str_weak(gc),
+  /* K20  */  be_nested_str_weak(Fabric),
+  /* K21  */  be_nested_str_weak(fromjson),
+  /* K22  */  be_nested_str_weak(set_no_expiration),
+  /* K23  */  be_nested_str_weak(set_persist),
+  /* K24  */  be_nested_str_weak(find),
+  /* K25  */  be_nested_str_weak(_sessions),
+  /* K26  */  be_nested_str_weak(Session),
+  /* K27  */  be_nested_str_weak(add_session),
+  /* K28  */  be_nested_str_weak(stop_iteration),
+  /* K29  */  be_nested_str_weak(push),
+  /* K30  */  be_nested_str_weak(log),
+  /* K31  */  be_nested_str_weak(MTR_X3A_X20Loaded_X20_X25i_X20fabric_X28s_X29),
+  /* K32  */  be_nested_str_weak(io_error),
+  /* K33  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+  /* K34  */  be_nested_str_weak(_X7C),
+  /* K35  */  be_nested_str_weak(get_device_id),
+  /* K36  */  be_nested_str_weak(get_fabric_id),
+  /* K37  */  be_nested_str_weak(active_fabrics),
+  /* K38  */  be_nested_str_weak(get_fabric_index),
+  /* K39  */  be_nested_str_weak(remove_expired),
+  /* K40  */  be_nested_str_weak(persistables),
+  /* K41  */  be_nested_str_weak(count_persistables),
+  /* K42  */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
+  /* K43  */  be_nested_str_weak(resumption_id),
+  /* K44  */  be_nested_str_weak(shared_secret),
+  /* K45  */  be_nested_str_weak(update),
+  /* K46  */  be_nested_str_weak(set_expire_in_seconds),
+  /* K47  */  be_nested_str_weak(get_session_by_source_node_id),
+  /* K48  */  be_nested_str_weak(_source_node_id),
+  /* K49  */  be_nested_str_weak(local_session_id),
+  /* K50  */  be_nested_str_weak(device),
+  /* K51  */  be_nested_str_weak(every_second),
+  /* K52  */  be_nested_str_weak(fabric_id),
+  /* K53  */  be_nested_str_weak(device_id),
+  /* K54  */  be_nested_str_weak(value_error),
+  /* K55  */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
+  /* K56  */  be_nested_str_weak(remove_redundant_fabric),
+  /* K57  */  be_nested_str_weak(fabric_index),
+  /* K58  */  be_nested_str_weak(int),
+  /* K59  */  be_nested_str_weak(path),
+  /* K60  */  be_nested_str_weak(_FABRICS_TEMP),
+  /* K61  */  be_nested_str_weak(w),
+  /* K62  */  be_nested_str_weak(write),
+  /* K63  */  be_nested_str_weak(_X5B),
+  /* K64  */  be_nested_str_weak(_X2C),
+  /* K65  */  be_nested_str_weak(writejson),
+  /* K66  */  be_nested_str_weak(_X5D),
+  /* K67  */  be_nested_str_weak(rename),
+  /* K68  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
+  /* K69  */  be_nested_str_weak(event_fabrics_saved),
+  /* K70  */  be_nested_str_weak(MTR_X3A_X20Saving_X20Fabrics_X20failed),
+  /* K71  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+  /* K72  */  be_nested_str_weak(remove_session),
+  /* K73  */  be_nested_str_weak(_fabric),
+};
+
 
 extern const bclass be_class_Matter_Session_Store;
 
@@ -13,18 +91,13 @@ be_local_closure(class_Matter_Session_Store_remove_session,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(remove_session),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
@@ -58,34 +131,27 @@ be_local_closure(class_Matter_Session_Store_gen_local_session_id,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(gen_local_session_id),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA4060800,  //  0000  IMPORT	R1	K4
       0x50080200,  //  0001  LDBOOL	R2	1	0
       0x780A000E,  //  0002  JMPF	R2	#0012
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
+      0x8C080305,  //  0003  GETMET	R2	R1	K5
+      0x58100006,  //  0004  LDCONST	R4	K6
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x58140002,  //  0008  LDCONST	R5	K2
+      0x8C080507,  //  0006  GETMET	R2	R2	K7
+      0x58100008,  //  0007  LDCONST	R4	K8
+      0x58140006,  //  0008  LDCONST	R5	K6
       0x7C080600,  //  0009  CALL	R2	3
-      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
+      0x8C0C0109,  //  000A  GETMET	R3	R0	K9
       0x5C140400,  //  000B  MOVE	R5	R2
       0x7C0C0400,  //  000C  CALL	R3	2
       0x4C100000,  //  000D  LDNIL	R4
@@ -107,67 +173,39 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Expirable_list),
-    /* K3   */  be_nested_str_weak(fabrics),
-    /* K4   */  be_nested_str_weak(_FABRICS),
-    /* K5   */  be_nested_str_weak(read),
-    /* K6   */  be_nested_str_weak(close),
-    /* K7   */  be_nested_str_weak(json),
-    /* K8   */  be_nested_str_weak(load),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(gc),
-    /* K11  */  be_nested_str_weak(Fabric),
-    /* K12  */  be_nested_str_weak(fromjson),
-    /* K13  */  be_nested_str_weak(set_no_expiration),
-    /* K14  */  be_nested_str_weak(set_persist),
-    /* K15  */  be_nested_str_weak(find),
-    /* K16  */  be_nested_str_weak(_sessions),
-    /* K17  */  be_nested_str_weak(Session),
-    /* K18  */  be_nested_str_weak(add_session),
-    /* K19  */  be_nested_str_weak(stop_iteration),
-    /* K20  */  be_nested_str_weak(push),
-    /* K21  */  be_nested_str_weak(log),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Loaded_X20_X25i_X20fabric_X28s_X29),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(io_error),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K26  */  be_nested_str_weak(_X7C),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(load_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[115]) {  /* code */
       0xA802005E,  //  0000  EXBLK	0	#0060
-      0xB8060200,  //  0001  GETNGBL	R1	K1
-      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0xB8061400,  //  0001  GETNGBL	R1	K10
+      0x8C04030B,  //  0002  GETMET	R1	R1	K11
       0x7C040200,  //  0003  CALL	R1	1
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0xB8061400,  //  0005  GETNGBL	R1	K10
+      0x8C04030B,  //  0006  GETMET	R1	R1	K11
       0x7C040200,  //  0007  CALL	R1	1
-      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x90021801,  //  0008  SETMBR	R0	K12	R1
       0x60040011,  //  0009  GETGBL	R1	G17
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x8808010D,  //  000A  GETMBR	R2	R0	K13
       0x7C040200,  //  000B  CALL	R1	1
-      0x8C080305,  //  000C  GETMET	R2	R1	K5
+      0x8C08030E,  //  000C  GETMET	R2	R1	K14
       0x7C080200,  //  000D  CALL	R2	1
-      0x8C0C0306,  //  000E  GETMET	R3	R1	K6
+      0x8C0C030F,  //  000E  GETMET	R3	R1	K15
       0x7C0C0200,  //  000F  CALL	R3	1
-      0xA40E0E00,  //  0010  IMPORT	R3	K7
-      0x8C100708,  //  0011  GETMET	R4	R3	K8
+      0xA40E2000,  //  0010  IMPORT	R3	K16
+      0x8C100711,  //  0011  GETMET	R4	R3	K17
       0x5C180400,  //  0012  MOVE	R6	R2
       0x7C100400,  //  0013  CALL	R4	2
       0x4C080000,  //  0014  LDNIL	R2
-      0xB8161200,  //  0015  GETNGBL	R5	K9
-      0x8C140B0A,  //  0016  GETMET	R5	R5	K10
+      0xB8162400,  //  0015  GETNGBL	R5	K18
+      0x8C140B13,  //  0016  GETMET	R5	R5	K19
       0x7C140200,  //  0017  CALL	R5	1
       0x60140010,  //  0018  GETGBL	R5	G16
       0x5C180800,  //  0019  MOVE	R6	R4
@@ -175,19 +213,19 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
       0xA8020035,  //  001B  EXBLK	0	#0052
       0x5C180A00,  //  001C  MOVE	R6	R5
       0x7C180000,  //  001D  CALL	R6	0
-      0xB81E0200,  //  001E  GETNGBL	R7	K1
-      0x881C0F0B,  //  001F  GETMBR	R7	R7	K11
-      0x8C1C0F0C,  //  0020  GETMET	R7	R7	K12
+      0xB81E1400,  //  001E  GETNGBL	R7	K10
+      0x881C0F14,  //  001F  GETMBR	R7	R7	K20
+      0x8C1C0F15,  //  0020  GETMET	R7	R7	K21
       0x5C240000,  //  0021  MOVE	R9	R0
       0x5C280C00,  //  0022  MOVE	R10	R6
       0x7C1C0600,  //  0023  CALL	R7	3
-      0x8C200F0D,  //  0024  GETMET	R8	R7	K13
+      0x8C200F16,  //  0024  GETMET	R8	R7	K22
       0x7C200200,  //  0025  CALL	R8	1
-      0x8C200F0E,  //  0026  GETMET	R8	R7	K14
+      0x8C200F17,  //  0026  GETMET	R8	R7	K23
       0x50280200,  //  0027  LDBOOL	R10	1	0
       0x7C200400,  //  0028  CALL	R8	2
-      0x8C200D0F,  //  0029  GETMET	R8	R6	K15
-      0x58280010,  //  002A  LDCONST	R10	K16
+      0x8C200D18,  //  0029  GETMET	R8	R6	K24
+      0x58280019,  //  002A  LDCONST	R10	K25
       0x602C0012,  //  002B  GETGBL	R11	G18
       0x7C2C0000,  //  002C  CALL	R11	0
       0x7C200600,  //  002D  CALL	R8	3
@@ -197,9 +235,9 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
       0xA8020017,  //  0031  EXBLK	0	#004A
       0x5C281200,  //  0032  MOVE	R10	R9
       0x7C280000,  //  0033  CALL	R10	0
-      0xB82E0200,  //  0034  GETNGBL	R11	K1
-      0x882C1711,  //  0035  GETMBR	R11	R11	K17
-      0x8C2C170C,  //  0036  GETMET	R11	R11	K12
+      0xB82E1400,  //  0034  GETNGBL	R11	K10
+      0x882C171A,  //  0035  GETMBR	R11	R11	K26
+      0x8C2C1715,  //  0036  GETMET	R11	R11	K21
       0x5C340000,  //  0037  MOVE	R13	R0
       0x5C381400,  //  0038  MOVE	R14	R10
       0x5C3C0E00,  //  0039  MOVE	R15	R7
@@ -207,55 +245,55 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
       0x4C300000,  //  003B  LDNIL	R12
       0x2030160C,  //  003C  NE	R12	R11	R12
       0x7832000A,  //  003D  JMPF	R12	#0049
-      0x8C30170D,  //  003E  GETMET	R12	R11	K13
+      0x8C301716,  //  003E  GETMET	R12	R11	K22
       0x7C300200,  //  003F  CALL	R12	1
-      0x8C30170E,  //  0040  GETMET	R12	R11	K14
+      0x8C301717,  //  0040  GETMET	R12	R11	K23
       0x50380200,  //  0041  LDBOOL	R14	1	0
       0x7C300400,  //  0042  CALL	R12	2
-      0x8C300112,  //  0043  GETMET	R12	R0	K18
+      0x8C30011B,  //  0043  GETMET	R12	R0	K27
       0x5C381600,  //  0044  MOVE	R14	R11
       0x7C300400,  //  0045  CALL	R12	2
-      0x8C300F12,  //  0046  GETMET	R12	R7	K18
+      0x8C300F1B,  //  0046  GETMET	R12	R7	K27
       0x5C381600,  //  0047  MOVE	R14	R11
       0x7C300400,  //  0048  CALL	R12	2
       0x7001FFE7,  //  0049  JMP		#0032
-      0x58240013,  //  004A  LDCONST	R9	K19
+      0x5824001C,  //  004A  LDCONST	R9	K28
       0xAC240200,  //  004B  CATCH	R9	1	0
       0xB0080000,  //  004C  RAISE	2	R0	R0
-      0x88240103,  //  004D  GETMBR	R9	R0	K3
-      0x8C241314,  //  004E  GETMET	R9	R9	K20
+      0x8824010C,  //  004D  GETMBR	R9	R0	K12
+      0x8C24131D,  //  004E  GETMET	R9	R9	K29
       0x5C2C0E00,  //  004F  MOVE	R11	R7
       0x7C240400,  //  0050  CALL	R9	2
       0x7001FFC9,  //  0051  JMP		#001C
-      0x58140013,  //  0052  LDCONST	R5	K19
+      0x5814001C,  //  0052  LDCONST	R5	K28
       0xAC140200,  //  0053  CATCH	R5	1	0
       0xB0080000,  //  0054  RAISE	2	R0	R0
-      0xB8162A00,  //  0055  GETNGBL	R5	K21
+      0xB8163C00,  //  0055  GETNGBL	R5	K30
       0x60180018,  //  0056  GETGBL	R6	G24
-      0x581C0016,  //  0057  LDCONST	R7	K22
+      0x581C001F,  //  0057  LDCONST	R7	K31
       0x6020000C,  //  0058  GETGBL	R8	G12
-      0x88240103,  //  0059  GETMBR	R9	R0	K3
+      0x8824010C,  //  0059  GETMBR	R9	R0	K12
       0x7C200200,  //  005A  CALL	R8	1
       0x7C180400,  //  005B  CALL	R6	2
-      0x581C0017,  //  005C  LDCONST	R7	K23
+      0x581C0006,  //  005C  LDCONST	R7	K6
       0x7C140400,  //  005D  CALL	R5	2
       0xA8040001,  //  005E  EXBLK	1	1
       0x70020011,  //  005F  JMP		#0072
       0xAC040002,  //  0060  CATCH	R1	0	2
       0x7002000E,  //  0061  JMP		#0071
-      0x200C0318,  //  0062  NE	R3	R1	K24
+      0x200C0320,  //  0062  NE	R3	R1	K32
       0x780E000B,  //  0063  JMPF	R3	#0070
-      0xB80E2A00,  //  0064  GETNGBL	R3	K21
+      0xB80E3C00,  //  0064  GETNGBL	R3	K30
       0x60100008,  //  0065  GETGBL	R4	G8
       0x5C140200,  //  0066  MOVE	R5	R1
       0x7C100200,  //  0067  CALL	R4	1
-      0x00123204,  //  0068  ADD	R4	K25	R4
-      0x0010091A,  //  0069  ADD	R4	R4	K26
+      0x00124204,  //  0068  ADD	R4	K33	R4
+      0x00100922,  //  0069  ADD	R4	R4	K34
       0x60140008,  //  006A  GETGBL	R5	G8
       0x5C180400,  //  006B  MOVE	R6	R2
       0x7C140200,  //  006C  CALL	R5	1
       0x00100805,  //  006D  ADD	R4	R4	R5
-      0x58140017,  //  006E  LDCONST	R5	K23
+      0x58140006,  //  006E  LDCONST	R5	K6
       0x7C0C0400,  //  006F  CALL	R3	2
       0x70020000,  //  0070  JMP		#0072
       0xB0080000,  //  0071  RAISE	2	R0	R0
@@ -273,7 +311,7 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -335,8 +373,8 @@ be_local_closure(class_Matter_Session_Store_find_children_fabrics,   /* name */
         })
       ),
     }),
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(find_children_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -368,20 +406,13 @@ be_local_closure(class_Matter_Session_Store_sessions_active,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(sessions_active),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
@@ -395,16 +426,16 @@ be_local_closure(class_Matter_Session_Store_sessions_active,   /* name */
       0x780E000C,  //  0007  JMPF	R3	#0015
       0x880C0101,  //  0008  GETMBR	R3	R0	K1
       0x940C0602,  //  0009  GETIDX	R3	R3	R2
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x8C100723,  //  000A  GETMET	R4	R3	K35
       0x7C100200,  //  000B  CALL	R4	1
       0x78120005,  //  000C  JMPF	R4	#0013
-      0x8C100703,  //  000D  GETMET	R4	R3	K3
+      0x8C100724,  //  000D  GETMET	R4	R3	K36
       0x7C100200,  //  000E  CALL	R4	1
       0x78120002,  //  000F  JMPF	R4	#0013
-      0x8C100304,  //  0010  GETMET	R4	R1	K4
+      0x8C10031D,  //  0010  GETMET	R4	R1	K29
       0x5C180600,  //  0011  MOVE	R6	R3
       0x7C100400,  //  0012  CALL	R4	2
-      0x00080505,  //  0013  ADD	R2	R2	K5
+      0x00080503,  //  0013  ADD	R2	R2	K3
       0x7001FFED,  //  0014  JMP		#0003
       0x80040200,  //  0015  RET	1	R1
     })
@@ -420,35 +451,31 @@ be_local_closure(class_Matter_Session_Store_find_fabric_by_index,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active_fabrics),
-    /* K1   */  be_nested_str_weak(get_fabric_index),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(find_fabric_by_index),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
       0x60080010,  //  0000  GETGBL	R2	G16
-      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
+      0x8C0C0125,  //  0001  GETMET	R3	R0	K37
       0x7C0C0200,  //  0002  CALL	R3	1
       0x7C080200,  //  0003  CALL	R2	1
       0xA8020008,  //  0004  EXBLK	0	#000E
       0x5C0C0400,  //  0005  MOVE	R3	R2
       0x7C0C0000,  //  0006  CALL	R3	0
-      0x8C100701,  //  0007  GETMET	R4	R3	K1
+      0x8C100726,  //  0007  GETMET	R4	R3	K38
       0x7C100200,  //  0008  CALL	R4	1
       0x1C100801,  //  0009  EQ	R4	R4	R1
       0x78120001,  //  000A  JMPF	R4	#000D
       0xA8040001,  //  000B  EXBLK	1	1
       0x80040600,  //  000C  RET	1	R3
       0x7001FFF6,  //  000D  JMP		#0005
-      0x58080002,  //  000E  LDCONST	R2	K2
+      0x5808001C,  //  000E  LDCONST	R2	K28
       0xAC080200,  //  000F  CATCH	R2	1	0
       0xB0080000,  //  0010  RAISE	2	R0	R0
       0x4C080000,  //  0011  LDNIL	R2
@@ -466,24 +493,20 @@ be_local_closure(class_Matter_Session_Store_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(persistables),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(active_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040127,  //  0000  GETMET	R1	R0	K39
       0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x8804010C,  //  0002  GETMBR	R1	R0	K12
+      0x8C040328,  //  0003  GETMET	R1	R1	K40
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
     })
@@ -499,21 +522,18 @@ be_local_closure(class_Matter_Session_Store_create_fabric,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(create_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB8061400,  //  0000  GETNGBL	R1	K10
+      0x8C040314,  //  0001  GETMET	R1	R1	K20
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0x80040200,  //  0004  RET	1	R1
@@ -530,33 +550,28 @@ be_local_closure(class_Matter_Session_Store_count_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(count_persistables),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(count_active_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040127,  //  0000  GETMET	R1	R0	K39
       0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8804010C,  //  0002  GETMBR	R1	R0	K12
       0x4C080000,  //  0003  LDNIL	R2
       0x20040202,  //  0004  NE	R1	R1	R2
       0x78060004,  //  0005  JMPF	R1	#000B
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x8804010C,  //  0006  GETMBR	R1	R0	K12
+      0x8C040329,  //  0007  GETMET	R1	R1	K41
       0x7C040200,  //  0008  CALL	R1	1
       0x80040200,  //  0009  RET	1	R1
       0x70020000,  //  000A  JMP		#000C
-      0x80060600,  //  000B  RET	1	K3
+      0x80060000,  //  000B  RET	1	K0
       0x80000000,  //  000C  RET	0
     })
   )
@@ -571,22 +586,13 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
-    /* K4   */  be_nested_str_weak(resumption_id),
-    /* K5   */  be_nested_str_weak(shared_secret),
-    /* K6   */  be_nested_str_weak(update),
-    /* K7   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(find_session_by_resumption_id),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
@@ -602,11 +608,11 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
       0x14100404,  //  0009  LT	R4	R2	R4
       0x78120018,  //  000A  JMPF	R4	#0024
       0x94100602,  //  000B  GETIDX	R4	R3	R2
-      0xB8160400,  //  000C  GETNGBL	R5	K2
+      0xB8163C00,  //  000C  GETNGBL	R5	K30
       0x60180018,  //  000D  GETGBL	R6	G24
-      0x581C0003,  //  000E  LDCONST	R7	K3
+      0x581C002A,  //  000E  LDCONST	R7	K42
       0x60200008,  //  000F  GETGBL	R8	G8
-      0x88240904,  //  0010  GETMBR	R9	R4	K4
+      0x8824092B,  //  0010  GETMBR	R9	R4	K43
       0x7C200200,  //  0011  CALL	R8	1
       0x60240008,  //  0012  GETGBL	R9	G8
       0x5C280200,  //  0013  MOVE	R10	R1
@@ -614,17 +620,17 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
       0x7C180600,  //  0015  CALL	R6	3
       0x541E0003,  //  0016  LDINT	R7	4
       0x7C140400,  //  0017  CALL	R5	2
-      0x88140904,  //  0018  GETMBR	R5	R4	K4
+      0x8814092B,  //  0018  GETMBR	R5	R4	K43
       0x1C140A01,  //  0019  EQ	R5	R5	R1
       0x78160006,  //  001A  JMPF	R5	#0022
-      0x88140905,  //  001B  GETMBR	R5	R4	K5
+      0x8814092C,  //  001B  GETMBR	R5	R4	K44
       0x4C180000,  //  001C  LDNIL	R6
       0x20140A06,  //  001D  NE	R5	R5	R6
       0x78160002,  //  001E  JMPF	R5	#0022
-      0x8C140906,  //  001F  GETMET	R5	R4	K6
+      0x8C14092D,  //  001F  GETMET	R5	R4	K45
       0x7C140200,  //  0020  CALL	R5	1
       0x80040800,  //  0021  RET	1	R4
-      0x00080507,  //  0022  ADD	R2	R2	K7
+      0x00080503,  //  0022  ADD	R2	R2	K3
       0x7001FFE1,  //  0023  JMP		#0006
       0x80000000,  //  0024  RET	0
     })
@@ -640,28 +646,24 @@ be_local_closure(class_Matter_Session_Store_add_session,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(add_session),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x200C0403,  //  0001  NE	R3	R2	R3
       0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x8C0C032E,  //  0003  GETMET	R3	R1	K46
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x8C0C071D,  //  0007  GETMET	R3	R3	K29
       0x5C140200,  //  0008  MOVE	R5	R1
       0x7C0C0400,  //  0009  CALL	R3	2
       0x80000000,  //  000A  RET	0
@@ -678,48 +680,38 @@ be_local_closure(class_Matter_Session_Store_find_session_source_id_unsecure,   /
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Session),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_source_node_id),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K8   */  be_nested_str_weak(update),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(find_session_source_id_unsecure),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C012F,  //  0000  GETMET	R3	R0	K47
       0x5C140200,  //  0001  MOVE	R5	R1
       0x7C0C0400,  //  0002  CALL	R3	2
       0x4C100000,  //  0003  LDNIL	R4
       0x1C100604,  //  0004  EQ	R4	R3	R4
       0x7812000E,  //  0005  JMPF	R4	#0015
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100902,  //  0007  GETMET	R4	R4	K2
+      0xB8121400,  //  0006  GETNGBL	R4	K10
+      0x8C10091A,  //  0007  GETMET	R4	R4	K26
       0x5C180000,  //  0008  MOVE	R6	R0
-      0x581C0003,  //  0009  LDCONST	R7	K3
-      0x58200003,  //  000A  LDCONST	R8	K3
+      0x581C0000,  //  0009  LDCONST	R7	K0
+      0x58200000,  //  000A  LDCONST	R8	K0
       0x7C100800,  //  000B  CALL	R4	4
       0x5C0C0800,  //  000C  MOVE	R3	R4
-      0x900E0801,  //  000D  SETMBR	R3	K4	R1
-      0x88100105,  //  000E  GETMBR	R4	R0	K5
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x900E6001,  //  000D  SETMBR	R3	K48	R1
+      0x88100101,  //  000E  GETMBR	R4	R0	K1
+      0x8C10091D,  //  000F  GETMET	R4	R4	K29
       0x5C180600,  //  0010  MOVE	R6	R3
       0x7C100400,  //  0011  CALL	R4	2
-      0x8C100707,  //  0012  GETMET	R4	R3	K7
+      0x8C10072E,  //  0012  GETMET	R4	R3	K46
       0x5C180400,  //  0013  MOVE	R6	R2
       0x7C100400,  //  0014  CALL	R4	2
-      0x8C100708,  //  0015  GETMET	R4	R3	K8
+      0x8C10072D,  //  0015  GETMET	R4	R3	K45
       0x7C100200,  //  0016  CALL	R4	1
       0x80040600,  //  0017  RET	1	R3
     })
@@ -735,19 +727,17 @@ be_local_closure(class_Matter_Session_Store_every_second,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040127,  //  0000  GETMET	R1	R0	K39
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -763,19 +753,13 @@ be_local_closure(class_Matter_Session_Store_get_session_by_local_session_id,   /
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(get_session_by_local_session_id),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
@@ -785,20 +769,20 @@ be_local_closure(class_Matter_Session_Store_get_session_by_local_session_id,   /
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
       0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x580C0008,  //  0008  LDCONST	R3	K8
+      0x88100101,  //  0009  GETMBR	R4	R0	K1
       0x14140602,  //  000A  LT	R5	R3	R2
       0x78160008,  //  000B  JMPF	R5	#0015
       0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x88180B31,  //  000D  GETMBR	R6	R5	K49
       0x1C180C01,  //  000E  EQ	R6	R6	R1
       0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x8C180B2D,  //  0010  GETMET	R6	R5	K45
       0x7C180200,  //  0011  CALL	R6	1
       0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x000C0703,  //  0013  ADD	R3	R3	K3
       0x7001FFF4,  //  0014  JMP		#000A
       0x80000000,  //  0015  RET	0
     })
@@ -814,31 +798,25 @@ be_local_closure(class_Matter_Session_Store_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Expirable_list),
-    /* K4   */  be_nested_str_weak(fabrics),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0xB80A0400,  //  0001  GETNGBL	R2	K2
-      0x8C080503,  //  0002  GETMET	R2	R2	K3
+      0x90026401,  //  0000  SETMBR	R0	K50	R1
+      0xB80A1400,  //  0001  GETNGBL	R2	K10
+      0x8C08050B,  //  0002  GETMET	R2	R2	K11
       0x7C080200,  //  0003  CALL	R2	1
       0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0005  GETNGBL	R2	K2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0xB80A1400,  //  0005  GETNGBL	R2	K10
+      0x8C08050B,  //  0006  GETMET	R2	R2	K11
       0x7C080200,  //  0007  CALL	R2	1
-      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x90021802,  //  0008  SETMBR	R0	K12	R2
       0x80000000,  //  0009  RET	0
     })
   )
@@ -853,25 +831,21 @@ be_local_closure(class_Matter_Session_Store_remove_expired,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(fabrics),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(remove_expired),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040333,  //  0001  GETMET	R1	R1	K51
       0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x8804010C,  //  0003  GETMBR	R1	R0	K12
+      0x8C040333,  //  0004  GETMET	R1	R1	K51
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -887,47 +861,40 @@ be_local_closure(class_Matter_Session_Store_remove_redundant_fabric,   /* name *
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(fabric_id),
-    /* K3   */  be_nested_str_weak(device_id),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(remove_redundant_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0x58080000,  //  0000  LDCONST	R2	K0
       0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x8810010C,  //  0002  GETMBR	R4	R0	K12
       0x7C0C0200,  //  0003  CALL	R3	1
       0x140C0403,  //  0004  LT	R3	R2	R3
       0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x880C010C,  //  0006  GETMBR	R3	R0	K12
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
       0x20100601,  //  0008  NE	R4	R3	R1
       0x7812000C,  //  0009  JMPF	R4	#0017
-      0x88100702,  //  000A  GETMBR	R4	R3	K2
-      0x88140302,  //  000B  GETMBR	R5	R1	K2
+      0x88100734,  //  000A  GETMBR	R4	R3	K52
+      0x88140334,  //  000B  GETMBR	R5	R1	K52
       0x1C100805,  //  000C  EQ	R4	R4	R5
       0x78120008,  //  000D  JMPF	R4	#0017
-      0x88100703,  //  000E  GETMBR	R4	R3	K3
-      0x88140303,  //  000F  GETMBR	R5	R1	K3
+      0x88100735,  //  000E  GETMBR	R4	R3	K53
+      0x88140335,  //  000F  GETMBR	R5	R1	K53
       0x1C100805,  //  0010  EQ	R4	R4	R5
       0x78120004,  //  0011  JMPF	R4	#0017
-      0x88100101,  //  0012  GETMBR	R4	R0	K1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x8810010C,  //  0012  GETMBR	R4	R0	K12
+      0x8C100902,  //  0013  GETMET	R4	R4	K2
       0x5C180400,  //  0014  MOVE	R6	R2
       0x7C100400,  //  0015  CALL	R4	2
       0x70020000,  //  0016  JMP		#0018
-      0x00080505,  //  0017  ADD	R2	R2	K5
+      0x00080503,  //  0017  ADD	R2	R2	K3
       0x7001FFE7,  //  0018  JMP		#0001
       0x80000000,  //  0019  RET	0
     })
@@ -943,44 +910,35 @@ be_local_closure(class_Matter_Session_Store_add_fabric,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    /* K2   */  be_nested_str_weak(value_error),
-    /* K3   */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
-    /* K4   */  be_nested_str_weak(fabrics),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(remove_redundant_fabric),
-    /* K7   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(add_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0x6008000F,  //  0000  GETGBL	R2	G15
       0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0xB8121400,  //  0002  GETNGBL	R4	K10
+      0x88100914,  //  0003  GETMBR	R4	R4	K20
       0x7C080400,  //  0004  CALL	R2	2
       0x740A0000,  //  0005  JMPT	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x88080104,  //  0007  GETMBR	R2	R0	K4
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0xB0066D37,  //  0006  RAISE	1	K54	K55
+      0x8808010C,  //  0007  GETMBR	R2	R0	K12
+      0x8C080518,  //  0008  GETMET	R2	R2	K24
       0x5C100200,  //  0009  MOVE	R4	R1
       0x7C080400,  //  000A  CALL	R2	2
       0x4C0C0000,  //  000B  LDNIL	R3
       0x1C080403,  //  000C  EQ	R2	R2	R3
       0x780A0006,  //  000D  JMPF	R2	#0015
-      0x8C080106,  //  000E  GETMET	R2	R0	K6
+      0x8C080138,  //  000E  GETMET	R2	R0	K56
       0x5C100200,  //  000F  MOVE	R4	R1
       0x7C080400,  //  0010  CALL	R2	2
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0x8C080507,  //  0012  GETMET	R2	R2	K7
+      0x8808010C,  //  0011  GETMBR	R2	R0	K12
+      0x8C08051D,  //  0012  GETMET	R2	R2	K29
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
       0x80000000,  //  0015  RET	0
@@ -997,19 +955,13 @@ be_local_closure(class_Matter_Session_Store_get_session_by_source_node_id,   /* 
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_source_node_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(get_session_by_source_node_id),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
@@ -1019,20 +971,20 @@ be_local_closure(class_Matter_Session_Store_get_session_by_source_node_id,   /* 
       0x4C080000,  //  0003  LDNIL	R2
       0x80040400,  //  0004  RET	1	R2
       0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x580C0008,  //  0008  LDCONST	R3	K8
+      0x88100101,  //  0009  GETMBR	R4	R0	K1
       0x14140602,  //  000A  LT	R5	R3	R2
       0x78160008,  //  000B  JMPF	R5	#0015
       0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x88180B30,  //  000D  GETMBR	R6	R5	K48
       0x1C180C01,  //  000E  EQ	R6	R6	R1
       0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x8C180B2D,  //  0010  GETMET	R6	R5	K45
       0x7C180200,  //  0011  CALL	R6	1
       0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x000C0703,  //  0013  ADD	R3	R3	K3
       0x7001FFF4,  //  0014  JMP		#000A
       0x80000000,  //  0015  RET	0
     })
@@ -1048,45 +1000,38 @@ be_local_closure(class_Matter_Session_Store_next_fabric_idx,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(active_fabrics),
-    /* K3   */  be_nested_str_weak(fabric_index),
-    /* K4   */  be_nested_str_weak(int),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(next_fabric_idx),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040127,  //  0000  GETMET	R1	R0	K39
       0x7C040200,  //  0001  CALL	R1	1
-      0x58040001,  //  0002  LDCONST	R1	K1
+      0x58040003,  //  0002  LDCONST	R1	K3
       0x60080010,  //  0003  GETGBL	R2	G16
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x8C0C0125,  //  0004  GETMET	R3	R0	K37
       0x7C0C0200,  //  0005  CALL	R3	1
       0x7C080200,  //  0006  CALL	R2	1
       0xA802000C,  //  0007  EXBLK	0	#0015
       0x5C0C0400,  //  0008  MOVE	R3	R2
       0x7C0C0000,  //  0009  CALL	R3	0
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x88100739,  //  000A  GETMBR	R4	R3	K57
       0x60140004,  //  000B  GETGBL	R5	G4
       0x5C180800,  //  000C  MOVE	R6	R4
       0x7C140200,  //  000D  CALL	R5	1
-      0x1C140B04,  //  000E  EQ	R5	R5	K4
+      0x1C140B3A,  //  000E  EQ	R5	R5	K58
       0x78160003,  //  000F  JMPF	R5	#0014
       0x28140801,  //  0010  GE	R5	R4	R1
       0x78160001,  //  0011  JMPF	R5	#0014
-      0x00140901,  //  0012  ADD	R5	R4	K1
+      0x00140903,  //  0012  ADD	R5	R4	K3
       0x5C040A00,  //  0013  MOVE	R1	R5
       0x7001FFF2,  //  0014  JMP		#0008
-      0x58080005,  //  0015  LDCONST	R2	K5
+      0x5808001C,  //  0015  LDCONST	R2	K28
       0xAC080200,  //  0016  CATCH	R2	1	0
       0xB0080000,  //  0017  RAISE	2	R0	R0
       0x80040200,  //  0018  RET	1	R1
@@ -1103,139 +1048,110 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(path),
-    /* K2   */  be_nested_str_weak(remove_expired),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_FABRICS_TEMP),
-    /* K5   */  be_nested_str_weak(w),
-    /* K6   */  be_nested_str_weak(write),
-    /* K7   */  be_nested_str_weak(_X5B),
-    /* K8   */  be_nested_str_weak(fabrics),
-    /* K9   */  be_nested_str_weak(persistables),
-    /* K10  */  be_nested_str_weak(_sessions),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(_X2C),
-    /* K14  */  be_nested_str_weak(writejson),
-    /* K15  */  be_nested_str_weak(_X5D),
-    /* K16  */  be_nested_str_weak(close),
-    /* K17  */  be_nested_str_weak(remove),
-    /* K18  */  be_nested_str_weak(_FABRICS),
-    /* K19  */  be_nested_str_weak(rename),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
-    /* K22  */  be_const_int(2),
-    /* K23  */  be_nested_str_weak(device),
-    /* K24  */  be_nested_str_weak(event_fabrics_saved),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Saving_X20Fabrics_X20failed),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K27  */  be_nested_str_weak(_X7C),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(save_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[98]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0xA40A7600,  //  0001  IMPORT	R2	K59
       0xA802004D,  //  0002  EXBLK	0	#0051
-      0x8C0C0102,  //  0003  GETMET	R3	R0	K2
+      0x8C0C0127,  //  0003  GETMET	R3	R0	K39
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x580C0003,  //  0005  LDCONST	R3	K3
-      0x58100003,  //  0006  LDCONST	R4	K3
+      0x580C0008,  //  0005  LDCONST	R3	K8
+      0x58100008,  //  0006  LDCONST	R4	K8
       0x60140011,  //  0007  GETGBL	R5	G17
-      0x88180104,  //  0008  GETMBR	R6	R0	K4
-      0x581C0005,  //  0009  LDCONST	R7	K5
+      0x8818013C,  //  0008  GETMBR	R6	R0	K60
+      0x581C003D,  //  0009  LDCONST	R7	K61
       0x7C140400,  //  000A  CALL	R5	2
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x58200007,  //  000C  LDCONST	R8	K7
+      0x8C180B3E,  //  000B  GETMET	R6	R5	K62
+      0x5820003F,  //  000C  LDCONST	R8	K63
       0x7C180400,  //  000D  CALL	R6	2
       0x60180010,  //  000E  GETGBL	R6	G16
-      0x881C0108,  //  000F  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  0010  GETMET	R7	R7	K9
+      0x881C010C,  //  000F  GETMBR	R7	R0	K12
+      0x8C1C0F28,  //  0010  GETMET	R7	R7	K40
       0x7C1C0200,  //  0011  CALL	R7	1
       0x7C180200,  //  0012  CALL	R6	1
       0xA8020018,  //  0013  EXBLK	0	#002D
       0x5C1C0C00,  //  0014  MOVE	R7	R6
       0x7C1C0000,  //  0015  CALL	R7	0
       0x60200010,  //  0016  GETGBL	R8	G16
-      0x88240F0A,  //  0017  GETMBR	R9	R7	K10
-      0x8C241309,  //  0018  GETMET	R9	R9	K9
+      0x88240F19,  //  0017  GETMBR	R9	R7	K25
+      0x8C241328,  //  0018  GETMET	R9	R9	K40
       0x7C240200,  //  0019  CALL	R9	1
       0x7C200200,  //  001A  CALL	R8	1
       0xA8020003,  //  001B  EXBLK	0	#0020
       0x5C241000,  //  001C  MOVE	R9	R8
       0x7C240000,  //  001D  CALL	R9	0
-      0x000C070B,  //  001E  ADD	R3	R3	K11
+      0x000C0703,  //  001E  ADD	R3	R3	K3
       0x7001FFFB,  //  001F  JMP		#001C
-      0x5820000C,  //  0020  LDCONST	R8	K12
+      0x5820001C,  //  0020  LDCONST	R8	K28
       0xAC200200,  //  0021  CATCH	R8	1	0
       0xB0080000,  //  0022  RAISE	2	R0	R0
-      0x24200903,  //  0023  GT	R8	R4	K3
+      0x24200908,  //  0023  GT	R8	R4	K8
       0x78220002,  //  0024  JMPF	R8	#0028
-      0x8C200B06,  //  0025  GETMET	R8	R5	K6
-      0x5828000D,  //  0026  LDCONST	R10	K13
+      0x8C200B3E,  //  0025  GETMET	R8	R5	K62
+      0x58280040,  //  0026  LDCONST	R10	K64
       0x7C200400,  //  0027  CALL	R8	2
-      0x8C200F0E,  //  0028  GETMET	R8	R7	K14
+      0x8C200F41,  //  0028  GETMET	R8	R7	K65
       0x5C280A00,  //  0029  MOVE	R10	R5
       0x7C200400,  //  002A  CALL	R8	2
-      0x0010090B,  //  002B  ADD	R4	R4	K11
+      0x00100903,  //  002B  ADD	R4	R4	K3
       0x7001FFE6,  //  002C  JMP		#0014
-      0x5818000C,  //  002D  LDCONST	R6	K12
+      0x5818001C,  //  002D  LDCONST	R6	K28
       0xAC180200,  //  002E  CATCH	R6	1	0
       0xB0080000,  //  002F  RAISE	2	R0	R0
-      0x8C180B06,  //  0030  GETMET	R6	R5	K6
-      0x5820000F,  //  0031  LDCONST	R8	K15
+      0x8C180B3E,  //  0030  GETMET	R6	R5	K62
+      0x58200042,  //  0031  LDCONST	R8	K66
       0x7C180400,  //  0032  CALL	R6	2
-      0x8C180B10,  //  0033  GETMET	R6	R5	K16
+      0x8C180B0F,  //  0033  GETMET	R6	R5	K15
       0x7C180200,  //  0034  CALL	R6	1
-      0x8C180511,  //  0035  GETMET	R6	R2	K17
-      0x88200112,  //  0036  GETMBR	R8	R0	K18
+      0x8C180502,  //  0035  GETMET	R6	R2	K2
+      0x8820010D,  //  0036  GETMBR	R8	R0	K13
       0x7C180400,  //  0037  CALL	R6	2
-      0x8C180513,  //  0038  GETMET	R6	R2	K19
-      0x88200104,  //  0039  GETMBR	R8	R0	K4
-      0x88240112,  //  003A  GETMBR	R9	R0	K18
+      0x8C180543,  //  0038  GETMET	R6	R2	K67
+      0x8820013C,  //  0039  GETMBR	R8	R0	K60
+      0x8824010D,  //  003A  GETMBR	R9	R0	K13
       0x7C180600,  //  003B  CALL	R6	3
       0x781A000B,  //  003C  JMPF	R6	#0049
-      0xB81A2800,  //  003D  GETNGBL	R6	K20
+      0xB81A3C00,  //  003D  GETNGBL	R6	K30
       0x601C0018,  //  003E  GETGBL	R7	G24
-      0x58200015,  //  003F  LDCONST	R8	K21
+      0x58200044,  //  003F  LDCONST	R8	K68
       0x5C240800,  //  0040  MOVE	R9	R4
       0x5C280600,  //  0041  MOVE	R10	R3
       0x7C1C0600,  //  0042  CALL	R7	3
-      0x58200016,  //  0043  LDCONST	R8	K22
+      0x58200006,  //  0043  LDCONST	R8	K6
       0x7C180400,  //  0044  CALL	R6	2
-      0x88180117,  //  0045  GETMBR	R6	R0	K23
-      0x8C180D18,  //  0046  GETMET	R6	R6	K24
+      0x88180132,  //  0045  GETMBR	R6	R0	K50
+      0x8C180D45,  //  0046  GETMET	R6	R6	K69
       0x7C180200,  //  0047  CALL	R6	1
       0x70020005,  //  0048  JMP		#004F
-      0xB81A2800,  //  0049  GETNGBL	R6	K20
+      0xB81A3C00,  //  0049  GETNGBL	R6	K30
       0x601C0018,  //  004A  GETGBL	R7	G24
-      0x58200019,  //  004B  LDCONST	R8	K25
+      0x58200046,  //  004B  LDCONST	R8	K70
       0x7C1C0200,  //  004C  CALL	R7	1
-      0x58200016,  //  004D  LDCONST	R8	K22
+      0x58200006,  //  004D  LDCONST	R8	K6
       0x7C180400,  //  004E  CALL	R6	2
       0xA8040001,  //  004F  EXBLK	1	1
       0x7002000F,  //  0050  JMP		#0061
       0xAC0C0002,  //  0051  CATCH	R3	0	2
       0x7002000C,  //  0052  JMP		#0060
-      0xB8162800,  //  0053  GETNGBL	R5	K20
+      0xB8163C00,  //  0053  GETNGBL	R5	K30
       0x60180008,  //  0054  GETGBL	R6	G8
       0x5C1C0600,  //  0055  MOVE	R7	R3
       0x7C180200,  //  0056  CALL	R6	1
-      0x001A3406,  //  0057  ADD	R6	K26	R6
-      0x00180D1B,  //  0058  ADD	R6	R6	K27
+      0x001A8E06,  //  0057  ADD	R6	K71	R6
+      0x00180D22,  //  0058  ADD	R6	R6	K34
       0x601C0008,  //  0059  GETGBL	R7	G8
       0x5C200800,  //  005A  MOVE	R8	R4
       0x7C1C0200,  //  005B  CALL	R7	1
       0x00180C07,  //  005C  ADD	R6	R6	R7
-      0x581C0016,  //  005D  LDCONST	R7	K22
+      0x581C0006,  //  005D  LDCONST	R7	K6
       0x7C140400,  //  005E  CALL	R5	2
       0x70020000,  //  005F  JMP		#0061
       0xB0080000,  //  0060  RAISE	2	R0	R0
@@ -1253,41 +1169,34 @@ be_local_closure(class_Matter_Session_Store_create_session,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K1   */  be_nested_str_weak(remove_session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Session),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(create_session),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C0109,  //  0000  GETMET	R3	R0	K9
       0x5C140200,  //  0001  MOVE	R5	R1
       0x7C0C0400,  //  0002  CALL	R3	2
       0x4C100000,  //  0003  LDNIL	R4
       0x20100604,  //  0004  NE	R4	R3	R4
       0x78120002,  //  0005  JMPF	R4	#0009
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x8C100148,  //  0006  GETMET	R4	R0	K72
       0x5C180600,  //  0007  MOVE	R6	R3
       0x7C100400,  //  0008  CALL	R4	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
+      0xB8121400,  //  0009  GETNGBL	R4	K10
+      0x8C10091A,  //  000A  GETMET	R4	R4	K26
       0x5C180000,  //  000B  MOVE	R6	R0
       0x5C1C0200,  //  000C  MOVE	R7	R1
       0x5C200400,  //  000D  MOVE	R8	R2
       0x7C100800,  //  000E  CALL	R4	4
       0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x8C100905,  //  0011  GETMET	R4	R4	K5
+      0x88100101,  //  0010  GETMBR	R4	R0	K1
+      0x8C10091D,  //  0011  GETMET	R4	R4	K29
       0x5C180600,  //  0012  MOVE	R6	R3
       0x7C100400,  //  0013  CALL	R4	2
       0x80040600,  //  0014  RET	1	R3
@@ -1304,54 +1213,46 @@ be_local_closure(class_Matter_Session_Store_remove_fabric,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_fabric),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fabrics),
-    /* K6   */  be_nested_str_weak(find),
-    }),
+    &be_ktab_class_Matter_Session_Store,     /* shared constants */
     be_str_weak(remove_fabric),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
       0x4C0C0000,  //  0001  LDNIL	R3
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0011,  //  0003  JMPF	R2	#0016
-      0x58080001,  //  0004  LDCONST	R2	K1
+      0x58080000,  //  0004  LDCONST	R2	K0
       0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0007  CALL	R3	1
       0x140C0403,  //  0008  LT	R3	R2	R3
       0x780E000B,  //  0009  JMPF	R3	#0016
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
       0x940C0602,  //  000B  GETIDX	R3	R3	R2
-      0x880C0702,  //  000C  GETMBR	R3	R3	K2
+      0x880C0749,  //  000C  GETMBR	R3	R3	K73
       0x1C0C0601,  //  000D  EQ	R3	R3	R1
       0x780E0004,  //  000E  JMPF	R3	#0014
-      0x880C0100,  //  000F  GETMBR	R3	R0	K0
-      0x8C0C0703,  //  0010  GETMET	R3	R3	K3
+      0x880C0101,  //  000F  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0010  GETMET	R3	R3	K2
       0x5C140400,  //  0011  MOVE	R5	R2
       0x7C0C0400,  //  0012  CALL	R3	2
       0x70020000,  //  0013  JMP		#0015
-      0x00080504,  //  0014  ADD	R2	R2	K4
+      0x00080503,  //  0014  ADD	R2	R2	K3
       0x7001FFEE,  //  0015  JMP		#0005
-      0x88080105,  //  0016  GETMBR	R2	R0	K5
+      0x8808010C,  //  0016  GETMBR	R2	R0	K12
       0x4C0C0000,  //  0017  LDNIL	R3
       0x20080403,  //  0018  NE	R2	R2	R3
       0x780A0006,  //  0019  JMPF	R2	#0021
-      0x88080105,  //  001A  GETMBR	R2	R0	K5
-      0x8C080503,  //  001B  GETMET	R2	R2	K3
-      0x88100105,  //  001C  GETMBR	R4	R0	K5
-      0x8C100906,  //  001D  GETMET	R4	R4	K6
+      0x8808010C,  //  001A  GETMBR	R2	R0	K12
+      0x8C080502,  //  001B  GETMET	R2	R2	K2
+      0x8810010C,  //  001C  GETMBR	R4	R0	K12
+      0x8C100918,  //  001D  GETMET	R4	R4	K24
       0x5C180200,  //  001E  MOVE	R6	R1
       0x7C100400,  //  001F  CALL	R4	2
       0x7C080400,  //  0020  CALL	R2	2

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
@@ -3,6 +3,51 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Matter_TCP_async' ktab size: 41, total: 80 (saved 312 bytes)
+static const bvalue be_ktab_class_Matter_TCP_async[41] = {
+  /* K0   */  be_nested_str_weak(tcp_connected),
+  /* K1   */  be_nested_str_weak(tcp),
+  /* K2   */  be_nested_str_weak(read),
+  /* K3   */  be_nested_str_weak(reset),
+  /* K4   */  be_nested_str_weak(tasmota),
+  /* K5   */  be_nested_str_weak(wifi),
+  /* K6   */  be_nested_str_weak(up),
+  /* K7   */  be_nested_str_weak(eth),
+  /* K8   */  be_nested_str_weak(time_start),
+  /* K9   */  be_nested_str_weak(millis),
+  /* K10  */  be_nested_str_weak(status),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str_weak(connect),
+  /* K13  */  be_nested_str_weak(addr),
+  /* K14  */  be_nested_str_weak(port),
+  /* K15  */  be_nested_str_weak(fast_loop),
+  /* K16  */  be_nested_str_weak(remove_fast_loop),
+  /* K17  */  be_nested_str_weak(add_fast_loop),
+  /* K18  */  be_nested_str_weak(add_driver),
+  /* K19  */  be_nested_str_weak(log),
+  /* K20  */  be_nested_str_weak(BRY_X3A_X20failed_X20to_X20resolve_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K21  */  be_const_int(3),
+  /* K22  */  be_nested_str_weak(close),
+  /* K23  */  be_nested_str_weak(event_dnsfailed),
+  /* K24  */  be_nested_str_weak(readbytes),
+  /* K25  */  be_nested_str_weak(available),
+  /* K26  */  be_nested_str_weak(timeout),
+  /* K27  */  be_nested_str_weak(TIMEOUT),
+  /* K28  */  be_nested_str_weak(tcpclientasync),
+  /* K29  */  be_nested_str_weak(loop),
+  /* K30  */  be_nested_str_weak(write),
+  /* K31  */  be_nested_str_weak(connected),
+  /* K32  */  be_const_int(1),
+  /* K33  */  be_nested_str_weak(event_established),
+  /* K34  */  be_nested_str_weak(event_refused),
+  /* K35  */  be_nested_str_weak(event_timeout),
+  /* K36  */  be_nested_str_weak(event_closed),
+  /* K37  */  be_nested_str_weak(event_available),
+  /* K38  */  be_nested_str_weak(listening),
+  /* K39  */  be_nested_str_weak(event_listening),
+  /* K40  */  be_nested_str_weak(remove_driver),
+};
+
 
 extern const bclass be_class_Matter_TCP_async;
 
@@ -13,17 +58,13 @@ be_local_closure(class_Matter_TCP_async_read,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tcp),
-    /* K2   */  be_nested_str_weak(read),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(read),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
@@ -48,98 +89,74 @@ be_local_closure(class_Matter_TCP_async_begin,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(wifi),
-    /* K3   */  be_nested_str_weak(up),
-    /* K4   */  be_nested_str_weak(eth),
-    /* K5   */  be_nested_str_weak(time_start),
-    /* K6   */  be_nested_str_weak(millis),
-    /* K7   */  be_nested_str_weak(status),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(tcp),
-    /* K10  */  be_nested_str_weak(connect),
-    /* K11  */  be_nested_str_weak(addr),
-    /* K12  */  be_nested_str_weak(port),
-    /* K13  */  be_nested_str_weak(fast_loop),
-    /* K14  */  be_nested_str_weak(remove_fast_loop),
-    /* K15  */  be_nested_str_weak(add_fast_loop),
-    /* K16  */  be_nested_str_weak(add_driver),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(BRY_X3A_X20failed_X20to_X20resolve_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(close),
-    /* K21  */  be_nested_str_weak(tcp_connected),
-    /* K22  */  be_nested_str_weak(event_dnsfailed),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(begin),
     &be_const_str_solidified,
     ( &(const binstruction[62]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040103,  //  0000  GETMET	R1	R0	K3
       0x7C040200,  //  0001  CALL	R1	1
-      0xB8060200,  //  0002  GETNGBL	R1	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0xB8060800,  //  0002  GETNGBL	R1	K4
+      0x8C040305,  //  0003  GETMET	R1	R1	K5
       0x7C040200,  //  0004  CALL	R1	1
-      0x94040303,  //  0005  GETIDX	R1	R1	K3
+      0x94040306,  //  0005  GETIDX	R1	R1	K6
       0x74060006,  //  0006  JMPT	R1	#000E
-      0xB8060200,  //  0007  GETNGBL	R1	K1
-      0x8C040304,  //  0008  GETMET	R1	R1	K4
+      0xB8060800,  //  0007  GETNGBL	R1	K4
+      0x8C040307,  //  0008  GETMET	R1	R1	K7
       0x7C040200,  //  0009  CALL	R1	1
-      0x94040303,  //  000A  GETIDX	R1	R1	K3
+      0x94040306,  //  000A  GETIDX	R1	R1	K6
       0x74060001,  //  000B  JMPT	R1	#000E
       0x4C040000,  //  000C  LDNIL	R1
       0x80040200,  //  000D  RET	1	R1
-      0xB8060200,  //  000E  GETNGBL	R1	K1
-      0x8C040306,  //  000F  GETMET	R1	R1	K6
+      0xB8060800,  //  000E  GETNGBL	R1	K4
+      0x8C040309,  //  000F  GETMET	R1	R1	K9
       0x7C040200,  //  0010  CALL	R1	1
-      0x90020A01,  //  0011  SETMBR	R0	K5	R1
-      0x90020F08,  //  0012  SETMBR	R0	K7	K8
-      0x88040109,  //  0013  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0014  GETMET	R1	R1	K10
-      0x880C010B,  //  0015  GETMBR	R3	R0	K11
-      0x8810010C,  //  0016  GETMBR	R4	R0	K12
+      0x90021001,  //  0011  SETMBR	R0	K8	R1
+      0x9002150B,  //  0012  SETMBR	R0	K10	K11
+      0x88040101,  //  0013  GETMBR	R1	R0	K1
+      0x8C04030C,  //  0014  GETMET	R1	R1	K12
+      0x880C010D,  //  0015  GETMBR	R3	R0	K13
+      0x8810010E,  //  0016  GETMBR	R4	R0	K14
       0x7C040600,  //  0017  CALL	R1	3
       0x78060011,  //  0018  JMPF	R1	#002B
-      0x8804010D,  //  0019  GETMBR	R1	R0	K13
+      0x8804010F,  //  0019  GETMBR	R1	R0	K15
       0x78060008,  //  001A  JMPF	R1	#0024
-      0xB8060200,  //  001B  GETNGBL	R1	K1
-      0x8C04030E,  //  001C  GETMET	R1	R1	K14
-      0x880C010D,  //  001D  GETMBR	R3	R0	K13
+      0xB8060800,  //  001B  GETNGBL	R1	K4
+      0x8C040310,  //  001C  GETMET	R1	R1	K16
+      0x880C010F,  //  001D  GETMBR	R3	R0	K15
       0x7C040400,  //  001E  CALL	R1	2
-      0xB8060200,  //  001F  GETNGBL	R1	K1
-      0x8C04030F,  //  0020  GETMET	R1	R1	K15
-      0x880C010D,  //  0021  GETMBR	R3	R0	K13
+      0xB8060800,  //  001F  GETNGBL	R1	K4
+      0x8C040311,  //  0020  GETMET	R1	R1	K17
+      0x880C010F,  //  0021  GETMBR	R3	R0	K15
       0x7C040400,  //  0022  CALL	R1	2
       0x70020003,  //  0023  JMP		#0028
-      0xB8060200,  //  0024  GETNGBL	R1	K1
-      0x8C040310,  //  0025  GETMET	R1	R1	K16
+      0xB8060800,  //  0024  GETNGBL	R1	K4
+      0x8C040312,  //  0025  GETMET	R1	R1	K18
       0x5C0C0000,  //  0026  MOVE	R3	R0
       0x7C040400,  //  0027  CALL	R1	2
       0x50040200,  //  0028  LDBOOL	R1	1	0
       0x80040200,  //  0029  RET	1	R1
       0x70020011,  //  002A  JMP		#003D
-      0xB8062200,  //  002B  GETNGBL	R1	K17
+      0xB8062600,  //  002B  GETNGBL	R1	K19
       0x60080018,  //  002C  GETGBL	R2	G24
-      0x580C0012,  //  002D  LDCONST	R3	K18
-      0x8810010B,  //  002E  GETMBR	R4	R0	K11
-      0x8814010C,  //  002F  GETMBR	R5	R0	K12
+      0x580C0014,  //  002D  LDCONST	R3	K20
+      0x8810010D,  //  002E  GETMBR	R4	R0	K13
+      0x8814010E,  //  002F  GETMBR	R5	R0	K14
       0x7C080600,  //  0030  CALL	R2	3
-      0x580C0013,  //  0031  LDCONST	R3	K19
+      0x580C0015,  //  0031  LDCONST	R3	K21
       0x7C040400,  //  0032  CALL	R1	2
-      0x8C040114,  //  0033  GETMET	R1	R0	K20
+      0x8C040116,  //  0033  GETMET	R1	R0	K22
       0x7C040200,  //  0034  CALL	R1	1
       0x5405FFFE,  //  0035  LDINT	R1	-1
-      0x90020E01,  //  0036  SETMBR	R0	K7	R1
+      0x90021401,  //  0036  SETMBR	R0	K10	R1
       0x50040000,  //  0037  LDBOOL	R1	0	0
-      0x90022A01,  //  0038  SETMBR	R0	K21	R1
-      0x8C040116,  //  0039  GETMET	R1	R0	K22
+      0x90020001,  //  0038  SETMBR	R0	K0	R1
+      0x8C040117,  //  0039  GETMET	R1	R0	K23
       0x7C040200,  //  003A  CALL	R1	1
       0x50040000,  //  003B  LDBOOL	R1	0	0
       0x80040200,  //  003C  RET	1	R1
@@ -157,24 +174,20 @@ be_local_closure(class_Matter_TCP_async_readbytes,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tcp),
-    /* K2   */  be_nested_str_weak(readbytes),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(readbytes),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060003,  //  0001  JMPF	R1	#0006
       0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x8C040318,  //  0003  GETMET	R1	R1	K24
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
       0x4C040000,  //  0006  LDNIL	R1
@@ -192,13 +205,13 @@ be_local_closure(class_Matter_TCP_async_event_closed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_closed),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -216,28 +229,23 @@ be_local_closure(class_Matter_TCP_async_available,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tcp),
-    /* K2   */  be_nested_str_weak(available),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(available),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060003,  //  0001  JMPF	R1	#0006
       0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x8C040319,  //  0003  GETMET	R1	R1	K25
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
-      0x80060600,  //  0006  RET	1	K3
+      0x80061600,  //  0006  RET	1	K11
     })
   )
 );
@@ -251,13 +259,13 @@ be_local_closure(class_Matter_TCP_async_event_listening,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_listening),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -275,19 +283,17 @@ be_local_closure(class_Matter_TCP_async_get_timeout,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(timeout),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(get_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011A,  //  0000  GETMBR	R1	R0	K26
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -302,7 +308,7 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -332,22 +338,14 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TIMEOUT),
-    /* K1   */  be_nested_str_weak(addr),
-    /* K2   */  be_nested_str_weak(port),
-    /* K3   */  be_nested_str_weak(timeout),
-    /* K4   */  be_nested_str_weak(tcp),
-    /* K5   */  be_nested_str_weak(tcpclientasync),
-    /* K6   */  be_nested_str_weak(fast_loop),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x4C140000,  //  0000  LDNIL	R5
       0x1C140605,  //  0001  EQ	R5	R3	R5
       0x78160000,  //  0002  JMPF	R5	#0004
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x880C011B,  //  0003  GETMBR	R3	R0	K27
       0x4C140000,  //  0004  LDNIL	R5
       0x1C140405,  //  0005  EQ	R5	R2	R5
       0x78160000,  //  0006  JMPF	R5	#0008
@@ -355,18 +353,18 @@ be_local_closure(class_Matter_TCP_async_init,   /* name */
       0x60140008,  //  0008  GETGBL	R5	G8
       0x5C180200,  //  0009  MOVE	R6	R1
       0x7C140200,  //  000A  CALL	R5	1
-      0x90020205,  //  000B  SETMBR	R0	K1	R5
+      0x90021A05,  //  000B  SETMBR	R0	K13	R5
       0x60140009,  //  000C  GETGBL	R5	G9
       0x5C180400,  //  000D  MOVE	R6	R2
       0x7C140200,  //  000E  CALL	R5	1
-      0x90020405,  //  000F  SETMBR	R0	K2	R5
-      0x90020603,  //  0010  SETMBR	R0	K3	R3
-      0xB8160A00,  //  0011  GETNGBL	R5	K5
+      0x90021C05,  //  000F  SETMBR	R0	K14	R5
+      0x90023403,  //  0010  SETMBR	R0	K26	R3
+      0xB8163800,  //  0011  GETNGBL	R5	K28
       0x7C140000,  //  0012  CALL	R5	0
-      0x90020805,  //  0013  SETMBR	R0	K4	R5
+      0x90020205,  //  0013  SETMBR	R0	K1	R5
       0x78120001,  //  0014  JMPF	R4	#0017
       0x84140000,  //  0015  CLOSURE	R5	P0
-      0x90020C05,  //  0016  SETMBR	R0	K6	R5
+      0x90021E05,  //  0016  SETMBR	R0	K15	R5
       0xA0000000,  //  0017  CLOSE	R0
       0x80000000,  //  0018  RET	0
     })
@@ -382,19 +380,17 @@ be_local_closure(class_Matter_TCP_async_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(loop),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04011D,  //  0000  GETMET	R1	R0	K29
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -410,13 +406,13 @@ be_local_closure(class_Matter_TCP_async_event_timeout,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -434,13 +430,13 @@ be_local_closure(class_Matter_TCP_async_event_available,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_available),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -458,29 +454,24 @@ be_local_closure(class_Matter_TCP_async_write,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tcp),
-    /* K2   */  be_nested_str_weak(write),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(write),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x780A0004,  //  0001  JMPF	R2	#0007
       0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x8C08051E,  //  0003  GETMET	R2	R2	K30
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x80040400,  //  0006  RET	1	R2
-      0x80060600,  //  0007  RET	1	K3
+      0x80061600,  //  0007  RET	1	K11
     })
   )
 );
@@ -494,13 +485,13 @@ be_local_closure(class_Matter_TCP_async_event_established,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_established),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -518,25 +509,21 @@ be_local_closure(class_Matter_TCP_async_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp),
-    /* K1   */  be_nested_str_weak(close),
-    /* K2   */  be_nested_str_weak(tcp_connected),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040316,  //  0001  GETMET	R1	R1	K22
       0x7C040200,  //  0002  CALL	R1	1
       0x4C040000,  //  0003  LDNIL	R1
-      0x90020401,  //  0004  SETMBR	R0	K2	R1
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
       0x80000000,  //  0005  RET	0
     })
   )
@@ -551,45 +538,26 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(status),
-    /* K2   */  be_nested_str_weak(close),
-    /* K3   */  be_nested_str_weak(tcp),
-    /* K4   */  be_nested_str_weak(connected),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(event_established),
-    /* K7   */  be_nested_str_weak(event_refused),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(millis),
-    /* K10  */  be_nested_str_weak(time_start),
-    /* K11  */  be_nested_str_weak(timeout),
-    /* K12  */  be_nested_str_weak(event_timeout),
-    /* K13  */  be_nested_str_weak(event_closed),
-    /* K14  */  be_nested_str_weak(available),
-    /* K15  */  be_nested_str_weak(event_available),
-    /* K16  */  be_nested_str_weak(listening),
-    /* K17  */  be_nested_str_weak(event_listening),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(loop),
     &be_const_str_solidified,
     ( &(const binstruction[89]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8808010A,  //  0001  GETMBR	R2	R0	K10
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C080403,  //  0003  EQ	R2	R2	R3
       0x780A0002,  //  0004  JMPF	R2	#0008
-      0x8C080102,  //  0005  GETMET	R2	R0	K2
+      0x8C080116,  //  0005  GETMET	R2	R0	K22
       0x7C080200,  //  0006  CALL	R2	1
       0x80000400,  //  0007  RET	0
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
-      0x8C080504,  //  0009  GETMET	R2	R2	K4
+      0x88080101,  //  0008  GETMBR	R2	R0	K1
+      0x8C08051F,  //  0009  GETMET	R2	R2	K31
       0x7C080200,  //  000A  CALL	R2	1
       0x90020002,  //  000B  SETMBR	R0	K0	R2
       0x4C080000,  //  000C  LDNIL	R2
@@ -599,8 +567,8 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
       0x500C0200,  //  0010  LDBOOL	R3	1	0
       0x1C080403,  //  0011  EQ	R2	R2	R3
       0x780A0003,  //  0012  JMPF	R2	#0017
-      0x90020305,  //  0013  SETMBR	R0	K1	K5
-      0x8C080106,  //  0014  GETMET	R2	R0	K6
+      0x90021520,  //  0013  SETMBR	R0	K10	K32
+      0x8C080121,  //  0014  GETMET	R2	R0	K33
       0x7C080200,  //  0015  CALL	R2	1
       0x70020019,  //  0016  JMP		#0031
       0x88080100,  //  0017  GETMBR	R2	R0	K0
@@ -608,40 +576,40 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
       0x1C080403,  //  0019  EQ	R2	R2	R3
       0x780A0007,  //  001A  JMPF	R2	#0023
       0x5409FFFD,  //  001B  LDINT	R2	-2
-      0x90020202,  //  001C  SETMBR	R0	K1	R2
-      0x8C080107,  //  001D  GETMET	R2	R0	K7
+      0x90021402,  //  001C  SETMBR	R0	K10	R2
+      0x8C080122,  //  001D  GETMET	R2	R0	K34
       0x7C080200,  //  001E  CALL	R2	1
-      0x8C080102,  //  001F  GETMET	R2	R0	K2
+      0x8C080116,  //  001F  GETMET	R2	R0	K22
       0x7C080200,  //  0020  CALL	R2	1
       0x80000400,  //  0021  RET	0
       0x7002000D,  //  0022  JMP		#0031
-      0xB80A1000,  //  0023  GETNGBL	R2	K8
+      0xB80A0800,  //  0023  GETNGBL	R2	K4
       0x8C080509,  //  0024  GETMET	R2	R2	K9
       0x7C080200,  //  0025  CALL	R2	1
-      0x880C010A,  //  0026  GETMBR	R3	R0	K10
+      0x880C0108,  //  0026  GETMBR	R3	R0	K8
       0x04080403,  //  0027  SUB	R2	R2	R3
-      0x880C010B,  //  0028  GETMBR	R3	R0	K11
+      0x880C011A,  //  0028  GETMBR	R3	R0	K26
       0x24080403,  //  0029  GT	R2	R2	R3
       0x780A0005,  //  002A  JMPF	R2	#0031
       0x5409FFFC,  //  002B  LDINT	R2	-3
-      0x90020202,  //  002C  SETMBR	R0	K1	R2
+      0x90021402,  //  002C  SETMBR	R0	K10	R2
       0x50080000,  //  002D  LDBOOL	R2	0	0
       0x90020002,  //  002E  SETMBR	R0	K0	R2
-      0x8C08010C,  //  002F  GETMET	R2	R0	K12
+      0x8C080123,  //  002F  GETMET	R2	R0	K35
       0x7C080200,  //  0030  CALL	R2	1
-      0xB80A1000,  //  0031  GETNGBL	R2	K8
+      0xB80A0800,  //  0031  GETNGBL	R2	K4
       0x8C080509,  //  0032  GETMET	R2	R2	K9
       0x7C080200,  //  0033  CALL	R2	1
-      0x880C010A,  //  0034  GETMBR	R3	R0	K10
+      0x880C0108,  //  0034  GETMBR	R3	R0	K8
       0x04080403,  //  0035  SUB	R2	R2	R3
-      0x880C010B,  //  0036  GETMBR	R3	R0	K11
+      0x880C011A,  //  0036  GETMBR	R3	R0	K26
       0x24080403,  //  0037  GT	R2	R2	R3
       0x780A0006,  //  0038  JMPF	R2	#0040
-      0x8C080102,  //  0039  GETMET	R2	R0	K2
+      0x8C080116,  //  0039  GETMET	R2	R0	K22
       0x7C080200,  //  003A  CALL	R2	1
       0x5409FFFC,  //  003B  LDINT	R2	-3
-      0x90020202,  //  003C  SETMBR	R0	K1	R2
-      0x8C08010C,  //  003D  GETMET	R2	R0	K12
+      0x90021402,  //  003C  SETMBR	R0	K10	R2
+      0x8C080123,  //  003D  GETMET	R2	R0	K35
       0x7C080200,  //  003E  CALL	R2	1
       0x80000400,  //  003F  RET	0
       0x88080100,  //  0040  GETMBR	R2	R0	K0
@@ -651,22 +619,22 @@ be_local_closure(class_Matter_TCP_async_loop,   /* name */
       0x50080200,  //  0044  LDBOOL	R2	1	0
       0x1C080202,  //  0045  EQ	R2	R1	R2
       0x780A0001,  //  0046  JMPF	R2	#0049
-      0x8C08010D,  //  0047  GETMET	R2	R0	K13
+      0x8C080124,  //  0047  GETMET	R2	R0	K36
       0x7C080200,  //  0048  CALL	R2	1
-      0x8C080102,  //  0049  GETMET	R2	R0	K2
+      0x8C080116,  //  0049  GETMET	R2	R0	K22
       0x7C080200,  //  004A  CALL	R2	1
       0x80000400,  //  004B  RET	0
-      0x88080103,  //  004C  GETMBR	R2	R0	K3
-      0x8C08050E,  //  004D  GETMET	R2	R2	K14
+      0x88080101,  //  004C  GETMBR	R2	R0	K1
+      0x8C080519,  //  004D  GETMET	R2	R2	K25
       0x7C080200,  //  004E  CALL	R2	1
       0x780A0001,  //  004F  JMPF	R2	#0052
-      0x8C08010F,  //  0050  GETMET	R2	R0	K15
+      0x8C080125,  //  0050  GETMET	R2	R0	K37
       0x7C080200,  //  0051  CALL	R2	1
-      0x88080103,  //  0052  GETMBR	R2	R0	K3
-      0x8C080510,  //  0053  GETMET	R2	R2	K16
+      0x88080101,  //  0052  GETMBR	R2	R0	K1
+      0x8C080526,  //  0053  GETMET	R2	R2	K38
       0x7C080200,  //  0054  CALL	R2	1
       0x780A0001,  //  0055  JMPF	R2	#0058
-      0x8C080111,  //  0056  GETMET	R2	R0	K17
+      0x8C080127,  //  0056  GETMET	R2	R0	K39
       0x7C080200,  //  0057  CALL	R2	1
       0x80000000,  //  0058  RET	0
     })
@@ -682,24 +650,20 @@ be_local_closure(class_Matter_TCP_async_listening,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tcp),
-    /* K2   */  be_nested_str_weak(listening),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(listening),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x78060003,  //  0001  JMPF	R1	#0006
       0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x8C040326,  //  0003  GETMET	R1	R1	K38
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
       0x50040000,  //  0006  LDBOOL	R1	0	0
@@ -717,24 +681,21 @@ be_local_closure(class_Matter_TCP_async_set_timeout,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TIMEOUT),
-    /* K1   */  be_nested_str_weak(timeout),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(set_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0x8804011B,  //  0003  GETMBR	R1	R0	K27
+      0x90023401,  //  0004  SETMBR	R0	K26	R1
       0x80000000,  //  0005  RET	0
     })
   )
@@ -749,13 +710,13 @@ be_local_closure(class_Matter_TCP_async_event_dnsfailed,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_dnsfailed),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -773,47 +734,38 @@ be_local_closure(class_Matter_TCP_async_close,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp),
-    /* K1   */  be_nested_str_weak(close),
-    /* K2   */  be_nested_str_weak(fast_loop),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(remove_fast_loop),
-    /* K5   */  be_nested_str_weak(remove_driver),
-    /* K6   */  be_nested_str_weak(tcp_connected),
-    /* K7   */  be_nested_str_weak(event_closed),
-    }),
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(close),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040316,  //  0001  GETMET	R1	R1	K22
       0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8804010F,  //  0003  GETMBR	R1	R0	K15
       0x78060004,  //  0004  JMPF	R1	#000A
-      0xB8060600,  //  0005  GETNGBL	R1	K3
-      0x8C040304,  //  0006  GETMET	R1	R1	K4
-      0x880C0102,  //  0007  GETMBR	R3	R0	K2
+      0xB8060800,  //  0005  GETNGBL	R1	K4
+      0x8C040310,  //  0006  GETMET	R1	R1	K16
+      0x880C010F,  //  0007  GETMBR	R3	R0	K15
       0x7C040400,  //  0008  CALL	R1	2
       0x70020003,  //  0009  JMP		#000E
-      0xB8060600,  //  000A  GETNGBL	R1	K3
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040328,  //  000B  GETMET	R1	R1	K40
       0x5C0C0000,  //  000C  MOVE	R3	R0
       0x7C040400,  //  000D  CALL	R1	2
-      0x88040106,  //  000E  GETMBR	R1	R0	K6
+      0x88040100,  //  000E  GETMBR	R1	R0	K0
       0x50080200,  //  000F  LDBOOL	R2	1	0
       0x1C040202,  //  0010  EQ	R1	R1	R2
       0x78060001,  //  0011  JMPF	R1	#0014
-      0x8C040107,  //  0012  GETMET	R1	R0	K7
+      0x8C040124,  //  0012  GETMET	R1	R0	K36
       0x7C040200,  //  0013  CALL	R1	1
       0x50040000,  //  0014  LDBOOL	R1	0	0
-      0x90020C01,  //  0015  SETMBR	R0	K6	R1
+      0x90020001,  //  0015  SETMBR	R0	K0	R1
       0x80000000,  //  0016  RET	0
     })
   )
@@ -828,13 +780,13 @@ be_local_closure(class_Matter_TCP_async_event_refused,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TCP_async,     /* shared constants */
     be_str_weak(event_refused),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -3,6 +3,104 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Matter_TLV_item;
+// compact class 'Matter_TLV_item' ktab size: 93, total: 205 (saved 896 bytes)
+static const bvalue be_ktab_class_Matter_TLV_item[93] = {
+  /* K0   */  be_nested_str_weak(parent),
+  /* K1   */  be_nested_str_weak(next_idx),
+  /* K2   */  be_nested_str_weak(tag_vendor),
+  /* K3   */  be_nested_str_weak(tag_profile),
+  /* K4   */  be_nested_str_weak(tag_number),
+  /* K5   */  be_nested_str_weak(tag_sub),
+  /* K6   */  be_nested_str_weak(typ),
+  /* K7   */  be_nested_str_weak(val),
+  /* K8   */  be_nested_str_weak(reset),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_const_int(0),
+  /* K11  */  be_nested_str_weak(RAW),
+  /* K12  */  be_nested_str_weak(BFALSE),
+  /* K13  */  be_nested_str_weak(BTRUE),
+  /* K14  */  be_nested_str_weak(I2),
+  /* K15  */  be_nested_str_weak(I4),
+  /* K16  */  be_nested_str_weak(I1),
+  /* K17  */  be_nested_str_weak(U2),
+  /* K18  */  be_nested_str_weak(U4),
+  /* K19  */  be_nested_str_weak(U1),
+  /* K20  */  be_nested_str_weak(B1),
+  /* K21  */  be_nested_str_weak(B8),
+  /* K22  */  be_nested_str_weak(B2),
+  /* K23  */  be_nested_str_weak(B4),
+  /* K24  */  be_nested_str_weak(UTF1),
+  /* K25  */  be_nested_str_weak(UTF8),
+  /* K26  */  be_nested_str_weak(UTF2),
+  /* K27  */  be_nested_str_weak(UTF4),
+  /* K28  */  be_nested_str_weak(_encode_tag_len),
+  /* K29  */  be_const_int(1),
+  /* K30  */  be_const_int(2),
+  /* K31  */  be_nested_str_weak(I8),
+  /* K32  */  be_nested_str_weak(U8),
+  /* K33  */  be_nested_str_weak(FLOAT),
+  /* K34  */  be_nested_str_weak(DOUBLE),
+  /* K35  */  be_nested_str_weak(value_error),
+  /* K36  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
+  /* K37  */  be_nested_str_weak(NULL),
+  /* K38  */  be_nested_str_weak(unsupported_X20type_X20),
+  /* K39  */  be_nested_str_weak(),
+  /* K40  */  be_nested_str_weak(Matter_X3A_X3A),
+  /* K41  */  be_nested_str_weak(0x_X2508X_X20),
+  /* K42  */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+  /* K43  */  be_nested_str_weak(0x_X2504X_X3A),
+  /* K44  */  be_nested_str_weak(_X25i_X20),
+  /* K45  */  be_const_int(0),
+  /* K46  */  be_nested_str_weak(_X3D_X20),
+  /* K47  */  be_nested_str_weak(int),
+  /* K48  */  be_nested_str_weak(_X25i),
+  /* K49  */  be_nested_str_weak(U),
+  /* K50  */  be_nested_str_weak(bool),
+  /* K51  */  be_nested_str_weak(true),
+  /* K52  */  be_nested_str_weak(false),
+  /* K53  */  be_nested_str_weak(null),
+  /* K54  */  be_nested_str_weak(real),
+  /* K55  */  be_nested_str_weak(_X25g),
+  /* K56  */  be_nested_str_weak(string),
+  /* K57  */  be_nested_str_weak(_X22_X25s_X22),
+  /* K58  */  be_nested_str_weak(int64),
+  /* K59  */  be_nested_str_weak(tostring),
+  /* K60  */  be_nested_str_weak(instance),
+  /* K61  */  be_nested_str_weak(_X25s),
+  /* K62  */  be_nested_str_weak(tohex),
+  /* K63  */  be_nested_str_weak(_X20),
+  /* K64  */  be_nested_str_weak(_len),
+  /* K65  */  be_nested_str_weak(frombytes),
+  /* K66  */  be_nested_str_weak(geti),
+  /* K67  */  be_nested_str_weak(get),
+  /* K68  */  be_nested_str_weak(getfloat),
+  /* K69  */  be_nested_str_weak(asstring),
+  /* K70  */  be_nested_str_weak(EOC),
+  /* K71  */  be_nested_str_weak(log),
+  /* K72  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20eoc),
+  /* K73  */  be_const_int(3),
+  /* K74  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20type_X3A_X20),
+  /* K75  */  be_nested_str_weak(set_fulltag),
+  /* K76  */  be_nested_str_weak(add),
+  /* K77  */  be_const_class(be_class_Matter_TLV_item),
+  /* K78  */  be_const_int(1),
+  /* K79  */  be_nested_str_weak(_cmp_gt),
+  /* K80  */  be_nested_str_weak(stop_iteration),
+  /* K81  */  be_nested_str_weak(_encode_tag),
+  /* K82  */  be_nested_str_weak(copy),
+  /* K83  */  be_nested_str_weak(resize),
+  /* K84  */  be_nested_str_weak(tobytes),
+  /* K85  */  be_nested_str_weak(fromu32),
+  /* K86  */  be_nested_str_weak(setfloat),
+  /* K87  */  be_nested_str_weak(string_X20too_X20big),
+  /* K88  */  be_nested_str_weak(fromstring),
+  /* K89  */  be_nested_str_weak(frostring),
+  /* K90  */  be_nested_str_weak(bytes_X20too_X20big),
+  /* K91  */  be_const_int(3),
+  /* K92  */  be_const_int(2),
+};
+
 
 extern const bclass be_class_Matter_TLV_item;
 
@@ -13,22 +111,13 @@ be_local_closure(class_Matter_TLV_item_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    /* K1   */  be_nested_str_weak(next_idx),
-    /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(tag_profile),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    /* K6   */  be_nested_str_weak(typ),
-    /* K7   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(reset),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -55,21 +144,17 @@ be_local_closure(class_Matter_TLV_item_set_or_nil,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_or_nil),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C0108,  //  0000  GETMET	R3	R0	K8
       0x7C0C0200,  //  0001  CALL	R3	1
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C0C0403,  //  0003  EQ	R3	R2	R3
@@ -81,8 +166,8 @@ be_local_closure(class_Matter_TLV_item_set_or_nil,   /* name */
       0x540E0013,  //  0009  LDINT	R3	20
       0x1C0C0203,  //  000A  EQ	R3	R1	R3
       0x780E0002,  //  000B  JMPF	R3	#000F
-      0x90020201,  //  000C  SETMBR	R0	K1	R1
-      0x90020402,  //  000D  SETMBR	R0	K2	R2
+      0x90020C01,  //  000C  SETMBR	R0	K6	R1
+      0x90020E02,  //  000D  SETMBR	R0	K7	R2
       0x80040000,  //  000E  RET	1	R0
       0x80000000,  //  000F  RET	0
     })
@@ -98,86 +183,53 @@ be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[32]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(typ),
-    /* K3   */  be_nested_str_weak(RAW),
-    /* K4   */  be_nested_str_weak(val),
-    /* K5   */  be_nested_str_weak(BFALSE),
-    /* K6   */  be_nested_str_weak(BTRUE),
-    /* K7   */  be_nested_str_weak(I2),
-    /* K8   */  be_nested_str_weak(I4),
-    /* K9   */  be_nested_str_weak(I1),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_nested_str_weak(B1),
-    /* K14  */  be_nested_str_weak(B8),
-    /* K15  */  be_nested_str_weak(B2),
-    /* K16  */  be_nested_str_weak(B4),
-    /* K17  */  be_nested_str_weak(UTF1),
-    /* K18  */  be_nested_str_weak(UTF8),
-    /* K19  */  be_nested_str_weak(UTF2),
-    /* K20  */  be_nested_str_weak(UTF4),
-    /* K21  */  be_nested_str_weak(_encode_tag_len),
-    /* K22  */  be_const_int(1),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(I8),
-    /* K25  */  be_nested_str_weak(U8),
-    /* K26  */  be_nested_str_weak(FLOAT),
-    /* K27  */  be_nested_str_weak(DOUBLE),
-    /* K28  */  be_nested_str_weak(value_error),
-    /* K29  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
-    /* K30  */  be_nested_str_weak(NULL),
-    /* K31  */  be_nested_str_weak(unsupported_X20type_X20),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(encode_len),
     &be_const_str_solidified,
     ( &(const binstruction[258]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x88100303,  //  0003  GETMBR	R4	R1	K3
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x5808000A,  //  0001  LDCONST	R2	K10
+      0x880C0106,  //  0002  GETMBR	R3	R0	K6
+      0x8810030B,  //  0003  GETMBR	R4	R1	K11
       0x1C0C0604,  //  0004  EQ	R3	R3	R4
       0x780E0003,  //  0005  JMPF	R3	#000A
       0x600C000C,  //  0006  GETGBL	R3	G12
-      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x88100107,  //  0007  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0008  CALL	R3	1
       0x80040600,  //  0009  RET	1	R3
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x88100305,  //  000B  GETMBR	R4	R1	K5
+      0x880C0106,  //  000A  GETMBR	R3	R0	K6
+      0x8810030C,  //  000B  GETMBR	R4	R1	K12
       0x1C0C0604,  //  000C  EQ	R3	R3	R4
       0x740E0003,  //  000D  JMPT	R3	#0012
-      0x880C0102,  //  000E  GETMBR	R3	R0	K2
-      0x88100306,  //  000F  GETMBR	R4	R1	K6
+      0x880C0106,  //  000E  GETMBR	R3	R0	K6
+      0x8810030D,  //  000F  GETMBR	R4	R1	K13
       0x1C0C0604,  //  0010  EQ	R3	R3	R4
       0x780E0008,  //  0011  JMPF	R3	#001B
       0x600C0017,  //  0012  GETGBL	R3	G23
-      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x88100107,  //  0013  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0014  CALL	R3	1
       0x780E0001,  //  0015  JMPF	R3	#0018
-      0x880C0306,  //  0016  GETMBR	R3	R1	K6
+      0x880C030D,  //  0016  GETMBR	R3	R1	K13
       0x70020000,  //  0017  JMP		#0019
-      0x880C0305,  //  0018  GETMBR	R3	R1	K5
-      0x90020403,  //  0019  SETMBR	R0	K2	R3
+      0x880C030C,  //  0018  GETMBR	R3	R1	K12
+      0x90020C03,  //  0019  SETMBR	R0	K6	R3
       0x70020070,  //  001A  JMP		#008C
-      0x880C0102,  //  001B  GETMBR	R3	R0	K2
-      0x88100307,  //  001C  GETMBR	R4	R1	K7
+      0x880C0106,  //  001B  GETMBR	R3	R0	K6
+      0x8810030E,  //  001C  GETMBR	R4	R1	K14
       0x280C0604,  //  001D  GE	R3	R3	R4
       0x780E0018,  //  001E  JMPF	R3	#0038
-      0x880C0102,  //  001F  GETMBR	R3	R0	K2
-      0x88100308,  //  0020  GETMBR	R4	R1	K8
+      0x880C0106,  //  001F  GETMBR	R3	R0	K6
+      0x8810030F,  //  0020  GETMBR	R4	R1	K15
       0x180C0604,  //  0021  LE	R3	R3	R4
       0x780E0014,  //  0022  JMPF	R3	#0038
       0x600C0009,  //  0023  GETGBL	R3	G9
-      0x88100104,  //  0024  GETMBR	R4	R0	K4
+      0x88100107,  //  0024  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0025  CALL	R3	1
       0x5412007E,  //  0026  LDINT	R4	127
       0x18100604,  //  0027  LE	R4	R3	R4
@@ -185,8 +237,8 @@ be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
       0x5411FF7F,  //  0029  LDINT	R4	-128
       0x28100604,  //  002A  GE	R4	R3	R4
       0x78120002,  //  002B  JMPF	R4	#002F
-      0x88100309,  //  002C  GETMBR	R4	R1	K9
-      0x90020404,  //  002D  SETMBR	R0	K2	R4
+      0x88100310,  //  002C  GETMBR	R4	R1	K16
+      0x90020C04,  //  002D  SETMBR	R0	K6	R4
       0x70020007,  //  002E  JMP		#0037
       0x54127FFE,  //  002F  LDINT	R4	32767
       0x18100604,  //  0030  LE	R4	R3	R4
@@ -194,210 +246,210 @@ be_local_closure(class_Matter_TLV_item_encode_len,   /* name */
       0x54117FFF,  //  0032  LDINT	R4	-32768
       0x28100604,  //  0033  GE	R4	R3	R4
       0x78120001,  //  0034  JMPF	R4	#0037
-      0x88100307,  //  0035  GETMBR	R4	R1	K7
-      0x90020404,  //  0036  SETMBR	R0	K2	R4
+      0x8810030E,  //  0035  GETMBR	R4	R1	K14
+      0x90020C04,  //  0036  SETMBR	R0	K6	R4
       0x70020053,  //  0037  JMP		#008C
-      0x880C0102,  //  0038  GETMBR	R3	R0	K2
-      0x8810030A,  //  0039  GETMBR	R4	R1	K10
+      0x880C0106,  //  0038  GETMBR	R3	R0	K6
+      0x88100311,  //  0039  GETMBR	R4	R1	K17
       0x280C0604,  //  003A  GE	R3	R3	R4
       0x780E0016,  //  003B  JMPF	R3	#0053
-      0x880C0102,  //  003C  GETMBR	R3	R0	K2
-      0x8810030B,  //  003D  GETMBR	R4	R1	K11
+      0x880C0106,  //  003C  GETMBR	R3	R0	K6
+      0x88100312,  //  003D  GETMBR	R4	R1	K18
       0x180C0604,  //  003E  LE	R3	R3	R4
       0x780E0012,  //  003F  JMPF	R3	#0053
       0x600C0009,  //  0040  GETGBL	R3	G9
-      0x88100104,  //  0041  GETMBR	R4	R0	K4
+      0x88100107,  //  0041  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0042  CALL	R3	1
       0x541200FE,  //  0043  LDINT	R4	255
       0x18100604,  //  0044  LE	R4	R3	R4
       0x78120004,  //  0045  JMPF	R4	#004B
-      0x28100701,  //  0046  GE	R4	R3	K1
+      0x2810070A,  //  0046  GE	R4	R3	K10
       0x78120002,  //  0047  JMPF	R4	#004B
-      0x8810030C,  //  0048  GETMBR	R4	R1	K12
-      0x90020404,  //  0049  SETMBR	R0	K2	R4
+      0x88100313,  //  0048  GETMBR	R4	R1	K19
+      0x90020C04,  //  0049  SETMBR	R0	K6	R4
       0x70020006,  //  004A  JMP		#0052
       0x5412FFFE,  //  004B  LDINT	R4	65535
       0x18100604,  //  004C  LE	R4	R3	R4
       0x78120003,  //  004D  JMPF	R4	#0052
-      0x28100701,  //  004E  GE	R4	R3	K1
+      0x2810070A,  //  004E  GE	R4	R3	K10
       0x78120001,  //  004F  JMPF	R4	#0052
-      0x8810030A,  //  0050  GETMBR	R4	R1	K10
-      0x90020404,  //  0051  SETMBR	R0	K2	R4
+      0x88100311,  //  0050  GETMBR	R4	R1	K17
+      0x90020C04,  //  0051  SETMBR	R0	K6	R4
       0x70020038,  //  0052  JMP		#008C
-      0x880C0102,  //  0053  GETMBR	R3	R0	K2
-      0x8810030D,  //  0054  GETMBR	R4	R1	K13
+      0x880C0106,  //  0053  GETMBR	R3	R0	K6
+      0x88100314,  //  0054  GETMBR	R4	R1	K20
       0x280C0604,  //  0055  GE	R3	R3	R4
       0x780E0018,  //  0056  JMPF	R3	#0070
-      0x880C0102,  //  0057  GETMBR	R3	R0	K2
-      0x8810030E,  //  0058  GETMBR	R4	R1	K14
+      0x880C0106,  //  0057  GETMBR	R3	R0	K6
+      0x88100315,  //  0058  GETMBR	R4	R1	K21
       0x180C0604,  //  0059  LE	R3	R3	R4
       0x780E0014,  //  005A  JMPF	R3	#0070
       0x600C000C,  //  005B  GETGBL	R3	G12
-      0x88100104,  //  005C  GETMBR	R4	R0	K4
+      0x88100107,  //  005C  GETMBR	R4	R0	K7
       0x7C0C0200,  //  005D  CALL	R3	1
       0x541200FE,  //  005E  LDINT	R4	255
       0x180C0604,  //  005F  LE	R3	R3	R4
       0x780E0002,  //  0060  JMPF	R3	#0064
-      0x880C030D,  //  0061  GETMBR	R3	R1	K13
-      0x90020403,  //  0062  SETMBR	R0	K2	R3
+      0x880C0314,  //  0061  GETMBR	R3	R1	K20
+      0x90020C03,  //  0062  SETMBR	R0	K6	R3
       0x7002000A,  //  0063  JMP		#006F
       0x600C000C,  //  0064  GETGBL	R3	G12
-      0x88100104,  //  0065  GETMBR	R4	R0	K4
+      0x88100107,  //  0065  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0066  CALL	R3	1
       0x5412FFFE,  //  0067  LDINT	R4	65535
       0x180C0604,  //  0068  LE	R3	R3	R4
       0x780E0002,  //  0069  JMPF	R3	#006D
-      0x880C030F,  //  006A  GETMBR	R3	R1	K15
-      0x90020403,  //  006B  SETMBR	R0	K2	R3
+      0x880C0316,  //  006A  GETMBR	R3	R1	K22
+      0x90020C03,  //  006B  SETMBR	R0	K6	R3
       0x70020001,  //  006C  JMP		#006F
-      0x880C0310,  //  006D  GETMBR	R3	R1	K16
-      0x90020403,  //  006E  SETMBR	R0	K2	R3
+      0x880C0317,  //  006D  GETMBR	R3	R1	K23
+      0x90020C03,  //  006E  SETMBR	R0	K6	R3
       0x7002001B,  //  006F  JMP		#008C
-      0x880C0102,  //  0070  GETMBR	R3	R0	K2
-      0x88100311,  //  0071  GETMBR	R4	R1	K17
+      0x880C0106,  //  0070  GETMBR	R3	R0	K6
+      0x88100318,  //  0071  GETMBR	R4	R1	K24
       0x280C0604,  //  0072  GE	R3	R3	R4
       0x780E0017,  //  0073  JMPF	R3	#008C
-      0x880C0102,  //  0074  GETMBR	R3	R0	K2
-      0x88100312,  //  0075  GETMBR	R4	R1	K18
+      0x880C0106,  //  0074  GETMBR	R3	R0	K6
+      0x88100319,  //  0075  GETMBR	R4	R1	K25
       0x180C0604,  //  0076  LE	R3	R3	R4
       0x780E0013,  //  0077  JMPF	R3	#008C
       0x600C000C,  //  0078  GETGBL	R3	G12
-      0x88100104,  //  0079  GETMBR	R4	R0	K4
+      0x88100107,  //  0079  GETMBR	R4	R0	K7
       0x7C0C0200,  //  007A  CALL	R3	1
       0x541200FE,  //  007B  LDINT	R4	255
       0x180C0604,  //  007C  LE	R3	R3	R4
       0x780E0002,  //  007D  JMPF	R3	#0081
-      0x880C0311,  //  007E  GETMBR	R3	R1	K17
-      0x90020403,  //  007F  SETMBR	R0	K2	R3
+      0x880C0318,  //  007E  GETMBR	R3	R1	K24
+      0x90020C03,  //  007F  SETMBR	R0	K6	R3
       0x7002000A,  //  0080  JMP		#008C
       0x600C000C,  //  0081  GETGBL	R3	G12
-      0x88100104,  //  0082  GETMBR	R4	R0	K4
+      0x88100107,  //  0082  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0083  CALL	R3	1
       0x5412FFFE,  //  0084  LDINT	R4	65535
       0x180C0604,  //  0085  LE	R3	R3	R4
       0x780E0002,  //  0086  JMPF	R3	#008A
-      0x880C0313,  //  0087  GETMBR	R3	R1	K19
-      0x90020403,  //  0088  SETMBR	R0	K2	R3
+      0x880C031A,  //  0087  GETMBR	R3	R1	K26
+      0x90020C03,  //  0088  SETMBR	R0	K6	R3
       0x70020001,  //  0089  JMP		#008C
-      0x880C0314,  //  008A  GETMBR	R3	R1	K20
-      0x90020403,  //  008B  SETMBR	R0	K2	R3
-      0x8C0C0115,  //  008C  GETMET	R3	R0	K21
+      0x880C031B,  //  008A  GETMBR	R3	R1	K27
+      0x90020C03,  //  008B  SETMBR	R0	K6	R3
+      0x8C0C011C,  //  008C  GETMET	R3	R0	K28
       0x7C0C0200,  //  008D  CALL	R3	1
       0x00080403,  //  008E  ADD	R2	R2	R3
-      0x880C0102,  //  008F  GETMBR	R3	R0	K2
-      0x88100309,  //  0090  GETMBR	R4	R1	K9
+      0x880C0106,  //  008F  GETMBR	R3	R0	K6
+      0x88100310,  //  0090  GETMBR	R4	R1	K16
       0x1C0C0604,  //  0091  EQ	R3	R3	R4
       0x740E0003,  //  0092  JMPT	R3	#0097
-      0x880C0102,  //  0093  GETMBR	R3	R0	K2
-      0x8810030C,  //  0094  GETMBR	R4	R1	K12
+      0x880C0106,  //  0093  GETMBR	R3	R0	K6
+      0x88100313,  //  0094  GETMBR	R4	R1	K19
       0x1C0C0604,  //  0095  EQ	R3	R3	R4
       0x780E0001,  //  0096  JMPF	R3	#0099
-      0x00080516,  //  0097  ADD	R2	R2	K22
+      0x0008051D,  //  0097  ADD	R2	R2	K29
       0x70020067,  //  0098  JMP		#0101
-      0x880C0102,  //  0099  GETMBR	R3	R0	K2
-      0x88100307,  //  009A  GETMBR	R4	R1	K7
+      0x880C0106,  //  0099  GETMBR	R3	R0	K6
+      0x8810030E,  //  009A  GETMBR	R4	R1	K14
       0x1C0C0604,  //  009B  EQ	R3	R3	R4
       0x740E0003,  //  009C  JMPT	R3	#00A1
-      0x880C0102,  //  009D  GETMBR	R3	R0	K2
-      0x8810030A,  //  009E  GETMBR	R4	R1	K10
+      0x880C0106,  //  009D  GETMBR	R3	R0	K6
+      0x88100311,  //  009E  GETMBR	R4	R1	K17
       0x1C0C0604,  //  009F  EQ	R3	R3	R4
       0x780E0001,  //  00A0  JMPF	R3	#00A3
-      0x00080517,  //  00A1  ADD	R2	R2	K23
+      0x0008051E,  //  00A1  ADD	R2	R2	K30
       0x7002005D,  //  00A2  JMP		#0101
-      0x880C0102,  //  00A3  GETMBR	R3	R0	K2
-      0x88100308,  //  00A4  GETMBR	R4	R1	K8
+      0x880C0106,  //  00A3  GETMBR	R3	R0	K6
+      0x8810030F,  //  00A4  GETMBR	R4	R1	K15
       0x1C0C0604,  //  00A5  EQ	R3	R3	R4
       0x740E0003,  //  00A6  JMPT	R3	#00AB
-      0x880C0102,  //  00A7  GETMBR	R3	R0	K2
-      0x8810030B,  //  00A8  GETMBR	R4	R1	K11
+      0x880C0106,  //  00A7  GETMBR	R3	R0	K6
+      0x88100312,  //  00A8  GETMBR	R4	R1	K18
       0x1C0C0604,  //  00A9  EQ	R3	R3	R4
       0x780E0002,  //  00AA  JMPF	R3	#00AE
       0x540E0003,  //  00AB  LDINT	R3	4
       0x00080403,  //  00AC  ADD	R2	R2	R3
       0x70020052,  //  00AD  JMP		#0101
-      0x880C0102,  //  00AE  GETMBR	R3	R0	K2
-      0x88100318,  //  00AF  GETMBR	R4	R1	K24
+      0x880C0106,  //  00AE  GETMBR	R3	R0	K6
+      0x8810031F,  //  00AF  GETMBR	R4	R1	K31
       0x1C0C0604,  //  00B0  EQ	R3	R3	R4
       0x740E0003,  //  00B1  JMPT	R3	#00B6
-      0x880C0102,  //  00B2  GETMBR	R3	R0	K2
-      0x88100319,  //  00B3  GETMBR	R4	R1	K25
+      0x880C0106,  //  00B2  GETMBR	R3	R0	K6
+      0x88100320,  //  00B3  GETMBR	R4	R1	K32
       0x1C0C0604,  //  00B4  EQ	R3	R3	R4
       0x780E0002,  //  00B5  JMPF	R3	#00B9
       0x540E0007,  //  00B6  LDINT	R3	8
       0x00080403,  //  00B7  ADD	R2	R2	R3
       0x70020047,  //  00B8  JMP		#0101
-      0x880C0102,  //  00B9  GETMBR	R3	R0	K2
-      0x88100305,  //  00BA  GETMBR	R4	R1	K5
+      0x880C0106,  //  00B9  GETMBR	R3	R0	K6
+      0x8810030C,  //  00BA  GETMBR	R4	R1	K12
       0x1C0C0604,  //  00BB  EQ	R3	R3	R4
       0x740E0003,  //  00BC  JMPT	R3	#00C1
-      0x880C0102,  //  00BD  GETMBR	R3	R0	K2
-      0x88100306,  //  00BE  GETMBR	R4	R1	K6
+      0x880C0106,  //  00BD  GETMBR	R3	R0	K6
+      0x8810030D,  //  00BE  GETMBR	R4	R1	K13
       0x1C0C0604,  //  00BF  EQ	R3	R3	R4
       0x780E0000,  //  00C0  JMPF	R3	#00C2
       0x7002003E,  //  00C1  JMP		#0101
-      0x880C0102,  //  00C2  GETMBR	R3	R0	K2
-      0x8810031A,  //  00C3  GETMBR	R4	R1	K26
+      0x880C0106,  //  00C2  GETMBR	R3	R0	K6
+      0x88100321,  //  00C3  GETMBR	R4	R1	K33
       0x1C0C0604,  //  00C4  EQ	R3	R3	R4
       0x780E0002,  //  00C5  JMPF	R3	#00C9
       0x540E0003,  //  00C6  LDINT	R3	4
       0x00080403,  //  00C7  ADD	R2	R2	R3
       0x70020037,  //  00C8  JMP		#0101
-      0x880C0102,  //  00C9  GETMBR	R3	R0	K2
-      0x8810031B,  //  00CA  GETMBR	R4	R1	K27
+      0x880C0106,  //  00C9  GETMBR	R3	R0	K6
+      0x88100322,  //  00CA  GETMBR	R4	R1	K34
       0x1C0C0604,  //  00CB  EQ	R3	R3	R4
       0x780E0001,  //  00CC  JMPF	R3	#00CF
-      0xB006391D,  //  00CD  RAISE	1	K28	K29
+      0xB0064724,  //  00CD  RAISE	1	K35	K36
       0x70020031,  //  00CE  JMP		#0101
-      0x880C0102,  //  00CF  GETMBR	R3	R0	K2
-      0x88100311,  //  00D0  GETMBR	R4	R1	K17
+      0x880C0106,  //  00CF  GETMBR	R3	R0	K6
+      0x88100318,  //  00D0  GETMBR	R4	R1	K24
       0x1C0C0604,  //  00D1  EQ	R3	R3	R4
       0x780E0005,  //  00D2  JMPF	R3	#00D9
       0x600C000C,  //  00D3  GETGBL	R3	G12
-      0x88100104,  //  00D4  GETMBR	R4	R0	K4
+      0x88100107,  //  00D4  GETMBR	R4	R0	K7
       0x7C0C0200,  //  00D5  CALL	R3	1
-      0x000E2C03,  //  00D6  ADD	R3	K22	R3
+      0x000E3A03,  //  00D6  ADD	R3	K29	R3
       0x00080403,  //  00D7  ADD	R2	R2	R3
       0x70020027,  //  00D8  JMP		#0101
-      0x880C0102,  //  00D9  GETMBR	R3	R0	K2
-      0x88100313,  //  00DA  GETMBR	R4	R1	K19
+      0x880C0106,  //  00D9  GETMBR	R3	R0	K6
+      0x8810031A,  //  00DA  GETMBR	R4	R1	K26
       0x1C0C0604,  //  00DB  EQ	R3	R3	R4
       0x780E0005,  //  00DC  JMPF	R3	#00E3
       0x600C000C,  //  00DD  GETGBL	R3	G12
-      0x88100104,  //  00DE  GETMBR	R4	R0	K4
+      0x88100107,  //  00DE  GETMBR	R4	R0	K7
       0x7C0C0200,  //  00DF  CALL	R3	1
-      0x000E2E03,  //  00E0  ADD	R3	K23	R3
+      0x000E3C03,  //  00E0  ADD	R3	K30	R3
       0x00080403,  //  00E1  ADD	R2	R2	R3
       0x7002001D,  //  00E2  JMP		#0101
-      0x880C0102,  //  00E3  GETMBR	R3	R0	K2
-      0x8810030D,  //  00E4  GETMBR	R4	R1	K13
+      0x880C0106,  //  00E3  GETMBR	R3	R0	K6
+      0x88100314,  //  00E4  GETMBR	R4	R1	K20
       0x1C0C0604,  //  00E5  EQ	R3	R3	R4
       0x780E0005,  //  00E6  JMPF	R3	#00ED
       0x600C000C,  //  00E7  GETGBL	R3	G12
-      0x88100104,  //  00E8  GETMBR	R4	R0	K4
+      0x88100107,  //  00E8  GETMBR	R4	R0	K7
       0x7C0C0200,  //  00E9  CALL	R3	1
-      0x000E2C03,  //  00EA  ADD	R3	K22	R3
+      0x000E3A03,  //  00EA  ADD	R3	K29	R3
       0x00080403,  //  00EB  ADD	R2	R2	R3
       0x70020013,  //  00EC  JMP		#0101
-      0x880C0102,  //  00ED  GETMBR	R3	R0	K2
-      0x8810030F,  //  00EE  GETMBR	R4	R1	K15
+      0x880C0106,  //  00ED  GETMBR	R3	R0	K6
+      0x88100316,  //  00EE  GETMBR	R4	R1	K22
       0x1C0C0604,  //  00EF  EQ	R3	R3	R4
       0x780E0005,  //  00F0  JMPF	R3	#00F7
       0x600C000C,  //  00F1  GETGBL	R3	G12
-      0x88100104,  //  00F2  GETMBR	R4	R0	K4
+      0x88100107,  //  00F2  GETMBR	R4	R0	K7
       0x7C0C0200,  //  00F3  CALL	R3	1
-      0x000E2E03,  //  00F4  ADD	R3	K23	R3
+      0x000E3C03,  //  00F4  ADD	R3	K30	R3
       0x00080403,  //  00F5  ADD	R2	R2	R3
       0x70020009,  //  00F6  JMP		#0101
-      0x880C0102,  //  00F7  GETMBR	R3	R0	K2
-      0x8810031E,  //  00F8  GETMBR	R4	R1	K30
+      0x880C0106,  //  00F7  GETMBR	R3	R0	K6
+      0x88100325,  //  00F8  GETMBR	R4	R1	K37
       0x1C0C0604,  //  00F9  EQ	R3	R3	R4
       0x780E0000,  //  00FA  JMPF	R3	#00FC
       0x70020004,  //  00FB  JMP		#0101
       0x600C0008,  //  00FC  GETGBL	R3	G8
-      0x88100102,  //  00FD  GETMBR	R4	R0	K2
+      0x88100106,  //  00FD  GETMBR	R4	R0	K6
       0x7C0C0200,  //  00FE  CALL	R3	1
-      0x000E3E03,  //  00FF  ADD	R3	K31	R3
-      0xB0063803,  //  0100  RAISE	1	K28	R3
+      0x000E4C03,  //  00FF  ADD	R3	K38	R3
+      0xB0064603,  //  0100  RAISE	1	K35	R3
       0x80040400,  //  0101  RET	1	R2
     })
   )
@@ -412,21 +464,17 @@ be_local_closure(class_Matter_TLV_item_set,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C0108,  //  0000  GETMET	R3	R0	K8
       0x7C0C0200,  //  0001  CALL	R3	1
       0x4C0C0000,  //  0002  LDNIL	R3
       0x200C0403,  //  0003  NE	R3	R2	R3
@@ -434,8 +482,8 @@ be_local_closure(class_Matter_TLV_item_set,   /* name */
       0x540E0013,  //  0005  LDINT	R3	20
       0x1C0C0203,  //  0006  EQ	R3	R1	R3
       0x780E0002,  //  0007  JMPF	R3	#000B
-      0x90020201,  //  0008  SETMBR	R0	K1	R1
-      0x90020402,  //  0009  SETMBR	R0	K2	R2
+      0x90020C01,  //  0008  SETMBR	R0	K6	R1
+      0x90020E02,  //  0009  SETMBR	R0	K7	R2
       0x80040000,  //  000A  RET	1	R0
       0x80000000,  //  000B  RET	0
     })
@@ -451,13 +499,13 @@ be_local_closure(class_Matter_TLV_item_to_TLV,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(to_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -475,205 +523,170 @@ be_local_closure(class_Matter_TLV_item_tostring,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[34]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(tag_profile),
-    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K3   */  be_nested_str_weak(tag_number),
-    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K5   */  be_nested_str_weak(tag_vendor),
-    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K8   */  be_nested_str_weak(tag_sub),
-    /* K9   */  be_nested_str_weak(_X25i_X20),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(_X3D_X20),
-    /* K12  */  be_nested_str_weak(val),
-    /* K13  */  be_nested_str_weak(int),
-    /* K14  */  be_nested_str_weak(_X25i),
-    /* K15  */  be_nested_str_weak(typ),
-    /* K16  */  be_nested_str_weak(TLV),
-    /* K17  */  be_nested_str_weak(U1),
-    /* K18  */  be_nested_str_weak(U8),
-    /* K19  */  be_nested_str_weak(U),
-    /* K20  */  be_nested_str_weak(bool),
-    /* K21  */  be_nested_str_weak(true),
-    /* K22  */  be_nested_str_weak(false),
-    /* K23  */  be_nested_str_weak(null),
-    /* K24  */  be_nested_str_weak(real),
-    /* K25  */  be_nested_str_weak(_X25g),
-    /* K26  */  be_nested_str_weak(string),
-    /* K27  */  be_nested_str_weak(_X22_X25s_X22),
-    /* K28  */  be_nested_str_weak(int64),
-    /* K29  */  be_nested_str_weak(tostring),
-    /* K30  */  be_nested_str_weak(instance),
-    /* K31  */  be_nested_str_weak(_X25s),
-    /* K32  */  be_nested_str_weak(tohex),
-    /* K33  */  be_nested_str_weak(_X20),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[167]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080027,  //  0000  LDCONST	R2	K39
       0xA802009C,  //  0001  EXBLK	0	#009F
       0x500C0200,  //  0002  LDBOOL	R3	1	0
       0x200C0203,  //  0003  NE	R3	R1	R3
       0x780E0038,  //  0004  JMPF	R3	#003E
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
       0x5411FFFE,  //  0006  LDINT	R4	-1
       0x1C0C0604,  //  0007  EQ	R3	R3	R4
       0x780E000A,  //  0008  JMPF	R3	#0014
-      0x00080502,  //  0009  ADD	R2	R2	K2
-      0x880C0103,  //  000A  GETMBR	R3	R0	K3
+      0x00080528,  //  0009  ADD	R2	R2	K40
+      0x880C0104,  //  000A  GETMBR	R3	R0	K4
       0x4C100000,  //  000B  LDNIL	R4
       0x200C0604,  //  000C  NE	R3	R3	R4
       0x780E0004,  //  000D  JMPF	R3	#0013
       0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100004,  //  000F  LDCONST	R4	K4
-      0x88140103,  //  0010  GETMBR	R5	R0	K3
+      0x58100029,  //  000F  LDCONST	R4	K41
+      0x88140104,  //  0010  GETMBR	R5	R0	K4
       0x7C0C0400,  //  0011  CALL	R3	2
       0x00080403,  //  0012  ADD	R2	R2	R3
       0x70020023,  //  0013  JMP		#0038
-      0x880C0105,  //  0014  GETMBR	R3	R0	K5
+      0x880C0102,  //  0014  GETMBR	R3	R0	K2
       0x4C100000,  //  0015  LDNIL	R4
       0x200C0604,  //  0016  NE	R3	R3	R4
       0x780E0004,  //  0017  JMPF	R3	#001D
       0x600C0018,  //  0018  GETGBL	R3	G24
-      0x58100006,  //  0019  LDCONST	R4	K6
-      0x88140105,  //  001A  GETMBR	R5	R0	K5
+      0x5810002A,  //  0019  LDCONST	R4	K42
+      0x88140102,  //  001A  GETMBR	R5	R0	K2
       0x7C0C0400,  //  001B  CALL	R3	2
       0x00080403,  //  001C  ADD	R2	R2	R3
-      0x880C0101,  //  001D  GETMBR	R3	R0	K1
+      0x880C0103,  //  001D  GETMBR	R3	R0	K3
       0x4C100000,  //  001E  LDNIL	R4
       0x200C0604,  //  001F  NE	R3	R3	R4
       0x780E0004,  //  0020  JMPF	R3	#0026
       0x600C0018,  //  0021  GETGBL	R3	G24
-      0x58100007,  //  0022  LDCONST	R4	K7
-      0x88140101,  //  0023  GETMBR	R5	R0	K1
+      0x5810002B,  //  0022  LDCONST	R4	K43
+      0x88140103,  //  0023  GETMBR	R5	R0	K3
       0x7C0C0400,  //  0024  CALL	R3	2
       0x00080403,  //  0025  ADD	R2	R2	R3
-      0x880C0103,  //  0026  GETMBR	R3	R0	K3
+      0x880C0104,  //  0026  GETMBR	R3	R0	K4
       0x4C100000,  //  0027  LDNIL	R4
       0x200C0604,  //  0028  NE	R3	R3	R4
       0x780E0004,  //  0029  JMPF	R3	#002F
       0x600C0018,  //  002A  GETGBL	R3	G24
-      0x58100004,  //  002B  LDCONST	R4	K4
-      0x88140103,  //  002C  GETMBR	R5	R0	K3
+      0x58100029,  //  002B  LDCONST	R4	K41
+      0x88140104,  //  002C  GETMBR	R5	R0	K4
       0x7C0C0400,  //  002D  CALL	R3	2
       0x00080403,  //  002E  ADD	R2	R2	R3
-      0x880C0108,  //  002F  GETMBR	R3	R0	K8
+      0x880C0105,  //  002F  GETMBR	R3	R0	K5
       0x4C100000,  //  0030  LDNIL	R4
       0x200C0604,  //  0031  NE	R3	R3	R4
       0x780E0004,  //  0032  JMPF	R3	#0038
       0x600C0018,  //  0033  GETGBL	R3	G24
-      0x58100009,  //  0034  LDCONST	R4	K9
-      0x88140108,  //  0035  GETMBR	R5	R0	K8
+      0x5810002C,  //  0034  LDCONST	R4	K44
+      0x88140105,  //  0035  GETMBR	R5	R0	K5
       0x7C0C0400,  //  0036  CALL	R3	2
       0x00080403,  //  0037  ADD	R2	R2	R3
       0x600C000C,  //  0038  GETGBL	R3	G12
       0x5C100400,  //  0039  MOVE	R4	R2
       0x7C0C0200,  //  003A  CALL	R3	1
-      0x240C070A,  //  003B  GT	R3	R3	K10
+      0x240C072D,  //  003B  GT	R3	R3	K45
       0x780E0000,  //  003C  JMPF	R3	#003E
-      0x0008050B,  //  003D  ADD	R2	R2	K11
+      0x0008052E,  //  003D  ADD	R2	R2	K46
       0x600C0004,  //  003E  GETGBL	R3	G4
-      0x8810010C,  //  003F  GETMBR	R4	R0	K12
+      0x88100107,  //  003F  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0040  CALL	R3	1
-      0x1C0C070D,  //  0041  EQ	R3	R3	K13
+      0x1C0C072F,  //  0041  EQ	R3	R3	K47
       0x780E0010,  //  0042  JMPF	R3	#0054
       0x600C0018,  //  0043  GETGBL	R3	G24
-      0x5810000E,  //  0044  LDCONST	R4	K14
-      0x8814010C,  //  0045  GETMBR	R5	R0	K12
+      0x58100030,  //  0044  LDCONST	R4	K48
+      0x88140107,  //  0045  GETMBR	R5	R0	K7
       0x7C0C0400,  //  0046  CALL	R3	2
       0x00080403,  //  0047  ADD	R2	R2	R3
-      0x880C010F,  //  0048  GETMBR	R3	R0	K15
-      0x88100110,  //  0049  GETMBR	R4	R0	K16
-      0x88100911,  //  004A  GETMBR	R4	R4	K17
+      0x880C0106,  //  0048  GETMBR	R3	R0	K6
+      0x88100109,  //  0049  GETMBR	R4	R0	K9
+      0x88100913,  //  004A  GETMBR	R4	R4	K19
       0x280C0604,  //  004B  GE	R3	R3	R4
       0x780E0005,  //  004C  JMPF	R3	#0053
-      0x880C010F,  //  004D  GETMBR	R3	R0	K15
-      0x88100110,  //  004E  GETMBR	R4	R0	K16
-      0x88100912,  //  004F  GETMBR	R4	R4	K18
+      0x880C0106,  //  004D  GETMBR	R3	R0	K6
+      0x88100109,  //  004E  GETMBR	R4	R0	K9
+      0x88100920,  //  004F  GETMBR	R4	R4	K32
       0x180C0604,  //  0050  LE	R3	R3	R4
       0x780E0000,  //  0051  JMPF	R3	#0053
-      0x00080513,  //  0052  ADD	R2	R2	K19
+      0x00080531,  //  0052  ADD	R2	R2	K49
       0x70020048,  //  0053  JMP		#009D
       0x600C0004,  //  0054  GETGBL	R3	G4
-      0x8810010C,  //  0055  GETMBR	R4	R0	K12
+      0x88100107,  //  0055  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0056  CALL	R3	1
-      0x1C0C0714,  //  0057  EQ	R3	R3	K20
+      0x1C0C0732,  //  0057  EQ	R3	R3	K50
       0x780E0006,  //  0058  JMPF	R3	#0060
-      0x880C010C,  //  0059  GETMBR	R3	R0	K12
+      0x880C0107,  //  0059  GETMBR	R3	R0	K7
       0x780E0001,  //  005A  JMPF	R3	#005D
-      0x580C0015,  //  005B  LDCONST	R3	K21
+      0x580C0033,  //  005B  LDCONST	R3	K51
       0x70020000,  //  005C  JMP		#005E
-      0x580C0016,  //  005D  LDCONST	R3	K22
+      0x580C0034,  //  005D  LDCONST	R3	K52
       0x00080403,  //  005E  ADD	R2	R2	R3
       0x7002003C,  //  005F  JMP		#009D
-      0x880C010C,  //  0060  GETMBR	R3	R0	K12
+      0x880C0107,  //  0060  GETMBR	R3	R0	K7
       0x4C100000,  //  0061  LDNIL	R4
       0x1C0C0604,  //  0062  EQ	R3	R3	R4
       0x780E0001,  //  0063  JMPF	R3	#0066
-      0x00080517,  //  0064  ADD	R2	R2	K23
+      0x00080535,  //  0064  ADD	R2	R2	K53
       0x70020036,  //  0065  JMP		#009D
       0x600C0004,  //  0066  GETGBL	R3	G4
-      0x8810010C,  //  0067  GETMBR	R4	R0	K12
+      0x88100107,  //  0067  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0068  CALL	R3	1
-      0x1C0C0718,  //  0069  EQ	R3	R3	K24
+      0x1C0C0736,  //  0069  EQ	R3	R3	K54
       0x780E0005,  //  006A  JMPF	R3	#0071
       0x600C0018,  //  006B  GETGBL	R3	G24
-      0x58100019,  //  006C  LDCONST	R4	K25
-      0x8814010C,  //  006D  GETMBR	R5	R0	K12
+      0x58100037,  //  006C  LDCONST	R4	K55
+      0x88140107,  //  006D  GETMBR	R5	R0	K7
       0x7C0C0400,  //  006E  CALL	R3	2
       0x00080403,  //  006F  ADD	R2	R2	R3
       0x7002002B,  //  0070  JMP		#009D
       0x600C0004,  //  0071  GETGBL	R3	G4
-      0x8810010C,  //  0072  GETMBR	R4	R0	K12
+      0x88100107,  //  0072  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0073  CALL	R3	1
-      0x1C0C071A,  //  0074  EQ	R3	R3	K26
+      0x1C0C0738,  //  0074  EQ	R3	R3	K56
       0x780E0005,  //  0075  JMPF	R3	#007C
       0x600C0018,  //  0076  GETGBL	R3	G24
-      0x5810001B,  //  0077  LDCONST	R4	K27
-      0x8814010C,  //  0078  GETMBR	R5	R0	K12
+      0x58100039,  //  0077  LDCONST	R4	K57
+      0x88140107,  //  0078  GETMBR	R5	R0	K7
       0x7C0C0400,  //  0079  CALL	R3	2
       0x00080403,  //  007A  ADD	R2	R2	R3
       0x70020020,  //  007B  JMP		#009D
       0x600C000F,  //  007C  GETGBL	R3	G15
-      0x8810010C,  //  007D  GETMBR	R4	R0	K12
-      0xB8163800,  //  007E  GETNGBL	R5	K28
+      0x88100107,  //  007D  GETMBR	R4	R0	K7
+      0xB8167400,  //  007E  GETNGBL	R5	K58
       0x7C0C0400,  //  007F  CALL	R3	2
       0x780E000F,  //  0080  JMPF	R3	#0091
-      0x880C010C,  //  0081  GETMBR	R3	R0	K12
-      0x8C0C071D,  //  0082  GETMET	R3	R3	K29
+      0x880C0107,  //  0081  GETMBR	R3	R0	K7
+      0x8C0C073B,  //  0082  GETMET	R3	R3	K59
       0x7C0C0200,  //  0083  CALL	R3	1
       0x00080403,  //  0084  ADD	R2	R2	R3
-      0x880C010F,  //  0085  GETMBR	R3	R0	K15
-      0x88100110,  //  0086  GETMBR	R4	R0	K16
-      0x88100911,  //  0087  GETMBR	R4	R4	K17
+      0x880C0106,  //  0085  GETMBR	R3	R0	K6
+      0x88100109,  //  0086  GETMBR	R4	R0	K9
+      0x88100913,  //  0087  GETMBR	R4	R4	K19
       0x280C0604,  //  0088  GE	R3	R3	R4
       0x780E0005,  //  0089  JMPF	R3	#0090
-      0x880C010F,  //  008A  GETMBR	R3	R0	K15
-      0x88100110,  //  008B  GETMBR	R4	R0	K16
-      0x88100912,  //  008C  GETMBR	R4	R4	K18
+      0x880C0106,  //  008A  GETMBR	R3	R0	K6
+      0x88100109,  //  008B  GETMBR	R4	R0	K9
+      0x88100920,  //  008C  GETMBR	R4	R4	K32
       0x180C0604,  //  008D  LE	R3	R3	R4
       0x780E0000,  //  008E  JMPF	R3	#0090
-      0x00080513,  //  008F  ADD	R2	R2	K19
+      0x00080531,  //  008F  ADD	R2	R2	K49
       0x7002000B,  //  0090  JMP		#009D
       0x600C0004,  //  0091  GETGBL	R3	G4
-      0x8810010C,  //  0092  GETMBR	R4	R0	K12
+      0x88100107,  //  0092  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0093  CALL	R3	1
-      0x1C0C071E,  //  0094  EQ	R3	R3	K30
+      0x1C0C073C,  //  0094  EQ	R3	R3	K60
       0x780E0006,  //  0095  JMPF	R3	#009D
       0x600C0018,  //  0096  GETGBL	R3	G24
-      0x5810001F,  //  0097  LDCONST	R4	K31
-      0x8814010C,  //  0098  GETMBR	R5	R0	K12
-      0x8C140B20,  //  0099  GETMET	R5	R5	K32
+      0x5810003D,  //  0097  LDCONST	R4	K61
+      0x88140107,  //  0098  GETMBR	R5	R0	K7
+      0x8C140B3E,  //  0099  GETMET	R5	R5	K62
       0x7C140200,  //  009A  CALL	R5	1
       0x7C0C0400,  //  009B  CALL	R3	2
       0x00080403,  //  009C  ADD	R2	R2	R3
@@ -681,7 +694,7 @@ be_local_closure(class_Matter_TLV_item_tostring,   /* name */
       0x70020006,  //  009E  JMP		#00A6
       0xAC0C0002,  //  009F  CATCH	R3	0	2
       0x70020003,  //  00A0  JMP		#00A5
-      0x00140721,  //  00A1  ADD	R5	R3	K33
+      0x0014073F,  //  00A1  ADD	R5	R3	K63
       0x00140A04,  //  00A2  ADD	R5	R5	R4
       0x80040A00,  //  00A3  RET	1	R5
       0x70020000,  //  00A4  JMP		#00A6
@@ -700,127 +713,110 @@ be_local_closure(class_Matter_TLV_item_to_str_val,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(int),
-    /* K2   */  be_nested_str_weak(typ),
-    /* K3   */  be_nested_str_weak(TLV),
-    /* K4   */  be_nested_str_weak(U1),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(U),
-    /* K7   */  be_nested_str_weak(bool),
-    /* K8   */  be_nested_str_weak(true),
-    /* K9   */  be_nested_str_weak(false),
-    /* K10  */  be_nested_str_weak(null),
-    /* K11  */  be_nested_str_weak(real),
-    /* K12  */  be_nested_str_weak(string),
-    /* K13  */  be_nested_str_weak(int64),
-    /* K14  */  be_nested_str_weak(tostring),
-    /* K15  */  be_nested_str_weak(instance),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(to_str_val),
     &be_const_str_solidified,
     ( &(const binstruction[98]) {  /* code */
       0x60040004,  //  0000  GETGBL	R1	G4
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080107,  //  0001  GETMBR	R2	R0	K7
       0x7C040200,  //  0002  CALL	R1	1
-      0x1C040301,  //  0003  EQ	R1	R1	K1
+      0x1C04032F,  //  0003  EQ	R1	R1	K47
       0x78060014,  //  0004  JMPF	R1	#001A
-      0x88040102,  //  0005  GETMBR	R1	R0	K2
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
-      0x88080504,  //  0007  GETMBR	R2	R2	K4
+      0x88040106,  //  0005  GETMBR	R1	R0	K6
+      0x88080109,  //  0006  GETMBR	R2	R0	K9
+      0x88080513,  //  0007  GETMBR	R2	R2	K19
       0x28040202,  //  0008  GE	R1	R1	R2
       0x7806000A,  //  0009  JMPF	R1	#0015
-      0x88040102,  //  000A  GETMBR	R1	R0	K2
-      0x88080103,  //  000B  GETMBR	R2	R0	K3
-      0x88080505,  //  000C  GETMBR	R2	R2	K5
+      0x88040106,  //  000A  GETMBR	R1	R0	K6
+      0x88080109,  //  000B  GETMBR	R2	R0	K9
+      0x88080520,  //  000C  GETMBR	R2	R2	K32
       0x18040202,  //  000D  LE	R1	R1	R2
       0x78060005,  //  000E  JMPF	R1	#0015
       0x60040008,  //  000F  GETGBL	R1	G8
-      0x88080100,  //  0010  GETMBR	R2	R0	K0
+      0x88080107,  //  0010  GETMBR	R2	R0	K7
       0x7C040200,  //  0011  CALL	R1	1
-      0x00040306,  //  0012  ADD	R1	R1	K6
+      0x00040331,  //  0012  ADD	R1	R1	K49
       0x80040200,  //  0013  RET	1	R1
       0x70020003,  //  0014  JMP		#0019
       0x60040008,  //  0015  GETGBL	R1	G8
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
+      0x88080107,  //  0016  GETMBR	R2	R0	K7
       0x7C040200,  //  0017  CALL	R1	1
       0x80040200,  //  0018  RET	1	R1
       0x70020046,  //  0019  JMP		#0061
       0x60040004,  //  001A  GETGBL	R1	G4
-      0x88080100,  //  001B  GETMBR	R2	R0	K0
+      0x88080107,  //  001B  GETMBR	R2	R0	K7
       0x7C040200,  //  001C  CALL	R1	1
-      0x1C040307,  //  001D  EQ	R1	R1	K7
+      0x1C040332,  //  001D  EQ	R1	R1	K50
       0x78060006,  //  001E  JMPF	R1	#0026
-      0x88040100,  //  001F  GETMBR	R1	R0	K0
+      0x88040107,  //  001F  GETMBR	R1	R0	K7
       0x78060001,  //  0020  JMPF	R1	#0023
-      0x58040008,  //  0021  LDCONST	R1	K8
+      0x58040033,  //  0021  LDCONST	R1	K51
       0x70020000,  //  0022  JMP		#0024
-      0x58040009,  //  0023  LDCONST	R1	K9
+      0x58040034,  //  0023  LDCONST	R1	K52
       0x80040200,  //  0024  RET	1	R1
       0x7002003A,  //  0025  JMP		#0061
-      0x88040100,  //  0026  GETMBR	R1	R0	K0
+      0x88040107,  //  0026  GETMBR	R1	R0	K7
       0x4C080000,  //  0027  LDNIL	R2
       0x1C040202,  //  0028  EQ	R1	R1	R2
       0x78060001,  //  0029  JMPF	R1	#002C
-      0x80061400,  //  002A  RET	1	K10
+      0x80066A00,  //  002A  RET	1	K53
       0x70020034,  //  002B  JMP		#0061
       0x60040004,  //  002C  GETGBL	R1	G4
-      0x88080100,  //  002D  GETMBR	R2	R0	K0
+      0x88080107,  //  002D  GETMBR	R2	R0	K7
       0x7C040200,  //  002E  CALL	R1	1
-      0x1C04030B,  //  002F  EQ	R1	R1	K11
+      0x1C040336,  //  002F  EQ	R1	R1	K54
       0x78060004,  //  0030  JMPF	R1	#0036
       0x60040008,  //  0031  GETGBL	R1	G8
-      0x88080100,  //  0032  GETMBR	R2	R0	K0
+      0x88080107,  //  0032  GETMBR	R2	R0	K7
       0x7C040200,  //  0033  CALL	R1	1
       0x80040200,  //  0034  RET	1	R1
       0x7002002A,  //  0035  JMP		#0061
       0x60040004,  //  0036  GETGBL	R1	G4
-      0x88080100,  //  0037  GETMBR	R2	R0	K0
+      0x88080107,  //  0037  GETMBR	R2	R0	K7
       0x7C040200,  //  0038  CALL	R1	1
-      0x1C04030C,  //  0039  EQ	R1	R1	K12
+      0x1C040338,  //  0039  EQ	R1	R1	K56
       0x78060002,  //  003A  JMPF	R1	#003E
-      0x88040100,  //  003B  GETMBR	R1	R0	K0
+      0x88040107,  //  003B  GETMBR	R1	R0	K7
       0x80040200,  //  003C  RET	1	R1
       0x70020022,  //  003D  JMP		#0061
       0x6004000F,  //  003E  GETGBL	R1	G15
-      0x88080100,  //  003F  GETMBR	R2	R0	K0
-      0xB80E1A00,  //  0040  GETNGBL	R3	K13
+      0x88080107,  //  003F  GETMBR	R2	R0	K7
+      0xB80E7400,  //  0040  GETNGBL	R3	K58
       0x7C040400,  //  0041  CALL	R1	2
       0x78060014,  //  0042  JMPF	R1	#0058
-      0x88040102,  //  0043  GETMBR	R1	R0	K2
-      0x88080103,  //  0044  GETMBR	R2	R0	K3
-      0x88080504,  //  0045  GETMBR	R2	R2	K4
+      0x88040106,  //  0043  GETMBR	R1	R0	K6
+      0x88080109,  //  0044  GETMBR	R2	R0	K9
+      0x88080513,  //  0045  GETMBR	R2	R2	K19
       0x28040202,  //  0046  GE	R1	R1	R2
       0x7806000A,  //  0047  JMPF	R1	#0053
-      0x88040102,  //  0048  GETMBR	R1	R0	K2
-      0x88080103,  //  0049  GETMBR	R2	R0	K3
-      0x88080505,  //  004A  GETMBR	R2	R2	K5
+      0x88040106,  //  0048  GETMBR	R1	R0	K6
+      0x88080109,  //  0049  GETMBR	R2	R0	K9
+      0x88080520,  //  004A  GETMBR	R2	R2	K32
       0x18040202,  //  004B  LE	R1	R1	R2
       0x78060005,  //  004C  JMPF	R1	#0053
-      0x88040100,  //  004D  GETMBR	R1	R0	K0
-      0x8C04030E,  //  004E  GETMET	R1	R1	K14
+      0x88040107,  //  004D  GETMBR	R1	R0	K7
+      0x8C04033B,  //  004E  GETMET	R1	R1	K59
       0x7C040200,  //  004F  CALL	R1	1
-      0x00040306,  //  0050  ADD	R1	R1	K6
+      0x00040331,  //  0050  ADD	R1	R1	K49
       0x80040200,  //  0051  RET	1	R1
       0x70020003,  //  0052  JMP		#0057
-      0x88040100,  //  0053  GETMBR	R1	R0	K0
-      0x8C04030E,  //  0054  GETMET	R1	R1	K14
+      0x88040107,  //  0053  GETMBR	R1	R0	K7
+      0x8C04033B,  //  0054  GETMET	R1	R1	K59
       0x7C040200,  //  0055  CALL	R1	1
       0x80040200,  //  0056  RET	1	R1
       0x70020008,  //  0057  JMP		#0061
       0x60040004,  //  0058  GETGBL	R1	G4
-      0x88080100,  //  0059  GETMBR	R2	R0	K0
+      0x88080107,  //  0059  GETMBR	R2	R0	K7
       0x7C040200,  //  005A  CALL	R1	1
-      0x1C04030F,  //  005B  EQ	R1	R1	K15
+      0x1C04033C,  //  005B  EQ	R1	R1	K60
       0x78060003,  //  005C  JMPF	R1	#0061
-      0x8C04010E,  //  005D  GETMET	R1	R0	K14
+      0x8C04013B,  //  005D  GETMET	R1	R0	K59
       0x500C0200,  //  005E  LDBOOL	R3	1	0
       0x7C040400,  //  005F  CALL	R1	2
       0x80040200,  //  0060  RET	1	R1
@@ -838,35 +834,30 @@ be_local_closure(class_Matter_TLV_item_set_fulltag,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_vendor),
-    /* K1   */  be_nested_str_weak(tag_profile),
-    /* K2   */  be_nested_str_weak(tag_number),
-    /* K3   */  be_nested_str_weak(tag_sub),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_fulltag),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
       0x60100009,  //  0000  GETGBL	R4	G9
       0x5C140200,  //  0001  MOVE	R5	R1
       0x7C100200,  //  0002  CALL	R4	1
-      0x90020004,  //  0003  SETMBR	R0	K0	R4
+      0x90020404,  //  0003  SETMBR	R0	K2	R4
       0x60100009,  //  0004  GETGBL	R4	G9
       0x5C140400,  //  0005  MOVE	R5	R2
       0x7C100200,  //  0006  CALL	R4	1
-      0x90020204,  //  0007  SETMBR	R0	K1	R4
+      0x90020604,  //  0007  SETMBR	R0	K3	R4
       0x60100009,  //  0008  GETGBL	R4	G9
       0x5C140600,  //  0009  MOVE	R5	R3
       0x7C100200,  //  000A  CALL	R4	1
-      0x90020404,  //  000B  SETMBR	R0	K2	R4
+      0x90020804,  //  000B  SETMBR	R0	K4	R4
       0x4C100000,  //  000C  LDNIL	R4
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x90020A04,  //  000D  SETMBR	R0	K5	R4
       0x80000000,  //  000E  RET	0
     })
   )
@@ -881,92 +872,67 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(typ),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(_len),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(int64),
-    /* K5   */  be_nested_str_weak(frombytes),
-    /* K6   */  be_nested_str_weak(BFALSE),
-    /* K7   */  be_nested_str_weak(BTRUE),
-    /* K8   */  be_nested_str_weak(U8),
-    /* K9   */  be_nested_str_weak(I8),
-    /* K10  */  be_nested_str_weak(geti),
-    /* K11  */  be_nested_str_weak(get),
-    /* K12  */  be_nested_str_weak(FLOAT),
-    /* K13  */  be_nested_str_weak(getfloat),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(UTF8),
-    /* K16  */  be_nested_str_weak(asstring),
-    /* K17  */  be_nested_str_weak(NULL),
-    /* K18  */  be_nested_str_weak(EOC),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20eoc),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20type_X3A_X20),
-    /* K23  */  be_nested_str_weak(next_idx),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[101]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x88140902,  //  0002  GETMBR	R5	R4	K2
+      0x880C0106,  //  0000  GETMBR	R3	R0	K6
+      0x88100109,  //  0001  GETMBR	R4	R0	K9
+      0x88140940,  //  0002  GETMBR	R5	R4	K64
       0x94140A03,  //  0003  GETIDX	R5	R5	R3
       0x541A0007,  //  0004  LDINT	R6	8
       0x1C180A06,  //  0005  EQ	R6	R5	R6
       0x781A0008,  //  0006  JMPF	R6	#0010
-      0xB81A0800,  //  0007  GETNGBL	R6	K4
-      0x8C180D05,  //  0008  GETMET	R6	R6	K5
+      0xB81A7400,  //  0007  GETNGBL	R6	K58
+      0x8C180D41,  //  0008  GETMET	R6	R6	K65
       0x5C200200,  //  0009  MOVE	R8	R1
       0x5C240400,  //  000A  MOVE	R9	R2
       0x7C180600,  //  000B  CALL	R6	3
-      0x90020606,  //  000C  SETMBR	R0	K3	R6
+      0x90020E06,  //  000C  SETMBR	R0	K7	R6
       0x541A0007,  //  000D  LDINT	R6	8
       0x00080406,  //  000E  ADD	R2	R2	R6
       0x70020052,  //  000F  JMP		#0063
-      0x88180906,  //  0010  GETMBR	R6	R4	K6
+      0x8818090C,  //  0010  GETMBR	R6	R4	K12
       0x1C180606,  //  0011  EQ	R6	R3	R6
       0x741A0002,  //  0012  JMPT	R6	#0016
-      0x88180907,  //  0013  GETMBR	R6	R4	K7
+      0x8818090D,  //  0013  GETMBR	R6	R4	K13
       0x1C180606,  //  0014  EQ	R6	R3	R6
       0x781A0003,  //  0015  JMPF	R6	#001A
-      0x88180907,  //  0016  GETMBR	R6	R4	K7
+      0x8818090D,  //  0016  GETMBR	R6	R4	K13
       0x1C180606,  //  0017  EQ	R6	R3	R6
-      0x90020606,  //  0018  SETMBR	R0	K3	R6
+      0x90020E06,  //  0018  SETMBR	R0	K7	R6
       0x70020048,  //  0019  JMP		#0063
-      0x88180908,  //  001A  GETMBR	R6	R4	K8
+      0x88180920,  //  001A  GETMBR	R6	R4	K32
       0x14180606,  //  001B  LT	R6	R3	R6
       0x781A000E,  //  001C  JMPF	R6	#002C
-      0x88180909,  //  001D  GETMBR	R6	R4	K9
+      0x8818091F,  //  001D  GETMBR	R6	R4	K31
       0x18180606,  //  001E  LE	R6	R3	R6
       0x781A0004,  //  001F  JMPF	R6	#0025
-      0x8C18030A,  //  0020  GETMET	R6	R1	K10
+      0x8C180342,  //  0020  GETMET	R6	R1	K66
       0x5C200400,  //  0021  MOVE	R8	R2
       0x5C240A00,  //  0022  MOVE	R9	R5
       0x7C180600,  //  0023  CALL	R6	3
       0x70020003,  //  0024  JMP		#0029
-      0x8C18030B,  //  0025  GETMET	R6	R1	K11
+      0x8C180343,  //  0025  GETMET	R6	R1	K67
       0x5C200400,  //  0026  MOVE	R8	R2
       0x5C240A00,  //  0027  MOVE	R9	R5
       0x7C180600,  //  0028  CALL	R6	3
-      0x90020606,  //  0029  SETMBR	R0	K3	R6
+      0x90020E06,  //  0029  SETMBR	R0	K7	R6
       0x00080405,  //  002A  ADD	R2	R2	R5
       0x70020036,  //  002B  JMP		#0063
-      0x8818090C,  //  002C  GETMBR	R6	R4	K12
+      0x88180921,  //  002C  GETMBR	R6	R4	K33
       0x1C180606,  //  002D  EQ	R6	R3	R6
       0x781A0006,  //  002E  JMPF	R6	#0036
-      0x8C18030D,  //  002F  GETMET	R6	R1	K13
+      0x8C180344,  //  002F  GETMET	R6	R1	K68
       0x5C200400,  //  0030  MOVE	R8	R2
       0x7C180400,  //  0031  CALL	R6	2
-      0x90020606,  //  0032  SETMBR	R0	K3	R6
+      0x90020E06,  //  0032  SETMBR	R0	K7	R6
       0x541A0003,  //  0033  LDINT	R6	4
       0x00080406,  //  0034  ADD	R2	R2	R6
       0x7002002C,  //  0035  JMP		#0063
@@ -976,46 +942,46 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x5419FFFE,  //  0039  LDINT	R6	-1
       0x18180A06,  //  003A  LE	R6	R5	R6
       0x781A0013,  //  003B  JMPF	R6	#0050
-      0x8C18030B,  //  003C  GETMET	R6	R1	K11
+      0x8C180343,  //  003C  GETMET	R6	R1	K67
       0x5C200400,  //  003D  MOVE	R8	R2
       0x44240A00,  //  003E  NEG	R9	R5
       0x7C180600,  //  003F  CALL	R6	3
       0x441C0A00,  //  0040  NEG	R7	R5
       0x00080407,  //  0041  ADD	R2	R2	R7
       0x001C0406,  //  0042  ADD	R7	R2	R6
-      0x041C0F0E,  //  0043  SUB	R7	R7	K14
+      0x041C0F1D,  //  0043  SUB	R7	R7	K29
       0x401C0407,  //  0044  CONNECT	R7	R2	R7
       0x941C0207,  //  0045  GETIDX	R7	R1	R7
-      0x90020607,  //  0046  SETMBR	R0	K3	R7
+      0x90020E07,  //  0046  SETMBR	R0	K7	R7
       0x00080406,  //  0047  ADD	R2	R2	R6
-      0x881C090F,  //  0048  GETMBR	R7	R4	K15
+      0x881C0919,  //  0048  GETMBR	R7	R4	K25
       0x181C0607,  //  0049  LE	R7	R3	R7
       0x781E0003,  //  004A  JMPF	R7	#004F
-      0x881C0103,  //  004B  GETMBR	R7	R0	K3
-      0x8C1C0F10,  //  004C  GETMET	R7	R7	K16
+      0x881C0107,  //  004B  GETMBR	R7	R0	K7
+      0x8C1C0F45,  //  004C  GETMET	R7	R7	K69
       0x7C1C0200,  //  004D  CALL	R7	1
-      0x90020607,  //  004E  SETMBR	R0	K3	R7
+      0x90020E07,  //  004E  SETMBR	R0	K7	R7
       0x70020012,  //  004F  JMP		#0063
-      0x88180911,  //  0050  GETMBR	R6	R4	K17
+      0x88180925,  //  0050  GETMBR	R6	R4	K37
       0x1C180606,  //  0051  EQ	R6	R3	R6
       0x781A0000,  //  0052  JMPF	R6	#0054
       0x7002000E,  //  0053  JMP		#0063
-      0x88180912,  //  0054  GETMBR	R6	R4	K18
+      0x88180946,  //  0054  GETMBR	R6	R4	K70
       0x1C180606,  //  0055  EQ	R6	R3	R6
       0x781A0004,  //  0056  JMPF	R6	#005C
-      0xB81A2600,  //  0057  GETNGBL	R6	K19
-      0x581C0014,  //  0058  LDCONST	R7	K20
-      0x58200015,  //  0059  LDCONST	R8	K21
+      0xB81A8E00,  //  0057  GETNGBL	R6	K71
+      0x581C0048,  //  0058  LDCONST	R7	K72
+      0x58200049,  //  0059  LDCONST	R8	K73
       0x7C180400,  //  005A  CALL	R6	2
       0x70020006,  //  005B  JMP		#0063
-      0xB81A2600,  //  005C  GETNGBL	R6	K19
+      0xB81A8E00,  //  005C  GETNGBL	R6	K71
       0x601C0008,  //  005D  GETGBL	R7	G8
       0x5C200600,  //  005E  MOVE	R8	R3
       0x7C1C0200,  //  005F  CALL	R7	1
-      0x001E2C07,  //  0060  ADD	R7	K22	R7
-      0x58200015,  //  0061  LDCONST	R8	K21
+      0x001E9407,  //  0060  ADD	R7	K74	R7
+      0x58200049,  //  0061  LDCONST	R8	K73
       0x7C180400,  //  0062  CALL	R6	2
-      0x90022E02,  //  0063  SETMBR	R0	K23	R2
+      0x90020202,  //  0063  SETMBR	R0	K1	R2
       0x80040400,  //  0064  RET	1	R2
     })
   )
@@ -1030,19 +996,17 @@ be_local_closure(class_Matter_TLV_item_set_commonprofile,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_commonprofile),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04014B,  //  0000  GETMET	R1	R0	K75
       0x4C0C0000,  //  0001  LDNIL	R3
       0x5411FFFE,  //  0002  LDINT	R4	-1
       0x4C140000,  //  0003  LDNIL	R5
@@ -1061,157 +1025,147 @@ be_local_closure(class_Matter_TLV_item__encode_tag,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_number),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(add),
-    /* K4   */  be_nested_str_weak(typ),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(tag_profile),
-    /* K8   */  be_nested_str_weak(tag_sub),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(_encode_tag),
     &be_const_str_solidified,
     ( &(const binstruction[133]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
       0x4C0C0000,  //  0001  LDNIL	R3
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0001,  //  0003  JMPF	R2	#0006
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x88080104,  //  0004  GETMBR	R2	R0	K4
       0x70020000,  //  0005  JMP		#0007
-      0x58080001,  //  0006  LDCONST	R2	K1
+      0x5808002D,  //  0006  LDCONST	R2	K45
       0x540EFFFF,  //  0007  LDINT	R3	65536
       0x280C0403,  //  0008  GE	R3	R2	R3
       0x740E0002,  //  0009  JMPT	R3	#000D
-      0x140C0501,  //  000A  LT	R3	R2	K1
+      0x140C052D,  //  000A  LT	R3	R2	K45
       0x740E0000,  //  000B  JMPT	R3	#000D
       0x500C0001,  //  000C  LDBOOL	R3	0	1
       0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x58100001,  //  000E  LDCONST	R4	K1
+      0x5810002D,  //  000E  LDCONST	R4	K45
       0x88140102,  //  000F  GETMBR	R5	R0	K2
       0x4C180000,  //  0010  LDNIL	R6
       0x20140A06,  //  0011  NE	R5	R5	R6
       0x78160026,  //  0012  JMPF	R5	#003A
       0x780E0012,  //  0013  JMPF	R3	#0027
-      0x8C140303,  //  0014  GETMET	R5	R1	K3
+      0x8C14034C,  //  0014  GETMET	R5	R1	K76
       0x541E00DF,  //  0015  LDINT	R7	224
-      0x88200104,  //  0016  GETMBR	R8	R0	K4
+      0x88200106,  //  0016  GETMBR	R8	R0	K6
       0x001C0E08,  //  0017  ADD	R7	R7	R8
-      0x58200005,  //  0018  LDCONST	R8	K5
+      0x5820001D,  //  0018  LDCONST	R8	K29
       0x7C140600,  //  0019  CALL	R5	3
-      0x8C140303,  //  001A  GETMET	R5	R1	K3
+      0x8C14034C,  //  001A  GETMET	R5	R1	K76
       0x881C0102,  //  001B  GETMBR	R7	R0	K2
-      0x58200006,  //  001C  LDCONST	R8	K6
+      0x5820001E,  //  001C  LDCONST	R8	K30
       0x7C140600,  //  001D  CALL	R5	3
-      0x8C140303,  //  001E  GETMET	R5	R1	K3
-      0x881C0107,  //  001F  GETMBR	R7	R0	K7
-      0x58200006,  //  0020  LDCONST	R8	K6
+      0x8C14034C,  //  001E  GETMET	R5	R1	K76
+      0x881C0103,  //  001F  GETMBR	R7	R0	K3
+      0x5820001E,  //  0020  LDCONST	R8	K30
       0x7C140600,  //  0021  CALL	R5	3
-      0x8C140303,  //  0022  GETMET	R5	R1	K3
-      0x881C0100,  //  0023  GETMBR	R7	R0	K0
+      0x8C14034C,  //  0022  GETMET	R5	R1	K76
+      0x881C0104,  //  0023  GETMBR	R7	R0	K4
       0x54220003,  //  0024  LDINT	R8	4
       0x7C140600,  //  0025  CALL	R5	3
       0x70020011,  //  0026  JMP		#0039
-      0x8C140303,  //  0027  GETMET	R5	R1	K3
+      0x8C14034C,  //  0027  GETMET	R5	R1	K76
       0x541E00BF,  //  0028  LDINT	R7	192
-      0x88200104,  //  0029  GETMBR	R8	R0	K4
+      0x88200106,  //  0029  GETMBR	R8	R0	K6
       0x001C0E08,  //  002A  ADD	R7	R7	R8
-      0x58200005,  //  002B  LDCONST	R8	K5
+      0x5820001D,  //  002B  LDCONST	R8	K29
       0x7C140600,  //  002C  CALL	R5	3
-      0x8C140303,  //  002D  GETMET	R5	R1	K3
+      0x8C14034C,  //  002D  GETMET	R5	R1	K76
       0x881C0102,  //  002E  GETMBR	R7	R0	K2
-      0x58200006,  //  002F  LDCONST	R8	K6
+      0x5820001E,  //  002F  LDCONST	R8	K30
       0x7C140600,  //  0030  CALL	R5	3
-      0x8C140303,  //  0031  GETMET	R5	R1	K3
-      0x881C0107,  //  0032  GETMBR	R7	R0	K7
-      0x58200006,  //  0033  LDCONST	R8	K6
+      0x8C14034C,  //  0031  GETMET	R5	R1	K76
+      0x881C0103,  //  0032  GETMBR	R7	R0	K3
+      0x5820001E,  //  0033  LDCONST	R8	K30
       0x7C140600,  //  0034  CALL	R5	3
-      0x8C140303,  //  0035  GETMET	R5	R1	K3
-      0x881C0100,  //  0036  GETMBR	R7	R0	K0
-      0x58200006,  //  0037  LDCONST	R8	K6
+      0x8C14034C,  //  0035  GETMET	R5	R1	K76
+      0x881C0104,  //  0036  GETMBR	R7	R0	K4
+      0x5820001E,  //  0037  LDCONST	R8	K30
       0x7C140600,  //  0038  CALL	R5	3
       0x70020049,  //  0039  JMP		#0084
-      0x88140107,  //  003A  GETMBR	R5	R0	K7
+      0x88140103,  //  003A  GETMBR	R5	R0	K3
       0x5419FFFE,  //  003B  LDINT	R6	-1
       0x1C140A06,  //  003C  EQ	R5	R5	R6
       0x78160016,  //  003D  JMPF	R5	#0055
       0x780E000A,  //  003E  JMPF	R3	#004A
-      0x8C140303,  //  003F  GETMET	R5	R1	K3
+      0x8C14034C,  //  003F  GETMET	R5	R1	K76
       0x541E005F,  //  0040  LDINT	R7	96
-      0x88200104,  //  0041  GETMBR	R8	R0	K4
+      0x88200106,  //  0041  GETMBR	R8	R0	K6
       0x001C0E08,  //  0042  ADD	R7	R7	R8
-      0x58200005,  //  0043  LDCONST	R8	K5
+      0x5820001D,  //  0043  LDCONST	R8	K29
       0x7C140600,  //  0044  CALL	R5	3
-      0x8C140303,  //  0045  GETMET	R5	R1	K3
-      0x881C0100,  //  0046  GETMBR	R7	R0	K0
+      0x8C14034C,  //  0045  GETMET	R5	R1	K76
+      0x881C0104,  //  0046  GETMBR	R7	R0	K4
       0x54220003,  //  0047  LDINT	R8	4
       0x7C140600,  //  0048  CALL	R5	3
       0x70020009,  //  0049  JMP		#0054
-      0x8C140303,  //  004A  GETMET	R5	R1	K3
+      0x8C14034C,  //  004A  GETMET	R5	R1	K76
       0x541E003F,  //  004B  LDINT	R7	64
-      0x88200104,  //  004C  GETMBR	R8	R0	K4
+      0x88200106,  //  004C  GETMBR	R8	R0	K6
       0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x58200005,  //  004E  LDCONST	R8	K5
+      0x5820001D,  //  004E  LDCONST	R8	K29
       0x7C140600,  //  004F  CALL	R5	3
-      0x8C140303,  //  0050  GETMET	R5	R1	K3
-      0x881C0100,  //  0051  GETMBR	R7	R0	K0
-      0x58200006,  //  0052  LDCONST	R8	K6
+      0x8C14034C,  //  0050  GETMET	R5	R1	K76
+      0x881C0104,  //  0051  GETMBR	R7	R0	K4
+      0x5820001E,  //  0052  LDCONST	R8	K30
       0x7C140600,  //  0053  CALL	R5	3
       0x7002002E,  //  0054  JMP		#0084
-      0x88140107,  //  0055  GETMBR	R5	R0	K7
+      0x88140103,  //  0055  GETMBR	R5	R0	K3
       0x4C180000,  //  0056  LDNIL	R6
       0x20140A06,  //  0057  NE	R5	R5	R6
       0x78160016,  //  0058  JMPF	R5	#0070
       0x780E000A,  //  0059  JMPF	R3	#0065
-      0x8C140303,  //  005A  GETMET	R5	R1	K3
+      0x8C14034C,  //  005A  GETMET	R5	R1	K76
       0x541E009F,  //  005B  LDINT	R7	160
-      0x88200104,  //  005C  GETMBR	R8	R0	K4
+      0x88200106,  //  005C  GETMBR	R8	R0	K6
       0x001C0E08,  //  005D  ADD	R7	R7	R8
-      0x58200005,  //  005E  LDCONST	R8	K5
+      0x5820001D,  //  005E  LDCONST	R8	K29
       0x7C140600,  //  005F  CALL	R5	3
-      0x8C140303,  //  0060  GETMET	R5	R1	K3
-      0x881C0100,  //  0061  GETMBR	R7	R0	K0
+      0x8C14034C,  //  0060  GETMET	R5	R1	K76
+      0x881C0104,  //  0061  GETMBR	R7	R0	K4
       0x54220003,  //  0062  LDINT	R8	4
       0x7C140600,  //  0063  CALL	R5	3
       0x70020009,  //  0064  JMP		#006F
-      0x8C140303,  //  0065  GETMET	R5	R1	K3
+      0x8C14034C,  //  0065  GETMET	R5	R1	K76
       0x541E007F,  //  0066  LDINT	R7	128
-      0x88200104,  //  0067  GETMBR	R8	R0	K4
+      0x88200106,  //  0067  GETMBR	R8	R0	K6
       0x001C0E08,  //  0068  ADD	R7	R7	R8
-      0x58200005,  //  0069  LDCONST	R8	K5
+      0x5820001D,  //  0069  LDCONST	R8	K29
       0x7C140600,  //  006A  CALL	R5	3
-      0x8C140303,  //  006B  GETMET	R5	R1	K3
-      0x881C0100,  //  006C  GETMBR	R7	R0	K0
-      0x58200006,  //  006D  LDCONST	R8	K6
+      0x8C14034C,  //  006B  GETMET	R5	R1	K76
+      0x881C0104,  //  006C  GETMBR	R7	R0	K4
+      0x5820001E,  //  006D  LDCONST	R8	K30
       0x7C140600,  //  006E  CALL	R5	3
       0x70020013,  //  006F  JMP		#0084
-      0x88140108,  //  0070  GETMBR	R5	R0	K8
+      0x88140105,  //  0070  GETMBR	R5	R0	K5
       0x4C180000,  //  0071  LDNIL	R6
       0x20140A06,  //  0072  NE	R5	R5	R6
       0x7816000A,  //  0073  JMPF	R5	#007F
-      0x8C140303,  //  0074  GETMET	R5	R1	K3
+      0x8C14034C,  //  0074  GETMET	R5	R1	K76
       0x541E001F,  //  0075  LDINT	R7	32
-      0x88200104,  //  0076  GETMBR	R8	R0	K4
+      0x88200106,  //  0076  GETMBR	R8	R0	K6
       0x001C0E08,  //  0077  ADD	R7	R7	R8
-      0x58200005,  //  0078  LDCONST	R8	K5
+      0x5820001D,  //  0078  LDCONST	R8	K29
       0x7C140600,  //  0079  CALL	R5	3
-      0x8C140303,  //  007A  GETMET	R5	R1	K3
-      0x881C0108,  //  007B  GETMBR	R7	R0	K8
-      0x58200005,  //  007C  LDCONST	R8	K5
+      0x8C14034C,  //  007A  GETMET	R5	R1	K76
+      0x881C0105,  //  007B  GETMBR	R7	R0	K5
+      0x5820001D,  //  007C  LDCONST	R8	K29
       0x7C140600,  //  007D  CALL	R5	3
       0x70020004,  //  007E  JMP		#0084
-      0x8C140303,  //  007F  GETMET	R5	R1	K3
-      0x881C0104,  //  0080  GETMBR	R7	R0	K4
-      0x001E0207,  //  0081  ADD	R7	K1	R7
-      0x58200005,  //  0082  LDCONST	R8	K5
+      0x8C14034C,  //  007F  GETMET	R5	R1	K76
+      0x881C0106,  //  0080  GETMBR	R7	R0	K6
+      0x001E5A07,  //  0081  ADD	R7	K45	R7
+      0x5820001D,  //  0082  LDCONST	R8	K29
       0x7C140600,  //  0083  CALL	R5	3
       0x80000000,  //  0084  RET	0
     })
@@ -1227,52 +1181,46 @@ be_local_closure(class_Matter_TLV_item_sort,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV_item),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_cmp_gt),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(sort),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804004D,  //  0000  LDCONST	R1	K77
       0x60080010,  //  0001  GETGBL	R2	G16
       0x600C000C,  //  0002  GETGBL	R3	G12
       0x5C100000,  //  0003  MOVE	R4	R0
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x040C074E,  //  0005  SUB	R3	R3	K78
+      0x400E9C03,  //  0006  CONNECT	R3	K78	R3
       0x7C080200,  //  0007  CALL	R2	1
       0xA8020013,  //  0008  EXBLK	0	#001D
       0x5C0C0400,  //  0009  MOVE	R3	R2
       0x7C0C0000,  //  000A  CALL	R3	0
       0x94100003,  //  000B  GETIDX	R4	R0	R3
       0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x24180B2D,  //  000D  GT	R6	R5	K45
       0x781A000B,  //  000E  JMPF	R6	#001B
-      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x04180B4E,  //  000F  SUB	R6	R5	K78
       0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x8C180D03,  //  0011  GETMET	R6	R6	K3
+      0x8C180D4F,  //  0011  GETMET	R6	R6	K79
       0x5C200800,  //  0012  MOVE	R8	R4
       0x7C180400,  //  0013  CALL	R6	2
-      0x24180D02,  //  0014  GT	R6	R6	K2
+      0x24180D2D,  //  0014  GT	R6	R6	K45
       0x781A0004,  //  0015  JMPF	R6	#001B
-      0x04180B01,  //  0016  SUB	R6	R5	K1
+      0x04180B4E,  //  0016  SUB	R6	R5	K78
       0x94180006,  //  0017  GETIDX	R6	R0	R6
       0x98000A06,  //  0018  SETIDX	R0	R5	R6
-      0x04140B01,  //  0019  SUB	R5	R5	K1
+      0x04140B4E,  //  0019  SUB	R5	R5	K78
       0x7001FFF1,  //  001A  JMP		#000D
       0x98000A04,  //  001B  SETIDX	R0	R5	R4
       0x7001FFEB,  //  001C  JMP		#0009
-      0x58080004,  //  001D  LDCONST	R2	K4
+      0x58080050,  //  001D  LDCONST	R2	K80
       0xAC080200,  //  001E  CATCH	R2	1	0
       0xB0080000,  //  001F  RAISE	2	R0	R0
       0x80040000,  //  0020  RET	1	R0
@@ -1289,15 +1237,13 @@ be_local_closure(class_Matter_TLV_item_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -1316,65 +1262,58 @@ be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_vendor),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(_cmp_gt),
     &be_const_str_solidified,
     ( &(const binstruction[72]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
       0x4C0C0000,  //  0001  LDNIL	R3
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0012,  //  0003  JMPF	R2	#0017
-      0x88080300,  //  0004  GETMBR	R2	R1	K0
+      0x88080302,  //  0004  GETMBR	R2	R1	K2
       0x4C0C0000,  //  0005  LDNIL	R3
       0x1C080403,  //  0006  EQ	R2	R2	R3
       0x780A0000,  //  0007  JMPF	R2	#0009
-      0x80060200,  //  0008  RET	1	K1
-      0x88080100,  //  0009  GETMBR	R2	R0	K0
-      0x880C0300,  //  000A  GETMBR	R3	R1	K0
+      0x80069C00,  //  0008  RET	1	K78
+      0x88080102,  //  0009  GETMBR	R2	R0	K2
+      0x880C0302,  //  000A  GETMBR	R3	R1	K2
       0x24080403,  //  000B  GT	R2	R2	R3
       0x780A0000,  //  000C  JMPF	R2	#000E
-      0x80060200,  //  000D  RET	1	K1
-      0x88080100,  //  000E  GETMBR	R2	R0	K0
-      0x880C0300,  //  000F  GETMBR	R3	R1	K0
+      0x80069C00,  //  000D  RET	1	K78
+      0x88080102,  //  000E  GETMBR	R2	R0	K2
+      0x880C0302,  //  000F  GETMBR	R3	R1	K2
       0x1C080403,  //  0010  EQ	R2	R2	R3
       0x780A0004,  //  0011  JMPF	R2	#0017
-      0x88080102,  //  0012  GETMBR	R2	R0	K2
-      0x880C0302,  //  0013  GETMBR	R3	R1	K2
+      0x88080103,  //  0012  GETMBR	R2	R0	K3
+      0x880C0303,  //  0013  GETMBR	R3	R1	K3
       0x24080403,  //  0014  GT	R2	R2	R3
       0x780A0000,  //  0015  JMPF	R2	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x88080102,  //  0017  GETMBR	R2	R0	K2
+      0x80069C00,  //  0016  RET	1	K78
+      0x88080103,  //  0017  GETMBR	R2	R0	K3
       0x540DFFFE,  //  0018  LDINT	R3	-1
       0x1C080403,  //  0019  EQ	R2	R2	R3
       0x780A0005,  //  001A  JMPF	R2	#0021
-      0x88080302,  //  001B  GETMBR	R2	R1	K2
+      0x88080303,  //  001B  GETMBR	R2	R1	K3
       0x4C0C0000,  //  001C  LDNIL	R3
       0x1C080403,  //  001D  EQ	R2	R2	R3
       0x780A0000,  //  001E  JMPF	R2	#0020
-      0x80060200,  //  001F  RET	1	K1
+      0x80069C00,  //  001F  RET	1	K78
       0x70020008,  //  0020  JMP		#002A
-      0x88080102,  //  0021  GETMBR	R2	R0	K2
+      0x88080103,  //  0021  GETMBR	R2	R0	K3
       0x4C0C0000,  //  0022  LDNIL	R3
       0x1C080403,  //  0023  EQ	R2	R2	R3
       0x780A0004,  //  0024  JMPF	R2	#002A
-      0x88080302,  //  0025  GETMBR	R2	R1	K2
+      0x88080303,  //  0025  GETMBR	R2	R1	K3
       0x540DFFFE,  //  0026  LDINT	R3	-1
       0x1C080403,  //  0027  EQ	R2	R2	R3
       0x780A0000,  //  0028  JMPF	R2	#002A
-      0x80060600,  //  0029  RET	1	K3
+      0x80061400,  //  0029  RET	1	K10
       0x88080104,  //  002A  GETMBR	R2	R0	K4
       0x4C0C0000,  //  002B  LDNIL	R3
       0x20080403,  //  002C  NE	R2	R2	R3
@@ -1383,13 +1322,13 @@ be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
       0x4C0C0000,  //  002F  LDNIL	R3
       0x1C080403,  //  0030  EQ	R2	R2	R3
       0x780A0000,  //  0031  JMPF	R2	#0033
-      0x80060200,  //  0032  RET	1	K1
+      0x80069C00,  //  0032  RET	1	K78
       0x88080104,  //  0033  GETMBR	R2	R0	K4
       0x880C0304,  //  0034  GETMBR	R3	R1	K4
       0x24080403,  //  0035  GT	R2	R2	R3
       0x780A0000,  //  0036  JMPF	R2	#0038
-      0x80060200,  //  0037  RET	1	K1
-      0x80060600,  //  0038  RET	1	K3
+      0x80069C00,  //  0037  RET	1	K78
+      0x80061400,  //  0038  RET	1	K10
       0x88080105,  //  0039  GETMBR	R2	R0	K5
       0x4C0C0000,  //  003A  LDNIL	R3
       0x20080403,  //  003B  NE	R2	R2	R3
@@ -1398,13 +1337,13 @@ be_local_closure(class_Matter_TLV_item__cmp_gt,   /* name */
       0x4C0C0000,  //  003E  LDNIL	R3
       0x1C080403,  //  003F  EQ	R2	R2	R3
       0x780A0000,  //  0040  JMPF	R2	#0042
-      0x80060200,  //  0041  RET	1	K1
+      0x80069C00,  //  0041  RET	1	K78
       0x88080105,  //  0042  GETMBR	R2	R0	K5
       0x880C0305,  //  0043  GETMBR	R3	R1	K5
       0x24080403,  //  0044  GT	R2	R2	R3
       0x780A0000,  //  0045  JMPF	R2	#0047
-      0x80060200,  //  0046  RET	1	K1
-      0x80060600,  //  0047  RET	1	K3
+      0x80069C00,  //  0046  RET	1	K78
+      0x80061400,  //  0047  RET	1	K10
     })
   )
 );
@@ -1418,124 +1357,79 @@ be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(RAW),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(I8),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(int),
-    /* K7   */  be_nested_str_weak(I4),
-    /* K8   */  be_nested_str_weak(U4),
-    /* K9   */  be_nested_str_weak(BFALSE),
-    /* K10  */  be_nested_str_weak(BTRUE),
-    /* K11  */  be_nested_str_weak(I2),
-    /* K12  */  be_nested_str_weak(I1),
-    /* K13  */  be_nested_str_weak(U2),
-    /* K14  */  be_const_int(0),
-    /* K15  */  be_nested_str_weak(U1),
-    /* K16  */  be_nested_str_weak(B1),
-    /* K17  */  be_nested_str_weak(B8),
-    /* K18  */  be_nested_str_weak(B2),
-    /* K19  */  be_nested_str_weak(B4),
-    /* K20  */  be_nested_str_weak(UTF1),
-    /* K21  */  be_nested_str_weak(UTF8),
-    /* K22  */  be_nested_str_weak(UTF2),
-    /* K23  */  be_nested_str_weak(UTF4),
-    /* K24  */  be_nested_str_weak(_encode_tag),
-    /* K25  */  be_nested_str_weak(add),
-    /* K26  */  be_const_int(1),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(copy),
-    /* K29  */  be_nested_str_weak(resize),
-    /* K30  */  be_nested_str_weak(int64),
-    /* K31  */  be_nested_str_weak(tobytes),
-    /* K32  */  be_nested_str_weak(fromu32),
-    /* K33  */  be_nested_str_weak(FLOAT),
-    /* K34  */  be_nested_str_weak(setfloat),
-    /* K35  */  be_nested_str_weak(DOUBLE),
-    /* K36  */  be_nested_str_weak(value_error),
-    /* K37  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
-    /* K38  */  be_nested_str_weak(string_X20too_X20big),
-    /* K39  */  be_nested_str_weak(fromstring),
-    /* K40  */  be_nested_str_weak(frostring),
-    /* K41  */  be_nested_str_weak(bytes_X20too_X20big),
-    /* K42  */  be_nested_str_weak(NULL),
-    /* K43  */  be_nested_str_weak(unsupported_X20type_X20),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[404]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080109,  //  0000  GETMBR	R2	R0	K9
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C0C0203,  //  0002  EQ	R3	R1	R3
       0x780E0002,  //  0003  JMPF	R3	#0007
       0x600C0015,  //  0004  GETGBL	R3	G21
       0x7C0C0000,  //  0005  CALL	R3	0
       0x5C040600,  //  0006  MOVE	R1	R3
-      0x880C0101,  //  0007  GETMBR	R3	R0	K1
-      0x88100502,  //  0008  GETMBR	R4	R2	K2
+      0x880C0106,  //  0007  GETMBR	R3	R0	K6
+      0x8810050B,  //  0008  GETMBR	R4	R2	K11
       0x1C0C0604,  //  0009  EQ	R3	R3	R4
       0x780E0002,  //  000A  JMPF	R3	#000E
-      0x880C0103,  //  000B  GETMBR	R3	R0	K3
+      0x880C0107,  //  000B  GETMBR	R3	R0	K7
       0x400C0203,  //  000C  CONNECT	R3	R1	R3
       0x80040200,  //  000D  RET	1	R1
-      0x880C0101,  //  000E  GETMBR	R3	R0	K1
-      0x88100504,  //  000F  GETMBR	R4	R2	K4
+      0x880C0106,  //  000E  GETMBR	R3	R0	K6
+      0x8810051F,  //  000F  GETMBR	R4	R2	K31
       0x1C0C0604,  //  0010  EQ	R3	R3	R4
       0x740E0003,  //  0011  JMPT	R3	#0016
-      0x880C0101,  //  0012  GETMBR	R3	R0	K1
-      0x88100505,  //  0013  GETMBR	R4	R2	K5
+      0x880C0106,  //  0012  GETMBR	R3	R0	K6
+      0x88100520,  //  0013  GETMBR	R4	R2	K32
       0x1C0C0604,  //  0014  EQ	R3	R3	R4
       0x780E000D,  //  0015  JMPF	R3	#0024
       0x600C0004,  //  0016  GETGBL	R3	G4
-      0x88100103,  //  0017  GETMBR	R4	R0	K3
+      0x88100107,  //  0017  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0018  CALL	R3	1
-      0x1C0C0706,  //  0019  EQ	R3	R3	K6
+      0x1C0C072F,  //  0019  EQ	R3	R3	K47
       0x780E0008,  //  001A  JMPF	R3	#0024
-      0x880C0101,  //  001B  GETMBR	R3	R0	K1
-      0x88100504,  //  001C  GETMBR	R4	R2	K4
+      0x880C0106,  //  001B  GETMBR	R3	R0	K6
+      0x8810051F,  //  001C  GETMBR	R4	R2	K31
       0x1C0C0604,  //  001D  EQ	R3	R3	R4
       0x780E0002,  //  001E  JMPF	R3	#0022
-      0x880C0507,  //  001F  GETMBR	R3	R2	K7
-      0x90020203,  //  0020  SETMBR	R0	K1	R3
+      0x880C050F,  //  001F  GETMBR	R3	R2	K15
+      0x90020C03,  //  0020  SETMBR	R0	K6	R3
       0x70020001,  //  0021  JMP		#0024
-      0x880C0508,  //  0022  GETMBR	R3	R2	K8
-      0x90020203,  //  0023  SETMBR	R0	K1	R3
-      0x880C0101,  //  0024  GETMBR	R3	R0	K1
-      0x88100509,  //  0025  GETMBR	R4	R2	K9
+      0x880C0512,  //  0022  GETMBR	R3	R2	K18
+      0x90020C03,  //  0023  SETMBR	R0	K6	R3
+      0x880C0106,  //  0024  GETMBR	R3	R0	K6
+      0x8810050C,  //  0025  GETMBR	R4	R2	K12
       0x1C0C0604,  //  0026  EQ	R3	R3	R4
       0x740E0003,  //  0027  JMPT	R3	#002C
-      0x880C0101,  //  0028  GETMBR	R3	R0	K1
-      0x8810050A,  //  0029  GETMBR	R4	R2	K10
+      0x880C0106,  //  0028  GETMBR	R3	R0	K6
+      0x8810050D,  //  0029  GETMBR	R4	R2	K13
       0x1C0C0604,  //  002A  EQ	R3	R3	R4
       0x780E0008,  //  002B  JMPF	R3	#0035
       0x600C0017,  //  002C  GETGBL	R3	G23
-      0x88100103,  //  002D  GETMBR	R4	R0	K3
+      0x88100107,  //  002D  GETMBR	R4	R0	K7
       0x7C0C0200,  //  002E  CALL	R3	1
       0x780E0001,  //  002F  JMPF	R3	#0032
-      0x880C050A,  //  0030  GETMBR	R3	R2	K10
+      0x880C050D,  //  0030  GETMBR	R3	R2	K13
       0x70020000,  //  0031  JMP		#0033
-      0x880C0509,  //  0032  GETMBR	R3	R2	K9
-      0x90020203,  //  0033  SETMBR	R0	K1	R3
+      0x880C050C,  //  0032  GETMBR	R3	R2	K12
+      0x90020C03,  //  0033  SETMBR	R0	K6	R3
       0x70020070,  //  0034  JMP		#00A6
-      0x880C0101,  //  0035  GETMBR	R3	R0	K1
-      0x8810050B,  //  0036  GETMBR	R4	R2	K11
+      0x880C0106,  //  0035  GETMBR	R3	R0	K6
+      0x8810050E,  //  0036  GETMBR	R4	R2	K14
       0x280C0604,  //  0037  GE	R3	R3	R4
       0x780E0018,  //  0038  JMPF	R3	#0052
-      0x880C0101,  //  0039  GETMBR	R3	R0	K1
-      0x88100507,  //  003A  GETMBR	R4	R2	K7
+      0x880C0106,  //  0039  GETMBR	R3	R0	K6
+      0x8810050F,  //  003A  GETMBR	R4	R2	K15
       0x180C0604,  //  003B  LE	R3	R3	R4
       0x780E0014,  //  003C  JMPF	R3	#0052
       0x600C0009,  //  003D  GETGBL	R3	G9
-      0x88100103,  //  003E  GETMBR	R4	R0	K3
+      0x88100107,  //  003E  GETMBR	R4	R0	K7
       0x7C0C0200,  //  003F  CALL	R3	1
       0x5412007E,  //  0040  LDINT	R4	127
       0x18100604,  //  0041  LE	R4	R3	R4
@@ -1543,8 +1437,8 @@ be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
       0x5411FF7F,  //  0043  LDINT	R4	-128
       0x28100604,  //  0044  GE	R4	R3	R4
       0x78120002,  //  0045  JMPF	R4	#0049
-      0x8810050C,  //  0046  GETMBR	R4	R2	K12
-      0x90020204,  //  0047  SETMBR	R0	K1	R4
+      0x88100510,  //  0046  GETMBR	R4	R2	K16
+      0x90020C04,  //  0047  SETMBR	R0	K6	R4
       0x70020007,  //  0048  JMP		#0051
       0x54127FFE,  //  0049  LDINT	R4	32767
       0x18100604,  //  004A  LE	R4	R3	R4
@@ -1552,330 +1446,330 @@ be_local_closure(class_Matter_TLV_item_tlv2raw,   /* name */
       0x54117FFF,  //  004C  LDINT	R4	-32768
       0x28100604,  //  004D  GE	R4	R3	R4
       0x78120001,  //  004E  JMPF	R4	#0051
-      0x8810050B,  //  004F  GETMBR	R4	R2	K11
-      0x90020204,  //  0050  SETMBR	R0	K1	R4
+      0x8810050E,  //  004F  GETMBR	R4	R2	K14
+      0x90020C04,  //  0050  SETMBR	R0	K6	R4
       0x70020053,  //  0051  JMP		#00A6
-      0x880C0101,  //  0052  GETMBR	R3	R0	K1
-      0x8810050D,  //  0053  GETMBR	R4	R2	K13
+      0x880C0106,  //  0052  GETMBR	R3	R0	K6
+      0x88100511,  //  0053  GETMBR	R4	R2	K17
       0x280C0604,  //  0054  GE	R3	R3	R4
       0x780E0016,  //  0055  JMPF	R3	#006D
-      0x880C0101,  //  0056  GETMBR	R3	R0	K1
-      0x88100508,  //  0057  GETMBR	R4	R2	K8
+      0x880C0106,  //  0056  GETMBR	R3	R0	K6
+      0x88100512,  //  0057  GETMBR	R4	R2	K18
       0x180C0604,  //  0058  LE	R3	R3	R4
       0x780E0012,  //  0059  JMPF	R3	#006D
       0x600C0009,  //  005A  GETGBL	R3	G9
-      0x88100103,  //  005B  GETMBR	R4	R0	K3
+      0x88100107,  //  005B  GETMBR	R4	R0	K7
       0x7C0C0200,  //  005C  CALL	R3	1
       0x541200FE,  //  005D  LDINT	R4	255
       0x18100604,  //  005E  LE	R4	R3	R4
       0x78120004,  //  005F  JMPF	R4	#0065
-      0x2810070E,  //  0060  GE	R4	R3	K14
+      0x2810072D,  //  0060  GE	R4	R3	K45
       0x78120002,  //  0061  JMPF	R4	#0065
-      0x8810050F,  //  0062  GETMBR	R4	R2	K15
-      0x90020204,  //  0063  SETMBR	R0	K1	R4
+      0x88100513,  //  0062  GETMBR	R4	R2	K19
+      0x90020C04,  //  0063  SETMBR	R0	K6	R4
       0x70020006,  //  0064  JMP		#006C
       0x5412FFFE,  //  0065  LDINT	R4	65535
       0x18100604,  //  0066  LE	R4	R3	R4
       0x78120003,  //  0067  JMPF	R4	#006C
-      0x2810070E,  //  0068  GE	R4	R3	K14
+      0x2810072D,  //  0068  GE	R4	R3	K45
       0x78120001,  //  0069  JMPF	R4	#006C
-      0x8810050D,  //  006A  GETMBR	R4	R2	K13
-      0x90020204,  //  006B  SETMBR	R0	K1	R4
+      0x88100511,  //  006A  GETMBR	R4	R2	K17
+      0x90020C04,  //  006B  SETMBR	R0	K6	R4
       0x70020038,  //  006C  JMP		#00A6
-      0x880C0101,  //  006D  GETMBR	R3	R0	K1
-      0x88100510,  //  006E  GETMBR	R4	R2	K16
+      0x880C0106,  //  006D  GETMBR	R3	R0	K6
+      0x88100514,  //  006E  GETMBR	R4	R2	K20
       0x280C0604,  //  006F  GE	R3	R3	R4
       0x780E0018,  //  0070  JMPF	R3	#008A
-      0x880C0101,  //  0071  GETMBR	R3	R0	K1
-      0x88100511,  //  0072  GETMBR	R4	R2	K17
+      0x880C0106,  //  0071  GETMBR	R3	R0	K6
+      0x88100515,  //  0072  GETMBR	R4	R2	K21
       0x180C0604,  //  0073  LE	R3	R3	R4
       0x780E0014,  //  0074  JMPF	R3	#008A
       0x600C000C,  //  0075  GETGBL	R3	G12
-      0x88100103,  //  0076  GETMBR	R4	R0	K3
+      0x88100107,  //  0076  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0077  CALL	R3	1
       0x541200FE,  //  0078  LDINT	R4	255
       0x180C0604,  //  0079  LE	R3	R3	R4
       0x780E0002,  //  007A  JMPF	R3	#007E
-      0x880C0510,  //  007B  GETMBR	R3	R2	K16
-      0x90020203,  //  007C  SETMBR	R0	K1	R3
+      0x880C0514,  //  007B  GETMBR	R3	R2	K20
+      0x90020C03,  //  007C  SETMBR	R0	K6	R3
       0x7002000A,  //  007D  JMP		#0089
       0x600C000C,  //  007E  GETGBL	R3	G12
-      0x88100103,  //  007F  GETMBR	R4	R0	K3
+      0x88100107,  //  007F  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0080  CALL	R3	1
       0x5412FFFE,  //  0081  LDINT	R4	65535
       0x180C0604,  //  0082  LE	R3	R3	R4
       0x780E0002,  //  0083  JMPF	R3	#0087
-      0x880C0512,  //  0084  GETMBR	R3	R2	K18
-      0x90020203,  //  0085  SETMBR	R0	K1	R3
+      0x880C0516,  //  0084  GETMBR	R3	R2	K22
+      0x90020C03,  //  0085  SETMBR	R0	K6	R3
       0x70020001,  //  0086  JMP		#0089
-      0x880C0513,  //  0087  GETMBR	R3	R2	K19
-      0x90020203,  //  0088  SETMBR	R0	K1	R3
+      0x880C0517,  //  0087  GETMBR	R3	R2	K23
+      0x90020C03,  //  0088  SETMBR	R0	K6	R3
       0x7002001B,  //  0089  JMP		#00A6
-      0x880C0101,  //  008A  GETMBR	R3	R0	K1
-      0x88100514,  //  008B  GETMBR	R4	R2	K20
+      0x880C0106,  //  008A  GETMBR	R3	R0	K6
+      0x88100518,  //  008B  GETMBR	R4	R2	K24
       0x280C0604,  //  008C  GE	R3	R3	R4
       0x780E0017,  //  008D  JMPF	R3	#00A6
-      0x880C0101,  //  008E  GETMBR	R3	R0	K1
-      0x88100515,  //  008F  GETMBR	R4	R2	K21
+      0x880C0106,  //  008E  GETMBR	R3	R0	K6
+      0x88100519,  //  008F  GETMBR	R4	R2	K25
       0x180C0604,  //  0090  LE	R3	R3	R4
       0x780E0013,  //  0091  JMPF	R3	#00A6
       0x600C000C,  //  0092  GETGBL	R3	G12
-      0x88100103,  //  0093  GETMBR	R4	R0	K3
+      0x88100107,  //  0093  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0094  CALL	R3	1
       0x541200FE,  //  0095  LDINT	R4	255
       0x180C0604,  //  0096  LE	R3	R3	R4
       0x780E0002,  //  0097  JMPF	R3	#009B
-      0x880C0514,  //  0098  GETMBR	R3	R2	K20
-      0x90020203,  //  0099  SETMBR	R0	K1	R3
+      0x880C0518,  //  0098  GETMBR	R3	R2	K24
+      0x90020C03,  //  0099  SETMBR	R0	K6	R3
       0x7002000A,  //  009A  JMP		#00A6
       0x600C000C,  //  009B  GETGBL	R3	G12
-      0x88100103,  //  009C  GETMBR	R4	R0	K3
+      0x88100107,  //  009C  GETMBR	R4	R0	K7
       0x7C0C0200,  //  009D  CALL	R3	1
       0x5412FFFE,  //  009E  LDINT	R4	65535
       0x180C0604,  //  009F  LE	R3	R3	R4
       0x780E0002,  //  00A0  JMPF	R3	#00A4
-      0x880C0516,  //  00A1  GETMBR	R3	R2	K22
-      0x90020203,  //  00A2  SETMBR	R0	K1	R3
+      0x880C051A,  //  00A1  GETMBR	R3	R2	K26
+      0x90020C03,  //  00A2  SETMBR	R0	K6	R3
       0x70020001,  //  00A3  JMP		#00A6
-      0x880C0517,  //  00A4  GETMBR	R3	R2	K23
-      0x90020203,  //  00A5  SETMBR	R0	K1	R3
-      0x8C0C0118,  //  00A6  GETMET	R3	R0	K24
+      0x880C051B,  //  00A4  GETMBR	R3	R2	K27
+      0x90020C03,  //  00A5  SETMBR	R0	K6	R3
+      0x8C0C0151,  //  00A6  GETMET	R3	R0	K81
       0x5C140200,  //  00A7  MOVE	R5	R1
       0x7C0C0400,  //  00A8  CALL	R3	2
-      0x880C0101,  //  00A9  GETMBR	R3	R0	K1
-      0x8810050C,  //  00AA  GETMBR	R4	R2	K12
+      0x880C0106,  //  00A9  GETMBR	R3	R0	K6
+      0x88100510,  //  00AA  GETMBR	R4	R2	K16
       0x1C0C0604,  //  00AB  EQ	R3	R3	R4
       0x740E0003,  //  00AC  JMPT	R3	#00B1
-      0x880C0101,  //  00AD  GETMBR	R3	R0	K1
-      0x8810050F,  //  00AE  GETMBR	R4	R2	K15
+      0x880C0106,  //  00AD  GETMBR	R3	R0	K6
+      0x88100513,  //  00AE  GETMBR	R4	R2	K19
       0x1C0C0604,  //  00AF  EQ	R3	R3	R4
       0x780E0006,  //  00B0  JMPF	R3	#00B8
-      0x8C0C0319,  //  00B1  GETMET	R3	R1	K25
+      0x8C0C034C,  //  00B1  GETMET	R3	R1	K76
       0x60140009,  //  00B2  GETGBL	R5	G9
-      0x88180103,  //  00B3  GETMBR	R6	R0	K3
+      0x88180107,  //  00B3  GETMBR	R6	R0	K7
       0x7C140200,  //  00B4  CALL	R5	1
-      0x5818001A,  //  00B5  LDCONST	R6	K26
+      0x5818001D,  //  00B5  LDCONST	R6	K29
       0x7C0C0600,  //  00B6  CALL	R3	3
       0x700200DA,  //  00B7  JMP		#0193
-      0x880C0101,  //  00B8  GETMBR	R3	R0	K1
-      0x8810050B,  //  00B9  GETMBR	R4	R2	K11
+      0x880C0106,  //  00B8  GETMBR	R3	R0	K6
+      0x8810050E,  //  00B9  GETMBR	R4	R2	K14
       0x1C0C0604,  //  00BA  EQ	R3	R3	R4
       0x740E0003,  //  00BB  JMPT	R3	#00C0
-      0x880C0101,  //  00BC  GETMBR	R3	R0	K1
-      0x8810050D,  //  00BD  GETMBR	R4	R2	K13
+      0x880C0106,  //  00BC  GETMBR	R3	R0	K6
+      0x88100511,  //  00BD  GETMBR	R4	R2	K17
       0x1C0C0604,  //  00BE  EQ	R3	R3	R4
       0x780E0006,  //  00BF  JMPF	R3	#00C7
-      0x8C0C0319,  //  00C0  GETMET	R3	R1	K25
+      0x8C0C034C,  //  00C0  GETMET	R3	R1	K76
       0x60140009,  //  00C1  GETGBL	R5	G9
-      0x88180103,  //  00C2  GETMBR	R6	R0	K3
+      0x88180107,  //  00C2  GETMBR	R6	R0	K7
       0x7C140200,  //  00C3  CALL	R5	1
-      0x5818001B,  //  00C4  LDCONST	R6	K27
+      0x5818001E,  //  00C4  LDCONST	R6	K30
       0x7C0C0600,  //  00C5  CALL	R3	3
       0x700200CB,  //  00C6  JMP		#0193
-      0x880C0101,  //  00C7  GETMBR	R3	R0	K1
-      0x88100507,  //  00C8  GETMBR	R4	R2	K7
+      0x880C0106,  //  00C7  GETMBR	R3	R0	K6
+      0x8810050F,  //  00C8  GETMBR	R4	R2	K15
       0x1C0C0604,  //  00C9  EQ	R3	R3	R4
       0x740E0003,  //  00CA  JMPT	R3	#00CF
-      0x880C0101,  //  00CB  GETMBR	R3	R0	K1
-      0x88100508,  //  00CC  GETMBR	R4	R2	K8
+      0x880C0106,  //  00CB  GETMBR	R3	R0	K6
+      0x88100512,  //  00CC  GETMBR	R4	R2	K18
       0x1C0C0604,  //  00CD  EQ	R3	R3	R4
       0x780E0006,  //  00CE  JMPF	R3	#00D6
-      0x8C0C0319,  //  00CF  GETMET	R3	R1	K25
+      0x8C0C034C,  //  00CF  GETMET	R3	R1	K76
       0x60140009,  //  00D0  GETGBL	R5	G9
-      0x88180103,  //  00D1  GETMBR	R6	R0	K3
+      0x88180107,  //  00D1  GETMBR	R6	R0	K7
       0x7C140200,  //  00D2  CALL	R5	1
       0x541A0003,  //  00D3  LDINT	R6	4
       0x7C0C0600,  //  00D4  CALL	R3	3
       0x700200BC,  //  00D5  JMP		#0193
-      0x880C0101,  //  00D6  GETMBR	R3	R0	K1
-      0x88100504,  //  00D7  GETMBR	R4	R2	K4
+      0x880C0106,  //  00D6  GETMBR	R3	R0	K6
+      0x8810051F,  //  00D7  GETMBR	R4	R2	K31
       0x1C0C0604,  //  00D8  EQ	R3	R3	R4
       0x740E0003,  //  00D9  JMPT	R3	#00DE
-      0x880C0101,  //  00DA  GETMBR	R3	R0	K1
-      0x88100505,  //  00DB  GETMBR	R4	R2	K5
+      0x880C0106,  //  00DA  GETMBR	R3	R0	K6
+      0x88100520,  //  00DB  GETMBR	R4	R2	K32
       0x1C0C0604,  //  00DC  EQ	R3	R3	R4
       0x780E002D,  //  00DD  JMPF	R3	#010C
-      0x880C0103,  //  00DE  GETMBR	R3	R0	K3
+      0x880C0107,  //  00DE  GETMBR	R3	R0	K7
       0x6010000F,  //  00DF  GETGBL	R4	G15
       0x5C140600,  //  00E0  MOVE	R5	R3
       0x60180015,  //  00E1  GETGBL	R6	G21
       0x7C100400,  //  00E2  CALL	R4	2
       0x78120006,  //  00E3  JMPF	R4	#00EB
-      0x8C10071C,  //  00E4  GETMET	R4	R3	K28
+      0x8C100752,  //  00E4  GETMET	R4	R3	K82
       0x7C100200,  //  00E5  CALL	R4	1
-      0x8C10091D,  //  00E6  GETMET	R4	R4	K29
+      0x8C100953,  //  00E6  GETMET	R4	R4	K83
       0x541A0007,  //  00E7  LDINT	R6	8
       0x7C100400,  //  00E8  CALL	R4	2
       0x5C0C0800,  //  00E9  MOVE	R3	R4
       0x7002001E,  //  00EA  JMP		#010A
       0x6010000F,  //  00EB  GETGBL	R4	G15
       0x5C140600,  //  00EC  MOVE	R5	R3
-      0xB81A3C00,  //  00ED  GETNGBL	R6	K30
+      0xB81A7400,  //  00ED  GETNGBL	R6	K58
       0x7C100400,  //  00EE  CALL	R4	2
       0x78120003,  //  00EF  JMPF	R4	#00F4
-      0x8C10071F,  //  00F0  GETMET	R4	R3	K31
+      0x8C100754,  //  00F0  GETMET	R4	R3	K84
       0x7C100200,  //  00F1  CALL	R4	1
       0x5C0C0800,  //  00F2  MOVE	R3	R4
       0x70020015,  //  00F3  JMP		#010A
-      0x88100101,  //  00F4  GETMBR	R4	R0	K1
-      0x88140504,  //  00F5  GETMBR	R5	R2	K4
+      0x88100106,  //  00F4  GETMBR	R4	R0	K6
+      0x8814051F,  //  00F5  GETMBR	R5	R2	K31
       0x1C100805,  //  00F6  EQ	R4	R4	R5
       0x78120008,  //  00F7  JMPF	R4	#0101
-      0xB8123C00,  //  00F8  GETNGBL	R4	K30
+      0xB8127400,  //  00F8  GETNGBL	R4	K58
       0x60140009,  //  00F9  GETGBL	R5	G9
       0x5C180600,  //  00FA  MOVE	R6	R3
       0x7C140200,  //  00FB  CALL	R5	1
       0x7C100200,  //  00FC  CALL	R4	1
-      0x8C10091F,  //  00FD  GETMET	R4	R4	K31
+      0x8C100954,  //  00FD  GETMET	R4	R4	K84
       0x7C100200,  //  00FE  CALL	R4	1
       0x5C0C0800,  //  00FF  MOVE	R3	R4
       0x70020008,  //  0100  JMP		#010A
-      0xB8123C00,  //  0101  GETNGBL	R4	K30
-      0x8C100920,  //  0102  GETMET	R4	R4	K32
+      0xB8127400,  //  0101  GETNGBL	R4	K58
+      0x8C100955,  //  0102  GETMET	R4	R4	K85
       0x60180009,  //  0103  GETGBL	R6	G9
       0x5C1C0600,  //  0104  MOVE	R7	R3
       0x7C180200,  //  0105  CALL	R6	1
       0x7C100400,  //  0106  CALL	R4	2
-      0x8C10091F,  //  0107  GETMET	R4	R4	K31
+      0x8C100954,  //  0107  GETMET	R4	R4	K84
       0x7C100200,  //  0108  CALL	R4	1
       0x5C0C0800,  //  0109  MOVE	R3	R4
       0x40100203,  //  010A  CONNECT	R4	R1	R3
       0x70020086,  //  010B  JMP		#0193
-      0x880C0101,  //  010C  GETMBR	R3	R0	K1
-      0x88100509,  //  010D  GETMBR	R4	R2	K9
+      0x880C0106,  //  010C  GETMBR	R3	R0	K6
+      0x8810050C,  //  010D  GETMBR	R4	R2	K12
       0x1C0C0604,  //  010E  EQ	R3	R3	R4
       0x740E0003,  //  010F  JMPT	R3	#0114
-      0x880C0101,  //  0110  GETMBR	R3	R0	K1
-      0x8810050A,  //  0111  GETMBR	R4	R2	K10
+      0x880C0106,  //  0110  GETMBR	R3	R0	K6
+      0x8810050D,  //  0111  GETMBR	R4	R2	K13
       0x1C0C0604,  //  0112  EQ	R3	R3	R4
       0x780E0000,  //  0113  JMPF	R3	#0115
       0x7002007D,  //  0114  JMP		#0193
-      0x880C0101,  //  0115  GETMBR	R3	R0	K1
+      0x880C0106,  //  0115  GETMBR	R3	R0	K6
       0x88100521,  //  0116  GETMBR	R4	R2	K33
       0x1C0C0604,  //  0117  EQ	R3	R3	R4
       0x780E000D,  //  0118  JMPF	R3	#0127
       0x600C000C,  //  0119  GETGBL	R3	G12
       0x5C100200,  //  011A  MOVE	R4	R1
       0x7C0C0200,  //  011B  CALL	R3	1
-      0x8C100319,  //  011C  GETMET	R4	R1	K25
-      0x5818000E,  //  011D  LDCONST	R6	K14
+      0x8C10034C,  //  011C  GETMET	R4	R1	K76
+      0x5818002D,  //  011D  LDCONST	R6	K45
       0x541E0003,  //  011E  LDINT	R7	4
       0x7C100600,  //  011F  CALL	R4	3
-      0x8C100322,  //  0120  GETMET	R4	R1	K34
+      0x8C100356,  //  0120  GETMET	R4	R1	K86
       0x5C180600,  //  0121  MOVE	R6	R3
       0x601C000A,  //  0122  GETGBL	R7	G10
-      0x88200103,  //  0123  GETMBR	R8	R0	K3
+      0x88200107,  //  0123  GETMBR	R8	R0	K7
       0x7C1C0200,  //  0124  CALL	R7	1
       0x7C100600,  //  0125  CALL	R4	3
       0x7002006B,  //  0126  JMP		#0193
-      0x880C0101,  //  0127  GETMBR	R3	R0	K1
-      0x88100523,  //  0128  GETMBR	R4	R2	K35
+      0x880C0106,  //  0127  GETMBR	R3	R0	K6
+      0x88100522,  //  0128  GETMBR	R4	R2	K34
       0x1C0C0604,  //  0129  EQ	R3	R3	R4
       0x780E0001,  //  012A  JMPF	R3	#012D
-      0xB0064925,  //  012B  RAISE	1	K36	K37
+      0xB0064724,  //  012B  RAISE	1	K35	K36
       0x70020065,  //  012C  JMP		#0193
-      0x880C0101,  //  012D  GETMBR	R3	R0	K1
-      0x88100514,  //  012E  GETMBR	R4	R2	K20
+      0x880C0106,  //  012D  GETMBR	R3	R0	K6
+      0x88100518,  //  012E  GETMBR	R4	R2	K24
       0x1C0C0604,  //  012F  EQ	R3	R3	R4
       0x780E0015,  //  0130  JMPF	R3	#0147
       0x600C000C,  //  0131  GETGBL	R3	G12
-      0x88100103,  //  0132  GETMBR	R4	R0	K3
+      0x88100107,  //  0132  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0133  CALL	R3	1
       0x541200FE,  //  0134  LDINT	R4	255
       0x240C0604,  //  0135  GT	R3	R3	R4
       0x780E0000,  //  0136  JMPF	R3	#0138
-      0xB0064926,  //  0137  RAISE	1	K36	K38
-      0x8C0C0319,  //  0138  GETMET	R3	R1	K25
+      0xB0064757,  //  0137  RAISE	1	K35	K87
+      0x8C0C034C,  //  0138  GETMET	R3	R1	K76
       0x6014000C,  //  0139  GETGBL	R5	G12
-      0x88180103,  //  013A  GETMBR	R6	R0	K3
+      0x88180107,  //  013A  GETMBR	R6	R0	K7
       0x7C140200,  //  013B  CALL	R5	1
-      0x5818001A,  //  013C  LDCONST	R6	K26
+      0x5818001D,  //  013C  LDCONST	R6	K29
       0x7C0C0600,  //  013D  CALL	R3	3
       0x600C0015,  //  013E  GETGBL	R3	G21
       0x7C0C0000,  //  013F  CALL	R3	0
-      0x8C0C0727,  //  0140  GETMET	R3	R3	K39
+      0x8C0C0758,  //  0140  GETMET	R3	R3	K88
       0x60140008,  //  0141  GETGBL	R5	G8
-      0x88180103,  //  0142  GETMBR	R6	R0	K3
+      0x88180107,  //  0142  GETMBR	R6	R0	K7
       0x7C140200,  //  0143  CALL	R5	1
       0x7C0C0400,  //  0144  CALL	R3	2
       0x400C0203,  //  0145  CONNECT	R3	R1	R3
       0x7002004B,  //  0146  JMP		#0193
-      0x880C0101,  //  0147  GETMBR	R3	R0	K1
-      0x88100516,  //  0148  GETMBR	R4	R2	K22
+      0x880C0106,  //  0147  GETMBR	R3	R0	K6
+      0x8810051A,  //  0148  GETMBR	R4	R2	K26
       0x1C0C0604,  //  0149  EQ	R3	R3	R4
       0x780E0015,  //  014A  JMPF	R3	#0161
       0x600C000C,  //  014B  GETGBL	R3	G12
-      0x88100103,  //  014C  GETMBR	R4	R0	K3
+      0x88100107,  //  014C  GETMBR	R4	R0	K7
       0x7C0C0200,  //  014D  CALL	R3	1
       0x5412FFFE,  //  014E  LDINT	R4	65535
       0x240C0604,  //  014F  GT	R3	R3	R4
       0x780E0000,  //  0150  JMPF	R3	#0152
-      0xB0064926,  //  0151  RAISE	1	K36	K38
-      0x8C0C0319,  //  0152  GETMET	R3	R1	K25
+      0xB0064757,  //  0151  RAISE	1	K35	K87
+      0x8C0C034C,  //  0152  GETMET	R3	R1	K76
       0x6014000C,  //  0153  GETGBL	R5	G12
-      0x88180103,  //  0154  GETMBR	R6	R0	K3
+      0x88180107,  //  0154  GETMBR	R6	R0	K7
       0x7C140200,  //  0155  CALL	R5	1
-      0x5818001B,  //  0156  LDCONST	R6	K27
+      0x5818001E,  //  0156  LDCONST	R6	K30
       0x7C0C0600,  //  0157  CALL	R3	3
       0x600C0015,  //  0158  GETGBL	R3	G21
       0x7C0C0000,  //  0159  CALL	R3	0
-      0x8C0C0728,  //  015A  GETMET	R3	R3	K40
+      0x8C0C0759,  //  015A  GETMET	R3	R3	K89
       0x60140008,  //  015B  GETGBL	R5	G8
-      0x88180103,  //  015C  GETMBR	R6	R0	K3
+      0x88180107,  //  015C  GETMBR	R6	R0	K7
       0x7C140200,  //  015D  CALL	R5	1
       0x7C0C0400,  //  015E  CALL	R3	2
       0x400C0203,  //  015F  CONNECT	R3	R1	R3
       0x70020031,  //  0160  JMP		#0193
-      0x880C0101,  //  0161  GETMBR	R3	R0	K1
-      0x88100510,  //  0162  GETMBR	R4	R2	K16
+      0x880C0106,  //  0161  GETMBR	R3	R0	K6
+      0x88100514,  //  0162  GETMBR	R4	R2	K20
       0x1C0C0604,  //  0163  EQ	R3	R3	R4
       0x780E000F,  //  0164  JMPF	R3	#0175
       0x600C000C,  //  0165  GETGBL	R3	G12
-      0x88100103,  //  0166  GETMBR	R4	R0	K3
+      0x88100107,  //  0166  GETMBR	R4	R0	K7
       0x7C0C0200,  //  0167  CALL	R3	1
       0x541200FE,  //  0168  LDINT	R4	255
       0x240C0604,  //  0169  GT	R3	R3	R4
       0x780E0000,  //  016A  JMPF	R3	#016C
-      0xB0064929,  //  016B  RAISE	1	K36	K41
-      0x8C0C0319,  //  016C  GETMET	R3	R1	K25
+      0xB006475A,  //  016B  RAISE	1	K35	K90
+      0x8C0C034C,  //  016C  GETMET	R3	R1	K76
       0x6014000C,  //  016D  GETGBL	R5	G12
-      0x88180103,  //  016E  GETMBR	R6	R0	K3
+      0x88180107,  //  016E  GETMBR	R6	R0	K7
       0x7C140200,  //  016F  CALL	R5	1
-      0x5818001A,  //  0170  LDCONST	R6	K26
+      0x5818001D,  //  0170  LDCONST	R6	K29
       0x7C0C0600,  //  0171  CALL	R3	3
-      0x880C0103,  //  0172  GETMBR	R3	R0	K3
+      0x880C0107,  //  0172  GETMBR	R3	R0	K7
       0x400C0203,  //  0173  CONNECT	R3	R1	R3
       0x7002001D,  //  0174  JMP		#0193
-      0x880C0101,  //  0175  GETMBR	R3	R0	K1
-      0x88100512,  //  0176  GETMBR	R4	R2	K18
+      0x880C0106,  //  0175  GETMBR	R3	R0	K6
+      0x88100516,  //  0176  GETMBR	R4	R2	K22
       0x1C0C0604,  //  0177  EQ	R3	R3	R4
       0x780E000F,  //  0178  JMPF	R3	#0189
       0x600C000C,  //  0179  GETGBL	R3	G12
-      0x88100103,  //  017A  GETMBR	R4	R0	K3
+      0x88100107,  //  017A  GETMBR	R4	R0	K7
       0x7C0C0200,  //  017B  CALL	R3	1
       0x5412FFFE,  //  017C  LDINT	R4	65535
       0x240C0604,  //  017D  GT	R3	R3	R4
       0x780E0000,  //  017E  JMPF	R3	#0180
-      0xB0064929,  //  017F  RAISE	1	K36	K41
-      0x8C0C0319,  //  0180  GETMET	R3	R1	K25
+      0xB006475A,  //  017F  RAISE	1	K35	K90
+      0x8C0C034C,  //  0180  GETMET	R3	R1	K76
       0x6014000C,  //  0181  GETGBL	R5	G12
-      0x88180103,  //  0182  GETMBR	R6	R0	K3
+      0x88180107,  //  0182  GETMBR	R6	R0	K7
       0x7C140200,  //  0183  CALL	R5	1
-      0x5818001B,  //  0184  LDCONST	R6	K27
+      0x5818001E,  //  0184  LDCONST	R6	K30
       0x7C0C0600,  //  0185  CALL	R3	3
-      0x880C0103,  //  0186  GETMBR	R3	R0	K3
+      0x880C0107,  //  0186  GETMBR	R3	R0	K7
       0x400C0203,  //  0187  CONNECT	R3	R1	R3
       0x70020009,  //  0188  JMP		#0193
-      0x880C0101,  //  0189  GETMBR	R3	R0	K1
-      0x8810052A,  //  018A  GETMBR	R4	R2	K42
+      0x880C0106,  //  0189  GETMBR	R3	R0	K6
+      0x88100525,  //  018A  GETMBR	R4	R2	K37
       0x1C0C0604,  //  018B  EQ	R3	R3	R4
       0x780E0000,  //  018C  JMPF	R3	#018E
       0x70020004,  //  018D  JMP		#0193
       0x600C0008,  //  018E  GETGBL	R3	G8
-      0x88100101,  //  018F  GETMBR	R4	R0	K1
+      0x88100106,  //  018F  GETMBR	R4	R0	K6
       0x7C0C0200,  //  0190  CALL	R3	1
-      0x000E5603,  //  0191  ADD	R3	K43	R3
-      0xB0064803,  //  0192  RAISE	1	K36	R3
+      0x000E4C03,  //  0191  ADD	R3	K38	R3
+      0xB0064603,  //  0192  RAISE	1	K35	R3
       0x80040200,  //  0193  RET	1	R1
     })
   )
@@ -1890,40 +1784,31 @@ be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_number),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(tag_profile),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(_encode_tag_len),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060001,  //  0003  JMPF	R1	#0006
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x88040104,  //  0004  GETMBR	R1	R0	K4
       0x70020000,  //  0005  JMP		#0007
-      0x58040001,  //  0006  LDCONST	R1	K1
+      0x5804002D,  //  0006  LDCONST	R1	K45
       0x540AFFFF,  //  0007  LDINT	R2	65536
       0x28080202,  //  0008  GE	R2	R1	R2
       0x740A0002,  //  0009  JMPT	R2	#000D
-      0x14080301,  //  000A  LT	R2	R1	K1
+      0x1408032D,  //  000A  LT	R2	R1	K45
       0x740A0000,  //  000B  JMPT	R2	#000D
       0x50080001,  //  000C  LDBOOL	R2	0	1
       0x50080200,  //  000D  LDBOOL	R2	1	0
-      0x580C0001,  //  000E  LDCONST	R3	K1
+      0x580C002D,  //  000E  LDCONST	R3	K45
       0x88100102,  //  000F  GETMBR	R4	R0	K2
       0x4C140000,  //  0010  LDNIL	R5
       0x20100805,  //  0011  NE	R4	R4	R5
@@ -1943,7 +1828,7 @@ be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
       0x54120004,  //  001F  LDINT	R4	5
       0x80040800,  //  0020  RET	1	R4
       0x70020000,  //  0021  JMP		#0023
-      0x80060800,  //  0022  RET	1	K4
+      0x8006B600,  //  0022  RET	1	K91
       0x70020010,  //  0023  JMP		#0035
       0x88100103,  //  0024  GETMBR	R4	R0	K3
       0x4C140000,  //  0025  LDNIL	R5
@@ -1953,15 +1838,15 @@ be_local_closure(class_Matter_TLV_item__encode_tag_len,   /* name */
       0x54120004,  //  0029  LDINT	R4	5
       0x80040800,  //  002A  RET	1	R4
       0x70020000,  //  002B  JMP		#002D
-      0x80060800,  //  002C  RET	1	K4
+      0x8006B600,  //  002C  RET	1	K91
       0x70020006,  //  002D  JMP		#0035
       0x88100105,  //  002E  GETMBR	R4	R0	K5
       0x4C140000,  //  002F  LDNIL	R5
       0x20100805,  //  0030  NE	R4	R4	R5
       0x78120001,  //  0031  JMPF	R4	#0034
-      0x80060C00,  //  0032  RET	1	K6
+      0x8006B800,  //  0032  RET	1	K92
       0x70020000,  //  0033  JMP		#0035
-      0x80060E00,  //  0034  RET	1	K7
+      0x80069C00,  //  0034  RET	1	K78
       0x80000000,  //  0035  RET	0
     })
   )
@@ -1976,25 +1861,22 @@ be_local_closure(class_Matter_TLV_item_set_contextspecific,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    /* K1   */  be_nested_str_weak(tag_sub),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_contextspecific),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08014B,  //  0000  GETMET	R2	R0	K75
       0x7C080200,  //  0001  CALL	R2	1
       0x60080009,  //  0002  GETGBL	R2	G9
       0x5C0C0200,  //  0003  MOVE	R3	R1
       0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x90020A02,  //  0005  SETMBR	R0	K5	R2
       0x80000000,  //  0006  RET	0
     })
   )
@@ -2009,15 +1891,13 @@ be_local_closure(class_Matter_TLV_item_set_parent,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_parent),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -2036,21 +1916,17 @@ be_local_closure(class_Matter_TLV_item_create_TLV,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV_item),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(create_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x5808004D,  //  0000  LDCONST	R2	K77
       0x4C0C0000,  //  0001  LDNIL	R3
       0x200C0203,  //  0002  NE	R3	R1	R3
       0x740E0002,  //  0003  JMPT	R3	#0007
@@ -2059,8 +1935,8 @@ be_local_closure(class_Matter_TLV_item_create_TLV,   /* name */
       0x780E0004,  //  0006  JMPF	R3	#000C
       0x5C0C0400,  //  0007  MOVE	R3	R2
       0x7C0C0000,  //  0008  CALL	R3	0
-      0x900E0200,  //  0009  SETMBR	R3	K1	R0
-      0x900E0401,  //  000A  SETMBR	R3	K2	R1
+      0x900E0C00,  //  0009  SETMBR	R3	K6	R0
+      0x900E0E01,  //  000A  SETMBR	R3	K7	R1
       0x80040600,  //  000B  RET	1	R3
       0x80000000,  //  000C  RET	0
     })
@@ -2076,19 +1952,17 @@ be_local_closure(class_Matter_TLV_item_set_anonymoustag,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    }),
+    &be_ktab_class_Matter_TLV_item,     /* shared constants */
     be_str_weak(set_anonymoustag),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04014B,  //  0000  GETMET	R1	R0	K75
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -2140,6 +2014,61 @@ be_local_class(Matter_TLV_item,
     })),
     be_str_weak(Matter_TLV_item)
 );
+// compact class 'Matter_TLV_list' ktab size: 51, total: 94 (saved 344 bytes)
+static const bvalue be_ktab_class_Matter_TLV_list[51] = {
+  /* K0   */  be_nested_str_weak(findsub),
+  /* K1   */  be_nested_str_weak(val),
+  /* K2   */  be_nested_str_weak(_encode_tag),
+  /* K3   */  be_nested_str_weak(is_struct),
+  /* K4   */  be_nested_str_weak(copy),
+  /* K5   */  be_nested_str_weak(sort),
+  /* K6   */  be_nested_str_weak(tlv2raw),
+  /* K7   */  be_nested_str_weak(stop_iteration),
+  /* K8   */  be_nested_str_weak(add),
+  /* K9   */  be_nested_str_weak(TLV),
+  /* K10  */  be_nested_str_weak(EOC),
+  /* K11  */  be_const_int(1),
+  /* K12  */  be_nested_str_weak(tostring),
+  /* K13  */  be_nested_str_weak(tostring_inner),
+  /* K14  */  be_nested_str_weak(_X5B_X5B),
+  /* K15  */  be_nested_str_weak(_X5D_X5D),
+  /* K16  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K17  */  be_nested_str_weak(tag_sub),
+  /* K18  */  be_nested_str_weak(push),
+  /* K19  */  be_nested_str_weak(Matter_TLV_list),
+  /* K20  */  be_nested_str_weak(parse),
+  /* K21  */  be_nested_str_weak(next_idx),
+  /* K22  */  be_nested_str_weak(init),
+  /* K23  */  be_nested_str_weak(typ),
+  /* K24  */  be_nested_str_weak(LIST),
+  /* K25  */  be_nested_str_weak(getsub),
+  /* K26  */  be_nested_str_weak(value_error),
+  /* K27  */  be_nested_str_weak(sub_X20not_X20found),
+  /* K28  */  be_nested_str_weak(to_TLV),
+  /* K29  */  be_nested_str_weak(matter),
+  /* K30  */  be_nested_str_weak(NULL),
+  /* K31  */  be_nested_str_weak(Matter_TLV_item),
+  /* K32  */  be_nested_str_weak(Matter_TLV_array),
+  /* K33  */  be_nested_str_weak(),
+  /* K34  */  be_nested_str_weak(tag_profile),
+  /* K35  */  be_nested_str_weak(Matter_X3A_X3A),
+  /* K36  */  be_nested_str_weak(tag_number),
+  /* K37  */  be_nested_str_weak(0x_X2508X_X20),
+  /* K38  */  be_nested_str_weak(tag_vendor),
+  /* K39  */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+  /* K40  */  be_nested_str_weak(0x_X2504X_X3A),
+  /* K41  */  be_nested_str_weak(_X25i_X20),
+  /* K42  */  be_const_int(0),
+  /* K43  */  be_nested_str_weak(_X3D_X20),
+  /* K44  */  be_nested_str_weak(concat),
+  /* K45  */  be_nested_str_weak(_X2C_X20),
+  /* K46  */  be_nested_str_weak(_X20),
+  /* K47  */  be_nested_str_weak(_encode_tag_len),
+  /* K48  */  be_const_int(0),
+  /* K49  */  be_nested_str_weak(encode_len),
+  /* K50  */  be_const_int(1),
+};
+
 
 extern const bclass be_class_Matter_TLV_list;
 
@@ -2150,16 +2079,13 @@ be_local_closure(class_Matter_TLV_list_findsubval,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(findsub),
-    /* K1   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(findsubval),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -2185,25 +2111,13 @@ be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_encode_tag),
-    /* K1   */  be_nested_str_weak(val),
-    /* K2   */  be_nested_str_weak(is_struct),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(sort),
-    /* K5   */  be_nested_str_weak(tlv2raw),
-    /* K6   */  be_nested_str_weak(stop_iteration),
-    /* K7   */  be_nested_str_weak(add),
-    /* K8   */  be_nested_str_weak(TLV),
-    /* K9   */  be_nested_str_weak(EOC),
-    /* K10  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
@@ -2213,16 +2127,16 @@ be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
       0x60080015,  //  0003  GETGBL	R2	G21
       0x7C080000,  //  0004  CALL	R2	0
       0x5C040400,  //  0005  MOVE	R1	R2
-      0x8C080100,  //  0006  GETMET	R2	R0	K0
+      0x8C080102,  //  0006  GETMET	R2	R0	K2
       0x5C100200,  //  0007  MOVE	R4	R1
       0x7C080400,  //  0008  CALL	R2	2
       0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x880C0103,  //  000A  GETMBR	R3	R0	K3
       0x780E0005,  //  000B  JMPF	R3	#0012
-      0x8C0C0503,  //  000C  GETMET	R3	R2	K3
+      0x8C0C0504,  //  000C  GETMET	R3	R2	K4
       0x7C0C0200,  //  000D  CALL	R3	1
       0x5C080600,  //  000E  MOVE	R2	R3
-      0x8C0C0104,  //  000F  GETMET	R3	R0	K4
+      0x8C0C0105,  //  000F  GETMET	R3	R0	K5
       0x5C140400,  //  0010  MOVE	R5	R2
       0x7C0C0400,  //  0011  CALL	R3	2
       0x600C0010,  //  0012  GETGBL	R3	G16
@@ -2238,17 +2152,17 @@ be_local_closure(class_Matter_TLV_list_tlv2raw,   /* name */
       0x78160001,  //  001C  JMPF	R5	#001F
       0x40140204,  //  001D  CONNECT	R5	R1	R4
       0x70020002,  //  001E  JMP		#0022
-      0x8C140905,  //  001F  GETMET	R5	R4	K5
+      0x8C140906,  //  001F  GETMET	R5	R4	K6
       0x5C1C0200,  //  0020  MOVE	R7	R1
       0x7C140400,  //  0021  CALL	R5	2
       0x7001FFF2,  //  0022  JMP		#0016
-      0x580C0006,  //  0023  LDCONST	R3	K6
+      0x580C0007,  //  0023  LDCONST	R3	K7
       0xAC0C0200,  //  0024  CATCH	R3	1	0
       0xB0080000,  //  0025  RAISE	2	R0	R0
-      0x8C0C0307,  //  0026  GETMET	R3	R1	K7
-      0x88140108,  //  0027  GETMBR	R5	R0	K8
-      0x88140B09,  //  0028  GETMBR	R5	R5	K9
-      0x5818000A,  //  0029  LDCONST	R6	K10
+      0x8C0C0308,  //  0026  GETMET	R3	R1	K8
+      0x88140109,  //  0027  GETMBR	R5	R0	K9
+      0x88140B0A,  //  0028  GETMBR	R5	R5	K10
+      0x5818000B,  //  0029  LDCONST	R6	K11
       0x7C0C0600,  //  002A  CALL	R3	3
       0x80040200,  //  002B  RET	1	R1
     })
@@ -2264,19 +2178,17 @@ be_local_closure(class_Matter_TLV_list_to_str_val,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tostring),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(to_str_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010C,  //  0000  GETMET	R1	R0	K12
       0x500C0200,  //  0001  LDBOOL	R3	1	0
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
@@ -2293,24 +2205,20 @@ be_local_closure(class_Matter_TLV_list_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tostring_inner),
-    /* K1   */  be_nested_str_weak(_X5B_X5B),
-    /* K2   */  be_nested_str_weak(_X5D_X5D),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08010D,  //  0000  GETMET	R2	R0	K13
       0x50100000,  //  0001  LDBOOL	R4	0	0
-      0x58140001,  //  0002  LDCONST	R5	K1
-      0x58180002,  //  0003  LDCONST	R6	K2
+      0x5814000E,  //  0002  LDCONST	R5	K14
+      0x5818000F,  //  0003  LDCONST	R6	K15
       0x5C1C0200,  //  0004  MOVE	R7	R1
       0x7C080A00,  //  0005  CALL	R2	5
       0x80040400,  //  0006  RET	1	R2
@@ -2327,20 +2235,18 @@ be_local_closure(class_Matter_TLV_list_size,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(size),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -2356,19 +2262,17 @@ be_local_closure(class_Matter_TLV_list_setitem,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(setitem),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0101,  //  0000  GETMBR	R3	R0	K1
       0x980C0202,  //  0001  SETIDX	R3	R1	R2
       0x80000000,  //  0002  RET	0
     })
@@ -2384,29 +2288,23 @@ be_local_closure(class_Matter_TLV_list_add_struct,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K2   */  be_nested_str_weak(tag_sub),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(add_struct),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080109,  //  0000  GETMBR	R2	R0	K9
+      0x8C080510,  //  0001  GETMET	R2	R2	K16
       0x5C100000,  //  0002  MOVE	R4	R0
       0x7C080400,  //  0003  CALL	R2	2
-      0x900A0401,  //  0004  SETMBR	R2	K2	R1
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x900A2201,  //  0004  SETMBR	R2	K17	R1
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x8C0C0712,  //  0006  GETMET	R3	R3	K18
       0x5C140400,  //  0007  MOVE	R5	R2
       0x7C0C0400,  //  0008  CALL	R3	2
       0x80040400,  //  0009  RET	1	R2
@@ -2423,29 +2321,23 @@ be_local_closure(class_Matter_TLV_list_add_list,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(Matter_TLV_list),
-    /* K2   */  be_nested_str_weak(tag_sub),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(add_list),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080109,  //  0000  GETMBR	R2	R0	K9
+      0x8C080513,  //  0001  GETMET	R2	R2	K19
       0x5C100000,  //  0002  MOVE	R4	R0
       0x7C080400,  //  0003  CALL	R2	2
-      0x900A0401,  //  0004  SETMBR	R2	K2	R1
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x900A2201,  //  0004  SETMBR	R2	K17	R1
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x8C0C0712,  //  0006  GETMET	R3	R3	K18
       0x5C140400,  //  0007  MOVE	R5	R2
       0x7C0C0400,  //  0008  CALL	R3	2
       0x80040400,  //  0009  RET	1	R2
@@ -2462,43 +2354,35 @@ be_local_closure(class_Matter_TLV_list_parse,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(EOC),
-    /* K2   */  be_nested_str_weak(parse),
-    /* K3   */  be_nested_str_weak(next_idx),
-    /* K4   */  be_nested_str_weak(val),
-    /* K5   */  be_nested_str_weak(push),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
       0x940C0202,  //  0000  GETIDX	R3	R1	R2
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x88100901,  //  0002  GETMBR	R4	R4	K1
+      0x88100109,  //  0001  GETMBR	R4	R0	K9
+      0x8810090A,  //  0002  GETMBR	R4	R4	K10
       0x200C0604,  //  0003  NE	R3	R3	R4
       0x780E000B,  //  0004  JMPF	R3	#0011
-      0x880C0100,  //  0005  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  0006  GETMET	R3	R3	K2
+      0x880C0109,  //  0005  GETMBR	R3	R0	K9
+      0x8C0C0714,  //  0006  GETMET	R3	R3	K20
       0x5C140200,  //  0007  MOVE	R5	R1
       0x5C180400,  //  0008  MOVE	R6	R2
       0x5C1C0000,  //  0009  MOVE	R7	R0
       0x7C0C0800,  //  000A  CALL	R3	4
-      0x88080703,  //  000B  GETMBR	R2	R3	K3
-      0x88100104,  //  000C  GETMBR	R4	R0	K4
-      0x8C100905,  //  000D  GETMET	R4	R4	K5
+      0x88080715,  //  000B  GETMBR	R2	R3	K21
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x8C100912,  //  000D  GETMET	R4	R4	K18
       0x5C180600,  //  000E  MOVE	R6	R3
       0x7C100400,  //  000F  CALL	R4	2
       0x7001FFEE,  //  0010  JMP		#0000
-      0x00080506,  //  0011  ADD	R2	R2	K6
-      0x90020602,  //  0012  SETMBR	R0	K3	R2
+      0x0008050B,  //  0011  ADD	R2	R2	K11
+      0x90022A02,  //  0012  SETMBR	R0	K21	R2
       0x80040400,  //  0013  RET	1	R2
     })
   )
@@ -2513,34 +2397,28 @@ be_local_closure(class_Matter_TLV_list_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(LIST),
-    /* K4   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080516,  //  0003  GETMET	R2	R2	K22
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x88080503,  //  0007  GETMBR	R2	R2	K3
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x88080109,  //  0006  GETMBR	R2	R0	K9
+      0x88080518,  //  0007  GETMBR	R2	R2	K24
+      0x90022E02,  //  0008  SETMBR	R0	K23	R2
       0x60080012,  //  0009  GETGBL	R2	G18
       0x7C080000,  //  000A  CALL	R2	0
-      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x90020202,  //  000B  SETMBR	R0	K1	R2
       0x80000000,  //  000C  RET	0
     })
   )
@@ -2555,19 +2433,17 @@ be_local_closure(class_Matter_TLV_list_item,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(item),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
       0x94080401,  //  0001  GETIDX	R2	R2	R1
       0x80040400,  //  0002  RET	1	R2
     })
@@ -2583,20 +2459,17 @@ be_local_closure(class_Matter_TLV_list_getsubval,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(getsub),
-    /* K1   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(getsubval),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080119,  //  0000  GETMET	R2	R0	K25
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x88080501,  //  0003  GETMBR	R2	R2	K1
@@ -2614,17 +2487,13 @@ be_local_closure(class_Matter_TLV_list_getsub,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(findsub),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(sub_X20not_X20found),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(getsub),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
@@ -2634,7 +2503,7 @@ be_local_closure(class_Matter_TLV_list_getsub,   /* name */
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C0C0403,  //  0004  EQ	R3	R2	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
-      0xB0060302,  //  0006  RAISE	1	K1	K2
+      0xB006351B,  //  0006  RAISE	1	K26	K27
       0x80040400,  //  0007  RET	1	R2
     })
   )
@@ -2649,18 +2518,13 @@ be_local_closure(class_Matter_TLV_list_add_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(to_TLV),
-    /* K3   */  be_nested_str_weak(tag_sub),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(add_obj),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
@@ -2672,16 +2536,16 @@ be_local_closure(class_Matter_TLV_list_add_obj,   /* name */
       0x60140015,  //  0005  GETGBL	R5	G21
       0x7C0C0400,  //  0006  CALL	R3	2
       0x780E0004,  //  0007  JMPF	R3	#000D
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0009  GETMET	R3	R3	K1
+      0x880C0101,  //  0008  GETMBR	R3	R0	K1
+      0x8C0C0712,  //  0009  GETMET	R3	R3	K18
       0x5C140400,  //  000A  MOVE	R5	R2
       0x7C0C0400,  //  000B  CALL	R3	2
       0x70020006,  //  000C  JMP		#0014
-      0x8C0C0502,  //  000D  GETMET	R3	R2	K2
+      0x8C0C051C,  //  000D  GETMET	R3	R2	K28
       0x7C0C0200,  //  000E  CALL	R3	1
-      0x900E0601,  //  000F  SETMBR	R3	K3	R1
-      0x88100100,  //  0010  GETMBR	R4	R0	K0
-      0x8C100901,  //  0011  GETMET	R4	R4	K1
+      0x900E2201,  //  000F  SETMBR	R3	K17	R1
+      0x88100101,  //  0010  GETMBR	R4	R0	K1
+      0x8C100912,  //  0011  GETMET	R4	R4	K18
       0x5C180600,  //  0012  MOVE	R6	R3
       0x7C100400,  //  0013  CALL	R4	2
       0x80040000,  //  0014  RET	1	R0
@@ -2698,42 +2562,33 @@ be_local_closure(class_Matter_TLV_list_add_TLV,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(NULL),
-    /* K3   */  be_nested_str_weak(Matter_TLV_item),
-    /* K4   */  be_nested_str_weak(tag_sub),
-    /* K5   */  be_nested_str_weak(typ),
-    /* K6   */  be_nested_str_weak(val),
-    /* K7   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(add_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x20100604,  //  0001  NE	R4	R3	R4
       0x74120004,  //  0002  JMPT	R4	#0008
-      0xB8120000,  //  0003  GETNGBL	R4	K0
-      0x88100901,  //  0004  GETMBR	R4	R4	K1
-      0x88100902,  //  0005  GETMBR	R4	R4	K2
+      0xB8123A00,  //  0003  GETNGBL	R4	K29
+      0x88100909,  //  0004  GETMBR	R4	R4	K9
+      0x8810091E,  //  0005  GETMBR	R4	R4	K30
       0x1C100404,  //  0006  EQ	R4	R2	R4
       0x7812000A,  //  0007  JMPF	R4	#0013
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
-      0x8C100903,  //  0009  GETMET	R4	R4	K3
+      0x88100109,  //  0008  GETMBR	R4	R0	K9
+      0x8C10091F,  //  0009  GETMET	R4	R4	K31
       0x5C180000,  //  000A  MOVE	R6	R0
       0x7C100400,  //  000B  CALL	R4	2
-      0x90120801,  //  000C  SETMBR	R4	K4	R1
-      0x90120A02,  //  000D  SETMBR	R4	K5	R2
-      0x90120C03,  //  000E  SETMBR	R4	K6	R3
-      0x88140106,  //  000F  GETMBR	R5	R0	K6
-      0x8C140B07,  //  0010  GETMET	R5	R5	K7
+      0x90122201,  //  000C  SETMBR	R4	K17	R1
+      0x90122E02,  //  000D  SETMBR	R4	K23	R2
+      0x90120203,  //  000E  SETMBR	R4	K1	R3
+      0x88140101,  //  000F  GETMBR	R5	R0	K1
+      0x8C140B12,  //  0010  GETMET	R5	R5	K18
       0x5C1C0800,  //  0011  MOVE	R7	R4
       0x7C140400,  //  0012  CALL	R5	2
       0x80040000,  //  0013  RET	1	R0
@@ -2750,29 +2605,23 @@ be_local_closure(class_Matter_TLV_list_add_array,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(Matter_TLV_array),
-    /* K2   */  be_nested_str_weak(tag_sub),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(add_array),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080109,  //  0000  GETMBR	R2	R0	K9
+      0x8C080520,  //  0001  GETMET	R2	R2	K32
       0x5C100000,  //  0002  MOVE	R4	R0
       0x7C080400,  //  0003  CALL	R2	2
-      0x900A0401,  //  0004  SETMBR	R2	K2	R1
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x900A2201,  //  0004  SETMBR	R2	K17	R1
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x8C0C0712,  //  0006  GETMET	R3	R3	K18
       0x5C140400,  //  0007  MOVE	R5	R2
       0x7C0C0400,  //  0008  CALL	R3	2
       0x80040400,  //  0009  RET	1	R2
@@ -2789,33 +2638,29 @@ be_local_closure(class_Matter_TLV_list_findsub,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(tag_sub),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(findsub),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x600C0010,  //  0000  GETGBL	R3	G16
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x88100101,  //  0001  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0002  CALL	R3	1
       0xA8020007,  //  0003  EXBLK	0	#000C
       0x5C100600,  //  0004  MOVE	R4	R3
       0x7C100000,  //  0005  CALL	R4	0
-      0x88140901,  //  0006  GETMBR	R5	R4	K1
+      0x88140911,  //  0006  GETMBR	R5	R4	K17
       0x1C140A01,  //  0007  EQ	R5	R5	R1
       0x78160001,  //  0008  JMPF	R5	#000B
       0xA8040001,  //  0009  EXBLK	1	1
       0x80040800,  //  000A  RET	1	R4
       0x7001FFF7,  //  000B  JMP		#0004
-      0x580C0002,  //  000C  LDCONST	R3	K2
+      0x580C0007,  //  000C  LDCONST	R3	K7
       0xAC0C0200,  //  000D  CATCH	R3	1	0
       0xB0080000,  //  000E  RAISE	2	R0	R0
       0x80040400,  //  000F  RET	1	R2
@@ -2832,107 +2677,88 @@ be_local_closure(class_Matter_TLV_list_tostring_inner,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(tag_profile),
-    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K3   */  be_nested_str_weak(tag_number),
-    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K5   */  be_nested_str_weak(tag_vendor),
-    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K8   */  be_nested_str_weak(tag_sub),
-    /* K9   */  be_nested_str_weak(_X25i_X20),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(_X3D_X20),
-    /* K12  */  be_nested_str_weak(val),
-    /* K13  */  be_nested_str_weak(copy),
-    /* K14  */  be_nested_str_weak(sort),
-    /* K15  */  be_nested_str_weak(concat),
-    /* K16  */  be_nested_str_weak(_X2C_X20),
-    /* K17  */  be_nested_str_weak(_X20),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(tostring_inner),
     &be_const_str_solidified,
     ( &(const binstruction[85]) {  /* code */
-      0x58140000,  //  0000  LDCONST	R5	K0
+      0x58140021,  //  0000  LDCONST	R5	K33
       0xA802004A,  //  0001  EXBLK	0	#004D
       0x50180200,  //  0002  LDBOOL	R6	1	0
       0x20180806,  //  0003  NE	R6	R4	R6
       0x781A0038,  //  0004  JMPF	R6	#003E
-      0x88180101,  //  0005  GETMBR	R6	R0	K1
+      0x88180122,  //  0005  GETMBR	R6	R0	K34
       0x541DFFFE,  //  0006  LDINT	R7	-1
       0x1C180C07,  //  0007  EQ	R6	R6	R7
       0x781A000A,  //  0008  JMPF	R6	#0014
-      0x00140B02,  //  0009  ADD	R5	R5	K2
-      0x88180103,  //  000A  GETMBR	R6	R0	K3
+      0x00140B23,  //  0009  ADD	R5	R5	K35
+      0x88180124,  //  000A  GETMBR	R6	R0	K36
       0x4C1C0000,  //  000B  LDNIL	R7
       0x20180C07,  //  000C  NE	R6	R6	R7
       0x781A0004,  //  000D  JMPF	R6	#0013
       0x60180018,  //  000E  GETGBL	R6	G24
-      0x581C0004,  //  000F  LDCONST	R7	K4
-      0x88200103,  //  0010  GETMBR	R8	R0	K3
+      0x581C0025,  //  000F  LDCONST	R7	K37
+      0x88200124,  //  0010  GETMBR	R8	R0	K36
       0x7C180400,  //  0011  CALL	R6	2
       0x00140A06,  //  0012  ADD	R5	R5	R6
       0x70020023,  //  0013  JMP		#0038
-      0x88180105,  //  0014  GETMBR	R6	R0	K5
+      0x88180126,  //  0014  GETMBR	R6	R0	K38
       0x4C1C0000,  //  0015  LDNIL	R7
       0x20180C07,  //  0016  NE	R6	R6	R7
       0x781A0004,  //  0017  JMPF	R6	#001D
       0x60180018,  //  0018  GETGBL	R6	G24
-      0x581C0006,  //  0019  LDCONST	R7	K6
-      0x88200105,  //  001A  GETMBR	R8	R0	K5
+      0x581C0027,  //  0019  LDCONST	R7	K39
+      0x88200126,  //  001A  GETMBR	R8	R0	K38
       0x7C180400,  //  001B  CALL	R6	2
       0x00140A06,  //  001C  ADD	R5	R5	R6
-      0x88180101,  //  001D  GETMBR	R6	R0	K1
+      0x88180122,  //  001D  GETMBR	R6	R0	K34
       0x4C1C0000,  //  001E  LDNIL	R7
       0x20180C07,  //  001F  NE	R6	R6	R7
       0x781A0004,  //  0020  JMPF	R6	#0026
       0x60180018,  //  0021  GETGBL	R6	G24
-      0x581C0007,  //  0022  LDCONST	R7	K7
-      0x88200101,  //  0023  GETMBR	R8	R0	K1
+      0x581C0028,  //  0022  LDCONST	R7	K40
+      0x88200122,  //  0023  GETMBR	R8	R0	K34
       0x7C180400,  //  0024  CALL	R6	2
       0x00140A06,  //  0025  ADD	R5	R5	R6
-      0x88180103,  //  0026  GETMBR	R6	R0	K3
+      0x88180124,  //  0026  GETMBR	R6	R0	K36
       0x4C1C0000,  //  0027  LDNIL	R7
       0x20180C07,  //  0028  NE	R6	R6	R7
       0x781A0004,  //  0029  JMPF	R6	#002F
       0x60180018,  //  002A  GETGBL	R6	G24
-      0x581C0004,  //  002B  LDCONST	R7	K4
-      0x88200103,  //  002C  GETMBR	R8	R0	K3
+      0x581C0025,  //  002B  LDCONST	R7	K37
+      0x88200124,  //  002C  GETMBR	R8	R0	K36
       0x7C180400,  //  002D  CALL	R6	2
       0x00140A06,  //  002E  ADD	R5	R5	R6
-      0x88180108,  //  002F  GETMBR	R6	R0	K8
+      0x88180111,  //  002F  GETMBR	R6	R0	K17
       0x4C1C0000,  //  0030  LDNIL	R7
       0x20180C07,  //  0031  NE	R6	R6	R7
       0x781A0004,  //  0032  JMPF	R6	#0038
       0x60180018,  //  0033  GETGBL	R6	G24
-      0x581C0009,  //  0034  LDCONST	R7	K9
-      0x88200108,  //  0035  GETMBR	R8	R0	K8
+      0x581C0029,  //  0034  LDCONST	R7	K41
+      0x88200111,  //  0035  GETMBR	R8	R0	K17
       0x7C180400,  //  0036  CALL	R6	2
       0x00140A06,  //  0037  ADD	R5	R5	R6
       0x6018000C,  //  0038  GETGBL	R6	G12
       0x5C1C0A00,  //  0039  MOVE	R7	R5
       0x7C180200,  //  003A  CALL	R6	1
-      0x24180D0A,  //  003B  GT	R6	R6	K10
+      0x24180D2A,  //  003B  GT	R6	R6	K42
       0x781A0000,  //  003C  JMPF	R6	#003E
-      0x00140B0B,  //  003D  ADD	R5	R5	K11
+      0x00140B2B,  //  003D  ADD	R5	R5	K43
       0x00140A02,  //  003E  ADD	R5	R5	R2
-      0x8818010C,  //  003F  GETMBR	R6	R0	K12
-      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x88180101,  //  003F  GETMBR	R6	R0	K1
+      0x8C180D04,  //  0040  GETMET	R6	R6	K4
       0x7C180200,  //  0041  CALL	R6	1
       0x78060002,  //  0042  JMPF	R1	#0046
-      0x8C1C010E,  //  0043  GETMET	R7	R0	K14
+      0x8C1C0105,  //  0043  GETMET	R7	R0	K5
       0x5C240C00,  //  0044  MOVE	R9	R6
       0x7C1C0400,  //  0045  CALL	R7	2
-      0x8C1C0D0F,  //  0046  GETMET	R7	R6	K15
-      0x58240010,  //  0047  LDCONST	R9	K16
+      0x8C1C0D2C,  //  0046  GETMET	R7	R6	K44
+      0x5824002D,  //  0047  LDCONST	R9	K45
       0x7C1C0400,  //  0048  CALL	R7	2
       0x00140A07,  //  0049  ADD	R5	R5	R7
       0x00140A03,  //  004A  ADD	R5	R5	R3
@@ -2940,7 +2766,7 @@ be_local_closure(class_Matter_TLV_list_tostring_inner,   /* name */
       0x70020006,  //  004C  JMP		#0054
       0xAC180002,  //  004D  CATCH	R6	0	2
       0x70020003,  //  004E  JMP		#0053
-      0x00200D11,  //  004F  ADD	R8	R6	K17
+      0x00200D2E,  //  004F  ADD	R8	R6	K46
       0x00201007,  //  0050  ADD	R8	R8	R7
       0x80041000,  //  0051  RET	1	R8
       0x70020000,  //  0052  JMP		#0054
@@ -2959,21 +2785,18 @@ be_local_closure(class_Matter_TLV_list_push,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(push),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C080512,  //  0001  GETMET	R2	R2	K18
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
@@ -2990,16 +2813,13 @@ be_local_closure(class_Matter_TLV_list_findsubtyp,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(findsub),
-    /* K1   */  be_nested_str_weak(typ),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(findsubtyp),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
@@ -3009,7 +2829,7 @@ be_local_closure(class_Matter_TLV_list_findsubtyp,   /* name */
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0001,  //  0005  JMPF	R3	#0008
-      0x880C0501,  //  0006  GETMBR	R3	R2	K1
+      0x880C0517,  //  0006  GETMBR	R3	R2	K23
       0x80040600,  //  0007  RET	1	R3
       0x4C0C0000,  //  0008  LDNIL	R3
       0x80040600,  //  0009  RET	1	R3
@@ -3026,38 +2846,32 @@ be_local_closure(class_Matter_TLV_list_encode_len,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_encode_tag_len),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(val),
-    /* K3   */  be_nested_str_weak(encode_len),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_TLV_list,     /* shared constants */
     be_str_weak(encode_len),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04012F,  //  0000  GETMET	R1	R0	K47
       0x7C040200,  //  0001  CALL	R1	1
-      0x58080001,  //  0002  LDCONST	R2	K1
+      0x58080030,  //  0002  LDCONST	R2	K48
       0x600C000C,  //  0003  GETGBL	R3	G12
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x88100101,  //  0004  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0005  CALL	R3	1
       0x140C0403,  //  0006  LT	R3	R2	R3
       0x780E0006,  //  0007  JMPF	R3	#000F
-      0x880C0102,  //  0008  GETMBR	R3	R0	K2
+      0x880C0101,  //  0008  GETMBR	R3	R0	K1
       0x940C0602,  //  0009  GETIDX	R3	R3	R2
-      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
+      0x8C0C0731,  //  000A  GETMET	R3	R3	K49
       0x7C0C0200,  //  000B  CALL	R3	1
       0x00040203,  //  000C  ADD	R1	R1	R3
-      0x00080504,  //  000D  ADD	R2	R2	K4
+      0x00080532,  //  000D  ADD	R2	R2	K50
       0x7001FFF3,  //  000E  JMP		#0003
-      0x00040304,  //  000F  ADD	R1	R1	K4
+      0x00040332,  //  000F  ADD	R1	R1	K50
       0x80040200,  //  0010  RET	1	R1
     })
   )
@@ -3194,6 +3008,27 @@ be_local_class(Matter_TLV_struct,
     })),
     be_str_weak(Matter_TLV_struct)
 );
+// compact class 'Matter_TLV_array' ktab size: 17, total: 19 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_TLV_array[17] = {
+  /* K0   */  be_nested_str_weak(tostring_inner),
+  /* K1   */  be_nested_str_weak(_X5B),
+  /* K2   */  be_nested_str_weak(_X5D),
+  /* K3   */  be_nested_str_weak(init),
+  /* K4   */  be_nested_str_weak(typ),
+  /* K5   */  be_nested_str_weak(TLV),
+  /* K6   */  be_nested_str_weak(ARRAY),
+  /* K7   */  be_nested_str_weak(val),
+  /* K8   */  be_nested_str_weak(EOC),
+  /* K9   */  be_nested_str_weak(parse),
+  /* K10  */  be_nested_str_weak(next_idx),
+  /* K11  */  be_nested_str_weak(tag_vendor),
+  /* K12  */  be_nested_str_weak(tag_profile),
+  /* K13  */  be_nested_str_weak(tag_number),
+  /* K14  */  be_nested_str_weak(tag_sub),
+  /* K15  */  be_nested_str_weak(push),
+  /* K16  */  be_const_int(1),
+};
+
 
 extern const bclass be_class_Matter_TLV_array;
 
@@ -3204,17 +3039,13 @@ be_local_closure(class_Matter_TLV_array_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tostring_inner),
-    /* K1   */  be_nested_str_weak(_X5B),
-    /* K2   */  be_nested_str_weak(_X5D),
-    }),
+    &be_ktab_class_Matter_TLV_array,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -3238,34 +3069,28 @@ be_local_closure(class_Matter_TLV_array_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(ARRAY),
-    /* K4   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_Matter_TLV_array,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080503,  //  0003  GETMET	R2	R2	K3
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x88080503,  //  0007  GETMBR	R2	R2	K3
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x88080105,  //  0006  GETMBR	R2	R0	K5
+      0x88080506,  //  0007  GETMBR	R2	R2	K6
+      0x90020802,  //  0008  SETMBR	R0	K4	R2
       0x60080012,  //  0009  GETGBL	R2	G18
       0x7C080000,  //  000A  CALL	R2	0
-      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x90020E02,  //  000B  SETMBR	R0	K7	R2
       0x80000000,  //  000C  RET	0
     })
   )
@@ -3280,55 +3105,43 @@ be_local_closure(class_Matter_TLV_array_parse,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(EOC),
-    /* K2   */  be_nested_str_weak(parse),
-    /* K3   */  be_nested_str_weak(next_idx),
-    /* K4   */  be_nested_str_weak(tag_vendor),
-    /* K5   */  be_nested_str_weak(tag_profile),
-    /* K6   */  be_nested_str_weak(tag_number),
-    /* K7   */  be_nested_str_weak(tag_sub),
-    /* K8   */  be_nested_str_weak(val),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_TLV_array,     /* shared constants */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
       0x940C0202,  //  0000  GETIDX	R3	R1	R2
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x88100901,  //  0002  GETMBR	R4	R4	K1
+      0x88100105,  //  0001  GETMBR	R4	R0	K5
+      0x88100908,  //  0002  GETMBR	R4	R4	K8
       0x200C0604,  //  0003  NE	R3	R3	R4
       0x780E0013,  //  0004  JMPF	R3	#0019
-      0x880C0100,  //  0005  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  0006  GETMET	R3	R3	K2
+      0x880C0105,  //  0005  GETMBR	R3	R0	K5
+      0x8C0C0709,  //  0006  GETMET	R3	R3	K9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x5C180400,  //  0008  MOVE	R6	R2
       0x5C1C0000,  //  0009  MOVE	R7	R0
       0x7C0C0800,  //  000A  CALL	R3	4
-      0x88080703,  //  000B  GETMBR	R2	R3	K3
+      0x8808070A,  //  000B  GETMBR	R2	R3	K10
       0x4C100000,  //  000C  LDNIL	R4
-      0x900E0804,  //  000D  SETMBR	R3	K4	R4
+      0x900E1604,  //  000D  SETMBR	R3	K11	R4
       0x4C100000,  //  000E  LDNIL	R4
-      0x900E0A04,  //  000F  SETMBR	R3	K5	R4
+      0x900E1804,  //  000F  SETMBR	R3	K12	R4
       0x4C100000,  //  0010  LDNIL	R4
-      0x900E0C04,  //  0011  SETMBR	R3	K6	R4
+      0x900E1A04,  //  0011  SETMBR	R3	K13	R4
       0x4C100000,  //  0012  LDNIL	R4
-      0x900E0E04,  //  0013  SETMBR	R3	K7	R4
-      0x88100108,  //  0014  GETMBR	R4	R0	K8
-      0x8C100909,  //  0015  GETMET	R4	R4	K9
+      0x900E1C04,  //  0013  SETMBR	R3	K14	R4
+      0x88100107,  //  0014  GETMBR	R4	R0	K7
+      0x8C10090F,  //  0015  GETMET	R4	R4	K15
       0x5C180600,  //  0016  MOVE	R6	R3
       0x7C100400,  //  0017  CALL	R4	2
       0x7001FFE6,  //  0018  JMP		#0000
-      0x0008050A,  //  0019  ADD	R2	R2	K10
-      0x90020602,  //  001A  SETMBR	R0	K3	R2
+      0x00080510,  //  0019  ADD	R2	R2	K16
+      0x90021402,  //  001A  SETMBR	R0	K10	R2
       0x80040400,  //  001B  RET	1	R2
     })
   )
@@ -3353,6 +3166,33 @@ be_local_class(Matter_TLV_array,
     })),
     be_str_weak(Matter_TLV_array)
 );
+extern const bclass be_class_Matter_TLV;
+// compact class 'Matter_TLV' ktab size: 22, total: 24 (saved 16 bytes)
+static const bvalue be_ktab_class_Matter_TLV[22] = {
+  /* K0   */  be_const_class(be_class_Matter_TLV),
+  /* K1   */  be_nested_str_weak(Matter_TLV_item),
+  /* K2   */  be_nested_str_weak(create_TLV),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str_weak(EOC),
+  /* K6   */  be_nested_str_weak(invalid_X20TLV_X20type_X20),
+  /* K7   */  be_nested_str_weak(TLV_error),
+  /* K8   */  be_nested_str_weak(STRUCT),
+  /* K9   */  be_nested_str_weak(Matter_TLV_struct),
+  /* K10  */  be_nested_str_weak(ARRAY),
+  /* K11  */  be_nested_str_weak(Matter_TLV_array),
+  /* K12  */  be_nested_str_weak(LIST),
+  /* K13  */  be_nested_str_weak(Matter_TLV_list),
+  /* K14  */  be_nested_str_weak(typ),
+  /* K15  */  be_nested_str_weak(tag_vendor),
+  /* K16  */  be_nested_str_weak(get),
+  /* K17  */  be_const_int(2),
+  /* K18  */  be_nested_str_weak(tag_profile),
+  /* K19  */  be_nested_str_weak(tag_sub),
+  /* K20  */  be_nested_str_weak(tag_number),
+  /* K21  */  be_nested_str_weak(parse),
+};
+
 
 extern const bclass be_class_Matter_TLV;
 
@@ -3363,17 +3203,13 @@ be_local_closure(class_Matter_TLV_create_TLV,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV),
-    /* K1   */  be_nested_str_weak(Matter_TLV_item),
-    /* K2   */  be_nested_str_weak(create_TLV),
-    }),
+    &be_ktab_class_Matter_TLV,     /* shared constants */
     be_str_weak(create_TLV),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -3397,35 +3233,13 @@ be_local_closure(class_Matter_TLV_parse,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(EOC),
-    /* K4   */  be_nested_str_weak(invalid_X20TLV_X20type_X20),
-    /* K5   */  be_nested_str_weak(TLV_error),
-    /* K6   */  be_nested_str_weak(STRUCT),
-    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K8   */  be_nested_str_weak(ARRAY),
-    /* K9   */  be_nested_str_weak(Matter_TLV_array),
-    /* K10  */  be_nested_str_weak(LIST),
-    /* K11  */  be_nested_str_weak(Matter_TLV_list),
-    /* K12  */  be_nested_str_weak(Matter_TLV_item),
-    /* K13  */  be_nested_str_weak(typ),
-    /* K14  */  be_nested_str_weak(tag_vendor),
-    /* K15  */  be_nested_str_weak(get),
-    /* K16  */  be_const_int(2),
-    /* K17  */  be_nested_str_weak(tag_profile),
-    /* K18  */  be_nested_str_weak(tag_sub),
-    /* K19  */  be_nested_str_weak(tag_number),
-    /* K20  */  be_nested_str_weak(parse),
-    }),
+    &be_ktab_class_Matter_TLV,     /* shared constants */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[118]) {  /* code */
@@ -3434,68 +3248,68 @@ be_local_closure(class_Matter_TLV_parse,   /* name */
       0x4C140000,  //  0002  LDNIL	R5
       0x1C140205,  //  0003  EQ	R5	R1	R5
       0x78160000,  //  0004  JMPF	R5	#0006
-      0x58040001,  //  0005  LDCONST	R1	K1
+      0x58040003,  //  0005  LDCONST	R1	K3
       0x94140001,  //  0006  GETIDX	R5	R0	R1
       0x541A001E,  //  0007  LDINT	R6	31
       0x2C140A06,  //  0008  AND	R5	R5	R6
       0x94180001,  //  0009  GETIDX	R6	R0	R1
       0x541E00DF,  //  000A  LDINT	R7	224
       0x2C180C07,  //  000B  AND	R6	R6	R7
-      0x00040302,  //  000C  ADD	R1	R1	K2
-      0x881C0903,  //  000D  GETMBR	R7	R4	K3
+      0x00040304,  //  000C  ADD	R1	R1	K4
+      0x881C0905,  //  000D  GETMBR	R7	R4	K5
       0x241C0A07,  //  000E  GT	R7	R5	R7
       0x781E0004,  //  000F  JMPF	R7	#0015
       0x601C0008,  //  0010  GETGBL	R7	G8
       0x5C200A00,  //  0011  MOVE	R8	R5
       0x7C1C0200,  //  0012  CALL	R7	1
-      0x001E0807,  //  0013  ADD	R7	K4	R7
-      0xB0060A07,  //  0014  RAISE	1	K5	R7
+      0x001E0C07,  //  0013  ADD	R7	K6	R7
+      0xB0060E07,  //  0014  RAISE	1	K7	R7
       0x4C1C0000,  //  0015  LDNIL	R7
-      0x88200906,  //  0016  GETMBR	R8	R4	K6
+      0x88200908,  //  0016  GETMBR	R8	R4	K8
       0x1C200A08,  //  0017  EQ	R8	R5	R8
       0x78220004,  //  0018  JMPF	R8	#001E
-      0x8C200707,  //  0019  GETMET	R8	R3	K7
+      0x8C200709,  //  0019  GETMET	R8	R3	K9
       0x5C280400,  //  001A  MOVE	R10	R2
       0x7C200400,  //  001B  CALL	R8	2
       0x5C1C1000,  //  001C  MOVE	R7	R8
       0x70020013,  //  001D  JMP		#0032
-      0x88200908,  //  001E  GETMBR	R8	R4	K8
+      0x8820090A,  //  001E  GETMBR	R8	R4	K10
       0x1C200A08,  //  001F  EQ	R8	R5	R8
       0x78220004,  //  0020  JMPF	R8	#0026
-      0x8C200709,  //  0021  GETMET	R8	R3	K9
+      0x8C20070B,  //  0021  GETMET	R8	R3	K11
       0x5C280400,  //  0022  MOVE	R10	R2
       0x7C200400,  //  0023  CALL	R8	2
       0x5C1C1000,  //  0024  MOVE	R7	R8
       0x7002000B,  //  0025  JMP		#0032
-      0x8820090A,  //  0026  GETMBR	R8	R4	K10
+      0x8820090C,  //  0026  GETMBR	R8	R4	K12
       0x1C200A08,  //  0027  EQ	R8	R5	R8
       0x78220004,  //  0028  JMPF	R8	#002E
-      0x8C20070B,  //  0029  GETMET	R8	R3	K11
+      0x8C20070D,  //  0029  GETMET	R8	R3	K13
       0x5C280400,  //  002A  MOVE	R10	R2
       0x7C200400,  //  002B  CALL	R8	2
       0x5C1C1000,  //  002C  MOVE	R7	R8
       0x70020003,  //  002D  JMP		#0032
-      0x8C20070C,  //  002E  GETMET	R8	R3	K12
+      0x8C200701,  //  002E  GETMET	R8	R3	K1
       0x5C280400,  //  002F  MOVE	R10	R2
       0x7C200400,  //  0030  CALL	R8	2
       0x5C1C1000,  //  0031  MOVE	R7	R8
-      0x901E1A05,  //  0032  SETMBR	R7	K13	R5
+      0x901E1C05,  //  0032  SETMBR	R7	K14	R5
       0x542200BF,  //  0033  LDINT	R8	192
       0x1C200C08,  //  0034  EQ	R8	R6	R8
       0x74220002,  //  0035  JMPT	R8	#0039
       0x542200DF,  //  0036  LDINT	R8	224
       0x1C200C08,  //  0037  EQ	R8	R6	R8
       0x7822000B,  //  0038  JMPF	R8	#0045
-      0x8C20010F,  //  0039  GETMET	R8	R0	K15
+      0x8C200110,  //  0039  GETMET	R8	R0	K16
       0x5C280200,  //  003A  MOVE	R10	R1
-      0x582C0010,  //  003B  LDCONST	R11	K16
+      0x582C0011,  //  003B  LDCONST	R11	K17
       0x7C200600,  //  003C  CALL	R8	3
-      0x901E1C08,  //  003D  SETMBR	R7	K14	R8
-      0x8C20010F,  //  003E  GETMET	R8	R0	K15
-      0x00280310,  //  003F  ADD	R10	R1	K16
-      0x582C0010,  //  0040  LDCONST	R11	K16
+      0x901E1E08,  //  003D  SETMBR	R7	K15	R8
+      0x8C200110,  //  003E  GETMET	R8	R0	K16
+      0x00280311,  //  003F  ADD	R10	R1	K17
+      0x582C0011,  //  0040  LDCONST	R11	K17
       0x7C200600,  //  0041  CALL	R8	3
-      0x901E2208,  //  0042  SETMBR	R7	K17	R8
+      0x901E2408,  //  0042  SETMBR	R7	K18	R8
       0x54220003,  //  0043  LDINT	R8	4
       0x00040208,  //  0044  ADD	R1	R1	R8
       0x5422003F,  //  0045  LDINT	R8	64
@@ -3505,18 +3319,18 @@ be_local_closure(class_Matter_TLV_parse,   /* name */
       0x1C200C08,  //  0049  EQ	R8	R6	R8
       0x78220003,  //  004A  JMPF	R8	#004F
       0x4C200000,  //  004B  LDNIL	R8
-      0x901E1C08,  //  004C  SETMBR	R7	K14	R8
+      0x901E1E08,  //  004C  SETMBR	R7	K15	R8
       0x5421FFFE,  //  004D  LDINT	R8	-1
-      0x901E2208,  //  004E  SETMBR	R7	K17	R8
-      0x1C200D01,  //  004F  EQ	R8	R6	K1
+      0x901E2408,  //  004E  SETMBR	R7	K18	R8
+      0x1C200D03,  //  004F  EQ	R8	R6	K3
       0x78220000,  //  0050  JMPF	R8	#0052
       0x7002001D,  //  0051  JMP		#0070
       0x5422001F,  //  0052  LDINT	R8	32
       0x1C200C08,  //  0053  EQ	R8	R6	R8
       0x78220003,  //  0054  JMPF	R8	#0059
       0x94200001,  //  0055  GETIDX	R8	R0	R1
-      0x901E2408,  //  0056  SETMBR	R7	K18	R8
-      0x00040302,  //  0057  ADD	R1	R1	K2
+      0x901E2608,  //  0056  SETMBR	R7	K19	R8
+      0x00040304,  //  0057  ADD	R1	R1	K4
       0x70020016,  //  0058  JMP		#0070
       0x542200BF,  //  0059  LDINT	R8	192
       0x1C200C08,  //  005A  EQ	R8	R6	R8
@@ -3527,21 +3341,21 @@ be_local_closure(class_Matter_TLV_parse,   /* name */
       0x5422003F,  //  005F  LDINT	R8	64
       0x1C200C08,  //  0060  EQ	R8	R6	R8
       0x78220006,  //  0061  JMPF	R8	#0069
-      0x8C20010F,  //  0062  GETMET	R8	R0	K15
+      0x8C200110,  //  0062  GETMET	R8	R0	K16
       0x5C280200,  //  0063  MOVE	R10	R1
-      0x582C0010,  //  0064  LDCONST	R11	K16
+      0x582C0011,  //  0064  LDCONST	R11	K17
       0x7C200600,  //  0065  CALL	R8	3
-      0x901E2608,  //  0066  SETMBR	R7	K19	R8
-      0x00040310,  //  0067  ADD	R1	R1	K16
+      0x901E2808,  //  0066  SETMBR	R7	K20	R8
+      0x00040311,  //  0067  ADD	R1	R1	K17
       0x70020006,  //  0068  JMP		#0070
-      0x8C20010F,  //  0069  GETMET	R8	R0	K15
+      0x8C200110,  //  0069  GETMET	R8	R0	K16
       0x5C280200,  //  006A  MOVE	R10	R1
       0x542E0003,  //  006B  LDINT	R11	4
       0x7C200600,  //  006C  CALL	R8	3
-      0x901E2608,  //  006D  SETMBR	R7	K19	R8
+      0x901E2808,  //  006D  SETMBR	R7	K20	R8
       0x54220003,  //  006E  LDINT	R8	4
       0x00040208,  //  006F  ADD	R1	R1	R8
-      0x8C200F14,  //  0070  GETMET	R8	R7	K20
+      0x8C200F15,  //  0070  GETMET	R8	R7	K21
       0x5C280000,  //  0071  MOVE	R10	R0
       0x5C2C0200,  //  0072  MOVE	R11	R1
       0x7C200600,  //  0073  CALL	R8	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -109,6 +109,73 @@ be_local_class(Matter_UDPPacket_sent,
     })),
     be_str_weak(Matter_UDPPacket_sent)
 );
+extern const bclass be_class_Matter_UDPServer;
+// compact class 'Matter_UDPServer' ktab size: 62, total: 103 (saved 328 bytes)
+static const bvalue be_ktab_class_Matter_UDPServer[62] = {
+  /* K0   */  be_nested_str_weak(loop),
+  /* K1   */  be_nested_str_weak(matter),
+  /* K2   */  be_nested_str_weak(UDPPacket_sent),
+  /* K3   */  be_nested_str_weak(send),
+  /* K4   */  be_nested_str_weak(msg_id),
+  /* K5   */  be_nested_str_weak(packets_sent),
+  /* K6   */  be_nested_str_weak(push),
+  /* K7   */  be_nested_str_weak(ack_message_counter),
+  /* K8   */  be_nested_str_weak(exchange_id),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_nested_str_weak(remove),
+  /* K11  */  be_nested_str_weak(tasmota),
+  /* K12  */  be_nested_str_weak(loglevel),
+  /* K13  */  be_nested_str_weak(log),
+  /* K14  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
+  /* K15  */  be_const_int(1),
+  /* K16  */  be_nested_str_weak(listening),
+  /* K17  */  be_nested_str_weak(udp_socket),
+  /* K18  */  be_nested_str_weak(udp),
+  /* K19  */  be_nested_str_weak(begin),
+  /* K20  */  be_nested_str_weak(addr),
+  /* K21  */  be_nested_str_weak(port),
+  /* K22  */  be_nested_str_weak(network_error),
+  /* K23  */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
+  /* K24  */  be_nested_str_weak(dispatch_cb),
+  /* K25  */  be_nested_str_weak(add_fast_loop),
+  /* K26  */  be_nested_str_weak(loop_cb),
+  /* K27  */  be_nested_str_weak(remote_ip),
+  /* K28  */  be_nested_str_weak(remote_port),
+  /* K29  */  be_nested_str_weak(raw),
+  /* K30  */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+  /* K31  */  be_const_int(3),
+  /* K32  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+  /* K33  */  be_nested_str_weak(stop),
+  /* K34  */  be_nested_str_weak(remove_fast_loop),
+  /* K35  */  be_nested_str_weak(device),
+  /* K36  */  be_nested_str_weak(),
+  /* K37  */  be_const_int(0),
+  /* K38  */  be_nested_str_weak(time_reached),
+  /* K39  */  be_nested_str_weak(next_try),
+  /* K40  */  be_nested_str_weak(retries),
+  /* K41  */  be_nested_str_weak(RETRIES),
+  /* K42  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Resending_X20packet_X20id_X3D),
+  /* K43  */  be_nested_str_weak(millis),
+  /* K44  */  be_nested_str_weak(_backoff_time),
+  /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
+  /* K46  */  be_nested_str_weak(session_id),
+  /* K47  */  be_const_class(be_class_Matter_UDPServer),
+  /* K48  */  be_nested_str_weak(math),
+  /* K49  */  be_nested_str_weak(rand),
+  /* K50  */  be_const_real_hex(0x3FCCCCCD),
+  /* K51  */  be_const_real_hex(0x3F800000),
+  /* K52  */  be_const_real_hex(0x3E800000),
+  /* K53  */  be_nested_str_weak(profiler),
+  /* K54  */  be_nested_str_weak(read),
+  /* K55  */  be_nested_str_weak(packet),
+  /* K56  */  be_nested_str_weak(start),
+  /* K57  */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K58  */  be_nested_str_weak(dump),
+  /* K59  */  be_const_int(2),
+  /* K60  */  be_nested_str_weak(MAX_PACKETS_READ),
+  /* K61  */  be_nested_str_weak(_resend_packets),
+};
+
 
 extern const bclass be_class_Matter_UDPServer;
 
@@ -119,15 +186,13 @@ be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(loop),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
@@ -147,34 +212,27 @@ be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(UDPPacket_sent),
-    /* K2   */  be_nested_str_weak(send),
-    /* K3   */  be_nested_str_weak(msg_id),
-    /* K4   */  be_nested_str_weak(packets_sent),
-    /* K5   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(send_UDP),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x8C0C0103,  //  0004  GETMET	R3	R0	K3
       0x5C140400,  //  0005  MOVE	R5	R2
       0x7C0C0400,  //  0006  CALL	R3	2
-      0x880C0503,  //  0007  GETMBR	R3	R2	K3
+      0x880C0504,  //  0007  GETMBR	R3	R2	K4
       0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C0104,  //  0009  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  000A  GETMET	R3	R3	K5
+      0x880C0105,  //  0009  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  000A  GETMET	R3	R3	K6
       0x5C140400,  //  000B  MOVE	R5	R2
       0x7C0C0400,  //  000C  CALL	R3	2
       0x80000000,  //  000D  RET	0
@@ -191,66 +249,54 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ack_message_counter),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(packets_sent),
-    /* K4   */  be_nested_str_weak(msg_id),
-    /* K5   */  be_nested_str_weak(remove),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(loglevel),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
-    /* K10  */  be_const_int(1),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(received_ack),
     &be_const_str_solidified,
     ( &(const binstruction[40]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
+      0x88080307,  //  0000  GETMBR	R2	R1	K7
+      0x880C0308,  //  0001  GETMBR	R3	R1	K8
       0x4C100000,  //  0002  LDNIL	R4
       0x1C100404,  //  0003  EQ	R4	R2	R4
       0x78120000,  //  0004  JMPF	R4	#0006
       0x80000800,  //  0005  RET	0
-      0x58100002,  //  0006  LDCONST	R4	K2
+      0x58100009,  //  0006  LDCONST	R4	K9
       0x6014000C,  //  0007  GETGBL	R5	G12
-      0x88180103,  //  0008  GETMBR	R6	R0	K3
+      0x88180105,  //  0008  GETMBR	R6	R0	K5
       0x7C140200,  //  0009  CALL	R5	1
       0x14140805,  //  000A  LT	R5	R4	R5
       0x7816001A,  //  000B  JMPF	R5	#0027
-      0x88140103,  //  000C  GETMBR	R5	R0	K3
+      0x88140105,  //  000C  GETMBR	R5	R0	K5
       0x94140A04,  //  000D  GETIDX	R5	R5	R4
       0x88180B04,  //  000E  GETMBR	R6	R5	K4
       0x1C180C02,  //  000F  EQ	R6	R6	R2
       0x781A0013,  //  0010  JMPF	R6	#0025
-      0x88180B01,  //  0011  GETMBR	R6	R5	K1
+      0x88180B08,  //  0011  GETMBR	R6	R5	K8
       0x1C180C03,  //  0012  EQ	R6	R6	R3
       0x781A0010,  //  0013  JMPF	R6	#0025
-      0x88180103,  //  0014  GETMBR	R6	R0	K3
-      0x8C180D05,  //  0015  GETMET	R6	R6	K5
+      0x88180105,  //  0014  GETMBR	R6	R0	K5
+      0x8C180D0A,  //  0015  GETMET	R6	R6	K10
       0x5C200800,  //  0016  MOVE	R8	R4
       0x7C180400,  //  0017  CALL	R6	2
-      0xB81A0C00,  //  0018  GETNGBL	R6	K6
-      0x8C180D07,  //  0019  GETMET	R6	R6	K7
+      0xB81A1600,  //  0018  GETNGBL	R6	K11
+      0x8C180D0C,  //  0019  GETMET	R6	R6	K12
       0x54220003,  //  001A  LDINT	R8	4
       0x7C180400,  //  001B  CALL	R6	2
       0x781A0006,  //  001C  JMPF	R6	#0024
-      0xB81A1000,  //  001D  GETNGBL	R6	K8
+      0xB81A1A00,  //  001D  GETNGBL	R6	K13
       0x601C0008,  //  001E  GETGBL	R7	G8
       0x5C200400,  //  001F  MOVE	R8	R2
       0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1207,  //  0021  ADD	R7	K9	R7
+      0x001E1C07,  //  0021  ADD	R7	K14	R7
       0x54220003,  //  0022  LDINT	R8	4
       0x7C180400,  //  0023  CALL	R6	2
       0x70020000,  //  0024  JMP		#0026
-      0x0010090A,  //  0025  ADD	R4	R4	K10
+      0x0010090F,  //  0025  ADD	R4	R4	K15
       0x7001FFDF,  //  0026  JMP		#0007
       0x80000000,  //  0027  RET	0
     })
@@ -266,48 +312,35 @@ be_local_closure(class_Matter_UDPServer_start,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(listening),
-    /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(udp),
-    /* K3   */  be_nested_str_weak(begin),
-    /* K4   */  be_nested_str_weak(addr),
-    /* K5   */  be_nested_str_weak(port),
-    /* K6   */  be_nested_str_weak(network_error),
-    /* K7   */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
-    /* K8   */  be_nested_str_weak(dispatch_cb),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(add_fast_loop),
-    /* K11  */  be_nested_str_weak(loop_cb),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080110,  //  0000  GETMBR	R2	R0	K16
       0x740A0011,  //  0001  JMPT	R2	#0014
-      0xB80A0400,  //  0002  GETNGBL	R2	K2
+      0xB80A2400,  //  0002  GETNGBL	R2	K18
       0x7C080000,  //  0003  CALL	R2	0
-      0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x88100104,  //  0007  GETMBR	R4	R0	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x90022202,  //  0004  SETMBR	R0	K17	R2
+      0x88080111,  //  0005  GETMBR	R2	R0	K17
+      0x8C080513,  //  0006  GETMET	R2	R2	K19
+      0x88100114,  //  0007  GETMBR	R4	R0	K20
+      0x88140115,  //  0008  GETMBR	R5	R0	K21
       0x7C080600,  //  0009  CALL	R2	3
       0x5C0C0400,  //  000A  MOVE	R3	R2
       0x740E0000,  //  000B  JMPT	R3	#000D
-      0xB0060D07,  //  000C  RAISE	1	K6	K7
+      0xB0062D17,  //  000C  RAISE	1	K22	K23
       0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x90020003,  //  000E  SETMBR	R0	K0	R3
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0xB80E1200,  //  0010  GETNGBL	R3	K9
-      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
-      0x8814010B,  //  0012  GETMBR	R5	R0	K11
+      0x90022003,  //  000E  SETMBR	R0	K16	R3
+      0x90023001,  //  000F  SETMBR	R0	K24	R1
+      0xB80E1600,  //  0010  GETNGBL	R3	K11
+      0x8C0C0719,  //  0011  GETMET	R3	R3	K25
+      0x8814011A,  //  0012  GETMBR	R5	R0	K26
       0x7C0C0400,  //  0013  CALL	R3	2
       0x80000000,  //  0014  RET	0
     })
@@ -323,73 +356,59 @@ be_local_closure(class_Matter_UDPServer_send,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_socket),
-    /* K1   */  be_nested_str_weak(send),
-    /* K2   */  be_nested_str_weak(addr),
-    /* K3   */  be_nested_str_weak(remote_ip),
-    /* K4   */  be_nested_str_weak(port),
-    /* K5   */  be_nested_str_weak(remote_port),
-    /* K6   */  be_nested_str_weak(raw),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(loglevel),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(send),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0x88080111,  //  0000  GETMBR	R2	R0	K17
+      0x8C080503,  //  0001  GETMET	R2	R2	K3
+      0x88100314,  //  0002  GETMBR	R4	R1	K20
       0x78120001,  //  0003  JMPF	R4	#0006
-      0x88100302,  //  0004  GETMBR	R4	R1	K2
+      0x88100314,  //  0004  GETMBR	R4	R1	K20
       0x70020001,  //  0005  JMP		#0008
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x88100903,  //  0007  GETMBR	R4	R4	K3
-      0x88140304,  //  0008  GETMBR	R5	R1	K4
+      0x88100111,  //  0006  GETMBR	R4	R0	K17
+      0x8810091B,  //  0007  GETMBR	R4	R4	K27
+      0x88140315,  //  0008  GETMBR	R5	R1	K21
       0x78160001,  //  0009  JMPF	R5	#000C
-      0x88140304,  //  000A  GETMBR	R5	R1	K4
+      0x88140315,  //  000A  GETMBR	R5	R1	K21
       0x70020001,  //  000B  JMP		#000E
-      0x88140100,  //  000C  GETMBR	R5	R0	K0
-      0x88140B05,  //  000D  GETMBR	R5	R5	K5
-      0x88180306,  //  000E  GETMBR	R6	R1	K6
+      0x88140111,  //  000C  GETMBR	R5	R0	K17
+      0x88140B1C,  //  000D  GETMBR	R5	R5	K28
+      0x8818031D,  //  000E  GETMBR	R6	R1	K29
       0x7C080800,  //  000F  CALL	R2	4
       0x780A000D,  //  0010  JMPF	R2	#001F
-      0xB80E0E00,  //  0011  GETNGBL	R3	K7
-      0x8C0C0708,  //  0012  GETMET	R3	R3	K8
+      0xB80E1600,  //  0011  GETNGBL	R3	K11
+      0x8C0C070C,  //  0012  GETMET	R3	R3	K12
       0x54160003,  //  0013  LDINT	R5	4
       0x7C0C0400,  //  0014  CALL	R3	2
       0x780E0007,  //  0015  JMPF	R3	#001E
-      0xB80E1200,  //  0016  GETNGBL	R3	K9
+      0xB80E1A00,  //  0016  GETNGBL	R3	K13
       0x60100018,  //  0017  GETGBL	R4	G24
-      0x5814000A,  //  0018  LDCONST	R5	K10
-      0x88180302,  //  0019  GETMBR	R6	R1	K2
-      0x881C0304,  //  001A  GETMBR	R7	R1	K4
+      0x5814001E,  //  0018  LDCONST	R5	K30
+      0x88180314,  //  0019  GETMBR	R6	R1	K20
+      0x881C0315,  //  001A  GETMBR	R7	R1	K21
       0x7C100600,  //  001B  CALL	R4	3
       0x54160003,  //  001C  LDINT	R5	4
       0x7C0C0400,  //  001D  CALL	R3	2
       0x7002000C,  //  001E  JMP		#002C
-      0xB80E0E00,  //  001F  GETNGBL	R3	K7
-      0x8C0C0708,  //  0020  GETMET	R3	R3	K8
-      0x5814000B,  //  0021  LDCONST	R5	K11
+      0xB80E1600,  //  001F  GETNGBL	R3	K11
+      0x8C0C070C,  //  0020  GETMET	R3	R3	K12
+      0x5814001F,  //  0021  LDCONST	R5	K31
       0x7C0C0400,  //  0022  CALL	R3	2
       0x780E0007,  //  0023  JMPF	R3	#002C
-      0xB80E1200,  //  0024  GETNGBL	R3	K9
+      0xB80E1A00,  //  0024  GETNGBL	R3	K13
       0x60100018,  //  0025  GETGBL	R4	G24
-      0x5814000C,  //  0026  LDCONST	R5	K12
-      0x88180302,  //  0027  GETMBR	R6	R1	K2
-      0x881C0304,  //  0028  GETMBR	R7	R1	K4
+      0x58140020,  //  0026  LDCONST	R5	K32
+      0x88180314,  //  0027  GETMBR	R6	R1	K20
+      0x881C0315,  //  0028  GETMBR	R7	R1	K21
       0x7C100600,  //  0029  CALL	R4	3
-      0x5814000B,  //  002A  LDCONST	R5	K11
+      0x5814001F,  //  002A  LDCONST	R5	K31
       0x7C0C0400,  //  002B  CALL	R3	2
       0x80040400,  //  002C  RET	1	R2
     })
@@ -405,33 +424,26 @@ be_local_closure(class_Matter_UDPServer_stop,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(listening),
-    /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(stop),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(remove_fast_loop),
-    /* K5   */  be_nested_str_weak(loop_cb),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(stop),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040110,  //  0000  GETMBR	R1	R0	K16
       0x78060008,  //  0001  JMPF	R1	#000B
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x88040111,  //  0002  GETMBR	R1	R0	K17
+      0x8C040321,  //  0003  GETMET	R1	R1	K33
       0x7C040200,  //  0004  CALL	R1	1
       0x50040000,  //  0005  LDBOOL	R1	0	0
-      0x90020001,  //  0006  SETMBR	R0	K0	R1
-      0xB8060600,  //  0007  GETNGBL	R1	K3
-      0x8C040304,  //  0008  GETMET	R1	R1	K4
-      0x880C0105,  //  0009  GETMBR	R3	R0	K5
+      0x90022001,  //  0006  SETMBR	R0	K16	R1
+      0xB8061600,  //  0007  GETNGBL	R1	K11
+      0x8C040322,  //  0008  GETMET	R1	R1	K34
+      0x880C011A,  //  0009  GETMBR	R3	R0	K26
       0x7C040400,  //  000A  CALL	R1	2
       0x80000000,  //  000B  RET	0
     })
@@ -447,7 +459,7 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -477,36 +489,28 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(addr),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(port),
-    /* K4   */  be_nested_str_weak(listening),
-    /* K5   */  be_nested_str_weak(packets_sent),
-    /* K6   */  be_nested_str_weak(loop_cb),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024601,  //  0000  SETMBR	R0	K35	R1
       0x780A0001,  //  0001  JMPF	R2	#0004
       0x5C100400,  //  0002  MOVE	R4	R2
       0x70020000,  //  0003  JMP		#0005
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x90020204,  //  0005  SETMBR	R0	K1	R4
+      0x58100024,  //  0004  LDCONST	R4	K36
+      0x90022804,  //  0005  SETMBR	R0	K20	R4
       0x780E0001,  //  0006  JMPF	R3	#0009
       0x5C100600,  //  0007  MOVE	R4	R3
       0x70020000,  //  0008  JMP		#000A
       0x541215A3,  //  0009  LDINT	R4	5540
-      0x90020604,  //  000A  SETMBR	R0	K3	R4
+      0x90022A04,  //  000A  SETMBR	R0	K21	R4
       0x50100000,  //  000B  LDBOOL	R4	0	0
-      0x90020804,  //  000C  SETMBR	R0	K4	R4
+      0x90022004,  //  000C  SETMBR	R0	K16	R4
       0x60100012,  //  000D  GETGBL	R4	G18
       0x7C100000,  //  000E  CALL	R4	0
       0x90020A04,  //  000F  SETMBR	R0	K5	R4
       0x84100000,  //  0010  CLOSURE	R4	P0
-      0x90020C04,  //  0011  SETMBR	R0	K6	R4
+      0x90023404,  //  0011  SETMBR	R0	K26	R4
       0xA0000000,  //  0012  CLOSE	R0
       0x80000000,  //  0013  RET	0
     })
@@ -522,93 +526,72 @@ be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(packets_sent),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(next_try),
-    /* K5   */  be_nested_str_weak(retries),
-    /* K6   */  be_nested_str_weak(RETRIES),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Resending_X20packet_X20id_X3D),
-    /* K9   */  be_nested_str_weak(msg_id),
-    /* K10  */  be_nested_str_weak(send),
-    /* K11  */  be_nested_str_weak(millis),
-    /* K12  */  be_nested_str_weak(_backoff_time),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(remove),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
-    /* K16  */  be_nested_str_weak(session_id),
-    /* K17  */  be_nested_str_weak(addr),
-    /* K18  */  be_nested_str_weak(port),
-    /* K19  */  be_const_int(3),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(_resend_packets),
     &be_const_str_solidified,
     ( &(const binstruction[58]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58040025,  //  0000  LDCONST	R1	K37
       0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x880C0105,  //  0002  GETMBR	R3	R0	K5
       0x7C080200,  //  0003  CALL	R2	1
       0x14080202,  //  0004  LT	R2	R1	R2
       0x780A0032,  //  0005  JMPF	R2	#0039
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x88080105,  //  0006  GETMBR	R2	R0	K5
       0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
+      0xB80E1600,  //  0008  GETNGBL	R3	K11
+      0x8C0C0726,  //  0009  GETMET	R3	R3	K38
+      0x88140527,  //  000A  GETMBR	R5	R2	K39
       0x7C0C0400,  //  000B  CALL	R3	2
       0x780E0029,  //  000C  JMPF	R3	#0037
-      0x880C0505,  //  000D  GETMBR	R3	R2	K5
-      0x88100106,  //  000E  GETMBR	R4	R0	K6
+      0x880C0528,  //  000D  GETMBR	R3	R2	K40
+      0x88100129,  //  000E  GETMBR	R4	R0	K41
       0x180C0604,  //  000F  LE	R3	R3	R4
       0x780E0016,  //  0010  JMPF	R3	#0028
-      0xB80E0E00,  //  0011  GETNGBL	R3	K7
+      0xB80E1A00,  //  0011  GETNGBL	R3	K13
       0x60100008,  //  0012  GETGBL	R4	G8
-      0x88140509,  //  0013  GETMBR	R5	R2	K9
+      0x88140504,  //  0013  GETMBR	R5	R2	K4
       0x7C100200,  //  0014  CALL	R4	1
-      0x00121004,  //  0015  ADD	R4	K8	R4
+      0x00125404,  //  0015  ADD	R4	K42	R4
       0x54160003,  //  0016  LDINT	R5	4
       0x7C0C0400,  //  0017  CALL	R3	2
-      0x8C0C010A,  //  0018  GETMET	R3	R0	K10
+      0x8C0C0103,  //  0018  GETMET	R3	R0	K3
       0x5C140400,  //  0019  MOVE	R5	R2
       0x7C0C0400,  //  001A  CALL	R3	2
-      0xB80E0400,  //  001B  GETNGBL	R3	K2
-      0x8C0C070B,  //  001C  GETMET	R3	R3	K11
+      0xB80E1600,  //  001B  GETNGBL	R3	K11
+      0x8C0C072B,  //  001C  GETMET	R3	R3	K43
       0x7C0C0200,  //  001D  CALL	R3	1
-      0x8C10010C,  //  001E  GETMET	R4	R0	K12
-      0x88180505,  //  001F  GETMBR	R6	R2	K5
+      0x8C10012C,  //  001E  GETMET	R4	R0	K44
+      0x88180528,  //  001F  GETMBR	R6	R2	K40
       0x7C100400,  //  0020  CALL	R4	2
       0x000C0604,  //  0021  ADD	R3	R3	R4
-      0x900A0803,  //  0022  SETMBR	R2	K4	R3
-      0x880C0505,  //  0023  GETMBR	R3	R2	K5
-      0x000C070D,  //  0024  ADD	R3	R3	K13
-      0x900A0A03,  //  0025  SETMBR	R2	K5	R3
-      0x0004030D,  //  0026  ADD	R1	R1	K13
+      0x900A4E03,  //  0022  SETMBR	R2	K39	R3
+      0x880C0528,  //  0023  GETMBR	R3	R2	K40
+      0x000C070F,  //  0024  ADD	R3	R3	K15
+      0x900A5003,  //  0025  SETMBR	R2	K40	R3
+      0x0004030F,  //  0026  ADD	R1	R1	K15
       0x7002000D,  //  0027  JMP		#0036
-      0x880C0101,  //  0028  GETMBR	R3	R0	K1
-      0x8C0C070E,  //  0029  GETMET	R3	R3	K14
+      0x880C0105,  //  0028  GETMBR	R3	R0	K5
+      0x8C0C070A,  //  0029  GETMET	R3	R3	K10
       0x5C140200,  //  002A  MOVE	R5	R1
       0x7C0C0400,  //  002B  CALL	R3	2
-      0xB80E0E00,  //  002C  GETNGBL	R3	K7
+      0xB80E1A00,  //  002C  GETNGBL	R3	K13
       0x60100018,  //  002D  GETGBL	R4	G24
-      0x5814000F,  //  002E  LDCONST	R5	K15
-      0x88180510,  //  002F  GETMBR	R6	R2	K16
-      0x881C0511,  //  0030  GETMBR	R7	R2	K17
-      0x88200512,  //  0031  GETMBR	R8	R2	K18
-      0x88240509,  //  0032  GETMBR	R9	R2	K9
+      0x5814002D,  //  002E  LDCONST	R5	K45
+      0x8818052E,  //  002F  GETMBR	R6	R2	K46
+      0x881C0514,  //  0030  GETMBR	R7	R2	K20
+      0x88200515,  //  0031  GETMBR	R8	R2	K21
+      0x88240504,  //  0032  GETMBR	R9	R2	K4
       0x7C100A00,  //  0033  CALL	R4	5
-      0x58140013,  //  0034  LDCONST	R5	K19
+      0x5814001F,  //  0034  LDCONST	R5	K31
       0x7C0C0400,  //  0035  CALL	R3	2
       0x70020000,  //  0036  JMP		#0038
-      0x0004030D,  //  0037  ADD	R1	R1	K13
+      0x0004030F,  //  0037  ADD	R1	R1	K15
       0x7001FFC7,  //  0038  JMP		#0001
       0x80000000,  //  0039  RET	0
     })
@@ -624,7 +607,7 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -656,43 +639,34 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_UDPServer),
-    /* K1   */  be_nested_str_weak(math),
-    /* K2   */  be_nested_str_weak(rand),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_real_hex(0x3FCCCCCD),
-    /* K6   */  be_const_real_hex(0x3F800000),
-    /* K7   */  be_const_real_hex(0x3E800000),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(_backoff_time),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804002F,  //  0000  LDCONST	R1	K47
       0x84080000,  //  0001  CLOSURE	R2	P0
-      0xA40E0200,  //  0002  IMPORT	R3	K1
+      0xA40E6000,  //  0002  IMPORT	R3	K48
       0x5412012B,  //  0003  LDINT	R4	300
       0x6014000A,  //  0004  GETGBL	R5	G10
-      0x8C180702,  //  0005  GETMET	R6	R3	K2
+      0x8C180731,  //  0005  GETMET	R6	R3	K49
       0x7C180200,  //  0006  CALL	R6	1
       0x541E00FE,  //  0007  LDINT	R7	255
       0x2C180C07,  //  0008  AND	R6	R6	R7
       0x7C140200,  //  0009  CALL	R5	1
       0x541A00FE,  //  000A  LDINT	R6	255
       0x0C140A06,  //  000B  DIV	R5	R5	R6
-      0x24180103,  //  000C  GT	R6	R0	K3
+      0x24180125,  //  000C  GT	R6	R0	K37
       0x781A0001,  //  000D  JMPF	R6	#0010
-      0x04180104,  //  000E  SUB	R6	R0	K4
+      0x0418010F,  //  000E  SUB	R6	R0	K15
       0x70020000,  //  000F  JMP		#0011
-      0x58180003,  //  0010  LDCONST	R6	K3
+      0x58180025,  //  0010  LDCONST	R6	K37
       0x5C1C0400,  //  0011  MOVE	R7	R2
-      0x58200005,  //  0012  LDCONST	R8	K5
+      0x58200032,  //  0012  LDCONST	R8	K50
       0x5C240C00,  //  0013  MOVE	R9	R6
       0x7C1C0400,  //  0014  CALL	R7	2
       0x081C0807,  //  0015  MUL	R7	R4	R7
-      0x08200B07,  //  0016  MUL	R8	R5	K7
-      0x00220C08,  //  0017  ADD	R8	K6	R8
+      0x08200B34,  //  0016  MUL	R8	R5	K52
+      0x00226608,  //  0017  ADD	R8	K51	R8
       0x081C0E08,  //  0018  MUL	R7	R7	R8
       0x60200009,  //  0019  GETGBL	R8	G9
       0x5C240E00,  //  001A  MOVE	R9	R7
@@ -711,93 +685,73 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(profiler),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(udp_socket),
-    /* K4   */  be_nested_str_weak(read),
-    /* K5   */  be_nested_str_weak(packet),
-    /* K6   */  be_nested_str_weak(start),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(remote_ip),
-    /* K9   */  be_nested_str_weak(remote_port),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(loglevel),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K14  */  be_nested_str_weak(dispatch_cb),
-    /* K15  */  be_nested_str_weak(dump),
-    /* K16  */  be_const_int(2),
-    /* K17  */  be_nested_str_weak(MAX_PACKETS_READ),
-    /* K18  */  be_nested_str_weak(_resend_packets),
-    }),
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(loop),
     &be_const_str_solidified,
     ( &(const binstruction[59]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x58080002,  //  0002  LDCONST	R2	K2
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88040335,  //  0001  GETMBR	R1	R1	K53
+      0x58080009,  //  0002  LDCONST	R2	K9
+      0x880C0111,  //  0003  GETMBR	R3	R0	K17
       0x4C100000,  //  0004  LDNIL	R4
       0x1C0C0604,  //  0005  EQ	R3	R3	R4
       0x780E0000,  //  0006  JMPF	R3	#0008
       0x80000600,  //  0007  RET	0
-      0x880C0103,  //  0008  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0009  GETMET	R3	R3	K4
-      0x88140105,  //  000A  GETMBR	R5	R0	K5
+      0x880C0111,  //  0008  GETMBR	R3	R0	K17
+      0x8C0C0736,  //  0009  GETMET	R3	R3	K54
+      0x88140137,  //  000A  GETMBR	R5	R0	K55
       0x7C0C0400,  //  000B  CALL	R3	2
       0x4C100000,  //  000C  LDNIL	R4
       0x20100604,  //  000D  NE	R4	R3	R4
       0x78120028,  //  000E  JMPF	R4	#0038
-      0x8C100306,  //  000F  GETMET	R4	R1	K6
+      0x8C100338,  //  000F  GETMET	R4	R1	K56
       0x7C100200,  //  0010  CALL	R4	1
-      0x90020A03,  //  0011  SETMBR	R0	K5	R3
-      0x00080507,  //  0012  ADD	R2	R2	K7
-      0x88100103,  //  0013  GETMBR	R4	R0	K3
-      0x88100908,  //  0014  GETMBR	R4	R4	K8
-      0x88140103,  //  0015  GETMBR	R5	R0	K3
-      0x88140B09,  //  0016  GETMBR	R5	R5	K9
-      0xB81A1400,  //  0017  GETNGBL	R6	K10
-      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x90026E03,  //  0011  SETMBR	R0	K55	R3
+      0x0008050F,  //  0012  ADD	R2	R2	K15
+      0x88100111,  //  0013  GETMBR	R4	R0	K17
+      0x8810091B,  //  0014  GETMBR	R4	R4	K27
+      0x88140111,  //  0015  GETMBR	R5	R0	K17
+      0x88140B1C,  //  0016  GETMBR	R5	R5	K28
+      0xB81A1600,  //  0017  GETNGBL	R6	K11
+      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
       0x54220003,  //  0019  LDINT	R8	4
       0x7C180400,  //  001A  CALL	R6	2
       0x781A0007,  //  001B  JMPF	R6	#0024
-      0xB81A1800,  //  001C  GETNGBL	R6	K12
+      0xB81A1A00,  //  001C  GETNGBL	R6	K13
       0x601C0018,  //  001D  GETGBL	R7	G24
-      0x5820000D,  //  001E  LDCONST	R8	K13
+      0x58200039,  //  001E  LDCONST	R8	K57
       0x5C240800,  //  001F  MOVE	R9	R4
       0x5C280A00,  //  0020  MOVE	R10	R5
       0x7C1C0600,  //  0021  CALL	R7	3
       0x54220003,  //  0022  LDINT	R8	4
       0x7C180400,  //  0023  CALL	R6	2
-      0x8818010E,  //  0024  GETMBR	R6	R0	K14
+      0x88180118,  //  0024  GETMBR	R6	R0	K24
       0x781A0004,  //  0025  JMPF	R6	#002B
-      0x8C18010E,  //  0026  GETMET	R6	R0	K14
+      0x8C180118,  //  0026  GETMET	R6	R0	K24
       0x5C200600,  //  0027  MOVE	R8	R3
       0x5C240800,  //  0028  MOVE	R9	R4
       0x5C280A00,  //  0029  MOVE	R10	R5
       0x7C180800,  //  002A  CALL	R6	4
-      0x8C18030F,  //  002B  GETMET	R6	R1	K15
-      0x58200010,  //  002C  LDCONST	R8	K16
+      0x8C18033A,  //  002B  GETMET	R6	R1	K58
+      0x5820003B,  //  002C  LDCONST	R8	K59
       0x7C180400,  //  002D  CALL	R6	2
-      0x88180111,  //  002E  GETMBR	R6	R0	K17
+      0x8818013C,  //  002E  GETMBR	R6	R0	K60
       0x14180406,  //  002F  LT	R6	R2	R6
       0x781A0004,  //  0030  JMPF	R6	#0036
-      0x88180103,  //  0031  GETMBR	R6	R0	K3
-      0x8C180D04,  //  0032  GETMET	R6	R6	K4
+      0x88180111,  //  0031  GETMBR	R6	R0	K17
+      0x8C180D36,  //  0032  GETMET	R6	R6	K54
       0x7C180200,  //  0033  CALL	R6	1
       0x5C0C0C00,  //  0034  MOVE	R3	R6
       0x70020000,  //  0035  JMP		#0037
       0x4C0C0000,  //  0036  LDNIL	R3
       0x7001FFD3,  //  0037  JMP		#000C
-      0x8C100112,  //  0038  GETMET	R4	R0	K18
+      0x8C10013D,  //  0038  GETMET	R4	R0	K61
       0x7C100200,  //  0039  CALL	R4	1
       0x80000000,  //  003A  RET	0
     })
@@ -813,13 +767,13 @@ be_local_closure(class_Matter_UDPServer_every_second,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -3,6 +3,7 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// ktab too big for class 'Matter_UI' - skipping
 
 extern const bclass be_class_Matter_UI;
 

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -3,6 +3,7 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// ktab too big for class 'Matter_Device' - skipping
 
 extern const bclass be_class_Matter_Device;
 

--- a/lib/libesp32/berry_tasmota/solidify_all.be
+++ b/lib/libesp32/berry_tasmota/solidify_all.be
@@ -7,6 +7,7 @@ import global
 import solidify
 import string as string2
 import re
+import introspect
 
 import sys
 sys.path().push('src/embedded')   # allow to import from src/embedded

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_autoconf_module.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_autoconf_module.h
@@ -3,6 +3,137 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Autoconf' ktab size: 127, total: 205 (saved 624 bytes)
+static const bvalue be_ktab_class_Autoconf[127] = {
+  /* K0   */  be_nested_str(webserver),
+  /* K1   */  be_nested_str(path),
+  /* K2   */  be_nested_str(check_privileged_access),
+  /* K3   */  be_nested_str(has_arg),
+  /* K4   */  be_nested_str(reapply),
+  /* K5   */  be_nested_str(tasmota),
+  /* K6   */  be_nested_str(log),
+  /* K7   */  be_nested_str(CFG_X3A_X20removing_X20first_X20time_X20marker),
+  /* K8   */  be_const_int(2),
+  /* K9   */  be_nested_str(clear_first_time),
+  /* K10  */  be_nested_str(redirect),
+  /* K11  */  be_nested_str(_X2F_X3Frst_X3D),
+  /* K12  */  be_nested_str(zip),
+  /* K13  */  be_nested_str(CFG_X3A_X20removing_X20autoconf_X20files),
+  /* K14  */  be_nested_str(delete_all_configs),
+  /* K15  */  be_nested_str(arg),
+  /* K16  */  be_nested_str(reset),
+  /* K17  */  be_nested_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf),
+  /* K18  */  be_nested_str(arch),
+  /* K19  */  be_nested_str(CFG_X3A_X20downloading_X20_X27_X25s_X27),
+  /* K20  */  be_nested_str(_X25s_X2Eautoconf),
+  /* K21  */  be_nested_str(webclient),
+  /* K22  */  be_nested_str(begin),
+  /* K23  */  be_nested_str(GET),
+  /* K24  */  be_nested_str(return_X20code_X3D_X25i),
+  /* K25  */  be_nested_str(connection_error),
+  /* K26  */  be_nested_str(write_file),
+  /* K27  */  be_nested_str(close),
+  /* K28  */  be_nested_str(value_error),
+  /* K29  */  be_nested_str(Unknown_X20command),
+  /* K30  */  be_nested_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K31  */  be_nested_str(content_start),
+  /* K32  */  be_nested_str(Parameter_X20error),
+  /* K33  */  be_nested_str(content_send_style),
+  /* K34  */  be_nested_str(content_send),
+  /* K35  */  be_nested_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+  /* K36  */  be_nested_str(content_button),
+  /* K37  */  be_nested_str(BUTTON_CONFIGURATION),
+  /* K38  */  be_nested_str(content_stop),
+  /* K39  */  be_nested_str(_archive),
+  /* K40  */  be_nested_str(_X23init_X2Ebat),
+  /* K41  */  be_nested_str(is_first_time),
+  /* K42  */  be_nested_str(exists),
+  /* K43  */  be_nested_str(set_first_time),
+  /* K44  */  be_nested_str(run_bat),
+  /* K45  */  be_nested_str(CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting),
+  /* K46  */  be_const_int(2),
+  /* K47  */  be_nested_str(_X23display_X2Eini),
+  /* K48  */  be_nested_str(display_X2Eini),
+  /* K49  */  be_nested_str(r),
+  /* K50  */  be_nested_str(w),
+  /* K51  */  be_nested_str(readbytes),
+  /* K52  */  be_nested_str(write),
+  /* K53  */  be_nested_str(CFG_X3A_X20_X27display_X2Eini_X27_X20extracted_X2C_X20restarting),
+  /* K54  */  be_nested_str(CFG_X3A_X20could_X20not_X20copy_X20_X27display_X2Eini_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29_X27),
+  /* K55  */  be_nested_str(cmd),
+  /* K56  */  be_nested_str(Restart_X201),
+  /* K57  */  be_nested_str(_X23autoexec_X2Ebat),
+  /* K58  */  be_nested_str(CFG_X3A_X20running_X20),
+  /* K59  */  be_const_int(3),
+  /* K60  */  be_nested_str(CFG_X3A_X20ran_X20_X20),
+  /* K61  */  be_nested_str(_X23autoexec_X2Ebe),
+  /* K62  */  be_nested_str(CFG_X3A_X20loading_X20),
+  /* K63  */  be_nested_str(load),
+  /* K64  */  be_nested_str(CFG_X3A_X20loaded_X20_X20),
+  /* K65  */  be_nested_str(readline),
+  /* K66  */  be_const_int(0),
+  /* K67  */  be_nested_str(_X0A),
+  /* K68  */  be_nested_str(_X0D),
+  /* K69  */  be_nested_str(CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29),
+  /* K70  */  be_const_int(1),
+  /* K71  */  be_nested_str(string),
+  /* K72  */  be_nested_str(Auto_X2Dconfiguration),
+  /* K73  */  be_nested_str(_X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E),
+  /* K74  */  be_nested_str(get_current_module_path),
+  /* K75  */  be_nested_str(tr),
+  /* K76  */  be_nested_str(get_current_module_name),
+  /* K77  */  be_nested_str(_),
+  /* K78  */  be_nested_str(_X20),
+  /* K79  */  be_nested_str(_error),
+  /* K80  */  be_nested_str(_X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B),
+  /* K81  */  be_nested_str(_X26lt_X3BNone_X26gt_X3B),
+  /* K82  */  be_nested_str(_X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E),
+  /* K83  */  be_nested_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27Autoconfiguration_X27_X3E_X26nbsp_X3BCurrent_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E),
+  /* K84  */  be_nested_str(_X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+  /* K85  */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20),
+  /* K86  */  be_nested_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
+  /* K87  */  be_nested_str(_X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E),
+  /* K88  */  be_nested_str(_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+  /* K89  */  be_nested_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K90  */  be_nested_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E),
+  /* K91  */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20),
+  /* K92  */  be_nested_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
+  /* K93  */  be_nested_str(_X3Clabel_X3EChoose_X20a_X20device_X20configuration_X3A_X3C_X2Flabel_X3E_X3Cbr_X3E),
+  /* K94  */  be_nested_str(_X3Cselect_X20name_X3D_X27zip_X27_X3E),
+  /* K95  */  be_nested_str(load_templates),
+  /* K96  */  be_nested_str(_X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E),
+  /* K97  */  be_nested_str(_X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E),
+  /* K98  */  be_nested_str(stop_iteration),
+  /* K99  */  be_nested_str(_X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K100 */  be_nested_str(_X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E),
+  /* K101 */  be_nested_str(listdir),
+  /* K102 */  be_nested_str(_X2F),
+  /* K103 */  be_nested_str(find),
+  /* K104 */  be_nested_str(_X2Eautoconf),
+  /* K105 */  be_nested_str(remove),
+  /* K106 */  be_nested_str(_X2F_X2Eautoconf),
+  /* K107 */  be_nested_str(json),
+  /* K108 */  be_nested_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson),
+  /* K109 */  be_nested_str(CFG_X3A_X20loading_X20_X27_X25s_X27),
+  /* K110 */  be_nested_str(CFG_X3A_X20return_code_X3D_X25i),
+  /* K111 */  be_const_int(2),
+  /* K112 */  be_nested_str(get_string),
+  /* K113 */  be_nested_str(CFG_X3A_X20loaded_X20_X27_X25s_X27),
+  /* K114 */  be_nested_str(files),
+  /* K115 */  be_nested_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27),
+  /* K116 */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+  /* K117 */  be_nested_str(add_driver),
+  /* K118 */  be_nested_str(CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29),
+  /* K119 */  be_nested_str(CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found),
+  /* K120 */  be_const_int(3),
+  /* K121 */  be_nested_str(_X23preinit_X2Ebe),
+  /* K122 */  be_nested_str(CFG_X3A_X20removed_X20file_X20_X27_X25s_X27),
+  /* K123 */  be_nested_str(on),
+  /* K124 */  be_nested_str(_X2Fac),
+  /* K125 */  be_nested_str(HTTP_GET),
+  /* K126 */  be_nested_str(HTTP_POST),
+};
+
 
 extern const bclass be_class_Autoconf;
 
@@ -13,53 +144,13 @@ be_local_closure(class_Autoconf_page_autoconf_ctl,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[39]) {     /* constants */
-    /* K0   */  be_nested_str(webserver),
-    /* K1   */  be_nested_str(path),
-    /* K2   */  be_nested_str(check_privileged_access),
-    /* K3   */  be_nested_str(has_arg),
-    /* K4   */  be_nested_str(reapply),
-    /* K5   */  be_nested_str(tasmota),
-    /* K6   */  be_nested_str(log),
-    /* K7   */  be_nested_str(CFG_X3A_X20removing_X20first_X20time_X20marker),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str(clear_first_time),
-    /* K10  */  be_nested_str(redirect),
-    /* K11  */  be_nested_str(_X2F_X3Frst_X3D),
-    /* K12  */  be_nested_str(zip),
-    /* K13  */  be_nested_str(CFG_X3A_X20removing_X20autoconf_X20files),
-    /* K14  */  be_nested_str(delete_all_configs),
-    /* K15  */  be_nested_str(arg),
-    /* K16  */  be_nested_str(reset),
-    /* K17  */  be_nested_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf),
-    /* K18  */  be_nested_str(arch),
-    /* K19  */  be_nested_str(CFG_X3A_X20downloading_X20_X27_X25s_X27),
-    /* K20  */  be_nested_str(_X25s_X2Eautoconf),
-    /* K21  */  be_nested_str(webclient),
-    /* K22  */  be_nested_str(begin),
-    /* K23  */  be_nested_str(GET),
-    /* K24  */  be_nested_str(return_X20code_X3D_X25i),
-    /* K25  */  be_nested_str(connection_error),
-    /* K26  */  be_nested_str(write_file),
-    /* K27  */  be_nested_str(close),
-    /* K28  */  be_nested_str(value_error),
-    /* K29  */  be_nested_str(Unknown_X20command),
-    /* K30  */  be_nested_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K31  */  be_nested_str(content_start),
-    /* K32  */  be_nested_str(Parameter_X20error),
-    /* K33  */  be_nested_str(content_send_style),
-    /* K34  */  be_nested_str(content_send),
-    /* K35  */  be_nested_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
-    /* K36  */  be_nested_str(content_button),
-    /* K37  */  be_nested_str(BUTTON_CONFIGURATION),
-    /* K38  */  be_nested_str(content_stop),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_page_autoconf_ctl,
     &be_const_str_solidified,
     ( &(const binstruction[116]) {  /* code */
@@ -192,123 +283,92 @@ be_local_closure(class_Autoconf_autoexec,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str(_archive),
-    /* K1   */  be_nested_str(path),
-    /* K2   */  be_nested_str(_X23init_X2Ebat),
-    /* K3   */  be_nested_str(is_first_time),
-    /* K4   */  be_nested_str(exists),
-    /* K5   */  be_nested_str(set_first_time),
-    /* K6   */  be_nested_str(run_bat),
-    /* K7   */  be_nested_str(tasmota),
-    /* K8   */  be_nested_str(log),
-    /* K9   */  be_nested_str(CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str(_X23display_X2Eini),
-    /* K12  */  be_nested_str(display_X2Eini),
-    /* K13  */  be_nested_str(r),
-    /* K14  */  be_nested_str(w),
-    /* K15  */  be_nested_str(readbytes),
-    /* K16  */  be_nested_str(write),
-    /* K17  */  be_nested_str(close),
-    /* K18  */  be_nested_str(CFG_X3A_X20_X27display_X2Eini_X27_X20extracted_X2C_X20restarting),
-    /* K19  */  be_nested_str(CFG_X3A_X20could_X20not_X20copy_X20_X27display_X2Eini_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29_X27),
-    /* K20  */  be_nested_str(cmd),
-    /* K21  */  be_nested_str(Restart_X201),
-    /* K22  */  be_nested_str(_X23autoexec_X2Ebat),
-    /* K23  */  be_nested_str(CFG_X3A_X20running_X20),
-    /* K24  */  be_const_int(3),
-    /* K25  */  be_nested_str(CFG_X3A_X20ran_X20_X20),
-    /* K26  */  be_nested_str(_X23autoexec_X2Ebe),
-    /* K27  */  be_nested_str(CFG_X3A_X20loading_X20),
-    /* K28  */  be_nested_str(load),
-    /* K29  */  be_nested_str(CFG_X3A_X20loaded_X20_X20),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_autoexec,
     &be_const_str_solidified,
     ( &(const binstruction[147]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040127,  //  0000  GETMBR	R1	R0	K39
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
       0xA4060200,  //  0005  IMPORT	R1	K1
       0x50080000,  //  0006  LDBOOL	R2	0	0
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x000C0702,  //  0008  ADD	R3	R3	K2
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x880C0127,  //  0007  GETMBR	R3	R0	K39
+      0x000C0728,  //  0008  ADD	R3	R3	K40
+      0x8C100129,  //  0009  GETMET	R4	R0	K41
       0x7C100200,  //  000A  CALL	R4	1
       0x7812000F,  //  000B  JMPF	R4	#001C
-      0x8C100304,  //  000C  GETMET	R4	R1	K4
+      0x8C10032A,  //  000C  GETMET	R4	R1	K42
       0x5C180600,  //  000D  MOVE	R6	R3
       0x7C100400,  //  000E  CALL	R4	2
       0x7812000B,  //  000F  JMPF	R4	#001C
-      0x8C100105,  //  0010  GETMET	R4	R0	K5
+      0x8C10012B,  //  0010  GETMET	R4	R0	K43
       0x7C100200,  //  0011  CALL	R4	1
-      0x8C100106,  //  0012  GETMET	R4	R0	K6
+      0x8C10012C,  //  0012  GETMET	R4	R0	K44
       0x5C180600,  //  0013  MOVE	R6	R3
       0x7C100400,  //  0014  CALL	R4	2
-      0xB8120E00,  //  0015  GETNGBL	R4	K7
-      0x8C100908,  //  0016  GETMET	R4	R4	K8
-      0x58180009,  //  0017  LDCONST	R6	K9
-      0x581C000A,  //  0018  LDCONST	R7	K10
+      0xB8120A00,  //  0015  GETNGBL	R4	K5
+      0x8C100906,  //  0016  GETMET	R4	R4	K6
+      0x5818002D,  //  0017  LDCONST	R6	K45
+      0x581C002E,  //  0018  LDCONST	R7	K46
       0x7C100600,  //  0019  CALL	R4	3
       0x50080200,  //  001A  LDBOOL	R2	1	0
       0x80000800,  //  001B  RET	0
-      0x88100100,  //  001C  GETMBR	R4	R0	K0
-      0x0010090B,  //  001D  ADD	R4	R4	K11
+      0x88100127,  //  001C  GETMBR	R4	R0	K39
+      0x0010092F,  //  001D  ADD	R4	R4	K47
       0x5C0C0800,  //  001E  MOVE	R3	R4
-      0x8C100304,  //  001F  GETMET	R4	R1	K4
+      0x8C10032A,  //  001F  GETMET	R4	R1	K42
       0x5C180600,  //  0020  MOVE	R6	R3
       0x7C100400,  //  0021  CALL	R4	2
       0x78120040,  //  0022  JMPF	R4	#0064
-      0x8C100103,  //  0023  GETMET	R4	R0	K3
+      0x8C100129,  //  0023  GETMET	R4	R0	K41
       0x7C100200,  //  0024  CALL	R4	1
       0x74120003,  //  0025  JMPT	R4	#002A
-      0x8C100304,  //  0026  GETMET	R4	R1	K4
-      0x5818000C,  //  0027  LDCONST	R6	K12
+      0x8C10032A,  //  0026  GETMET	R4	R1	K42
+      0x58180030,  //  0027  LDCONST	R6	K48
       0x7C100400,  //  0028  CALL	R4	2
       0x74120039,  //  0029  JMPT	R4	#0064
-      0x8C100103,  //  002A  GETMET	R4	R0	K3
+      0x8C100129,  //  002A  GETMET	R4	R0	K41
       0x7C100200,  //  002B  CALL	R4	1
       0x78120003,  //  002C  JMPF	R4	#0031
       0x5C100400,  //  002D  MOVE	R4	R2
       0x74120001,  //  002E  JMPT	R4	#0031
-      0x8C100105,  //  002F  GETMET	R4	R0	K5
+      0x8C10012B,  //  002F  GETMET	R4	R0	K43
       0x7C100200,  //  0030  CALL	R4	1
       0x4C100000,  //  0031  LDNIL	R4
       0x4C140000,  //  0032  LDNIL	R5
       0xA802001A,  //  0033  EXBLK	0	#004F
       0x60180011,  //  0034  GETGBL	R6	G17
       0x5C1C0600,  //  0035  MOVE	R7	R3
-      0x5820000D,  //  0036  LDCONST	R8	K13
+      0x58200031,  //  0036  LDCONST	R8	K49
       0x7C180400,  //  0037  CALL	R6	2
       0x5C100C00,  //  0038  MOVE	R4	R6
       0x60180011,  //  0039  GETGBL	R6	G17
-      0x581C000C,  //  003A  LDCONST	R7	K12
-      0x5820000E,  //  003B  LDCONST	R8	K14
+      0x581C0030,  //  003A  LDCONST	R7	K48
+      0x58200032,  //  003B  LDCONST	R8	K50
       0x7C180400,  //  003C  CALL	R6	2
       0x5C140C00,  //  003D  MOVE	R5	R6
-      0x8C18090F,  //  003E  GETMET	R6	R4	K15
+      0x8C180933,  //  003E  GETMET	R6	R4	K51
       0x7C180200,  //  003F  CALL	R6	1
-      0x8C1C0B10,  //  0040  GETMET	R7	R5	K16
+      0x8C1C0B34,  //  0040  GETMET	R7	R5	K52
       0x5C240C00,  //  0041  MOVE	R9	R6
       0x7C1C0400,  //  0042  CALL	R7	2
-      0x8C1C0911,  //  0043  GETMET	R7	R4	K17
+      0x8C1C091B,  //  0043  GETMET	R7	R4	K27
       0x7C1C0200,  //  0044  CALL	R7	1
-      0x8C1C0B11,  //  0045  GETMET	R7	R5	K17
+      0x8C1C0B1B,  //  0045  GETMET	R7	R5	K27
       0x7C1C0200,  //  0046  CALL	R7	1
       0x50080200,  //  0047  LDBOOL	R2	1	0
-      0xB81E0E00,  //  0048  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0049  GETMET	R7	R7	K8
-      0x58240012,  //  004A  LDCONST	R9	K18
-      0x5828000A,  //  004B  LDCONST	R10	K10
+      0xB81E0A00,  //  0048  GETNGBL	R7	K5
+      0x8C1C0F06,  //  0049  GETMET	R7	R7	K6
+      0x58240035,  //  004A  LDCONST	R9	K53
+      0x5828002E,  //  004B  LDCONST	R10	K46
       0x7C1C0600,  //  004C  CALL	R7	3
       0xA8040001,  //  004D  EXBLK	1	1
       0x70020014,  //  004E  JMP		#0064
@@ -316,7 +376,7 @@ be_local_closure(class_Autoconf_autoexec,   /* name */
       0x70020011,  //  0050  JMP		#0063
       0x60200001,  //  0051  GETGBL	R8	G1
       0x60240018,  //  0052  GETGBL	R9	G24
-      0x58280013,  //  0053  LDCONST	R10	K19
+      0x58280036,  //  0053  LDCONST	R10	K54
       0x5C2C0C00,  //  0054  MOVE	R11	R6
       0x5C300E00,  //  0055  MOVE	R12	R7
       0x7C240600,  //  0056  CALL	R9	3
@@ -324,60 +384,60 @@ be_local_closure(class_Autoconf_autoexec,   /* name */
       0x4C200000,  //  0058  LDNIL	R8
       0x20200808,  //  0059  NE	R8	R4	R8
       0x78220001,  //  005A  JMPF	R8	#005D
-      0x8C200911,  //  005B  GETMET	R8	R4	K17
+      0x8C20091B,  //  005B  GETMET	R8	R4	K27
       0x7C200200,  //  005C  CALL	R8	1
       0x4C200000,  //  005D  LDNIL	R8
       0x20200A08,  //  005E  NE	R8	R5	R8
       0x78220001,  //  005F  JMPF	R8	#0062
-      0x8C200B11,  //  0060  GETMET	R8	R5	K17
+      0x8C200B1B,  //  0060  GETMET	R8	R5	K27
       0x7C200200,  //  0061  CALL	R8	1
       0x70020000,  //  0062  JMP		#0064
       0xB0080000,  //  0063  RAISE	2	R0	R0
       0x780A0004,  //  0064  JMPF	R2	#006A
-      0xB8120E00,  //  0065  GETNGBL	R4	K7
-      0x8C100914,  //  0066  GETMET	R4	R4	K20
-      0x58180015,  //  0067  LDCONST	R6	K21
+      0xB8120A00,  //  0065  GETNGBL	R4	K5
+      0x8C100937,  //  0066  GETMET	R4	R4	K55
+      0x58180038,  //  0067  LDCONST	R6	K56
       0x7C100400,  //  0068  CALL	R4	2
       0x80000800,  //  0069  RET	0
-      0x88100100,  //  006A  GETMBR	R4	R0	K0
-      0x00100916,  //  006B  ADD	R4	R4	K22
+      0x88100127,  //  006A  GETMBR	R4	R0	K39
+      0x00100939,  //  006B  ADD	R4	R4	K57
       0x5C0C0800,  //  006C  MOVE	R3	R4
-      0x8C100304,  //  006D  GETMET	R4	R1	K4
+      0x8C10032A,  //  006D  GETMET	R4	R1	K42
       0x5C180600,  //  006E  MOVE	R6	R3
       0x7C100400,  //  006F  CALL	R4	2
       0x7812000C,  //  0070  JMPF	R4	#007E
-      0xB8120E00,  //  0071  GETNGBL	R4	K7
-      0x8C100908,  //  0072  GETMET	R4	R4	K8
-      0x001A2E03,  //  0073  ADD	R6	K23	R3
-      0x581C0018,  //  0074  LDCONST	R7	K24
+      0xB8120A00,  //  0071  GETNGBL	R4	K5
+      0x8C100906,  //  0072  GETMET	R4	R4	K6
+      0x001A7403,  //  0073  ADD	R6	K58	R3
+      0x581C003B,  //  0074  LDCONST	R7	K59
       0x7C100600,  //  0075  CALL	R4	3
-      0x8C100106,  //  0076  GETMET	R4	R0	K6
+      0x8C10012C,  //  0076  GETMET	R4	R0	K44
       0x5C180600,  //  0077  MOVE	R6	R3
       0x7C100400,  //  0078  CALL	R4	2
-      0xB8120E00,  //  0079  GETNGBL	R4	K7
-      0x8C100908,  //  007A  GETMET	R4	R4	K8
-      0x001A3203,  //  007B  ADD	R6	K25	R3
-      0x581C0018,  //  007C  LDCONST	R7	K24
+      0xB8120A00,  //  0079  GETNGBL	R4	K5
+      0x8C100906,  //  007A  GETMET	R4	R4	K6
+      0x001A7803,  //  007B  ADD	R6	K60	R3
+      0x581C003B,  //  007C  LDCONST	R7	K59
       0x7C100600,  //  007D  CALL	R4	3
-      0x88100100,  //  007E  GETMBR	R4	R0	K0
-      0x0010091A,  //  007F  ADD	R4	R4	K26
+      0x88100127,  //  007E  GETMBR	R4	R0	K39
+      0x0010093D,  //  007F  ADD	R4	R4	K61
       0x5C0C0800,  //  0080  MOVE	R3	R4
-      0x8C100304,  //  0081  GETMET	R4	R1	K4
+      0x8C10032A,  //  0081  GETMET	R4	R1	K42
       0x5C180600,  //  0082  MOVE	R6	R3
       0x7C100400,  //  0083  CALL	R4	2
       0x7812000C,  //  0084  JMPF	R4	#0092
-      0xB8120E00,  //  0085  GETNGBL	R4	K7
-      0x8C100908,  //  0086  GETMET	R4	R4	K8
-      0x001A3603,  //  0087  ADD	R6	K27	R3
-      0x581C0018,  //  0088  LDCONST	R7	K24
+      0xB8120A00,  //  0085  GETNGBL	R4	K5
+      0x8C100906,  //  0086  GETMET	R4	R4	K6
+      0x001A7C03,  //  0087  ADD	R6	K62	R3
+      0x581C003B,  //  0088  LDCONST	R7	K59
       0x7C100600,  //  0089  CALL	R4	3
-      0xB8123800,  //  008A  GETNGBL	R4	K28
+      0xB8127E00,  //  008A  GETNGBL	R4	K63
       0x5C140600,  //  008B  MOVE	R5	R3
       0x7C100200,  //  008C  CALL	R4	1
-      0xB8120E00,  //  008D  GETNGBL	R4	K7
-      0x8C100908,  //  008E  GETMET	R4	R4	K8
-      0x001A3A03,  //  008F  ADD	R6	K29	R3
-      0x581C0018,  //  0090  LDCONST	R7	K24
+      0xB8120A00,  //  008D  GETNGBL	R4	K5
+      0x8C100906,  //  008E  GETMET	R4	R4	K6
+      0x001A8003,  //  008F  ADD	R6	K64	R3
+      0x581C003B,  //  0090  LDCONST	R7	K59
       0x7C100600,  //  0091  CALL	R4	3
       0x80000000,  //  0092  RET	0
     })
@@ -393,25 +453,13 @@ be_local_closure(class_Autoconf_run_bat,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str(r),
-    /* K1   */  be_nested_str(readline),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(_X0A),
-    /* K4   */  be_nested_str(_X0D),
-    /* K5   */  be_nested_str(tasmota),
-    /* K6   */  be_nested_str(cmd),
-    /* K7   */  be_nested_str(close),
-    /* K8   */  be_nested_str(log),
-    /* K9   */  be_nested_str(CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29),
-    /* K10  */  be_const_int(1),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_run_bat,
     &be_const_str_solidified,
     ( &(const binstruction[68]) {  /* code */
@@ -419,66 +467,66 @@ be_local_closure(class_Autoconf_run_bat,   /* name */
       0xA802002D,  //  0001  EXBLK	0	#0030
       0x600C0011,  //  0002  GETGBL	R3	G17
       0x5C100200,  //  0003  MOVE	R4	R1
-      0x58140000,  //  0004  LDCONST	R5	K0
+      0x58140031,  //  0004  LDCONST	R5	K49
       0x7C0C0400,  //  0005  CALL	R3	2
       0x5C080600,  //  0006  MOVE	R2	R3
       0x500C0200,  //  0007  LDBOOL	R3	1	0
       0x780E0022,  //  0008  JMPF	R3	#002C
-      0x8C0C0501,  //  0009  GETMET	R3	R2	K1
+      0x8C0C0541,  //  0009  GETMET	R3	R2	K65
       0x7C0C0200,  //  000A  CALL	R3	1
       0x6010000C,  //  000B  GETGBL	R4	G12
       0x5C140600,  //  000C  MOVE	R5	R3
       0x7C100200,  //  000D  CALL	R4	1
-      0x1C100902,  //  000E  EQ	R4	R4	K2
+      0x1C100942,  //  000E  EQ	R4	R4	K66
       0x78120000,  //  000F  JMPF	R4	#0011
       0x7002001A,  //  0010  JMP		#002C
       0x6010000C,  //  0011  GETGBL	R4	G12
       0x5C140600,  //  0012  MOVE	R5	R3
       0x7C100200,  //  0013  CALL	R4	1
-      0x24100902,  //  0014  GT	R4	R4	K2
+      0x24100942,  //  0014  GT	R4	R4	K66
       0x7812000B,  //  0015  JMPF	R4	#0022
       0x5411FFFE,  //  0016  LDINT	R4	-1
       0x94100604,  //  0017  GETIDX	R4	R3	R4
-      0x1C100903,  //  0018  EQ	R4	R4	K3
+      0x1C100943,  //  0018  EQ	R4	R4	K67
       0x74120003,  //  0019  JMPT	R4	#001E
       0x5411FFFE,  //  001A  LDINT	R4	-1
       0x94100604,  //  001B  GETIDX	R4	R3	R4
-      0x1C100904,  //  001C  EQ	R4	R4	K4
+      0x1C100944,  //  001C  EQ	R4	R4	K68
       0x78120003,  //  001D  JMPF	R4	#0022
       0x5411FFFD,  //  001E  LDINT	R4	-2
-      0x40120404,  //  001F  CONNECT	R4	K2	R4
+      0x40128404,  //  001F  CONNECT	R4	K66	R4
       0x940C0604,  //  0020  GETIDX	R3	R3	R4
       0x7001FFEE,  //  0021  JMP		#0011
       0x6010000C,  //  0022  GETGBL	R4	G12
       0x5C140600,  //  0023  MOVE	R5	R3
       0x7C100200,  //  0024  CALL	R4	1
-      0x24100902,  //  0025  GT	R4	R4	K2
+      0x24100942,  //  0025  GT	R4	R4	K66
       0x78120003,  //  0026  JMPF	R4	#002B
       0xB8120A00,  //  0027  GETNGBL	R4	K5
-      0x8C100906,  //  0028  GETMET	R4	R4	K6
+      0x8C100937,  //  0028  GETMET	R4	R4	K55
       0x5C180600,  //  0029  MOVE	R6	R3
       0x7C100400,  //  002A  CALL	R4	2
       0x7001FFDA,  //  002B  JMP		#0007
-      0x8C0C0507,  //  002C  GETMET	R3	R2	K7
+      0x8C0C051B,  //  002C  GETMET	R3	R2	K27
       0x7C0C0200,  //  002D  CALL	R3	1
       0xA8040001,  //  002E  EXBLK	1	1
       0x70020012,  //  002F  JMP		#0043
       0xAC0C0002,  //  0030  CATCH	R3	0	2
       0x7002000F,  //  0031  JMP		#0042
       0xB8160A00,  //  0032  GETNGBL	R5	K5
-      0x8C140B08,  //  0033  GETMET	R5	R5	K8
+      0x8C140B06,  //  0033  GETMET	R5	R5	K6
       0x601C0018,  //  0034  GETGBL	R7	G24
-      0x58200009,  //  0035  LDCONST	R8	K9
+      0x58200045,  //  0035  LDCONST	R8	K69
       0x5C240200,  //  0036  MOVE	R9	R1
       0x5C280600,  //  0037  MOVE	R10	R3
       0x5C2C0800,  //  0038  MOVE	R11	R4
       0x7C1C0800,  //  0039  CALL	R7	4
-      0x5820000A,  //  003A  LDCONST	R8	K10
+      0x58200046,  //  003A  LDCONST	R8	K70
       0x7C140600,  //  003B  CALL	R5	3
       0x4C140000,  //  003C  LDNIL	R5
       0x20140405,  //  003D  NE	R5	R2	R5
       0x78160001,  //  003E  JMPF	R5	#0041
-      0x8C140507,  //  003F  GETMET	R5	R2	K7
+      0x8C14051B,  //  003F  GETMET	R5	R2	K27
       0x7C140200,  //  0040  CALL	R5	1
       0x70020000,  //  0041  JMP		#0043
       0xB0080000,  //  0042  RAISE	2	R0	R0
@@ -496,139 +544,100 @@ be_local_closure(class_Autoconf_page_autoconf_mgr,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[38]) {     /* constants */
-    /* K0   */  be_nested_str(webserver),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(check_privileged_access),
-    /* K3   */  be_nested_str(content_start),
-    /* K4   */  be_nested_str(Auto_X2Dconfiguration),
-    /* K5   */  be_nested_str(content_send_style),
-    /* K6   */  be_nested_str(content_send),
-    /* K7   */  be_nested_str(_X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E),
-    /* K8   */  be_nested_str(get_current_module_path),
-    /* K9   */  be_nested_str(tr),
-    /* K10  */  be_nested_str(get_current_module_name),
-    /* K11  */  be_nested_str(_),
-    /* K12  */  be_nested_str(_X20),
-    /* K13  */  be_nested_str(_error),
-    /* K14  */  be_nested_str(_X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B),
-    /* K15  */  be_nested_str(_X26lt_X3BNone_X26gt_X3B),
-    /* K16  */  be_nested_str(_X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E),
-    /* K17  */  be_nested_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27Autoconfiguration_X27_X3E_X26nbsp_X3BCurrent_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E),
-    /* K18  */  be_nested_str(_X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-    /* K19  */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20),
-    /* K20  */  be_nested_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
-    /* K21  */  be_nested_str(_X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E),
-    /* K22  */  be_nested_str(_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K23  */  be_nested_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K24  */  be_nested_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E),
-    /* K25  */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20),
-    /* K26  */  be_nested_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
-    /* K27  */  be_nested_str(_X3Clabel_X3EChoose_X20a_X20device_X20configuration_X3A_X3C_X2Flabel_X3E_X3Cbr_X3E),
-    /* K28  */  be_nested_str(_X3Cselect_X20name_X3D_X27zip_X27_X3E),
-    /* K29  */  be_nested_str(load_templates),
-    /* K30  */  be_nested_str(_X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E),
-    /* K31  */  be_nested_str(_X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E),
-    /* K32  */  be_nested_str(stop_iteration),
-    /* K33  */  be_nested_str(_X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K34  */  be_nested_str(_X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E),
-    /* K35  */  be_nested_str(content_button),
-    /* K36  */  be_nested_str(BUTTON_CONFIGURATION),
-    /* K37  */  be_nested_str(content_stop),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_page_autoconf_mgr,
     &be_const_str_solidified,
     ( &(const binstruction[124]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA40A8E00,  //  0001  IMPORT	R2	K71
       0x8C0C0302,  //  0002  GETMET	R3	R1	K2
       0x7C0C0200,  //  0003  CALL	R3	1
       0x740E0001,  //  0004  JMPT	R3	#0007
       0x4C0C0000,  //  0005  LDNIL	R3
       0x80040600,  //  0006  RET	1	R3
-      0x8C0C0303,  //  0007  GETMET	R3	R1	K3
-      0x58140004,  //  0008  LDCONST	R5	K4
+      0x8C0C031F,  //  0007  GETMET	R3	R1	K31
+      0x58140048,  //  0008  LDCONST	R5	K72
       0x7C0C0400,  //  0009  CALL	R3	2
-      0x8C0C0305,  //  000A  GETMET	R3	R1	K5
+      0x8C0C0321,  //  000A  GETMET	R3	R1	K33
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x8C0C0306,  //  000C  GETMET	R3	R1	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
+      0x8C0C0322,  //  000C  GETMET	R3	R1	K34
+      0x58140049,  //  000D  LDCONST	R5	K73
       0x7C0C0400,  //  000E  CALL	R3	2
-      0x8C0C0108,  //  000F  GETMET	R3	R0	K8
+      0x8C0C014A,  //  000F  GETMET	R3	R0	K74
       0x7C0C0200,  //  0010  CALL	R3	1
       0x780E0006,  //  0011  JMPF	R3	#0019
-      0x8C100509,  //  0012  GETMET	R4	R2	K9
-      0x8C18010A,  //  0013  GETMET	R6	R0	K10
+      0x8C10054B,  //  0012  GETMET	R4	R2	K75
+      0x8C18014C,  //  0013  GETMET	R6	R0	K76
       0x7C180200,  //  0014  CALL	R6	1
-      0x581C000B,  //  0015  LDCONST	R7	K11
-      0x5820000C,  //  0016  LDCONST	R8	K12
+      0x581C004D,  //  0015  LDCONST	R7	K77
+      0x5820004E,  //  0016  LDCONST	R8	K78
       0x7C100800,  //  0017  CALL	R4	4
       0x70020004,  //  0018  JMP		#001E
-      0x8810010D,  //  0019  GETMBR	R4	R0	K13
+      0x8810014F,  //  0019  GETMBR	R4	R0	K79
       0x78120001,  //  001A  JMPF	R4	#001D
-      0x5810000E,  //  001B  LDCONST	R4	K14
+      0x58100050,  //  001B  LDCONST	R4	K80
       0x70020000,  //  001C  JMP		#001E
-      0x5810000F,  //  001D  LDCONST	R4	K15
-      0x8C140306,  //  001E  GETMET	R5	R1	K6
-      0x581C0010,  //  001F  LDCONST	R7	K16
+      0x58100051,  //  001D  LDCONST	R4	K81
+      0x8C140322,  //  001E  GETMET	R5	R1	K34
+      0x581C0052,  //  001F  LDCONST	R7	K82
       0x7C140400,  //  0020  CALL	R5	2
-      0x8C140306,  //  0021  GETMET	R5	R1	K6
+      0x8C140322,  //  0021  GETMET	R5	R1	K34
       0x601C0018,  //  0022  GETGBL	R7	G24
-      0x58200011,  //  0023  LDCONST	R8	K17
+      0x58200053,  //  0023  LDCONST	R8	K83
       0x7C1C0200,  //  0024  CALL	R7	1
       0x7C140400,  //  0025  CALL	R5	2
-      0x8C140306,  //  0026  GETMET	R5	R1	K6
+      0x8C140322,  //  0026  GETMET	R5	R1	K34
       0x601C0018,  //  0027  GETGBL	R7	G24
-      0x58200012,  //  0028  LDCONST	R8	K18
+      0x58200054,  //  0028  LDCONST	R8	K84
       0x5C240800,  //  0029  MOVE	R9	R4
       0x7C1C0400,  //  002A  CALL	R7	2
       0x7C140400,  //  002B  CALL	R5	2
       0x780E000B,  //  002C  JMPF	R3	#0039
-      0x8C140306,  //  002D  GETMET	R5	R1	K6
-      0x581C0013,  //  002E  LDCONST	R7	K19
+      0x8C140322,  //  002D  GETMET	R5	R1	K34
+      0x581C0055,  //  002E  LDCONST	R7	K85
       0x7C140400,  //  002F  CALL	R5	2
-      0x8C140306,  //  0030  GETMET	R5	R1	K6
-      0x581C0014,  //  0031  LDCONST	R7	K20
+      0x8C140322,  //  0030  GETMET	R5	R1	K34
+      0x581C0056,  //  0031  LDCONST	R7	K86
       0x7C140400,  //  0032  CALL	R5	2
-      0x8C140306,  //  0033  GETMET	R5	R1	K6
-      0x581C0015,  //  0034  LDCONST	R7	K21
+      0x8C140322,  //  0033  GETMET	R5	R1	K34
+      0x581C0057,  //  0034  LDCONST	R7	K87
       0x7C140400,  //  0035  CALL	R5	2
-      0x8C140306,  //  0036  GETMET	R5	R1	K6
-      0x581C0016,  //  0037  LDCONST	R7	K22
+      0x8C140322,  //  0036  GETMET	R5	R1	K34
+      0x581C0058,  //  0037  LDCONST	R7	K88
       0x7C140400,  //  0038  CALL	R5	2
-      0x8C140306,  //  0039  GETMET	R5	R1	K6
-      0x581C0017,  //  003A  LDCONST	R7	K23
+      0x8C140322,  //  0039  GETMET	R5	R1	K34
+      0x581C0059,  //  003A  LDCONST	R7	K89
       0x7C140400,  //  003B  CALL	R5	2
-      0x8C140306,  //  003C  GETMET	R5	R1	K6
-      0x581C0010,  //  003D  LDCONST	R7	K16
+      0x8C140322,  //  003C  GETMET	R5	R1	K34
+      0x581C0052,  //  003D  LDCONST	R7	K82
       0x7C140400,  //  003E  CALL	R5	2
-      0x8C140306,  //  003F  GETMET	R5	R1	K6
+      0x8C140322,  //  003F  GETMET	R5	R1	K34
       0x601C0018,  //  0040  GETGBL	R7	G24
-      0x58200018,  //  0041  LDCONST	R8	K24
+      0x5820005A,  //  0041  LDCONST	R8	K90
       0x7C1C0200,  //  0042  CALL	R7	1
       0x7C140400,  //  0043  CALL	R5	2
-      0x8C140306,  //  0044  GETMET	R5	R1	K6
-      0x581C0019,  //  0045  LDCONST	R7	K25
+      0x8C140322,  //  0044  GETMET	R5	R1	K34
+      0x581C005B,  //  0045  LDCONST	R7	K91
       0x7C140400,  //  0046  CALL	R5	2
-      0x8C140306,  //  0047  GETMET	R5	R1	K6
-      0x581C001A,  //  0048  LDCONST	R7	K26
+      0x8C140322,  //  0047  GETMET	R5	R1	K34
+      0x581C005C,  //  0048  LDCONST	R7	K92
       0x7C140400,  //  0049  CALL	R5	2
-      0x8C140306,  //  004A  GETMET	R5	R1	K6
-      0x581C001B,  //  004B  LDCONST	R7	K27
+      0x8C140322,  //  004A  GETMET	R5	R1	K34
+      0x581C005D,  //  004B  LDCONST	R7	K93
       0x7C140400,  //  004C  CALL	R5	2
-      0x8C140306,  //  004D  GETMET	R5	R1	K6
-      0x581C001C,  //  004E  LDCONST	R7	K28
+      0x8C140322,  //  004D  GETMET	R5	R1	K34
+      0x581C005E,  //  004E  LDCONST	R7	K94
       0x7C140400,  //  004F  CALL	R5	2
-      0x8C14011D,  //  0050  GETMET	R5	R0	K29
+      0x8C14015F,  //  0050  GETMET	R5	R0	K95
       0x7C140200,  //  0051  CALL	R5	1
-      0x8C180306,  //  0052  GETMET	R6	R1	K6
-      0x5820001E,  //  0053  LDCONST	R8	K30
+      0x8C180322,  //  0052  GETMET	R6	R1	K34
+      0x58200060,  //  0053  LDCONST	R8	K96
       0x7C180400,  //  0054  CALL	R6	2
       0x60180010,  //  0055  GETGBL	R6	G16
       0x5C1C0A00,  //  0056  MOVE	R7	R5
@@ -636,37 +645,37 @@ be_local_closure(class_Autoconf_page_autoconf_mgr,   /* name */
       0xA802000D,  //  0058  EXBLK	0	#0067
       0x5C1C0C00,  //  0059  MOVE	R7	R6
       0x7C1C0000,  //  005A  CALL	R7	0
-      0x8C200306,  //  005B  GETMET	R8	R1	K6
+      0x8C200322,  //  005B  GETMET	R8	R1	K34
       0x60280018,  //  005C  GETGBL	R10	G24
-      0x582C001F,  //  005D  LDCONST	R11	K31
+      0x582C0061,  //  005D  LDCONST	R11	K97
       0x5C300E00,  //  005E  MOVE	R12	R7
-      0x8C340509,  //  005F  GETMET	R13	R2	K9
+      0x8C34054B,  //  005F  GETMET	R13	R2	K75
       0x5C3C0E00,  //  0060  MOVE	R15	R7
-      0x5840000B,  //  0061  LDCONST	R16	K11
-      0x5844000C,  //  0062  LDCONST	R17	K12
+      0x5840004D,  //  0061  LDCONST	R16	K77
+      0x5844004E,  //  0062  LDCONST	R17	K78
       0x7C340800,  //  0063  CALL	R13	4
       0x7C280600,  //  0064  CALL	R10	3
       0x7C200400,  //  0065  CALL	R8	2
       0x7001FFF1,  //  0066  JMP		#0059
-      0x58180020,  //  0067  LDCONST	R6	K32
+      0x58180062,  //  0067  LDCONST	R6	K98
       0xAC180200,  //  0068  CATCH	R6	1	0
       0xB0080000,  //  0069  RAISE	2	R0	R0
-      0x8C180306,  //  006A  GETMET	R6	R1	K6
-      0x58200021,  //  006B  LDCONST	R8	K33
+      0x8C180322,  //  006A  GETMET	R6	R1	K34
+      0x58200063,  //  006B  LDCONST	R8	K99
       0x7C180400,  //  006C  CALL	R6	2
-      0x8C180306,  //  006D  GETMET	R6	R1	K6
-      0x58200022,  //  006E  LDCONST	R8	K34
+      0x8C180322,  //  006D  GETMET	R6	R1	K34
+      0x58200064,  //  006E  LDCONST	R8	K100
       0x7C180400,  //  006F  CALL	R6	2
-      0x8C180306,  //  0070  GETMET	R6	R1	K6
-      0x58200016,  //  0071  LDCONST	R8	K22
+      0x8C180322,  //  0070  GETMET	R6	R1	K34
+      0x58200058,  //  0071  LDCONST	R8	K88
       0x7C180400,  //  0072  CALL	R6	2
-      0x8C180306,  //  0073  GETMET	R6	R1	K6
-      0x58200017,  //  0074  LDCONST	R8	K23
+      0x8C180322,  //  0073  GETMET	R6	R1	K34
+      0x58200059,  //  0074  LDCONST	R8	K89
       0x7C180400,  //  0075  CALL	R6	2
-      0x8C180323,  //  0076  GETMET	R6	R1	K35
-      0x88200324,  //  0077  GETMBR	R8	R1	K36
+      0x8C180324,  //  0076  GETMET	R6	R1	K36
+      0x88200325,  //  0077  GETMBR	R8	R1	K37
       0x7C180400,  //  0078  CALL	R6	2
-      0x8C180325,  //  0079  GETMET	R6	R1	K37
+      0x8C180326,  //  0079  GETMET	R6	R1	K38
       0x7C180200,  //  007A  CALL	R6	1
       0x80000000,  //  007B  RET	0
     })
@@ -682,22 +691,19 @@ be_local_closure(class_Autoconf_get_current_module_name,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_archive),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_get_current_module_name,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x5405FFF5,  //  0000  LDINT	R1	-10
-      0x40060201,  //  0001  CONNECT	R1	K1	R1
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x40068401,  //  0001  CONNECT	R1	K66	R1
+      0x88080127,  //  0002  GETMBR	R2	R0	K39
       0x94040401,  //  0003  GETIDX	R1	R2	R1
       0x80040200,  //  0004  RET	1	R1
     })
@@ -713,30 +719,20 @@ be_local_closure(class_Autoconf_delete_all_configs,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(listdir),
-    /* K3   */  be_nested_str(_X2F),
-    /* K4   */  be_nested_str(find),
-    /* K5   */  be_nested_str(_X2Eautoconf),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str(remove),
-    /* K8   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_delete_all_configs,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0xA40A8E00,  //  0001  IMPORT	R2	K71
+      0x8C0C0365,  //  0002  GETMET	R3	R1	K101
+      0x58140066,  //  0003  LDCONST	R5	K102
       0x7C0C0400,  //  0004  CALL	R3	2
       0x60100010,  //  0005  GETGBL	R4	G16
       0x5C140600,  //  0006  MOVE	R5	R3
@@ -744,17 +740,17 @@ be_local_closure(class_Autoconf_delete_all_configs,   /* name */
       0xA802000B,  //  0008  EXBLK	0	#0015
       0x5C140800,  //  0009  MOVE	R5	R4
       0x7C140000,  //  000A  CALL	R5	0
-      0x8C180504,  //  000B  GETMET	R6	R2	K4
+      0x8C180567,  //  000B  GETMET	R6	R2	K103
       0x5C200A00,  //  000C  MOVE	R8	R5
-      0x58240005,  //  000D  LDCONST	R9	K5
+      0x58240068,  //  000D  LDCONST	R9	K104
       0x7C180600,  //  000E  CALL	R6	3
-      0x24180D06,  //  000F  GT	R6	R6	K6
+      0x24180D42,  //  000F  GT	R6	R6	K66
       0x781A0002,  //  0010  JMPF	R6	#0014
-      0x8C180307,  //  0011  GETMET	R6	R1	K7
+      0x8C180369,  //  0011  GETMET	R6	R1	K105
       0x5C200A00,  //  0012  MOVE	R8	R5
       0x7C180400,  //  0013  CALL	R6	2
       0x7001FFF3,  //  0014  JMP		#0009
-      0x58100008,  //  0015  LDCONST	R4	K8
+      0x58100062,  //  0015  LDCONST	R4	K98
       0xAC100200,  //  0016  CATCH	R4	1	0
       0xB0080000,  //  0017  RAISE	2	R0	R0
       0x80000000,  //  0018  RET	0
@@ -771,25 +767,21 @@ be_local_closure(class_Autoconf_set_first_time,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_X2F_X2Eautoconf),
-    /* K1   */  be_nested_str(w),
-    /* K2   */  be_nested_str(close),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_set_first_time,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60040011,  //  0000  GETGBL	R1	G17
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x5808006A,  //  0001  LDCONST	R2	K106
+      0x580C0032,  //  0002  LDCONST	R3	K50
       0x7C040400,  //  0003  CALL	R1	2
-      0x8C080302,  //  0004  GETMET	R2	R1	K2
+      0x8C08031B,  //  0004  GETMET	R2	R1	K27
       0x7C080200,  //  0005  CALL	R2	1
       0x80000000,  //  0006  RET	0
     })
@@ -805,92 +797,72 @@ be_local_closure(class_Autoconf_load_templates,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson),
-    /* K2   */  be_nested_str(tasmota),
-    /* K3   */  be_nested_str(arch),
-    /* K4   */  be_nested_str(log),
-    /* K5   */  be_nested_str(CFG_X3A_X20loading_X20_X27_X25s_X27),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str(webclient),
-    /* K8   */  be_nested_str(begin),
-    /* K9   */  be_nested_str(GET),
-    /* K10  */  be_nested_str(CFG_X3A_X20return_code_X3D_X25i),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str(get_string),
-    /* K13  */  be_nested_str(close),
-    /* K14  */  be_nested_str(load),
-    /* K15  */  be_nested_str(CFG_X3A_X20loaded_X20_X27_X25s_X27),
-    /* K16  */  be_nested_str(find),
-    /* K17  */  be_nested_str(files),
-    /* K18  */  be_nested_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_load_templates,
     &be_const_str_solidified,
     ( &(const binstruction[85]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA406D600,  //  0000  IMPORT	R1	K107
       0xA8020042,  //  0001  EXBLK	0	#0045
       0x60080018,  //  0002  GETGBL	R2	G24
-      0x580C0001,  //  0003  LDCONST	R3	K1
-      0xB8120400,  //  0004  GETNGBL	R4	K2
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x580C006C,  //  0003  LDCONST	R3	K108
+      0xB8120A00,  //  0004  GETNGBL	R4	K5
+      0x8C100912,  //  0005  GETMET	R4	R4	K18
       0x7C100200,  //  0006  CALL	R4	1
       0x7C080400,  //  0007  CALL	R2	2
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0704,  //  0009  GETMET	R3	R3	K4
+      0xB80E0A00,  //  0008  GETNGBL	R3	K5
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
       0x60140018,  //  000A  GETGBL	R5	G24
-      0x58180005,  //  000B  LDCONST	R6	K5
+      0x5818006D,  //  000B  LDCONST	R6	K109
       0x5C1C0400,  //  000C  MOVE	R7	R2
       0x7C140400,  //  000D  CALL	R5	2
-      0x58180006,  //  000E  LDCONST	R6	K6
+      0x5818003B,  //  000E  LDCONST	R6	K59
       0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0E00,  //  0010  GETNGBL	R3	K7
+      0xB80E2A00,  //  0010  GETNGBL	R3	K21
       0x7C0C0000,  //  0011  CALL	R3	0
-      0x8C100708,  //  0012  GETMET	R4	R3	K8
+      0x8C100716,  //  0012  GETMET	R4	R3	K22
       0x5C180400,  //  0013  MOVE	R6	R2
       0x7C100400,  //  0014  CALL	R4	2
-      0x8C100709,  //  0015  GETMET	R4	R3	K9
+      0x8C100717,  //  0015  GETMET	R4	R3	K23
       0x7C100200,  //  0016  CALL	R4	1
       0x541600C7,  //  0017  LDINT	R5	200
       0x20140805,  //  0018  NE	R5	R4	R5
       0x7816000A,  //  0019  JMPF	R5	#0025
-      0xB8160400,  //  001A  GETNGBL	R5	K2
-      0x8C140B04,  //  001B  GETMET	R5	R5	K4
+      0xB8160A00,  //  001A  GETNGBL	R5	K5
+      0x8C140B06,  //  001B  GETMET	R5	R5	K6
       0x601C0018,  //  001C  GETGBL	R7	G24
-      0x5820000A,  //  001D  LDCONST	R8	K10
+      0x5820006E,  //  001D  LDCONST	R8	K110
       0x5C240800,  //  001E  MOVE	R9	R4
       0x7C1C0400,  //  001F  CALL	R7	2
-      0x5820000B,  //  0020  LDCONST	R8	K11
+      0x5820006F,  //  0020  LDCONST	R8	K111
       0x7C140600,  //  0021  CALL	R5	3
       0x4C140000,  //  0022  LDNIL	R5
       0xA8040001,  //  0023  EXBLK	1	1
       0x80040A00,  //  0024  RET	1	R5
-      0x8C14070C,  //  0025  GETMET	R5	R3	K12
+      0x8C140770,  //  0025  GETMET	R5	R3	K112
       0x7C140200,  //  0026  CALL	R5	1
-      0x8C18070D,  //  0027  GETMET	R6	R3	K13
+      0x8C18071B,  //  0027  GETMET	R6	R3	K27
       0x7C180200,  //  0028  CALL	R6	1
-      0x8C18030E,  //  0029  GETMET	R6	R1	K14
+      0x8C18033F,  //  0029  GETMET	R6	R1	K63
       0x5C200A00,  //  002A  MOVE	R8	R5
       0x7C180400,  //  002B  CALL	R6	2
-      0xB81E0400,  //  002C  GETNGBL	R7	K2
-      0x8C1C0F04,  //  002D  GETMET	R7	R7	K4
+      0xB81E0A00,  //  002C  GETNGBL	R7	K5
+      0x8C1C0F06,  //  002D  GETMET	R7	R7	K6
       0x60240018,  //  002E  GETGBL	R9	G24
-      0x5828000F,  //  002F  LDCONST	R10	K15
+      0x58280071,  //  002F  LDCONST	R10	K113
       0x602C0008,  //  0030  GETGBL	R11	G8
       0x5C300C00,  //  0031  MOVE	R12	R6
       0x7C2C0200,  //  0032  CALL	R11	1
       0x7C240400,  //  0033  CALL	R9	2
-      0x58280006,  //  0034  LDCONST	R10	K6
+      0x5828003B,  //  0034  LDCONST	R10	K59
       0x7C1C0600,  //  0035  CALL	R7	3
-      0x8C1C0D10,  //  0036  GETMET	R7	R6	K16
-      0x58240011,  //  0037  LDCONST	R9	K17
+      0x8C1C0D67,  //  0036  GETMET	R7	R6	K103
+      0x58240072,  //  0037  LDCONST	R9	K114
       0x7C1C0400,  //  0038  CALL	R7	2
       0x6020000F,  //  0039  GETGBL	R8	G15
       0x5C240E00,  //  003A  MOVE	R9	R7
@@ -906,14 +878,14 @@ be_local_closure(class_Autoconf_load_templates,   /* name */
       0x7002000E,  //  0044  JMP		#0054
       0xAC080002,  //  0045  CATCH	R2	0	2
       0x7002000B,  //  0046  JMP		#0053
-      0xB8120400,  //  0047  GETNGBL	R4	K2
-      0x8C100904,  //  0048  GETMET	R4	R4	K4
+      0xB8120A00,  //  0047  GETNGBL	R4	K5
+      0x8C100906,  //  0048  GETMET	R4	R4	K6
       0x60180018,  //  0049  GETGBL	R6	G24
-      0x581C0012,  //  004A  LDCONST	R7	K18
+      0x581C0073,  //  004A  LDCONST	R7	K115
       0x5C200400,  //  004B  MOVE	R8	R2
       0x5C240600,  //  004C  MOVE	R9	R3
       0x7C180600,  //  004D  CALL	R6	3
-      0x581C000B,  //  004E  LDCONST	R7	K11
+      0x581C006F,  //  004E  LDCONST	R7	K111
       0x7C100600,  //  004F  CALL	R4	3
       0x4C100000,  //  0050  LDNIL	R4
       0x80040800,  //  0051  RET	1	R4
@@ -933,23 +905,19 @@ be_local_closure(class_Autoconf_web_add_config_button,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(webserver),
-    /* K1   */  be_nested_str(content_send),
-    /* K2   */  be_nested_str(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_web_add_config_button,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
+      0x8C080322,  //  0001  GETMET	R2	R1	K34
+      0x58100074,  //  0002  LDCONST	R4	K116
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
     })
@@ -965,23 +933,19 @@ be_local_closure(class_Autoconf_is_first_time,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(exists),
-    /* K2   */  be_nested_str(_X2F_X2Eautoconf),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_is_first_time,
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0x8C08032A,  //  0001  GETMET	R2	R1	K42
+      0x5810006A,  //  0002  LDCONST	R4	K106
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0000,  //  0004  JMPF	R2	#0006
       0x50080001,  //  0005  LDBOOL	R2	0	1
@@ -1000,86 +964,68 @@ be_local_closure(class_Autoconf_init,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(listdir),
-    /* K3   */  be_nested_str(_X2F),
-    /* K4   */  be_nested_str(tasmota),
-    /* K5   */  be_nested_str(add_driver),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str(find),
-    /* K8   */  be_nested_str(_X2Eautoconf),
-    /* K9   */  be_nested_str(log),
-    /* K10  */  be_nested_str(CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str(_error),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str(CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str(_archive),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0xA40A8E00,  //  0001  IMPORT	R2	K71
+      0x8C0C0365,  //  0002  GETMET	R3	R1	K101
+      0x58140066,  //  0003  LDCONST	R5	K102
       0x7C0C0400,  //  0004  CALL	R3	2
       0x4C100000,  //  0005  LDNIL	R4
-      0xB8160800,  //  0006  GETNGBL	R5	K4
-      0x8C140B05,  //  0007  GETMET	R5	R5	K5
+      0xB8160A00,  //  0006  GETNGBL	R5	K5
+      0x8C140B75,  //  0007  GETMET	R5	R5	K117
       0x5C1C0000,  //  0008  MOVE	R7	R0
       0x7C140400,  //  0009  CALL	R5	2
-      0x58140006,  //  000A  LDCONST	R5	K6
+      0x58140042,  //  000A  LDCONST	R5	K66
       0x6018000C,  //  000B  GETGBL	R6	G12
       0x5C1C0600,  //  000C  MOVE	R7	R3
       0x7C180200,  //  000D  CALL	R6	1
       0x14180A06,  //  000E  LT	R6	R5	R6
       0x781A0018,  //  000F  JMPF	R6	#0029
-      0x8C180507,  //  0010  GETMET	R6	R2	K7
+      0x8C180567,  //  0010  GETMET	R6	R2	K103
       0x94200605,  //  0011  GETIDX	R8	R3	R5
-      0x58240008,  //  0012  LDCONST	R9	K8
+      0x58240068,  //  0012  LDCONST	R9	K104
       0x7C180600,  //  0013  CALL	R6	3
-      0x24180D06,  //  0014  GT	R6	R6	K6
+      0x24180D42,  //  0014  GT	R6	R6	K66
       0x781A0010,  //  0015  JMPF	R6	#0027
       0x4C180000,  //  0016  LDNIL	R6
       0x20180806,  //  0017  NE	R6	R4	R6
       0x781A000C,  //  0018  JMPF	R6	#0026
-      0xB81A0800,  //  0019  GETNGBL	R6	K4
-      0x8C180D09,  //  001A  GETMET	R6	R6	K9
+      0xB81A0A00,  //  0019  GETNGBL	R6	K5
+      0x8C180D06,  //  001A  GETMET	R6	R6	K6
       0x60200018,  //  001B  GETGBL	R8	G24
-      0x5824000A,  //  001C  LDCONST	R9	K10
+      0x58240076,  //  001C  LDCONST	R9	K118
       0x5C280800,  //  001D  MOVE	R10	R4
       0x942C0605,  //  001E  GETIDX	R11	R3	R5
       0x7C200600,  //  001F  CALL	R8	3
-      0x5824000B,  //  0020  LDCONST	R9	K11
+      0x5824006F,  //  0020  LDCONST	R9	K111
       0x7C180600,  //  0021  CALL	R6	3
       0x50180200,  //  0022  LDBOOL	R6	1	0
-      0x90021806,  //  0023  SETMBR	R0	K12	R6
+      0x90029E06,  //  0023  SETMBR	R0	K79	R6
       0x4C180000,  //  0024  LDNIL	R6
       0x80040C00,  //  0025  RET	1	R6
       0x94100605,  //  0026  GETIDX	R4	R3	R5
-      0x00140B0D,  //  0027  ADD	R5	R5	K13
+      0x00140B46,  //  0027  ADD	R5	R5	K70
       0x7001FFE1,  //  0028  JMP		#000B
       0x4C180000,  //  0029  LDNIL	R6
       0x1C180806,  //  002A  EQ	R6	R4	R6
       0x781A0006,  //  002B  JMPF	R6	#0033
-      0xB81A0800,  //  002C  GETNGBL	R6	K4
-      0x8C180D09,  //  002D  GETMET	R6	R6	K9
-      0x5820000E,  //  002E  LDCONST	R8	K14
-      0x5824000F,  //  002F  LDCONST	R9	K15
+      0xB81A0A00,  //  002C  GETNGBL	R6	K5
+      0x8C180D06,  //  002D  GETMET	R6	R6	K6
+      0x58200077,  //  002E  LDCONST	R8	K119
+      0x58240078,  //  002F  LDCONST	R9	K120
       0x7C180600,  //  0030  CALL	R6	3
       0x4C180000,  //  0031  LDNIL	R6
       0x80040C00,  //  0032  RET	1	R6
-      0x90022004,  //  0033  SETMBR	R0	K16	R4
+      0x90024E04,  //  0033  SETMBR	R0	K39	R4
       0x80000000,  //  0034  RET	0
     })
   )
@@ -1094,51 +1040,40 @@ be_local_closure(class_Autoconf_preinit,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(_archive),
-    /* K1   */  be_nested_str(path),
-    /* K2   */  be_nested_str(_X23preinit_X2Ebe),
-    /* K3   */  be_nested_str(exists),
-    /* K4   */  be_nested_str(tasmota),
-    /* K5   */  be_nested_str(log),
-    /* K6   */  be_nested_str(CFG_X3A_X20loading_X20),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str(load),
-    /* K9   */  be_nested_str(CFG_X3A_X20loaded_X20_X20),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_preinit,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040127,  //  0000  GETMBR	R1	R0	K39
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
       0xA4060200,  //  0005  IMPORT	R1	K1
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x00080502,  //  0007  ADD	R2	R2	K2
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x88080127,  //  0006  GETMBR	R2	R0	K39
+      0x00080579,  //  0007  ADD	R2	R2	K121
+      0x8C0C032A,  //  0008  GETMET	R3	R1	K42
       0x5C140400,  //  0009  MOVE	R5	R2
       0x7C0C0400,  //  000A  CALL	R3	2
       0x780E000C,  //  000B  JMPF	R3	#0019
-      0xB80E0800,  //  000C  GETNGBL	R3	K4
-      0x8C0C0705,  //  000D  GETMET	R3	R3	K5
-      0x00160C02,  //  000E  ADD	R5	K6	R2
-      0x58180007,  //  000F  LDCONST	R6	K7
+      0xB80E0A00,  //  000C  GETNGBL	R3	K5
+      0x8C0C0706,  //  000D  GETMET	R3	R3	K6
+      0x00167C02,  //  000E  ADD	R5	K62	R2
+      0x5818003B,  //  000F  LDCONST	R6	K59
       0x7C0C0600,  //  0010  CALL	R3	3
-      0xB80E1000,  //  0011  GETNGBL	R3	K8
+      0xB80E7E00,  //  0011  GETNGBL	R3	K63
       0x5C100400,  //  0012  MOVE	R4	R2
       0x7C0C0200,  //  0013  CALL	R3	1
-      0xB80E0800,  //  0014  GETNGBL	R3	K4
-      0x8C0C0705,  //  0015  GETMET	R3	R3	K5
-      0x00161202,  //  0016  ADD	R5	K9	R2
-      0x58180007,  //  0017  LDCONST	R6	K7
+      0xB80E0A00,  //  0014  GETNGBL	R3	K5
+      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
+      0x00168002,  //  0016  ADD	R5	K64	R2
+      0x5818003B,  //  0017  LDCONST	R6	K59
       0x7C0C0600,  //  0018  CALL	R3	3
       0x80000000,  //  0019  RET	0
     })
@@ -1154,63 +1089,50 @@ be_local_closure(class_Autoconf_reset,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(listdir),
-    /* K3   */  be_nested_str(_X2F),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str(find),
-    /* K6   */  be_nested_str(_X2Eautoconf),
-    /* K7   */  be_nested_str(remove),
-    /* K8   */  be_nested_str(CFG_X3A_X20removed_X20file_X20_X27_X25s_X27),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str(_archive),
-    /* K11  */  be_nested_str(_error),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_reset,
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0xA40A8E00,  //  0001  IMPORT	R2	K71
+      0x8C0C0365,  //  0002  GETMET	R3	R1	K101
+      0x58140066,  //  0003  LDCONST	R5	K102
       0x7C0C0400,  //  0004  CALL	R3	2
       0x4C100000,  //  0005  LDNIL	R4
-      0x58140004,  //  0006  LDCONST	R5	K4
+      0x58140042,  //  0006  LDCONST	R5	K66
       0x6018000C,  //  0007  GETGBL	R6	G12
       0x5C1C0600,  //  0008  MOVE	R7	R3
       0x7C180200,  //  0009  CALL	R6	1
       0x14180A06,  //  000A  LT	R6	R5	R6
       0x781A0011,  //  000B  JMPF	R6	#001E
       0x94180605,  //  000C  GETIDX	R6	R3	R5
-      0x8C1C0505,  //  000D  GETMET	R7	R2	K5
+      0x8C1C0567,  //  000D  GETMET	R7	R2	K103
       0x5C240C00,  //  000E  MOVE	R9	R6
-      0x58280006,  //  000F  LDCONST	R10	K6
+      0x58280068,  //  000F  LDCONST	R10	K104
       0x7C1C0600,  //  0010  CALL	R7	3
-      0x241C0F04,  //  0011  GT	R7	R7	K4
+      0x241C0F42,  //  0011  GT	R7	R7	K66
       0x781E0008,  //  0012  JMPF	R7	#001C
-      0x8C1C0307,  //  0013  GETMET	R7	R1	K7
+      0x8C1C0369,  //  0013  GETMET	R7	R1	K105
       0x5C240C00,  //  0014  MOVE	R9	R6
       0x7C1C0400,  //  0015  CALL	R7	2
       0x601C0001,  //  0016  GETGBL	R7	G1
       0x60200018,  //  0017  GETGBL	R8	G24
-      0x58240008,  //  0018  LDCONST	R9	K8
+      0x5824007A,  //  0018  LDCONST	R9	K122
       0x5C280C00,  //  0019  MOVE	R10	R6
       0x7C200400,  //  001A  CALL	R8	2
       0x7C1C0200,  //  001B  CALL	R7	1
-      0x00140B09,  //  001C  ADD	R5	R5	K9
+      0x00140B46,  //  001C  ADD	R5	R5	K70
       0x7001FFE8,  //  001D  JMP		#0007
       0x4C180000,  //  001E  LDNIL	R6
-      0x90021406,  //  001F  SETMBR	R0	K10	R6
+      0x90024E06,  //  001F  SETMBR	R0	K39	R6
       0x4C180000,  //  0020  LDNIL	R6
-      0x90021606,  //  0021  SETMBR	R0	K11	R6
+      0x90029E06,  //  0021  SETMBR	R0	K79	R6
       0x80000000,  //  0022  RET	0
     })
   )
@@ -1225,7 +1147,7 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1278,26 +1200,20 @@ be_local_closure(class_Autoconf_web_add_handler,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(webserver),
-    /* K1   */  be_nested_str(on),
-    /* K2   */  be_nested_str(_X2Fac),
-    /* K3   */  be_nested_str(HTTP_GET),
-    /* K4   */  be_nested_str(HTTP_POST),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_web_add_handler,
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
+      0x8C08037B,  //  0001  GETMET	R2	R1	K123
+      0x5810007C,  //  0002  LDCONST	R4	K124
       0x84140000,  //  0003  CLOSURE	R5	P0
-      0x88180303,  //  0004  GETMBR	R6	R1	K3
+      0x8818037D,  //  0004  GETMBR	R6	R1	K125
       0x7C080800,  //  0005  CALL	R2	4
-      0x8C080301,  //  0006  GETMET	R2	R1	K1
-      0x58100002,  //  0007  LDCONST	R4	K2
+      0x8C08037B,  //  0006  GETMET	R2	R1	K123
+      0x5810007C,  //  0007  LDCONST	R4	K124
       0x84140001,  //  0008  CLOSURE	R5	P1
-      0x88180304,  //  0009  GETMBR	R6	R1	K4
+      0x8818037E,  //  0009  GETMBR	R6	R1	K126
       0x7C080800,  //  000A  CALL	R2	4
       0xA0000000,  //  000B  CLOSE	R0
       0x80000000,  //  000C  RET	0
@@ -1314,23 +1230,19 @@ be_local_closure(class_Autoconf_clear_first_time,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(remove),
-    /* K2   */  be_nested_str(_X2F_X2Eautoconf),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_clear_first_time,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0x8C080369,  //  0001  GETMET	R2	R1	K105
+      0x5810006A,  //  0002  LDCONST	R4	K106
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
     })
@@ -1346,19 +1258,17 @@ be_local_closure(class_Autoconf_get_current_module_path,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(_archive),
-    }),
+    &be_ktab_class_Autoconf,     /* shared constants */
     &be_const_str_get_current_module_path,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040127,  //  0000  GETMBR	R1	R0	K39
       0x80040200,  //  0001  RET	1	R1
     })
   )

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
@@ -3,6 +3,183 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_SPAKE_Hasher;
+// compact class 'SPAKE_Hasher' ktab size: 8, total: 10 (saved 16 bytes)
+static const bvalue be_ktab_class_SPAKE_Hasher[8] = {
+  /* K0   */  be_nested_str_weak(crypto),
+  /* K1   */  be_nested_str_weak(hash),
+  /* K2   */  be_nested_str_weak(SHA256),
+  /* K3   */  be_nested_str_weak(size),
+  /* K4   */  be_nested_str_weak(add),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(update),
+  /* K7   */  be_nested_str_weak(out),
+};
+
+
+extern const bclass be_class_SPAKE_Hasher;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_SPAKE_Hasher_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SPAKE_Hasher,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080302,  //  0001  GETMET	R2	R1	K2
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_item
+********************************************************************/
+be_local_closure(class_SPAKE_Hasher_add_item,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SPAKE_Hasher,     /* shared constants */
+    be_str_weak(add_item),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C080303,  //  0000  GETMET	R2	R1	K3
+      0x7C080200,  //  0001  CALL	R2	1
+      0x600C0015,  //  0002  GETGBL	R3	G21
+      0x7C0C0000,  //  0003  CALL	R3	0
+      0x8C0C0704,  //  0004  GETMET	R3	R3	K4
+      0x5C140400,  //  0005  MOVE	R5	R2
+      0x541A0003,  //  0006  LDINT	R6	4
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x541A0003,  //  000A  LDINT	R6	4
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x8C100906,  //  000D  GETMET	R4	R4	K6
+      0x5C180600,  //  000E  MOVE	R6	R3
+      0x7C100400,  //  000F  CALL	R4	2
+      0x88100101,  //  0010  GETMBR	R4	R0	K1
+      0x8C100906,  //  0011  GETMET	R4	R4	K6
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: out
+********************************************************************/
+be_local_closure(class_SPAKE_Hasher_out,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SPAKE_Hasher,     /* shared constants */
+    be_str_weak(out),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: SPAKE_Hasher
+********************************************************************/
+be_local_class(SPAKE_Hasher,
+    1,
+    NULL,
+    be_nested_map(4,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(out, -1), be_const_closure(class_SPAKE_Hasher_out_closure) },
+        { be_const_key_weak(hash, -1), be_const_var(0) },
+        { be_const_key_weak(add_item, -1), be_const_closure(class_SPAKE_Hasher_add_item_closure) },
+        { be_const_key_weak(init, 0), be_const_closure(class_SPAKE_Hasher_init_closure) },
+    })),
+    be_str_weak(SPAKE_Hasher)
+);
+// compact class 'SPAKE2P_Matter' ktab size: 43, total: 84 (saved 328 bytes)
+static const bvalue be_ktab_class_SPAKE2P_Matter[43] = {
+  /* K0   */  be_nested_str_weak(crypto),
+  /* K1   */  be_nested_str_weak(random),
+  /* K2   */  be_nested_str_weak(EC_P256),
+  /* K3   */  be_nested_str_weak(y),
+  /* K4   */  be_nested_str_weak(mod),
+  /* K5   */  be_nested_str_weak(pB),
+  /* K6   */  be_nested_str_weak(muladd),
+  /* K7   */  be_nested_str_weak(w0),
+  /* K8   */  be_nested_str_weak(N),
+  /* K9   */  be_const_class(be_class_SPAKE_Hasher),
+  /* K10  */  be_nested_str_weak(add_item),
+  /* K11  */  be_nested_str_weak(Context),
+  /* K12  */  be_nested_str_weak(A),
+  /* K13  */  be_nested_str_weak(B),
+  /* K14  */  be_nested_str_weak(M),
+  /* K15  */  be_nested_str_weak(pA),
+  /* K16  */  be_nested_str_weak(Z),
+  /* K17  */  be_nested_str_weak(V),
+  /* K18  */  be_nested_str_weak(Kmain),
+  /* K19  */  be_nested_str_weak(out),
+  /* K20  */  be_nested_str_weak(Ke),
+  /* K21  */  be_const_int(0),
+  /* K22  */  be_nested_str_weak(HKDF_SHA256),
+  /* K23  */  be_nested_str_weak(derive),
+  /* K24  */  be_nested_str_weak(fromstring),
+  /* K25  */  be_nested_str_weak(ConfirmationKeys),
+  /* K26  */  be_nested_str_weak(KcA),
+  /* K27  */  be_nested_str_weak(KcB),
+  /* K28  */  be_nested_str_weak(K_shared),
+  /* K29  */  be_nested_str_weak(SharedKey),
+  /* K30  */  be_nested_str_weak(cA),
+  /* K31  */  be_nested_str_weak(HMAC_SHA256),
+  /* K32  */  be_nested_str_weak(update),
+  /* K33  */  be_nested_str_weak(cB),
+  /* K34  */  be_nested_str_weak(fromhex),
+  /* K35  */  be_nested_str_weak(spake_M_hex),
+  /* K36  */  be_nested_str_weak(spake_N_hex),
+  /* K37  */  be_nested_str_weak(w1),
+  /* K38  */  be_nested_str_weak(L),
+  /* K39  */  be_nested_str_weak(x),
+  /* K40  */  be_nested_str_weak(neg),
+  /* K41  */  be_nested_str_weak(01),
+  /* K42  */  be_nested_str_weak(mul),
+};
+
 
 extern const bclass be_class_SPAKE2P_Matter;
 
@@ -13,23 +190,13 @@ be_local_closure(class_SPAKE2P_Matter_compute_pB,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(y),
-    /* K4   */  be_nested_str_weak(mod),
-    /* K5   */  be_nested_str_weak(pB),
-    /* K6   */  be_nested_str_weak(muladd),
-    /* K7   */  be_nested_str_weak(w0),
-    /* K8   */  be_nested_str_weak(N),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(compute_pB),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -63,136 +230,6 @@ be_local_closure(class_SPAKE2P_Matter_compute_pB,   /* name */
 /*******************************************************************/
 
 
-extern const bclass be_class_SPAKE_Hasher;
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_SPAKE_Hasher_init,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(hash),
-    /* K2   */  be_nested_str_weak(SHA256),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080302,  //  0001  GETMET	R2	R1	K2
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_item
-********************************************************************/
-be_local_closure(class_SPAKE_Hasher_add_item,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(size),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(hash),
-    /* K4   */  be_nested_str_weak(update),
-    }),
-    be_str_weak(add_item),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x600C0015,  //  0002  GETGBL	R3	G21
-      0x7C0C0000,  //  0003  CALL	R3	0
-      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x541A0003,  //  0006  LDINT	R6	4
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
-      0x58140002,  //  0009  LDCONST	R5	K2
-      0x541A0003,  //  000A  LDINT	R6	4
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x88100103,  //  000C  GETMBR	R4	R0	K3
-      0x8C100904,  //  000D  GETMET	R4	R4	K4
-      0x5C180600,  //  000E  MOVE	R6	R3
-      0x7C100400,  //  000F  CALL	R4	2
-      0x88100103,  //  0010  GETMBR	R4	R0	K3
-      0x8C100904,  //  0011  GETMET	R4	R4	K4
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: out
-********************************************************************/
-be_local_closure(class_SPAKE_Hasher_out,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(hash),
-    /* K1   */  be_nested_str_weak(out),
-    }),
-    be_str_weak(out),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: SPAKE_Hasher
-********************************************************************/
-be_local_class(SPAKE_Hasher,
-    1,
-    NULL,
-    be_nested_map(4,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(out, -1), be_const_closure(class_SPAKE_Hasher_out_closure) },
-        { be_const_key_weak(hash, -1), be_const_var(0) },
-        { be_const_key_weak(add_item, -1), be_const_closure(class_SPAKE_Hasher_add_item_closure) },
-        { be_const_key_weak(init, 0), be_const_closure(class_SPAKE_Hasher_init_closure) },
-    })),
-    be_str_weak(SPAKE_Hasher)
-);
-
 /********************************************************************
 ** Solidified function: compute_TT_hash
 ********************************************************************/
@@ -200,119 +237,89 @@ be_local_closure(class_SPAKE2P_Matter_compute_TT_hash,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_const_class(be_class_SPAKE_Hasher),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(add_item),
-    /* K3   */  be_nested_str_weak(Context),
-    /* K4   */  be_nested_str_weak(A),
-    /* K5   */  be_nested_str_weak(B),
-    /* K6   */  be_nested_str_weak(M),
-    /* K7   */  be_nested_str_weak(N),
-    /* K8   */  be_nested_str_weak(pA),
-    /* K9   */  be_nested_str_weak(pB),
-    /* K10  */  be_nested_str_weak(Z),
-    /* K11  */  be_nested_str_weak(V),
-    /* K12  */  be_nested_str_weak(w0),
-    /* K13  */  be_nested_str_weak(Kmain),
-    /* K14  */  be_nested_str_weak(out),
-    /* K15  */  be_nested_str_weak(Ke),
-    /* K16  */  be_const_int(0),
-    /* K17  */  be_nested_str_weak(HKDF_SHA256),
-    /* K18  */  be_nested_str_weak(derive),
-    /* K19  */  be_nested_str_weak(fromstring),
-    /* K20  */  be_nested_str_weak(ConfirmationKeys),
-    /* K21  */  be_nested_str_weak(KcA),
-    /* K22  */  be_nested_str_weak(KcB),
-    /* K23  */  be_nested_str_weak(K_shared),
-    /* K24  */  be_nested_str_weak(SharedKey),
-    /* K25  */  be_nested_str_weak(cA),
-    /* K26  */  be_nested_str_weak(HMAC_SHA256),
-    /* K27  */  be_nested_str_weak(update),
-    /* K28  */  be_nested_str_weak(cB),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(compute_TT_hash),
     &be_const_str_solidified,
     ( &(const binstruction[115]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xB4000000,  //  0001  CLASS	K0
+      0x58080009,  //  0000  LDCONST	R2	K9
+      0xB4000009,  //  0001  CLASS	K9
       0x5C0C0400,  //  0002  MOVE	R3	R2
-      0xA40E0200,  //  0003  IMPORT	R3	K1
+      0xA40E0000,  //  0003  IMPORT	R3	K0
       0x5C100400,  //  0004  MOVE	R4	R2
       0x7C100000,  //  0005  CALL	R4	0
-      0x8C140902,  //  0006  GETMET	R5	R4	K2
-      0x881C0103,  //  0007  GETMBR	R7	R0	K3
+      0x8C14090A,  //  0006  GETMET	R5	R4	K10
+      0x881C010B,  //  0007  GETMBR	R7	R0	K11
       0x7C140400,  //  0008  CALL	R5	2
-      0x8C140902,  //  0009  GETMET	R5	R4	K2
-      0x881C0104,  //  000A  GETMBR	R7	R0	K4
+      0x8C14090A,  //  0009  GETMET	R5	R4	K10
+      0x881C010C,  //  000A  GETMBR	R7	R0	K12
       0x7C140400,  //  000B  CALL	R5	2
-      0x8C140902,  //  000C  GETMET	R5	R4	K2
-      0x881C0105,  //  000D  GETMBR	R7	R0	K5
+      0x8C14090A,  //  000C  GETMET	R5	R4	K10
+      0x881C010D,  //  000D  GETMBR	R7	R0	K13
       0x7C140400,  //  000E  CALL	R5	2
-      0x8C140902,  //  000F  GETMET	R5	R4	K2
-      0x881C0106,  //  0010  GETMBR	R7	R0	K6
+      0x8C14090A,  //  000F  GETMET	R5	R4	K10
+      0x881C010E,  //  0010  GETMBR	R7	R0	K14
       0x7C140400,  //  0011  CALL	R5	2
-      0x8C140902,  //  0012  GETMET	R5	R4	K2
-      0x881C0107,  //  0013  GETMBR	R7	R0	K7
+      0x8C14090A,  //  0012  GETMET	R5	R4	K10
+      0x881C0108,  //  0013  GETMBR	R7	R0	K8
       0x7C140400,  //  0014  CALL	R5	2
-      0x8C140902,  //  0015  GETMET	R5	R4	K2
-      0x881C0108,  //  0016  GETMBR	R7	R0	K8
+      0x8C14090A,  //  0015  GETMET	R5	R4	K10
+      0x881C010F,  //  0016  GETMBR	R7	R0	K15
       0x7C140400,  //  0017  CALL	R5	2
-      0x8C140902,  //  0018  GETMET	R5	R4	K2
-      0x881C0109,  //  0019  GETMBR	R7	R0	K9
+      0x8C14090A,  //  0018  GETMET	R5	R4	K10
+      0x881C0105,  //  0019  GETMBR	R7	R0	K5
       0x7C140400,  //  001A  CALL	R5	2
-      0x8C140902,  //  001B  GETMET	R5	R4	K2
-      0x881C010A,  //  001C  GETMBR	R7	R0	K10
+      0x8C14090A,  //  001B  GETMET	R5	R4	K10
+      0x881C0110,  //  001C  GETMBR	R7	R0	K16
       0x7C140400,  //  001D  CALL	R5	2
-      0x8C140902,  //  001E  GETMET	R5	R4	K2
-      0x881C010B,  //  001F  GETMBR	R7	R0	K11
+      0x8C14090A,  //  001E  GETMET	R5	R4	K10
+      0x881C0111,  //  001F  GETMBR	R7	R0	K17
       0x7C140400,  //  0020  CALL	R5	2
-      0x8C140902,  //  0021  GETMET	R5	R4	K2
-      0x881C010C,  //  0022  GETMBR	R7	R0	K12
+      0x8C14090A,  //  0021  GETMET	R5	R4	K10
+      0x881C0107,  //  0022  GETMBR	R7	R0	K7
       0x7C140400,  //  0023  CALL	R5	2
-      0x8C14090E,  //  0024  GETMET	R5	R4	K14
+      0x8C140913,  //  0024  GETMET	R5	R4	K19
       0x7C140200,  //  0025  CALL	R5	1
-      0x90021A05,  //  0026  SETMBR	R0	K13	R5
+      0x90022405,  //  0026  SETMBR	R0	K18	R5
       0x7806000A,  //  0027  JMPF	R1	#0033
       0x5416000F,  //  0028  LDINT	R5	16
       0x541A001E,  //  0029  LDINT	R6	31
       0x40140A06,  //  002A  CONNECT	R5	R5	R6
-      0x8818010D,  //  002B  GETMBR	R6	R0	K13
+      0x88180112,  //  002B  GETMBR	R6	R0	K18
       0x94140C05,  //  002C  GETIDX	R5	R6	R5
-      0x90021E05,  //  002D  SETMBR	R0	K15	R5
+      0x90022805,  //  002D  SETMBR	R0	K20	R5
       0x5416000E,  //  002E  LDINT	R5	15
-      0x40162005,  //  002F  CONNECT	R5	K16	R5
-      0x8818010D,  //  0030  GETMBR	R6	R0	K13
+      0x40162A05,  //  002F  CONNECT	R5	K21	R5
+      0x88180112,  //  0030  GETMBR	R6	R0	K18
       0x94140C05,  //  0031  GETIDX	R5	R6	R5
-      0x90021A05,  //  0032  SETMBR	R0	K13	R5
-      0x8C140711,  //  0033  GETMET	R5	R3	K17
+      0x90022405,  //  0032  SETMBR	R0	K18	R5
+      0x8C140716,  //  0033  GETMET	R5	R3	K22
       0x7C140200,  //  0034  CALL	R5	1
-      0x8C180B12,  //  0035  GETMET	R6	R5	K18
-      0x8820010D,  //  0036  GETMBR	R8	R0	K13
+      0x8C180B17,  //  0035  GETMET	R6	R5	K23
+      0x88200112,  //  0036  GETMBR	R8	R0	K18
       0x60240015,  //  0037  GETGBL	R9	G21
       0x7C240000,  //  0038  CALL	R9	0
       0x60280015,  //  0039  GETGBL	R10	G21
       0x7C280000,  //  003A  CALL	R10	0
-      0x8C281513,  //  003B  GETMET	R10	R10	K19
-      0x58300014,  //  003C  LDCONST	R12	K20
+      0x8C281518,  //  003B  GETMET	R10	R10	K24
+      0x58300019,  //  003C  LDCONST	R12	K25
       0x7C280400,  //  003D  CALL	R10	2
       0x542E003F,  //  003E  LDINT	R11	64
       0x7C180A00,  //  003F  CALL	R6	5
       0x78060003,  //  0040  JMPF	R1	#0045
       0x541E000E,  //  0041  LDINT	R7	15
-      0x401E2007,  //  0042  CONNECT	R7	K16	R7
+      0x401E2A07,  //  0042  CONNECT	R7	K21	R7
       0x941C0C07,  //  0043  GETIDX	R7	R6	R7
       0x70020002,  //  0044  JMP		#0048
       0x541E001E,  //  0045  LDINT	R7	31
-      0x401E2007,  //  0046  CONNECT	R7	K16	R7
+      0x401E2A07,  //  0046  CONNECT	R7	K21	R7
       0x941C0C07,  //  0047  GETIDX	R7	R6	R7
-      0x90022A07,  //  0048  SETMBR	R0	K21	R7
+      0x90023407,  //  0048  SETMBR	R0	K26	R7
       0x78060004,  //  0049  JMPF	R1	#004F
       0x541E000F,  //  004A  LDINT	R7	16
       0x5422001E,  //  004B  LDINT	R8	31
@@ -323,37 +330,37 @@ be_local_closure(class_SPAKE2P_Matter_compute_TT_hash,   /* name */
       0x5422003E,  //  0050  LDINT	R8	63
       0x401C0E08,  //  0051  CONNECT	R7	R7	R8
       0x941C0C07,  //  0052  GETIDX	R7	R6	R7
-      0x90022C07,  //  0053  SETMBR	R0	K22	R7
-      0x8C1C0B12,  //  0054  GETMET	R7	R5	K18
-      0x8824010D,  //  0055  GETMBR	R9	R0	K13
+      0x90023607,  //  0053  SETMBR	R0	K27	R7
+      0x8C1C0B17,  //  0054  GETMET	R7	R5	K23
+      0x88240112,  //  0055  GETMBR	R9	R0	K18
       0x60280015,  //  0056  GETGBL	R10	G21
       0x7C280000,  //  0057  CALL	R10	0
       0x602C0015,  //  0058  GETGBL	R11	G21
       0x7C2C0000,  //  0059  CALL	R11	0
-      0x8C2C1713,  //  005A  GETMET	R11	R11	K19
-      0x58340018,  //  005B  LDCONST	R13	K24
+      0x8C2C1718,  //  005A  GETMET	R11	R11	K24
+      0x5834001D,  //  005B  LDCONST	R13	K29
       0x7C2C0400,  //  005C  CALL	R11	2
       0x5432001F,  //  005D  LDINT	R12	32
       0x7C1C0A00,  //  005E  CALL	R7	5
-      0x90022E07,  //  005F  SETMBR	R0	K23	R7
-      0x8C1C071A,  //  0060  GETMET	R7	R3	K26
-      0x88240115,  //  0061  GETMBR	R9	R0	K21
+      0x90023807,  //  005F  SETMBR	R0	K28	R7
+      0x8C1C071F,  //  0060  GETMET	R7	R3	K31
+      0x8824011A,  //  0061  GETMBR	R9	R0	K26
       0x7C1C0400,  //  0062  CALL	R7	2
-      0x8C1C0F1B,  //  0063  GETMET	R7	R7	K27
-      0x88240109,  //  0064  GETMBR	R9	R0	K9
+      0x8C1C0F20,  //  0063  GETMET	R7	R7	K32
+      0x88240105,  //  0064  GETMBR	R9	R0	K5
       0x7C1C0400,  //  0065  CALL	R7	2
-      0x8C1C0F0E,  //  0066  GETMET	R7	R7	K14
+      0x8C1C0F13,  //  0066  GETMET	R7	R7	K19
       0x7C1C0200,  //  0067  CALL	R7	1
-      0x90023207,  //  0068  SETMBR	R0	K25	R7
-      0x8C1C071A,  //  0069  GETMET	R7	R3	K26
-      0x88240116,  //  006A  GETMBR	R9	R0	K22
+      0x90023C07,  //  0068  SETMBR	R0	K30	R7
+      0x8C1C071F,  //  0069  GETMET	R7	R3	K31
+      0x8824011B,  //  006A  GETMBR	R9	R0	K27
       0x7C1C0400,  //  006B  CALL	R7	2
-      0x8C1C0F1B,  //  006C  GETMET	R7	R7	K27
-      0x88240108,  //  006D  GETMBR	R9	R0	K8
+      0x8C1C0F20,  //  006C  GETMET	R7	R7	K32
+      0x8824010F,  //  006D  GETMBR	R9	R0	K15
       0x7C1C0400,  //  006E  CALL	R7	2
-      0x8C1C0F0E,  //  006F  GETMET	R7	R7	K14
+      0x8C1C0F13,  //  006F  GETMET	R7	R7	K19
       0x7C1C0200,  //  0070  CALL	R7	1
-      0x90023807,  //  0071  SETMBR	R0	K28	R7
+      0x90024207,  //  0071  SETMBR	R0	K33	R7
       0x80000000,  //  0072  RET	0
     })
   )
@@ -368,40 +375,31 @@ be_local_closure(class_SPAKE2P_Matter_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(M),
-    /* K1   */  be_nested_str_weak(fromhex),
-    /* K2   */  be_nested_str_weak(spake_M_hex),
-    /* K3   */  be_nested_str_weak(N),
-    /* K4   */  be_nested_str_weak(spake_N_hex),
-    /* K5   */  be_nested_str_weak(w0),
-    /* K6   */  be_nested_str_weak(w1),
-    /* K7   */  be_nested_str_weak(L),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60100015,  //  0000  GETGBL	R4	G21
       0x7C100000,  //  0001  CALL	R4	0
-      0x8C100901,  //  0002  GETMET	R4	R4	K1
-      0x88180102,  //  0003  GETMBR	R6	R0	K2
+      0x8C100922,  //  0002  GETMET	R4	R4	K34
+      0x88180123,  //  0003  GETMBR	R6	R0	K35
       0x7C100400,  //  0004  CALL	R4	2
-      0x90020004,  //  0005  SETMBR	R0	K0	R4
+      0x90021C04,  //  0005  SETMBR	R0	K14	R4
       0x60100015,  //  0006  GETGBL	R4	G21
       0x7C100000,  //  0007  CALL	R4	0
-      0x8C100901,  //  0008  GETMET	R4	R4	K1
-      0x88180104,  //  0009  GETMBR	R6	R0	K4
+      0x8C100922,  //  0008  GETMET	R4	R4	K34
+      0x88180124,  //  0009  GETMBR	R6	R0	K36
       0x7C100400,  //  000A  CALL	R4	2
-      0x90020604,  //  000B  SETMBR	R0	K3	R4
-      0x90020A01,  //  000C  SETMBR	R0	K5	R1
-      0x90020C02,  //  000D  SETMBR	R0	K6	R2
-      0x90020E03,  //  000E  SETMBR	R0	K7	R3
+      0x90021004,  //  000B  SETMBR	R0	K8	R4
+      0x90020E01,  //  000C  SETMBR	R0	K7	R1
+      0x90024A02,  //  000D  SETMBR	R0	K37	R2
+      0x90024C03,  //  000E  SETMBR	R0	K38	R3
       0x80000000,  //  000F  RET	0
     })
   )
@@ -416,23 +414,13 @@ be_local_closure(class_SPAKE2P_Matter_compute_pA,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(x),
-    /* K4   */  be_nested_str_weak(mod),
-    /* K5   */  be_nested_str_weak(pA),
-    /* K6   */  be_nested_str_weak(muladd),
-    /* K7   */  be_nested_str_weak(w0),
-    /* K8   */  be_nested_str_weak(M),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(compute_pA),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -449,16 +437,16 @@ be_local_closure(class_SPAKE2P_Matter_compute_pA,   /* name */
       0x8C100704,  //  000A  GETMET	R4	R3	K4
       0x5C180200,  //  000B  MOVE	R6	R1
       0x7C100400,  //  000C  CALL	R4	2
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x90024E04,  //  000D  SETMBR	R0	K39	R4
       0x8C100706,  //  000E  GETMET	R4	R3	K6
       0x88180107,  //  000F  GETMBR	R6	R0	K7
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x88200103,  //  0011  GETMBR	R8	R0	K3
+      0x881C010E,  //  0010  GETMBR	R7	R0	K14
+      0x88200127,  //  0011  GETMBR	R8	R0	K39
       0x60240015,  //  0012  GETGBL	R9	G21
       0x7C240000,  //  0013  CALL	R9	0
       0x7C100A00,  //  0014  CALL	R4	5
-      0x90020A04,  //  0015  SETMBR	R0	K5	R4
-      0x88100105,  //  0016  GETMBR	R4	R0	K5
+      0x90021E04,  //  0015  SETMBR	R0	K15	R4
+      0x8810010F,  //  0016  GETMBR	R4	R0	K15
       0x80040800,  //  0017  RET	1	R4
     })
   )
@@ -473,17 +461,13 @@ be_local_closure(class_SPAKE2P_Matter_set_context,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(Context),
-    /* K1   */  be_nested_str_weak(A),
-    /* K2   */  be_nested_str_weak(B),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(set_context),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -499,9 +483,9 @@ be_local_closure(class_SPAKE2P_Matter_set_context,   /* name */
       0x60100015,  //  0009  GETGBL	R4	G21
       0x7C100000,  //  000A  CALL	R4	0
       0x5C0C0800,  //  000B  MOVE	R3	R4
-      0x90020001,  //  000C  SETMBR	R0	K0	R1
-      0x90020202,  //  000D  SETMBR	R0	K1	R2
-      0x90020403,  //  000E  SETMBR	R0	K2	R3
+      0x90021601,  //  000C  SETMBR	R0	K11	R1
+      0x90021802,  //  000D  SETMBR	R0	K12	R2
+      0x90021A03,  //  000E  SETMBR	R0	K13	R3
       0x80000000,  //  000F  RET	0
     })
   )
@@ -516,55 +500,41 @@ be_local_closure(class_SPAKE2P_Matter_compute_ZV_verifier,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(EC_P256),
-    /* K2   */  be_nested_str_weak(pA),
-    /* K3   */  be_nested_str_weak(neg),
-    /* K4   */  be_nested_str_weak(w0),
-    /* K5   */  be_nested_str_weak(muladd),
-    /* K6   */  be_nested_str_weak(01),
-    /* K7   */  be_nested_str_weak(M),
-    /* K8   */  be_nested_str_weak(Z),
-    /* K9   */  be_nested_str_weak(mul),
-    /* K10  */  be_nested_str_weak(y),
-    /* K11  */  be_nested_str_weak(V),
-    /* K12  */  be_nested_str_weak(L),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(compute_ZV_verifier),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x8C0C0502,  //  0001  GETMET	R3	R2	K2
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x8C100703,  //  0004  GETMET	R4	R3	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x90021E01,  //  0003  SETMBR	R0	K15	R1
+      0x8C100728,  //  0004  GETMET	R4	R3	K40
+      0x88180107,  //  0005  GETMBR	R6	R0	K7
       0x7C100400,  //  0006  CALL	R4	2
-      0x8C140705,  //  0007  GETMET	R5	R3	K5
+      0x8C140706,  //  0007  GETMET	R5	R3	K6
       0x601C0015,  //  0008  GETGBL	R7	G21
-      0x58200006,  //  0009  LDCONST	R8	K6
+      0x58200029,  //  0009  LDCONST	R8	K41
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200102,  //  000B  GETMBR	R8	R0	K2
+      0x8820010F,  //  000B  GETMBR	R8	R0	K15
       0x5C240800,  //  000C  MOVE	R9	R4
-      0x88280107,  //  000D  GETMBR	R10	R0	K7
+      0x8828010E,  //  000D  GETMBR	R10	R0	K14
       0x7C140A00,  //  000E  CALL	R5	5
-      0x8C180709,  //  000F  GETMET	R6	R3	K9
-      0x8820010A,  //  0010  GETMBR	R8	R0	K10
+      0x8C18072A,  //  000F  GETMET	R6	R3	K42
+      0x88200103,  //  0010  GETMBR	R8	R0	K3
       0x5C240A00,  //  0011  MOVE	R9	R5
       0x7C180600,  //  0012  CALL	R6	3
-      0x90021006,  //  0013  SETMBR	R0	K8	R6
-      0x8C180709,  //  0014  GETMET	R6	R3	K9
-      0x8820010A,  //  0015  GETMBR	R8	R0	K10
-      0x8824010C,  //  0016  GETMBR	R9	R0	K12
+      0x90022006,  //  0013  SETMBR	R0	K16	R6
+      0x8C18072A,  //  0014  GETMET	R6	R3	K42
+      0x88200103,  //  0015  GETMBR	R8	R0	K3
+      0x88240126,  //  0016  GETMBR	R9	R0	K38
       0x7C180600,  //  0017  CALL	R6	3
-      0x90021606,  //  0018  SETMBR	R0	K11	R6
+      0x90022206,  //  0018  SETMBR	R0	K17	R6
       0x80000000,  //  0019  RET	0
     })
   )
@@ -579,55 +549,41 @@ be_local_closure(class_SPAKE2P_Matter_compute_ZV_prover,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(EC_P256),
-    /* K2   */  be_nested_str_weak(pB),
-    /* K3   */  be_nested_str_weak(neg),
-    /* K4   */  be_nested_str_weak(w0),
-    /* K5   */  be_nested_str_weak(muladd),
-    /* K6   */  be_nested_str_weak(01),
-    /* K7   */  be_nested_str_weak(N),
-    /* K8   */  be_nested_str_weak(Z),
-    /* K9   */  be_nested_str_weak(mul),
-    /* K10  */  be_nested_str_weak(x),
-    /* K11  */  be_nested_str_weak(V),
-    /* K12  */  be_nested_str_weak(w1),
-    }),
+    &be_ktab_class_SPAKE2P_Matter,     /* shared constants */
     be_str_weak(compute_ZV_prover),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x8C0C0502,  //  0001  GETMET	R3	R2	K2
       0x7C0C0200,  //  0002  CALL	R3	1
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x8C100703,  //  0004  GETMET	R4	R3	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x90020A01,  //  0003  SETMBR	R0	K5	R1
+      0x8C100728,  //  0004  GETMET	R4	R3	K40
+      0x88180107,  //  0005  GETMBR	R6	R0	K7
       0x7C100400,  //  0006  CALL	R4	2
-      0x8C140705,  //  0007  GETMET	R5	R3	K5
+      0x8C140706,  //  0007  GETMET	R5	R3	K6
       0x601C0015,  //  0008  GETGBL	R7	G21
-      0x58200006,  //  0009  LDCONST	R8	K6
+      0x58200029,  //  0009  LDCONST	R8	K41
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200102,  //  000B  GETMBR	R8	R0	K2
+      0x88200105,  //  000B  GETMBR	R8	R0	K5
       0x5C240800,  //  000C  MOVE	R9	R4
-      0x88280107,  //  000D  GETMBR	R10	R0	K7
+      0x88280108,  //  000D  GETMBR	R10	R0	K8
       0x7C140A00,  //  000E  CALL	R5	5
-      0x8C180709,  //  000F  GETMET	R6	R3	K9
-      0x8820010A,  //  0010  GETMBR	R8	R0	K10
+      0x8C18072A,  //  000F  GETMET	R6	R3	K42
+      0x88200127,  //  0010  GETMBR	R8	R0	K39
       0x5C240A00,  //  0011  MOVE	R9	R5
       0x7C180600,  //  0012  CALL	R6	3
-      0x90021006,  //  0013  SETMBR	R0	K8	R6
-      0x8C180709,  //  0014  GETMET	R6	R3	K9
-      0x8820010C,  //  0015  GETMBR	R8	R0	K12
+      0x90022006,  //  0013  SETMBR	R0	K16	R6
+      0x8C18072A,  //  0014  GETMET	R6	R3	K42
+      0x88200125,  //  0015  GETMBR	R8	R0	K37
       0x5C240A00,  //  0016  MOVE	R9	R5
       0x7C180600,  //  0017  CALL	R6	3
-      0x90021606,  //  0018  SETMBR	R0	K11	R6
+      0x90022206,  //  0018  SETMBR	R0	K17	R6
       0x80000000,  //  0019  RET	0
     })
   )

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_dyn.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_dyn.h
@@ -3,6 +3,14 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'dyn' ktab size: 4, total: 7 (saved 24 bytes)
+static const bvalue be_ktab_class_dyn[4] = {
+  /* K0   */  be_nested_str(_attr),
+  /* K1   */  be_nested_str(tostring),
+  /* K2   */  be_nested_str(contains),
+  /* K3   */  be_nested_str(undefined),
+};
+
 
 extern const bclass be_class_dyn;
 
@@ -13,16 +21,13 @@ be_local_closure(class_dyn_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_attr),
-    /* K1   */  be_nested_str(tostring),
-    }),
+    &be_ktab_class_dyn,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -43,22 +48,18 @@ be_local_closure(class_dyn_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_attr),
-    /* K1   */  be_nested_str(contains),
-    /* K2   */  be_nested_str(undefined),
-    }),
+    &be_ktab_class_dyn,     /* shared constants */
     &be_const_str_member,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0003,  //  0004  JMPF	R2	#0009
@@ -66,7 +67,7 @@ be_local_closure(class_dyn_member,   /* name */
       0x94080401,  //  0006  GETIDX	R2	R2	R1
       0x80040400,  //  0007  RET	1	R2
       0x70020001,  //  0008  JMP		#000B
-      0xA40A0400,  //  0009  IMPORT	R2	K2
+      0xA40A0600,  //  0009  IMPORT	R2	K3
       0x80040400,  //  000A  RET	1	R2
       0x80000000,  //  000B  RET	0
     })
@@ -82,15 +83,13 @@ be_local_closure(class_dyn_setmember,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(_attr),
-    }),
+    &be_ktab_class_dyn,     /* shared constants */
     &be_const_str_setmember,
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
@@ -110,15 +109,13 @@ be_local_closure(class_dyn_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(_attr),
-    }),
+    &be_ktab_class_dyn,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
@@ -3,6 +3,61 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'hue_bridge_monad' ktab size: 51, total: 85 (saved 272 bytes)
+static const bvalue be_ktab_class_hue_bridge_monad[51] = {
+  /* K0   */  be_nested_str(hue_ntv),
+  /* K1   */  be_nested_str(lights),
+  /* K2   */  be_nested_str(contains),
+  /* K3   */  be_nested_str(full_state),
+  /* K4   */  be_nested_str(light),
+  /* K5   */  be_nested_str(name),
+  /* K6   */  be_nested_str(model),
+  /* K7   */  be_nested_str(manuf),
+  /* K8   */  be_nested_str(light_state),
+  /* K9   */  be_nested_str(int),
+  /* K10  */  be_nested_str(value_error),
+  /* K11  */  be_nested_str(id_X20must_X20be_X20of_X20type_X20_X27int_X27),
+  /* K12  */  be_nested_str(light_X20must_X20be_X20of_X20class_X20_X27light_state_X27),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_nested_str(missing_X20name),
+  /* K15  */  be_nested_str(Unknown),
+  /* K16  */  be_nested_str(Tasmota),
+  /* K17  */  be_nested_str(remove),
+  /* K18  */  be_nested_str(json),
+  /* K19  */  be_nested_str(keys),
+  /* K20  */  be_nested_str(full_status),
+  /* K21  */  be_nested_str(_X22),
+  /* K22  */  be_nested_str(_X22_X3A),
+  /* K23  */  be_nested_str(push),
+  /* K24  */  be_nested_str(stop_iteration),
+  /* K25  */  be_nested_str(concat),
+  /* K26  */  be_nested_str(_X2C),
+  /* K27  */  be_nested_str(load),
+  /* K28  */  be_nested_str(tasmota),
+  /* K29  */  be_nested_str(log),
+  /* K30  */  be_nested_str(BRY_X3A_X20invalid_X20hue_X20payload_X3A_X20),
+  /* K31  */  be_const_int(3),
+  /* K32  */  be_nested_str(on),
+  /* K33  */  be_nested_str(set_power),
+  /* K34  */  be_nested_str(xy),
+  /* K35  */  be_const_int(0),
+  /* K36  */  be_const_int(1),
+  /* K37  */  be_nested_str(set_xy),
+  /* K38  */  be_nested_str(hue),
+  /* K39  */  be_nested_str(sat),
+  /* K40  */  be_nested_str(type),
+  /* K41  */  be_nested_str(set_hue16sat),
+  /* K42  */  be_nested_str(ct),
+  /* K43  */  be_nested_str(set_ct),
+  /* K44  */  be_nested_str(bri),
+  /* K45  */  be_nested_str(set_bri),
+  /* K46  */  be_nested_str(_X2Flights_X2F),
+  /* K47  */  be_nested_str(_X2Fstate_X2F),
+  /* K48  */  be_nested_str(success),
+  /* K49  */  be_nested_str(signal_change),
+  /* K50  */  be_nested_str(dump),
+};
+
 
 extern const bclass be_class_hue_bridge_monad;
 
@@ -13,22 +68,13 @@ be_local_closure(class_hue_bridge_monad_full_status,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(hue_ntv),
-    /* K1   */  be_nested_str(lights),
-    /* K2   */  be_nested_str(contains),
-    /* K3   */  be_nested_str(full_state),
-    /* K4   */  be_nested_str(light),
-    /* K5   */  be_nested_str(name),
-    /* K6   */  be_nested_str(model),
-    /* K7   */  be_nested_str(manuf),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_full_status,
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
@@ -62,19 +108,13 @@ be_local_closure(class_hue_bridge_monad_hue_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(hue_ntv),
-    /* K1   */  be_nested_str(lights),
-    /* K2   */  be_nested_str(contains),
-    /* K3   */  be_nested_str(light_state),
-    /* K4   */  be_nested_str(light),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_hue_status,
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -84,7 +124,7 @@ be_local_closure(class_hue_bridge_monad_hue_status,   /* name */
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C0C0400,  //  0004  CALL	R3	2
       0x780E0005,  //  0005  JMPF	R3	#000C
-      0x8C0C0503,  //  0006  GETMET	R3	R2	K3
+      0x8C0C0508,  //  0006  GETMET	R3	R2	K8
       0x88140101,  //  0007  GETMBR	R5	R0	K1
       0x94140A01,  //  0008  GETIDX	R5	R5	R1
       0x94140B04,  //  0009  GETIDX	R5	R5	K4
@@ -104,43 +144,28 @@ be_local_closure(class_hue_bridge_monad_add_light,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str(int),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(id_X20must_X20be_X20of_X20type_X20_X27int_X27),
-    /* K3   */  be_nested_str(light_state),
-    /* K4   */  be_nested_str(light_X20must_X20be_X20of_X20class_X20_X27light_state_X27),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str(missing_X20name),
-    /* K7   */  be_nested_str(Unknown),
-    /* K8   */  be_nested_str(Tasmota),
-    /* K9   */  be_nested_str(lights),
-    /* K10  */  be_nested_str(light),
-    /* K11  */  be_nested_str(name),
-    /* K12  */  be_nested_str(model),
-    /* K13  */  be_nested_str(manuf),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_add_light,
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
       0x60180004,  //  0000  GETGBL	R6	G4
       0x5C1C0200,  //  0001  MOVE	R7	R1
       0x7C180200,  //  0002  CALL	R6	1
-      0x20180D00,  //  0003  NE	R6	R6	K0
+      0x20180D09,  //  0003  NE	R6	R6	K9
       0x781A0000,  //  0004  JMPF	R6	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
+      0xB006150B,  //  0005  RAISE	1	K10	K11
       0x6018000F,  //  0006  GETGBL	R6	G15
       0x5C1C0400,  //  0007  MOVE	R7	R2
-      0xB8220600,  //  0008  GETNGBL	R8	K3
+      0xB8221000,  //  0008  GETNGBL	R8	K8
       0x7C180400,  //  0009  CALL	R6	2
       0x741A0000,  //  000A  JMPT	R6	#000C
-      0xB0060304,  //  000B  RAISE	1	K1	K4
+      0xB006150C,  //  000B  RAISE	1	K10	K12
       0x60180008,  //  000C  GETGBL	R6	G8
       0x5C1C0600,  //  000D  MOVE	R7	R3
       0x7C180200,  //  000E  CALL	R6	1
@@ -148,28 +173,28 @@ be_local_closure(class_hue_bridge_monad_add_light,   /* name */
       0x6018000C,  //  0010  GETGBL	R6	G12
       0x5C1C0600,  //  0011  MOVE	R7	R3
       0x7C180200,  //  0012  CALL	R6	1
-      0x1C180D05,  //  0013  EQ	R6	R6	K5
+      0x1C180D0D,  //  0013  EQ	R6	R6	K13
       0x781A0000,  //  0014  JMPF	R6	#0016
-      0xB0060306,  //  0015  RAISE	1	K1	K6
+      0xB006150E,  //  0015  RAISE	1	K10	K14
       0x5C180800,  //  0016  MOVE	R6	R4
       0x741A0000,  //  0017  JMPT	R6	#0019
-      0x58100007,  //  0018  LDCONST	R4	K7
+      0x5810000F,  //  0018  LDCONST	R4	K15
       0x5C180A00,  //  0019  MOVE	R6	R5
       0x741A0000,  //  001A  JMPT	R6	#001C
-      0x58140008,  //  001B  LDCONST	R5	K8
-      0x88180109,  //  001C  GETMBR	R6	R0	K9
+      0x58140010,  //  001B  LDCONST	R5	K16
+      0x88180101,  //  001C  GETMBR	R6	R0	K1
       0x601C0013,  //  001D  GETGBL	R7	G19
       0x7C1C0000,  //  001E  CALL	R7	0
-      0x981E1402,  //  001F  SETIDX	R7	K10	R2
-      0x981E1603,  //  0020  SETIDX	R7	K11	R3
+      0x981E0802,  //  001F  SETIDX	R7	K4	R2
+      0x981E0A03,  //  0020  SETIDX	R7	K5	R3
       0x60200008,  //  0021  GETGBL	R8	G8
       0x5C240800,  //  0022  MOVE	R9	R4
       0x7C200200,  //  0023  CALL	R8	1
-      0x981E1808,  //  0024  SETIDX	R7	K12	R8
+      0x981E0C08,  //  0024  SETIDX	R7	K6	R8
       0x60200008,  //  0025  GETGBL	R8	G8
       0x5C240A00,  //  0026  MOVE	R9	R5
       0x7C200200,  //  0027  CALL	R8	1
-      0x981E1A08,  //  0028  SETIDX	R7	K13	R8
+      0x981E0E08,  //  0028  SETIDX	R7	K7	R8
       0x98180207,  //  0029  SETIDX	R6	R1	R7
       0x80040400,  //  002A  RET	1	R2
     })
@@ -185,21 +210,18 @@ be_local_closure(class_hue_bridge_monad_remove_light,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(lights),
-    /* K1   */  be_nested_str(remove),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_remove_light,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C080511,  //  0001  GETMET	R2	R2	K17
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
@@ -216,21 +238,19 @@ be_local_closure(class_hue_bridge_monad_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(lights),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x90020201,  //  0002  SETMBR	R0	K1	R1
       0x80000000,  //  0003  RET	0
     })
   )
@@ -245,65 +265,52 @@ be_local_closure(class_hue_bridge_monad_discover,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(hue_ntv),
-    /* K1   */  be_nested_str(json),
-    /* K2   */  be_nested_str(lights),
-    /* K3   */  be_nested_str(keys),
-    /* K4   */  be_nested_str(full_status),
-    /* K5   */  be_nested_str(_X22),
-    /* K6   */  be_nested_str(_X22_X3A),
-    /* K7   */  be_nested_str(push),
-    /* K8   */  be_nested_str(stop_iteration),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str(concat),
-    /* K11  */  be_nested_str(_X2C),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_discover,
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA40A2400,  //  0001  IMPORT	R2	K18
       0x600C0012,  //  0002  GETGBL	R3	G18
       0x7C0C0000,  //  0003  CALL	R3	0
       0x60100010,  //  0004  GETGBL	R4	G16
-      0x88140102,  //  0005  GETMBR	R5	R0	K2
-      0x8C140B03,  //  0006  GETMET	R5	R5	K3
+      0x88140101,  //  0005  GETMBR	R5	R0	K1
+      0x8C140B13,  //  0006  GETMET	R5	R5	K19
       0x7C140200,  //  0007  CALL	R5	1
       0x7C100200,  //  0008  CALL	R4	1
       0xA802000F,  //  0009  EXBLK	0	#001A
       0x5C140800,  //  000A  MOVE	R5	R4
       0x7C140000,  //  000B  CALL	R5	0
-      0x8C180104,  //  000C  GETMET	R6	R0	K4
+      0x8C180114,  //  000C  GETMET	R6	R0	K20
       0x5C200A00,  //  000D  MOVE	R8	R5
       0x7C180400,  //  000E  CALL	R6	2
       0x781A0008,  //  000F  JMPF	R6	#0019
       0x601C0008,  //  0010  GETGBL	R7	G8
       0x5C200A00,  //  0011  MOVE	R8	R5
       0x7C1C0200,  //  0012  CALL	R7	1
-      0x001E0A07,  //  0013  ADD	R7	K5	R7
-      0x001C0F06,  //  0014  ADD	R7	R7	K6
+      0x001E2A07,  //  0013  ADD	R7	K21	R7
+      0x001C0F16,  //  0014  ADD	R7	R7	K22
       0x00180E06,  //  0015  ADD	R6	R7	R6
-      0x8C1C0707,  //  0016  GETMET	R7	R3	K7
+      0x8C1C0717,  //  0016  GETMET	R7	R3	K23
       0x5C240C00,  //  0017  MOVE	R9	R6
       0x7C1C0400,  //  0018  CALL	R7	2
       0x7001FFEF,  //  0019  JMP		#000A
-      0x58100008,  //  001A  LDCONST	R4	K8
+      0x58100018,  //  001A  LDCONST	R4	K24
       0xAC100200,  //  001B  CATCH	R4	1	0
       0xB0080000,  //  001C  RAISE	2	R0	R0
       0x6010000C,  //  001D  GETGBL	R4	G12
       0x5C140600,  //  001E  MOVE	R5	R3
       0x7C100200,  //  001F  CALL	R4	1
-      0x24100909,  //  0020  GT	R4	R4	K9
+      0x2410090D,  //  0020  GT	R4	R4	K13
       0x78120003,  //  0021  JMPF	R4	#0026
-      0x8C10070A,  //  0022  GETMET	R4	R3	K10
-      0x5818000B,  //  0023  LDCONST	R6	K11
+      0x8C100719,  //  0022  GETMET	R4	R3	K25
+      0x5818001A,  //  0023  LDCONST	R6	K26
       0x7C100400,  //  0024  CALL	R4	2
       0x80040800,  //  0025  RET	1	R4
       0x80000000,  //  0026  RET	0
@@ -320,38 +327,33 @@ be_local_closure(class_hue_bridge_monad_light_to_id,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(lights),
-    /* K1   */  be_nested_str(keys),
-    /* K2   */  be_nested_str(light),
-    /* K3   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_light_to_id,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
       0x60080010,  //  0000  GETGBL	R2	G16
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0002  GETMET	R3	R3	K1
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x8C0C0713,  //  0002  GETMET	R3	R3	K19
       0x7C0C0200,  //  0003  CALL	R3	1
       0x7C080200,  //  0004  CALL	R2	1
       0xA8020009,  //  0005  EXBLK	0	#0010
       0x5C0C0400,  //  0006  MOVE	R3	R2
       0x7C0C0000,  //  0007  CALL	R3	0
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
       0x94100803,  //  0009  GETIDX	R4	R4	R3
-      0x94100902,  //  000A  GETIDX	R4	R4	K2
+      0x94100904,  //  000A  GETIDX	R4	R4	K4
       0x1C100204,  //  000B  EQ	R4	R1	R4
       0x78120001,  //  000C  JMPF	R4	#000F
       0xA8040001,  //  000D  EXBLK	1	1
       0x80040600,  //  000E  RET	1	R3
       0x7001FFF5,  //  000F  JMP		#0006
-      0x58080003,  //  0010  LDCONST	R2	K3
+      0x58080018,  //  0010  LDCONST	R2	K24
       0xAC080200,  //  0011  CATCH	R2	1	0
       0xB0080000,  //  0012  RAISE	2	R0	R0
       0x80000000,  //  0013  RET	0
@@ -368,49 +370,17 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
   be_nested_proto(
     18,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(lights),
-    /* K2   */  be_nested_str(contains),
-    /* K3   */  be_nested_str(light),
-    /* K4   */  be_nested_str(load),
-    /* K5   */  be_nested_str(tasmota),
-    /* K6   */  be_nested_str(log),
-    /* K7   */  be_nested_str(BRY_X3A_X20invalid_X20hue_X20payload_X3A_X20),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str(on),
-    /* K10  */  be_nested_str(set_power),
-    /* K11  */  be_nested_str(xy),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str(set_xy),
-    /* K15  */  be_nested_str(hue),
-    /* K16  */  be_nested_str(sat),
-    /* K17  */  be_nested_str(type),
-    /* K18  */  be_nested_str(set_hue16sat),
-    /* K19  */  be_nested_str(ct),
-    /* K20  */  be_nested_str(set_ct),
-    /* K21  */  be_nested_str(bri),
-    /* K22  */  be_nested_str(set_bri),
-    /* K23  */  be_nested_str(keys),
-    /* K24  */  be_nested_str(_X2Flights_X2F),
-    /* K25  */  be_nested_str(_X2Fstate_X2F),
-    /* K26  */  be_nested_str(success),
-    /* K27  */  be_nested_str(push),
-    /* K28  */  be_nested_str(stop_iteration),
-    /* K29  */  be_nested_str(signal_change),
-    /* K30  */  be_nested_str(dump),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[167]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA40E2400,  //  0000  IMPORT	R3	K18
       0x88100101,  //  0001  GETMBR	R4	R0	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
       0x5C180200,  //  0003  MOVE	R6	R1
@@ -419,128 +389,128 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
       0x80000800,  //  0006  RET	0
       0x88100101,  //  0007  GETMBR	R4	R0	K1
       0x94100801,  //  0008  GETIDX	R4	R4	R1
-      0x94100903,  //  0009  GETIDX	R4	R4	K3
+      0x94100904,  //  0009  GETIDX	R4	R4	K4
       0x60140013,  //  000A  GETGBL	R5	G19
       0x7C140000,  //  000B  CALL	R5	0
-      0x8C180704,  //  000C  GETMET	R6	R3	K4
+      0x8C18071B,  //  000C  GETMET	R6	R3	K27
       0x5C200400,  //  000D  MOVE	R8	R2
       0x7C180400,  //  000E  CALL	R6	2
       0x4C1C0000,  //  000F  LDNIL	R7
       0x1C1C0407,  //  0010  EQ	R7	R2	R7
       0x781E0008,  //  0011  JMPF	R7	#001B
-      0xB81E0A00,  //  0012  GETNGBL	R7	K5
-      0x8C1C0F06,  //  0013  GETMET	R7	R7	K6
+      0xB81E3800,  //  0012  GETNGBL	R7	K28
+      0x8C1C0F1D,  //  0013  GETMET	R7	R7	K29
       0x60240008,  //  0014  GETGBL	R9	G8
       0x5C280400,  //  0015  MOVE	R10	R2
       0x7C240200,  //  0016  CALL	R9	1
-      0x00260E09,  //  0017  ADD	R9	K7	R9
-      0x58280008,  //  0018  LDCONST	R10	K8
+      0x00263C09,  //  0017  ADD	R9	K30	R9
+      0x5828001F,  //  0018  LDCONST	R10	K31
       0x7C1C0600,  //  0019  CALL	R7	3
       0x80000E00,  //  001A  RET	0
       0x8C1C0D02,  //  001B  GETMET	R7	R6	K2
-      0x58240009,  //  001C  LDCONST	R9	K9
+      0x58240020,  //  001C  LDCONST	R9	K32
       0x7C1C0400,  //  001D  CALL	R7	2
       0x781E0006,  //  001E  JMPF	R7	#0026
       0x601C0017,  //  001F  GETGBL	R7	G23
-      0x94200D09,  //  0020  GETIDX	R8	R6	K9
+      0x94200D20,  //  0020  GETIDX	R8	R6	K32
       0x7C1C0200,  //  0021  CALL	R7	1
-      0x98161207,  //  0022  SETIDX	R5	K9	R7
-      0x8C20090A,  //  0023  GETMET	R8	R4	K10
+      0x98164007,  //  0022  SETIDX	R5	K32	R7
+      0x8C200921,  //  0023  GETMET	R8	R4	K33
       0x5C280E00,  //  0024  MOVE	R10	R7
       0x7C200400,  //  0025  CALL	R8	2
       0x8C1C0D02,  //  0026  GETMET	R7	R6	K2
-      0x5824000B,  //  0027  LDCONST	R9	K11
+      0x58240022,  //  0027  LDCONST	R9	K34
       0x7C1C0400,  //  0028  CALL	R7	2
       0x781E0013,  //  0029  JMPF	R7	#003E
-      0x941C0D0B,  //  002A  GETIDX	R7	R6	K11
+      0x941C0D22,  //  002A  GETIDX	R7	R6	K34
       0x6020000A,  //  002B  GETGBL	R8	G10
-      0x94240F0C,  //  002C  GETIDX	R9	R7	K12
+      0x94240F23,  //  002C  GETIDX	R9	R7	K35
       0x7C200200,  //  002D  CALL	R8	1
       0x6024000A,  //  002E  GETGBL	R9	G10
-      0x94280F0D,  //  002F  GETIDX	R10	R7	K13
+      0x94280F24,  //  002F  GETIDX	R10	R7	K36
       0x7C240200,  //  0030  CALL	R9	1
       0x60280012,  //  0031  GETGBL	R10	G18
       0x7C280000,  //  0032  CALL	R10	0
       0x402C1408,  //  0033  CONNECT	R11	R10	R8
       0x402C1409,  //  0034  CONNECT	R11	R10	R9
-      0x9816160A,  //  0035  SETIDX	R5	K11	R10
+      0x9816440A,  //  0035  SETIDX	R5	K34	R10
       0x542AFFFF,  //  0036  LDINT	R10	65536
       0x0820100A,  //  0037  MUL	R8	R8	R10
       0x542AFFFF,  //  0038  LDINT	R10	65536
       0x0824120A,  //  0039  MUL	R9	R9	R10
-      0x8C28090E,  //  003A  GETMET	R10	R4	K14
+      0x8C280925,  //  003A  GETMET	R10	R4	K37
       0x5C301000,  //  003B  MOVE	R12	R8
       0x5C341200,  //  003C  MOVE	R13	R9
       0x7C280600,  //  003D  CALL	R10	3
       0x501C0000,  //  003E  LDBOOL	R7	0	0
-      0x8820090F,  //  003F  GETMBR	R8	R4	K15
-      0x88240910,  //  0040  GETMBR	R9	R4	K16
+      0x88200926,  //  003F  GETMBR	R8	R4	K38
+      0x88240927,  //  0040  GETMBR	R9	R4	K39
       0x8C280D02,  //  0041  GETMET	R10	R6	K2
-      0x5830000F,  //  0042  LDCONST	R12	K15
+      0x58300026,  //  0042  LDCONST	R12	K38
       0x7C280400,  //  0043  CALL	R10	2
       0x782A0009,  //  0044  JMPF	R10	#004F
       0x60280009,  //  0045  GETGBL	R10	G9
-      0x942C0D0F,  //  0046  GETIDX	R11	R6	K15
+      0x942C0D26,  //  0046  GETIDX	R11	R6	K38
       0x7C280200,  //  0047  CALL	R10	1
       0x5C201400,  //  0048  MOVE	R8	R10
-      0x98161E08,  //  0049  SETIDX	R5	K15	R8
+      0x98164C08,  //  0049  SETIDX	R5	K38	R8
       0x542AFFFE,  //  004A  LDINT	R10	65535
       0x2428100A,  //  004B  GT	R10	R8	R10
       0x782A0000,  //  004C  JMPF	R10	#004E
       0x5422FFFE,  //  004D  LDINT	R8	65535
       0x501C0200,  //  004E  LDBOOL	R7	1	0
       0x8C280D02,  //  004F  GETMET	R10	R6	K2
-      0x58300010,  //  0050  LDCONST	R12	K16
+      0x58300027,  //  0050  LDCONST	R12	K39
       0x7C280400,  //  0051  CALL	R10	2
       0x782A000C,  //  0052  JMPF	R10	#0060
       0x60280009,  //  0053  GETGBL	R10	G9
-      0x942C0D10,  //  0054  GETIDX	R11	R6	K16
+      0x942C0D27,  //  0054  GETIDX	R11	R6	K39
       0x7C280200,  //  0055  CALL	R10	1
       0x5C241400,  //  0056  MOVE	R9	R10
-      0x98162009,  //  0057  SETIDX	R5	K16	R9
+      0x98164E09,  //  0057  SETIDX	R5	K39	R9
       0x542A00FD,  //  0058  LDINT	R10	254
       0x2828120A,  //  0059  GE	R10	R9	R10
       0x782A0000,  //  005A  JMPF	R10	#005C
       0x542600FE,  //  005B  LDINT	R9	255
-      0x88280911,  //  005C  GETMBR	R10	R4	K17
-      0x28281508,  //  005D  GE	R10	R10	K8
+      0x88280928,  //  005C  GETMBR	R10	R4	K40
+      0x2828151F,  //  005D  GE	R10	R10	K31
       0x782A0000,  //  005E  JMPF	R10	#0060
       0x501C0200,  //  005F  LDBOOL	R7	1	0
       0x781E0003,  //  0060  JMPF	R7	#0065
-      0x8C280912,  //  0061  GETMET	R10	R4	K18
+      0x8C280929,  //  0061  GETMET	R10	R4	K41
       0x5C301000,  //  0062  MOVE	R12	R8
       0x5C341200,  //  0063  MOVE	R13	R9
       0x7C280600,  //  0064  CALL	R10	3
       0x8C280D02,  //  0065  GETMET	R10	R6	K2
-      0x58300013,  //  0066  LDCONST	R12	K19
+      0x5830002A,  //  0066  LDCONST	R12	K42
       0x7C280400,  //  0067  CALL	R10	2
       0x782A0006,  //  0068  JMPF	R10	#0070
       0x60280009,  //  0069  GETGBL	R10	G9
-      0x942C0D13,  //  006A  GETIDX	R11	R6	K19
+      0x942C0D2A,  //  006A  GETIDX	R11	R6	K42
       0x7C280200,  //  006B  CALL	R10	1
-      0x9816260A,  //  006C  SETIDX	R5	K19	R10
-      0x8C2C0914,  //  006D  GETMET	R11	R4	K20
+      0x9816540A,  //  006C  SETIDX	R5	K42	R10
+      0x8C2C092B,  //  006D  GETMET	R11	R4	K43
       0x5C341400,  //  006E  MOVE	R13	R10
       0x7C2C0400,  //  006F  CALL	R11	2
       0x8C280D02,  //  0070  GETMET	R10	R6	K2
-      0x58300015,  //  0071  LDCONST	R12	K21
+      0x5830002C,  //  0071  LDCONST	R12	K44
       0x7C280400,  //  0072  CALL	R10	2
       0x782A000A,  //  0073  JMPF	R10	#007F
       0x60280009,  //  0074  GETGBL	R10	G9
-      0x942C0D15,  //  0075  GETIDX	R11	R6	K21
+      0x942C0D2C,  //  0075  GETIDX	R11	R6	K44
       0x7C280200,  //  0076  CALL	R10	1
-      0x98162A0A,  //  0077  SETIDX	R5	K21	R10
+      0x9816580A,  //  0077  SETIDX	R5	K44	R10
       0x542E00FD,  //  0078  LDINT	R11	254
       0x282C140B,  //  0079  GE	R11	R10	R11
       0x782E0000,  //  007A  JMPF	R11	#007C
       0x542A00FE,  //  007B  LDINT	R10	255
-      0x8C2C0916,  //  007C  GETMET	R11	R4	K22
+      0x8C2C092D,  //  007C  GETMET	R11	R4	K45
       0x5C341400,  //  007D  MOVE	R13	R10
       0x7C2C0400,  //  007E  CALL	R11	2
       0x60280012,  //  007F  GETGBL	R10	G18
       0x7C280000,  //  0080  CALL	R10	0
       0x602C0010,  //  0081  GETGBL	R11	G16
-      0x8C300B17,  //  0082  GETMET	R12	R5	K23
+      0x8C300B13,  //  0082  GETMET	R12	R5	K19
       0x7C300200,  //  0083  CALL	R12	1
       0x7C2C0200,  //  0084  CALL	R11	1
       0xA8020012,  //  0085  EXBLK	0	#0099
@@ -549,8 +519,8 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
       0x60340008,  //  0088  GETGBL	R13	G8
       0x5C380200,  //  0089  MOVE	R14	R1
       0x7C340200,  //  008A  CALL	R13	1
-      0x0036300D,  //  008B  ADD	R13	K24	R13
-      0x00341B19,  //  008C  ADD	R13	R13	K25
+      0x00365C0D,  //  008B  ADD	R13	K46	R13
+      0x00341B2F,  //  008C  ADD	R13	R13	K47
       0x00341A0C,  //  008D  ADD	R13	R13	R12
       0x60380013,  //  008E  GETGBL	R14	G19
       0x7C380000,  //  008F  CALL	R14	0
@@ -558,22 +528,22 @@ be_local_closure(class_hue_bridge_monad_cmd,   /* name */
       0x7C3C0000,  //  0091  CALL	R15	0
       0x94400A0C,  //  0092  GETIDX	R16	R5	R12
       0x983C1A10,  //  0093  SETIDX	R15	R13	R16
-      0x983A340F,  //  0094  SETIDX	R14	K26	R15
-      0x8C3C151B,  //  0095  GETMET	R15	R10	K27
+      0x983A600F,  //  0094  SETIDX	R14	K48	R15
+      0x8C3C1517,  //  0095  GETMET	R15	R10	K23
       0x5C441C00,  //  0096  MOVE	R17	R14
       0x7C3C0400,  //  0097  CALL	R15	2
       0x7001FFEC,  //  0098  JMP		#0086
-      0x582C001C,  //  0099  LDCONST	R11	K28
+      0x582C0018,  //  0099  LDCONST	R11	K24
       0xAC2C0200,  //  009A  CATCH	R11	1	0
       0xB0080000,  //  009B  RAISE	2	R0	R0
       0x602C000C,  //  009C  GETGBL	R11	G12
       0x5C301400,  //  009D  MOVE	R12	R10
       0x7C2C0200,  //  009E  CALL	R11	1
-      0x242C170C,  //  009F  GT	R11	R11	K12
+      0x242C1723,  //  009F  GT	R11	R11	K35
       0x782E0001,  //  00A0  JMPF	R11	#00A3
-      0x8C2C091D,  //  00A1  GETMET	R11	R4	K29
+      0x8C2C0931,  //  00A1  GETMET	R11	R4	K49
       0x7C2C0200,  //  00A2  CALL	R11	1
-      0x8C2C071E,  //  00A3  GETMET	R11	R3	K30
+      0x8C2C0732,  //  00A3  GETMET	R11	R3	K50
       0x5C341400,  //  00A4  MOVE	R13	R10
       0x7C2C0400,  //  00A5  CALL	R11	2
       0x80041600,  //  00A6  RET	1	R11
@@ -590,53 +560,44 @@ be_local_closure(class_hue_bridge_monad_groups,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(lights),
-    /* K1   */  be_nested_str(keys),
-    /* K2   */  be_nested_str(push),
-    /* K3   */  be_nested_str(_X22),
-    /* K4   */  be_nested_str(stop_iteration),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str(concat),
-    /* K7   */  be_nested_str(_X2C),
-    }),
+    &be_ktab_class_hue_bridge_monad,     /* shared constants */
     &be_const_str_groups,
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
       0x60040012,  //  0000  GETGBL	R1	G18
       0x7C040000,  //  0001  CALL	R1	0
       0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x8C0C0713,  //  0004  GETMET	R3	R3	K19
       0x7C0C0200,  //  0005  CALL	R3	1
       0x7C080200,  //  0006  CALL	R2	1
       0xA8020009,  //  0007  EXBLK	0	#0012
       0x5C0C0400,  //  0008  MOVE	R3	R2
       0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100302,  //  000A  GETMET	R4	R1	K2
+      0x8C100317,  //  000A  GETMET	R4	R1	K23
       0x60180008,  //  000B  GETGBL	R6	G8
       0x5C1C0600,  //  000C  MOVE	R7	R3
       0x7C180200,  //  000D  CALL	R6	1
-      0x001A0606,  //  000E  ADD	R6	K3	R6
-      0x00180D03,  //  000F  ADD	R6	R6	K3
+      0x001A2A06,  //  000E  ADD	R6	K21	R6
+      0x00180D15,  //  000F  ADD	R6	R6	K21
       0x7C100400,  //  0010  CALL	R4	2
       0x7001FFF5,  //  0011  JMP		#0008
-      0x58080004,  //  0012  LDCONST	R2	K4
+      0x58080018,  //  0012  LDCONST	R2	K24
       0xAC080200,  //  0013  CATCH	R2	1	0
       0xB0080000,  //  0014  RAISE	2	R0	R0
       0x6008000C,  //  0015  GETGBL	R2	G12
       0x5C0C0200,  //  0016  MOVE	R3	R1
       0x7C080200,  //  0017  CALL	R2	1
-      0x24080505,  //  0018  GT	R2	R2	K5
+      0x2408050D,  //  0018  GT	R2	R2	K13
       0x780A0003,  //  0019  JMPF	R2	#001E
-      0x8C080306,  //  001A  GETMET	R2	R1	K6
-      0x58100007,  //  001B  LDCONST	R4	K7
+      0x8C080319,  //  001A  GETMET	R2	R1	K25
+      0x5810001A,  //  001B  LDCONST	R4	K26
       0x7C080400,  //  001C  CALL	R2	2
       0x80040400,  //  001D  RET	1	R2
       0x80000000,  //  001E  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
@@ -3,6 +3,54 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'AXP192' ktab size: 44, total: 82 (saved 304 bytes)
+static const bvalue be_ktab_class_AXP192[44] = {
+  /* K0   */  be_const_int(1),
+  /* K1   */  be_nested_str(write_bit),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_const_int(2),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_nested_str(read24),
+  /* K6   */  be_const_real_hex(0x3A102DE1),
+  /* K7   */  be_nested_str(read12),
+  /* K8   */  be_const_real_hex(0x3A902DE0),
+  /* K9   */  be_const_real_hex(0x3EC00000),
+  /* K10  */  be_const_int(1),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_const_int(3),
+  /* K13  */  be_nested_str(wire),
+  /* K14  */  be_nested_str(read),
+  /* K15  */  be_nested_str(addr),
+  /* K16  */  be_const_real_hex(0x3AB78035),
+  /* K17  */  be_const_real_hex(0x3ADED28A),
+  /* K18  */  be_const_int(0),
+  /* K19  */  be_const_int(3),
+  /* K20  */  be_nested_str(write8),
+  /* K21  */  be_nested_str(read8),
+  /* K22  */  be_nested_str(_X2C_X22AXP192_X22_X3A_X7B_X22VBusVoltage_X22_X3A_X25_X2E3f_X2C_X22VBusCurrent_X22_X3A_X25_X2E1f_X2C_X22BattVoltage_X22_X3A_X25_X2E3f_X2C_X22BattCurrent_X22_X3A_X25_X2E1f_X2C_X22Temperature_X22_X3A_X25_X2E1f_X7D),
+  /* K23  */  be_nested_str(get_vbus_voltage),
+  /* K24  */  be_nested_str(get_bat_voltage),
+  /* K25  */  be_nested_str(get_bat_current),
+  /* K26  */  be_nested_str(get_temp),
+  /* K27  */  be_nested_str(tasmota),
+  /* K28  */  be_nested_str(response_append),
+  /* K29  */  be_nested_str(I2C_Driver),
+  /* K30  */  be_nested_str(init),
+  /* K31  */  be_nested_str(AXP192),
+  /* K32  */  be_nested_str(read13),
+  /* K33  */  be_const_real_hex(0x3F000000),
+  /* K34  */  be_nested_str(_X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D),
+  /* K35  */  be_nested_str(_X7Bs_X7DVBus_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D),
+  /* K36  */  be_nested_str(_X7Bs_X7DBatt_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D),
+  /* K37  */  be_nested_str(_X7Bs_X7DBatt_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D),
+  /* K38  */  be_nested_str(_X7Bs_X7DAXP_X20Temperature_X7Bm_X7D_X25_X2E1f_X20_X26deg_X3BC_X7Be_X7D),
+  /* K39  */  be_nested_str(web_send_decimal),
+  /* K40  */  be_const_real_hex(0x3DCCCCCD),
+  /* K41  */  be_const_real_hex(0x4310B333),
+  /* K42  */  be_const_int(1),
+  /* K43  */  be_const_real_hex(0x3F000000),
+};
+
 
 extern const bclass be_class_AXP192;
 
@@ -13,19 +61,13 @@ be_local_closure(class_AXP192_set_dcdc_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(1),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_dcdc_enable,
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
@@ -64,23 +106,20 @@ be_local_closure(class_AXP192_get_bat_power,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_bat_power,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040105,  //  0000  GETMET	R1	R0	K5
       0x540E006F,  //  0001  LDINT	R3	112
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040306,  //  0003  MUL	R1	R1	K6
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -95,23 +134,20 @@ be_local_closure(class_AXP192_get_bat_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3A902DE0),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_bat_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E0077,  //  0001  LDINT	R3	120
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040308,  //  0003  MUL	R1	R1	K8
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -126,23 +162,20 @@ be_local_closure(class_AXP192_get_vbus_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3EC00000),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_vbus_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E005B,  //  0001  LDINT	R3	92
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040309,  //  0003  MUL	R1	R1	K9
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -157,23 +190,20 @@ be_local_closure(class_AXP192_get_warning_level,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_warning_level,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E0046,  //  0001  LDINT	R3	71
       0x7C040400,  //  0002  CALL	R1	2
-      0x2C040301,  //  0003  AND	R1	R1	K1
+      0x2C04030A,  //  0003  AND	R1	R1	K10
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -188,32 +218,28 @@ be_local_closure(class_AXP192_set_ldo_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_ldo_enable,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x1C0C030B,  //  0000  EQ	R3	R1	K11
       0x780E0004,  //  0001  JMPF	R3	#0007
       0x8C0C0101,  //  0002  GETMET	R3	R0	K1
       0x54160011,  //  0003  LDINT	R5	18
-      0x58180000,  //  0004  LDCONST	R6	K0
+      0x5818000B,  //  0004  LDCONST	R6	K11
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0302,  //  0007  EQ	R3	R1	K2
+      0x1C0C030C,  //  0007  EQ	R3	R1	K12
       0x780E0004,  //  0008  JMPF	R3	#000E
       0x8C0C0101,  //  0009  GETMET	R3	R0	K1
       0x54160011,  //  000A  LDINT	R5	18
-      0x58180002,  //  000B  LDCONST	R6	K2
+      0x5818000C,  //  000B  LDCONST	R6	K12
       0x5C1C0400,  //  000C  MOVE	R7	R2
       0x7C0C0800,  //  000D  CALL	R3	4
       0x80000000,  //  000E  RET	0
@@ -230,27 +256,21 @@ be_local_closure(class_AXP192_get_input_power_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_input_power_status,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x8C04030E,  //  0001  GETMET	R1	R1	K14
+      0x880C010F,  //  0002  GETMBR	R3	R0	K15
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x58140000,  //  0004  LDCONST	R5	K0
       0x7C040800,  //  0005  CALL	R1	4
       0x80040200,  //  0006  RET	1	R1
     })
@@ -266,23 +286,20 @@ be_local_closure(class_AXP192_get_aps_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3AB78035),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_aps_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E007D,  //  0001  LDINT	R3	126
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040310,  //  0003  MUL	R1	R1	K16
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -297,19 +314,17 @@ be_local_closure(class_AXP192_set_exten,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(write_bit),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_exten,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080101,  //  0000  GETMET	R2	R0	K1
       0x54120011,  //  0001  LDINT	R4	18
       0x54160005,  //  0002  LDINT	R5	6
       0x5C180200,  //  0003  MOVE	R6	R1
@@ -328,26 +343,21 @@ be_local_closure(class_AXP192_battery_present,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_battery_present,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x8C04030E,  //  0001  GETMET	R1	R1	K14
+      0x880C010F,  //  0002  GETMBR	R3	R0	K15
+      0x58100000,  //  0003  LDCONST	R4	K0
+      0x58140000,  //  0004  LDCONST	R5	K0
       0x7C040800,  //  0005  CALL	R1	4
       0x540A001F,  //  0006  LDINT	R2	32
       0x2C040202,  //  0007  AND	R1	R1	R2
@@ -371,23 +381,20 @@ be_local_closure(class_AXP192_get_vbus_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3ADED28A),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_vbus_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E0059,  //  0001  LDINT	R3	90
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040311,  //  0003  MUL	R1	R1	K17
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -402,39 +409,34 @@ be_local_closure(class_AXP192_write_gpio,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_const_int(2),
-    /* K2   */  be_nested_str(write_bit),
-    /* K3   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_write_gpio,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x280C0300,  //  0000  GE	R3	R1	K0
+      0x280C0312,  //  0000  GE	R3	R1	K18
       0x780E0007,  //  0001  JMPF	R3	#000A
-      0x180C0301,  //  0002  LE	R3	R1	K1
+      0x180C0303,  //  0002  LE	R3	R1	K3
       0x780E0005,  //  0003  JMPF	R3	#000A
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x8C0C0101,  //  0004  GETMET	R3	R0	K1
       0x54160093,  //  0005  LDINT	R5	148
       0x5C180200,  //  0006  MOVE	R6	R1
       0x5C1C0400,  //  0007  MOVE	R7	R2
       0x7C0C0800,  //  0008  CALL	R3	4
       0x70020009,  //  0009  JMP		#0014
-      0x280C0303,  //  000A  GE	R3	R1	K3
+      0x280C0313,  //  000A  GE	R3	R1	K19
       0x780E0007,  //  000B  JMPF	R3	#0014
       0x540E0003,  //  000C  LDINT	R3	4
       0x180C0203,  //  000D  LE	R3	R1	R3
       0x780E0004,  //  000E  JMPF	R3	#0014
-      0x8C0C0102,  //  000F  GETMET	R3	R0	K2
+      0x8C0C0101,  //  000F  GETMET	R3	R0	K1
       0x54160095,  //  0010  LDINT	R5	150
-      0x04180303,  //  0011  SUB	R6	R1	K3
+      0x04180313,  //  0011  SUB	R6	R1	K19
       0x5C1C0400,  //  0012  MOVE	R7	R2
       0x7C0C0800,  //  0013  CALL	R3	4
       0x80000000,  //  0014  RET	0
@@ -451,18 +453,13 @@ be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write8),
-    /* K2   */  be_nested_str(read8),
-    /* K3   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_ldo_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
@@ -476,11 +473,11 @@ be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
       0x54120011,  //  0007  LDINT	R4	18
       0x040C0604,  //  0008  SUB	R3	R3	R4
       0x5C080600,  //  0009  MOVE	R2	R3
-      0x1C0C0300,  //  000A  EQ	R3	R1	K0
+      0x1C0C0303,  //  000A  EQ	R3	R1	K3
       0x780E000C,  //  000B  JMPF	R3	#0019
-      0x8C0C0101,  //  000C  GETMET	R3	R0	K1
+      0x8C0C0114,  //  000C  GETMET	R3	R0	K20
       0x54160027,  //  000D  LDINT	R5	40
-      0x8C180102,  //  000E  GETMET	R6	R0	K2
+      0x8C180115,  //  000E  GETMET	R6	R0	K21
       0x54220027,  //  000F  LDINT	R8	40
       0x7C180400,  //  0010  CALL	R6	2
       0x541E000E,  //  0011  LDINT	R7	15
@@ -491,11 +488,11 @@ be_local_closure(class_AXP192_set_ldo_voltage,   /* name */
       0x381C0E08,  //  0016  SHL	R7	R7	R8
       0x30180C07,  //  0017  OR	R6	R6	R7
       0x7C0C0600,  //  0018  CALL	R3	3
-      0x1C0C0303,  //  0019  EQ	R3	R1	K3
+      0x1C0C030C,  //  0019  EQ	R3	R1	K12
       0x780E000A,  //  001A  JMPF	R3	#0026
-      0x8C0C0101,  //  001B  GETMET	R3	R0	K1
+      0x8C0C0114,  //  001B  GETMET	R3	R0	K20
       0x54160027,  //  001C  LDINT	R5	40
-      0x8C180102,  //  001D  GETMET	R6	R0	K2
+      0x8C180115,  //  001D  GETMET	R6	R0	K21
       0x54220027,  //  001E  LDINT	R8	40
       0x7C180400,  //  001F  CALL	R6	2
       0x541E00EF,  //  0020  LDINT	R7	240
@@ -518,44 +515,35 @@ be_local_closure(class_AXP192_json_append,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(_X2C_X22AXP192_X22_X3A_X7B_X22VBusVoltage_X22_X3A_X25_X2E3f_X2C_X22VBusCurrent_X22_X3A_X25_X2E1f_X2C_X22BattVoltage_X22_X3A_X25_X2E3f_X2C_X22BattCurrent_X22_X3A_X25_X2E1f_X2C_X22Temperature_X22_X3A_X25_X2E1f_X7D),
-    /* K2   */  be_nested_str(get_vbus_voltage),
-    /* K3   */  be_nested_str(get_bat_voltage),
-    /* K4   */  be_nested_str(get_bat_current),
-    /* K5   */  be_nested_str(get_temp),
-    /* K6   */  be_nested_str(tasmota),
-    /* K7   */  be_nested_str(response_append),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_json_append,
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
       0x74060001,  //  0001  JMPT	R1	#0004
       0x4C040000,  //  0002  LDNIL	R1
       0x80040200,  //  0003  RET	1	R1
       0x60040018,  //  0004  GETGBL	R1	G24
-      0x58080001,  //  0005  LDCONST	R2	K1
-      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
+      0x58080016,  //  0005  LDCONST	R2	K22
+      0x8C0C0117,  //  0006  GETMET	R3	R0	K23
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C100102,  //  0008  GETMET	R4	R0	K2
+      0x8C100117,  //  0008  GETMET	R4	R0	K23
       0x7C100200,  //  0009  CALL	R4	1
-      0x8C140103,  //  000A  GETMET	R5	R0	K3
+      0x8C140118,  //  000A  GETMET	R5	R0	K24
       0x7C140200,  //  000B  CALL	R5	1
-      0x8C180104,  //  000C  GETMET	R6	R0	K4
+      0x8C180119,  //  000C  GETMET	R6	R0	K25
       0x7C180200,  //  000D  CALL	R6	1
-      0x8C1C0105,  //  000E  GETMET	R7	R0	K5
+      0x8C1C011A,  //  000E  GETMET	R7	R0	K26
       0x7C1C0200,  //  000F  CALL	R7	1
       0x7C040C00,  //  0010  CALL	R1	6
-      0xB80A0C00,  //  0011  GETNGBL	R2	K6
-      0x8C080507,  //  0012  GETMET	R2	R2	K7
+      0xB80A3600,  //  0011  GETNGBL	R2	K27
+      0x8C08051C,  //  0012  GETMET	R2	R2	K28
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
       0x80000000,  //  0015  RET	0
@@ -572,26 +560,22 @@ be_local_closure(class_AXP192_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(I2C_Driver),
-    /* K1   */  be_nested_str(init),
-    /* K2   */  be_nested_str(AXP192),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0xB80E3A00,  //  0002  GETNGBL	R3	K29
       0x7C040400,  //  0003  CALL	R1	2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x580C0002,  //  0005  LDCONST	R3	K2
+      0x8C04031E,  //  0004  GETMET	R1	R1	K30
+      0x580C001F,  //  0005  LDCONST	R3	K31
       0x54120033,  //  0006  LDINT	R4	52
       0x7C040600,  //  0007  CALL	R1	3
       0x80000000,  //  0008  RET	0
@@ -608,27 +592,24 @@ be_local_closure(class_AXP192_get_bat_current,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_bat_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040120,  //  0000  GETMET	R1	R0	K32
       0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C080100,  //  0003  GETMET	R2	R0	K0
+      0x8C080120,  //  0003  GETMET	R2	R0	K32
       0x5412007B,  //  0004  LDINT	R4	124
       0x7C080400,  //  0005  CALL	R2	2
       0x04040202,  //  0006  SUB	R1	R1	R2
-      0x08040301,  //  0007  MUL	R1	R1	K1
+      0x08040321,  //  0007  MUL	R1	R1	K33
       0x80040200,  //  0008  RET	1	R1
     })
   )
@@ -643,51 +624,38 @@ be_local_closure(class_AXP192_web_sensor,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(_X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D),
-    /* K2   */  be_nested_str(_X7Bs_X7DVBus_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D),
-    /* K3   */  be_nested_str(_X7Bs_X7DBatt_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D),
-    /* K4   */  be_nested_str(_X7Bs_X7DBatt_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D),
-    /* K5   */  be_nested_str(_X7Bs_X7DAXP_X20Temperature_X7Bm_X7D_X25_X2E1f_X20_X26deg_X3BC_X7Be_X7D),
-    /* K6   */  be_nested_str(get_vbus_voltage),
-    /* K7   */  be_nested_str(get_bat_voltage),
-    /* K8   */  be_nested_str(get_bat_current),
-    /* K9   */  be_nested_str(get_temp),
-    /* K10  */  be_nested_str(tasmota),
-    /* K11  */  be_nested_str(web_send_decimal),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_web_sensor,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
       0x74060001,  //  0001  JMPT	R1	#0004
       0x4C040000,  //  0002  LDNIL	R1
       0x80040200,  //  0003  RET	1	R1
       0x60040018,  //  0004  GETGBL	R1	G24
-      0x400A0302,  //  0005  CONNECT	R2	K1	K2
-      0x40080503,  //  0006  CONNECT	R2	R2	K3
-      0x40080504,  //  0007  CONNECT	R2	R2	K4
-      0x40080505,  //  0008  CONNECT	R2	R2	K5
-      0x8C0C0106,  //  0009  GETMET	R3	R0	K6
+      0x400A4523,  //  0005  CONNECT	R2	K34	K35
+      0x40080524,  //  0006  CONNECT	R2	R2	K36
+      0x40080525,  //  0007  CONNECT	R2	R2	K37
+      0x40080526,  //  0008  CONNECT	R2	R2	K38
+      0x8C0C0117,  //  0009  GETMET	R3	R0	K23
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x8C100106,  //  000B  GETMET	R4	R0	K6
+      0x8C100117,  //  000B  GETMET	R4	R0	K23
       0x7C100200,  //  000C  CALL	R4	1
-      0x8C140107,  //  000D  GETMET	R5	R0	K7
+      0x8C140118,  //  000D  GETMET	R5	R0	K24
       0x7C140200,  //  000E  CALL	R5	1
-      0x8C180108,  //  000F  GETMET	R6	R0	K8
+      0x8C180119,  //  000F  GETMET	R6	R0	K25
       0x7C180200,  //  0010  CALL	R6	1
-      0x8C1C0109,  //  0011  GETMET	R7	R0	K9
+      0x8C1C011A,  //  0011  GETMET	R7	R0	K26
       0x7C1C0200,  //  0012  CALL	R7	1
       0x7C040C00,  //  0013  CALL	R1	6
-      0xB80A1400,  //  0014  GETNGBL	R2	K10
-      0x8C08050B,  //  0015  GETMET	R2	R2	K11
+      0xB80A3600,  //  0014  GETNGBL	R2	K27
+      0x8C080527,  //  0015  GETMET	R2	R2	K39
       0x5C100200,  //  0016  MOVE	R4	R1
       0x7C080400,  //  0017  CALL	R2	2
       0x80000000,  //  0018  RET	0
@@ -704,22 +672,19 @@ be_local_closure(class_AXP192_set_chg_current,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(write8),
-    /* K1   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_chg_current,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080114,  //  0000  GETMET	R2	R0	K20
       0x54120032,  //  0001  LDINT	R4	51
-      0x8C140101,  //  0002  GETMET	R5	R0	K1
+      0x8C140115,  //  0002  GETMET	R5	R0	K21
       0x541E0032,  //  0003  LDINT	R7	51
       0x7C140400,  //  0004  CALL	R5	2
       0x541A00EF,  //  0005  LDINT	R6	240
@@ -742,25 +707,21 @@ be_local_closure(class_AXP192_get_temp,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3DCCCCCD),
-    /* K2   */  be_const_real_hex(0x4310B333),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_temp,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040107,  //  0000  GETMET	R1	R0	K7
       0x540E005D,  //  0001  LDINT	R3	94
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x04040302,  //  0004  SUB	R1	R1	K2
+      0x08040328,  //  0003  MUL	R1	R1	K40
+      0x04040329,  //  0004  SUB	R1	R1	K41
       0x80040200,  //  0005  RET	1	R1
     })
   )
@@ -775,26 +736,19 @@ be_local_closure(class_AXP192_set_dc_voltage,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(1),
-    /* K1   */  be_const_int(3),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str(write8),
-    /* K5   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_set_dc_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
-      0x140C0300,  //  0000  LT	R3	R1	K0
+      0x140C032A,  //  0000  LT	R3	R1	K42
       0x740E0001,  //  0001  JMPT	R3	#0004
-      0x240C0301,  //  0002  GT	R3	R1	K1
+      0x240C0304,  //  0002  GT	R3	R1	K4
       0x780E0000,  //  0003  JMPF	R3	#0005
       0x80000600,  //  0004  RET	0
       0x4C0C0000,  //  0005  LDNIL	R3
@@ -808,7 +762,7 @@ be_local_closure(class_AXP192_set_dc_voltage,   /* name */
       0x78120001,  //  000D  JMPF	R4	#0010
       0x540E006F,  //  000E  LDINT	R3	112
       0x7002000B,  //  000F  JMP		#001C
-      0x1C100303,  //  0010  EQ	R4	R1	K3
+      0x1C10030B,  //  0010  EQ	R4	R1	K11
       0x78120004,  //  0011  JMPF	R4	#0017
       0x541208E2,  //  0012  LDINT	R4	2275
       0x24100404,  //  0013  GT	R4	R2	R4
@@ -821,16 +775,16 @@ be_local_closure(class_AXP192_set_dc_voltage,   /* name */
       0x0C100805,  //  001A  DIV	R4	R4	R5
       0x5C0C0800,  //  001B  MOVE	R3	R4
       0x54120025,  //  001C  LDINT	R4	38
-      0x1C140301,  //  001D  EQ	R5	R1	K1
+      0x1C140304,  //  001D  EQ	R5	R1	K4
       0x78160001,  //  001E  JMPF	R5	#0021
       0x54120026,  //  001F  LDINT	R4	39
       0x70020002,  //  0020  JMP		#0024
-      0x1C140303,  //  0021  EQ	R5	R1	K3
+      0x1C14030B,  //  0021  EQ	R5	R1	K11
       0x78160000,  //  0022  JMPF	R5	#0024
       0x54120022,  //  0023  LDINT	R4	35
-      0x8C140104,  //  0024  GETMET	R5	R0	K4
+      0x8C140114,  //  0024  GETMET	R5	R0	K20
       0x5C1C0800,  //  0025  MOVE	R7	R4
-      0x8C200105,  //  0026  GETMET	R8	R0	K5
+      0x8C200115,  //  0026  GETMET	R8	R0	K21
       0x5C280800,  //  0027  MOVE	R10	R4
       0x7C200400,  //  0028  CALL	R8	2
       0x5426007F,  //  0029  LDINT	R9	128
@@ -853,23 +807,20 @@ be_local_closure(class_AXP192_power_off,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(write_bit),
-    /* K1   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_power_off,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040101,  //  0000  GETMET	R1	R0	K1
       0x540E0031,  //  0001  LDINT	R3	50
       0x54120006,  //  0002  LDINT	R4	7
-      0x58140001,  //  0003  LDCONST	R5	K1
+      0x58140000,  //  0003  LDCONST	R5	K0
       0x7C040800,  //  0004  CALL	R1	4
       0x80000000,  //  0005  RET	0
     })
@@ -885,26 +836,21 @@ be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_battery_chargin_status,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x8C04030E,  //  0001  GETMET	R1	R1	K14
+      0x880C010F,  //  0002  GETMBR	R3	R0	K15
+      0x58100000,  //  0003  LDCONST	R4	K0
+      0x58140000,  //  0004  LDCONST	R5	K0
       0x7C040800,  //  0005  CALL	R1	4
       0x80040200,  //  0006  RET	1	R1
     })
@@ -920,23 +866,20 @@ be_local_closure(class_AXP192_get_bat_charge_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
-    }),
+    &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_get_bat_charge_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040120,  //  0000  GETMET	R1	R0	K32
       0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x0804032B,  //  0003  MUL	R1	R1	K43
       0x80040200,  //  0004  RET	1	R1
     })
   )

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
@@ -3,6 +3,38 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'AXP202' ktab size: 28, total: 64 (saved 288 bytes)
+static const bvalue be_ktab_class_AXP202[28] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_const_int(1),
+  /* K2   */  be_const_int(2),
+  /* K3   */  be_const_int(3),
+  /* K4   */  be_nested_str(write8),
+  /* K5   */  be_nested_str(read8),
+  /* K6   */  be_nested_str(read12),
+  /* K7   */  be_const_real_hex(0x3EC00000),
+  /* K8   */  be_const_real_hex(0x3A902DE0),
+  /* K9   */  be_nested_str(read13),
+  /* K10  */  be_const_real_hex(0x3F000000),
+  /* K11  */  be_nested_str(read24),
+  /* K12  */  be_const_real_hex(0x3A102DE1),
+  /* K13  */  be_const_real_hex(0x3AB78035),
+  /* K14  */  be_const_real_hex(0x3ADED28A),
+  /* K15  */  be_nested_str(write_bit),
+  /* K16  */  be_nested_str(wire),
+  /* K17  */  be_nested_str(read),
+  /* K18  */  be_nested_str(addr),
+  /* K19  */  be_const_int(3),
+  /* K20  */  be_nested_str(I2C_Driver),
+  /* K21  */  be_nested_str(init),
+  /* K22  */  be_nested_str(AXP202),
+  /* K23  */  be_const_int(0),
+  /* K24  */  be_const_int(2),
+  /* K25  */  be_const_real_hex(0x3F000000),
+  /* K26  */  be_const_real_hex(0x3DCCCCCD),
+  /* K27  */  be_const_real_hex(0x4310B333),
+};
+
 
 extern const bclass be_class_AXP202;
 
@@ -13,20 +45,13 @@ be_local_closure(class_AXP202_set_shutdown_time,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str(write8),
-    /* K5   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_shutdown_time,
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
@@ -67,23 +92,20 @@ be_local_closure(class_AXP202_get_vbus_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3EC00000),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_vbus_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E005B,  //  0001  LDINT	R3	92
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040307,  //  0003  MUL	R1	R1	K7
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -98,23 +120,20 @@ be_local_closure(class_AXP202_get_bat_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3A902DE0),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_bat_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E0077,  //  0001  LDINT	R3	120
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040308,  //  0003  MUL	R1	R1	K8
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -129,27 +148,24 @@ be_local_closure(class_AXP202_get_bat_current,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_bat_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
       0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C080100,  //  0003  GETMET	R2	R0	K0
+      0x8C080109,  //  0003  GETMET	R2	R0	K9
       0x5412007B,  //  0004  LDINT	R4	124
       0x7C080400,  //  0005  CALL	R2	2
       0x04040202,  //  0006  SUB	R1	R1	R2
-      0x08040301,  //  0007  MUL	R1	R1	K1
+      0x0804030A,  //  0007  MUL	R1	R1	K10
       0x80040200,  //  0008  RET	1	R1
     })
   )
@@ -164,23 +180,20 @@ be_local_closure(class_AXP202_get_bat_power,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_bat_power,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010B,  //  0000  GETMET	R1	R0	K11
       0x540E006F,  //  0001  LDINT	R3	112
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x0804030C,  //  0003  MUL	R1	R1	K12
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -195,23 +208,20 @@ be_local_closure(class_AXP202_get_aps_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3AB78035),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_aps_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E007D,  //  0001  LDINT	R3	126
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x0804030D,  //  0003  MUL	R1	R1	K13
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -226,23 +236,20 @@ be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3ADED28A),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_vbus_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E0059,  //  0001  LDINT	R3	90
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x0804030E,  //  0003  MUL	R1	R1	K14
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -257,30 +264,26 @@ be_local_closure(class_AXP202_set_ldo_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_ldo_enable,
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x1C0C0302,  //  0000  EQ	R3	R1	K2
       0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
+      0x8C0C010F,  //  0002  GETMET	R3	R0	K15
       0x54160011,  //  0003  LDINT	R5	18
-      0x58180000,  //  0004  LDCONST	R6	K0
+      0x58180002,  //  0004  LDCONST	R6	K2
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0302,  //  0007  EQ	R3	R1	K2
+      0x1C0C0303,  //  0007  EQ	R3	R1	K3
       0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
+      0x8C0C010F,  //  0009  GETMET	R3	R0	K15
       0x54160011,  //  000A  LDINT	R5	18
       0x541A0005,  //  000B  LDINT	R6	6
       0x5C1C0400,  //  000C  MOVE	R7	R2
@@ -288,9 +291,9 @@ be_local_closure(class_AXP202_set_ldo_enable,   /* name */
       0x540E0003,  //  000E  LDINT	R3	4
       0x1C0C0203,  //  000F  EQ	R3	R1	R3
       0x780E0004,  //  0010  JMPF	R3	#0016
-      0x8C0C0101,  //  0011  GETMET	R3	R0	K1
+      0x8C0C010F,  //  0011  GETMET	R3	R0	K15
       0x54160011,  //  0012  LDINT	R5	18
-      0x58180002,  //  0013  LDCONST	R6	K2
+      0x58180003,  //  0013  LDCONST	R6	K3
       0x5C1C0400,  //  0014  MOVE	R7	R2
       0x7C0C0800,  //  0015  CALL	R3	4
       0x80000000,  //  0016  RET	0
@@ -307,26 +310,21 @@ be_local_closure(class_AXP202_battery_present,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_battery_present,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x88040110,  //  0000  GETMBR	R1	R0	K16
+      0x8C040311,  //  0001  GETMET	R1	R1	K17
+      0x880C0112,  //  0002  GETMBR	R3	R0	K18
+      0x58100001,  //  0003  LDCONST	R4	K1
+      0x58140001,  //  0004  LDCONST	R5	K1
       0x7C040800,  //  0005  CALL	R1	4
       0x540A001F,  //  0006  LDINT	R2	32
       0x2C040202,  //  0007  AND	R1	R1	R2
@@ -350,16 +348,13 @@ be_local_closure(class_AXP202_set_chg_current_ma,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(write8),
-    /* K1   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_chg_current_ma,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -367,9 +362,9 @@ be_local_closure(class_AXP202_set_chg_current_ma,   /* name */
       0x04080202,  //  0001  SUB	R2	R1	R2
       0x540E0063,  //  0002  LDINT	R3	100
       0x0C080403,  //  0003  DIV	R2	R2	R3
-      0x8C0C0100,  //  0004  GETMET	R3	R0	K0
+      0x8C0C0104,  //  0004  GETMET	R3	R0	K4
       0x54160032,  //  0005  LDINT	R5	51
-      0x8C180101,  //  0006  GETMET	R6	R0	K1
+      0x8C180105,  //  0006  GETMET	R6	R0	K5
       0x54220032,  //  0007  LDINT	R8	51
       0x7C180400,  //  0008  CALL	R6	2
       0x541E00EF,  //  0009  LDINT	R7	240
@@ -392,33 +387,28 @@ be_local_closure(class_AXP202_set_dcdc_enable,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(3),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_dcdc_enable,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x1C0C0302,  //  0000  EQ	R3	R1	K2
       0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
+      0x8C0C010F,  //  0002  GETMET	R3	R0	K15
       0x54160011,  //  0003  LDINT	R5	18
       0x541A0003,  //  0004  LDINT	R6	4
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0302,  //  0007  EQ	R3	R1	K2
+      0x1C0C0303,  //  0007  EQ	R3	R1	K3
       0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
+      0x8C0C010F,  //  0009  GETMET	R3	R0	K15
       0x54160011,  //  000A  LDINT	R5	18
-      0x58180003,  //  000B  LDCONST	R6	K3
+      0x58180001,  //  000B  LDCONST	R6	K1
       0x5C1C0400,  //  000C  MOVE	R7	R2
       0x7C0C0800,  //  000D  CALL	R3	4
       0x80000000,  //  000E  RET	0
@@ -435,21 +425,17 @@ be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(read8),
-    /* K1   */  be_const_int(3),
-    /* K2   */  be_nested_str(write8),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_chg_led_mode,
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080105,  //  0000  GETMET	R2	R0	K5
       0x54120031,  //  0001  LDINT	R4	50
       0x7C080400,  //  0002  CALL	R2	2
       0x540E00CE,  //  0003  LDINT	R3	207
@@ -457,11 +443,11 @@ be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
       0x54120007,  //  0005  LDINT	R4	8
       0x300C0604,  //  0006  OR	R3	R3	R4
       0x5C080600,  //  0007  MOVE	R2	R3
-      0x2C0C0301,  //  0008  AND	R3	R1	K1
+      0x2C0C0313,  //  0008  AND	R3	R1	K19
       0x54120003,  //  0009  LDINT	R4	4
       0x380C0604,  //  000A  SHL	R3	R3	R4
       0x30080403,  //  000B  OR	R2	R2	R3
-      0x8C0C0102,  //  000C  GETMET	R3	R0	K2
+      0x8C0C0104,  //  000C  GETMET	R3	R0	K4
       0x54160031,  //  000D  LDINT	R5	50
       0x5C180400,  //  000E  MOVE	R6	R2
       0x7C0C0600,  //  000F  CALL	R3	3
@@ -479,26 +465,22 @@ be_local_closure(class_AXP202_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(I2C_Driver),
-    /* K1   */  be_nested_str(init),
-    /* K2   */  be_nested_str(AXP202),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0xB80E2800,  //  0002  GETNGBL	R3	K20
       0x7C040400,  //  0003  CALL	R1	2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x580C0002,  //  0005  LDCONST	R3	K2
+      0x8C040315,  //  0004  GETMET	R1	R1	K21
+      0x580C0016,  //  0005  LDCONST	R3	K22
       0x54120034,  //  0006  LDINT	R4	53
       0x7C040600,  //  0007  CALL	R1	3
       0x80000000,  //  0008  RET	0
@@ -515,22 +497,19 @@ be_local_closure(class_AXP202_set_exten,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(write_bit),
-    /* K1   */  be_const_int(0),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_exten,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08010F,  //  0000  GETMET	R2	R0	K15
       0x54120011,  //  0001  LDINT	R4	18
-      0x58140001,  //  0002  LDCONST	R5	K1
+      0x58140017,  //  0002  LDCONST	R5	K23
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C080800,  //  0004  CALL	R2	4
       0x80000000,  //  0005  RET	0
@@ -547,26 +526,21 @@ be_local_closure(class_AXP202_get_battery_chargin_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_battery_chargin_status,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x88040110,  //  0000  GETMBR	R1	R0	K16
+      0x8C040311,  //  0001  GETMET	R1	R1	K17
+      0x880C0112,  //  0002  GETMBR	R3	R0	K18
+      0x58100001,  //  0003  LDCONST	R4	K1
+      0x58140001,  //  0004  LDCONST	R5	K1
       0x7C040800,  //  0005  CALL	R1	4
       0x80040200,  //  0006  RET	1	R1
     })
@@ -582,39 +556,33 @@ be_local_closure(class_AXP202_set_dc_voltage,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_const_int(3),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(write8),
-    /* K4   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_dc_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
-      0x140C0300,  //  0000  LT	R3	R1	K0
+      0x140C0318,  //  0000  LT	R3	R1	K24
       0x740E0001,  //  0001  JMPT	R3	#0004
-      0x240C0301,  //  0002  GT	R3	R1	K1
+      0x240C0303,  //  0002  GT	R3	R1	K3
       0x780E0000,  //  0003  JMPF	R3	#0005
       0x80000600,  //  0004  RET	0
       0x4C0C0000,  //  0005  LDNIL	R3
       0x541202BB,  //  0006  LDINT	R4	700
       0x14100404,  //  0007  LT	R4	R2	R4
       0x78120001,  //  0008  JMPF	R4	#000B
-      0x580C0002,  //  0009  LDCONST	R3	K2
+      0x580C0017,  //  0009  LDCONST	R3	K23
       0x70020010,  //  000A  JMP		#001C
       0x54120DAB,  //  000B  LDINT	R4	3500
       0x24100404,  //  000C  GT	R4	R2	R4
       0x78120001,  //  000D  JMPF	R4	#0010
       0x540E006F,  //  000E  LDINT	R3	112
       0x7002000B,  //  000F  JMP		#001C
-      0x1C100300,  //  0010  EQ	R4	R1	K0
+      0x1C100318,  //  0010  EQ	R4	R1	K24
       0x78120004,  //  0011  JMPF	R4	#0017
       0x541208E2,  //  0012  LDINT	R4	2275
       0x24100404,  //  0013  GT	R4	R2	R4
@@ -627,12 +595,12 @@ be_local_closure(class_AXP202_set_dc_voltage,   /* name */
       0x0C100805,  //  001A  DIV	R4	R4	R5
       0x5C0C0800,  //  001B  MOVE	R3	R4
       0x54120022,  //  001C  LDINT	R4	35
-      0x1C140301,  //  001D  EQ	R5	R1	K1
+      0x1C140303,  //  001D  EQ	R5	R1	K3
       0x78160000,  //  001E  JMPF	R5	#0020
       0x54120026,  //  001F  LDINT	R4	39
-      0x8C140103,  //  0020  GETMET	R5	R0	K3
+      0x8C140104,  //  0020  GETMET	R5	R0	K4
       0x5C1C0800,  //  0021  MOVE	R7	R4
-      0x8C200104,  //  0022  GETMET	R8	R0	K4
+      0x8C200105,  //  0022  GETMET	R8	R0	K5
       0x5C280800,  //  0023  MOVE	R10	R4
       0x7C200400,  //  0024  CALL	R8	2
       0x5426007F,  //  0025  LDINT	R9	128
@@ -655,23 +623,20 @@ be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_bat_charge_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
       0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x08040319,  //  0003  MUL	R1	R1	K25
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -686,25 +651,21 @@ be_local_closure(class_AXP202_get_temp,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3DCCCCCD),
-    /* K2   */  be_const_real_hex(0x4310B333),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_temp,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E005D,  //  0001  LDINT	R3	94
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x04040302,  //  0004  SUB	R1	R1	K2
+      0x0804031A,  //  0003  MUL	R1	R1	K26
+      0x0404031B,  //  0004  SUB	R1	R1	K27
       0x80040200,  //  0005  RET	1	R1
     })
   )
@@ -719,17 +680,13 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write8),
-    /* K2   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_ldo_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[59]) {  /* code */
@@ -737,7 +694,7 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
       0x240C0403,  //  0001  GT	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
       0x540A000E,  //  0003  LDINT	R2	15
-      0x1C0C0300,  //  0004  EQ	R3	R1	K0
+      0x1C0C0302,  //  0004  EQ	R3	R1	K2
       0x740E0002,  //  0005  JMPT	R3	#0009
       0x540E0003,  //  0006  LDINT	R3	4
       0x1C0C0203,  //  0007  EQ	R3	R1	R3
@@ -747,11 +704,11 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
       0x54120011,  //  000B  LDINT	R4	18
       0x040C0604,  //  000C  SUB	R3	R3	R4
       0x5C080600,  //  000D  MOVE	R2	R3
-      0x1C0C0300,  //  000E  EQ	R3	R1	K0
+      0x1C0C0302,  //  000E  EQ	R3	R1	K2
       0x780E000D,  //  000F  JMPF	R3	#001E
-      0x8C0C0101,  //  0010  GETMET	R3	R0	K1
+      0x8C0C0104,  //  0010  GETMET	R3	R0	K4
       0x54160027,  //  0011  LDINT	R5	40
-      0x8C180102,  //  0012  GETMET	R6	R0	K2
+      0x8C180105,  //  0012  GETMET	R6	R0	K5
       0x54220027,  //  0013  LDINT	R8	40
       0x7C180400,  //  0014  CALL	R6	2
       0x541E000E,  //  0015  LDINT	R7	15
@@ -763,9 +720,9 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
       0x30180C07,  //  001B  OR	R6	R6	R7
       0x7C0C0600,  //  001C  CALL	R3	3
       0x7002000A,  //  001D  JMP		#0029
-      0x8C0C0101,  //  001E  GETMET	R3	R0	K1
+      0x8C0C0104,  //  001E  GETMET	R3	R0	K4
       0x54160027,  //  001F  LDINT	R5	40
-      0x8C180102,  //  0020  GETMET	R6	R0	K2
+      0x8C180105,  //  0020  GETMET	R6	R0	K5
       0x54220027,  //  0021  LDINT	R8	40
       0x7C180400,  //  0022  CALL	R6	2
       0x541E00EF,  //  0023  LDINT	R7	240
@@ -780,9 +737,9 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
       0x5412001B,  //  002C  LDINT	R4	28
       0x040C0604,  //  002D  SUB	R3	R3	R4
       0x5C080600,  //  002E  MOVE	R2	R3
-      0x8C0C0101,  //  002F  GETMET	R3	R0	K1
+      0x8C0C0104,  //  002F  GETMET	R3	R0	K4
       0x54160027,  //  0030  LDINT	R5	40
-      0x8C180102,  //  0031  GETMET	R6	R0	K2
+      0x8C180105,  //  0031  GETMET	R6	R0	K5
       0x54220028,  //  0032  LDINT	R8	41
       0x7C180400,  //  0033  CALL	R6	2
       0x541E007F,  //  0034  LDINT	R7	128
@@ -805,26 +762,22 @@ be_local_closure(class_AXP202_set_limiting_off,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(write8),
-    /* K1   */  be_nested_str(read8),
-    /* K2   */  be_const_int(3),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_set_limiting_off,
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040104,  //  0000  GETMET	R1	R0	K4
       0x540E002F,  //  0001  LDINT	R3	48
-      0x8C100101,  //  0002  GETMET	R4	R0	K1
+      0x8C100105,  //  0002  GETMET	R4	R0	K5
       0x541A002F,  //  0003  LDINT	R6	48
       0x7C100400,  //  0004  CALL	R4	2
-      0x30100902,  //  0005  OR	R4	R4	K2
+      0x30100903,  //  0005  OR	R4	R4	K3
       0x7C040600,  //  0006  CALL	R1	3
       0x80000000,  //  0007  RET	0
     })
@@ -840,27 +793,21 @@ be_local_closure(class_AXP202_get_input_power_status,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_get_input_power_status,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
+      0x88040110,  //  0000  GETMBR	R1	R0	K16
+      0x8C040311,  //  0001  GETMET	R1	R1	K17
+      0x880C0112,  //  0002  GETMBR	R3	R0	K18
+      0x58100017,  //  0003  LDCONST	R4	K23
+      0x58140001,  //  0004  LDCONST	R5	K1
       0x7C040800,  //  0005  CALL	R1	4
       0x80040200,  //  0006  RET	1	R1
     })

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_driver.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_driver.h
@@ -3,6 +3,32 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'I2C_Driver' ktab size: 22, total: 60 (saved 304 bytes)
+static const bvalue be_ktab_class_I2C_Driver[22] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_const_int(1),
+  /* K2   */  be_nested_str(write8),
+  /* K3   */  be_nested_str(read8),
+  /* K4   */  be_nested_str(wire),
+  /* K5   */  be_nested_str(read_bytes),
+  /* K6   */  be_nested_str(addr),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_const_int(2),
+  /* K9   */  be_const_int(3),
+  /* K10  */  be_const_int(3),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str(tasmota),
+  /* K13  */  be_nested_str(i2c_enabled),
+  /* K14  */  be_nested_str(wire_scan),
+  /* K15  */  be_nested_str(function),
+  /* K16  */  be_nested_str(name),
+  /* K17  */  be_nested_str(I2C_X3A),
+  /* K18  */  be_nested_str(detected_X20on_X20bus),
+  /* K19  */  be_nested_str(bus),
+  /* K20  */  be_nested_str(write),
+  /* K21  */  be_nested_str(read),
+};
+
 
 extern const bclass be_class_I2C_Driver;
 
@@ -13,18 +39,13 @@ be_local_closure(class_I2C_Driver_write_bit,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str(write8),
-    /* K3   */  be_nested_str(read8),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_write_bit,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
@@ -67,42 +88,34 @@ be_local_closure(class_I2C_Driver_read32,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_const_int(3),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read32,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
       0x541A0003,  //  0004  LDINT	R6	4
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0503,  //  0006  GETIDX	R3	R2	K3
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x54120017,  //  0007  LDINT	R4	24
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100504,  //  0009  GETIDX	R4	R2	K4
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x5416000F,  //  000A  LDINT	R5	16
       0x38100805,  //  000B  SHL	R4	R4	R5
       0x000C0604,  //  000C  ADD	R3	R3	R4
-      0x94100505,  //  000D  GETIDX	R4	R2	K5
+      0x94100508,  //  000D  GETIDX	R4	R2	K8
       0x54160007,  //  000E  LDINT	R5	8
       0x38100805,  //  000F  SHL	R4	R4	R5
       0x000C0604,  //  0010  ADD	R3	R3	R4
-      0x94100506,  //  0011  GETIDX	R4	R2	K6
+      0x94100509,  //  0011  GETIDX	R4	R2	K9
       0x000C0604,  //  0012  ADD	R3	R3	R4
       0x80040600,  //  0013  RET	1	R3
     })
@@ -118,33 +131,26 @@ be_local_closure(class_I2C_Driver_read13,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read13,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x58180008,  //  0004  LDCONST	R6	K8
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0504,  //  0006  GETIDX	R3	R2	K4
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x54120004,  //  0007  LDINT	R4	5
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100505,  //  0009  GETIDX	R4	R2	K5
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x000C0604,  //  000A  ADD	R3	R3	R4
       0x80040600,  //  000B  RET	1	R3
     })
@@ -160,38 +166,30 @@ be_local_closure(class_I2C_Driver_read24,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_const_int(2),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read24,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x5818000A,  //  0004  LDCONST	R6	K10
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0504,  //  0006  GETIDX	R3	R2	K4
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x5412000F,  //  0007  LDINT	R4	16
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100505,  //  0009  GETIDX	R4	R2	K5
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x54160007,  //  000A  LDINT	R5	8
       0x38100805,  //  000B  SHL	R4	R4	R5
       0x000C0604,  //  000C  ADD	R3	R3	R4
-      0x94100506,  //  000D  GETIDX	R4	R2	K6
+      0x9410050B,  //  000D  GETIDX	R4	R2	K11
       0x000C0604,  //  000E  ADD	R3	R3	R4
       0x80040600,  //  000F  RET	1	R3
     })
@@ -207,33 +205,26 @@ be_local_closure(class_I2C_Driver_read14,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read14,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x58180008,  //  0004  LDCONST	R6	K8
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0504,  //  0006  GETIDX	R3	R2	K4
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x54120005,  //  0007  LDINT	R4	6
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100505,  //  0009  GETIDX	R4	R2	K5
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x000C0604,  //  000A  ADD	R3	R3	R4
       0x80040600,  //  000B  RET	1	R3
     })
@@ -249,69 +240,58 @@ be_local_closure(class_I2C_Driver_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    /* K1   */  be_nested_str(i2c_enabled),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_nested_str(wire),
-    /* K4   */  be_nested_str(wire_scan),
-    /* K5   */  be_nested_str(function),
-    /* K6   */  be_nested_str(name),
-    /* K7   */  be_nested_str(I2C_X3A),
-    /* K8   */  be_nested_str(detected_X20on_X20bus),
-    /* K9   */  be_nested_str(bus),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x20100604,  //  0001  NE	R4	R3	R4
       0x78120005,  //  0002  JMPF	R4	#0009
-      0xB8120000,  //  0003  GETNGBL	R4	K0
-      0x8C100901,  //  0004  GETMET	R4	R4	K1
+      0xB8121800,  //  0003  GETNGBL	R4	K12
+      0x8C10090D,  //  0004  GETMET	R4	R4	K13
       0x5C180600,  //  0005  MOVE	R6	R3
       0x7C100400,  //  0006  CALL	R4	2
       0x74120000,  //  0007  JMPT	R4	#0009
       0x80000800,  //  0008  RET	0
-      0x90020402,  //  0009  SETMBR	R0	K2	R2
-      0xB8120000,  //  000A  GETNGBL	R4	K0
-      0x8C100904,  //  000B  GETMET	R4	R4	K4
-      0x88180102,  //  000C  GETMBR	R6	R0	K2
+      0x90020C02,  //  0009  SETMBR	R0	K6	R2
+      0xB8121800,  //  000A  GETNGBL	R4	K12
+      0x8C10090E,  //  000B  GETMET	R4	R4	K14
+      0x88180106,  //  000C  GETMBR	R6	R0	K6
       0x7C100400,  //  000D  CALL	R4	2
-      0x90020604,  //  000E  SETMBR	R0	K3	R4
-      0x88100103,  //  000F  GETMBR	R4	R0	K3
+      0x90020804,  //  000E  SETMBR	R0	K4	R4
+      0x88100104,  //  000F  GETMBR	R4	R0	K4
       0x78120019,  //  0010  JMPF	R4	#002B
       0x60100004,  //  0011  GETGBL	R4	G4
       0x5C140200,  //  0012  MOVE	R5	R1
       0x7C100200,  //  0013  CALL	R4	1
-      0x1C100905,  //  0014  EQ	R4	R4	K5
+      0x1C10090F,  //  0014  EQ	R4	R4	K15
       0x78120004,  //  0015  JMPF	R4	#001B
       0x5C100200,  //  0016  MOVE	R4	R1
       0x5C140000,  //  0017  MOVE	R5	R0
       0x7C100200,  //  0018  CALL	R4	1
-      0x90020C04,  //  0019  SETMBR	R0	K6	R4
+      0x90022004,  //  0019  SETMBR	R0	K16	R4
       0x70020000,  //  001A  JMP		#001C
-      0x90020C01,  //  001B  SETMBR	R0	K6	R1
-      0x88100106,  //  001C  GETMBR	R4	R0	K6
+      0x90022001,  //  001B  SETMBR	R0	K16	R1
+      0x88100110,  //  001C  GETMBR	R4	R0	K16
       0x4C140000,  //  001D  LDNIL	R5
       0x1C100805,  //  001E  EQ	R4	R4	R5
       0x78120001,  //  001F  JMPF	R4	#0022
       0x4C100000,  //  0020  LDNIL	R4
-      0x90020604,  //  0021  SETMBR	R0	K3	R4
-      0x88100103,  //  0022  GETMBR	R4	R0	K3
+      0x90020804,  //  0021  SETMBR	R0	K4	R4
+      0x88100104,  //  0022  GETMBR	R4	R0	K4
       0x78120006,  //  0023  JMPF	R4	#002B
       0x60100001,  //  0024  GETGBL	R4	G1
-      0x58140007,  //  0025  LDCONST	R5	K7
-      0x88180106,  //  0026  GETMBR	R6	R0	K6
-      0x581C0008,  //  0027  LDCONST	R7	K8
-      0x88200103,  //  0028  GETMBR	R8	R0	K3
-      0x88201109,  //  0029  GETMBR	R8	R8	K9
+      0x58140011,  //  0025  LDCONST	R5	K17
+      0x88180110,  //  0026  GETMBR	R6	R0	K16
+      0x581C0012,  //  0027  LDCONST	R7	K18
+      0x88200104,  //  0028  GETMBR	R8	R0	K4
+      0x88201113,  //  0029  GETMBR	R8	R8	K19
       0x7C100800,  //  002A  CALL	R4	4
       0x80000000,  //  002B  RET	0
     })
@@ -327,27 +307,22 @@ be_local_closure(class_I2C_Driver_write8,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(write),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_write8,
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x880C0104,  //  0000  GETMBR	R3	R0	K4
+      0x8C0C0714,  //  0001  GETMET	R3	R3	K20
+      0x88140106,  //  0002  GETMBR	R5	R0	K6
       0x5C180200,  //  0003  MOVE	R6	R1
       0x5C1C0400,  //  0004  MOVE	R7	R2
-      0x58200003,  //  0005  LDCONST	R8	K3
+      0x58200001,  //  0005  LDCONST	R8	K1
       0x7C0C0A00,  //  0006  CALL	R3	5
       0x80040600,  //  0007  RET	1	R3
     })
@@ -363,26 +338,21 @@ be_local_closure(class_I2C_Driver_read8,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read8,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080515,  //  0001  GETMET	R2	R2	K21
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x58180007,  //  0004  LDCONST	R6	K7
       0x7C080800,  //  0005  CALL	R2	4
       0x80040400,  //  0006  RET	1	R2
     })
@@ -398,33 +368,26 @@ be_local_closure(class_I2C_Driver_read12,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read12,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x58180008,  //  0004  LDCONST	R6	K8
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0504,  //  0006  GETIDX	R3	R2	K4
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x54120003,  //  0007  LDINT	R4	4
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100505,  //  0009  GETIDX	R4	R2	K5
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x000C0604,  //  000A  ADD	R3	R3	R4
       0x80040600,  //  000B  RET	1	R3
     })
@@ -440,33 +403,26 @@ be_local_closure(class_I2C_Driver_read16,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read_bytes),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_I2C_Driver,     /* shared constants */
     &be_const_str_read16,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
       0x5C140200,  //  0003  MOVE	R5	R1
-      0x58180003,  //  0004  LDCONST	R6	K3
+      0x58180008,  //  0004  LDCONST	R6	K8
       0x7C080800,  //  0005  CALL	R2	4
-      0x940C0504,  //  0006  GETIDX	R3	R2	K4
+      0x940C0500,  //  0006  GETIDX	R3	R2	K0
       0x54120007,  //  0007  LDINT	R4	8
       0x380C0604,  //  0008  SHL	R3	R3	R4
-      0x94100505,  //  0009  GETIDX	R4	R2	K5
+      0x94100507,  //  0009  GETIDX	R4	R2	K7
       0x000C0604,  //  000A  ADD	R3	R3	R4
       0x80040600,  //  000B  RET	1	R3
     })

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_ft3663.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_ft3663.h
@@ -3,6 +3,32 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'FT3663' ktab size: 22, total: 25 (saved 24 bytes)
+static const bvalue be_ktab_class_FT3663[22] = {
+  /* K0   */  be_nested_str(wire),
+  /* K1   */  be_nested_str(ts_loop),
+  /* K2   */  be_nested_str(init),
+  /* K3   */  be_nested_str(FT3663),
+  /* K4   */  be_nested_str(read8),
+  /* K5   */  be_nested_str(tasmota),
+  /* K6   */  be_nested_str(log),
+  /* K7   */  be_nested_str(I2C_X3A_X20ignoring_X20address_X200x38_X2C_X20not_X20FT3663),
+  /* K8   */  be_const_int(2),
+  /* K9   */  be_nested_str(TS_X20_X3A_X20FT3663_X20Touch_X20Screen_X20detected),
+  /* K10  */  be_nested_str(write8),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str(add_driver),
+  /* K13  */  be_nested_str(display),
+  /* K14  */  be_nested_str(read_bytes),
+  /* K15  */  be_nested_str(addr),
+  /* K16  */  be_const_int(2),
+  /* K17  */  be_const_int(3),
+  /* K18  */  be_nested_str(gest_id_codes),
+  /* K19  */  be_nested_str(find),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_nested_str(touch_update),
+};
+
 
 extern const bclass be_class_FT3663;
 
@@ -13,16 +39,13 @@ be_local_closure(class_FT3663_every_100ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(ts_loop),
-    }),
+    &be_ktab_class_FT3663,     /* shared constants */
     &be_const_str_every_100ms,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,42 +67,29 @@ be_local_closure(class_FT3663_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(init),
-    /* K1   */  be_nested_str(FT3663),
-    /* K2   */  be_nested_str(wire),
-    /* K3   */  be_nested_str(read8),
-    /* K4   */  be_nested_str(tasmota),
-    /* K5   */  be_nested_str(log),
-    /* K6   */  be_nested_str(I2C_X3A_X20ignoring_X20address_X200x38_X2C_X20not_X20FT3663),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str(TS_X20_X3A_X20FT3663_X20Touch_X20Screen_X20detected),
-    /* K9   */  be_nested_str(write8),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str(add_driver),
-    }),
+    &be_ktab_class_FT3663,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
-      0x580C0001,  //  0004  LDCONST	R3	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x580C0003,  //  0004  LDCONST	R3	K3
       0x54120037,  //  0005  LDINT	R4	56
       0x7C040600,  //  0006  CALL	R1	3
-      0x88040102,  //  0007  GETMBR	R1	R0	K2
+      0x88040100,  //  0007  GETMBR	R1	R0	K0
       0x78060027,  //  0008  JMPF	R1	#0031
-      0x8C040103,  //  0009  GETMET	R1	R0	K3
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
       0x540E00A7,  //  000A  LDINT	R3	168
       0x7C040400,  //  000B  CALL	R1	2
-      0x8C080103,  //  000C  GETMET	R2	R0	K3
+      0x8C080104,  //  000C  GETMET	R2	R0	K4
       0x541200A2,  //  000D  LDINT	R4	163
       0x7C080400,  //  000E  CALL	R2	2
       0x540E0010,  //  000F  LDINT	R3	17
@@ -88,32 +98,32 @@ be_local_closure(class_FT3663_init,   /* name */
       0x540E0063,  //  0012  LDINT	R3	100
       0x200C0403,  //  0013  NE	R3	R2	R3
       0x780E0007,  //  0014  JMPF	R3	#001D
-      0xB80E0800,  //  0015  GETNGBL	R3	K4
-      0x8C0C0705,  //  0016  GETMET	R3	R3	K5
-      0x58140006,  //  0017  LDCONST	R5	K6
-      0x58180007,  //  0018  LDCONST	R6	K7
+      0xB80E0A00,  //  0015  GETNGBL	R3	K5
+      0x8C0C0706,  //  0016  GETMET	R3	R3	K6
+      0x58140007,  //  0017  LDCONST	R5	K7
+      0x58180008,  //  0018  LDCONST	R6	K8
       0x7C0C0600,  //  0019  CALL	R3	3
       0x4C0C0000,  //  001A  LDNIL	R3
-      0x90020403,  //  001B  SETMBR	R0	K2	R3
+      0x90020003,  //  001B  SETMBR	R0	K0	R3
       0x80000600,  //  001C  RET	0
-      0xB80E0800,  //  001D  GETNGBL	R3	K4
-      0x8C0C0705,  //  001E  GETMET	R3	R3	K5
-      0x58140008,  //  001F  LDCONST	R5	K8
+      0xB80E0A00,  //  001D  GETNGBL	R3	K5
+      0x8C0C0706,  //  001E  GETMET	R3	R3	K6
+      0x58140009,  //  001F  LDCONST	R5	K9
       0x7C0C0400,  //  0020  CALL	R3	2
-      0x8C0C0109,  //  0021  GETMET	R3	R0	K9
-      0x5814000A,  //  0022  LDCONST	R5	K10
-      0x5818000A,  //  0023  LDCONST	R6	K10
+      0x8C0C010A,  //  0021  GETMET	R3	R0	K10
+      0x5814000B,  //  0022  LDCONST	R5	K11
+      0x5818000B,  //  0023  LDCONST	R6	K11
       0x7C0C0600,  //  0024  CALL	R3	3
-      0x8C0C0109,  //  0025  GETMET	R3	R0	K9
+      0x8C0C010A,  //  0025  GETMET	R3	R0	K10
       0x5416007F,  //  0026  LDINT	R5	128
       0x541A0015,  //  0027  LDINT	R6	22
       0x7C0C0600,  //  0028  CALL	R3	3
-      0x8C0C0109,  //  0029  GETMET	R3	R0	K9
+      0x8C0C010A,  //  0029  GETMET	R3	R0	K10
       0x54160087,  //  002A  LDINT	R5	136
       0x541A000D,  //  002B  LDINT	R6	14
       0x7C0C0600,  //  002C  CALL	R3	3
-      0xB80E0800,  //  002D  GETNGBL	R3	K4
-      0x8C0C070B,  //  002E  GETMET	R3	R3	K11
+      0xB80E0A00,  //  002D  GETNGBL	R3	K5
+      0x8C0C070C,  //  002E  GETMET	R3	R3	K12
       0x5C140000,  //  002F  MOVE	R5	R0
       0x7C0C0400,  //  0030  CALL	R3	2
       0x80000000,  //  0031  RET	0
@@ -130,42 +140,30 @@ be_local_closure(class_FT3663_ts_loop,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(display),
-    /* K2   */  be_nested_str(read_bytes),
-    /* K3   */  be_nested_str(addr),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str(gest_id_codes),
-    /* K8   */  be_nested_str(find),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str(touch_update),
-    }),
+    &be_ktab_class_FT3663,     /* shared constants */
     &be_const_str_ts_loop,
     &be_const_str_solidified,
     ( &(const binstruction[63]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x74060000,  //  0001  JMPT	R1	#0003
       0x80000200,  //  0002  RET	0
-      0xA4060200,  //  0003  IMPORT	R1	K1
+      0xA4061A00,  //  0003  IMPORT	R1	K13
       0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x58140004,  //  0007  LDCONST	R5	K4
+      0x8C08050E,  //  0005  GETMET	R2	R2	K14
+      0x8810010F,  //  0006  GETMBR	R4	R0	K15
+      0x5814000B,  //  0007  LDCONST	R5	K11
       0x541A000E,  //  0008  LDINT	R6	15
       0x7C080800,  //  0009  CALL	R2	4
-      0x940C0505,  //  000A  GETIDX	R3	R2	K5
+      0x940C0510,  //  000A  GETIDX	R3	R2	K16
       0x5412000E,  //  000B  LDINT	R4	15
       0x2C0C0604,  //  000C  AND	R3	R3	R4
-      0x94100506,  //  000D  GETIDX	R4	R2	K6
+      0x94100511,  //  000D  GETIDX	R4	R2	K17
       0x5416000E,  //  000E  LDINT	R5	15
       0x2C100805,  //  000F  AND	R4	R4	R5
       0x54160007,  //  0010  LDINT	R5	8
@@ -184,7 +182,7 @@ be_local_closure(class_FT3663_ts_loop,   /* name */
       0x30140A06,  //  001D  OR	R5	R5	R6
       0x541A0006,  //  001E  LDINT	R6	7
       0x94180406,  //  001F  GETIDX	R6	R2	R6
-      0x941C0506,  //  0020  GETIDX	R7	R2	K6
+      0x941C0511,  //  0020  GETIDX	R7	R2	K17
       0x54220008,  //  0021  LDINT	R8	9
       0x2C1C0E08,  //  0022  AND	R7	R7	R8
       0x54220007,  //  0023  LDINT	R8	8
@@ -203,12 +201,12 @@ be_local_closure(class_FT3663_ts_loop,   /* name */
       0x30201009,  //  0030  OR	R8	R8	R9
       0x5426000C,  //  0031  LDINT	R9	13
       0x94240409,  //  0032  GETIDX	R9	R2	R9
-      0x88280107,  //  0033  GETMBR	R10	R0	K7
-      0x8C281508,  //  0034  GETMET	R10	R10	K8
-      0x94300509,  //  0035  GETIDX	R12	R2	K9
-      0x58340004,  //  0036  LDCONST	R13	K4
+      0x88280112,  //  0033  GETMBR	R10	R0	K18
+      0x8C281513,  //  0034  GETMET	R10	R10	K19
+      0x94300514,  //  0035  GETIDX	R12	R2	K20
+      0x5834000B,  //  0036  LDCONST	R13	K11
       0x7C280600,  //  0037  CALL	R10	3
-      0x8C2C030A,  //  0038  GETMET	R11	R1	K10
+      0x8C2C0315,  //  0038  GETMET	R11	R1	K21
       0x5C340600,  //  0039  MOVE	R13	R3
       0x5C380800,  //  003A  MOVE	R14	R4
       0x5C3C0A00,  //  003B  MOVE	R15	R5

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -3,8 +3,30 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-
+extern const bclass be_class_Leds_segment;
 extern const bclass be_class_Leds;
+extern const bclass be_class_Leds_matrix;
+// compact class 'Leds_segment' ktab size: 17, total: 34 (saved 136 bytes)
+static const bvalue be_ktab_class_Leds_segment[17] = {
+  /* K0   */  be_nested_str(offset),
+  /* K1   */  be_nested_str(bri),
+  /* K2   */  be_nested_str(strip),
+  /* K3   */  be_nested_str(call_native),
+  /* K4   */  be_nested_str(to_gamma),
+  /* K5   */  be_nested_str(leds),
+  /* K6   */  be_nested_str(dirty),
+  /* K7   */  be_nested_str(can_show),
+  /* K8   */  be_nested_str(set_pixel_color),
+  /* K9   */  be_nested_str(is_dirty),
+  /* K10  */  be_nested_str(clear_to),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str(show),
+  /* K13  */  be_nested_str(get_pixel_color),
+  /* K14  */  be_nested_str(offseta),
+  /* K15  */  be_nested_str(pixel_size),
+  /* K16  */  be_const_int(0),
+};
+
 
 extern const bclass be_class_Leds_segment;
 
@@ -15,15 +37,13 @@ be_local_closure(class_Leds_segment_pixel_offset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(offset),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_pixel_offset,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -42,36 +62,29 @@ be_local_closure(class_Leds_segment_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    /* K1   */  be_nested_str(strip),
-    /* K2   */  be_nested_str(call_native),
-    /* K3   */  be_nested_str(to_gamma),
-    /* K4   */  be_nested_str(offset),
-    /* K5   */  be_nested_str(leds),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_clear_to,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0005  GETMET	R3	R3	K2
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
       0x54160008,  //  0006  LDINT	R5	9
-      0x88180101,  //  0007  GETMBR	R6	R0	K1
-      0x8C180D03,  //  0008  GETMET	R6	R6	K3
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x8C180D04,  //  0008  GETMET	R6	R6	K4
       0x5C200200,  //  0009  MOVE	R8	R1
       0x5C240400,  //  000A  MOVE	R9	R2
       0x7C180600,  //  000B  CALL	R6	3
-      0x881C0104,  //  000C  GETMBR	R7	R0	K4
+      0x881C0100,  //  000C  GETMBR	R7	R0	K0
       0x88200105,  //  000D  GETMBR	R8	R0	K5
       0x7C0C0A00,  //  000E  CALL	R3	5
       0x80000000,  //  000F  RET	0
@@ -88,19 +101,17 @@ be_local_closure(class_Leds_segment_pixel_count,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(leds),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_pixel_count,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -115,13 +126,13 @@ be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_pixels_buffer,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -140,21 +151,18 @@ be_local_closure(class_Leds_segment_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(dirty),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040306,  //  0001  GETMET	R1	R1	K6
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -170,21 +178,18 @@ be_local_closure(class_Leds_segment_can_show,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(can_show),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_can_show,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -200,28 +205,23 @@ be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    /* K1   */  be_nested_str(strip),
-    /* K2   */  be_nested_str(set_pixel_color),
-    /* K3   */  be_nested_str(offset),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_set_pixel_color,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x1C100604,  //  0001  EQ	R4	R3	R4
       0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
-      0x88100101,  //  0004  GETMBR	R4	R0	K1
-      0x8C100902,  //  0005  GETMET	R4	R4	K2
-      0x88180103,  //  0006  GETMBR	R6	R0	K3
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x8C100908,  //  0005  GETMET	R4	R4	K8
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
       0x00180206,  //  0007  ADD	R6	R1	R6
       0x5C1C0400,  //  0008  MOVE	R7	R2
       0x5C200600,  //  0009  MOVE	R8	R3
@@ -240,21 +240,18 @@ be_local_closure(class_Leds_segment_is_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(is_dirty),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_is_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -270,24 +267,20 @@ be_local_closure(class_Leds_segment_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(clear_to),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(show),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_clear,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
+      0x580C000B,  //  0001  LDCONST	R3	K11
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x8C04010C,  //  0003  GETMET	R1	R0	K12
       0x7C040200,  //  0004  CALL	R1	1
       0x80000000,  //  0005  RET	0
     })
@@ -303,13 +296,13 @@ be_local_closure(class_Leds_segment_begin,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_begin,
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -327,23 +320,19 @@ be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(get_pixel_color),
-    /* K2   */  be_nested_str(offseta),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_get_pixel_color,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C08050D,  //  0001  GETMET	R2	R2	K13
+      0x8810010E,  //  0002  GETMBR	R4	R0	K14
       0x00100204,  //  0003  ADD	R4	R1	R4
       0x7C080400,  //  0004  CALL	R2	2
       0x80040400,  //  0005  RET	1	R2
@@ -360,21 +349,18 @@ be_local_closure(class_Leds_segment_pixel_size,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(pixel_size),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_pixel_size,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -390,29 +376,25 @@ be_local_closure(class_Leds_segment_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(offset),
-    /* K2   */  be_nested_str(leds),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020401,  //  0000  SETMBR	R0	K2	R1
       0x60100009,  //  0001  GETGBL	R4	G9
       0x5C140400,  //  0002  MOVE	R5	R2
       0x7C100200,  //  0003  CALL	R4	1
-      0x90020204,  //  0004  SETMBR	R0	K1	R4
+      0x90020004,  //  0004  SETMBR	R0	K0	R4
       0x60100009,  //  0005  GETGBL	R4	G9
       0x5C140600,  //  0006  MOVE	R5	R3
       0x7C100200,  //  0007  CALL	R4	1
-      0x90020404,  //  0008  SETMBR	R0	K2	R4
+      0x90020A04,  //  0008  SETMBR	R0	K5	R4
       0x80000000,  //  0009  RET	0
     })
   )
@@ -427,19 +409,13 @@ be_local_closure(class_Leds_segment_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(offset),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(leds),
-    /* K3   */  be_nested_str(strip),
-    /* K4   */  be_nested_str(show),
-    }),
+    &be_ktab_class_Leds_segment,     /* shared constants */
     &be_const_str_show,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
@@ -448,15 +424,15 @@ be_local_closure(class_Leds_segment_show,   /* name */
       0x7C080200,  //  0002  CALL	R2	1
       0x740A0007,  //  0003  JMPT	R2	#000C
       0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x1C080501,  //  0005  EQ	R2	R2	K1
+      0x1C080510,  //  0005  EQ	R2	R2	K16
       0x780A0007,  //  0006  JMPF	R2	#000F
-      0x88080102,  //  0007  GETMBR	R2	R0	K2
-      0x880C0103,  //  0008  GETMBR	R3	R0	K3
-      0x880C0702,  //  0009  GETMBR	R3	R3	K2
+      0x88080105,  //  0007  GETMBR	R2	R0	K5
+      0x880C0102,  //  0008  GETMBR	R3	R0	K2
+      0x880C0705,  //  0009  GETMBR	R3	R3	K5
       0x1C080403,  //  000A  EQ	R2	R2	R3
       0x780A0002,  //  000B  JMPF	R2	#000F
-      0x88080103,  //  000C  GETMBR	R2	R0	K3
-      0x8C080504,  //  000D  GETMET	R2	R2	K4
+      0x88080102,  //  000C  GETMBR	R2	R0	K2
+      0x8C08050C,  //  000D  GETMET	R2	R2	K12
       0x7C080200,  //  000E  CALL	R2	1
       0x80000000,  //  000F  RET	0
     })
@@ -493,623 +469,34 @@ be_local_class(Leds_segment,
     })),
     (bstring*) &be_const_str_Leds_segment
 );
-
-/********************************************************************
-** Solidified function: create_segment
-********************************************************************/
-be_local_closure(class_Leds_create_segment,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(leds),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(value_error),
-    /* K3   */  be_nested_str(out_X20of_X20range),
-    /* K4   */  be_const_class(be_class_Leds_segment),
-    }),
-    &be_const_str_create_segment,
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x600C0009,  //  0000  GETGBL	R3	G9
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x60100009,  //  0003  GETGBL	R4	G9
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C100200,  //  0005  CALL	R4	1
-      0x000C0604,  //  0006  ADD	R3	R3	R4
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x240C0604,  //  0008  GT	R3	R3	R4
-      0x740E0003,  //  0009  JMPT	R3	#000E
-      0x140C0301,  //  000A  LT	R3	R1	K1
-      0x740E0001,  //  000B  JMPT	R3	#000E
-      0x140C0501,  //  000C  LT	R3	R2	K1
-      0x780E0000,  //  000D  JMPF	R3	#000F
-      0xB0060503,  //  000E  RAISE	1	K2	K3
-      0x580C0004,  //  000F  LDCONST	R3	K4
-      0xB4000004,  //  0010  CLASS	K4
-      0x5C100600,  //  0011  MOVE	R4	R3
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C100600,  //  0015  CALL	R4	3
-      0x80040800,  //  0016  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bri
-********************************************************************/
-be_local_closure(class_Leds_set_bri,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(bri),
-    }),
-    &be_const_str_set_bri,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x14080300,  //  0000  LT	R2	R1	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x58040000,  //  0002  LDCONST	R1	K0
-      0x540A00FE,  //  0003  LDINT	R2	255
-      0x24080202,  //  0004  GT	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540600FE,  //  0006  LDINT	R1	255
-      0x90020201,  //  0007  SETMBR	R0	K1	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin
-********************************************************************/
-be_local_closure(class_Leds_begin,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    /* K1   */  be_const_int(1),
-    }),
-    &be_const_str_begin,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(class_Leds_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(clear_to),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(show),
-    }),
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Leds_init,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str(gpio),
-    /* K1   */  be_nested_str(gamma),
-    /* K2   */  be_nested_str(pin),
-    /* K3   */  be_nested_str(WS2812),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str(ctor),
-    /* K6   */  be_nested_str(leds),
-    /* K7   */  be_nested_str(pixel_count),
-    /* K8   */  be_nested_str(light),
-    /* K9   */  be_nested_str(bri),
-    /* K10  */  be_nested_str(get),
-    /* K11  */  be_nested_str(_p),
-    /* K12  */  be_nested_str(internal_error),
-    /* K13  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
-    /* K14  */  be_nested_str(begin),
-    }),
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x50180200,  //  0001  LDBOOL	R6	1	0
-      0x90020206,  //  0002  SETMBR	R0	K1	R6
-      0x4C180000,  //  0003  LDNIL	R6
-      0x1C180406,  //  0004  EQ	R6	R2	R6
-      0x741A0005,  //  0005  JMPT	R6	#000C
-      0x8C180B02,  //  0006  GETMET	R6	R5	K2
-      0x88200B03,  //  0007  GETMBR	R8	R5	K3
-      0x58240004,  //  0008  LDCONST	R9	K4
-      0x7C180600,  //  0009  CALL	R6	3
-      0x1C180406,  //  000A  EQ	R6	R2	R6
-      0x781A000A,  //  000B  JMPF	R6	#0017
-      0x8C180105,  //  000C  GETMET	R6	R0	K5
-      0x7C180200,  //  000D  CALL	R6	1
-      0x8C180107,  //  000E  GETMET	R6	R0	K7
-      0x7C180200,  //  000F  CALL	R6	1
-      0x90020C06,  //  0010  SETMBR	R0	K6	R6
-      0xA41A1000,  //  0011  IMPORT	R6	K8
-      0x8C1C0D0A,  //  0012  GETMET	R7	R6	K10
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x941C0F09,  //  0014  GETIDX	R7	R7	K9
-      0x90021207,  //  0015  SETMBR	R0	K9	R7
-      0x7002000B,  //  0016  JMP		#0023
-      0x60180009,  //  0017  GETGBL	R6	G9
-      0x5C1C0200,  //  0018  MOVE	R7	R1
-      0x7C180200,  //  0019  CALL	R6	1
-      0x90020C06,  //  001A  SETMBR	R0	K6	R6
-      0x541A007E,  //  001B  LDINT	R6	127
-      0x90021206,  //  001C  SETMBR	R0	K9	R6
-      0x8C180105,  //  001D  GETMET	R6	R0	K5
-      0x88200106,  //  001E  GETMBR	R8	R0	K6
-      0x5C240400,  //  001F  MOVE	R9	R2
-      0x5C280600,  //  0020  MOVE	R10	R3
-      0x5C2C0800,  //  0021  MOVE	R11	R4
-      0x7C180A00,  //  0022  CALL	R6	5
-      0x8818010B,  //  0023  GETMBR	R6	R0	K11
-      0x4C1C0000,  //  0024  LDNIL	R7
-      0x1C180C07,  //  0025  EQ	R6	R6	R7
-      0x781A0000,  //  0026  JMPF	R6	#0028
-      0xB006190D,  //  0027  RAISE	1	K12	K13
-      0x8C18010E,  //  0028  GETMET	R6	R0	K14
-      0x7C180200,  //  0029  CALL	R6	1
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: to_gamma
-********************************************************************/
-be_local_closure(class_Leds_to_gamma,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    /* K1   */  be_nested_str(apply_bri_gamma),
-    /* K2   */  be_nested_str(gamma),
-    }),
-    &be_const_str_to_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x8C0C0101,  //  0004  GETMET	R3	R0	K1
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x881C0102,  //  0007  GETMBR	R7	R0	K2
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x80040600,  //  0009  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show
-********************************************************************/
-be_local_closure(class_Leds_show,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    /* K1   */  be_const_int(2),
-    }),
-    &be_const_str_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_count
-********************************************************************/
-be_local_closure(class_Leds_pixel_count,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    }),
-    &be_const_str_pixel_count,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0007,  //  0001  LDINT	R3	8
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bri
-********************************************************************/
-be_local_closure(class_Leds_get_bri,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    }),
-    &be_const_str_get_bri,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_gamma
-********************************************************************/
-be_local_closure(class_Leds_set_gamma,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(gamma),
-    }),
-    &be_const_str_set_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_get_pixel_color,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    }),
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5412000A,  //  0001  LDINT	R4	11
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C080600,  //  0003  CALL	R2	3
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: dirty
-********************************************************************/
-be_local_closure(class_Leds_dirty,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    }),
-    &be_const_str_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0004,  //  0001  LDINT	R3	5
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: matrix
-********************************************************************/
-be_local_closure(class_Leds_matrix,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    4,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Leds),
-    /* K1   */  be_nested_str(Leds),
-    /* K2   */  be_nested_str(create_matrix),
-    /* K3   */  be_const_int(0),
-    }),
-    &be_const_str_matrix,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x08180001,  //  0002  MUL	R6	R0	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C140600,  //  0005  CALL	R5	3
-      0x8C180B02,  //  0006  GETMET	R6	R5	K2
-      0x5C200000,  //  0007  MOVE	R8	R0
-      0x5C240200,  //  0008  MOVE	R9	R1
-      0x58280003,  //  0009  LDCONST	R10	K3
-      0x7C180800,  //  000A  CALL	R6	4
-      0x80040C00,  //  000B  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_offset
-********************************************************************/
-be_local_closure(class_Leds_pixel_offset,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    }),
-    &be_const_str_pixel_offset,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80060000,  //  0000  RET	1	K0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_to
-********************************************************************/
-be_local_closure(class_Leds_clear_to,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    /* K1   */  be_nested_str(call_native),
-    /* K2   */  be_nested_str(to_gamma),
-    }),
-    &be_const_str_clear_to,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x8C0C0101,  //  0004  GETMET	R3	R0	K1
-      0x54160008,  //  0005  LDINT	R5	9
-      0x8C180102,  //  0006  GETMET	R6	R0	K2
-      0x5C200200,  //  0007  MOVE	R8	R1
-      0x5C240400,  //  0008  MOVE	R9	R2
-      0x7C180600,  //  0009  CALL	R6	3
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_set_pixel_color,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(bri),
-    /* K1   */  be_nested_str(call_native),
-    /* K2   */  be_nested_str(to_gamma),
-    }),
-    &be_const_str_set_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100604,  //  0001  EQ	R4	R3	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
-      0x8C100101,  //  0004  GETMET	R4	R0	K1
-      0x541A0009,  //  0005  LDINT	R6	10
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x8C200102,  //  0007  GETMET	R8	R0	K2
-      0x5C280400,  //  0008  MOVE	R10	R2
-      0x5C2C0600,  //  0009  MOVE	R11	R3
-      0x7C200600,  //  000A  CALL	R8	3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_size
-********************************************************************/
-be_local_closure(class_Leds_pixel_size,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    }),
-    &be_const_str_pixel_size,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0006,  //  0001  LDINT	R3	7
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
+// compact class 'Leds_matrix' ktab size: 25, total: 62 (saved 296 bytes)
+static const bvalue be_ktab_class_Leds_matrix[25] = {
+  /* K0   */  be_nested_str(strip),
+  /* K1   */  be_nested_str(bri),
+  /* K2   */  be_nested_str(call_native),
+  /* K3   */  be_nested_str(to_gamma),
+  /* K4   */  be_nested_str(offset),
+  /* K5   */  be_nested_str(w),
+  /* K6   */  be_nested_str(h),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str(leds),
+  /* K9   */  be_nested_str(show),
+  /* K10  */  be_nested_str(pix_buffer),
+  /* K11  */  be_nested_str(pixels_buffer),
+  /* K12  */  be_nested_str(pix_size),
+  /* K13  */  be_nested_str(alternate),
+  /* K14  */  be_nested_str(pixel_size),
+  /* K15  */  be_nested_str(set_pixel_color),
+  /* K16  */  be_nested_str(dirty),
+  /* K17  */  be_const_int(1),
+  /* K18  */  be_nested_str(is_dirty),
+  /* K19  */  be_nested_str(can_show),
+  /* K20  */  be_nested_str(setbytes),
+  /* K21  */  be_nested_str(get_pixel_color),
+  /* K22  */  be_nested_str(offseta),
+  /* K23  */  be_nested_str(clear_to),
+  /* K24  */  be_const_int(0),
+};
 
 
 extern const bclass be_class_Leds_matrix;
@@ -1121,21 +508,13 @@ be_local_closure(class_Leds_matrix_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(bri),
-    /* K2   */  be_nested_str(call_native),
-    /* K3   */  be_nested_str(to_gamma),
-    /* K4   */  be_nested_str(offset),
-    /* K5   */  be_nested_str(w),
-    /* K6   */  be_nested_str(h),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_clear_to,
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
@@ -1171,23 +550,13 @@ be_local_closure(class_Leds_matrix_show,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(offset),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(w),
-    /* K3   */  be_nested_str(h),
-    /* K4   */  be_nested_str(strip),
-    /* K5   */  be_nested_str(leds),
-    /* K6   */  be_nested_str(show),
-    /* K7   */  be_nested_str(pix_buffer),
-    /* K8   */  be_nested_str(pixels_buffer),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_show,
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -1195,24 +564,24 @@ be_local_closure(class_Leds_matrix_show,   /* name */
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x740A0009,  //  0003  JMPT	R2	#000E
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x1C080501,  //  0005  EQ	R2	R2	K1
+      0x88080104,  //  0004  GETMBR	R2	R0	K4
+      0x1C080507,  //  0005  EQ	R2	R2	K7
       0x780A000E,  //  0006  JMPF	R2	#0016
-      0x88080102,  //  0007  GETMBR	R2	R0	K2
-      0x880C0103,  //  0008  GETMBR	R3	R0	K3
+      0x88080105,  //  0007  GETMBR	R2	R0	K5
+      0x880C0106,  //  0008  GETMBR	R3	R0	K6
       0x08080403,  //  0009  MUL	R2	R2	R3
-      0x880C0104,  //  000A  GETMBR	R3	R0	K4
-      0x880C0705,  //  000B  GETMBR	R3	R3	K5
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x880C0708,  //  000B  GETMBR	R3	R3	K8
       0x1C080403,  //  000C  EQ	R2	R2	R3
       0x780A0007,  //  000D  JMPF	R2	#0016
-      0x88080104,  //  000E  GETMBR	R2	R0	K4
-      0x8C080506,  //  000F  GETMET	R2	R2	K6
+      0x88080100,  //  000E  GETMBR	R2	R0	K0
+      0x8C080509,  //  000F  GETMET	R2	R2	K9
       0x7C080200,  //  0010  CALL	R2	1
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0x8C080508,  //  0012  GETMET	R2	R2	K8
-      0x88100107,  //  0013  GETMBR	R4	R0	K7
+      0x88080100,  //  0011  GETMBR	R2	R0	K0
+      0x8C08050B,  //  0012  GETMET	R2	R2	K11
+      0x8810010A,  //  0013  GETMBR	R4	R0	K10
       0x7C080400,  //  0014  CALL	R2	2
-      0x90020E02,  //  0015  SETMBR	R0	K7	R2
+      0x90021402,  //  0015  SETMBR	R0	K10	R2
       0x80000000,  //  0016  RET	0
     })
   )
@@ -1227,19 +596,17 @@ be_local_closure(class_Leds_matrix_pixel_size,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(pix_size),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_pixel_size,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1254,40 +621,30 @@ be_local_closure(class_Leds_matrix_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(offset),
-    /* K2   */  be_nested_str(h),
-    /* K3   */  be_nested_str(w),
-    /* K4   */  be_nested_str(alternate),
-    /* K5   */  be_nested_str(pix_buffer),
-    /* K6   */  be_nested_str(pixels_buffer),
-    /* K7   */  be_nested_str(pix_size),
-    /* K8   */  be_nested_str(pixel_size),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020204,  //  0001  SETMBR	R0	K1	R4
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x90020602,  //  0003  SETMBR	R0	K3	R2
+      0x90020804,  //  0001  SETMBR	R0	K4	R4
+      0x90020C03,  //  0002  SETMBR	R0	K6	R3
+      0x90020A02,  //  0003  SETMBR	R0	K5	R2
       0x50140000,  //  0004  LDBOOL	R5	0	0
-      0x90020805,  //  0005  SETMBR	R0	K4	R5
+      0x90021A05,  //  0005  SETMBR	R0	K13	R5
       0x88140100,  //  0006  GETMBR	R5	R0	K0
-      0x8C140B06,  //  0007  GETMET	R5	R5	K6
+      0x8C140B0B,  //  0007  GETMET	R5	R5	K11
       0x7C140200,  //  0008  CALL	R5	1
-      0x90020A05,  //  0009  SETMBR	R0	K5	R5
+      0x90021405,  //  0009  SETMBR	R0	K10	R5
       0x88140100,  //  000A  GETMBR	R5	R0	K0
-      0x8C140B08,  //  000B  GETMET	R5	R5	K8
+      0x8C140B0E,  //  000B  GETMET	R5	R5	K14
       0x7C140200,  //  000C  CALL	R5	1
-      0x90020E05,  //  000D  SETMBR	R0	K7	R5
+      0x90021805,  //  000D  SETMBR	R0	K12	R5
       0x80000000,  //  000E  RET	0
     })
   )
@@ -1302,18 +659,13 @@ be_local_closure(class_Leds_matrix_set_pixel_color,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(bri),
-    /* K2   */  be_nested_str(set_pixel_color),
-    /* K3   */  be_nested_str(offset),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_set_pixel_color,
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -1323,8 +675,8 @@ be_local_closure(class_Leds_matrix_set_pixel_color,   /* name */
       0x88100100,  //  0003  GETMBR	R4	R0	K0
       0x880C0901,  //  0004  GETMBR	R3	R4	K1
       0x88100100,  //  0005  GETMBR	R4	R0	K0
-      0x8C100902,  //  0006  GETMET	R4	R4	K2
-      0x88180103,  //  0007  GETMBR	R6	R0	K3
+      0x8C10090F,  //  0006  GETMET	R4	R4	K15
+      0x88180104,  //  0007  GETMBR	R6	R0	K4
       0x00180206,  //  0008  ADD	R6	R1	R6
       0x5C1C0400,  //  0009  MOVE	R7	R2
       0x5C200600,  //  000A  MOVE	R8	R3
@@ -1343,21 +695,18 @@ be_local_closure(class_Leds_matrix_pixels_buffer,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(pixels_buffer),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_pixels_buffer,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C04030B,  //  0001  GETMET	R1	R1	K11
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1373,21 +722,18 @@ be_local_closure(class_Leds_matrix_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(dirty),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040310,  //  0001  GETMET	R1	R1	K16
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -1403,22 +749,13 @@ be_local_closure(class_Leds_matrix_set_matrix_pixel_color,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(bri),
-    /* K2   */  be_nested_str(alternate),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str(set_pixel_color),
-    /* K5   */  be_nested_str(w),
-    /* K6   */  be_nested_str(h),
-    /* K7   */  be_nested_str(offset),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_set_matrix_pixel_color,
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
@@ -1427,30 +764,30 @@ be_local_closure(class_Leds_matrix_set_matrix_pixel_color,   /* name */
       0x78160001,  //  0002  JMPF	R5	#0005
       0x88140100,  //  0003  GETMBR	R5	R0	K0
       0x88100B01,  //  0004  GETMBR	R4	R5	K1
-      0x88140102,  //  0005  GETMBR	R5	R0	K2
+      0x8814010D,  //  0005  GETMBR	R5	R0	K13
       0x7816000F,  //  0006  JMPF	R5	#0017
-      0x2C140503,  //  0007  AND	R5	R2	K3
+      0x2C140511,  //  0007  AND	R5	R2	K17
       0x7816000D,  //  0008  JMPF	R5	#0017
       0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0x8C140B04,  //  000A  GETMET	R5	R5	K4
+      0x8C140B0F,  //  000A  GETMET	R5	R5	K15
       0x881C0105,  //  000B  GETMBR	R7	R0	K5
       0x081C0207,  //  000C  MUL	R7	R1	R7
       0x88200106,  //  000D  GETMBR	R8	R0	K6
       0x001C0E08,  //  000E  ADD	R7	R7	R8
       0x041C0E02,  //  000F  SUB	R7	R7	R2
-      0x041C0F03,  //  0010  SUB	R7	R7	K3
-      0x88200107,  //  0011  GETMBR	R8	R0	K7
+      0x041C0F11,  //  0010  SUB	R7	R7	K17
+      0x88200104,  //  0011  GETMBR	R8	R0	K4
       0x001C0E08,  //  0012  ADD	R7	R7	R8
       0x5C200600,  //  0013  MOVE	R8	R3
       0x5C240800,  //  0014  MOVE	R9	R4
       0x7C140800,  //  0015  CALL	R5	4
       0x70020009,  //  0016  JMP		#0021
       0x88140100,  //  0017  GETMBR	R5	R0	K0
-      0x8C140B04,  //  0018  GETMET	R5	R5	K4
+      0x8C140B0F,  //  0018  GETMET	R5	R5	K15
       0x881C0105,  //  0019  GETMBR	R7	R0	K5
       0x081C0207,  //  001A  MUL	R7	R1	R7
       0x001C0E02,  //  001B  ADD	R7	R7	R2
-      0x88200107,  //  001C  GETMBR	R8	R0	K7
+      0x88200104,  //  001C  GETMBR	R8	R0	K4
       0x001C0E08,  //  001D  ADD	R7	R7	R8
       0x5C200600,  //  001E  MOVE	R8	R3
       0x5C240800,  //  001F  MOVE	R9	R4
@@ -1469,21 +806,18 @@ be_local_closure(class_Leds_matrix_is_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(is_dirty),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_is_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040312,  //  0001  GETMET	R1	R1	K18
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1499,19 +833,17 @@ be_local_closure(class_Leds_matrix_set_alternate,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(alternate),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_set_alternate,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021A01,  //  0000  SETMBR	R0	K13	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1526,13 +858,13 @@ be_local_closure(class_Leds_matrix_begin,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_begin,
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -1550,21 +882,18 @@ be_local_closure(class_Leds_matrix_pixel_count,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(w),
-    /* K1   */  be_nested_str(h),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_pixel_count,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x88080106,  //  0001  GETMBR	R2	R0	K6
       0x08040202,  //  0002  MUL	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1580,19 +909,17 @@ be_local_closure(class_Leds_matrix_get_alternate,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(alternate),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_get_alternate,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1607,19 +934,17 @@ be_local_closure(class_Leds_matrix_pixel_offset,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(offset),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_pixel_offset,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1634,21 +959,18 @@ be_local_closure(class_Leds_matrix_can_show,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(can_show),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_can_show,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040313,  //  0001  GETMET	R1	R1	K19
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1664,33 +986,27 @@ be_local_closure(class_Leds_matrix_set_bytes,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(h),
-    /* K1   */  be_nested_str(pix_size),
-    /* K2   */  be_nested_str(offset),
-    /* K3   */  be_nested_str(pix_buffer),
-    /* K4   */  be_nested_str(setbytes),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_set_bytes,
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88140100,  //  0000  GETMBR	R5	R0	K0
-      0x88180101,  //  0001  GETMBR	R6	R0	K1
+      0x88140106,  //  0000  GETMBR	R5	R0	K6
+      0x8818010C,  //  0001  GETMBR	R6	R0	K12
       0x08140A06,  //  0002  MUL	R5	R5	R6
       0x24180805,  //  0003  GT	R6	R4	R5
       0x781A0000,  //  0004  JMPF	R6	#0006
       0x5C100A00,  //  0005  MOVE	R4	R5
-      0x88180102,  //  0006  GETMBR	R6	R0	K2
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
       0x00180C01,  //  0007  ADD	R6	R6	R1
       0x08180C05,  //  0008  MUL	R6	R6	R5
-      0x881C0103,  //  0009  GETMBR	R7	R0	K3
-      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
+      0x881C010A,  //  0009  GETMBR	R7	R0	K10
+      0x8C1C0F14,  //  000A  GETMET	R7	R7	K20
       0x5C240C00,  //  000B  MOVE	R9	R6
       0x5C280400,  //  000C  MOVE	R10	R2
       0x5C2C0600,  //  000D  MOVE	R11	R3
@@ -1710,23 +1026,19 @@ be_local_closure(class_Leds_matrix_get_pixel_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(get_pixel_color),
-    /* K2   */  be_nested_str(offseta),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_get_pixel_color,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x8C080515,  //  0001  GETMET	R2	R2	K21
+      0x88100116,  //  0002  GETMBR	R4	R0	K22
       0x00100204,  //  0003  ADD	R4	R1	R4
       0x7C080400,  //  0004  CALL	R2	2
       0x80040400,  //  0005  RET	1	R2
@@ -1743,24 +1055,20 @@ be_local_closure(class_Leds_matrix_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(clear_to),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(show),
-    }),
+    &be_ktab_class_Leds_matrix,     /* shared constants */
     &be_const_str_clear,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x8C040117,  //  0000  GETMET	R1	R0	K23
+      0x580C0018,  //  0001  LDCONST	R3	K24
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x8C040109,  //  0003  GETMET	R1	R0	K9
       0x7C040200,  //  0004  CALL	R1	1
       0x80000000,  //  0005  RET	0
     })
@@ -1805,6 +1113,610 @@ be_local_class(Leds_matrix,
     })),
     (bstring*) &be_const_str_Leds_matrix
 );
+// compact class 'Leds' ktab size: 46, total: 83 (saved 296 bytes)
+static const bvalue be_ktab_class_Leds[46] = {
+  /* K0   */  be_nested_str(leds),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str(value_error),
+  /* K3   */  be_nested_str(out_X20of_X20range),
+  /* K4   */  be_const_class(be_class_Leds_segment),
+  /* K5   */  be_nested_str(bri),
+  /* K6   */  be_nested_str(call_native),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_nested_str(clear_to),
+  /* K9   */  be_nested_str(show),
+  /* K10  */  be_nested_str(gpio),
+  /* K11  */  be_nested_str(gamma),
+  /* K12  */  be_nested_str(pin),
+  /* K13  */  be_nested_str(WS2812),
+  /* K14  */  be_nested_str(ctor),
+  /* K15  */  be_nested_str(pixel_count),
+  /* K16  */  be_nested_str(light),
+  /* K17  */  be_nested_str(get),
+  /* K18  */  be_nested_str(_p),
+  /* K19  */  be_nested_str(internal_error),
+  /* K20  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
+  /* K21  */  be_nested_str(begin),
+  /* K22  */  be_nested_str(apply_bri_gamma),
+  /* K23  */  be_const_int(2),
+  /* K24  */  be_const_class(be_class_Leds),
+  /* K25  */  be_nested_str(Leds),
+  /* K26  */  be_nested_str(create_matrix),
+  /* K27  */  be_const_int(0),
+  /* K28  */  be_const_int(0),
+  /* K29  */  be_nested_str(to_gamma),
+  /* K30  */  be_const_class(be_class_Leds_matrix),
+  /* K31  */  be_const_int(3),
+  /* K32  */  be_nested_str(invalid_X20GPIO_X20number),
+  /* K33  */  be_nested_str(global),
+  /* K34  */  be_nested_str(contains),
+  /* K35  */  be_nested_str(_rmt),
+  /* K36  */  be_nested_str(MAX_RMT),
+  /* K37  */  be_const_int(1),
+  /* K38  */  be_nested_str(push),
+  /* K39  */  be_nested_str(stop_iteration),
+  /* K40  */  be_nested_str(pin_used),
+  /* K41  */  be_nested_str(no_X20more_X20RMT_X20channel_X20available),
+  /* K42  */  be_nested_str(WS2812_GRB),
+  /* K43  */  be_nested_str(assign_rmt),
+  /* K44  */  be_nested_str(pixel_size),
+  /* K45  */  be_nested_str(_change_buffer),
+};
+
+
+extern const bclass be_class_Leds;
+
+/********************************************************************
+** Solidified function: create_segment
+********************************************************************/
+be_local_closure(class_Leds_create_segment,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_create_segment,
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x600C0009,  //  0000  GETGBL	R3	G9
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x60100009,  //  0003  GETGBL	R4	G9
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C100200,  //  0005  CALL	R4	1
+      0x000C0604,  //  0006  ADD	R3	R3	R4
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x240C0604,  //  0008  GT	R3	R3	R4
+      0x740E0003,  //  0009  JMPT	R3	#000E
+      0x140C0301,  //  000A  LT	R3	R1	K1
+      0x740E0001,  //  000B  JMPT	R3	#000E
+      0x140C0501,  //  000C  LT	R3	R2	K1
+      0x780E0000,  //  000D  JMPF	R3	#000F
+      0xB0060503,  //  000E  RAISE	1	K2	K3
+      0x580C0004,  //  000F  LDCONST	R3	K4
+      0xB4000004,  //  0010  CLASS	K4
+      0x5C100600,  //  0011  MOVE	R4	R3
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C100600,  //  0015  CALL	R4	3
+      0x80040800,  //  0016  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_bri
+********************************************************************/
+be_local_closure(class_Leds_set_bri,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_bri,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x14080301,  //  0000  LT	R2	R1	K1
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0x540A00FE,  //  0003  LDINT	R2	255
+      0x24080202,  //  0004  GT	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540600FE,  //  0006  LDINT	R1	255
+      0x90020A01,  //  0007  SETMBR	R0	K5	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(class_Leds_begin,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x580C0007,  //  0001  LDCONST	R3	K7
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_Leds_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040108,  //  0000  GETMET	R1	R0	K8
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C040109,  //  0003  GETMET	R1	R0	K9
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Leds_init,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[43]) {  /* code */
+      0xA4161400,  //  0000  IMPORT	R5	K10
+      0x50180200,  //  0001  LDBOOL	R6	1	0
+      0x90021606,  //  0002  SETMBR	R0	K11	R6
+      0x4C180000,  //  0003  LDNIL	R6
+      0x1C180406,  //  0004  EQ	R6	R2	R6
+      0x741A0005,  //  0005  JMPT	R6	#000C
+      0x8C180B0C,  //  0006  GETMET	R6	R5	K12
+      0x88200B0D,  //  0007  GETMBR	R8	R5	K13
+      0x58240001,  //  0008  LDCONST	R9	K1
+      0x7C180600,  //  0009  CALL	R6	3
+      0x1C180406,  //  000A  EQ	R6	R2	R6
+      0x781A000A,  //  000B  JMPF	R6	#0017
+      0x8C18010E,  //  000C  GETMET	R6	R0	K14
+      0x7C180200,  //  000D  CALL	R6	1
+      0x8C18010F,  //  000E  GETMET	R6	R0	K15
+      0x7C180200,  //  000F  CALL	R6	1
+      0x90020006,  //  0010  SETMBR	R0	K0	R6
+      0xA41A2000,  //  0011  IMPORT	R6	K16
+      0x8C1C0D11,  //  0012  GETMET	R7	R6	K17
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x941C0F05,  //  0014  GETIDX	R7	R7	K5
+      0x90020A07,  //  0015  SETMBR	R0	K5	R7
+      0x7002000B,  //  0016  JMP		#0023
+      0x60180009,  //  0017  GETGBL	R6	G9
+      0x5C1C0200,  //  0018  MOVE	R7	R1
+      0x7C180200,  //  0019  CALL	R6	1
+      0x90020006,  //  001A  SETMBR	R0	K0	R6
+      0x541A007E,  //  001B  LDINT	R6	127
+      0x90020A06,  //  001C  SETMBR	R0	K5	R6
+      0x8C18010E,  //  001D  GETMET	R6	R0	K14
+      0x88200100,  //  001E  GETMBR	R8	R0	K0
+      0x5C240400,  //  001F  MOVE	R9	R2
+      0x5C280600,  //  0020  MOVE	R10	R3
+      0x5C2C0800,  //  0021  MOVE	R11	R4
+      0x7C180A00,  //  0022  CALL	R6	5
+      0x88180112,  //  0023  GETMBR	R6	R0	K18
+      0x4C1C0000,  //  0024  LDNIL	R7
+      0x1C180C07,  //  0025  EQ	R6	R6	R7
+      0x781A0000,  //  0026  JMPF	R6	#0028
+      0xB0062714,  //  0027  RAISE	1	K19	K20
+      0x8C180115,  //  0028  GETMET	R6	R0	K21
+      0x7C180200,  //  0029  CALL	R6	1
+      0x80000000,  //  002A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_gamma
+********************************************************************/
+be_local_closure(class_Leds_to_gamma,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_to_gamma,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x88080105,  //  0003  GETMBR	R2	R0	K5
+      0x8C0C0116,  //  0004  GETMET	R3	R0	K22
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x881C010B,  //  0007  GETMBR	R7	R0	K11
+      0x7C0C0800,  //  0008  CALL	R3	4
+      0x80040600,  //  0009  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show
+********************************************************************/
+be_local_closure(class_Leds_show,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x580C0017,  //  0001  LDCONST	R3	K23
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_count
+********************************************************************/
+be_local_closure(class_Leds_pixel_count,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixel_count,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E0007,  //  0001  LDINT	R3	8
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bri
+********************************************************************/
+be_local_closure(class_Leds_get_bri,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_bri,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_gamma
+********************************************************************/
+be_local_closure(class_Leds_set_gamma,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_gamma,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90021602,  //  0003  SETMBR	R0	K11	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_get_pixel_color,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C080106,  //  0000  GETMET	R2	R0	K6
+      0x5412000A,  //  0001  LDINT	R4	11
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C080600,  //  0003  CALL	R2	3
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Leds_dirty,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E0004,  //  0001  LDINT	R3	5
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: matrix
+********************************************************************/
+be_local_closure(class_Leds_matrix,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_matrix,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x58100018,  //  0000  LDCONST	R4	K24
+      0xB8163200,  //  0001  GETNGBL	R5	K25
+      0x08180001,  //  0002  MUL	R6	R0	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C140600,  //  0005  CALL	R5	3
+      0x8C180B1A,  //  0006  GETMET	R6	R5	K26
+      0x5C200000,  //  0007  MOVE	R8	R0
+      0x5C240200,  //  0008  MOVE	R9	R1
+      0x5828001B,  //  0009  LDCONST	R10	K27
+      0x7C180800,  //  000A  CALL	R6	4
+      0x80040C00,  //  000B  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_offset
+********************************************************************/
+be_local_closure(class_Leds_pixel_offset,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixel_offset,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80063800,  //  0000  RET	1	K28
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear_to
+********************************************************************/
+be_local_closure(class_Leds_clear_to,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_clear_to,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x88080105,  //  0003  GETMBR	R2	R0	K5
+      0x8C0C0106,  //  0004  GETMET	R3	R0	K6
+      0x54160008,  //  0005  LDINT	R5	9
+      0x8C18011D,  //  0006  GETMET	R6	R0	K29
+      0x5C200200,  //  0007  MOVE	R8	R1
+      0x5C240400,  //  0008  MOVE	R9	R2
+      0x7C180600,  //  0009  CALL	R6	3
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_set_pixel_color,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120000,  //  0002  JMPF	R4	#0004
+      0x880C0105,  //  0003  GETMBR	R3	R0	K5
+      0x8C100106,  //  0004  GETMET	R4	R0	K6
+      0x541A0009,  //  0005  LDINT	R6	10
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x8C20011D,  //  0007  GETMET	R8	R0	K29
+      0x5C280400,  //  0008  MOVE	R10	R2
+      0x5C2C0600,  //  0009  MOVE	R11	R3
+      0x7C200600,  //  000A  CALL	R8	3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_size
+********************************************************************/
+be_local_closure(class_Leds_pixel_size,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixel_size,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E0006,  //  0001  LDINT	R3	7
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: create_matrix
@@ -1813,19 +1725,13 @@ be_local_closure(class_Leds_create_matrix,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(leds),
-    /* K2   */  be_nested_str(value_error),
-    /* K3   */  be_nested_str(out_X20of_X20range),
-    /* K4   */  be_const_class(be_class_Leds_matrix),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_create_matrix,
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
@@ -1844,21 +1750,21 @@ be_local_closure(class_Leds_create_matrix,   /* name */
       0x4C100000,  //  000C  LDNIL	R4
       0x1C100604,  //  000D  EQ	R4	R3	R4
       0x78120000,  //  000E  JMPF	R4	#0010
-      0x580C0000,  //  000F  LDCONST	R3	K0
+      0x580C0001,  //  000F  LDCONST	R3	K1
       0x08100202,  //  0010  MUL	R4	R1	R2
       0x00100803,  //  0011  ADD	R4	R4	R3
-      0x88140101,  //  0012  GETMBR	R5	R0	K1
+      0x88140100,  //  0012  GETMBR	R5	R0	K0
       0x24100805,  //  0013  GT	R4	R4	R5
       0x74120005,  //  0014  JMPT	R4	#001B
-      0x14100500,  //  0015  LT	R4	R2	K0
+      0x14100501,  //  0015  LT	R4	R2	K1
       0x74120003,  //  0016  JMPT	R4	#001B
-      0x14100300,  //  0017  LT	R4	R1	K0
+      0x14100301,  //  0017  LT	R4	R1	K1
       0x74120001,  //  0018  JMPT	R4	#001B
-      0x14100700,  //  0019  LT	R4	R3	K0
+      0x14100701,  //  0019  LT	R4	R3	K1
       0x78120000,  //  001A  JMPF	R4	#001C
       0xB0060503,  //  001B  RAISE	1	K2	K3
-      0x58100004,  //  001C  LDCONST	R4	K4
-      0xB4000004,  //  001D  CLASS	K4
+      0x5810001E,  //  001C  LDCONST	R4	K30
+      0xB400001E,  //  001D  CLASS	K30
       0x5C140800,  //  001E  MOVE	R5	R4
       0x5C180000,  //  001F  MOVE	R6	R0
       0x5C1C0200,  //  0020  MOVE	R7	R1
@@ -1879,19 +1785,17 @@ be_local_closure(class_Leds_get_gamma,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(gamma),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_get_gamma,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010B,  //  0000  GETMBR	R1	R0	K11
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1906,19 +1810,17 @@ be_local_closure(class_Leds_is_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_is_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E0003,  //  0001  LDINT	R3	4
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
@@ -1935,21 +1837,18 @@ be_local_closure(class_Leds_can_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    /* K1   */  be_const_int(3),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_can_show,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x580C001F,  //  0001  LDCONST	R3	K31
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1965,87 +1864,69 @@ be_local_closure(class_Leds_assign_rmt,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Leds),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(value_error),
-    /* K3   */  be_nested_str(invalid_X20GPIO_X20number),
-    /* K4   */  be_nested_str(global),
-    /* K5   */  be_nested_str(contains),
-    /* K6   */  be_nested_str(_rmt),
-    /* K7   */  be_nested_str(gpio),
-    /* K8   */  be_nested_str(MAX_RMT),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str(push),
-    /* K11  */  be_nested_str(stop_iteration),
-    /* K12  */  be_nested_str(pin_used),
-    /* K13  */  be_nested_str(WS2812),
-    /* K14  */  be_nested_str(pin),
-    /* K15  */  be_nested_str(internal_error),
-    /* K16  */  be_nested_str(no_X20more_X20RMT_X20channel_X20available),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_assign_rmt,
     &be_const_str_solidified,
     ( &(const binstruction[72]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58040018,  //  0000  LDCONST	R1	K24
       0x60080009,  //  0001  GETGBL	R2	G9
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C080200,  //  0003  CALL	R2	1
       0x5C000400,  //  0004  MOVE	R0	R2
       0x14080101,  //  0005  LT	R2	R0	K1
       0x780A0000,  //  0006  JMPF	R2	#0008
-      0xB0060503,  //  0007  RAISE	1	K2	K3
-      0xA40A0800,  //  0008  IMPORT	R2	K4
+      0xB0060520,  //  0007  RAISE	1	K2	K32
+      0xA40A4200,  //  0008  IMPORT	R2	K33
       0x4C0C0000,  //  0009  LDNIL	R3
-      0x8C100505,  //  000A  GETMET	R4	R2	K5
-      0x58180006,  //  000B  LDCONST	R6	K6
+      0x8C100522,  //  000A  GETMET	R4	R2	K34
+      0x58180023,  //  000B  LDCONST	R6	K35
       0x7C100400,  //  000C  CALL	R4	2
       0x74120021,  //  000D  JMPT	R4	#0030
       0x60100012,  //  000E  GETGBL	R4	G18
       0x7C100000,  //  000F  CALL	R4	0
       0x5C0C0800,  //  0010  MOVE	R3	R4
-      0x900A0C03,  //  0011  SETMBR	R2	K6	R3
+      0x900A4603,  //  0011  SETMBR	R2	K35	R3
       0x60100010,  //  0012  GETGBL	R4	G16
-      0xB8160E00,  //  0013  GETNGBL	R5	K7
-      0x88140B08,  //  0014  GETMBR	R5	R5	K8
-      0x04140B09,  //  0015  SUB	R5	R5	K9
+      0xB8161400,  //  0013  GETNGBL	R5	K10
+      0x88140B24,  //  0014  GETMBR	R5	R5	K36
+      0x04140B25,  //  0015  SUB	R5	R5	K37
       0x40160205,  //  0016  CONNECT	R5	K1	R5
       0x7C100200,  //  0017  CALL	R4	1
       0xA8020005,  //  0018  EXBLK	0	#001F
       0x5C140800,  //  0019  MOVE	R5	R4
       0x7C140000,  //  001A  CALL	R5	0
-      0x8C18070A,  //  001B  GETMET	R6	R3	K10
+      0x8C180726,  //  001B  GETMET	R6	R3	K38
       0x5421FFFE,  //  001C  LDINT	R8	-1
       0x7C180400,  //  001D  CALL	R6	2
       0x7001FFF9,  //  001E  JMP		#0019
-      0x5810000B,  //  001F  LDCONST	R4	K11
+      0x58100027,  //  001F  LDCONST	R4	K39
       0xAC100200,  //  0020  CATCH	R4	1	0
       0xB0080000,  //  0021  RAISE	2	R0	R0
-      0xB8120E00,  //  0022  GETNGBL	R4	K7
-      0x8C10090C,  //  0023  GETMET	R4	R4	K12
-      0xB81A0E00,  //  0024  GETNGBL	R6	K7
+      0xB8121400,  //  0022  GETNGBL	R4	K10
+      0x8C100928,  //  0023  GETMET	R4	R4	K40
+      0xB81A1400,  //  0024  GETNGBL	R6	K10
       0x88180D0D,  //  0025  GETMBR	R6	R6	K13
       0x581C0001,  //  0026  LDCONST	R7	K1
       0x7C100600,  //  0027  CALL	R4	3
       0x78120006,  //  0028  JMPF	R4	#0030
-      0xB8120E00,  //  0029  GETNGBL	R4	K7
-      0x8C10090E,  //  002A  GETMET	R4	R4	K14
-      0xB81A0E00,  //  002B  GETNGBL	R6	K7
+      0xB8121400,  //  0029  GETNGBL	R4	K10
+      0x8C10090C,  //  002A  GETMET	R4	R4	K12
+      0xB81A1400,  //  002B  GETNGBL	R6	K10
       0x88180D0D,  //  002C  GETMBR	R6	R6	K13
       0x581C0001,  //  002D  LDCONST	R7	K1
       0x7C100600,  //  002E  CALL	R4	3
       0x980E0204,  //  002F  SETIDX	R3	K1	R4
-      0x880C0506,  //  0030  GETMBR	R3	R2	K6
+      0x880C0523,  //  0030  GETMBR	R3	R2	K35
       0x58100001,  //  0031  LDCONST	R4	K1
       0x5415FFFE,  //  0032  LDINT	R5	-1
-      0xB81A0E00,  //  0033  GETNGBL	R6	K7
-      0x88180D08,  //  0034  GETMBR	R6	R6	K8
+      0xB81A1400,  //  0033  GETNGBL	R6	K10
+      0x88180D24,  //  0034  GETMBR	R6	R6	K36
       0x14180806,  //  0035  LT	R6	R4	R6
       0x781A000A,  //  0036  JMPF	R6	#0042
       0x94180604,  //  0037  GETIDX	R6	R3	R4
@@ -2057,13 +1938,13 @@ be_local_closure(class_Leds_assign_rmt,   /* name */
       0x141C0B01,  //  003D  LT	R7	R5	K1
       0x781E0000,  //  003E  JMPF	R7	#0040
       0x5C140800,  //  003F  MOVE	R5	R4
-      0x00100909,  //  0040  ADD	R4	R4	K9
+      0x00100925,  //  0040  ADD	R4	R4	K37
       0x7001FFF0,  //  0041  JMP		#0033
       0x28180B01,  //  0042  GE	R6	R5	K1
       0x781A0001,  //  0043  JMPF	R6	#0046
       0x980C0A00,  //  0044  SETIDX	R3	R5	R0
       0x80040A00,  //  0045  RET	1	R5
-      0xB0061F10,  //  0046  RAISE	1	K15	K16
+      0xB0062729,  //  0046  RAISE	1	K19	K41
       0x80000000,  //  0047  RET	0
     })
   )
@@ -2078,40 +1959,35 @@ be_local_closure(class_Leds_ctor,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(WS2812_GRB),
-    /* K3   */  be_nested_str(assign_rmt),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_ctor,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0x4C140000,  //  0000  LDNIL	R5
       0x1C140405,  //  0001  EQ	R5	R2	R5
       0x78160003,  //  0002  JMPF	R5	#0007
-      0x8C140100,  //  0003  GETMET	R5	R0	K0
+      0x8C140106,  //  0003  GETMET	R5	R0	K6
       0x581C0001,  //  0004  LDCONST	R7	K1
       0x7C140400,  //  0005  CALL	R5	2
       0x70020011,  //  0006  JMP		#0019
       0x4C140000,  //  0007  LDNIL	R5
       0x1C140605,  //  0008  EQ	R5	R3	R5
       0x78160000,  //  0009  JMPF	R5	#000B
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x880C012A,  //  000A  GETMBR	R3	R0	K42
       0x4C140000,  //  000B  LDNIL	R5
       0x1C140805,  //  000C  EQ	R5	R4	R5
       0x78160003,  //  000D  JMPF	R5	#0012
-      0x8C140103,  //  000E  GETMET	R5	R0	K3
+      0x8C14012B,  //  000E  GETMET	R5	R0	K43
       0x5C1C0400,  //  000F  MOVE	R7	R2
       0x7C140400,  //  0010  CALL	R5	2
       0x5C100A00,  //  0011  MOVE	R4	R5
-      0x8C140100,  //  0012  GETMET	R5	R0	K0
+      0x8C140106,  //  0012  GETMET	R5	R0	K6
       0x581C0001,  //  0013  LDCONST	R7	K1
       0x5C200200,  //  0014  MOVE	R8	R1
       0x5C240400,  //  0015  MOVE	R9	R2
@@ -2132,22 +2008,17 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(call_native),
-    /* K1   */  be_nested_str(pixel_size),
-    /* K2   */  be_nested_str(pixel_count),
-    /* K3   */  be_nested_str(_change_buffer),
-    }),
+    &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_pixels_buffer,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080106,  //  0000  GETMET	R2	R0	K6
       0x54120005,  //  0001  LDINT	R4	6
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -2155,15 +2026,15 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
       0x780E0009,  //  0005  JMPF	R3	#0010
       0x600C0015,  //  0006  GETGBL	R3	G21
       0x5C100400,  //  0007  MOVE	R4	R2
-      0x8C140101,  //  0008  GETMET	R5	R0	K1
+      0x8C14012C,  //  0008  GETMET	R5	R0	K44
       0x7C140200,  //  0009  CALL	R5	1
-      0x8C180102,  //  000A  GETMET	R6	R0	K2
+      0x8C18010F,  //  000A  GETMET	R6	R0	K15
       0x7C180200,  //  000B  CALL	R6	1
       0x08140A06,  //  000C  MUL	R5	R5	R6
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80040600,  //  000E  RET	1	R3
       0x70020003,  //  000F  JMP		#0014
-      0x8C0C0303,  //  0010  GETMET	R3	R1	K3
+      0x8C0C032D,  //  0010  GETMET	R3	R1	K45
       0x5C140400,  //  0011  MOVE	R5	R2
       0x7C0C0400,  //  0012  CALL	R3	2
       0x80040200,  //  0013  RET	1	R1

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota.h
@@ -121,6 +121,18 @@ be_local_closure(module_lv_tasmota_init,   /* name */
 );
 /*******************************************************************/
 
+// compact class 'splash_runner' ktab size: 8, total: 9 (saved 8 bytes)
+static const bvalue be_ktab_class_splash_runner[8] = {
+  /* K0   */  be_nested_str_weak(tasmota),
+  /* K1   */  be_nested_str_weak(add_driver),
+  /* K2   */  be_nested_str_weak(display),
+  /* K3   */  be_nested_str_weak(dim),
+  /* K4   */  be_nested_str_weak(started),
+  /* K5   */  be_nested_str_weak(remove_driver),
+  /* K6   */  be_nested_str_weak(lv),
+  /* K7   */  be_nested_str_weak(splash),
+};
+
 
 extern const bclass be_class_splash_runner;
 
@@ -131,16 +143,13 @@ be_local_closure(class_splash_runner_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(add_driver),
-    }),
+    &be_ktab_class_splash_runner,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -162,36 +171,28 @@ be_local_closure(class_splash_runner_display,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(display),
-    /* K1   */  be_nested_str_weak(dim),
-    /* K2   */  be_nested_str_weak(started),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(remove_driver),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(splash),
-    }),
+    &be_ktab_class_splash_runner,     /* shared constants */
     be_str_weak(display),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x1C180301,  //  0001  EQ	R6	R1	K1
+      0xA4160400,  //  0000  IMPORT	R5	K2
+      0x1C180303,  //  0001  EQ	R6	R1	K3
       0x781A0009,  //  0002  JMPF	R6	#000D
-      0x8C180B02,  //  0003  GETMET	R6	R5	K2
+      0x8C180B04,  //  0003  GETMET	R6	R5	K4
       0x7C180200,  //  0004  CALL	R6	1
       0x781A0006,  //  0005  JMPF	R6	#000D
-      0xB81A0600,  //  0006  GETNGBL	R6	K3
-      0x8C180D04,  //  0007  GETMET	R6	R6	K4
+      0xB81A0000,  //  0006  GETNGBL	R6	K0
+      0x8C180D05,  //  0007  GETMET	R6	R6	K5
       0x5C200000,  //  0008  MOVE	R8	R0
       0x7C180400,  //  0009  CALL	R6	2
-      0xB81A0A00,  //  000A  GETNGBL	R6	K5
-      0x8C180D06,  //  000B  GETMET	R6	R6	K6
+      0xB81A0C00,  //  000A  GETNGBL	R6	K6
+      0x8C180D07,  //  000B  GETMET	R6	R6	K7
       0x7C180200,  //  000C  CALL	R6	1
       0x80000000,  //  000D  RET	0
     })

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota_widgets.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_lv_tasmota_widgets.h
@@ -3,6 +3,37 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'lv_clock' ktab size: 27, total: 32 (saved 40 bytes)
+static const bvalue be_ktab_class_lv_clock[27] = {
+  /* K0   */  be_nested_str_weak(hour),
+  /* K1   */  be_nested_str_weak(minute),
+  /* K2   */  be_nested_str_weak(sec),
+  /* K3   */  be_nested_str_weak(_X2502d_X25s_X2502d),
+  /* K4   */  be_const_int(2),
+  /* K5   */  be_nested_str_weak(_X3A),
+  /* K6   */  be_nested_str_weak(_X20),
+  /* K7   */  be_nested_str_weak(set_text),
+  /* K8   */  be_nested_str_weak(tasmota),
+  /* K9   */  be_nested_str_weak(time_dump),
+  /* K10  */  be_nested_str_weak(rtc),
+  /* K11  */  be_nested_str_weak(local),
+  /* K12  */  be_nested_str_weak(year),
+  /* K13  */  be_nested_str_weak(set_time),
+  /* K14  */  be_nested_str_weak(min),
+  /* K15  */  be_nested_str_weak(init),
+  /* K16  */  be_nested_str_weak(lv),
+  /* K17  */  be_nested_str_weak(seg7_font),
+  /* K18  */  be_nested_str_weak(set_style_text_font),
+  /* K19  */  be_nested_str_weak(PART_MAIN),
+  /* K20  */  be_nested_str_weak(STATE_DEFAULT),
+  /* K21  */  be_nested_str_weak(_X2D_X2D_X3A_X2D_X2D),
+  /* K22  */  be_nested_str_weak(add_event_cb),
+  /* K23  */  be_nested_str_weak(EVENT_DELETE),
+  /* K24  */  be_const_int(0),
+  /* K25  */  be_nested_str_weak(add_driver),
+  /* K26  */  be_nested_str_weak(remove_driver),
+};
+
 
 extern const bclass be_class_lv_clock;
 
@@ -13,22 +44,13 @@ be_local_closure(class_lv_clock_set_time,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(hour),
-    /* K1   */  be_nested_str_weak(minute),
-    /* K2   */  be_nested_str_weak(sec),
-    /* K3   */  be_nested_str_weak(_X2502d_X25s_X2502d),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(_X3A),
-    /* K6   */  be_nested_str_weak(_X20),
-    /* K7   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lv_clock,     /* shared constants */
     be_str_weak(set_time),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
@@ -71,41 +93,31 @@ be_local_closure(class_lv_clock_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(time_dump),
-    /* K2   */  be_nested_str_weak(rtc),
-    /* K3   */  be_nested_str_weak(local),
-    /* K4   */  be_nested_str_weak(year),
-    /* K5   */  be_nested_str_weak(set_time),
-    /* K6   */  be_nested_str_weak(hour),
-    /* K7   */  be_nested_str_weak(min),
-    /* K8   */  be_nested_str_weak(sec),
-    }),
+    &be_ktab_class_lv_clock,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0xB8061000,  //  0000  GETNGBL	R1	K8
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
+      0xB80E1000,  //  0002  GETNGBL	R3	K8
+      0x8C0C070A,  //  0003  GETMET	R3	R3	K10
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x940C0703,  //  0005  GETIDX	R3	R3	K3
+      0x940C070B,  //  0005  GETIDX	R3	R3	K11
       0x7C040400,  //  0006  CALL	R1	2
-      0x94080304,  //  0007  GETIDX	R2	R1	K4
+      0x9408030C,  //  0007  GETIDX	R2	R1	K12
       0x540E07B1,  //  0008  LDINT	R3	1970
       0x20080403,  //  0009  NE	R2	R2	R3
       0x780A0004,  //  000A  JMPF	R2	#0010
-      0x8C080105,  //  000B  GETMET	R2	R0	K5
-      0x94100306,  //  000C  GETIDX	R4	R1	K6
-      0x94140307,  //  000D  GETIDX	R5	R1	K7
-      0x94180308,  //  000E  GETIDX	R6	R1	K8
+      0x8C08010D,  //  000B  GETMET	R2	R0	K13
+      0x94100300,  //  000C  GETIDX	R4	R1	K0
+      0x9414030E,  //  000D  GETIDX	R5	R1	K14
+      0x94180302,  //  000E  GETIDX	R6	R1	K2
       0x7C080800,  //  000F  CALL	R2	4
       0x80000000,  //  0010  RET	0
     })
@@ -121,7 +133,7 @@ be_local_closure(class_lv_clock_init,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -151,56 +163,42 @@ be_local_closure(class_lv_clock_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(seg7_font),
-    /* K3   */  be_nested_str_weak(set_style_text_font),
-    /* K4   */  be_nested_str_weak(PART_MAIN),
-    /* K5   */  be_nested_str_weak(STATE_DEFAULT),
-    /* K6   */  be_nested_str_weak(set_text),
-    /* K7   */  be_nested_str_weak(_X2D_X2D_X3A_X2D_X2D),
-    /* K8   */  be_nested_str_weak(add_event_cb),
-    /* K9   */  be_nested_str_weak(EVENT_DELETE),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(add_driver),
-    }),
+    &be_ktab_class_lv_clock,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[36]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C08050F,  //  0003  GETMET	R2	R2	K15
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x8C080502,  //  0007  GETMET	R2	R2	K2
+      0xB80A2000,  //  0006  GETNGBL	R2	K16
+      0x8C080511,  //  0007  GETMET	R2	R2	K17
       0x5412000F,  //  0008  LDINT	R4	16
       0x7C080400,  //  0009  CALL	R2	2
       0x4C0C0000,  //  000A  LDNIL	R3
       0x200C0403,  //  000B  NE	R3	R2	R3
       0x780E0007,  //  000C  JMPF	R3	#0015
-      0x8C0C0103,  //  000D  GETMET	R3	R0	K3
+      0x8C0C0112,  //  000D  GETMET	R3	R0	K18
       0x5C140400,  //  000E  MOVE	R5	R2
-      0xB81A0200,  //  000F  GETNGBL	R6	K1
-      0x88180D04,  //  0010  GETMBR	R6	R6	K4
-      0xB81E0200,  //  0011  GETNGBL	R7	K1
-      0x881C0F05,  //  0012  GETMBR	R7	R7	K5
+      0xB81A2000,  //  000F  GETNGBL	R6	K16
+      0x88180D13,  //  0010  GETMBR	R6	R6	K19
+      0xB81E2000,  //  0011  GETNGBL	R7	K16
+      0x881C0F14,  //  0012  GETMBR	R7	R7	K20
       0x30180C07,  //  0013  OR	R6	R6	R7
       0x7C0C0600,  //  0014  CALL	R3	3
-      0x8C0C0106,  //  0015  GETMET	R3	R0	K6
-      0x58140007,  //  0016  LDCONST	R5	K7
+      0x8C0C0107,  //  0015  GETMET	R3	R0	K7
+      0x58140015,  //  0016  LDCONST	R5	K21
       0x7C0C0400,  //  0017  CALL	R3	2
-      0x8C0C0108,  //  0018  GETMET	R3	R0	K8
+      0x8C0C0116,  //  0018  GETMET	R3	R0	K22
       0x84140000,  //  0019  CLOSURE	R5	P0
-      0xB81A0200,  //  001A  GETNGBL	R6	K1
-      0x88180D09,  //  001B  GETMBR	R6	R6	K9
-      0x581C000A,  //  001C  LDCONST	R7	K10
+      0xB81A2000,  //  001A  GETNGBL	R6	K16
+      0x88180D17,  //  001B  GETMBR	R6	R6	K23
+      0x581C0018,  //  001C  LDCONST	R7	K24
       0x7C0C0800,  //  001D  CALL	R3	4
-      0xB80E1600,  //  001E  GETNGBL	R3	K11
-      0x8C0C070C,  //  001F  GETMET	R3	R3	K12
+      0xB80E1000,  //  001E  GETNGBL	R3	K8
+      0x8C0C0719,  //  001F  GETMET	R3	R3	K25
       0x5C140000,  //  0020  MOVE	R5	R0
       0x7C0C0400,  //  0021  CALL	R3	2
       0xA0000000,  //  0022  CLOSE	R0
@@ -218,21 +216,18 @@ be_local_closure(class_lv_clock_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    }),
+    &be_ktab_class_lv_clock,     /* shared constants */
     be_str_weak(before_del),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB8061000,  //  0000  GETNGBL	R1	K8
+      0x8C04031A,  //  0001  GETMET	R1	R1	K26
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0x80000000,  //  0004  RET	0
@@ -377,6 +372,54 @@ be_local_class(lv_clock_icon,
     })),
     be_str_weak(lv_clock_icon)
 );
+// compact class 'lv_signal_arcs' ktab size: 44, total: 52 (saved 64 bytes)
+static const bvalue be_ktab_class_lv_signal_arcs[44] = {
+  /* K0   */  be_nested_str_weak(get_code),
+  /* K1   */  be_nested_str_weak(math),
+  /* K2   */  be_nested_str_weak(get_height),
+  /* K3   */  be_nested_str_weak(get_width),
+  /* K4   */  be_const_int(2),
+  /* K5   */  be_const_int(3),
+  /* K6   */  be_nested_str_weak(lv),
+  /* K7   */  be_nested_str_weak(EVENT_DRAW_MAIN),
+  /* K8   */  be_nested_str_weak(arc_dsc),
+  /* K9   */  be_nested_str_weak(get_param),
+  /* K10  */  be_nested_str_weak(get_layer),
+  /* K11  */  be_nested_str_weak(get_coords),
+  /* K12  */  be_nested_str_weak(area),
+  /* K13  */  be_nested_str_weak(x1),
+  /* K14  */  be_nested_str_weak(y1),
+  /* K15  */  be_nested_str_weak(draw_arc_dsc_init),
+  /* K16  */  be_nested_str_weak(init_draw_arc_dsc),
+  /* K17  */  be_nested_str_weak(PART_MAIN),
+  /* K18  */  be_nested_str_weak(rounded),
+  /* K19  */  be_const_int(1),
+  /* K20  */  be_nested_str_weak(width),
+  /* K21  */  be_nested_str_weak(get_style_line_color),
+  /* K22  */  be_nested_str_weak(STATE_DEFAULT),
+  /* K23  */  be_nested_str_weak(get_style_bg_color),
+  /* K24  */  be_nested_str_weak(deg),
+  /* K25  */  be_nested_str_weak(acos),
+  /* K26  */  be_nested_str_weak(center_x),
+  /* K27  */  be_nested_str_weak(center_y),
+  /* K28  */  be_nested_str_weak(color),
+  /* K29  */  be_nested_str_weak(percentage),
+  /* K30  */  be_nested_str_weak(radius),
+  /* K31  */  be_const_int(0),
+  /* K32  */  be_nested_str_weak(start_angle),
+  /* K33  */  be_nested_str_weak(end_angle),
+  /* K34  */  be_nested_str_weak(draw_arc),
+  /* K35  */  be_nested_str_weak(init),
+  /* K36  */  be_nested_str_weak(set_style_bg_opa),
+  /* K37  */  be_nested_str_weak(set_style_border_width),
+  /* K38  */  be_nested_str_weak(set_style_pad_all),
+  /* K39  */  be_nested_str_weak(draw_arc_dsc),
+  /* K40  */  be_nested_str_weak(add_event_cb),
+  /* K41  */  be_nested_str_weak(widget_event),
+  /* K42  */  be_const_int(0),
+  /* K43  */  be_nested_str_weak(invalidate),
+};
+
 
 extern const bclass be_class_lv_signal_arcs;
 
@@ -387,7 +430,7 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
   be_nested_proto(
     28,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -417,43 +460,7 @@ be_local_closure(class_lv_signal_arcs_widget_event,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_code),
-    /* K1   */  be_nested_str_weak(math),
-    /* K2   */  be_nested_str_weak(get_height),
-    /* K3   */  be_nested_str_weak(get_width),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(EVENT_DRAW_MAIN),
-    /* K8   */  be_nested_str_weak(arc_dsc),
-    /* K9   */  be_nested_str_weak(get_param),
-    /* K10  */  be_nested_str_weak(get_layer),
-    /* K11  */  be_nested_str_weak(get_coords),
-    /* K12  */  be_nested_str_weak(area),
-    /* K13  */  be_nested_str_weak(x1),
-    /* K14  */  be_nested_str_weak(y1),
-    /* K15  */  be_nested_str_weak(draw_arc_dsc_init),
-    /* K16  */  be_nested_str_weak(init_draw_arc_dsc),
-    /* K17  */  be_nested_str_weak(PART_MAIN),
-    /* K18  */  be_nested_str_weak(rounded),
-    /* K19  */  be_const_int(1),
-    /* K20  */  be_nested_str_weak(width),
-    /* K21  */  be_nested_str_weak(get_style_line_color),
-    /* K22  */  be_nested_str_weak(STATE_DEFAULT),
-    /* K23  */  be_nested_str_weak(get_style_bg_color),
-    /* K24  */  be_nested_str_weak(deg),
-    /* K25  */  be_nested_str_weak(acos),
-    /* K26  */  be_nested_str_weak(center_x),
-    /* K27  */  be_nested_str_weak(center_y),
-    /* K28  */  be_nested_str_weak(color),
-    /* K29  */  be_nested_str_weak(percentage),
-    /* K30  */  be_nested_str_weak(radius),
-    /* K31  */  be_const_int(0),
-    /* K32  */  be_nested_str_weak(start_angle),
-    /* K33  */  be_nested_str_weak(end_angle),
-    /* K34  */  be_nested_str_weak(draw_arc),
-    }),
+    &be_ktab_class_lv_signal_arcs,     /* shared constants */
     be_str_weak(widget_event),
     &be_const_str_solidified,
     ( &(const binstruction[161]) {  /* code */
@@ -631,19 +638,17 @@ be_local_closure(class_lv_signal_arcs_get_percentage,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(percentage),
-    }),
+    &be_ktab_class_lv_signal_arcs,     /* shared constants */
     be_str_weak(get_percentage),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011D,  //  0000  GETMBR	R1	R0	K29
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -658,63 +663,49 @@ be_local_closure(class_lv_signal_arcs_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(set_style_bg_opa),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(set_style_border_width),
-    /* K4   */  be_nested_str_weak(set_style_pad_all),
-    /* K5   */  be_nested_str_weak(percentage),
-    /* K6   */  be_nested_str_weak(area),
-    /* K7   */  be_nested_str_weak(lv),
-    /* K8   */  be_nested_str_weak(arc_dsc),
-    /* K9   */  be_nested_str_weak(draw_arc_dsc),
-    /* K10  */  be_nested_str_weak(add_event_cb),
-    /* K11  */  be_nested_str_weak(widget_event),
-    /* K12  */  be_nested_str_weak(EVENT_DRAW_MAIN),
-    }),
+    &be_ktab_class_lv_signal_arcs,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080523,  //  0003  GETMET	R2	R2	K35
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080101,  //  0006  GETMET	R2	R0	K1
-      0x58100002,  //  0007  LDCONST	R4	K2
-      0x58140002,  //  0008  LDCONST	R5	K2
+      0x8C080124,  //  0006  GETMET	R2	R0	K36
+      0x5810001F,  //  0007  LDCONST	R4	K31
+      0x5814001F,  //  0008  LDCONST	R5	K31
       0x7C080600,  //  0009  CALL	R2	3
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100002,  //  000B  LDCONST	R4	K2
-      0x58140002,  //  000C  LDCONST	R5	K2
+      0x8C080125,  //  000A  GETMET	R2	R0	K37
+      0x5810001F,  //  000B  LDCONST	R4	K31
+      0x5814001F,  //  000C  LDCONST	R5	K31
       0x7C080600,  //  000D  CALL	R2	3
-      0x8C080104,  //  000E  GETMET	R2	R0	K4
-      0x58100002,  //  000F  LDCONST	R4	K2
-      0x58140002,  //  0010  LDCONST	R5	K2
+      0x8C080126,  //  000E  GETMET	R2	R0	K38
+      0x5810001F,  //  000F  LDCONST	R4	K31
+      0x5814001F,  //  0010  LDCONST	R5	K31
       0x7C080600,  //  0011  CALL	R2	3
       0x540A0063,  //  0012  LDINT	R2	100
-      0x90020A02,  //  0013  SETMBR	R0	K5	R2
-      0xB80A0E00,  //  0014  GETNGBL	R2	K7
-      0x8C080506,  //  0015  GETMET	R2	R2	K6
+      0x90023A02,  //  0013  SETMBR	R0	K29	R2
+      0xB80A0C00,  //  0014  GETNGBL	R2	K6
+      0x8C08050C,  //  0015  GETMET	R2	R2	K12
       0x7C080200,  //  0016  CALL	R2	1
-      0x90020C02,  //  0017  SETMBR	R0	K6	R2
-      0xB80A0E00,  //  0018  GETNGBL	R2	K7
-      0x8C080509,  //  0019  GETMET	R2	R2	K9
+      0x90021802,  //  0017  SETMBR	R0	K12	R2
+      0xB80A0C00,  //  0018  GETNGBL	R2	K6
+      0x8C080527,  //  0019  GETMET	R2	R2	K39
       0x7C080200,  //  001A  CALL	R2	1
       0x90021002,  //  001B  SETMBR	R0	K8	R2
-      0x8C08010A,  //  001C  GETMET	R2	R0	K10
-      0x8810010B,  //  001D  GETMBR	R4	R0	K11
-      0xB8160E00,  //  001E  GETNGBL	R5	K7
-      0x88140B0C,  //  001F  GETMBR	R5	R5	K12
-      0x58180002,  //  0020  LDCONST	R6	K2
+      0x8C080128,  //  001C  GETMET	R2	R0	K40
+      0x88100129,  //  001D  GETMBR	R4	R0	K41
+      0xB8160C00,  //  001E  GETNGBL	R5	K6
+      0x88140B07,  //  001F  GETMBR	R5	R5	K7
+      0x5818001F,  //  0020  LDCONST	R6	K31
       0x7C080800,  //  0021  CALL	R2	4
       0x80000000,  //  0022  RET	0
     })
@@ -730,36 +721,32 @@ be_local_closure(class_lv_signal_arcs_set_percentage,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(percentage),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(invalidate),
-    }),
+    &be_ktab_class_lv_signal_arcs,     /* shared constants */
     be_str_weak(set_percentage),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808011D,  //  0000  GETMBR	R2	R0	K29
       0x540E0018,  //  0001  LDINT	R3	25
       0x0C080403,  //  0002  DIV	R2	R2	R3
       0x540E0063,  //  0003  LDINT	R3	100
       0x240C0203,  //  0004  GT	R3	R1	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x54060063,  //  0006  LDINT	R1	100
-      0x140C0301,  //  0007  LT	R3	R1	K1
+      0x140C032A,  //  0007  LT	R3	R1	K42
       0x780E0000,  //  0008  JMPF	R3	#000A
-      0x58040001,  //  0009  LDCONST	R1	K1
-      0x90020001,  //  000A  SETMBR	R0	K0	R1
+      0x5804002A,  //  0009  LDCONST	R1	K42
+      0x90023A01,  //  000A  SETMBR	R0	K29	R1
       0x540E0018,  //  000B  LDINT	R3	25
       0x0C0C0203,  //  000C  DIV	R3	R1	R3
       0x200C0403,  //  000D  NE	R3	R2	R3
       0x780E0001,  //  000E  JMPF	R3	#0011
-      0x8C0C0102,  //  000F  GETMET	R3	R0	K2
+      0x8C0C012B,  //  000F  GETMET	R3	R0	K43
       0x7C0C0200,  //  0010  CALL	R3	1
       0x80000000,  //  0011  RET	0
     })
@@ -787,6 +774,20 @@ be_local_class(lv_signal_arcs,
     })),
     be_str_weak(lv_signal_arcs)
 );
+// compact class 'lv_wifi_arcs' ktab size: 10, total: 14 (saved 32 bytes)
+static const bvalue be_ktab_class_lv_wifi_arcs[10] = {
+  /* K0   */  be_nested_str_weak(tasmota),
+  /* K1   */  be_nested_str_weak(remove_driver),
+  /* K2   */  be_nested_str_weak(init),
+  /* K3   */  be_nested_str_weak(add_driver),
+  /* K4   */  be_nested_str_weak(set_percentage),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(wifi),
+  /* K7   */  be_nested_str_weak(find),
+  /* K8   */  be_nested_str_weak(quality),
+  /* K9   */  be_nested_str_weak(ip),
+};
+
 
 extern const bclass be_class_lv_wifi_arcs;
 
@@ -797,16 +798,13 @@ be_local_closure(class_lv_wifi_arcs_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    }),
+    &be_ktab_class_lv_wifi_arcs,     /* shared constants */
     be_str_weak(before_del),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -828,34 +826,28 @@ be_local_closure(class_lv_wifi_arcs_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(add_driver),
-    /* K3   */  be_nested_str_weak(set_percentage),
-    /* K4   */  be_const_int(0),
-    }),
+    &be_ktab_class_lv_wifi_arcs,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x8C080502,  //  0007  GETMET	R2	R2	K2
+      0xB80A0000,  //  0006  GETNGBL	R2	K0
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
       0x5C100000,  //  0008  MOVE	R4	R0
       0x7C080400,  //  0009  CALL	R2	2
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100004,  //  000B  LDCONST	R4	K4
+      0x8C080104,  //  000A  GETMET	R2	R0	K4
+      0x58100005,  //  000B  LDCONST	R4	K5
       0x7C080400,  //  000C  CALL	R2	2
       0x80000000,  //  000D  RET	0
     })
@@ -871,44 +863,36 @@ be_local_closure(class_lv_wifi_arcs_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(quality),
-    /* K4   */  be_nested_str_weak(ip),
-    /* K5   */  be_nested_str_weak(set_percentage),
-    /* K6   */  be_const_int(0),
-    }),
+    &be_ktab_class_lv_wifi_arcs,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040306,  //  0001  GETMET	R1	R1	K6
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x58100003,  //  0004  LDCONST	R4	K3
+      0x8C080307,  //  0003  GETMET	R2	R1	K7
+      0x58100008,  //  0004  LDCONST	R4	K8
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C0C0302,  //  0006  GETMET	R3	R1	K2
-      0x58140004,  //  0007  LDCONST	R5	K4
+      0x8C0C0307,  //  0006  GETMET	R3	R1	K7
+      0x58140009,  //  0007  LDCONST	R5	K9
       0x7C0C0400,  //  0008  CALL	R3	2
       0x4C100000,  //  0009  LDNIL	R4
       0x1C100604,  //  000A  EQ	R4	R3	R4
       0x78120003,  //  000B  JMPF	R4	#0010
-      0x8C100105,  //  000C  GETMET	R4	R0	K5
-      0x58180006,  //  000D  LDCONST	R6	K6
+      0x8C100104,  //  000C  GETMET	R4	R0	K4
+      0x58180005,  //  000D  LDCONST	R6	K5
       0x7C100400,  //  000E  CALL	R4	2
       0x70020005,  //  000F  JMP		#0016
       0x4C100000,  //  0010  LDNIL	R4
       0x20100404,  //  0011  NE	R4	R2	R4
       0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C100105,  //  0013  GETMET	R4	R0	K5
+      0x8C100104,  //  0013  GETMET	R4	R0	K4
       0x5C180400,  //  0014  MOVE	R6	R2
       0x7C100400,  //  0015  CALL	R4	2
       0x80000000,  //  0016  RET	0
@@ -1058,6 +1042,51 @@ be_local_class(lv_wifi_arcs_icon,
     })),
     be_str_weak(lv_wifi_arcs_icon)
 );
+// compact class 'lv_signal_bars' ktab size: 41, total: 49 (saved 64 bytes)
+static const bvalue be_ktab_class_lv_signal_bars[41] = {
+  /* K0   */  be_nested_str_weak(percentage),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(invalidate),
+  /* K3   */  be_nested_str_weak(get_code),
+  /* K4   */  be_nested_str_weak(get_height),
+  /* K5   */  be_nested_str_weak(get_width),
+  /* K6   */  be_const_int(3),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_nested_str_weak(lv),
+  /* K9   */  be_nested_str_weak(EVENT_DRAW_MAIN),
+  /* K10  */  be_nested_str_weak(line_dsc),
+  /* K11  */  be_nested_str_weak(get_param),
+  /* K12  */  be_nested_str_weak(get_layer),
+  /* K13  */  be_nested_str_weak(get_coords),
+  /* K14  */  be_nested_str_weak(area),
+  /* K15  */  be_nested_str_weak(x1),
+  /* K16  */  be_nested_str_weak(y1),
+  /* K17  */  be_nested_str_weak(draw_line_dsc_init),
+  /* K18  */  be_nested_str_weak(init_draw_line_dsc),
+  /* K19  */  be_nested_str_weak(PART_MAIN),
+  /* K20  */  be_nested_str_weak(round_start),
+  /* K21  */  be_const_int(1),
+  /* K22  */  be_nested_str_weak(round_end),
+  /* K23  */  be_nested_str_weak(width),
+  /* K24  */  be_nested_str_weak(get_style_line_color),
+  /* K25  */  be_nested_str_weak(STATE_DEFAULT),
+  /* K26  */  be_nested_str_weak(get_style_bg_color),
+  /* K27  */  be_nested_str_weak(color),
+  /* K28  */  be_nested_str_weak(p1_y),
+  /* K29  */  be_nested_str_weak(p1_x),
+  /* K30  */  be_nested_str_weak(p2_y),
+  /* K31  */  be_nested_str_weak(p2_x),
+  /* K32  */  be_nested_str_weak(draw_line),
+  /* K33  */  be_nested_str_weak(stop_iteration),
+  /* K34  */  be_nested_str_weak(init),
+  /* K35  */  be_nested_str_weak(set_style_bg_opa),
+  /* K36  */  be_const_int(0),
+  /* K37  */  be_nested_str_weak(set_style_border_width),
+  /* K38  */  be_nested_str_weak(draw_line_dsc),
+  /* K39  */  be_nested_str_weak(add_event_cb),
+  /* K40  */  be_nested_str_weak(widget_event),
+};
+
 
 extern const bclass be_class_lv_signal_bars;
 
@@ -1068,17 +1097,13 @@ be_local_closure(class_lv_signal_bars_set_percentage,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(percentage),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(invalidate),
-    }),
+    &be_ktab_class_lv_signal_bars,     /* shared constants */
     be_str_weak(set_percentage),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -1113,15 +1138,13 @@ be_local_closure(class_lv_signal_bars_get_percentage,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(percentage),
-    }),
+    &be_ktab_class_lv_signal_bars,     /* shared constants */
     be_str_weak(get_percentage),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -1140,7 +1163,7 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
   be_nested_proto(
     22,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1170,112 +1193,78 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[33]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_code),
-    /* K1   */  be_nested_str_weak(get_height),
-    /* K2   */  be_nested_str_weak(get_width),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(EVENT_DRAW_MAIN),
-    /* K7   */  be_nested_str_weak(line_dsc),
-    /* K8   */  be_nested_str_weak(get_param),
-    /* K9   */  be_nested_str_weak(get_layer),
-    /* K10  */  be_nested_str_weak(get_coords),
-    /* K11  */  be_nested_str_weak(area),
-    /* K12  */  be_nested_str_weak(x1),
-    /* K13  */  be_nested_str_weak(y1),
-    /* K14  */  be_nested_str_weak(draw_line_dsc_init),
-    /* K15  */  be_nested_str_weak(init_draw_line_dsc),
-    /* K16  */  be_nested_str_weak(PART_MAIN),
-    /* K17  */  be_nested_str_weak(round_start),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(round_end),
-    /* K20  */  be_nested_str_weak(width),
-    /* K21  */  be_nested_str_weak(get_style_line_color),
-    /* K22  */  be_nested_str_weak(STATE_DEFAULT),
-    /* K23  */  be_nested_str_weak(get_style_bg_color),
-    /* K24  */  be_const_int(0),
-    /* K25  */  be_nested_str_weak(color),
-    /* K26  */  be_nested_str_weak(percentage),
-    /* K27  */  be_nested_str_weak(p1_y),
-    /* K28  */  be_nested_str_weak(p1_x),
-    /* K29  */  be_nested_str_weak(p2_y),
-    /* K30  */  be_nested_str_weak(p2_x),
-    /* K31  */  be_nested_str_weak(draw_line),
-    /* K32  */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_lv_signal_bars,     /* shared constants */
     be_str_weak(widget_event),
     &be_const_str_solidified,
     ( &(const binstruction[105]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x8C080303,  //  0000  GETMET	R2	R1	K3
       0x7C080200,  //  0001  CALL	R2	1
       0x840C0000,  //  0002  CLOSURE	R3	P0
-      0x8C100101,  //  0003  GETMET	R4	R0	K1
+      0x8C100104,  //  0003  GETMET	R4	R0	K4
       0x7C100200,  //  0004  CALL	R4	1
-      0x8C140102,  //  0005  GETMET	R5	R0	K2
+      0x8C140105,  //  0005  GETMET	R5	R0	K5
       0x7C140200,  //  0006  CALL	R5	1
       0x5C180600,  //  0007  MOVE	R6	R3
       0x541E000E,  //  0008  LDINT	R7	15
       0x0C1C0A07,  //  0009  DIV	R7	R5	R7
       0x7C180200,  //  000A  CALL	R6	1
       0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x08200D03,  //  000C  MUL	R8	R6	K3
+      0x08200D06,  //  000C  MUL	R8	R6	K6
       0x04200A08,  //  000D  SUB	R8	R5	R8
       0x54260003,  //  000E  LDINT	R9	4
       0x0C201009,  //  000F  DIV	R8	R8	R9
       0x7C1C0200,  //  0010  CALL	R7	1
-      0x0C200F04,  //  0011  DIV	R8	R7	K4
-      0xB8260A00,  //  0012  GETNGBL	R9	K5
-      0x88241306,  //  0013  GETMBR	R9	R9	K6
+      0x0C200F07,  //  0011  DIV	R8	R7	K7
+      0xB8261000,  //  0012  GETNGBL	R9	K8
+      0x88241309,  //  0013  GETMBR	R9	R9	K9
       0x1C240409,  //  0014  EQ	R9	R2	R9
       0x78260051,  //  0015  JMPF	R9	#0068
-      0x88240107,  //  0016  GETMBR	R9	R0	K7
-      0x8C280308,  //  0017  GETMET	R10	R1	K8
+      0x8824010A,  //  0016  GETMBR	R9	R0	K10
+      0x8C28030B,  //  0017  GETMET	R10	R1	K11
       0x7C280200,  //  0018  CALL	R10	1
-      0x8C2C0309,  //  0019  GETMET	R11	R1	K9
+      0x8C2C030C,  //  0019  GETMET	R11	R1	K12
       0x7C2C0200,  //  001A  CALL	R11	1
-      0x8C30010A,  //  001B  GETMET	R12	R0	K10
-      0x8838010B,  //  001C  GETMBR	R14	R0	K11
+      0x8C30010D,  //  001B  GETMET	R12	R0	K13
+      0x8838010E,  //  001C  GETMBR	R14	R0	K14
       0x7C300400,  //  001D  CALL	R12	2
-      0x8830010B,  //  001E  GETMBR	R12	R0	K11
-      0x8830190C,  //  001F  GETMBR	R12	R12	K12
-      0x8834010B,  //  0020  GETMBR	R13	R0	K11
-      0x88341B0D,  //  0021  GETMBR	R13	R13	K13
-      0xB83A0A00,  //  0022  GETNGBL	R14	K5
-      0x8C381D0E,  //  0023  GETMET	R14	R14	K14
+      0x8830010E,  //  001E  GETMBR	R12	R0	K14
+      0x8830190F,  //  001F  GETMBR	R12	R12	K15
+      0x8834010E,  //  0020  GETMBR	R13	R0	K14
+      0x88341B10,  //  0021  GETMBR	R13	R13	K16
+      0xB83A1000,  //  0022  GETNGBL	R14	K8
+      0x8C381D11,  //  0023  GETMET	R14	R14	K17
       0x5C401200,  //  0024  MOVE	R16	R9
       0x7C380400,  //  0025  CALL	R14	2
-      0x8C38010F,  //  0026  GETMET	R14	R0	K15
-      0xB8420A00,  //  0027  GETNGBL	R16	K5
-      0x88402110,  //  0028  GETMBR	R16	R16	K16
+      0x8C380112,  //  0026  GETMET	R14	R0	K18
+      0xB8421000,  //  0027  GETNGBL	R16	K8
+      0x88402113,  //  0028  GETMBR	R16	R16	K19
       0x5C441200,  //  0029  MOVE	R17	R9
       0x7C380600,  //  002A  CALL	R14	3
-      0x90262312,  //  002B  SETMBR	R9	K17	K18
-      0x90262712,  //  002C  SETMBR	R9	K19	K18
-      0x90262807,  //  002D  SETMBR	R9	K20	R7
-      0x8C380115,  //  002E  GETMET	R14	R0	K21
-      0xB8420A00,  //  002F  GETNGBL	R16	K5
-      0x88402110,  //  0030  GETMBR	R16	R16	K16
-      0xB8460A00,  //  0031  GETNGBL	R17	K5
-      0x88442316,  //  0032  GETMBR	R17	R17	K22
+      0x90262915,  //  002B  SETMBR	R9	K20	K21
+      0x90262D15,  //  002C  SETMBR	R9	K22	K21
+      0x90262E07,  //  002D  SETMBR	R9	K23	R7
+      0x8C380118,  //  002E  GETMET	R14	R0	K24
+      0xB8421000,  //  002F  GETNGBL	R16	K8
+      0x88402113,  //  0030  GETMBR	R16	R16	K19
+      0xB8461000,  //  0031  GETNGBL	R17	K8
+      0x88442319,  //  0032  GETMBR	R17	R17	K25
       0x30402011,  //  0033  OR	R16	R16	R17
       0x7C380400,  //  0034  CALL	R14	2
-      0x8C3C0117,  //  0035  GETMET	R15	R0	K23
-      0xB8460A00,  //  0036  GETNGBL	R17	K5
-      0x88442310,  //  0037  GETMBR	R17	R17	K16
-      0xB84A0A00,  //  0038  GETNGBL	R18	K5
-      0x88482516,  //  0039  GETMBR	R18	R18	K22
+      0x8C3C011A,  //  0035  GETMET	R15	R0	K26
+      0xB8461000,  //  0036  GETNGBL	R17	K8
+      0x88442313,  //  0037  GETMBR	R17	R17	K19
+      0xB84A1000,  //  0038  GETNGBL	R18	K8
+      0x88482519,  //  0039  GETMBR	R18	R18	K25
       0x30442212,  //  003A  OR	R17	R17	R18
       0x7C3C0400,  //  003B  CALL	R15	2
       0x60400010,  //  003C  GETGBL	R16	G16
-      0x40463103,  //  003D  CONNECT	R17	K24	K3
+      0x40460306,  //  003D  CONNECT	R17	K1	K6
       0x7C400200,  //  003E  CALL	R16	1
       0xA8020024,  //  003F  EXBLK	0	#0065
       0x5C442000,  //  0040  MOVE	R17	R16
       0x7C440000,  //  0041  CALL	R17	0
-      0x8848011A,  //  0042  GETMBR	R18	R0	K26
-      0x004C2312,  //  0043  ADD	R19	R17	K18
+      0x88480100,  //  0042  GETMBR	R18	R0	K0
+      0x004C2315,  //  0043  ADD	R19	R17	K21
       0x54520013,  //  0044  LDINT	R20	20
       0x084C2614,  //  0045  MUL	R19	R19	R20
       0x28482413,  //  0046  GE	R18	R18	R19
@@ -1283,33 +1272,33 @@ be_local_closure(class_lv_signal_bars_widget_event,   /* name */
       0x5C481C00,  //  0048  MOVE	R18	R14
       0x70020000,  //  0049  JMP		#004B
       0x5C481E00,  //  004A  MOVE	R18	R15
-      0x90263212,  //  004B  SETMBR	R9	K25	R18
+      0x90263612,  //  004B  SETMBR	R9	K27	R18
       0x00481A04,  //  004C  ADD	R18	R13	R4
-      0x04482512,  //  004D  SUB	R18	R18	K18
+      0x04482515,  //  004D  SUB	R18	R18	K21
       0x04482408,  //  004E  SUB	R18	R18	R8
-      0x90263612,  //  004F  SETMBR	R9	K27	R18
+      0x90263812,  //  004F  SETMBR	R9	K28	R18
       0x00480E06,  //  0050  ADD	R18	R7	R6
       0x08482212,  //  0051  MUL	R18	R17	R18
       0x00481812,  //  0052  ADD	R18	R12	R18
       0x00482408,  //  0053  ADD	R18	R18	R8
-      0x90263812,  //  0054  SETMBR	R9	K28	R18
-      0x044A0611,  //  0055  SUB	R18	K3	R17
+      0x90263A12,  //  0054  SETMBR	R9	K29	R18
+      0x044A0C11,  //  0055  SUB	R18	K6	R17
       0x044C0807,  //  0056  SUB	R19	R4	R7
       0x08482413,  //  0057  MUL	R18	R18	R19
       0x544E0003,  //  0058  LDINT	R19	4
       0x0C482413,  //  0059  DIV	R18	R18	R19
       0x00481A12,  //  005A  ADD	R18	R13	R18
       0x00482408,  //  005B  ADD	R18	R18	R8
-      0x90263A12,  //  005C  SETMBR	R9	K29	R18
-      0x8848131C,  //  005D  GETMBR	R18	R9	K28
-      0x90263C12,  //  005E  SETMBR	R9	K30	R18
-      0xB84A0A00,  //  005F  GETNGBL	R18	K5
-      0x8C48251F,  //  0060  GETMET	R18	R18	K31
+      0x90263C12,  //  005C  SETMBR	R9	K30	R18
+      0x8848131D,  //  005D  GETMBR	R18	R9	K29
+      0x90263E12,  //  005E  SETMBR	R9	K31	R18
+      0xB84A1000,  //  005F  GETNGBL	R18	K8
+      0x8C482520,  //  0060  GETMET	R18	R18	K32
       0x5C501600,  //  0061  MOVE	R20	R11
       0x5C541200,  //  0062  MOVE	R21	R9
       0x7C480600,  //  0063  CALL	R18	3
       0x7001FFDA,  //  0064  JMP		#0040
-      0x58400020,  //  0065  LDCONST	R16	K32
+      0x58400021,  //  0065  LDCONST	R16	K33
       0xAC400200,  //  0066  CATCH	R16	1	0
       0xB0080000,  //  0067  RAISE	2	R0	R0
       0x80000000,  //  0068  RET	0
@@ -1326,58 +1315,45 @@ be_local_closure(class_lv_signal_bars_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(set_style_bg_opa),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(set_style_border_width),
-    /* K4   */  be_nested_str_weak(percentage),
-    /* K5   */  be_nested_str_weak(area),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(line_dsc),
-    /* K8   */  be_nested_str_weak(draw_line_dsc),
-    /* K9   */  be_nested_str_weak(add_event_cb),
-    /* K10  */  be_nested_str_weak(widget_event),
-    /* K11  */  be_nested_str_weak(EVENT_DRAW_MAIN),
-    }),
+    &be_ktab_class_lv_signal_bars,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080522,  //  0003  GETMET	R2	R2	K34
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080101,  //  0006  GETMET	R2	R0	K1
-      0x58100002,  //  0007  LDCONST	R4	K2
-      0x58140002,  //  0008  LDCONST	R5	K2
+      0x8C080123,  //  0006  GETMET	R2	R0	K35
+      0x58100024,  //  0007  LDCONST	R4	K36
+      0x58140024,  //  0008  LDCONST	R5	K36
       0x7C080600,  //  0009  CALL	R2	3
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100002,  //  000B  LDCONST	R4	K2
-      0x58140002,  //  000C  LDCONST	R5	K2
+      0x8C080125,  //  000A  GETMET	R2	R0	K37
+      0x58100024,  //  000B  LDCONST	R4	K36
+      0x58140024,  //  000C  LDCONST	R5	K36
       0x7C080600,  //  000D  CALL	R2	3
       0x540A0063,  //  000E  LDINT	R2	100
-      0x90020802,  //  000F  SETMBR	R0	K4	R2
-      0xB80A0C00,  //  0010  GETNGBL	R2	K6
-      0x8C080505,  //  0011  GETMET	R2	R2	K5
+      0x90020002,  //  000F  SETMBR	R0	K0	R2
+      0xB80A1000,  //  0010  GETNGBL	R2	K8
+      0x8C08050E,  //  0011  GETMET	R2	R2	K14
       0x7C080200,  //  0012  CALL	R2	1
-      0x90020A02,  //  0013  SETMBR	R0	K5	R2
-      0xB80A0C00,  //  0014  GETNGBL	R2	K6
-      0x8C080508,  //  0015  GETMET	R2	R2	K8
+      0x90021C02,  //  0013  SETMBR	R0	K14	R2
+      0xB80A1000,  //  0014  GETNGBL	R2	K8
+      0x8C080526,  //  0015  GETMET	R2	R2	K38
       0x7C080200,  //  0016  CALL	R2	1
-      0x90020E02,  //  0017  SETMBR	R0	K7	R2
-      0x8C080109,  //  0018  GETMET	R2	R0	K9
-      0x8810010A,  //  0019  GETMBR	R4	R0	K10
-      0xB8160C00,  //  001A  GETNGBL	R5	K6
-      0x88140B0B,  //  001B  GETMBR	R5	R5	K11
-      0x58180002,  //  001C  LDCONST	R6	K2
+      0x90021402,  //  0017  SETMBR	R0	K10	R2
+      0x8C080127,  //  0018  GETMET	R2	R0	K39
+      0x88100128,  //  0019  GETMBR	R4	R0	K40
+      0xB8161000,  //  001A  GETNGBL	R5	K8
+      0x88140B09,  //  001B  GETMBR	R5	R5	K9
+      0x58180024,  //  001C  LDCONST	R6	K36
       0x7C080800,  //  001D  CALL	R2	4
       0x80000000,  //  001E  RET	0
     })
@@ -1405,6 +1381,20 @@ be_local_class(lv_signal_bars,
     })),
     be_str_weak(lv_signal_bars)
 );
+// compact class 'lv_wifi_bars' ktab size: 10, total: 14 (saved 32 bytes)
+static const bvalue be_ktab_class_lv_wifi_bars[10] = {
+  /* K0   */  be_nested_str_weak(tasmota),
+  /* K1   */  be_nested_str_weak(remove_driver),
+  /* K2   */  be_nested_str_weak(init),
+  /* K3   */  be_nested_str_weak(add_driver),
+  /* K4   */  be_nested_str_weak(set_percentage),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(wifi),
+  /* K7   */  be_nested_str_weak(find),
+  /* K8   */  be_nested_str_weak(quality),
+  /* K9   */  be_nested_str_weak(ip),
+};
+
 
 extern const bclass be_class_lv_wifi_bars;
 
@@ -1415,16 +1405,13 @@ be_local_closure(class_lv_wifi_bars_before_del,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    }),
+    &be_ktab_class_lv_wifi_bars,     /* shared constants */
     be_str_weak(before_del),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -1446,34 +1433,28 @@ be_local_closure(class_lv_wifi_bars_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(add_driver),
-    /* K3   */  be_nested_str_weak(set_percentage),
-    /* K4   */  be_const_int(0),
-    }),
+    &be_ktab_class_lv_wifi_bars,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x8C080502,  //  0007  GETMET	R2	R2	K2
+      0xB80A0000,  //  0006  GETNGBL	R2	K0
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
       0x5C100000,  //  0008  MOVE	R4	R0
       0x7C080400,  //  0009  CALL	R2	2
-      0x8C080103,  //  000A  GETMET	R2	R0	K3
-      0x58100004,  //  000B  LDCONST	R4	K4
+      0x8C080104,  //  000A  GETMET	R2	R0	K4
+      0x58100005,  //  000B  LDCONST	R4	K5
       0x7C080400,  //  000C  CALL	R2	2
       0x80000000,  //  000D  RET	0
     })
@@ -1489,44 +1470,36 @@ be_local_closure(class_lv_wifi_bars_every_second,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(quality),
-    /* K4   */  be_nested_str_weak(ip),
-    /* K5   */  be_nested_str_weak(set_percentage),
-    /* K6   */  be_const_int(0),
-    }),
+    &be_ktab_class_lv_wifi_bars,     /* shared constants */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040306,  //  0001  GETMET	R1	R1	K6
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x58100003,  //  0004  LDCONST	R4	K3
+      0x8C080307,  //  0003  GETMET	R2	R1	K7
+      0x58100008,  //  0004  LDCONST	R4	K8
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C0C0302,  //  0006  GETMET	R3	R1	K2
-      0x58140004,  //  0007  LDCONST	R5	K4
+      0x8C0C0307,  //  0006  GETMET	R3	R1	K7
+      0x58140009,  //  0007  LDCONST	R5	K9
       0x7C0C0400,  //  0008  CALL	R3	2
       0x4C100000,  //  0009  LDNIL	R4
       0x1C100604,  //  000A  EQ	R4	R3	R4
       0x78120003,  //  000B  JMPF	R4	#0010
-      0x8C100105,  //  000C  GETMET	R4	R0	K5
-      0x58180006,  //  000D  LDCONST	R6	K6
+      0x8C100104,  //  000C  GETMET	R4	R0	K4
+      0x58180005,  //  000D  LDCONST	R6	K5
       0x7C100400,  //  000E  CALL	R4	2
       0x70020005,  //  000F  JMP		#0016
       0x4C100000,  //  0010  LDNIL	R4
       0x20100404,  //  0011  NE	R4	R2	R4
       0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C100105,  //  0013  GETMET	R4	R0	K5
+      0x8C100104,  //  0013  GETMET	R4	R0	K4
       0x5C180400,  //  0014  MOVE	R6	R2
       0x7C100400,  //  0015  CALL	R4	2
       0x80000000,  //  0016  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_mqtt.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_mqtt.h
@@ -3,6 +3,208 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_mqtt_listener;
+// compact class 'mqtt_listener' ktab size: 11, total: 17 (saved 48 bytes)
+static const bvalue be_ktab_class_mqtt_listener[11] = {
+  /* K0   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X27_X25s_X27_X29_X3E),
+  /* K1   */  be_nested_str(fulltopic),
+  /* K2   */  be_nested_str(string),
+  /* K3   */  be_nested_str(topic),
+  /* K4   */  be_nested_str(split),
+  /* K5   */  be_nested_str(_X2F),
+  /* K6   */  be_nested_str(closure),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str(_X23),
+  /* K9   */  be_nested_str(_X2B),
+  /* K10  */  be_const_int(1),
+};
+
+
+extern const bclass be_class_mqtt_listener;
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_mqtt_listener_tostring,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_mqtt_listener,     /* shared constants */
+    &be_const_str_tostring,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x600C0005,  //  0002  GETGBL	R3	G5
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x88100101,  //  0005  GETMBR	R4	R0	K1
+      0x7C040600,  //  0006  CALL	R1	3
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_mqtt_listener_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_mqtt_listener,     /* shared constants */
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xA40E0400,  //  0000  IMPORT	R3	K2
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0x8C100704,  //  0002  GETMET	R4	R3	K4
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x581C0005,  //  0004  LDCONST	R7	K5
+      0x7C100600,  //  0005  CALL	R4	3
+      0x90020604,  //  0006  SETMBR	R0	K3	R4
+      0x90020C02,  //  0007  SETMBR	R0	K6	R2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mqtt_data
+********************************************************************/
+be_local_closure(class_mqtt_listener_mqtt_data,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_mqtt_listener,     /* shared constants */
+    &be_const_str_mqtt_data,
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0xA4160400,  //  0000  IMPORT	R5	K2
+      0x8C180B04,  //  0001  GETMET	R6	R5	K4
+      0x5C200200,  //  0002  MOVE	R8	R1
+      0x58240005,  //  0003  LDCONST	R9	K5
+      0x7C180600,  //  0004  CALL	R6	3
+      0x601C000C,  //  0005  GETGBL	R7	G12
+      0x5C200C00,  //  0006  MOVE	R8	R6
+      0x7C1C0200,  //  0007  CALL	R7	1
+      0x88200103,  //  0008  GETMBR	R8	R0	K3
+      0x6024000C,  //  0009  GETGBL	R9	G12
+      0x5C281000,  //  000A  MOVE	R10	R8
+      0x7C240200,  //  000B  CALL	R9	1
+      0x58280007,  //  000C  LDCONST	R10	K7
+      0x142C1409,  //  000D  LT	R11	R10	R9
+      0x782E0013,  //  000E  JMPF	R11	#0023
+      0x942C100A,  //  000F  GETIDX	R11	R8	R10
+      0x1C301708,  //  0010  EQ	R12	R11	K8
+      0x78320001,  //  0011  JMPF	R12	#0014
+      0x7002000F,  //  0012  JMP		#0023
+      0x7002000C,  //  0013  JMP		#0021
+      0x28301407,  //  0014  GE	R12	R10	R7
+      0x78320002,  //  0015  JMPF	R12	#0019
+      0x50300000,  //  0016  LDBOOL	R12	0	0
+      0x80041800,  //  0017  RET	1	R12
+      0x70020007,  //  0018  JMP		#0021
+      0x1C301709,  //  0019  EQ	R12	R11	K9
+      0x78320000,  //  001A  JMPF	R12	#001C
+      0x70020004,  //  001B  JMP		#0021
+      0x94300C0A,  //  001C  GETIDX	R12	R6	R10
+      0x2030160C,  //  001D  NE	R12	R11	R12
+      0x78320001,  //  001E  JMPF	R12	#0021
+      0x50300000,  //  001F  LDBOOL	R12	0	0
+      0x80041800,  //  0020  RET	1	R12
+      0x0028150A,  //  0021  ADD	R10	R10	K10
+      0x7001FFE9,  //  0022  JMP		#000D
+      0x282C1409,  //  0023  GE	R11	R10	R9
+      0x782E0003,  //  0024  JMPF	R11	#0029
+      0x202C1207,  //  0025  NE	R11	R9	R7
+      0x782E0001,  //  0026  JMPF	R11	#0029
+      0x502C0000,  //  0027  LDBOOL	R11	0	0
+      0x80041600,  //  0028  RET	1	R11
+      0x882C0106,  //  0029  GETMBR	R11	R0	K6
+      0x5C301600,  //  002A  MOVE	R12	R11
+      0x5C340200,  //  002B  MOVE	R13	R1
+      0x5C380400,  //  002C  MOVE	R14	R2
+      0x5C3C0600,  //  002D  MOVE	R15	R3
+      0x5C400800,  //  002E  MOVE	R16	R4
+      0x7C300800,  //  002F  CALL	R12	4
+      0x4C340000,  //  0030  LDNIL	R13
+      0x1C34180D,  //  0031  EQ	R13	R12	R13
+      0x78360000,  //  0032  JMPF	R13	#0034
+      0x50300200,  //  0033  LDBOOL	R12	1	0
+      0x80041800,  //  0034  RET	1	R12
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: mqtt_listener
+********************************************************************/
+be_local_class(mqtt_listener,
+    3,
+    NULL,
+    be_nested_map(6,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(mqtt_data, -1), be_const_closure(class_mqtt_listener_mqtt_data_closure) },
+        { be_const_key(tostring, -1), be_const_closure(class_mqtt_listener_tostring_closure) },
+        { be_const_key(topic, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_closure(class_mqtt_listener_init_closure) },
+        { be_const_key(closure, 0), be_const_var(2) },
+        { be_const_key(fulltopic, -1), be_const_var(1) },
+    })),
+    (bstring*) &be_const_str_mqtt_listener
+);
+// compact class 'MQTT' ktab size: 23, total: 35 (saved 96 bytes)
+static const bvalue be_ktab_class_MQTT[23] = {
+  /* K0   */  be_nested_str(topics),
+  /* K1   */  be_nested_str(closure),
+  /* K2   */  be_nested_str(mqtt_data),
+  /* K3   */  be_nested_str(stop_iteration),
+  /* K4   */  be_nested_str(tasmota),
+  /* K5   */  be_nested_str(add_driver),
+  /* K6   */  be_nested_str(add_rule),
+  /* K7   */  be_nested_str(Mqtt_X23Connected),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str(fulltopic),
+  /* K10  */  be_nested_str(_unsubscribe),
+  /* K11  */  be_nested_str(remove),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_nested_str(log),
+  /* K14  */  be_nested_str(BRY_X3A_X20mqtt_X20subscribe_X20all_X20registered_X20topics),
+  /* K15  */  be_const_int(3),
+  /* K16  */  be_nested_str(_subscribe),
+  /* K17  */  be_const_class(be_class_mqtt_listener),
+  /* K18  */  be_nested_str(lazy_init),
+  /* K19  */  be_nested_str(mqtt_listener_class),
+  /* K20  */  be_nested_str(function),
+  /* K21  */  be_nested_str(check_not_method),
+  /* K22  */  be_nested_str(push),
+};
+
 
 extern const bclass be_class_MQTT;
 
@@ -13,18 +215,13 @@ be_local_closure(class_MQTT_mqtt_data,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(topics),
-    /* K1   */  be_nested_str(closure),
-    /* K2   */  be_nested_str(mqtt_data),
-    /* K3   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_mqtt_data,
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
@@ -72,7 +269,7 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -102,13 +299,7 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(topics),
-    /* K1   */  be_nested_str(tasmota),
-    /* K2   */  be_nested_str(add_driver),
-    /* K3   */  be_nested_str(add_rule),
-    /* K4   */  be_nested_str(Mqtt_X23Connected),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_lazy_init,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -119,13 +310,13 @@ be_local_closure(class_MQTT_lazy_init,   /* name */
       0x60040012,  //  0004  GETGBL	R1	G18
       0x7C040000,  //  0005  CALL	R1	0
       0x90020001,  //  0006  SETMBR	R0	K0	R1
-      0xB8060200,  //  0007  GETNGBL	R1	K1
-      0x8C040302,  //  0008  GETMET	R1	R1	K2
+      0xB8060800,  //  0007  GETNGBL	R1	K4
+      0x8C040305,  //  0008  GETMET	R1	R1	K5
       0x5C0C0000,  //  0009  MOVE	R3	R0
       0x7C040400,  //  000A  CALL	R1	2
-      0xB8060200,  //  000B  GETNGBL	R1	K1
-      0x8C040303,  //  000C  GETMET	R1	R1	K3
-      0x580C0004,  //  000D  LDCONST	R3	K4
+      0xB8060800,  //  000B  GETNGBL	R1	K4
+      0x8C040306,  //  000C  GETMET	R1	R1	K6
+      0x580C0007,  //  000D  LDCONST	R3	K7
       0x84100000,  //  000E  CLOSURE	R4	P0
       0x7C040600,  //  000F  CALL	R1	3
       0xA0000000,  //  0010  CLOSE	R0
@@ -143,20 +334,13 @@ be_local_closure(class_MQTT_unsubscribe,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(topics),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(fulltopic),
-    /* K3   */  be_nested_str(_unsubscribe),
-    /* K4   */  be_nested_str(remove),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_unsubscribe,
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
@@ -165,7 +349,7 @@ be_local_closure(class_MQTT_unsubscribe,   /* name */
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x780A0000,  //  0003  JMPF	R2	#0005
       0x80000400,  //  0004  RET	0
-      0x58080001,  //  0005  LDCONST	R2	K1
+      0x58080008,  //  0005  LDCONST	R2	K8
       0x600C000C,  //  0006  GETGBL	R3	G12
       0x88100100,  //  0007  GETMBR	R4	R0	K0
       0x7C0C0200,  //  0008  CALL	R3	1
@@ -176,28 +360,28 @@ be_local_closure(class_MQTT_unsubscribe,   /* name */
       0x740E0004,  //  000D  JMPT	R3	#0013
       0x880C0100,  //  000E  GETMBR	R3	R0	K0
       0x940C0602,  //  000F  GETIDX	R3	R3	R2
-      0x880C0702,  //  0010  GETMBR	R3	R3	K2
+      0x880C0709,  //  0010  GETMBR	R3	R3	K9
       0x1C0C0601,  //  0011  EQ	R3	R3	R1
       0x780E000C,  //  0012  JMPF	R3	#0020
       0x4C0C0000,  //  0013  LDNIL	R3
       0x1C0C0203,  //  0014  EQ	R3	R1	R3
       0x780E0004,  //  0015  JMPF	R3	#001B
-      0x8C0C0103,  //  0016  GETMET	R3	R0	K3
+      0x8C0C010A,  //  0016  GETMET	R3	R0	K10
       0x88140100,  //  0017  GETMBR	R5	R0	K0
       0x94140A02,  //  0018  GETIDX	R5	R5	R2
-      0x88140B02,  //  0019  GETMBR	R5	R5	K2
+      0x88140B09,  //  0019  GETMBR	R5	R5	K9
       0x7C0C0400,  //  001A  CALL	R3	2
       0x880C0100,  //  001B  GETMBR	R3	R0	K0
-      0x8C0C0704,  //  001C  GETMET	R3	R3	K4
+      0x8C0C070B,  //  001C  GETMET	R3	R3	K11
       0x5C140400,  //  001D  MOVE	R5	R2
       0x7C0C0400,  //  001E  CALL	R3	2
       0x70020000,  //  001F  JMP		#0021
-      0x00080505,  //  0020  ADD	R2	R2	K5
+      0x0008050C,  //  0020  ADD	R2	R2	K12
       0x7001FFE3,  //  0021  JMP		#0006
       0x4C0C0000,  //  0022  LDNIL	R3
       0x200C0203,  //  0023  NE	R3	R1	R3
       0x780E0002,  //  0024  JMPF	R3	#0028
-      0x8C0C0103,  //  0025  GETMET	R3	R0	K3
+      0x8C0C010A,  //  0025  GETMET	R3	R0	K10
       0x5C140200,  //  0026  MOVE	R5	R1
       0x7C0C0400,  //  0027  CALL	R3	2
       0x80000000,  //  0028  RET	0
@@ -214,42 +398,33 @@ be_local_closure(class_MQTT_mqtt_connect,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    /* K1   */  be_nested_str(log),
-    /* K2   */  be_nested_str(BRY_X3A_X20mqtt_X20subscribe_X20all_X20registered_X20topics),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str(topics),
-    /* K5   */  be_nested_str(fulltopic),
-    /* K6   */  be_nested_str(_subscribe),
-    /* K7   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_mqtt_connect,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
+      0xB8060800,  //  0000  GETNGBL	R1	K4
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x580C000E,  //  0002  LDCONST	R3	K14
+      0x5810000F,  //  0003  LDCONST	R4	K15
       0x7C040600,  //  0004  CALL	R1	3
       0x60040010,  //  0005  GETGBL	R1	G16
-      0x88080104,  //  0006  GETMBR	R2	R0	K4
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
       0x7C040200,  //  0007  CALL	R1	1
       0xA8020006,  //  0008  EXBLK	0	#0010
       0x5C080200,  //  0009  MOVE	R2	R1
       0x7C080000,  //  000A  CALL	R2	0
-      0x880C0505,  //  000B  GETMBR	R3	R2	K5
-      0x8C100106,  //  000C  GETMET	R4	R0	K6
+      0x880C0509,  //  000B  GETMBR	R3	R2	K9
+      0x8C100110,  //  000C  GETMET	R4	R0	K16
       0x5C180600,  //  000D  MOVE	R6	R3
       0x7C100400,  //  000E  CALL	R4	2
       0x7001FFF8,  //  000F  JMP		#0009
-      0x58040007,  //  0010  LDCONST	R1	K7
+      0x58040003,  //  0010  LDCONST	R1	K3
       0xAC040200,  //  0011  CATCH	R1	1	0
       0xB0080000,  //  0012  RAISE	2	R0	R0
       0x50040000,  //  0013  LDBOOL	R1	0	0
@@ -260,185 +435,6 @@ be_local_closure(class_MQTT_mqtt_connect,   /* name */
 /*******************************************************************/
 
 
-extern const bclass be_class_mqtt_listener;
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_mqtt_listener_tostring,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X27_X25s_X27_X29_X3E),
-    /* K1   */  be_nested_str(fulltopic),
-    }),
-    &be_const_str_tostring,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x600C0005,  //  0002  GETGBL	R3	G5
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x88100101,  //  0005  GETMBR	R4	R0	K1
-      0x7C040600,  //  0006  CALL	R1	3
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_mqtt_listener_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(fulltopic),
-    /* K2   */  be_nested_str(topic),
-    /* K3   */  be_nested_str(split),
-    /* K4   */  be_nested_str(_X2F),
-    /* K5   */  be_nested_str(closure),
-    }),
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x8C100703,  //  0002  GETMET	R4	R3	K3
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x7C100600,  //  0005  CALL	R4	3
-      0x90020404,  //  0006  SETMBR	R0	K2	R4
-      0x90020A02,  //  0007  SETMBR	R0	K5	R2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mqtt_data
-********************************************************************/
-be_local_closure(class_mqtt_listener_mqtt_data,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(split),
-    /* K2   */  be_nested_str(_X2F),
-    /* K3   */  be_nested_str(topic),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str(_X23),
-    /* K6   */  be_nested_str(_X2B),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str(closure),
-    }),
-    &be_const_str_mqtt_data,
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x8C180B01,  //  0001  GETMET	R6	R5	K1
-      0x5C200200,  //  0002  MOVE	R8	R1
-      0x58240002,  //  0003  LDCONST	R9	K2
-      0x7C180600,  //  0004  CALL	R6	3
-      0x601C000C,  //  0005  GETGBL	R7	G12
-      0x5C200C00,  //  0006  MOVE	R8	R6
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0x88200103,  //  0008  GETMBR	R8	R0	K3
-      0x6024000C,  //  0009  GETGBL	R9	G12
-      0x5C281000,  //  000A  MOVE	R10	R8
-      0x7C240200,  //  000B  CALL	R9	1
-      0x58280004,  //  000C  LDCONST	R10	K4
-      0x142C1409,  //  000D  LT	R11	R10	R9
-      0x782E0013,  //  000E  JMPF	R11	#0023
-      0x942C100A,  //  000F  GETIDX	R11	R8	R10
-      0x1C301705,  //  0010  EQ	R12	R11	K5
-      0x78320001,  //  0011  JMPF	R12	#0014
-      0x7002000F,  //  0012  JMP		#0023
-      0x7002000C,  //  0013  JMP		#0021
-      0x28301407,  //  0014  GE	R12	R10	R7
-      0x78320002,  //  0015  JMPF	R12	#0019
-      0x50300000,  //  0016  LDBOOL	R12	0	0
-      0x80041800,  //  0017  RET	1	R12
-      0x70020007,  //  0018  JMP		#0021
-      0x1C301706,  //  0019  EQ	R12	R11	K6
-      0x78320000,  //  001A  JMPF	R12	#001C
-      0x70020004,  //  001B  JMP		#0021
-      0x94300C0A,  //  001C  GETIDX	R12	R6	R10
-      0x2030160C,  //  001D  NE	R12	R11	R12
-      0x78320001,  //  001E  JMPF	R12	#0021
-      0x50300000,  //  001F  LDBOOL	R12	0	0
-      0x80041800,  //  0020  RET	1	R12
-      0x00281507,  //  0021  ADD	R10	R10	K7
-      0x7001FFE9,  //  0022  JMP		#000D
-      0x282C1409,  //  0023  GE	R11	R10	R9
-      0x782E0003,  //  0024  JMPF	R11	#0029
-      0x202C1207,  //  0025  NE	R11	R9	R7
-      0x782E0001,  //  0026  JMPF	R11	#0029
-      0x502C0000,  //  0027  LDBOOL	R11	0	0
-      0x80041600,  //  0028  RET	1	R11
-      0x882C0108,  //  0029  GETMBR	R11	R0	K8
-      0x5C301600,  //  002A  MOVE	R12	R11
-      0x5C340200,  //  002B  MOVE	R13	R1
-      0x5C380400,  //  002C  MOVE	R14	R2
-      0x5C3C0600,  //  002D  MOVE	R15	R3
-      0x5C400800,  //  002E  MOVE	R16	R4
-      0x7C300800,  //  002F  CALL	R12	4
-      0x4C340000,  //  0030  LDNIL	R13
-      0x1C34180D,  //  0031  EQ	R13	R12	R13
-      0x78360000,  //  0032  JMPF	R13	#0034
-      0x50300200,  //  0033  LDBOOL	R12	1	0
-      0x80041800,  //  0034  RET	1	R12
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: mqtt_listener
-********************************************************************/
-be_local_class(mqtt_listener,
-    3,
-    NULL,
-    be_nested_map(6,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(mqtt_data, -1), be_const_closure(class_mqtt_listener_mqtt_data_closure) },
-        { be_const_key(tostring, -1), be_const_closure(class_mqtt_listener_tostring_closure) },
-        { be_const_key(topic, -1), be_const_var(0) },
-        { be_const_key(init, -1), be_const_closure(class_mqtt_listener_init_closure) },
-        { be_const_key(closure, 0), be_const_var(2) },
-        { be_const_key(fulltopic, -1), be_const_var(1) },
-    })),
-    (bstring*) &be_const_str_mqtt_listener
-);
-
 /********************************************************************
 ** Solidified function: mqtt_listener_class
 ********************************************************************/
@@ -446,20 +442,18 @@ be_local_closure(class_MQTT_mqtt_listener_class,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_const_class(be_class_mqtt_listener),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_mqtt_listener_class,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xB4000000,  //  0001  CLASS	K0
+      0x58040011,  //  0000  LDCONST	R1	K17
+      0xB4000011,  //  0001  CLASS	K17
       0x5C080200,  //  0002  MOVE	R2	R1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -475,75 +469,63 @@ be_local_closure(class_MQTT_subscribe,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str(lazy_init),
-    /* K1   */  be_nested_str(topics),
-    /* K2   */  be_nested_str(fulltopic),
-    /* K3   */  be_nested_str(closure),
-    /* K4   */  be_nested_str(stop_iteration),
-    /* K5   */  be_nested_str(mqtt_listener_class),
-    /* K6   */  be_nested_str(function),
-    /* K7   */  be_nested_str(tasmota),
-    /* K8   */  be_nested_str(check_not_method),
-    /* K9   */  be_nested_str(push),
-    /* K10  */  be_nested_str(_subscribe),
-    }),
+    &be_ktab_class_MQTT,     /* shared constants */
     &be_const_str_subscribe,
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C0112,  //  0000  GETMET	R3	R0	K18
       0x7C0C0200,  //  0001  CALL	R3	1
       0x500C0000,  //  0002  LDBOOL	R3	0	0
       0x60100010,  //  0003  GETGBL	R4	G16
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
       0x7C100200,  //  0005  CALL	R4	1
       0xA802000A,  //  0006  EXBLK	0	#0012
       0x5C140800,  //  0007  MOVE	R5	R4
       0x7C140000,  //  0008  CALL	R5	0
-      0x88180B02,  //  0009  GETMBR	R6	R5	K2
+      0x88180B09,  //  0009  GETMBR	R6	R5	K9
       0x1C180C01,  //  000A  EQ	R6	R6	R1
       0x781A0004,  //  000B  JMPF	R6	#0011
-      0x88180B03,  //  000C  GETMBR	R6	R5	K3
+      0x88180B01,  //  000C  GETMBR	R6	R5	K1
       0x1C180C02,  //  000D  EQ	R6	R6	R2
       0x781A0001,  //  000E  JMPF	R6	#0011
       0xA8040001,  //  000F  EXBLK	1	1
       0x80000C00,  //  0010  RET	0
       0x7001FFF4,  //  0011  JMP		#0007
-      0x58100004,  //  0012  LDCONST	R4	K4
+      0x58100003,  //  0012  LDCONST	R4	K3
       0xAC100200,  //  0013  CATCH	R4	1	0
       0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x8C100105,  //  0015  GETMET	R4	R0	K5
+      0x8C100113,  //  0015  GETMET	R4	R0	K19
       0x7C100200,  //  0016  CALL	R4	1
       0x60140004,  //  0017  GETGBL	R5	G4
       0x5C180400,  //  0018  MOVE	R6	R2
       0x7C140200,  //  0019  CALL	R5	1
-      0x1C140B06,  //  001A  EQ	R5	R5	K6
+      0x1C140B14,  //  001A  EQ	R5	R5	K20
       0x7816000B,  //  001B  JMPF	R5	#0028
-      0xB8160E00,  //  001C  GETNGBL	R5	K7
-      0x8C140B08,  //  001D  GETMET	R5	R5	K8
+      0xB8160800,  //  001C  GETNGBL	R5	K4
+      0x8C140B15,  //  001D  GETMET	R5	R5	K21
       0x5C1C0400,  //  001E  MOVE	R7	R2
       0x7C140400,  //  001F  CALL	R5	2
-      0x88140101,  //  0020  GETMBR	R5	R0	K1
-      0x8C140B09,  //  0021  GETMET	R5	R5	K9
+      0x88140100,  //  0020  GETMBR	R5	R0	K0
+      0x8C140B16,  //  0021  GETMET	R5	R5	K22
       0x5C1C0800,  //  0022  MOVE	R7	R4
       0x5C200200,  //  0023  MOVE	R8	R1
       0x5C240400,  //  0024  MOVE	R9	R2
       0x7C1C0400,  //  0025  CALL	R7	2
       0x7C140400,  //  0026  CALL	R5	2
       0x70020005,  //  0027  JMP		#002E
-      0x88140101,  //  0028  GETMBR	R5	R0	K1
-      0x8C140B09,  //  0029  GETMET	R5	R5	K9
+      0x88140100,  //  0028  GETMBR	R5	R0	K0
+      0x8C140B16,  //  0029  GETMET	R5	R5	K22
       0x5C1C0800,  //  002A  MOVE	R7	R4
       0x5C200200,  //  002B  MOVE	R8	R1
       0x7C1C0200,  //  002C  CALL	R7	1
       0x7C140400,  //  002D  CALL	R5	2
-      0x8C14010A,  //  002E  GETMET	R5	R0	K10
+      0x8C140110,  //  002E  GETMET	R5	R0	K16
       0x5C1C0200,  //  002F  MOVE	R7	R1
       0x7C140400,  //  0030  CALL	R5	2
       0x80000000,  //  0031  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
@@ -3,6 +3,37 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Partition_otadata;
+// compact class 'Partition_otadata' ktab size: 26, total: 52 (saved 208 bytes)
+static const bvalue be_ktab_class_Partition_otadata[26] = {
+  /* K0   */  be_nested_str(flash),
+  /* K1   */  be_nested_str(seq0),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_nested_str(seq1),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str(offset),
+  /* K6   */  be_nested_str(add),
+  /* K7   */  be_nested_str(FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
+  /* K8   */  be_nested_str(crc32_ota_seq),
+  /* K9   */  be_nested_str(erase),
+  /* K10  */  be_nested_str(write),
+  /* K11  */  be_nested_str(_X3Cinstance_X3A_X20Partition_otadata_X28ota_active_X3A_X25s_X2C_X20ota_seq_X3D_X5B_X25d_X2C_X25d_X5D_X2C_X20ota_max_X3D_X25d_X29_X3E),
+  /* K12  */  be_nested_str(active_otadata),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_nested_str(ota_),
+  /* K15  */  be_nested_str(factory),
+  /* K16  */  be_nested_str(maxota),
+  /* K17  */  be_nested_str(has_factory),
+  /* K18  */  be_const_int(1),
+  /* K19  */  be_nested_str(read),
+  /* K20  */  be_nested_str(get),
+  /* K21  */  be_nested_str(_validate),
+  /* K22  */  be_const_class(be_class_Partition_otadata),
+  /* K23  */  be_nested_str(crc),
+  /* K24  */  be_nested_str(crc32),
+  /* K25  */  be_nested_str(load),
+};
+
 
 extern const bclass be_class_Partition_otadata;
 
@@ -13,25 +44,13 @@ be_local_closure(class_Partition_otadata_save,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(seq0),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(seq1),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str(offset),
-    /* K6   */  be_nested_str(add),
-    /* K7   */  be_nested_str(FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
-    /* K8   */  be_nested_str(crc32_ota_seq),
-    /* K9   */  be_nested_str(erase),
-    /* K10  */  be_nested_str(write),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_save,
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
@@ -101,39 +120,30 @@ be_local_closure(class_Partition_otadata_tostring,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(_X3Cinstance_X3A_X20Partition_otadata_X28ota_active_X3A_X25s_X2C_X20ota_seq_X3D_X5B_X25d_X2C_X25d_X5D_X2C_X20ota_max_X3D_X25d_X29_X3E),
-    /* K1   */  be_nested_str(active_otadata),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(ota_),
-    /* K4   */  be_nested_str(factory),
-    /* K5   */  be_nested_str(seq0),
-    /* K6   */  be_nested_str(seq1),
-    /* K7   */  be_nested_str(maxota),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x280C0702,  //  0003  GE	R3	R3	K2
+      0x5808000B,  //  0001  LDCONST	R2	K11
+      0x880C010C,  //  0002  GETMBR	R3	R0	K12
+      0x280C070D,  //  0003  GE	R3	R3	K13
       0x780E0004,  //  0004  JMPF	R3	#000A
       0x600C0008,  //  0005  GETGBL	R3	G8
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x8810010C,  //  0006  GETMBR	R4	R0	K12
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x000E0603,  //  0008  ADD	R3	K3	R3
+      0x000E1C03,  //  0008  ADD	R3	K14	R3
       0x70020000,  //  0009  JMP		#000B
-      0x580C0004,  //  000A  LDCONST	R3	K4
-      0x88100105,  //  000B  GETMBR	R4	R0	K5
-      0x88140106,  //  000C  GETMBR	R5	R0	K6
-      0x88180107,  //  000D  GETMBR	R6	R0	K7
+      0x580C000F,  //  000A  LDCONST	R3	K15
+      0x88100101,  //  000B  GETMBR	R4	R0	K1
+      0x88140103,  //  000C  GETMBR	R5	R0	K3
+      0x88180110,  //  000D  GETMBR	R6	R0	K16
       0x7C040A00,  //  000E  CALL	R1	5
       0x80040200,  //  000F  RET	1	R1
     })
@@ -149,58 +159,50 @@ be_local_closure(class_Partition_otadata__validate,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(active_otadata),
-    /* K1   */  be_nested_str(has_factory),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(seq0),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str(maxota),
-    /* K6   */  be_nested_str(seq1),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str__validate,
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
       0x78060001,  //  0001  JMPF	R1	#0004
       0x5405FFFE,  //  0002  LDINT	R1	-1
       0x70020000,  //  0003  JMP		#0005
       0x58040002,  //  0004  LDCONST	R1	K2
-      0x90020001,  //  0005  SETMBR	R0	K0	R1
-      0x88040103,  //  0006  GETMBR	R1	R0	K3
+      0x90021801,  //  0005  SETMBR	R0	K12	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
       0x4C080000,  //  0007  LDNIL	R2
       0x20040202,  //  0008  NE	R1	R1	R2
       0x78060005,  //  0009  JMPF	R1	#0010
-      0x88040103,  //  000A  GETMBR	R1	R0	K3
-      0x04040304,  //  000B  SUB	R1	R1	K4
-      0x88080105,  //  000C  GETMBR	R2	R0	K5
-      0x00080504,  //  000D  ADD	R2	R2	K4
+      0x88040101,  //  000A  GETMBR	R1	R0	K1
+      0x04040312,  //  000B  SUB	R1	R1	K18
+      0x88080110,  //  000C  GETMBR	R2	R0	K16
+      0x00080512,  //  000D  ADD	R2	R2	K18
       0x10040202,  //  000E  MOD	R1	R1	R2
-      0x90020001,  //  000F  SETMBR	R0	K0	R1
-      0x88040106,  //  0010  GETMBR	R1	R0	K6
+      0x90021801,  //  000F  SETMBR	R0	K12	R1
+      0x88040103,  //  0010  GETMBR	R1	R0	K3
       0x4C080000,  //  0011  LDNIL	R2
       0x20040202,  //  0012  NE	R1	R1	R2
       0x7806000D,  //  0013  JMPF	R1	#0022
-      0x88040103,  //  0014  GETMBR	R1	R0	K3
+      0x88040101,  //  0014  GETMBR	R1	R0	K1
       0x4C080000,  //  0015  LDNIL	R2
       0x1C040202,  //  0016  EQ	R1	R1	R2
       0x74060003,  //  0017  JMPT	R1	#001C
-      0x88040106,  //  0018  GETMBR	R1	R0	K6
-      0x88080103,  //  0019  GETMBR	R2	R0	K3
+      0x88040103,  //  0018  GETMBR	R1	R0	K3
+      0x88080101,  //  0019  GETMBR	R2	R0	K1
       0x24040202,  //  001A  GT	R1	R1	R2
       0x78060005,  //  001B  JMPF	R1	#0022
-      0x88040106,  //  001C  GETMBR	R1	R0	K6
-      0x04040304,  //  001D  SUB	R1	R1	K4
-      0x88080105,  //  001E  GETMBR	R2	R0	K5
-      0x00080504,  //  001F  ADD	R2	R2	K4
+      0x88040103,  //  001C  GETMBR	R1	R0	K3
+      0x04040312,  //  001D  SUB	R1	R1	K18
+      0x88080110,  //  001E  GETMBR	R2	R0	K16
+      0x00080512,  //  001F  ADD	R2	R2	K18
       0x10040202,  //  0020  MOD	R1	R1	R2
-      0x90020001,  //  0021  SETMBR	R0	K0	R1
+      0x90021801,  //  0021  SETMBR	R0	K12	R1
       0x80000000,  //  0022  RET	0
     })
   )
@@ -215,19 +217,17 @@ be_local_closure(class_Partition_otadata_set_ota_max,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(maxota),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_set_ota_max,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90022001,  //  0000  SETMBR	R0	K16	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -242,72 +242,62 @@ be_local_closure(class_Partition_otadata_load,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(offset),
-    /* K3   */  be_nested_str(seq0),
-    /* K4   */  be_nested_str(get),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str(seq1),
-    /* K7   */  be_nested_str(crc32_ota_seq),
-    /* K8   */  be_nested_str(_validate),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_load,
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x8C080313,  //  0001  GETMET	R2	R1	K19
+      0x88100105,  //  0002  GETMBR	R4	R0	K5
       0x5416001F,  //  0003  LDINT	R5	32
       0x7C080600,  //  0004  CALL	R2	3
-      0x8C0C0301,  //  0005  GETMET	R3	R1	K1
-      0x88140102,  //  0006  GETMBR	R5	R0	K2
+      0x8C0C0313,  //  0005  GETMET	R3	R1	K19
+      0x88140105,  //  0006  GETMBR	R5	R0	K5
       0x541A0FFF,  //  0007  LDINT	R6	4096
       0x00140A06,  //  0008  ADD	R5	R5	R6
       0x541A001F,  //  0009  LDINT	R6	32
       0x7C0C0600,  //  000A  CALL	R3	3
-      0x8C100504,  //  000B  GETMET	R4	R2	K4
-      0x58180005,  //  000C  LDCONST	R6	K5
+      0x8C100514,  //  000B  GETMET	R4	R2	K20
+      0x58180002,  //  000C  LDCONST	R6	K2
       0x541E0003,  //  000D  LDINT	R7	4
       0x7C100600,  //  000E  CALL	R4	3
-      0x90020604,  //  000F  SETMBR	R0	K3	R4
-      0x8C100704,  //  0010  GETMET	R4	R3	K4
-      0x58180005,  //  0011  LDCONST	R6	K5
+      0x90020204,  //  000F  SETMBR	R0	K1	R4
+      0x8C100714,  //  0010  GETMET	R4	R3	K20
+      0x58180002,  //  0011  LDCONST	R6	K2
       0x541E0003,  //  0012  LDINT	R7	4
       0x7C100600,  //  0013  CALL	R4	3
-      0x90020C04,  //  0014  SETMBR	R0	K6	R4
-      0x8C100504,  //  0015  GETMET	R4	R2	K4
+      0x90020604,  //  0014  SETMBR	R0	K3	R4
+      0x8C100514,  //  0015  GETMET	R4	R2	K20
       0x541A001B,  //  0016  LDINT	R6	28
       0x541E0003,  //  0017  LDINT	R7	4
       0x7C100600,  //  0018  CALL	R4	3
-      0x8C140107,  //  0019  GETMET	R5	R0	K7
-      0x881C0103,  //  001A  GETMBR	R7	R0	K3
+      0x8C140108,  //  0019  GETMET	R5	R0	K8
+      0x881C0101,  //  001A  GETMBR	R7	R0	K1
       0x7C140400,  //  001B  CALL	R5	2
       0x1C100805,  //  001C  EQ	R4	R4	R5
-      0x8C140704,  //  001D  GETMET	R5	R3	K4
+      0x8C140714,  //  001D  GETMET	R5	R3	K20
       0x541E001B,  //  001E  LDINT	R7	28
       0x54220003,  //  001F  LDINT	R8	4
       0x7C140600,  //  0020  CALL	R5	3
-      0x8C180107,  //  0021  GETMET	R6	R0	K7
-      0x88200106,  //  0022  GETMBR	R8	R0	K6
+      0x8C180108,  //  0021  GETMET	R6	R0	K8
+      0x88200103,  //  0022  GETMBR	R8	R0	K3
       0x7C180400,  //  0023  CALL	R6	2
       0x1C140A06,  //  0024  EQ	R5	R5	R6
       0x5C180800,  //  0025  MOVE	R6	R4
       0x741A0001,  //  0026  JMPT	R6	#0029
       0x4C180000,  //  0027  LDNIL	R6
-      0x90020606,  //  0028  SETMBR	R0	K3	R6
+      0x90020206,  //  0028  SETMBR	R0	K1	R6
       0x5C180A00,  //  0029  MOVE	R6	R5
       0x741A0001,  //  002A  JMPT	R6	#002D
       0x4C180000,  //  002B  LDNIL	R6
-      0x90020C06,  //  002C  SETMBR	R0	K6	R6
-      0x8C180108,  //  002D  GETMET	R6	R0	K8
+      0x90020606,  //  002C  SETMBR	R0	K3	R6
+      0x8C180115,  //  002D  GETMET	R6	R0	K21
       0x7C180200,  //  002E  CALL	R6	1
       0x80000000,  //  002F  RET	0
     })
@@ -323,28 +313,23 @@ be_local_closure(class_Partition_otadata_crc32_ota_seq,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Partition_otadata),
-    /* K1   */  be_nested_str(crc),
-    /* K2   */  be_nested_str(crc32),
-    /* K3   */  be_nested_str(add),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_crc32_ota_seq,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x58040016,  //  0000  LDCONST	R1	K22
+      0xA40A2E00,  //  0001  IMPORT	R2	K23
+      0x8C0C0518,  //  0002  GETMET	R3	R2	K24
       0x5415FFFE,  //  0003  LDINT	R5	-1
       0x60180015,  //  0004  GETGBL	R6	G21
       0x7C180000,  //  0005  CALL	R6	0
-      0x8C180D03,  //  0006  GETMET	R6	R6	K3
+      0x8C180D06,  //  0006  GETMET	R6	R6	K6
       0x5C200000,  //  0007  MOVE	R8	R0
       0x54260003,  //  0008  LDINT	R9	4
       0x7C180600,  //  0009  CALL	R6	3
@@ -363,43 +348,36 @@ be_local_closure(class_Partition_otadata_set_active,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(seq0),
-    /* K2   */  be_nested_str(seq1),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str(maxota),
-    /* K5   */  be_nested_str(_validate),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_set_active,
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x580C0000,  //  0001  LDCONST	R3	K0
+      0x5808000D,  //  0000  LDCONST	R2	K13
+      0x580C000D,  //  0001  LDCONST	R3	K13
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x4C140000,  //  0003  LDNIL	R5
       0x20100805,  //  0004  NE	R4	R4	R5
       0x78120001,  //  0005  JMPF	R4	#0008
       0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x580C0000,  //  0007  LDCONST	R3	K0
-      0x88100102,  //  0008  GETMBR	R4	R0	K2
+      0x580C000D,  //  0007  LDCONST	R3	K13
+      0x88100103,  //  0008  GETMBR	R4	R0	K3
       0x4C140000,  //  0009  LDNIL	R5
       0x20100805,  //  000A  NE	R4	R4	R5
       0x78120004,  //  000B  JMPF	R4	#0011
-      0x88100102,  //  000C  GETMBR	R4	R0	K2
+      0x88100103,  //  000C  GETMBR	R4	R0	K3
       0x24100802,  //  000D  GT	R4	R4	R2
       0x78120001,  //  000E  JMPF	R4	#0011
-      0x88080102,  //  000F  GETMBR	R2	R0	K2
-      0x580C0003,  //  0010  LDCONST	R3	K3
-      0x04100503,  //  0011  SUB	R4	R2	K3
-      0x88140104,  //  0012  GETMBR	R5	R0	K4
-      0x00140B03,  //  0013  ADD	R5	R5	K3
+      0x88080103,  //  000F  GETMBR	R2	R0	K3
+      0x580C0004,  //  0010  LDCONST	R3	K4
+      0x04100504,  //  0011  SUB	R4	R2	K4
+      0x88140110,  //  0012  GETMBR	R5	R0	K16
+      0x00140B04,  //  0013  ADD	R5	R5	K4
       0x10100805,  //  0014  MOD	R4	R4	R5
       0x20140801,  //  0015  NE	R5	R4	R1
       0x78160010,  //  0016  JMPF	R5	#0028
@@ -408,17 +386,17 @@ be_local_closure(class_Partition_otadata_set_active,   /* name */
       0x04140204,  //  0019  SUB	R5	R1	R4
       0x00080405,  //  001A  ADD	R2	R2	R5
       0x70020004,  //  001B  JMP		#0021
-      0x88140104,  //  001C  GETMBR	R5	R0	K4
-      0x00140B03,  //  001D  ADD	R5	R5	K3
+      0x88140110,  //  001C  GETMBR	R5	R0	K16
+      0x00140B04,  //  001D  ADD	R5	R5	K4
       0x04140A04,  //  001E  SUB	R5	R5	R4
       0x00140A01,  //  001F  ADD	R5	R5	R1
       0x00080405,  //  0020  ADD	R2	R2	R5
-      0x1C140703,  //  0021  EQ	R5	R3	K3
+      0x1C140704,  //  0021  EQ	R5	R3	K4
       0x78160001,  //  0022  JMPF	R5	#0025
       0x90020202,  //  0023  SETMBR	R0	K1	R2
       0x70020000,  //  0024  JMP		#0026
-      0x90020402,  //  0025  SETMBR	R0	K2	R2
-      0x8C140105,  //  0026  GETMET	R5	R0	K5
+      0x90020602,  //  0025  SETMBR	R0	K3	R2
+      0x8C140115,  //  0026  GETMET	R5	R0	K21
       0x7C140200,  //  0027  CALL	R5	1
       0x80000000,  //  0028  RET	0
     })
@@ -434,40 +412,33 @@ be_local_closure(class_Partition_otadata_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(maxota),
-    /* K1   */  be_nested_str(has_factory),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str(offset),
-    /* K4   */  be_nested_str(active_otadata),
-    /* K5   */  be_nested_str(load),
-    }),
+    &be_ktab_class_Partition_otadata,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x90022001,  //  0000  SETMBR	R0	K16	R1
+      0x90022202,  //  0001  SETMBR	R0	K17	R2
+      0x88100110,  //  0002  GETMBR	R4	R0	K16
       0x4C140000,  //  0003  LDNIL	R5
       0x1C100805,  //  0004  EQ	R4	R4	R5
       0x78120000,  //  0005  JMPF	R4	#0007
-      0x90020102,  //  0006  SETMBR	R0	K0	K2
-      0x90020603,  //  0007  SETMBR	R0	K3	R3
-      0x88100103,  //  0008  GETMBR	R4	R0	K3
+      0x90022104,  //  0006  SETMBR	R0	K16	K4
+      0x90020A03,  //  0007  SETMBR	R0	K5	R3
+      0x88100105,  //  0008  GETMBR	R4	R0	K5
       0x4C140000,  //  0009  LDNIL	R5
       0x1C100805,  //  000A  EQ	R4	R4	R5
       0x78120001,  //  000B  JMPF	R4	#000E
       0x5412DFFF,  //  000C  LDINT	R4	57344
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x90020A04,  //  000D  SETMBR	R0	K5	R4
       0x5411FFFE,  //  000E  LDINT	R4	-1
-      0x90020804,  //  000F  SETMBR	R0	K4	R4
-      0x8C100105,  //  0010  GETMET	R4	R0	K5
+      0x90021804,  //  000F  SETMBR	R0	K12	R4
+      0x8C100119,  //  0010  GETMET	R4	R0	K25
       0x7C100200,  //  0011  CALL	R4	1
       0x80000000,  //  0012  RET	0
     })
@@ -501,6 +472,85 @@ be_local_class(Partition_otadata,
     })),
     (bstring*) &be_const_str_Partition_otadata
 );
+extern const bclass be_class_Partition;
+// compact class 'Partition' ktab size: 74, total: 134 (saved 480 bytes)
+static const bvalue be_ktab_class_Partition[74] = {
+  /* K0   */  be_nested_str(flash),
+  /* K1   */  be_nested_str(tobytes),
+  /* K2   */  be_nested_str(erase),
+  /* K3   */  be_nested_str(write),
+  /* K4   */  be_nested_str(otadata),
+  /* K5   */  be_nested_str(save),
+  /* K6   */  be_nested_str(raw),
+  /* K7   */  be_nested_str(read),
+  /* K8   */  be_nested_str(active_otadata),
+  /* K9   */  be_nested_str(slots),
+  /* K10  */  be_nested_str(load),
+  /* K11  */  be_nested_str(parse),
+  /* K12  */  be_nested_str(load_otadata),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str(get),
+  /* K16  */  be_const_int(2),
+  /* K17  */  be_nested_str(partition_core),
+  /* K18  */  be_nested_str(Partition_info),
+  /* K19  */  be_nested_str(push),
+  /* K20  */  be_nested_str(md5),
+  /* K21  */  be_nested_str(stop_iteration),
+  /* K22  */  be_nested_str(tasmota),
+  /* K23  */  be_nested_str(memory),
+  /* K24  */  be_nested_str(find),
+  /* K25  */  be_nested_str(flash_real),
+  /* K26  */  be_nested_str(get_flash_definition_sector),
+  /* K27  */  be_const_int(3),
+  /* K28  */  be_const_int(1),
+  /* K29  */  be_const_int(2),
+  /* K30  */  be_nested_str(log),
+  /* K31  */  be_nested_str(UPL_X3A_X20changing_X20flash_X20definition_X20from_X200x02X_X20to_X200x_X2502X),
+  /* K32  */  be_nested_str(wrong_X20flash_X20size_X20),
+  /* K33  */  be_nested_str(internal_error),
+  /* K34  */  be_const_class(be_class_Partition),
+  /* K35  */  be_const_int(0),
+  /* K36  */  be_nested_str(E9),
+  /* K37  */  be_nested_str(get_unallocated_k),
+  /* K38  */  be_nested_str(BRY_X3A_X20Trying_X20to_X20expand_X20FS_X20by_X20_X25i_X20kB),
+  /* K39  */  be_nested_str(resize_max_flash_size_k),
+  /* K40  */  be_nested_str(sz),
+  /* K41  */  be_nested_str(global),
+  /* K42  */  be_nested_str(restart_flag),
+  /* K43  */  be_nested_str(BRY_X3A_X20Successfully_X20resized_X20FS_X2C_X20restarting),
+  /* K44  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K45  */  be_nested_str(factory),
+  /* K46  */  be_nested_str(ota_max),
+  /* K47  */  be_nested_str(type),
+  /* K48  */  be_nested_str(subtype),
+  /* K49  */  be_nested_str(start),
+  /* K50  */  be_nested_str(Partition_otadata),
+  /* K51  */  be_nested_str(has_factory),
+  /* K52  */  be_nested_str(_X3Cinstance_X3A_X20Partition_X28_X5B_X0A),
+  /* K53  */  be_nested_str(_X20_X20),
+  /* K54  */  be_nested_str(tostring),
+  /* K55  */  be_nested_str(_X0A),
+  /* K56  */  be_nested_str(_X5D_X2C_X0A_X20_X20),
+  /* K57  */  be_nested_str(_X0A_X29_X3E),
+  /* K58  */  be_nested_str(get_factory_slot),
+  /* K59  */  be_nested_str(value_error),
+  /* K60  */  be_nested_str(Too_X20many_X20partiition_X20slots),
+  /* K61  */  be_nested_str(MD5),
+  /* K62  */  be_nested_str(update),
+  /* K63  */  be_nested_str(EBEBFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
+  /* K64  */  be_nested_str(finish),
+  /* K65  */  be_nested_str(is_spiffs),
+  /* K66  */  be_nested_str(No_X20FS_X20partition_X20found),
+  /* K67  */  be_nested_str(00),
+  /* K68  */  be_nested_str(is_factory),
+  /* K69  */  be_nested_str(Invalid_X20ota_X20partition_X20number),
+  /* K70  */  be_nested_str(set_ota_max),
+  /* K71  */  be_nested_str(set_active),
+  /* K72  */  be_nested_str(get_max_flash_size_k),
+  /* K73  */  be_nested_str(is_ota),
+};
+
 
 extern const bclass be_class_Partition;
 
@@ -511,20 +561,13 @@ be_local_closure(class_Partition_save,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(tobytes),
-    /* K2   */  be_nested_str(erase),
-    /* K3   */  be_nested_str(write),
-    /* K4   */  be_nested_str(otadata),
-    /* K5   */  be_nested_str(save),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_save,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -556,26 +599,22 @@ be_local_closure(class_Partition_load,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(raw),
-    /* K2   */  be_nested_str(read),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_load,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080302,  //  0001  GETMET	R2	R1	K2
+      0x8C080307,  //  0001  GETMET	R2	R1	K7
       0x54127FFF,  //  0002  LDINT	R4	32768
       0x54160FFF,  //  0003  LDINT	R5	4096
       0x7C080600,  //  0004  CALL	R2	3
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x90020C02,  //  0005  SETMBR	R0	K6	R2
       0x80000000,  //  0006  RET	0
     })
   )
@@ -590,21 +629,18 @@ be_local_closure(class_Partition_get_active,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(otadata),
-    /* K1   */  be_nested_str(active_otadata),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_active,
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x88040308,  //  0001  GETMBR	R1	R1	K8
       0x80040200,  //  0002  RET	1	R1
     })
   )
@@ -619,29 +655,24 @@ be_local_closure(class_Partition_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(load),
-    /* K2   */  be_nested_str(parse),
-    /* K3   */  be_nested_str(load_otadata),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x60040012,  //  0000  GETGBL	R1	G18
       0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x90021201,  //  0002  SETMBR	R0	K9	R1
+      0x8C04010A,  //  0003  GETMET	R1	R0	K10
       0x7C040200,  //  0004  CALL	R1	1
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x8C04010B,  //  0005  GETMET	R1	R0	K11
       0x7C040200,  //  0006  CALL	R1	1
-      0x8C040103,  //  0007  GETMET	R1	R0	K3
+      0x8C04010C,  //  0007  GETMET	R1	R0	K12
       0x7C040200,  //  0008  CALL	R1	1
       0x80000000,  //  0009  RET	0
     })
@@ -657,58 +688,46 @@ be_local_closure(class_Partition_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(raw),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str(get),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str(partition_core),
-    /* K6   */  be_nested_str(Partition_info),
-    /* K7   */  be_nested_str(slots),
-    /* K8   */  be_nested_str(push),
-    /* K9   */  be_nested_str(md5),
-    /* K10  */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_parse,
     &be_const_str_solidified,
     ( &(const binstruction[57]) {  /* code */
       0x60040010,  //  0000  GETGBL	R1	G16
       0x540A005D,  //  0001  LDINT	R2	94
-      0x400A0002,  //  0002  CONNECT	R2	K0	R2
+      0x400A1A02,  //  0002  CONNECT	R2	K13	R2
       0x7C040200,  //  0003  CALL	R1	1
       0xA802002F,  //  0004  EXBLK	0	#0035
       0x5C080200,  //  0005  MOVE	R2	R1
       0x7C080000,  //  0006  CALL	R2	0
       0x540E001F,  //  0007  LDINT	R3	32
       0x080C0403,  //  0008  MUL	R3	R2	R3
-      0x00100502,  //  0009  ADD	R4	R2	K2
+      0x0010050E,  //  0009  ADD	R4	R2	K14
       0x5416001F,  //  000A  LDINT	R5	32
       0x08100805,  //  000B  MUL	R4	R4	R5
-      0x04100902,  //  000C  SUB	R4	R4	K2
+      0x0410090E,  //  000C  SUB	R4	R4	K14
       0x400C0604,  //  000D  CONNECT	R3	R3	R4
-      0x88100101,  //  000E  GETMBR	R4	R0	K1
+      0x88100106,  //  000E  GETMBR	R4	R0	K6
       0x940C0803,  //  000F  GETIDX	R3	R4	R3
-      0x8C140703,  //  0010  GETMET	R5	R3	K3
-      0x581C0000,  //  0011  LDCONST	R7	K0
-      0x58200004,  //  0012  LDCONST	R8	K4
+      0x8C14070F,  //  0010  GETMET	R5	R3	K15
+      0x581C000D,  //  0011  LDCONST	R7	K13
+      0x58200010,  //  0012  LDCONST	R8	K16
       0x7C140600,  //  0013  CALL	R5	3
       0x5C100A00,  //  0014  MOVE	R4	R5
       0x541650A9,  //  0015  LDINT	R5	20650
       0x1C140805,  //  0016  EQ	R5	R4	R5
       0x78160008,  //  0017  JMPF	R5	#0021
-      0xB8160A00,  //  0018  GETNGBL	R5	K5
-      0x8C140B06,  //  0019  GETMET	R5	R5	K6
+      0xB8162200,  //  0018  GETNGBL	R5	K17
+      0x8C140B12,  //  0019  GETMET	R5	R5	K18
       0x5C1C0600,  //  001A  MOVE	R7	R3
       0x7C140400,  //  001B  CALL	R5	2
-      0x88180107,  //  001C  GETMBR	R6	R0	K7
-      0x8C180D08,  //  001D  GETMET	R6	R6	K8
+      0x88180109,  //  001C  GETMBR	R6	R0	K9
+      0x8C180D13,  //  001D  GETMET	R6	R6	K19
       0x5C200A00,  //  001E  MOVE	R8	R5
       0x7C180400,  //  001F  CALL	R6	2
       0x70020010,  //  0020  JMP		#0032
@@ -721,18 +740,18 @@ be_local_closure(class_Partition_parse,   /* name */
       0x00140A06,  //  0027  ADD	R5	R5	R6
       0x541A0020,  //  0028  LDINT	R6	33
       0x08180406,  //  0029  MUL	R6	R2	R6
-      0x04180D02,  //  002A  SUB	R6	R6	K2
+      0x04180D0E,  //  002A  SUB	R6	R6	K14
       0x40140A06,  //  002B  CONNECT	R5	R5	R6
-      0x88180101,  //  002C  GETMBR	R6	R0	K1
+      0x88180106,  //  002C  GETMBR	R6	R0	K6
       0x94140C05,  //  002D  GETIDX	R5	R6	R5
-      0x90021205,  //  002E  SETMBR	R0	K9	R5
+      0x90022805,  //  002E  SETMBR	R0	K20	R5
       0x70020002,  //  002F  JMP		#0033
       0x70020000,  //  0030  JMP		#0032
       0x70020000,  //  0031  JMP		#0033
       0x7001FFD1,  //  0032  JMP		#0005
       0xA8040001,  //  0033  EXBLK	1	1
       0x70020002,  //  0034  JMP		#0038
-      0x5804000A,  //  0035  LDCONST	R1	K10
+      0x58040015,  //  0035  LDCONST	R1	K21
       0xAC040200,  //  0036  CATCH	R1	1	0
       0xB0080000,  //  0037  RAISE	2	R0	R0
       0x80000000,  //  0038  RET	0
@@ -749,37 +768,30 @@ be_local_closure(class_Partition_get_max_flash_size_k,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    /* K1   */  be_nested_str(memory),
-    /* K2   */  be_nested_str(flash),
-    /* K3   */  be_nested_str(find),
-    /* K4   */  be_nested_str(flash_real),
-    /* K5   */  be_nested_str(get_flash_definition_sector),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_max_flash_size_k,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB8062C00,  //  0000  GETNGBL	R1	K22
+      0x8C040317,  //  0001  GETMET	R1	R1	K23
       0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x94040300,  //  0003  GETIDX	R1	R1	K0
+      0xB80A2C00,  //  0004  GETNGBL	R2	K22
+      0x8C080517,  //  0005  GETMET	R2	R2	K23
       0x7C080200,  //  0006  CALL	R2	1
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
+      0x8C080518,  //  0007  GETMET	R2	R2	K24
+      0x58100019,  //  0008  LDCONST	R4	K25
       0x5C140200,  //  0009  MOVE	R5	R1
       0x7C080600,  //  000A  CALL	R2	3
       0x200C0202,  //  000B  NE	R3	R1	R2
       0x780E0005,  //  000C  JMPF	R3	#0013
-      0x8C0C0105,  //  000D  GETMET	R3	R0	K5
+      0x8C0C011A,  //  000D  GETMET	R3	R0	K26
       0x7C0C0200,  //  000E  CALL	R3	1
       0x4C100000,  //  000F  LDNIL	R4
       0x200C0604,  //  0010  NE	R3	R3	R4
@@ -799,66 +811,49 @@ be_local_closure(class_Partition_resize_max_flash_size_k,   /* name */
   be_nested_proto(
     16,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    /* K1   */  be_nested_str(memory),
-    /* K2   */  be_nested_str(flash),
-    /* K3   */  be_nested_str(find),
-    /* K4   */  be_nested_str(flash_real),
-    /* K5   */  be_nested_str(get_flash_definition_sector),
-    /* K6   */  be_nested_str(read),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str(write),
-    /* K12  */  be_nested_str(log),
-    /* K13  */  be_nested_str(UPL_X3A_X20changing_X20flash_X20definition_X20from_X200x02X_X20to_X200x_X2502X),
-    /* K14  */  be_nested_str(wrong_X20flash_X20size_X20),
-    /* K15  */  be_nested_str(internal_error),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_resize_max_flash_size_k,
     &be_const_str_solidified,
     ( &(const binstruction[94]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB8062C00,  //  0000  GETNGBL	R1	K22
+      0x8C040317,  //  0001  GETMET	R1	R1	K23
       0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x94040300,  //  0003  GETIDX	R1	R1	K0
+      0xB80A2C00,  //  0004  GETNGBL	R2	K22
+      0x8C080517,  //  0005  GETMET	R2	R2	K23
       0x7C080200,  //  0006  CALL	R2	1
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
+      0x8C080518,  //  0007  GETMET	R2	R2	K24
+      0x58100019,  //  0008  LDCONST	R4	K25
       0x5C140200,  //  0009  MOVE	R5	R1
       0x7C080600,  //  000A  CALL	R2	3
-      0x8C0C0105,  //  000B  GETMET	R3	R0	K5
+      0x8C0C011A,  //  000B  GETMET	R3	R0	K26
       0x7C0C0200,  //  000C  CALL	R3	1
       0x20100202,  //  000D  NE	R4	R1	R2
       0x7812004D,  //  000E  JMPF	R4	#005D
       0x4C100000,  //  000F  LDNIL	R4
       0x20100604,  //  0010  NE	R4	R3	R4
       0x7812004A,  //  0011  JMPF	R4	#005D
-      0xA4120400,  //  0012  IMPORT	R4	K2
+      0xA4120000,  //  0012  IMPORT	R4	K0
       0x5C040400,  //  0013  MOVE	R1	R2
-      0x8C140906,  //  0014  GETMET	R5	R4	K6
+      0x8C140907,  //  0014  GETMET	R5	R4	K7
       0x5C1C0600,  //  0015  MOVE	R7	R3
       0x54220003,  //  0016  LDINT	R8	4
       0x7C140600,  //  0017  CALL	R5	3
-      0x94180B07,  //  0018  GETIDX	R6	R5	K7
+      0x94180B1B,  //  0018  GETIDX	R6	R5	K27
       0x4C1C0000,  //  0019  LDNIL	R7
       0x542203FF,  //  001A  LDINT	R8	1024
       0x0C200408,  //  001B  DIV	R8	R2	R8
-      0x1C241108,  //  001C  EQ	R9	R8	K8
+      0x1C24111C,  //  001C  EQ	R9	R8	K28
       0x78260001,  //  001D  JMPF	R9	#0020
-      0x581C0009,  //  001E  LDCONST	R7	K9
+      0x581C000D,  //  001E  LDCONST	R7	K13
       0x70020020,  //  001F  JMP		#0041
-      0x1C24110A,  //  0020  EQ	R9	R8	K10
+      0x1C24111D,  //  0020  EQ	R9	R8	K29
       0x78260001,  //  0021  JMPF	R9	#0024
       0x541E000F,  //  0022  LDINT	R7	16
       0x7002001C,  //  0023  JMP		#0041
@@ -894,31 +889,31 @@ be_local_closure(class_Partition_resize_max_flash_size_k,   /* name */
       0x4C240000,  //  0041  LDNIL	R9
       0x20240E09,  //  0042  NE	R9	R7	R9
       0x78260013,  //  0043  JMPF	R9	#0058
-      0x94240B07,  //  0044  GETIDX	R9	R5	K7
-      0x94280B07,  //  0045  GETIDX	R10	R5	K7
+      0x94240B1B,  //  0044  GETIDX	R9	R5	K27
+      0x94280B1B,  //  0045  GETIDX	R10	R5	K27
       0x542E000E,  //  0046  LDINT	R11	15
       0x2C28140B,  //  0047  AND	R10	R10	R11
       0x30281407,  //  0048  OR	R10	R10	R7
-      0x98160E0A,  //  0049  SETIDX	R5	K7	R10
-      0x8C28090B,  //  004A  GETMET	R10	R4	K11
+      0x9816360A,  //  0049  SETIDX	R5	K27	R10
+      0x8C280903,  //  004A  GETMET	R10	R4	K3
       0x5C300600,  //  004B  MOVE	R12	R3
       0x5C340A00,  //  004C  MOVE	R13	R5
       0x7C280600,  //  004D  CALL	R10	3
-      0xB82A0000,  //  004E  GETNGBL	R10	K0
-      0x8C28150C,  //  004F  GETMET	R10	R10	K12
+      0xB82A2C00,  //  004E  GETNGBL	R10	K22
+      0x8C28151E,  //  004F  GETMET	R10	R10	K30
       0x60300018,  //  0050  GETGBL	R12	G24
-      0x5834000D,  //  0051  LDCONST	R13	K13
+      0x5834001F,  //  0051  LDCONST	R13	K31
       0x5C381200,  //  0052  MOVE	R14	R9
-      0x943C0B07,  //  0053  GETIDX	R15	R5	K7
+      0x943C0B1B,  //  0053  GETIDX	R15	R5	K27
       0x7C300600,  //  0054  CALL	R12	3
-      0x58340007,  //  0055  LDCONST	R13	K7
+      0x5834001B,  //  0055  LDCONST	R13	K27
       0x7C280600,  //  0056  CALL	R10	3
       0x70020004,  //  0057  JMP		#005D
       0x60240008,  //  0058  GETGBL	R9	G8
       0x5C281000,  //  0059  MOVE	R10	R8
       0x7C240200,  //  005A  CALL	R9	1
-      0x00261C09,  //  005B  ADD	R9	K14	R9
-      0xB0061E09,  //  005C  RAISE	1	K15	R9
+      0x00264009,  //  005B  ADD	R9	K32	R9
+      0xB0064209,  //  005C  RAISE	1	K33	R9
       0x80000000,  //  005D  RET	0
     })
   )
@@ -933,47 +928,39 @@ be_local_closure(class_Partition_get_flash_definition_sector,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     0,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Partition),
-    /* K1   */  be_nested_str(flash),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str(read),
-    /* K5   */  be_nested_str(E9),
-    /* K6   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_flash_definition_sector,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x58000000,  //  0000  LDCONST	R0	K0
-      0xA4060200,  //  0001  IMPORT	R1	K1
+      0x58000022,  //  0000  LDCONST	R0	K34
+      0xA4060000,  //  0001  IMPORT	R1	K0
       0x60080010,  //  0002  GETGBL	R2	G16
-      0x400E0503,  //  0003  CONNECT	R3	K2	K3
+      0x400E471C,  //  0003  CONNECT	R3	K35	K28
       0x7C080200,  //  0004  CALL	R2	1
       0xA802000F,  //  0005  EXBLK	0	#0016
       0x5C0C0400,  //  0006  MOVE	R3	R2
       0x7C0C0000,  //  0007  CALL	R3	0
       0x54120FFF,  //  0008  LDINT	R4	4096
       0x08100604,  //  0009  MUL	R4	R3	R4
-      0x8C140304,  //  000A  GETMET	R5	R1	K4
+      0x8C140307,  //  000A  GETMET	R5	R1	K7
       0x5C1C0800,  //  000B  MOVE	R7	R4
-      0x58200003,  //  000C  LDCONST	R8	K3
+      0x5820001C,  //  000C  LDCONST	R8	K28
       0x7C140600,  //  000D  CALL	R5	3
       0x60180015,  //  000E  GETGBL	R6	G21
-      0x581C0005,  //  000F  LDCONST	R7	K5
+      0x581C0024,  //  000F  LDCONST	R7	K36
       0x7C180200,  //  0010  CALL	R6	1
       0x1C140A06,  //  0011  EQ	R5	R5	R6
       0x78160001,  //  0012  JMPF	R5	#0015
       0xA8040001,  //  0013  EXBLK	1	1
       0x80040800,  //  0014  RET	1	R4
       0x7001FFEF,  //  0015  JMP		#0006
-      0x58080006,  //  0016  LDCONST	R2	K6
+      0x58080015,  //  0016  LDCONST	R2	K21
       0xAC080200,  //  0017  CATCH	R2	1	0
       0xB0080000,  //  0018  RAISE	2	R0	R0
       0x80000000,  //  0019  RET	0
@@ -990,79 +977,64 @@ be_local_closure(class_Partition_resize_fs_to_max,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str(get_unallocated_k),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(tasmota),
-    /* K3   */  be_nested_str(log),
-    /* K4   */  be_nested_str(BRY_X3A_X20Trying_X20to_X20expand_X20FS_X20by_X20_X25i_X20kB),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str(resize_max_flash_size_k),
-    /* K7   */  be_nested_str(slots),
-    /* K8   */  be_nested_str(sz),
-    /* K9   */  be_nested_str(save),
-    /* K10  */  be_nested_str(global),
-    /* K11  */  be_nested_str(restart_flag),
-    /* K12  */  be_nested_str(BRY_X3A_X20Successfully_X20resized_X20FS_X2C_X20restarting),
-    /* K13  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_resize_fs_to_max,
     &be_const_str_solidified,
     ( &(const binstruction[52]) {  /* code */
       0xA8020024,  //  0000  EXBLK	0	#0026
-      0x8C040100,  //  0001  GETMET	R1	R0	K0
+      0x8C040125,  //  0001  GETMET	R1	R0	K37
       0x7C040200,  //  0002  CALL	R1	1
-      0x18080301,  //  0003  LE	R2	R1	K1
+      0x1808030D,  //  0003  LE	R2	R1	K13
       0x780A0002,  //  0004  JMPF	R2	#0008
       0x4C080000,  //  0005  LDNIL	R2
       0xA8040001,  //  0006  EXBLK	1	1
       0x80040400,  //  0007  RET	1	R2
-      0xB80A0400,  //  0008  GETNGBL	R2	K2
-      0x8C080503,  //  0009  GETMET	R2	R2	K3
+      0xB80A2C00,  //  0008  GETNGBL	R2	K22
+      0x8C08051E,  //  0009  GETMET	R2	R2	K30
       0x60100018,  //  000A  GETGBL	R4	G24
-      0x58140004,  //  000B  LDCONST	R5	K4
+      0x58140026,  //  000B  LDCONST	R5	K38
       0x5C180200,  //  000C  MOVE	R6	R1
       0x7C100400,  //  000D  CALL	R4	2
-      0x58140005,  //  000E  LDCONST	R5	K5
+      0x58140010,  //  000E  LDCONST	R5	K16
       0x7C080600,  //  000F  CALL	R2	3
-      0x8C080106,  //  0010  GETMET	R2	R0	K6
+      0x8C080127,  //  0010  GETMET	R2	R0	K39
       0x7C080200,  //  0011  CALL	R2	1
-      0x88080107,  //  0012  GETMBR	R2	R0	K7
+      0x88080109,  //  0012  GETMBR	R2	R0	K9
       0x540DFFFE,  //  0013  LDINT	R3	-1
       0x94080403,  //  0014  GETIDX	R2	R2	R3
       0x541203FF,  //  0015  LDINT	R4	1024
       0x08100204,  //  0016  MUL	R4	R1	R4
-      0x880C0508,  //  0017  GETMBR	R3	R2	K8
+      0x880C0528,  //  0017  GETMBR	R3	R2	K40
       0x000C0604,  //  0018  ADD	R3	R3	R4
-      0x900A1003,  //  0019  SETMBR	R2	K8	R3
-      0x8C0C0109,  //  001A  GETMET	R3	R0	K9
+      0x900A5003,  //  0019  SETMBR	R2	K40	R3
+      0x8C0C0105,  //  001A  GETMET	R3	R0	K5
       0x7C0C0200,  //  001B  CALL	R3	1
-      0xB80E0400,  //  001C  GETNGBL	R3	K2
-      0x880C070A,  //  001D  GETMBR	R3	R3	K10
-      0x900E1705,  //  001E  SETMBR	R3	K11	K5
-      0xB80E0400,  //  001F  GETNGBL	R3	K2
-      0x8C0C0703,  //  0020  GETMET	R3	R3	K3
-      0x5814000C,  //  0021  LDCONST	R5	K12
-      0x58180005,  //  0022  LDCONST	R6	K5
+      0xB80E2C00,  //  001C  GETNGBL	R3	K22
+      0x880C0729,  //  001D  GETMBR	R3	R3	K41
+      0x900E5510,  //  001E  SETMBR	R3	K42	K16
+      0xB80E2C00,  //  001F  GETNGBL	R3	K22
+      0x8C0C071E,  //  0020  GETMET	R3	R3	K30
+      0x5814002B,  //  0021  LDCONST	R5	K43
+      0x58180010,  //  0022  LDCONST	R6	K16
       0x7C0C0600,  //  0023  CALL	R3	3
       0xA8040001,  //  0024  EXBLK	1	1
       0x7002000C,  //  0025  JMP		#0033
       0xAC040002,  //  0026  CATCH	R1	0	2
       0x70020009,  //  0027  JMP		#0032
-      0xB80E0400,  //  0028  GETNGBL	R3	K2
-      0x8C0C0703,  //  0029  GETMET	R3	R3	K3
+      0xB80E2C00,  //  0028  GETNGBL	R3	K22
+      0x8C0C071E,  //  0029  GETMET	R3	R3	K30
       0x60140018,  //  002A  GETGBL	R5	G24
-      0x5818000D,  //  002B  LDCONST	R6	K13
+      0x5818002C,  //  002B  LDCONST	R6	K44
       0x5C1C0200,  //  002C  MOVE	R7	R1
       0x5C200400,  //  002D  MOVE	R8	R2
       0x7C140600,  //  002E  CALL	R5	3
-      0x58180005,  //  002F  LDCONST	R6	K5
+      0x58180010,  //  002F  LDCONST	R6	K16
       0x7C0C0600,  //  0030  CALL	R3	3
       0x70020000,  //  0031  JMP		#0033
       0xB0080000,  //  0032  RAISE	2	R0	R0
@@ -1080,21 +1052,18 @@ be_local_closure(class_Partition_switch_factory,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(factory),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_switch_factory,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x8C0C052D,  //  0001  GETMET	R3	R2	K45
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x80000000,  //  0004  RET	0
@@ -1111,57 +1080,44 @@ be_local_closure(class_Partition_load_otadata,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(ota_max),
-    /* K1   */  be_nested_str(slots),
-    /* K2   */  be_nested_str(type),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str(subtype),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str(start),
-    /* K7   */  be_nested_str(stop_iteration),
-    /* K8   */  be_nested_str(otadata),
-    /* K9   */  be_nested_str(partition_core),
-    /* K10  */  be_nested_str(Partition_otadata),
-    /* K11  */  be_nested_str(has_factory),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_load_otadata,
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
       0x5406DFFF,  //  0000  LDINT	R1	57344
-      0x8C080100,  //  0001  GETMET	R2	R0	K0
+      0x8C08012E,  //  0001  GETMET	R2	R0	K46
       0x7C080200,  //  0002  CALL	R2	1
       0x600C0010,  //  0003  GETGBL	R3	G16
-      0x88100101,  //  0004  GETMBR	R4	R0	K1
+      0x88100109,  //  0004  GETMBR	R4	R0	K9
       0x7C0C0200,  //  0005  CALL	R3	1
       0xA8020009,  //  0006  EXBLK	0	#0011
       0x5C100600,  //  0007  MOVE	R4	R3
       0x7C100000,  //  0008  CALL	R4	0
-      0x88140902,  //  0009  GETMBR	R5	R4	K2
-      0x1C140B03,  //  000A  EQ	R5	R5	K3
+      0x8814092F,  //  0009  GETMBR	R5	R4	K47
+      0x1C140B1C,  //  000A  EQ	R5	R5	K28
       0x78160003,  //  000B  JMPF	R5	#0010
-      0x88140904,  //  000C  GETMBR	R5	R4	K4
-      0x1C140B05,  //  000D  EQ	R5	R5	K5
+      0x88140930,  //  000C  GETMBR	R5	R4	K48
+      0x1C140B23,  //  000D  EQ	R5	R5	K35
       0x78160000,  //  000E  JMPF	R5	#0010
-      0x88040906,  //  000F  GETMBR	R1	R4	K6
+      0x88040931,  //  000F  GETMBR	R1	R4	K49
       0x7001FFF5,  //  0010  JMP		#0007
-      0x580C0007,  //  0011  LDCONST	R3	K7
+      0x580C0015,  //  0011  LDCONST	R3	K21
       0xAC0C0200,  //  0012  CATCH	R3	1	0
       0xB0080000,  //  0013  RAISE	2	R0	R0
-      0xB80E1200,  //  0014  GETNGBL	R3	K9
-      0x8C0C070A,  //  0015  GETMET	R3	R3	K10
+      0xB80E2200,  //  0014  GETNGBL	R3	K17
+      0x8C0C0732,  //  0015  GETMET	R3	R3	K50
       0x5C140400,  //  0016  MOVE	R5	R2
-      0x8C18010B,  //  0017  GETMET	R6	R0	K11
+      0x8C180133,  //  0017  GETMET	R6	R0	K51
       0x7C180200,  //  0018  CALL	R6	1
       0x5C1C0200,  //  0019  MOVE	R7	R1
       0x7C0C0800,  //  001A  CALL	R3	4
-      0x90021003,  //  001B  SETMBR	R0	K8	R3
+      0x90020803,  //  001B  SETMBR	R0	K4	R3
       0x80000000,  //  001C  RET	0
     })
   )
@@ -1176,48 +1132,38 @@ be_local_closure(class_Partition_tostring,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(_X3Cinstance_X3A_X20Partition_X28_X5B_X0A),
-    /* K1   */  be_nested_str(slots),
-    /* K2   */  be_nested_str(_X20_X20),
-    /* K3   */  be_nested_str(tostring),
-    /* K4   */  be_nested_str(_X0A),
-    /* K5   */  be_nested_str(stop_iteration),
-    /* K6   */  be_nested_str(_X5D_X2C_X0A_X20_X20),
-    /* K7   */  be_nested_str(otadata),
-    /* K8   */  be_nested_str(_X0A_X29_X3E),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58040034,  //  0000  LDCONST	R1	K52
       0x60080010,  //  0001  GETGBL	R2	G16
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x880C0109,  //  0002  GETMBR	R3	R0	K9
       0x7C080200,  //  0003  CALL	R2	1
       0xA8020007,  //  0004  EXBLK	0	#000D
       0x5C0C0400,  //  0005  MOVE	R3	R2
       0x7C0C0000,  //  0006  CALL	R3	0
-      0x00040302,  //  0007  ADD	R1	R1	K2
-      0x8C100703,  //  0008  GETMET	R4	R3	K3
+      0x00040335,  //  0007  ADD	R1	R1	K53
+      0x8C100736,  //  0008  GETMET	R4	R3	K54
       0x7C100200,  //  0009  CALL	R4	1
       0x00040204,  //  000A  ADD	R1	R1	R4
-      0x00040304,  //  000B  ADD	R1	R1	K4
+      0x00040337,  //  000B  ADD	R1	R1	K55
       0x7001FFF7,  //  000C  JMP		#0005
-      0x58080005,  //  000D  LDCONST	R2	K5
+      0x58080015,  //  000D  LDCONST	R2	K21
       0xAC080200,  //  000E  CATCH	R2	1	0
       0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x00040306,  //  0010  ADD	R1	R1	K6
-      0x88080107,  //  0011  GETMBR	R2	R0	K7
-      0x8C080503,  //  0012  GETMET	R2	R2	K3
+      0x00040338,  //  0010  ADD	R1	R1	K56
+      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x8C080536,  //  0012  GETMET	R2	R2	K54
       0x7C080200,  //  0013  CALL	R2	1
       0x00040202,  //  0014  ADD	R1	R1	R2
-      0x00040308,  //  0015  ADD	R1	R1	K8
+      0x00040339,  //  0015  ADD	R1	R1	K57
       0x80040200,  //  0016  RET	1	R1
     })
   )
@@ -1232,19 +1178,17 @@ be_local_closure(class_Partition_has_factory,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(get_factory_slot),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_has_factory,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04013A,  //  0000  GETMET	R1	R0	K58
       0x7C040200,  //  0001  CALL	R1	1
       0x4C080000,  //  0002  LDNIL	R2
       0x20040202,  //  0003  NE	R1	R1	R2
@@ -1262,58 +1206,48 @@ be_local_closure(class_Partition_tobytes,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(Too_X20many_X20partiition_X20slots),
-    /* K3   */  be_nested_str(tobytes),
-    /* K4   */  be_nested_str(stop_iteration),
-    /* K5   */  be_nested_str(MD5),
-    /* K6   */  be_nested_str(update),
-    /* K7   */  be_nested_str(EBEBFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
-    /* K8   */  be_nested_str(finish),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_tobytes,
     &be_const_str_solidified,
     ( &(const binstruction[35]) {  /* code */
       0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080109,  //  0001  GETMBR	R2	R0	K9
       0x7C040200,  //  0002  CALL	R1	1
       0x540A005E,  //  0003  LDINT	R2	95
       0x24040202,  //  0004  GT	R1	R1	R2
       0x78060000,  //  0005  JMPF	R1	#0007
-      0xB0060302,  //  0006  RAISE	1	K1	K2
+      0xB006773C,  //  0006  RAISE	1	K59	K60
       0x60040015,  //  0007  GETGBL	R1	G21
       0x7C040000,  //  0008  CALL	R1	0
       0x60080010,  //  0009  GETGBL	R2	G16
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x880C0109,  //  000A  GETMBR	R3	R0	K9
       0x7C080200,  //  000B  CALL	R2	1
       0xA8020005,  //  000C  EXBLK	0	#0013
       0x5C0C0400,  //  000D  MOVE	R3	R2
       0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C100703,  //  000F  GETMET	R4	R3	K3
+      0x8C100701,  //  000F  GETMET	R4	R3	K1
       0x7C100200,  //  0010  CALL	R4	1
       0x00040204,  //  0011  ADD	R1	R1	R4
       0x7001FFF9,  //  0012  JMP		#000D
-      0x58080004,  //  0013  LDCONST	R2	K4
+      0x58080015,  //  0013  LDCONST	R2	K21
       0xAC080200,  //  0014  CATCH	R2	1	0
       0xB0080000,  //  0015  RAISE	2	R0	R0
-      0xB80A0A00,  //  0016  GETNGBL	R2	K5
+      0xB80A7A00,  //  0016  GETNGBL	R2	K61
       0x7C080000,  //  0017  CALL	R2	0
-      0x8C0C0506,  //  0018  GETMET	R3	R2	K6
+      0x8C0C053E,  //  0018  GETMET	R3	R2	K62
       0x5C140200,  //  0019  MOVE	R5	R1
       0x7C0C0400,  //  001A  CALL	R3	2
       0x600C0015,  //  001B  GETGBL	R3	G21
-      0x58100007,  //  001C  LDCONST	R4	K7
+      0x5810003F,  //  001C  LDCONST	R4	K63
       0x7C0C0200,  //  001D  CALL	R3	1
       0x00040203,  //  001E  ADD	R1	R1	R3
-      0x8C0C0508,  //  001F  GETMET	R3	R2	K8
+      0x8C0C0540,  //  001F  GETMET	R3	R2	K64
       0x7C0C0200,  //  0020  CALL	R3	1
       0x00040203,  //  0021  ADD	R1	R1	R3
       0x80040200,  //  0022  RET	1	R1
@@ -1330,41 +1264,35 @@ be_local_closure(class_Partition_ota_max,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(type),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(subtype),
-    /* K4   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_ota_max,
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
       0x60080010,  //  0001  GETGBL	R2	G16
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x880C0109,  //  0002  GETMBR	R3	R0	K9
       0x7C080200,  //  0003  CALL	R2	1
       0xA8020016,  //  0004  EXBLK	0	#001C
       0x5C0C0400,  //  0005  MOVE	R3	R2
       0x7C0C0000,  //  0006  CALL	R3	0
-      0x88100701,  //  0007  GETMBR	R4	R3	K1
-      0x1C100902,  //  0008  EQ	R4	R4	K2
+      0x8810072F,  //  0007  GETMBR	R4	R3	K47
+      0x1C100923,  //  0008  EQ	R4	R4	K35
       0x78120010,  //  0009  JMPF	R4	#001B
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x88100730,  //  000A  GETMBR	R4	R3	K48
       0x5416000F,  //  000B  LDINT	R5	16
       0x28100805,  //  000C  GE	R4	R4	R5
       0x7812000C,  //  000D  JMPF	R4	#001B
-      0x88100703,  //  000E  GETMBR	R4	R3	K3
+      0x88100730,  //  000E  GETMBR	R4	R3	K48
       0x5416001F,  //  000F  LDINT	R5	32
       0x14100805,  //  0010  LT	R4	R4	R5
       0x78120008,  //  0011  JMPF	R4	#001B
-      0x88100703,  //  0012  GETMBR	R4	R3	K3
+      0x88100730,  //  0012  GETMBR	R4	R3	K48
       0x5416000F,  //  0013  LDINT	R5	16
       0x04100805,  //  0014  SUB	R4	R4	R5
       0x4C140000,  //  0015  LDNIL	R5
@@ -1374,7 +1302,7 @@ be_local_closure(class_Partition_ota_max,   /* name */
       0x78160000,  //  0019  JMPF	R5	#001B
       0x5C040800,  //  001A  MOVE	R1	R4
       0x7001FFE8,  //  001B  JMP		#0005
-      0x58080004,  //  001C  LDCONST	R2	K4
+      0x58080015,  //  001C  LDCONST	R2	K21
       0xAC080200,  //  001D  CATCH	R2	1	0
       0xB0080000,  //  001E  RAISE	2	R0	R0
       0x80040200,  //  001F  RET	1	R1
@@ -1391,42 +1319,33 @@ be_local_closure(class_Partition_invalidate_spiffs,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(slots),
-    /* K2   */  be_nested_str(is_spiffs),
-    /* K3   */  be_nested_str(value_error),
-    /* K4   */  be_nested_str(No_X20FS_X20partition_X20found),
-    /* K5   */  be_nested_str(00),
-    /* K6   */  be_nested_str(write),
-    /* K7   */  be_nested_str(start),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_invalidate_spiffs,
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080109,  //  0001  GETMBR	R2	R0	K9
       0x540DFFFE,  //  0002  LDINT	R3	-1
       0x94080403,  //  0003  GETIDX	R2	R2	R3
-      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
+      0x8C0C0541,  //  0004  GETMET	R3	R2	K65
       0x7C0C0200,  //  0005  CALL	R3	1
       0x740E0000,  //  0006  JMPT	R3	#0008
-      0xB0060704,  //  0007  RAISE	1	K3	K4
+      0xB0067742,  //  0007  RAISE	1	K59	K66
       0x600C0015,  //  0008  GETGBL	R3	G21
-      0x58100005,  //  0009  LDCONST	R4	K5
+      0x58100043,  //  0009  LDCONST	R4	K67
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x8C100306,  //  000B  GETMET	R4	R1	K6
-      0x88180507,  //  000C  GETMBR	R6	R2	K7
+      0x8C100303,  //  000B  GETMET	R4	R1	K3
+      0x88180531,  //  000C  GETMBR	R6	R2	K49
       0x5C1C0600,  //  000D  MOVE	R7	R3
       0x7C100600,  //  000E  CALL	R4	3
-      0x8C100306,  //  000F  GETMET	R4	R1	K6
-      0x88180507,  //  0010  GETMBR	R6	R2	K7
+      0x8C100303,  //  000F  GETMET	R4	R1	K3
+      0x88180531,  //  0010  GETMBR	R6	R2	K49
       0x541E0FFF,  //  0011  LDINT	R7	4096
       0x00180C07,  //  0012  ADD	R6	R6	R7
       0x5C1C0600,  //  0013  MOVE	R7	R3
@@ -1445,33 +1364,29 @@ be_local_closure(class_Partition_get_factory_slot,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(is_factory),
-    /* K2   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_factory_slot,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080109,  //  0001  GETMBR	R2	R0	K9
       0x7C040200,  //  0002  CALL	R1	1
       0xA8020007,  //  0003  EXBLK	0	#000C
       0x5C080200,  //  0004  MOVE	R2	R1
       0x7C080000,  //  0005  CALL	R2	0
-      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
+      0x8C0C0544,  //  0006  GETMET	R3	R2	K68
       0x7C0C0200,  //  0007  CALL	R3	1
       0x780E0001,  //  0008  JMPF	R3	#000B
       0xA8040001,  //  0009  EXBLK	1	1
       0x80040400,  //  000A  RET	1	R2
       0x7001FFF7,  //  000B  JMP		#0004
-      0x58040002,  //  000C  LDCONST	R1	K2
+      0x58040015,  //  000C  LDCONST	R1	K21
       0xAC040200,  //  000D  CATCH	R1	1	0
       0xB0080000,  //  000E  RAISE	2	R0	R0
       0x80000000,  //  000F  RET	0
@@ -1488,38 +1403,30 @@ be_local_closure(class_Partition_set_active,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(ota_max),
-    /* K2   */  be_nested_str(value_error),
-    /* K3   */  be_nested_str(Invalid_X20ota_X20partition_X20number),
-    /* K4   */  be_nested_str(otadata),
-    /* K5   */  be_nested_str(set_ota_max),
-    /* K6   */  be_nested_str(set_active),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_set_active,
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x14080300,  //  0000  LT	R2	R1	K0
+      0x1408030D,  //  0000  LT	R2	R1	K13
       0x740A0003,  //  0001  JMPT	R2	#0006
-      0x8C080101,  //  0002  GETMET	R2	R0	K1
+      0x8C08012E,  //  0002  GETMET	R2	R0	K46
       0x7C080200,  //  0003  CALL	R2	1
       0x24080202,  //  0004  GT	R2	R1	R2
       0x780A0000,  //  0005  JMPF	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0xB0067745,  //  0006  RAISE	1	K59	K69
       0x88080104,  //  0007  GETMBR	R2	R0	K4
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x8C100101,  //  0009  GETMET	R4	R0	K1
+      0x8C080546,  //  0008  GETMET	R2	R2	K70
+      0x8C10012E,  //  0009  GETMET	R4	R0	K46
       0x7C100200,  //  000A  CALL	R4	1
       0x7C080400,  //  000B  CALL	R2	2
       0x88080104,  //  000C  GETMBR	R2	R0	K4
-      0x8C080506,  //  000D  GETMET	R2	R2	K6
+      0x8C080547,  //  000D  GETMET	R2	R2	K71
       0x5C100200,  //  000E  MOVE	R4	R1
       0x7C080400,  //  000F  CALL	R2	2
       0x80000000,  //  0010  RET	0
@@ -1536,33 +1443,26 @@ be_local_closure(class_Partition_get_unallocated_k,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(is_spiffs),
-    /* K2   */  be_nested_str(get_max_flash_size_k),
-    /* K3   */  be_nested_str(start),
-    /* K4   */  be_nested_str(sz),
-    /* K5   */  be_const_int(0),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_unallocated_k,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x5409FFFE,  //  0001  LDINT	R2	-1
       0x94040202,  //  0002  GETIDX	R1	R1	R2
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x8C080341,  //  0003  GETMET	R2	R1	K65
       0x7C080200,  //  0004  CALL	R2	1
       0x780A000A,  //  0005  JMPF	R2	#0011
-      0x8C080102,  //  0006  GETMET	R2	R0	K2
+      0x8C080148,  //  0006  GETMET	R2	R0	K72
       0x7C080200,  //  0007  CALL	R2	1
-      0x880C0303,  //  0008  GETMBR	R3	R1	K3
-      0x88100304,  //  0009  GETMBR	R4	R1	K4
+      0x880C0331,  //  0008  GETMBR	R3	R1	K49
+      0x88100328,  //  0009  GETMBR	R4	R1	K40
       0x000C0604,  //  000A  ADD	R3	R3	R4
       0x541203FF,  //  000B  LDINT	R4	1024
       0x0C0C0604,  //  000C  DIV	R3	R3	R4
@@ -1570,7 +1470,7 @@ be_local_closure(class_Partition_get_unallocated_k,   /* name */
       0x78120001,  //  000E  JMPF	R4	#0011
       0x04100403,  //  000F  SUB	R4	R2	R3
       0x80040800,  //  0010  RET	1	R4
-      0x80060A00,  //  0011  RET	1	K5
+      0x80061A00,  //  0011  RET	1	K13
     })
   )
 );
@@ -1584,34 +1484,30 @@ be_local_closure(class_Partition_get_ota_slot,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(slots),
-    /* K1   */  be_nested_str(is_ota),
-    /* K2   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Partition,     /* shared constants */
     &be_const_str_get_ota_slot,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x60080010,  //  0000  GETGBL	R2	G16
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x880C0109,  //  0001  GETMBR	R3	R0	K9
       0x7C080200,  //  0002  CALL	R2	1
       0xA8020008,  //  0003  EXBLK	0	#000D
       0x5C0C0400,  //  0004  MOVE	R3	R2
       0x7C0C0000,  //  0005  CALL	R3	0
-      0x8C100701,  //  0006  GETMET	R4	R3	K1
+      0x8C100749,  //  0006  GETMET	R4	R3	K73
       0x7C100200,  //  0007  CALL	R4	1
       0x1C100801,  //  0008  EQ	R4	R4	R1
       0x78120001,  //  0009  JMPF	R4	#000C
       0xA8040001,  //  000A  EXBLK	1	1
       0x80040600,  //  000B  RET	1	R3
       0x7001FFF6,  //  000C  JMP		#0004
-      0x58080002,  //  000D  LDCONST	R2	K2
+      0x58080015,  //  000D  LDCONST	R2	K21
       0xAC080200,  //  000E  CATCH	R2	1	0
       0xB0080000,  //  000F  RAISE	2	R0	R0
       0x4C080000,  //  0010  LDNIL	R2
@@ -1657,6 +1553,64 @@ be_local_class(Partition,
     })),
     (bstring*) &be_const_str_Partition
 );
+extern const bclass be_class_Partition_info;
+// compact class 'Partition_info' ktab size: 53, total: 92 (saved 312 bytes)
+static const bvalue be_ktab_class_Partition_info[53] = {
+  /* K0   */  be_nested_str(type),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str(subtype),
+  /* K3   */  be_nested_str(app),
+  /* K4   */  be_const_int(1),
+  /* K5   */  be_nested_str(data),
+  /* K6   */  be_nested_str(0x_X2502X),
+  /* K7   */  be_nested_str(start),
+  /* K8   */  be_nested_str(sz),
+  /* K9   */  be_nested_str(label),
+  /* K10  */  be_nested_str(),
+  /* K11  */  be_nested_str(flags),
+  /* K12  */  be_nested_str(get),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_const_int(3),
+  /* K15  */  be_nested_str(remove_trailing_zeroes),
+  /* K16  */  be_nested_str(asstring),
+  /* K17  */  be_nested_str(invalid_X20magic_X20number_X20_X2502X),
+  /* K18  */  be_nested_str(internal_error),
+  /* K19  */  be_nested_str(factory),
+  /* K20  */  be_nested_str(ota_),
+  /* K21  */  be_nested_str(test),
+  /* K22  */  be_nested_str(otadata),
+  /* K23  */  be_nested_str(phy),
+  /* K24  */  be_const_int(2),
+  /* K25  */  be_nested_str(nvs),
+  /* K26  */  be_const_int(3),
+  /* K27  */  be_nested_str(coredump),
+  /* K28  */  be_nested_str(nvskeys),
+  /* K29  */  be_nested_str(efuse_em),
+  /* K30  */  be_nested_str(esphttpd),
+  /* K31  */  be_nested_str(fat),
+  /* K32  */  be_nested_str(spiffs),
+  /* K33  */  be_nested_str(type_to_string),
+  /* K34  */  be_nested_str(subtype_to_string),
+  /* K35  */  be_nested_str(_X20_X28),
+  /* K36  */  be_nested_str(_X29),
+  /* K37  */  be_nested_str(_X3Cinstance_X3A_X20Partition_info_X28_X25d_X25s_X2C_X25d_X25s_X2C0x_X2508X_X2C0x_X2508X_X2C_X27_X25s_X27_X2C0x_X25X_X29_X3E),
+  /* K38  */  be_nested_str(AA50),
+  /* K39  */  be_nested_str(resize),
+  /* K40  */  be_nested_str(add),
+  /* K41  */  be_const_int(1),
+  /* K42  */  be_nested_str(fromstring),
+  /* K43  */  be_const_class(be_class_Partition_info),
+  /* K44  */  be_const_int(0),
+  /* K45  */  be_nested_str(flash),
+  /* K46  */  be_nested_str(is_ota),
+  /* K47  */  be_nested_str(is_factory),
+  /* K48  */  be_nested_str(read),
+  /* K49  */  be_nested_str(tasmota),
+  /* K50  */  be_nested_str(log),
+  /* K51  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27),
+  /* K52  */  be_nested_str(_X27_X20_X2D_X20),
+};
+
 
 extern const bclass be_class_Partition_info;
 
@@ -1667,17 +1621,13 @@ be_local_closure(class_Partition_info_is_factory,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(type),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(subtype),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_is_factory,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -1703,34 +1653,27 @@ be_local_closure(class_Partition_info_type_to_string,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(type),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(app),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str(data),
-    /* K5   */  be_nested_str(0x_X2502X),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_type_to_string,
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x1C040301,  //  0001  EQ	R1	R1	K1
       0x78060001,  //  0002  JMPF	R1	#0005
-      0x80060400,  //  0003  RET	1	K2
+      0x80060600,  //  0003  RET	1	K3
       0x70020003,  //  0004  JMP		#0009
       0x88040100,  //  0005  GETMBR	R1	R0	K0
-      0x1C040303,  //  0006  EQ	R1	R1	K3
+      0x1C040304,  //  0006  EQ	R1	R1	K4
       0x78060000,  //  0007  JMPF	R1	#0009
-      0x80060800,  //  0008  RET	1	K4
+      0x80060A00,  //  0008  RET	1	K5
       0x60040018,  //  0009  GETGBL	R1	G24
-      0x58080005,  //  000A  LDCONST	R2	K5
+      0x58080006,  //  000A  LDCONST	R2	K6
       0x880C0100,  //  000B  GETMBR	R3	R0	K0
       0x7C040400,  //  000C  CALL	R1	2
       0x80040200,  //  000D  RET	1	R1
@@ -1747,92 +1690,75 @@ be_local_closure(class_Partition_info_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str(type),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(subtype),
-    /* K3   */  be_nested_str(start),
-    /* K4   */  be_nested_str(sz),
-    /* K5   */  be_nested_str(label),
-    /* K6   */  be_nested_str(),
-    /* K7   */  be_nested_str(flags),
-    /* K8   */  be_nested_str(get),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str(remove_trailing_zeroes),
-    /* K13  */  be_nested_str(asstring),
-    /* K14  */  be_nested_str(invalid_X20magic_X20number_X20_X2502X),
-    /* K15  */  be_nested_str(internal_error),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[60]) {  /* code */
       0x90020101,  //  0000  SETMBR	R0	K0	K1
       0x90020501,  //  0001  SETMBR	R0	K2	K1
-      0x90020701,  //  0002  SETMBR	R0	K3	K1
-      0x90020901,  //  0003  SETMBR	R0	K4	K1
-      0x90020B06,  //  0004  SETMBR	R0	K5	K6
-      0x90020F01,  //  0005  SETMBR	R0	K7	K1
+      0x90020F01,  //  0002  SETMBR	R0	K7	K1
+      0x90021101,  //  0003  SETMBR	R0	K8	K1
+      0x9002130A,  //  0004  SETMBR	R0	K9	K10
+      0x90021701,  //  0005  SETMBR	R0	K11	K1
       0x6008000E,  //  0006  GETGBL	R2	G14
       0x600C0015,  //  0007  GETGBL	R3	G21
       0x5C100200,  //  0008  MOVE	R4	R1
       0x7C080400,  //  0009  CALL	R2	2
       0x740A0000,  //  000A  JMPT	R2	#000C
       0x80000400,  //  000B  RET	0
-      0x8C080308,  //  000C  GETMET	R2	R1	K8
+      0x8C08030C,  //  000C  GETMET	R2	R1	K12
       0x58100001,  //  000D  LDCONST	R4	K1
-      0x58140009,  //  000E  LDCONST	R5	K9
+      0x5814000D,  //  000E  LDCONST	R5	K13
       0x7C080600,  //  000F  CALL	R2	3
       0x540E50A9,  //  0010  LDINT	R3	20650
       0x1C0C0403,  //  0011  EQ	R3	R2	R3
       0x780E0022,  //  0012  JMPF	R3	#0036
-      0x8C0C0308,  //  0013  GETMET	R3	R1	K8
-      0x58140009,  //  0014  LDCONST	R5	K9
-      0x5818000A,  //  0015  LDCONST	R6	K10
+      0x8C0C030C,  //  0013  GETMET	R3	R1	K12
+      0x5814000D,  //  0014  LDCONST	R5	K13
+      0x58180004,  //  0015  LDCONST	R6	K4
       0x7C0C0600,  //  0016  CALL	R3	3
       0x90020003,  //  0017  SETMBR	R0	K0	R3
-      0x8C0C0308,  //  0018  GETMET	R3	R1	K8
-      0x5814000B,  //  0019  LDCONST	R5	K11
-      0x5818000A,  //  001A  LDCONST	R6	K10
+      0x8C0C030C,  //  0018  GETMET	R3	R1	K12
+      0x5814000E,  //  0019  LDCONST	R5	K14
+      0x58180004,  //  001A  LDCONST	R6	K4
       0x7C0C0600,  //  001B  CALL	R3	3
       0x90020403,  //  001C  SETMBR	R0	K2	R3
-      0x8C0C0308,  //  001D  GETMET	R3	R1	K8
+      0x8C0C030C,  //  001D  GETMET	R3	R1	K12
       0x54160003,  //  001E  LDINT	R5	4
       0x541A0003,  //  001F  LDINT	R6	4
       0x7C0C0600,  //  0020  CALL	R3	3
-      0x90020603,  //  0021  SETMBR	R0	K3	R3
-      0x8C0C0308,  //  0022  GETMET	R3	R1	K8
+      0x90020E03,  //  0021  SETMBR	R0	K7	R3
+      0x8C0C030C,  //  0022  GETMET	R3	R1	K12
       0x54160007,  //  0023  LDINT	R5	8
       0x541A0003,  //  0024  LDINT	R6	4
       0x7C0C0600,  //  0025  CALL	R3	3
-      0x90020803,  //  0026  SETMBR	R0	K4	R3
-      0x8C0C010C,  //  0027  GETMET	R3	R0	K12
+      0x90021003,  //  0026  SETMBR	R0	K8	R3
+      0x8C0C010F,  //  0027  GETMET	R3	R0	K15
       0x5416000B,  //  0028  LDINT	R5	12
       0x541A001A,  //  0029  LDINT	R6	27
       0x40140A06,  //  002A  CONNECT	R5	R5	R6
       0x94140205,  //  002B  GETIDX	R5	R1	R5
       0x7C0C0400,  //  002C  CALL	R3	2
-      0x8C0C070D,  //  002D  GETMET	R3	R3	K13
+      0x8C0C0710,  //  002D  GETMET	R3	R3	K16
       0x7C0C0200,  //  002E  CALL	R3	1
-      0x90020A03,  //  002F  SETMBR	R0	K5	R3
-      0x8C0C0308,  //  0030  GETMET	R3	R1	K8
+      0x90021203,  //  002F  SETMBR	R0	K9	R3
+      0x8C0C030C,  //  0030  GETMET	R3	R1	K12
       0x5416001B,  //  0031  LDINT	R5	28
       0x541A0003,  //  0032  LDINT	R6	4
       0x7C0C0600,  //  0033  CALL	R3	3
-      0x90020E03,  //  0034  SETMBR	R0	K7	R3
+      0x90021603,  //  0034  SETMBR	R0	K11	R3
       0x70020004,  //  0035  JMP		#003B
       0x600C0018,  //  0036  GETGBL	R3	G24
-      0x5810000E,  //  0037  LDCONST	R4	K14
+      0x58100011,  //  0037  LDCONST	R4	K17
       0x5C140400,  //  0038  MOVE	R5	R2
       0x7C0C0400,  //  0039  CALL	R3	2
-      0xB0061E03,  //  003A  RAISE	1	K15	R3
+      0xB0062403,  //  003A  RAISE	1	K18	R3
       0x80000000,  //  003B  RET	0
     })
   )
@@ -1847,33 +1773,13 @@ be_local_closure(class_Partition_info_subtype_to_string,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str(type),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(subtype),
-    /* K3   */  be_nested_str(factory),
-    /* K4   */  be_nested_str(ota_),
-    /* K5   */  be_nested_str(test),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str(otadata),
-    /* K8   */  be_nested_str(phy),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str(nvs),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str(coredump),
-    /* K13  */  be_nested_str(nvskeys),
-    /* K14  */  be_nested_str(efuse_em),
-    /* K15  */  be_nested_str(esphttpd),
-    /* K16  */  be_nested_str(fat),
-    /* K17  */  be_nested_str(spiffs),
-    /* K18  */  be_nested_str(0x_X2502X),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_subtype_to_string,
     &be_const_str_solidified,
     ( &(const binstruction[87]) {  /* code */
@@ -1883,7 +1789,7 @@ be_local_closure(class_Partition_info_subtype_to_string,   /* name */
       0x88040102,  //  0003  GETMBR	R1	R0	K2
       0x1C040301,  //  0004  EQ	R1	R1	K1
       0x78060001,  //  0005  JMPF	R1	#0008
-      0x80060600,  //  0006  RET	1	K3
+      0x80062600,  //  0006  RET	1	K19
       0x70020014,  //  0007  JMP		#001D
       0x88040102,  //  0008  GETMBR	R1	R0	K2
       0x540A000F,  //  0009  LDINT	R2	16
@@ -1898,69 +1804,69 @@ be_local_closure(class_Partition_info_subtype_to_string,   /* name */
       0x540E000F,  //  0012  LDINT	R3	16
       0x04080403,  //  0013  SUB	R2	R2	R3
       0x7C040200,  //  0014  CALL	R1	1
-      0x00060801,  //  0015  ADD	R1	K4	R1
+      0x00062801,  //  0015  ADD	R1	K20	R1
       0x80040200,  //  0016  RET	1	R1
       0x70020004,  //  0017  JMP		#001D
       0x88040102,  //  0018  GETMBR	R1	R0	K2
       0x540A001F,  //  0019  LDINT	R2	32
       0x1C040202,  //  001A  EQ	R1	R1	R2
       0x78060000,  //  001B  JMPF	R1	#001D
-      0x80060A00,  //  001C  RET	1	K5
+      0x80062A00,  //  001C  RET	1	K21
       0x70020033,  //  001D  JMP		#0052
       0x88040100,  //  001E  GETMBR	R1	R0	K0
-      0x1C040306,  //  001F  EQ	R1	R1	K6
+      0x1C040304,  //  001F  EQ	R1	R1	K4
       0x78060030,  //  0020  JMPF	R1	#0052
       0x88040102,  //  0021  GETMBR	R1	R0	K2
       0x1C040301,  //  0022  EQ	R1	R1	K1
       0x78060001,  //  0023  JMPF	R1	#0026
-      0x80060E00,  //  0024  RET	1	K7
+      0x80062C00,  //  0024  RET	1	K22
       0x7002002B,  //  0025  JMP		#0052
       0x88040102,  //  0026  GETMBR	R1	R0	K2
-      0x1C040306,  //  0027  EQ	R1	R1	K6
+      0x1C040304,  //  0027  EQ	R1	R1	K4
       0x78060001,  //  0028  JMPF	R1	#002B
-      0x80061000,  //  0029  RET	1	K8
+      0x80062E00,  //  0029  RET	1	K23
       0x70020026,  //  002A  JMP		#0052
       0x88040102,  //  002B  GETMBR	R1	R0	K2
-      0x1C040309,  //  002C  EQ	R1	R1	K9
+      0x1C040318,  //  002C  EQ	R1	R1	K24
       0x78060001,  //  002D  JMPF	R1	#0030
-      0x80061400,  //  002E  RET	1	K10
+      0x80063200,  //  002E  RET	1	K25
       0x70020021,  //  002F  JMP		#0052
       0x88040102,  //  0030  GETMBR	R1	R0	K2
-      0x1C04030B,  //  0031  EQ	R1	R1	K11
+      0x1C04031A,  //  0031  EQ	R1	R1	K26
       0x78060001,  //  0032  JMPF	R1	#0035
-      0x80061800,  //  0033  RET	1	K12
+      0x80063600,  //  0033  RET	1	K27
       0x7002001C,  //  0034  JMP		#0052
       0x88040102,  //  0035  GETMBR	R1	R0	K2
       0x540A0003,  //  0036  LDINT	R2	4
       0x1C040202,  //  0037  EQ	R1	R1	R2
       0x78060001,  //  0038  JMPF	R1	#003B
-      0x80061A00,  //  0039  RET	1	K13
+      0x80063800,  //  0039  RET	1	K28
       0x70020016,  //  003A  JMP		#0052
       0x88040102,  //  003B  GETMBR	R1	R0	K2
       0x540A0004,  //  003C  LDINT	R2	5
       0x1C040202,  //  003D  EQ	R1	R1	R2
       0x78060001,  //  003E  JMPF	R1	#0041
-      0x80061C00,  //  003F  RET	1	K14
+      0x80063A00,  //  003F  RET	1	K29
       0x70020010,  //  0040  JMP		#0052
       0x88040102,  //  0041  GETMBR	R1	R0	K2
       0x540A007F,  //  0042  LDINT	R2	128
       0x1C040202,  //  0043  EQ	R1	R1	R2
       0x78060001,  //  0044  JMPF	R1	#0047
-      0x80061E00,  //  0045  RET	1	K15
+      0x80063C00,  //  0045  RET	1	K30
       0x7002000A,  //  0046  JMP		#0052
       0x88040102,  //  0047  GETMBR	R1	R0	K2
       0x540A0080,  //  0048  LDINT	R2	129
       0x1C040202,  //  0049  EQ	R1	R1	R2
       0x78060001,  //  004A  JMPF	R1	#004D
-      0x80062000,  //  004B  RET	1	K16
+      0x80063E00,  //  004B  RET	1	K31
       0x70020004,  //  004C  JMP		#0052
       0x88040102,  //  004D  GETMBR	R1	R0	K2
       0x540A0081,  //  004E  LDINT	R2	130
       0x1C040202,  //  004F  EQ	R1	R1	R2
       0x78060000,  //  0050  JMPF	R1	#0052
-      0x80062200,  //  0051  RET	1	K17
+      0x80064000,  //  0051  RET	1	K32
       0x60040018,  //  0052  GETGBL	R1	G24
-      0x58080012,  //  0053  LDCONST	R2	K18
+      0x58080006,  //  0053  LDCONST	R2	K6
       0x880C0102,  //  0054  GETMBR	R3	R0	K2
       0x7C040400,  //  0055  CALL	R1	2
       0x80040200,  //  0056  RET	1	R1
@@ -1977,52 +1883,39 @@ be_local_closure(class_Partition_info_tostring,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(type_to_string),
-    /* K1   */  be_nested_str(subtype_to_string),
-    /* K2   */  be_nested_str(),
-    /* K3   */  be_nested_str(_X20_X28),
-    /* K4   */  be_nested_str(_X29),
-    /* K5   */  be_nested_str(_X3Cinstance_X3A_X20Partition_info_X28_X25d_X25s_X2C_X25d_X25s_X2C0x_X2508X_X2C0x_X2508X_X2C_X27_X25s_X27_X2C0x_X25X_X29_X3E),
-    /* K6   */  be_nested_str(type),
-    /* K7   */  be_nested_str(subtype),
-    /* K8   */  be_nested_str(start),
-    /* K9   */  be_nested_str(sz),
-    /* K10  */  be_nested_str(label),
-    /* K11  */  be_nested_str(flags),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040121,  //  0000  GETMET	R1	R0	K33
       0x7C040200,  //  0001  CALL	R1	1
-      0x8C080101,  //  0002  GETMET	R2	R0	K1
+      0x8C080122,  //  0002  GETMET	R2	R0	K34
       0x7C080200,  //  0003  CALL	R2	1
-      0x200C0302,  //  0004  NE	R3	R1	K2
+      0x200C030A,  //  0004  NE	R3	R1	K10
       0x780E0002,  //  0005  JMPF	R3	#0009
-      0x000E0601,  //  0006  ADD	R3	K3	R1
-      0x000C0704,  //  0007  ADD	R3	R3	K4
+      0x000E4601,  //  0006  ADD	R3	K35	R1
+      0x000C0724,  //  0007  ADD	R3	R3	K36
       0x5C040600,  //  0008  MOVE	R1	R3
-      0x200C0502,  //  0009  NE	R3	R2	K2
+      0x200C050A,  //  0009  NE	R3	R2	K10
       0x780E0002,  //  000A  JMPF	R3	#000E
-      0x000E0602,  //  000B  ADD	R3	K3	R2
-      0x000C0704,  //  000C  ADD	R3	R3	K4
+      0x000E4602,  //  000B  ADD	R3	K35	R2
+      0x000C0724,  //  000C  ADD	R3	R3	K36
       0x5C080600,  //  000D  MOVE	R2	R3
       0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100005,  //  000F  LDCONST	R4	K5
-      0x88140106,  //  0010  GETMBR	R5	R0	K6
+      0x58100025,  //  000F  LDCONST	R4	K37
+      0x88140100,  //  0010  GETMBR	R5	R0	K0
       0x5C180200,  //  0011  MOVE	R6	R1
-      0x881C0107,  //  0012  GETMBR	R7	R0	K7
+      0x881C0102,  //  0012  GETMBR	R7	R0	K2
       0x5C200400,  //  0013  MOVE	R8	R2
-      0x88240108,  //  0014  GETMBR	R9	R0	K8
-      0x88280109,  //  0015  GETMBR	R10	R0	K9
-      0x882C010A,  //  0016  GETMBR	R11	R0	K10
+      0x88240107,  //  0014  GETMBR	R9	R0	K7
+      0x88280108,  //  0015  GETMBR	R10	R0	K8
+      0x882C0109,  //  0016  GETMBR	R11	R0	K9
       0x8830010B,  //  0017  GETMBR	R12	R0	K11
       0x7C0C1200,  //  0018  CALL	R3	9
       0x80040600,  //  0019  RET	1	R3
@@ -2039,23 +1932,19 @@ be_local_closure(class_Partition_info_is_ota,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(subtype),
-    /* K1   */  be_nested_str(type),
-    /* K2   */  be_const_int(0),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_is_ota,
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C080502,  //  0002  EQ	R2	R2	K2
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x1C080501,  //  0002  EQ	R2	R2	K1
       0x780A0008,  //  0003  JMPF	R2	#000D
       0x540A000F,  //  0004  LDINT	R2	16
       0x28080202,  //  0005  GE	R2	R1	R2
@@ -2080,64 +1969,51 @@ be_local_closure(class_Partition_info_tobytes,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(AA50),
-    /* K1   */  be_nested_str(resize),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str(add),
-    /* K4   */  be_nested_str(type),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str(subtype),
-    /* K7   */  be_nested_str(start),
-    /* K8   */  be_nested_str(sz),
-    /* K9   */  be_nested_str(fromstring),
-    /* K10  */  be_nested_str(label),
-    /* K11  */  be_nested_str(flags),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_tobytes,
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
       0x60040015,  //  0000  GETGBL	R1	G21
-      0x58080000,  //  0001  LDCONST	R2	K0
+      0x58080026,  //  0001  LDCONST	R2	K38
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x8C080327,  //  0003  GETMET	R2	R1	K39
       0x5412001F,  //  0004  LDINT	R4	32
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080501,  //  0006  GETMET	R2	R2	K1
-      0x58100002,  //  0007  LDCONST	R4	K2
+      0x8C080527,  //  0006  GETMET	R2	R2	K39
+      0x5810000D,  //  0007  LDCONST	R4	K13
       0x7C080400,  //  0008  CALL	R2	2
-      0x8C080303,  //  0009  GETMET	R2	R1	K3
-      0x88100104,  //  000A  GETMBR	R4	R0	K4
-      0x58140005,  //  000B  LDCONST	R5	K5
+      0x8C080328,  //  0009  GETMET	R2	R1	K40
+      0x88100100,  //  000A  GETMBR	R4	R0	K0
+      0x58140029,  //  000B  LDCONST	R5	K41
       0x7C080600,  //  000C  CALL	R2	3
-      0x8C080303,  //  000D  GETMET	R2	R1	K3
-      0x88100106,  //  000E  GETMBR	R4	R0	K6
-      0x58140005,  //  000F  LDCONST	R5	K5
+      0x8C080328,  //  000D  GETMET	R2	R1	K40
+      0x88100102,  //  000E  GETMBR	R4	R0	K2
+      0x58140029,  //  000F  LDCONST	R5	K41
       0x7C080600,  //  0010  CALL	R2	3
-      0x8C080303,  //  0011  GETMET	R2	R1	K3
+      0x8C080328,  //  0011  GETMET	R2	R1	K40
       0x88100107,  //  0012  GETMBR	R4	R0	K7
       0x54160003,  //  0013  LDINT	R5	4
       0x7C080600,  //  0014  CALL	R2	3
-      0x8C080303,  //  0015  GETMET	R2	R1	K3
+      0x8C080328,  //  0015  GETMET	R2	R1	K40
       0x88100108,  //  0016  GETMBR	R4	R0	K8
       0x54160003,  //  0017  LDINT	R5	4
       0x7C080600,  //  0018  CALL	R2	3
       0x60080015,  //  0019  GETGBL	R2	G21
       0x7C080000,  //  001A  CALL	R2	0
-      0x8C080509,  //  001B  GETMET	R2	R2	K9
-      0x8810010A,  //  001C  GETMBR	R4	R0	K10
+      0x8C08052A,  //  001B  GETMET	R2	R2	K42
+      0x88100109,  //  001C  GETMBR	R4	R0	K9
       0x7C080400,  //  001D  CALL	R2	2
-      0x8C0C0501,  //  001E  GETMET	R3	R2	K1
+      0x8C0C0527,  //  001E  GETMET	R3	R2	K39
       0x5416000F,  //  001F  LDINT	R5	16
       0x7C0C0400,  //  0020  CALL	R3	2
       0x00040202,  //  0021  ADD	R1	R1	R2
-      0x8C0C0303,  //  0022  GETMET	R3	R1	K3
+      0x8C0C0328,  //  0022  GETMET	R3	R1	K40
       0x8814010B,  //  0023  GETMBR	R5	R0	K11
       0x541A0003,  //  0024  LDINT	R6	4
       0x7C0C0600,  //  0025  CALL	R3	3
@@ -2155,39 +2031,34 @@ be_local_closure(class_Partition_info_remove_trailing_zeroes,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Partition_info),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str(resize),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_remove_trailing_zeroes,
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804002B,  //  0000  LDCONST	R1	K43
       0x6008000C,  //  0001  GETGBL	R2	G12
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C080200,  //  0003  CALL	R2	1
-      0x580C0001,  //  0004  LDCONST	R3	K1
+      0x580C002C,  //  0004  LDCONST	R3	K44
       0x14100602,  //  0005  LT	R4	R3	R2
       0x78120007,  //  0006  JMPF	R4	#000F
       0x5411FFFE,  //  0007  LDINT	R4	-1
       0x04100803,  //  0008  SUB	R4	R4	R3
       0x94100004,  //  0009  GETIDX	R4	R0	R4
-      0x20100901,  //  000A  NE	R4	R4	K1
+      0x2010092C,  //  000A  NE	R4	R4	K44
       0x78120000,  //  000B  JMPF	R4	#000D
       0x70020001,  //  000C  JMP		#000F
-      0x000C0702,  //  000D  ADD	R3	R3	K2
+      0x000C0729,  //  000D  ADD	R3	R3	K41
       0x7001FFF5,  //  000E  JMP		#0005
-      0x24100701,  //  000F  GT	R4	R3	K1
+      0x2410072C,  //  000F  GT	R4	R3	K44
       0x78120005,  //  0010  JMPF	R4	#0017
-      0x8C100103,  //  0011  GETMET	R4	R0	K3
+      0x8C100127,  //  0011  GETMET	R4	R0	K39
       0x6018000C,  //  0012  GETGBL	R6	G12
       0x5C1C0000,  //  0013  MOVE	R7	R0
       0x7C180200,  //  0014  CALL	R6	1
@@ -2207,22 +2078,18 @@ be_local_closure(class_Partition_info_is_spiffs,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(type),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str(subtype),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_is_spiffs,
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x1C040304,  //  0001  EQ	R1	R1	K4
       0x78060003,  //  0002  JMPF	R1	#0007
       0x88040102,  //  0003  GETMBR	R1	R0	K2
       0x540A0081,  //  0004  LDINT	R2	130
@@ -2244,52 +2111,37 @@ be_local_closure(class_Partition_info_get_image_size,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str(flash),
-    /* K1   */  be_nested_str(is_ota),
-    /* K2   */  be_nested_str(is_factory),
-    /* K3   */  be_nested_str(start),
-    /* K4   */  be_nested_str(sz),
-    /* K5   */  be_nested_str(read),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str(get),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str(tasmota),
-    /* K10  */  be_nested_str(log),
-    /* K11  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27),
-    /* K12  */  be_nested_str(_X27_X20_X2D_X20),
-    /* K13  */  be_const_int(2),
-    }),
+    &be_ktab_class_Partition_info,     /* shared constants */
     &be_const_str_get_image_size,
     &be_const_str_solidified,
     ( &(const binstruction[85]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0xA4065A00,  //  0000  IMPORT	R1	K45
+      0x8C08012E,  //  0001  GETMET	R2	R0	K46
       0x7C080200,  //  0002  CALL	R2	1
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C080403,  //  0004  EQ	R2	R2	R3
       0x780A0004,  //  0005  JMPF	R2	#000B
-      0x8C080102,  //  0006  GETMET	R2	R0	K2
+      0x8C08012F,  //  0006  GETMET	R2	R0	K47
       0x7C080200,  //  0007  CALL	R2	1
       0x740A0001,  //  0008  JMPT	R2	#000B
       0x5409FFFE,  //  0009  LDINT	R2	-1
       0x80040400,  //  000A  RET	1	R2
       0xA802003A,  //  000B  EXBLK	0	#0047
-      0x88080103,  //  000C  GETMBR	R2	R0	K3
-      0x880C0104,  //  000D  GETMBR	R3	R0	K4
-      0x8C100305,  //  000E  GETMET	R4	R1	K5
+      0x88080107,  //  000C  GETMBR	R2	R0	K7
+      0x880C0108,  //  000D  GETMBR	R3	R0	K8
+      0x8C100330,  //  000E  GETMET	R4	R1	K48
       0x5C180400,  //  000F  MOVE	R6	R2
-      0x581C0006,  //  0010  LDCONST	R7	K6
+      0x581C0029,  //  0010  LDCONST	R7	K41
       0x7C100600,  //  0011  CALL	R4	3
-      0x8C100907,  //  0012  GETMET	R4	R4	K7
-      0x58180008,  //  0013  LDCONST	R6	K8
-      0x581C0006,  //  0014  LDCONST	R7	K6
+      0x8C10090C,  //  0012  GETMET	R4	R4	K12
+      0x5818002C,  //  0013  LDCONST	R6	K44
+      0x581C0029,  //  0014  LDCONST	R7	K41
       0x7C100600,  //  0015  CALL	R4	3
       0x541600E8,  //  0016  LDINT	R5	233
       0x20140805,  //  0017  NE	R5	R4	R5
@@ -2297,29 +2149,29 @@ be_local_closure(class_Partition_info_get_image_size,   /* name */
       0x5415FFFE,  //  0019  LDINT	R5	-1
       0xA8040001,  //  001A  EXBLK	1	1
       0x80040A00,  //  001B  RET	1	R5
-      0x8C140305,  //  001C  GETMET	R5	R1	K5
-      0x001C0506,  //  001D  ADD	R7	R2	K6
-      0x58200006,  //  001E  LDCONST	R8	K6
+      0x8C140330,  //  001C  GETMET	R5	R1	K48
+      0x001C0529,  //  001D  ADD	R7	R2	K41
+      0x58200029,  //  001E  LDCONST	R8	K41
       0x7C140600,  //  001F  CALL	R5	3
-      0x8C140B07,  //  0020  GETMET	R5	R5	K7
-      0x581C0008,  //  0021  LDCONST	R7	K8
-      0x58200006,  //  0022  LDCONST	R8	K6
+      0x8C140B0C,  //  0020  GETMET	R5	R5	K12
+      0x581C002C,  //  0021  LDCONST	R7	K44
+      0x58200029,  //  0022  LDCONST	R8	K41
       0x7C140600,  //  0023  CALL	R5	3
       0x541A001F,  //  0024  LDINT	R6	32
       0x00180406,  //  0025  ADD	R6	R2	R6
-      0x581C0008,  //  0026  LDCONST	R7	K8
+      0x581C002C,  //  0026  LDCONST	R7	K44
       0x14200E05,  //  0027  LT	R8	R7	R5
       0x78220017,  //  0028  JMPF	R8	#0041
-      0x8C200305,  //  0029  GETMET	R8	R1	K5
+      0x8C200330,  //  0029  GETMET	R8	R1	K48
       0x542A0007,  //  002A  LDINT	R10	8
       0x04280C0A,  //  002B  SUB	R10	R6	R10
       0x542E0007,  //  002C  LDINT	R11	8
       0x7C200600,  //  002D  CALL	R8	3
-      0x8C241107,  //  002E  GETMET	R9	R8	K7
-      0x582C0008,  //  002F  LDCONST	R11	K8
+      0x8C24110C,  //  002E  GETMET	R9	R8	K12
+      0x582C002C,  //  002F  LDCONST	R11	K44
       0x54320003,  //  0030  LDINT	R12	4
       0x7C240600,  //  0031  CALL	R9	3
-      0x8C281107,  //  0032  GETMET	R10	R8	K7
+      0x8C28110C,  //  0032  GETMET	R10	R8	K12
       0x54320003,  //  0033  LDINT	R12	4
       0x54360003,  //  0034  LDINT	R13	4
       0x7C280600,  //  0035  CALL	R10	3
@@ -2332,20 +2184,20 @@ be_local_closure(class_Partition_info_get_image_size,   /* name */
       0x542DFFFE,  //  003C  LDINT	R11	-1
       0xA8040001,  //  003D  EXBLK	1	1
       0x80041600,  //  003E  RET	1	R11
-      0x001C0F06,  //  003F  ADD	R7	R7	K6
+      0x001C0F29,  //  003F  ADD	R7	R7	K41
       0x7001FFE5,  //  0040  JMP		#0027
       0x04200C02,  //  0041  SUB	R8	R6	R2
-      0x00201106,  //  0042  ADD	R8	R8	K6
+      0x00201129,  //  0042  ADD	R8	R8	K41
       0xA8040001,  //  0043  EXBLK	1	1
       0x80041000,  //  0044  RET	1	R8
       0xA8040001,  //  0045  EXBLK	1	1
       0x7002000C,  //  0046  JMP		#0054
       0xAC080002,  //  0047  CATCH	R2	0	2
       0x70020009,  //  0048  JMP		#0053
-      0xB8121200,  //  0049  GETNGBL	R4	K9
-      0x8C10090A,  //  004A  GETMET	R4	R4	K10
-      0x001A1602,  //  004B  ADD	R6	K11	R2
-      0x00180D0C,  //  004C  ADD	R6	R6	K12
+      0xB8126200,  //  0049  GETNGBL	R4	K49
+      0x8C100932,  //  004A  GETMET	R4	R4	K50
+      0x001A6602,  //  004B  ADD	R6	K51	R2
+      0x00180D34,  //  004C  ADD	R6	R6	K52
       0x00180C03,  //  004D  ADD	R6	R6	R3
       0x581C000D,  //  004E  LDCONST	R7	K13
       0x7C100600,  //  004F  CALL	R4	3

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
@@ -31,6 +31,45 @@ be_local_closure(_anonymous_,   /* name */
 );
 /*******************************************************************/
 
+// compact class 'Persist' ktab size: 35, total: 65 (saved 240 bytes)
+static const bvalue be_ktab_class_Persist[35] = {
+  /* K0   */  be_nested_str(json),
+  /* K1   */  be_nested_str(write),
+  /* K2   */  be_nested_str(_X7B),
+  /* K3   */  be_nested_str(keys),
+  /* K4   */  be_nested_str(dump),
+  /* K5   */  be_nested_str(_X3A),
+  /* K6   */  be_nested_str(json_fdump_any),
+  /* K7   */  be_nested_str(_X2C),
+  /* K8   */  be_nested_str(stop_iteration),
+  /* K9   */  be_nested_str(_X7D),
+  /* K10  */  be_nested_str(json_fdump_map),
+  /* K11  */  be_nested_str(json_fdump_list),
+  /* K12  */  be_nested_str(_p),
+  /* K13  */  be_nested_str(_dirty),
+  /* K14  */  be_nested_str(load),
+  /* K15  */  be_nested_str(_filename),
+  /* K16  */  be_nested_str(w),
+  /* K17  */  be_nested_str(json_fdump),
+  /* K18  */  be_nested_str(close),
+  /* K19  */  be_nested_str(_X7B_X7D),
+  /* K20  */  be_nested_str(find),
+  /* K21  */  be_nested_str(contains),
+  /* K22  */  be_nested_str(_X5B),
+  /* K23  */  be_const_int(0),
+  /* K24  */  be_const_int(1),
+  /* K25  */  be_nested_str(_X5D),
+  /* K26  */  be_nested_str(internal_error),
+  /* K27  */  be_nested_str(persist_X2E_p_X20is_X20not_X20a_X20map),
+  /* K28  */  be_nested_str(path),
+  /* K29  */  be_nested_str(exists),
+  /* K30  */  be_nested_str(r),
+  /* K31  */  be_nested_str(read),
+  /* K32  */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson),
+  /* K33  */  be_nested_str(save),
+  /* K34  */  be_nested_str(remove),
+};
+
 
 extern const bclass be_class_Persist;
 
@@ -41,24 +80,13 @@ be_local_closure(class_Persist_json_fdump_map,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(write),
-    /* K2   */  be_nested_str(_X7B),
-    /* K3   */  be_nested_str(keys),
-    /* K4   */  be_nested_str(dump),
-    /* K5   */  be_nested_str(_X3A),
-    /* K6   */  be_nested_str(json_fdump_any),
-    /* K7   */  be_nested_str(_X2C),
-    /* K8   */  be_nested_str(stop_iteration),
-    /* K9   */  be_nested_str(_X7D),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_json_fdump_map,
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
@@ -116,19 +144,13 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(json_fdump_map),
-    /* K2   */  be_nested_str(json_fdump_list),
-    /* K3   */  be_nested_str(write),
-    /* K4   */  be_nested_str(dump),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_json_fdump_any,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
@@ -138,7 +160,7 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
       0x60180013,  //  0003  GETGBL	R6	G19
       0x7C100400,  //  0004  CALL	R4	2
       0x78120004,  //  0005  JMPF	R4	#000B
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x8C10010A,  //  0006  GETMET	R4	R0	K10
       0x5C180200,  //  0007  MOVE	R6	R1
       0x5C1C0400,  //  0008  MOVE	R7	R2
       0x7C100600,  //  0009  CALL	R4	3
@@ -148,12 +170,12 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
       0x60180012,  //  000D  GETGBL	R6	G18
       0x7C100400,  //  000E  CALL	R4	2
       0x78120004,  //  000F  JMPF	R4	#0015
-      0x8C100102,  //  0010  GETMET	R4	R0	K2
+      0x8C10010B,  //  0010  GETMET	R4	R0	K11
       0x5C180200,  //  0011  MOVE	R6	R1
       0x5C1C0400,  //  0012  MOVE	R7	R2
       0x7C100600,  //  0013  CALL	R4	3
       0x70020004,  //  0014  JMP		#001A
-      0x8C100303,  //  0015  GETMET	R4	R1	K3
+      0x8C100301,  //  0015  GETMET	R4	R1	K1
       0x8C180704,  //  0016  GETMET	R6	R3	K4
       0x5C200400,  //  0017  MOVE	R8	R2
       0x7C180400,  //  0018  CALL	R6	2
@@ -172,26 +194,22 @@ be_local_closure(class_Persist_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(_dirty),
-    /* K2   */  be_nested_str(load),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x90021801,  //  0002  SETMBR	R0	K12	R1
       0x50040000,  //  0003  LDBOOL	R1	0	0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x90021A01,  //  0004  SETMBR	R0	K13	R1
+      0x8C04010E,  //  0005  GETMET	R1	R0	K14
       0x7C040200,  //  0006  CALL	R1	1
       0x80000000,  //  0007  RET	0
     })
@@ -207,37 +225,29 @@ be_local_closure(class_Persist_save,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(_dirty),
-    /* K1   */  be_nested_str(_filename),
-    /* K2   */  be_nested_str(w),
-    /* K3   */  be_nested_str(json_fdump),
-    /* K4   */  be_nested_str(close),
-    /* K5   */  be_nested_str(write),
-    /* K6   */  be_nested_str(_X7B_X7D),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_save,
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
       0x7806002E,  //  0001  JMPF	R1	#0031
       0x4C040000,  //  0002  LDNIL	R1
       0xA802000B,  //  0003  EXBLK	0	#0010
       0x60080011,  //  0004  GETGBL	R2	G17
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
+      0x880C010F,  //  0005  GETMBR	R3	R0	K15
+      0x58100010,  //  0006  LDCONST	R4	K16
       0x7C080400,  //  0007  CALL	R2	2
       0x5C040400,  //  0008  MOVE	R1	R2
-      0x8C080103,  //  0009  GETMET	R2	R0	K3
+      0x8C080111,  //  0009  GETMET	R2	R0	K17
       0x5C100200,  //  000A  MOVE	R4	R1
       0x7C080400,  //  000B  CALL	R2	2
-      0x8C080304,  //  000C  GETMET	R2	R1	K4
+      0x8C080312,  //  000C  GETMET	R2	R1	K18
       0x7C080200,  //  000D  CALL	R2	1
       0xA8040001,  //  000E  EXBLK	1	1
       0x7002001E,  //  000F  JMP		#002F
@@ -246,17 +256,17 @@ be_local_closure(class_Persist_save,   /* name */
       0x4C100000,  //  0012  LDNIL	R4
       0x20100204,  //  0013  NE	R4	R1	R4
       0x78120001,  //  0014  JMPF	R4	#0017
-      0x8C100304,  //  0015  GETMET	R4	R1	K4
+      0x8C100312,  //  0015  GETMET	R4	R1	K18
       0x7C100200,  //  0016  CALL	R4	1
       0x4C040000,  //  0017  LDNIL	R1
       0xA8020009,  //  0018  EXBLK	0	#0023
       0x60100011,  //  0019  GETGBL	R4	G17
-      0x88140101,  //  001A  GETMBR	R5	R0	K1
-      0x58180002,  //  001B  LDCONST	R6	K2
+      0x8814010F,  //  001A  GETMBR	R5	R0	K15
+      0x58180010,  //  001B  LDCONST	R6	K16
       0x7C100400,  //  001C  CALL	R4	2
       0x5C040800,  //  001D  MOVE	R1	R4
-      0x8C100305,  //  001E  GETMET	R4	R1	K5
-      0x58180006,  //  001F  LDCONST	R6	K6
+      0x8C100301,  //  001E  GETMET	R4	R1	K1
+      0x58180013,  //  001F  LDCONST	R6	K19
       0x7C100400,  //  0020  CALL	R4	2
       0xA8040001,  //  0021  EXBLK	1	1
       0x70020003,  //  0022  JMP		#0027
@@ -267,13 +277,13 @@ be_local_closure(class_Persist_save,   /* name */
       0x4C100000,  //  0027  LDNIL	R4
       0x20100204,  //  0028  NE	R4	R1	R4
       0x78120001,  //  0029  JMPF	R4	#002C
-      0x8C100304,  //  002A  GETMET	R4	R1	K4
+      0x8C100312,  //  002A  GETMET	R4	R1	K18
       0x7C100200,  //  002B  CALL	R4	1
       0xB0040403,  //  002C  RAISE	1	R2	R3
       0x70020000,  //  002D  JMP		#002F
       0xB0080000,  //  002E  RAISE	2	R0	R0
       0x50080000,  //  002F  LDBOOL	R2	0	0
-      0x90020002,  //  0030  SETMBR	R0	K0	R2
+      0x90021A02,  //  0030  SETMBR	R0	K13	R2
       0x80000000,  //  0031  RET	0
     })
   )
@@ -288,24 +298,21 @@ be_local_closure(class_Persist_zero,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(_dirty),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_zero,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x90021801,  //  0002  SETMBR	R0	K12	R1
       0x50040200,  //  0003  LDBOOL	R1	1	0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0x90021A01,  //  0004  SETMBR	R0	K13	R1
       0x80000000,  //  0005  RET	0
     })
   )
@@ -320,21 +327,18 @@ be_local_closure(class_Persist_find,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(find),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_find,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x880C010C,  //  0000  GETMBR	R3	R0	K12
+      0x8C0C0714,  //  0001  GETMET	R3	R3	K20
       0x5C140200,  //  0002  MOVE	R5	R1
       0x5C180400,  //  0003  MOVE	R6	R2
       0x7C0C0600,  //  0004  CALL	R3	3
@@ -352,21 +356,18 @@ be_local_closure(class_Persist_has,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(contains),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_has,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
+      0x8C080515,  //  0001  GETMET	R2	R2	K21
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -383,48 +384,39 @@ be_local_closure(class_Persist_json_fdump_list,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(write),
-    /* K2   */  be_nested_str(_X5B),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str(_X2C),
-    /* K5   */  be_nested_str(json_fdump_any),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str(_X5D),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_json_fdump_list,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0x8C100301,  //  0001  GETMET	R4	R1	K1
-      0x58180002,  //  0002  LDCONST	R6	K2
+      0x58180016,  //  0002  LDCONST	R6	K22
       0x7C100400,  //  0003  CALL	R4	2
-      0x58100003,  //  0004  LDCONST	R4	K3
+      0x58100017,  //  0004  LDCONST	R4	K23
       0x6014000C,  //  0005  GETGBL	R5	G12
       0x5C180400,  //  0006  MOVE	R6	R2
       0x7C140200,  //  0007  CALL	R5	1
       0x14140805,  //  0008  LT	R5	R4	R5
       0x7816000A,  //  0009  JMPF	R5	#0015
-      0x24140903,  //  000A  GT	R5	R4	K3
+      0x24140917,  //  000A  GT	R5	R4	K23
       0x78160002,  //  000B  JMPF	R5	#000F
       0x8C140301,  //  000C  GETMET	R5	R1	K1
-      0x581C0004,  //  000D  LDCONST	R7	K4
+      0x581C0007,  //  000D  LDCONST	R7	K7
       0x7C140400,  //  000E  CALL	R5	2
-      0x8C140105,  //  000F  GETMET	R5	R0	K5
+      0x8C140106,  //  000F  GETMET	R5	R0	K6
       0x5C1C0200,  //  0010  MOVE	R7	R1
       0x94200404,  //  0011  GETIDX	R8	R2	R4
       0x7C140600,  //  0012  CALL	R5	3
-      0x00100906,  //  0013  ADD	R4	R4	K6
+      0x00100918,  //  0013  ADD	R4	R4	K24
       0x7001FFEF,  //  0014  JMP		#0005
       0x8C140301,  //  0015  GETMET	R5	R1	K1
-      0x581C0007,  //  0016  LDCONST	R7	K7
+      0x581C0019,  //  0016  LDCONST	R7	K25
       0x7C140400,  //  0017  CALL	R5	2
       0x80000000,  //  0018  RET	0
     })
@@ -440,21 +432,18 @@ be_local_closure(class_Persist_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(find),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_member,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
+      0x8C080514,  //  0001  GETMET	R2	R2	K20
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -471,23 +460,20 @@ be_local_closure(class_Persist_setmember,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(_dirty),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_setmember,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C010C,  //  0000  GETMBR	R3	R0	K12
       0x980C0202,  //  0001  SETIDX	R3	R1	R2
       0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x90020203,  //  0003  SETMBR	R0	K1	R3
+      0x90021A03,  //  0003  SETMBR	R0	K13	R3
       0x80000000,  //  0004  RET	0
     })
   )
@@ -502,21 +488,18 @@ be_local_closure(class_Persist_contains,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(contains),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_contains,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
+      0x8C080515,  //  0001  GETMET	R2	R2	K21
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -533,34 +516,28 @@ be_local_closure(class_Persist_json_fdump,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(_p),
-    /* K2   */  be_nested_str(json_fdump_map),
-    /* K3   */  be_nested_str(internal_error),
-    /* K4   */  be_nested_str(persist_X2E_p_X20is_X20not_X20a_X20map),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_json_fdump,
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x600C000F,  //  0001  GETGBL	R3	G15
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x8810010C,  //  0002  GETMBR	R4	R0	K12
       0x60140013,  //  0003  GETGBL	R5	G19
       0x7C0C0400,  //  0004  CALL	R3	2
       0x780E0004,  //  0005  JMPF	R3	#000B
-      0x8C0C0102,  //  0006  GETMET	R3	R0	K2
+      0x8C0C010A,  //  0006  GETMET	R3	R0	K10
       0x5C140200,  //  0007  MOVE	R5	R1
-      0x88180101,  //  0008  GETMBR	R6	R0	K1
+      0x8818010C,  //  0008  GETMBR	R6	R0	K12
       0x7C0C0600,  //  0009  CALL	R3	3
       0x70020000,  //  000A  JMP		#000C
-      0xB0060704,  //  000B  RAISE	1	K3	K4
+      0xB006351B,  //  000B  RAISE	1	K26	K27
       0x80000000,  //  000C  RET	0
     })
   )
@@ -575,49 +552,36 @@ be_local_closure(class_Persist_load,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(json),
-    /* K1   */  be_nested_str(path),
-    /* K2   */  be_nested_str(exists),
-    /* K3   */  be_nested_str(_filename),
-    /* K4   */  be_nested_str(r),
-    /* K5   */  be_nested_str(load),
-    /* K6   */  be_nested_str(read),
-    /* K7   */  be_nested_str(close),
-    /* K8   */  be_nested_str(_p),
-    /* K9   */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson),
-    /* K10  */  be_nested_str(_dirty),
-    /* K11  */  be_nested_str(save),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_load,
     &be_const_str_solidified,
     ( &(const binstruction[49]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA40A3800,  //  0001  IMPORT	R2	K28
       0x4C0C0000,  //  0002  LDNIL	R3
       0x4C100000,  //  0003  LDNIL	R4
-      0x8C140502,  //  0004  GETMET	R5	R2	K2
-      0x881C0103,  //  0005  GETMBR	R7	R0	K3
+      0x8C14051D,  //  0004  GETMET	R5	R2	K29
+      0x881C010F,  //  0005  GETMBR	R7	R0	K15
       0x7C140400,  //  0006  CALL	R5	2
       0x78160025,  //  0007  JMPF	R5	#002E
       0xA802000D,  //  0008  EXBLK	0	#0017
       0x60140011,  //  0009  GETGBL	R5	G17
-      0x88180103,  //  000A  GETMBR	R6	R0	K3
-      0x581C0004,  //  000B  LDCONST	R7	K4
+      0x8818010F,  //  000A  GETMBR	R6	R0	K15
+      0x581C001E,  //  000B  LDCONST	R7	K30
       0x7C140400,  //  000C  CALL	R5	2
       0x5C0C0A00,  //  000D  MOVE	R3	R5
-      0x8C140305,  //  000E  GETMET	R5	R1	K5
-      0x8C1C0706,  //  000F  GETMET	R7	R3	K6
+      0x8C14030E,  //  000E  GETMET	R5	R1	K14
+      0x8C1C071F,  //  000F  GETMET	R7	R3	K31
       0x7C1C0200,  //  0010  CALL	R7	1
       0x7C140400,  //  0011  CALL	R5	2
       0x5C100A00,  //  0012  MOVE	R4	R5
-      0x8C140707,  //  0013  GETMET	R5	R3	K7
+      0x8C140712,  //  0013  GETMET	R5	R3	K18
       0x7C140200,  //  0014  CALL	R5	1
       0xA8040001,  //  0015  EXBLK	1	1
       0x70020009,  //  0016  JMP		#0021
@@ -626,7 +590,7 @@ be_local_closure(class_Persist_load,   /* name */
       0x4C1C0000,  //  0019  LDNIL	R7
       0x201C0607,  //  001A  NE	R7	R3	R7
       0x781E0001,  //  001B  JMPF	R7	#001E
-      0x8C1C0707,  //  001C  GETMET	R7	R3	K7
+      0x8C1C0712,  //  001C  GETMET	R7	R3	K18
       0x7C1C0200,  //  001D  CALL	R7	1
       0xB0040A06,  //  001E  RAISE	1	R5	R6
       0x70020000,  //  001F  JMP		#0021
@@ -636,15 +600,15 @@ be_local_closure(class_Persist_load,   /* name */
       0x601C0013,  //  0023  GETGBL	R7	G19
       0x7C140400,  //  0024  CALL	R5	2
       0x78160001,  //  0025  JMPF	R5	#0028
-      0x90021004,  //  0026  SETMBR	R0	K8	R4
+      0x90021804,  //  0026  SETMBR	R0	K12	R4
       0x70020002,  //  0027  JMP		#002B
       0x60140001,  //  0028  GETGBL	R5	G1
-      0x58180009,  //  0029  LDCONST	R6	K9
+      0x58180020,  //  0029  LDCONST	R6	K32
       0x7C140200,  //  002A  CALL	R5	1
       0x50140000,  //  002B  LDBOOL	R5	0	0
-      0x90021405,  //  002C  SETMBR	R0	K10	R5
+      0x90021A05,  //  002C  SETMBR	R0	K13	R5
       0x70020001,  //  002D  JMP		#0030
-      0x8C14010B,  //  002E  GETMET	R5	R0	K11
+      0x8C140121,  //  002E  GETMET	R5	R0	K33
       0x7C140200,  //  002F  CALL	R5	1
       0x80000000,  //  0030  RET	0
     })
@@ -660,26 +624,22 @@ be_local_closure(class_Persist_remove,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_p),
-    /* K1   */  be_nested_str(remove),
-    /* K2   */  be_nested_str(_dirty),
-    }),
+    &be_ktab_class_Persist,     /* shared constants */
     &be_const_str_remove,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8808010C,  //  0000  GETMBR	R2	R0	K12
+      0x8C080522,  //  0001  GETMET	R2	R2	K34
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x50080200,  //  0004  LDBOOL	R2	1	0
-      0x90020402,  //  0005  SETMBR	R0	K2	R2
+      0x90021A02,  //  0005  SETMBR	R0	K13	R2
       0x80000000,  //  0006  RET	0
     })
   )

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
@@ -3,6 +3,20 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Rule_Matcher_Key;
+// compact class 'Rule_Matcher_Key' ktab size: 9, total: 11 (saved 16 bytes)
+static const bvalue be_ktab_class_Rule_Matcher_Key[9] = {
+  /* K0   */  be_nested_str(_X3CMatcher_X20key_X3D_X27),
+  /* K1   */  be_nested_str(name),
+  /* K2   */  be_nested_str(_X27_X3E),
+  /* K3   */  be_const_class(be_class_Rule_Matcher_Key),
+  /* K4   */  be_nested_str(string),
+  /* K5   */  be_nested_str(toupper),
+  /* K6   */  be_nested_str(keys),
+  /* K7   */  be_nested_str(stop_iteration),
+  /* K8   */  be_nested_str(find_key_i),
+};
+
 
 extern const bclass be_class_Rule_Matcher_Key;
 
@@ -13,17 +27,13 @@ be_local_closure(class_Rule_Matcher_Key_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_X3CMatcher_X20key_X3D_X27),
-    /* K1   */  be_nested_str(name),
-    /* K2   */  be_nested_str(_X27_X3E),
-    }),
+    &be_ktab_class_Rule_Matcher_Key,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
@@ -46,25 +56,19 @@ be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Rule_Matcher_Key),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(toupper),
-    /* K3   */  be_nested_str(keys),
-    /* K4   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Rule_Matcher_Key,     /* shared constants */
     &be_const_str_find_key_i,
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100702,  //  0002  GETMET	R4	R3	K2
+      0x58080003,  //  0000  LDCONST	R2	K3
+      0xA40E0800,  //  0001  IMPORT	R3	K4
+      0x8C100705,  //  0002  GETMET	R4	R3	K5
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
       0x6014000F,  //  0005  GETGBL	R5	G15
@@ -73,13 +77,13 @@ be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
       0x7C140400,  //  0008  CALL	R5	2
       0x78160013,  //  0009  JMPF	R5	#001E
       0x60140010,  //  000A  GETGBL	R5	G16
-      0x8C180103,  //  000B  GETMET	R6	R0	K3
+      0x8C180106,  //  000B  GETMET	R6	R0	K6
       0x7C180200,  //  000C  CALL	R6	1
       0x7C140200,  //  000D  CALL	R5	1
       0xA802000B,  //  000E  EXBLK	0	#001B
       0x5C180A00,  //  000F  MOVE	R6	R5
       0x7C180000,  //  0010  CALL	R6	0
-      0x8C1C0702,  //  0011  GETMET	R7	R3	K2
+      0x8C1C0705,  //  0011  GETMET	R7	R3	K5
       0x60240008,  //  0012  GETGBL	R9	G8
       0x5C280C00,  //  0013  MOVE	R10	R6
       0x7C240200,  //  0014  CALL	R9	1
@@ -89,7 +93,7 @@ be_local_closure(class_Rule_Matcher_Key_find_key_i,   /* name */
       0xA8040001,  //  0018  EXBLK	1	1
       0x80040C00,  //  0019  RET	1	R6
       0x7001FFF3,  //  001A  JMP		#000F
-      0x58140004,  //  001B  LDCONST	R5	K4
+      0x58140007,  //  001B  LDCONST	R5	K7
       0xAC140200,  //  001C  CATCH	R5	1	0
       0xB0080000,  //  001D  RAISE	2	R0	R0
       0x80000000,  //  001E  RET	0
@@ -106,16 +110,13 @@ be_local_closure(class_Rule_Matcher_Key_match,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(find_key_i),
-    /* K1   */  be_nested_str(name),
-    }),
+    &be_ktab_class_Rule_Matcher_Key,     /* shared constants */
     &be_const_str_match,
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
@@ -131,7 +132,7 @@ be_local_closure(class_Rule_Matcher_Key_match,   /* name */
       0x740A0001,  //  0009  JMPT	R2	#000C
       0x4C080000,  //  000A  LDNIL	R2
       0x80040400,  //  000B  RET	1	R2
-      0x8C080100,  //  000C  GETMET	R2	R0	K0
+      0x8C080108,  //  000C  GETMET	R2	R0	K8
       0x5C100200,  //  000D  MOVE	R4	R1
       0x88140101,  //  000E  GETMBR	R5	R0	K1
       0x7C080600,  //  000F  CALL	R2	3
@@ -155,19 +156,17 @@ be_local_closure(class_Rule_Matcher_Key_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(name),
-    }),
+    &be_ktab_class_Rule_Matcher_Key,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020201,  //  0000  SETMBR	R0	K1	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -282,6 +281,39 @@ be_local_class(Rule_Matcher_Wildcard,
     })),
     (bstring*) &be_const_str_Rule_Matcher_Wildcard
 );
+// compact class 'Rule_Matcher_Operator' ktab size: 29, total: 37 (saved 64 bytes)
+static const bvalue be_ktab_class_Rule_Matcher_Operator[29] = {
+  /* K0   */  be_nested_str(int),
+  /* K1   */  be_nested_str(real),
+  /* K2   */  be_nested_str(string),
+  /* K3   */  be_nested_str(op_func),
+  /* K4   */  be_nested_str(op_value),
+  /* K5   */  be_nested_str(op_str),
+  /* K6   */  be_nested_str(_X3D),
+  /* K7   */  be_nested_str(_X21_X3D_X3D),
+  /* K8   */  be_nested_str(_X24_X21),
+  /* K9   */  be_nested_str(_X24_X3C),
+  /* K10  */  be_nested_str(_X24_X3E),
+  /* K11  */  be_nested_str(_X24_X7C),
+  /* K12  */  be_nested_str(_X24_X5E),
+  /* K13  */  be_nested_str(_X3D_X3D),
+  /* K14  */  be_nested_str(_X21_X3D),
+  /* K15  */  be_nested_str(_X3E),
+  /* K16  */  be_nested_str(_X3E_X3D),
+  /* K17  */  be_nested_str(_X3C),
+  /* K18  */  be_nested_str(_X3C_X3D),
+  /* K19  */  be_nested_str(_X7C),
+  /* K20  */  be_nested_str(json),
+  /* K21  */  be_nested_str(load),
+  /* K22  */  be_nested_str(value_error),
+  /* K23  */  be_nested_str(value_X20needs_X20to_X20be_X20a_X20number),
+  /* K24  */  be_nested_str(_X3CMatcher_X20op_X20_X27),
+  /* K25  */  be_nested_str(_X27_X20val_X3D_X27),
+  /* K26  */  be_nested_str(_X27_X3E),
+  /* K27  */  be_nested_str(_X27_X20val_X3D),
+  /* K28  */  be_nested_str(op_parse),
+};
+
 
 extern const bclass be_class_Rule_Matcher_Operator;
 
@@ -292,19 +324,13 @@ be_local_closure(class_Rule_Matcher_Operator_match,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(int),
-    /* K1   */  be_nested_str(real),
-    /* K2   */  be_nested_str(string),
-    /* K3   */  be_nested_str(op_func),
-    /* K4   */  be_nested_str(op_value),
-    }),
+    &be_ktab_class_Rule_Matcher_Operator,     /* shared constants */
     &be_const_str_match,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
@@ -341,7 +367,7 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
   be_nested_proto(
     22,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -656,35 +682,11 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str(op_str),
-    /* K1   */  be_nested_str(_X3D),
-    /* K2   */  be_nested_str(_X21_X3D_X3D),
-    /* K3   */  be_nested_str(_X24_X21),
-    /* K4   */  be_nested_str(_X24_X3C),
-    /* K5   */  be_nested_str(_X24_X3E),
-    /* K6   */  be_nested_str(_X24_X7C),
-    /* K7   */  be_nested_str(_X24_X5E),
-    /* K8   */  be_nested_str(_X3D_X3D),
-    /* K9   */  be_nested_str(_X21_X3D),
-    /* K10  */  be_nested_str(_X3E),
-    /* K11  */  be_nested_str(_X3E_X3D),
-    /* K12  */  be_nested_str(_X3C),
-    /* K13  */  be_nested_str(_X3C_X3D),
-    /* K14  */  be_nested_str(_X7C),
-    /* K15  */  be_nested_str(op_func),
-    /* K16  */  be_nested_str(json),
-    /* K17  */  be_nested_str(load),
-    /* K18  */  be_nested_str(int),
-    /* K19  */  be_nested_str(real),
-    /* K20  */  be_nested_str(value_error),
-    /* K21  */  be_nested_str(value_X20needs_X20to_X20be_X20a_X20number),
-    /* K22  */  be_nested_str(op_value),
-    }),
+    &be_ktab_class_Rule_Matcher_Operator,     /* shared constants */
     &be_const_str_op_parse,
     &be_const_str_solidified,
     ( &(const binstruction[97]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020A01,  //  0000  SETMBR	R0	K5	R1
       0x840C0000,  //  0001  CLOSURE	R3	P0
       0x84100001,  //  0002  CLOSURE	R4	P1
       0x84140002,  //  0003  CLOSURE	R5	P2
@@ -700,86 +702,86 @@ be_local_closure(class_Rule_Matcher_Operator_op_parse,   /* name */
       0x843C000C,  //  000D  CLOSURE	R15	P12
       0x50400000,  //  000E  LDBOOL	R16	0	0
       0x4C440000,  //  000F  LDNIL	R17
-      0x1C480301,  //  0010  EQ	R18	R1	K1
+      0x1C480306,  //  0010  EQ	R18	R1	K6
       0x784A0001,  //  0011  JMPF	R18	#0014
       0x5C440600,  //  0012  MOVE	R17	R3
       0x70020033,  //  0013  JMP		#0048
-      0x1C480302,  //  0014  EQ	R18	R1	K2
+      0x1C480307,  //  0014  EQ	R18	R1	K7
       0x784A0001,  //  0015  JMPF	R18	#0018
       0x5C440800,  //  0016  MOVE	R17	R4
       0x7002002F,  //  0017  JMP		#0048
-      0x1C480303,  //  0018  EQ	R18	R1	K3
+      0x1C480308,  //  0018  EQ	R18	R1	K8
       0x784A0001,  //  0019  JMPF	R18	#001C
       0x5C440800,  //  001A  MOVE	R17	R4
       0x7002002B,  //  001B  JMP		#0048
-      0x1C480304,  //  001C  EQ	R18	R1	K4
+      0x1C480309,  //  001C  EQ	R18	R1	K9
       0x784A0001,  //  001D  JMPF	R18	#0020
       0x5C440A00,  //  001E  MOVE	R17	R5
       0x70020027,  //  001F  JMP		#0048
-      0x1C480305,  //  0020  EQ	R18	R1	K5
+      0x1C48030A,  //  0020  EQ	R18	R1	K10
       0x784A0001,  //  0021  JMPF	R18	#0024
       0x5C440C00,  //  0022  MOVE	R17	R6
       0x70020023,  //  0023  JMP		#0048
-      0x1C480306,  //  0024  EQ	R18	R1	K6
+      0x1C48030B,  //  0024  EQ	R18	R1	K11
       0x784A0001,  //  0025  JMPF	R18	#0028
       0x5C440E00,  //  0026  MOVE	R17	R7
       0x7002001F,  //  0027  JMP		#0048
-      0x1C480307,  //  0028  EQ	R18	R1	K7
+      0x1C48030C,  //  0028  EQ	R18	R1	K12
       0x784A0001,  //  0029  JMPF	R18	#002C
       0x5C441000,  //  002A  MOVE	R17	R8
       0x7002001B,  //  002B  JMP		#0048
       0x50400200,  //  002C  LDBOOL	R16	1	0
-      0x1C480308,  //  002D  EQ	R18	R1	K8
+      0x1C48030D,  //  002D  EQ	R18	R1	K13
       0x784A0001,  //  002E  JMPF	R18	#0031
       0x5C441200,  //  002F  MOVE	R17	R9
       0x70020016,  //  0030  JMP		#0048
-      0x1C480309,  //  0031  EQ	R18	R1	K9
+      0x1C48030E,  //  0031  EQ	R18	R1	K14
       0x784A0001,  //  0032  JMPF	R18	#0035
       0x5C441400,  //  0033  MOVE	R17	R10
       0x70020012,  //  0034  JMP		#0048
-      0x1C48030A,  //  0035  EQ	R18	R1	K10
+      0x1C48030F,  //  0035  EQ	R18	R1	K15
       0x784A0001,  //  0036  JMPF	R18	#0039
       0x5C441600,  //  0037  MOVE	R17	R11
       0x7002000E,  //  0038  JMP		#0048
-      0x1C48030B,  //  0039  EQ	R18	R1	K11
+      0x1C480310,  //  0039  EQ	R18	R1	K16
       0x784A0001,  //  003A  JMPF	R18	#003D
       0x5C441800,  //  003B  MOVE	R17	R12
       0x7002000A,  //  003C  JMP		#0048
-      0x1C48030C,  //  003D  EQ	R18	R1	K12
+      0x1C480311,  //  003D  EQ	R18	R1	K17
       0x784A0001,  //  003E  JMPF	R18	#0041
       0x5C441A00,  //  003F  MOVE	R17	R13
       0x70020006,  //  0040  JMP		#0048
-      0x1C48030D,  //  0041  EQ	R18	R1	K13
+      0x1C480312,  //  0041  EQ	R18	R1	K18
       0x784A0001,  //  0042  JMPF	R18	#0045
       0x5C441C00,  //  0043  MOVE	R17	R14
       0x70020002,  //  0044  JMP		#0048
-      0x1C48030E,  //  0045  EQ	R18	R1	K14
+      0x1C480313,  //  0045  EQ	R18	R1	K19
       0x784A0000,  //  0046  JMPF	R18	#0048
       0x5C441E00,  //  0047  MOVE	R17	R15
-      0x90021E11,  //  0048  SETMBR	R0	K15	R17
+      0x90020611,  //  0048  SETMBR	R0	K3	R17
       0x78420011,  //  0049  JMPF	R16	#005C
-      0xA44A2000,  //  004A  IMPORT	R18	K16
-      0x8C4C2511,  //  004B  GETMET	R19	R18	K17
+      0xA44A2800,  //  004A  IMPORT	R18	K20
+      0x8C4C2515,  //  004B  GETMET	R19	R18	K21
       0x5C540400,  //  004C  MOVE	R21	R2
       0x7C4C0400,  //  004D  CALL	R19	2
       0x60500004,  //  004E  GETGBL	R20	G4
       0x5C542600,  //  004F  MOVE	R21	R19
       0x7C500200,  //  0050  CALL	R20	1
-      0x20502912,  //  0051  NE	R20	R20	K18
+      0x20502900,  //  0051  NE	R20	R20	K0
       0x78520006,  //  0052  JMPF	R20	#005A
       0x60500004,  //  0053  GETGBL	R20	G4
       0x5C542600,  //  0054  MOVE	R21	R19
       0x7C500200,  //  0055  CALL	R20	1
-      0x20502913,  //  0056  NE	R20	R20	K19
+      0x20502901,  //  0056  NE	R20	R20	K1
       0x78520001,  //  0057  JMPF	R20	#005A
-      0xB0062915,  //  0058  RAISE	1	K20	K21
+      0xB0062D17,  //  0058  RAISE	1	K22	K23
       0x70020000,  //  0059  JMP		#005B
-      0x90022C13,  //  005A  SETMBR	R0	K22	R19
+      0x90020813,  //  005A  SETMBR	R0	K4	R19
       0x70020003,  //  005B  JMP		#0060
       0x60480008,  //  005C  GETGBL	R18	G8
       0x5C4C0400,  //  005D  MOVE	R19	R2
       0x7C480200,  //  005E  CALL	R18	1
-      0x90022C12,  //  005F  SETMBR	R0	K22	R18
+      0x90020812,  //  005F  SETMBR	R0	K4	R18
       0x80000000,  //  0060  RET	0
     })
   )
@@ -794,48 +796,39 @@ be_local_closure(class_Rule_Matcher_Operator_tostring,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(op_value),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(_X3CMatcher_X20op_X20_X27),
-    /* K3   */  be_nested_str(op_str),
-    /* K4   */  be_nested_str(_X27_X20val_X3D_X27),
-    /* K5   */  be_nested_str(_X27_X3E),
-    /* K6   */  be_nested_str(_X27_X20val_X3D),
-    /* K7   */  be_nested_str(_X3E),
-    }),
+    &be_ktab_class_Rule_Matcher_Operator,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x60040004,  //  0000  GETGBL	R1	G4
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080104,  //  0001  GETMBR	R2	R0	K4
       0x7C040200,  //  0002  CALL	R1	1
-      0x1C040301,  //  0003  EQ	R1	R1	K1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
       0x78060009,  //  0004  JMPF	R1	#000F
-      0x88040103,  //  0005  GETMBR	R1	R0	K3
-      0x00060401,  //  0006  ADD	R1	K2	R1
-      0x00040304,  //  0007  ADD	R1	R1	K4
+      0x88040105,  //  0005  GETMBR	R1	R0	K5
+      0x00063001,  //  0006  ADD	R1	K24	R1
+      0x00040319,  //  0007  ADD	R1	R1	K25
       0x60080008,  //  0008  GETGBL	R2	G8
-      0x880C0100,  //  0009  GETMBR	R3	R0	K0
+      0x880C0104,  //  0009  GETMBR	R3	R0	K4
       0x7C080200,  //  000A  CALL	R2	1
       0x00040202,  //  000B  ADD	R1	R1	R2
-      0x00040305,  //  000C  ADD	R1	R1	K5
+      0x0004031A,  //  000C  ADD	R1	R1	K26
       0x80040200,  //  000D  RET	1	R1
       0x70020008,  //  000E  JMP		#0018
-      0x88040103,  //  000F  GETMBR	R1	R0	K3
-      0x00060401,  //  0010  ADD	R1	K2	R1
-      0x00040306,  //  0011  ADD	R1	R1	K6
+      0x88040105,  //  000F  GETMBR	R1	R0	K5
+      0x00063001,  //  0010  ADD	R1	K24	R1
+      0x0004031B,  //  0011  ADD	R1	R1	K27
       0x60080008,  //  0012  GETGBL	R2	G8
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
+      0x880C0104,  //  0013  GETMBR	R3	R0	K4
       0x7C080200,  //  0014  CALL	R2	1
       0x00040202,  //  0015  ADD	R1	R1	R2
-      0x00040307,  //  0016  ADD	R1	R1	K7
+      0x0004030F,  //  0016  ADD	R1	R1	K15
       0x80040200,  //  0017  RET	1	R1
       0x80000000,  //  0018  RET	0
     })
@@ -851,19 +844,17 @@ be_local_closure(class_Rule_Matcher_Operator_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(op_parse),
-    }),
+    &be_ktab_class_Rule_Matcher_Operator,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C011C,  //  0000  GETMET	R3	R0	K28
       0x5C140200,  //  0001  MOVE	R5	R1
       0x5C180400,  //  0002  MOVE	R6	R2
       0x7C0C0600,  //  0003  CALL	R3	3
@@ -892,6 +883,15 @@ be_local_class(Rule_Matcher_Operator,
     })),
     (bstring*) &be_const_str_Rule_Matcher_Operator
 );
+// compact class 'Rule_Matcher_Array' ktab size: 5, total: 7 (saved 16 bytes)
+static const bvalue be_ktab_class_Rule_Matcher_Array[5] = {
+  /* K0   */  be_nested_str(index),
+  /* K1   */  be_nested_str(_X3CMatcher_X20_X5B),
+  /* K2   */  be_nested_str(_X5D_X3E),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_const_int(1),
+};
+
 
 extern const bclass be_class_Rule_Matcher_Array;
 
@@ -902,15 +902,13 @@ be_local_closure(class_Rule_Matcher_Array_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(index),
-    }),
+    &be_ktab_class_Rule_Matcher_Array,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -929,24 +927,20 @@ be_local_closure(class_Rule_Matcher_Array_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_X3CMatcher_X20_X5B),
-    /* K1   */  be_nested_str(index),
-    /* K2   */  be_nested_str(_X5D_X3E),
-    }),
+    &be_ktab_class_Rule_Matcher_Array,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x60040008,  //  0000  GETGBL	R1	G8
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
       0x7C040200,  //  0002  CALL	R1	1
-      0x00060001,  //  0003  ADD	R1	K0	R1
+      0x00060201,  //  0003  ADD	R1	K1	R1
       0x00040302,  //  0004  ADD	R1	R1	K2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -962,17 +956,13 @@ be_local_closure(class_Rule_Matcher_Array_match,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(index),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    }),
+    &be_ktab_class_Rule_Matcher_Array,     /* shared constants */
     &be_const_str_match,
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
@@ -988,7 +978,7 @@ be_local_closure(class_Rule_Matcher_Array_match,   /* name */
       0x740A0000,  //  0009  JMPT	R2	#000B
       0x80040200,  //  000A  RET	1	R1
       0x88080100,  //  000B  GETMBR	R2	R0	K0
-      0x18080501,  //  000C  LE	R2	R2	K1
+      0x18080503,  //  000C  LE	R2	R2	K3
       0x780A0001,  //  000D  JMPF	R2	#0010
       0x4C080000,  //  000E  LDNIL	R2
       0x80040400,  //  000F  RET	1	R2
@@ -1001,7 +991,7 @@ be_local_closure(class_Rule_Matcher_Array_match,   /* name */
       0x4C080000,  //  0016  LDNIL	R2
       0x80040400,  //  0017  RET	1	R2
       0x88080100,  //  0018  GETMBR	R2	R0	K0
-      0x04080502,  //  0019  SUB	R2	R2	K2
+      0x04080504,  //  0019  SUB	R2	R2	K4
       0x94080202,  //  001A  GETIDX	R2	R1	R2
       0x80040400,  //  001B  RET	1	R2
     })
@@ -1025,6 +1015,17 @@ be_local_class(Rule_Matcher_Array,
     })),
     (bstring*) &be_const_str_Rule_Matcher_Array
 );
+// compact class 'Rule_Matcher_AND_List' ktab size: 7, total: 9 (saved 16 bytes)
+static const bvalue be_ktab_class_Rule_Matcher_AND_List[7] = {
+  /* K0   */  be_nested_str(and_list),
+  /* K1   */  be_nested_str(_X3CMatcher_AND_List_X20),
+  /* K2   */  be_nested_str(_X3E),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str(match),
+  /* K5   */  be_nested_str(push),
+  /* K6   */  be_const_int(1),
+};
+
 
 extern const bclass be_class_Rule_Matcher_AND_List;
 
@@ -1035,15 +1036,13 @@ be_local_closure(class_Rule_Matcher_AND_List_init,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(and_list),
-    }),
+    &be_ktab_class_Rule_Matcher_AND_List,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -1062,24 +1061,20 @@ be_local_closure(class_Rule_Matcher_AND_List_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_X3CMatcher_AND_List_X20),
-    /* K1   */  be_nested_str(and_list),
-    /* K2   */  be_nested_str(_X3E),
-    }),
+    &be_ktab_class_Rule_Matcher_AND_List,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x60040008,  //  0000  GETGBL	R1	G8
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
       0x7C040200,  //  0002  CALL	R1	1
-      0x00060001,  //  0003  ADD	R1	K0	R1
+      0x00060201,  //  0003  ADD	R1	K1	R1
       0x00040302,  //  0004  ADD	R1	R1	K2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -1095,33 +1090,27 @@ be_local_closure(class_Rule_Matcher_AND_List_match,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(and_list),
-    /* K2   */  be_nested_str(match),
-    /* K3   */  be_nested_str(push),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_Rule_Matcher_AND_List,     /* shared constants */
     &be_const_str_match,
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
+      0x58080003,  //  0000  LDCONST	R2	K3
       0x600C0012,  //  0001  GETGBL	R3	G18
       0x7C0C0000,  //  0002  CALL	R3	0
       0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
       0x7C100200,  //  0005  CALL	R4	1
       0x14100404,  //  0006  LT	R4	R2	R4
       0x7812000E,  //  0007  JMPF	R4	#0017
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
       0x94100802,  //  0009  GETIDX	R4	R4	R2
-      0x8C140902,  //  000A  GETMET	R5	R4	K2
+      0x8C140904,  //  000A  GETMET	R5	R4	K4
       0x5C1C0200,  //  000B  MOVE	R7	R1
       0x7C140400,  //  000C  CALL	R5	2
       0x4C180000,  //  000D  LDNIL	R6
@@ -1129,10 +1118,10 @@ be_local_closure(class_Rule_Matcher_AND_List_match,   /* name */
       0x781A0001,  //  000F  JMPF	R6	#0012
       0x4C180000,  //  0010  LDNIL	R6
       0x80040C00,  //  0011  RET	1	R6
-      0x8C180703,  //  0012  GETMET	R6	R3	K3
+      0x8C180705,  //  0012  GETMET	R6	R3	K5
       0x5C200A00,  //  0013  MOVE	R8	R5
       0x7C180400,  //  0014  CALL	R6	2
-      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x00080506,  //  0015  ADD	R2	R2	K6
       0x7001FFEB,  //  0016  JMP		#0003
       0x80040600,  //  0017  RET	1	R3
     })
@@ -1156,6 +1145,40 @@ be_local_class(Rule_Matcher_AND_List,
     })),
     (bstring*) &be_const_str_Rule_Matcher_AND_List
 );
+extern const bclass be_class_Rule_Matcher;
+// compact class 'Rule_Matcher' ktab size: 29, total: 34 (saved 40 bytes)
+static const bvalue be_ktab_class_Rule_Matcher[29] = {
+  /* K0   */  be_nested_str(matchers),
+  /* K1   */  be_nested_str(rule),
+  /* K2   */  be_nested_str(trigger),
+  /* K3   */  be_const_class(be_class_Rule_Matcher),
+  /* K4   */  be_nested_str(string),
+  /* K5   */  be_nested_str(parse),
+  /* K6   */  be_nested_str(push),
+  /* K7   */  be_nested_str(stop_iteration),
+  /* K8   */  be_nested_str(Rule_Matcher_AND_List),
+  /* K9   */  be_nested_str(tasmota),
+  /* K10  */  be_nested_str(find_op),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_nested_str(find),
+  /* K15  */  be_nested_str(_X23),
+  /* K16  */  be_nested_str(pattern_error),
+  /* K17  */  be_nested_str(empty_X20pattern_X20not_X20allowed),
+  /* K18  */  be_const_int(2147483647),
+  /* K19  */  be_nested_str(_X5B),
+  /* K20  */  be_nested_str(_X5D),
+  /* K21  */  be_nested_str(value_error),
+  /* K22  */  be_nested_str(missing_X20_X27_X5D_X27_X20in_X20rule_X20pattern),
+  /* K23  */  be_nested_str(_X3F),
+  /* K24  */  be_nested_str(Rule_Matcher_Wildcard),
+  /* K25  */  be_nested_str(Rule_Matcher_Key),
+  /* K26  */  be_nested_str(Rule_Matcher_Array),
+  /* K27  */  be_nested_str(Rule_Matcher_Operator),
+  /* K28  */  be_nested_str(match),
+};
+
 
 extern const bclass be_class_Rule_Matcher;
 
@@ -1166,15 +1189,13 @@ be_local_closure(class_Rule_Matcher_tostring,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(matchers),
-    }),
+    &be_ktab_class_Rule_Matcher,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -1195,23 +1216,19 @@ be_local_closure(class_Rule_Matcher_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(rule),
-    /* K1   */  be_nested_str(trigger),
-    /* K2   */  be_nested_str(matchers),
-    }),
+    &be_ktab_class_Rule_Matcher,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x90020201,  //  0000  SETMBR	R0	K1	R1
+      0x90020402,  //  0001  SETMBR	R0	K2	R2
+      0x90020003,  //  0002  SETMBR	R0	K0	R3
       0x80000000,  //  0003  RET	0
     })
   )
@@ -1226,45 +1243,18 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
   be_nested_proto(
     20,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Rule_Matcher),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(parse),
-    /* K3   */  be_nested_str(push),
-    /* K4   */  be_nested_str(trigger),
-    /* K5   */  be_nested_str(stop_iteration),
-    /* K6   */  be_nested_str(Rule_Matcher_AND_List),
-    /* K7   */  be_nested_str(tasmota),
-    /* K8   */  be_nested_str(find_op),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str(find),
-    /* K13  */  be_nested_str(_X23),
-    /* K14  */  be_nested_str(pattern_error),
-    /* K15  */  be_nested_str(empty_X20pattern_X20not_X20allowed),
-    /* K16  */  be_const_int(2147483647),
-    /* K17  */  be_nested_str(_X5B),
-    /* K18  */  be_nested_str(_X5D),
-    /* K19  */  be_nested_str(value_error),
-    /* K20  */  be_nested_str(missing_X20_X27_X5D_X27_X20in_X20rule_X20pattern),
-    /* K21  */  be_nested_str(_X3F),
-    /* K22  */  be_nested_str(Rule_Matcher_Wildcard),
-    /* K23  */  be_nested_str(Rule_Matcher_Key),
-    /* K24  */  be_nested_str(Rule_Matcher_Array),
-    /* K25  */  be_nested_str(Rule_Matcher_Operator),
-    }),
+    &be_ktab_class_Rule_Matcher,     /* shared constants */
     &be_const_str_parse,
     &be_const_str_solidified,
     ( &(const binstruction[147]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x58040003,  //  0000  LDCONST	R1	K3
+      0xA40A0800,  //  0001  IMPORT	R2	K4
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C0C0003,  //  0003  EQ	R3	R0	R3
       0x780E0001,  //  0004  JMPF	R3	#0007
@@ -1285,17 +1275,17 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
       0xA802000B,  //  0013  EXBLK	0	#0020
       0x5C180A00,  //  0014  MOVE	R6	R5
       0x7C180000,  //  0015  CALL	R6	0
-      0x8C1C0302,  //  0016  GETMET	R7	R1	K2
+      0x8C1C0305,  //  0016  GETMET	R7	R1	K5
       0x5C240C00,  //  0017  MOVE	R9	R6
       0x7C1C0400,  //  0018  CALL	R7	2
-      0x8C200703,  //  0019  GETMET	R8	R3	K3
+      0x8C200706,  //  0019  GETMET	R8	R3	K6
       0x5C280E00,  //  001A  MOVE	R10	R7
       0x7C200400,  //  001B  CALL	R8	2
-      0x8C200903,  //  001C  GETMET	R8	R4	K3
-      0x88280F04,  //  001D  GETMBR	R10	R7	K4
+      0x8C200906,  //  001C  GETMET	R8	R4	K6
+      0x88280F02,  //  001D  GETMBR	R10	R7	K2
       0x7C200400,  //  001E  CALL	R8	2
       0x7001FFF3,  //  001F  JMP		#0014
-      0x58140005,  //  0020  LDCONST	R5	K5
+      0x58140007,  //  0020  LDCONST	R5	K7
       0xAC140200,  //  0021  CATCH	R5	1	0
       0xB0080000,  //  0022  RAISE	2	R0	R0
       0x5C140200,  //  0023  MOVE	R5	R1
@@ -1303,7 +1293,7 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
       0x5C1C0800,  //  0025  MOVE	R7	R4
       0x60200012,  //  0026  GETGBL	R8	G18
       0x7C200000,  //  0027  CALL	R8	0
-      0x8C240306,  //  0028  GETMET	R9	R1	K6
+      0x8C240308,  //  0028  GETMET	R9	R1	K8
       0x5C2C0600,  //  0029  MOVE	R11	R3
       0x7C240400,  //  002A  CALL	R9	2
       0x40241009,  //  002B  CONNECT	R9	R8	R9
@@ -1311,83 +1301,83 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
       0x80040A00,  //  002D  RET	1	R5
       0x600C0012,  //  002E  GETGBL	R3	G18
       0x7C0C0000,  //  002F  CALL	R3	0
-      0xB8120E00,  //  0030  GETNGBL	R4	K7
-      0x8C100908,  //  0031  GETMET	R4	R4	K8
+      0xB8121200,  //  0030  GETNGBL	R4	K9
+      0x8C10090A,  //  0031  GETMET	R4	R4	K10
       0x5C180000,  //  0032  MOVE	R6	R0
       0x7C100400,  //  0033  CALL	R4	2
-      0x94140909,  //  0034  GETIDX	R5	R4	K9
-      0x9418090A,  //  0035  GETIDX	R6	R4	K10
-      0x941C090B,  //  0036  GETIDX	R7	R4	K11
+      0x9414090B,  //  0034  GETIDX	R5	R4	K11
+      0x9418090C,  //  0035  GETIDX	R6	R4	K12
+      0x941C090D,  //  0036  GETIDX	R7	R4	K13
       0x6020000C,  //  0037  GETGBL	R8	G12
       0x5C240A00,  //  0038  MOVE	R9	R5
       0x7C200200,  //  0039  CALL	R8	1
-      0x58240009,  //  003A  LDCONST	R9	K9
+      0x5824000B,  //  003A  LDCONST	R9	K11
       0x5429FFFE,  //  003B  LDINT	R10	-1
       0x142C1208,  //  003C  LT	R11	R9	R8
       0x782E0042,  //  003D  JMPF	R11	#0081
-      0x8C2C050C,  //  003E  GETMET	R11	R2	K12
+      0x8C2C050E,  //  003E  GETMET	R11	R2	K14
       0x5C340A00,  //  003F  MOVE	R13	R5
-      0x5838000D,  //  0040  LDCONST	R14	K13
+      0x5838000F,  //  0040  LDCONST	R14	K15
       0x5C3C1200,  //  0041  MOVE	R15	R9
       0x7C2C0800,  //  0042  CALL	R11	4
       0x4C300000,  //  0043  LDNIL	R12
-      0x28341709,  //  0044  GE	R13	R11	K9
+      0x2834170B,  //  0044  GE	R13	R11	K11
       0x78360008,  //  0045  JMPF	R13	#004F
       0x1C341609,  //  0046  EQ	R13	R11	R9
       0x78360000,  //  0047  JMPF	R13	#0049
-      0xB0061D0F,  //  0048  RAISE	1	K14	K15
-      0x0434170A,  //  0049  SUB	R13	R11	K10
+      0xB0062111,  //  0048  RAISE	1	K16	K17
+      0x0434170C,  //  0049  SUB	R13	R11	K12
       0x4034120D,  //  004A  CONNECT	R13	R9	R13
       0x94300A0D,  //  004B  GETIDX	R12	R5	R13
-      0x0034170A,  //  004C  ADD	R13	R11	K10
+      0x0034170C,  //  004C  ADD	R13	R11	K12
       0x5C241A00,  //  004D  MOVE	R9	R13
       0x70020002,  //  004E  JMP		#0052
-      0x40341310,  //  004F  CONNECT	R13	R9	K16
+      0x40341312,  //  004F  CONNECT	R13	R9	K18
       0x94300A0D,  //  0050  GETIDX	R12	R5	R13
       0x5C241000,  //  0051  MOVE	R9	R8
-      0x8C34050C,  //  0052  GETMET	R13	R2	K12
+      0x8C34050E,  //  0052  GETMET	R13	R2	K14
       0x5C3C1800,  //  0053  MOVE	R15	R12
-      0x58400011,  //  0054  LDCONST	R16	K17
+      0x58400013,  //  0054  LDCONST	R16	K19
       0x7C340600,  //  0055  CALL	R13	3
       0x4C380000,  //  0056  LDNIL	R14
-      0x283C1B09,  //  0057  GE	R15	R13	K9
+      0x283C1B0B,  //  0057  GE	R15	R13	K11
       0x783E0012,  //  0058  JMPF	R15	#006C
-      0x8C3C050C,  //  0059  GETMET	R15	R2	K12
+      0x8C3C050E,  //  0059  GETMET	R15	R2	K14
       0x5C441800,  //  005A  MOVE	R17	R12
-      0x58480012,  //  005B  LDCONST	R18	K18
+      0x58480014,  //  005B  LDCONST	R18	K20
       0x5C4C1A00,  //  005C  MOVE	R19	R13
       0x7C3C0800,  //  005D  CALL	R15	4
-      0x14401F09,  //  005E  LT	R16	R15	K9
+      0x14401F0B,  //  005E  LT	R16	R15	K11
       0x78420000,  //  005F  JMPF	R16	#0061
-      0xB0062714,  //  0060  RAISE	1	K19	K20
-      0x00401B0A,  //  0061  ADD	R16	R13	K10
-      0x04441F0A,  //  0062  SUB	R17	R15	K10
+      0xB0062B16,  //  0060  RAISE	1	K21	K22
+      0x00401B0C,  //  0061  ADD	R16	R13	K12
+      0x04441F0C,  //  0062  SUB	R17	R15	K12
       0x40402011,  //  0063  CONNECT	R16	R16	R17
       0x94401810,  //  0064  GETIDX	R16	R12	R16
-      0x04441B0A,  //  0065  SUB	R17	R13	K10
-      0x40461211,  //  0066  CONNECT	R17	K9	R17
+      0x04441B0C,  //  0065  SUB	R17	R13	K12
+      0x40461611,  //  0066  CONNECT	R17	K11	R17
       0x94301811,  //  0067  GETIDX	R12	R12	R17
       0x60440009,  //  0068  GETGBL	R17	G9
       0x5C482000,  //  0069  MOVE	R18	R16
       0x7C440200,  //  006A  CALL	R17	1
       0x5C382200,  //  006B  MOVE	R14	R17
-      0x1C3C1915,  //  006C  EQ	R15	R12	K21
+      0x1C3C1917,  //  006C  EQ	R15	R12	K23
       0x783E0004,  //  006D  JMPF	R15	#0073
-      0x8C3C0703,  //  006E  GETMET	R15	R3	K3
-      0x8C440316,  //  006F  GETMET	R17	R1	K22
+      0x8C3C0706,  //  006E  GETMET	R15	R3	K6
+      0x8C440318,  //  006F  GETMET	R17	R1	K24
       0x7C440200,  //  0070  CALL	R17	1
       0x7C3C0400,  //  0071  CALL	R15	2
       0x70020004,  //  0072  JMP		#0078
-      0x8C3C0703,  //  0073  GETMET	R15	R3	K3
-      0x8C440317,  //  0074  GETMET	R17	R1	K23
+      0x8C3C0706,  //  0073  GETMET	R15	R3	K6
+      0x8C440319,  //  0074  GETMET	R17	R1	K25
       0x5C4C1800,  //  0075  MOVE	R19	R12
       0x7C440400,  //  0076  CALL	R17	2
       0x7C3C0400,  //  0077  CALL	R15	2
       0x4C3C0000,  //  0078  LDNIL	R15
       0x203C1C0F,  //  0079  NE	R15	R14	R15
       0x783E0004,  //  007A  JMPF	R15	#0080
-      0x8C3C0703,  //  007B  GETMET	R15	R3	K3
-      0x8C440318,  //  007C  GETMET	R17	R1	K24
+      0x8C3C0706,  //  007B  GETMET	R15	R3	K6
+      0x8C44031A,  //  007C  GETMET	R17	R1	K26
       0x5C4C1C00,  //  007D  MOVE	R19	R14
       0x7C440400,  //  007E  CALL	R17	2
       0x7C3C0400,  //  007F  CALL	R15	2
@@ -1398,8 +1388,8 @@ be_local_closure(class_Rule_Matcher_parse,   /* name */
       0x4C2C0000,  //  0084  LDNIL	R11
       0x202C0E0B,  //  0085  NE	R11	R7	R11
       0x782E0005,  //  0086  JMPF	R11	#008D
-      0x8C2C0703,  //  0087  GETMET	R11	R3	K3
-      0x8C340319,  //  0088  GETMET	R13	R1	K25
+      0x8C2C0706,  //  0087  GETMET	R11	R3	K6
+      0x8C34031B,  //  0088  GETMET	R13	R1	K27
       0x5C3C0C00,  //  0089  MOVE	R15	R6
       0x5C400E00,  //  008A  MOVE	R16	R7
       0x7C340600,  //  008B  CALL	R13	3
@@ -1423,18 +1413,13 @@ be_local_closure(class_Rule_Matcher_match,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(matchers),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(match),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Rule_Matcher,     /* shared constants */
     &be_const_str_match,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
@@ -1445,7 +1430,7 @@ be_local_closure(class_Rule_Matcher_match,   /* name */
       0x4C080000,  //  0004  LDNIL	R2
       0x80040400,  //  0005  RET	1	R2
       0x5C080200,  //  0006  MOVE	R2	R1
-      0x580C0001,  //  0007  LDCONST	R3	K1
+      0x580C000B,  //  0007  LDCONST	R3	K11
       0x6010000C,  //  0008  GETGBL	R4	G12
       0x88140100,  //  0009  GETMBR	R5	R0	K0
       0x7C100200,  //  000A  CALL	R4	1
@@ -1453,7 +1438,7 @@ be_local_closure(class_Rule_Matcher_match,   /* name */
       0x7812000C,  //  000C  JMPF	R4	#001A
       0x88100100,  //  000D  GETMBR	R4	R0	K0
       0x94100803,  //  000E  GETIDX	R4	R4	R3
-      0x8C100902,  //  000F  GETMET	R4	R4	K2
+      0x8C10091C,  //  000F  GETMET	R4	R4	K28
       0x5C180400,  //  0010  MOVE	R6	R2
       0x7C100400,  //  0011  CALL	R4	2
       0x5C080800,  //  0012  MOVE	R2	R4
@@ -1462,7 +1447,7 @@ be_local_closure(class_Rule_Matcher_match,   /* name */
       0x78120001,  //  0015  JMPF	R4	#0018
       0x4C100000,  //  0016  LDNIL	R4
       0x80040800,  //  0017  RET	1	R4
-      0x000C0703,  //  0018  ADD	R3	R3	K3
+      0x000C070C,  //  0018  ADD	R3	R3	K12
       0x7001FFED,  //  0019  JMP		#0008
       0x80040400,  //  001A  RET	1	R2
     })

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
@@ -3,6 +3,25 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Tapp' ktab size: 15, total: 16 (saved 8 bytes)
+static const bvalue be_ktab_class_Tapp[15] = {
+  /* K0   */  be_nested_str(tasmota),
+  /* K1   */  be_nested_str(add_driver),
+  /* K2   */  be_nested_str(path),
+  /* K3   */  be_nested_str(string),
+  /* K4   */  be_nested_str(listdir),
+  /* K5   */  be_nested_str(_X2F),
+  /* K6   */  be_nested_str(find),
+  /* K7   */  be_nested_str(_X2Etapp),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str(log),
+  /* K10  */  be_nested_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str(load),
+  /* K13  */  be_nested_str(_X23autoexec_X2Ebe),
+  /* K14  */  be_nested_str(stop_iteration),
+};
+
 
 extern const bclass be_class_Tapp;
 
@@ -13,16 +32,13 @@ be_local_closure(class_Tapp_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    /* K1   */  be_nested_str(add_driver),
-    }),
+    &be_ktab_class_Tapp,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -44,35 +60,20 @@ be_local_closure(class_Tapp_autoexec,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str(path),
-    /* K1   */  be_nested_str(string),
-    /* K2   */  be_nested_str(listdir),
-    /* K3   */  be_nested_str(_X2F),
-    /* K4   */  be_nested_str(find),
-    /* K5   */  be_nested_str(_X2Etapp),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str(tasmota),
-    /* K8   */  be_nested_str(log),
-    /* K9   */  be_nested_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str(load),
-    /* K12  */  be_nested_str(_X23autoexec_X2Ebe),
-    /* K13  */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Tapp,     /* shared constants */
     &be_const_str_autoexec,
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0xA4060400,  //  0000  IMPORT	R1	K2
+      0xA40A0600,  //  0001  IMPORT	R2	K3
+      0x8C0C0304,  //  0002  GETMET	R3	R1	K4
+      0x58140005,  //  0003  LDCONST	R5	K5
       0x7C0C0400,  //  0004  CALL	R3	2
       0x60100010,  //  0005  GETGBL	R4	G16
       0x5C140600,  //  0006  MOVE	R5	R3
@@ -80,26 +81,26 @@ be_local_closure(class_Tapp_autoexec,   /* name */
       0xA8020014,  //  0008  EXBLK	0	#001E
       0x5C140800,  //  0009  MOVE	R5	R4
       0x7C140000,  //  000A  CALL	R5	0
-      0x8C180504,  //  000B  GETMET	R6	R2	K4
+      0x8C180506,  //  000B  GETMET	R6	R2	K6
       0x5C200A00,  //  000C  MOVE	R8	R5
-      0x58240005,  //  000D  LDCONST	R9	K5
+      0x58240007,  //  000D  LDCONST	R9	K7
       0x7C180600,  //  000E  CALL	R6	3
-      0x24180D06,  //  000F  GT	R6	R6	K6
+      0x24180D08,  //  000F  GT	R6	R6	K8
       0x781A000B,  //  0010  JMPF	R6	#001D
-      0xB81A0E00,  //  0011  GETNGBL	R6	K7
-      0x8C180D08,  //  0012  GETMET	R6	R6	K8
+      0xB81A0000,  //  0011  GETNGBL	R6	K0
+      0x8C180D09,  //  0012  GETMET	R6	R6	K9
       0x60200018,  //  0013  GETGBL	R8	G24
-      0x58240009,  //  0014  LDCONST	R9	K9
+      0x5824000A,  //  0014  LDCONST	R9	K10
       0x5C280A00,  //  0015  MOVE	R10	R5
       0x7C200400,  //  0016  CALL	R8	2
-      0x5824000A,  //  0017  LDCONST	R9	K10
+      0x5824000B,  //  0017  LDCONST	R9	K11
       0x7C180600,  //  0018  CALL	R6	3
-      0xB81A0E00,  //  0019  GETNGBL	R6	K7
-      0x8C180D0B,  //  001A  GETMET	R6	R6	K11
-      0x00200B0C,  //  001B  ADD	R8	R5	K12
+      0xB81A0000,  //  0019  GETNGBL	R6	K0
+      0x8C180D0C,  //  001A  GETMET	R6	R6	K12
+      0x00200B0D,  //  001B  ADD	R8	R5	K13
       0x7C180400,  //  001C  CALL	R6	2
       0x7001FFEA,  //  001D  JMP		#0009
-      0x5810000D,  //  001E  LDCONST	R4	K13
+      0x5810000E,  //  001E  LDCONST	R4	K14
       0xAC100200,  //  001F  CATCH	R4	1	0
       0xB0080000,  //  0020  RAISE	2	R0	R0
       0x80000000,  //  0021  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -3,6 +3,165 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Tasmota' ktab size: 155, total: 285 (saved 1040 bytes)
+static const bvalue be_ktab_class_Tasmota[155] = {
+  /* K0   */  be_nested_str(cmd_res),
+  /* K1   */  be_nested_str(tasmota),
+  /* K2   */  be_nested_str(global),
+  /* K3   */  be_nested_str(maxlog_level),
+  /* K4   */  be_const_int(2),
+  /* K5   */  be_const_int(1),
+  /* K6   */  be_nested_str(_cmd),
+  /* K7   */  be_nested_str(introspect),
+  /* K8   */  be_nested_str(function),
+  /* K9   */  be_nested_str(type_error),
+  /* K10  */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
+  /* K11  */  be_nested_str(ismethod),
+  /* K12  */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
+  /* K13  */  be_nested_str(_drivers),
+  /* K14  */  be_nested_str(find),
+  /* K15  */  be_nested_str(pop),
+  /* K16  */  be_nested_str(every_50ms),
+  /* K17  */  be_nested_str(run_deferred),
+  /* K18  */  be_nested_str(every_250ms),
+  /* K19  */  be_nested_str(run_cron),
+  /* K20  */  be_nested_str(mqtt_data),
+  /* K21  */  be_nested_str(cmd),
+  /* K22  */  be_nested_str(exec_cmd),
+  /* K23  */  be_nested_str(tele),
+  /* K24  */  be_nested_str(exec_tele),
+  /* K25  */  be_nested_str(rule),
+  /* K26  */  be_nested_str(exec_rules),
+  /* K27  */  be_nested_str(gc),
+  /* K28  */  be_const_int(0),
+  /* K29  */  be_nested_str(get),
+  /* K30  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K31  */  be_nested_str(_debug_present),
+  /* K32  */  be_nested_str(debug),
+  /* K33  */  be_nested_str(traceback),
+  /* K34  */  be_nested_str(save_before_restart),
+  /* K35  */  be_nested_str(persist),
+  /* K36  */  be_nested_str(save),
+  /* K37  */  be_nested_str(_ccmd),
+  /* K38  */  be_nested_str(json),
+  /* K39  */  be_nested_str(load),
+  /* K40  */  be_nested_str(find_key_i),
+  /* K41  */  be_nested_str(resolvecmnd),
+  /* K42  */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
+  /* K43  */  be_nested_str(light),
+  /* K44  */  be_nested_str(set),
+  /* K45  */  be_nested_str(_crons),
+  /* K46  */  be_nested_str(ccronexpr),
+  /* K47  */  be_nested_str(now),
+  /* K48  */  be_nested_str(size),
+  /* K49  */  be_nested_str(trig),
+  /* K50  */  be_nested_str(next),
+  /* K51  */  be_nested_str(time_reached),
+  /* K52  */  be_nested_str(f),
+  /* K53  */  be_nested_str(check_not_method),
+  /* K54  */  be_nested_str(_timers),
+  /* K55  */  be_nested_str(push),
+  /* K56  */  be_nested_str(Trigger),
+  /* K57  */  be_nested_str(millis),
+  /* K58  */  be_nested_str(instance),
+  /* K59  */  be_nested_str(value_error),
+  /* K60  */  be_nested_str(instance_X20required),
+  /* K61  */  be_nested_str(id),
+  /* K62  */  be_nested_str(ctypes_bytes_dyn),
+  /* K63  */  be_nested_str(_global_addr),
+  /* K64  */  be_nested_str(_global_def),
+  /* K65  */  be_nested_str(_settings_ptr),
+  /* K66  */  be_nested_str(settings),
+  /* K67  */  be_nested_str(toptr),
+  /* K68  */  be_nested_str(_settings_def),
+  /* K69  */  be_nested_str(wd),
+  /* K70  */  be_nested_str(),
+  /* K71  */  be_nested_str(contains),
+  /* K72  */  be_nested_str(add_cmd),
+  /* K73  */  be_nested_str(UrlFetch),
+  /* K74  */  be_nested_str(_rules),
+  /* K75  */  be_nested_str(Rule_Matcher),
+  /* K76  */  be_nested_str(parse),
+  /* K77  */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
+  /* K78  */  be_nested_str(match),
+  /* K79  */  be_nested_str(trigger),
+  /* K80  */  be_nested_str(_find_op),
+  /* K81  */  be_const_int(2147483647),
+  /* K82  */  be_nested_str(remove),
+  /* K83  */  be_nested_str(collect),
+  /* K84  */  be_nested_str(allocated),
+  /* K85  */  be_nested_str(string),
+  /* K86  */  be_const_int(0),
+  /* K87  */  be_nested_str(toupper),
+  /* K88  */  be_nested_str(_fl),
+  /* K89  */  be_nested_str(log),
+  /* K90  */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
+  /* K91  */  be_const_int(3),
+  /* K92  */  be_nested_str(try_rule),
+  /* K93  */  be_const_int(1),
+  /* K94  */  be_nested_str(endswith),
+  /* K95  */  be_nested_str(_X2Ebe),
+  /* K96  */  be_nested_str(BRY_X3A_X20file_X20_X27_X25s_X27_X20does_X20not_X20have_X20_X27_X2Ebe_X27_X20extension),
+  /* K97  */  be_nested_str(_X23),
+  /* K98  */  be_nested_str(BRY_X3A_X20cannot_X20compile_X20file_X20in_X20read_X2Donly_X20archive),
+  /* K99  */  be_nested_str(file),
+  /* K100 */  be_nested_str(BRY_X3A_X20empty_X20compiled_X20file),
+  /* K101 */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_X27_X25s_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29),
+  /* K102 */  be_nested_str(c),
+  /* K103 */  be_nested_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29),
+  /* K104 */  be_nested_str(Tele),
+  /* K105 */  be_nested_str(i2c_enabled),
+  /* K106 */  be_nested_str(wire1),
+  /* K107 */  be_nested_str(enabled),
+  /* K108 */  be_nested_str(detect),
+  /* K109 */  be_nested_str(wire2),
+  /* K110 */  be_nested_str(keys),
+  /* K111 */  be_nested_str(_X3F),
+  /* K112 */  be_nested_str(stop_iteration),
+  /* K113 */  be_nested_str(split),
+  /* K114 */  be_nested_str(_X2F),
+  /* K115 */  be_nested_str(index_X2Ehtml),
+  /* K116 */  be_nested_str(webclient),
+  /* K117 */  be_nested_str(set_follow_redirects),
+  /* K118 */  be_nested_str(begin),
+  /* K119 */  be_nested_str(GET),
+  /* K120 */  be_nested_str(status_X3A_X20),
+  /* K121 */  be_nested_str(connection_error),
+  /* K122 */  be_nested_str(write_file),
+  /* K123 */  be_nested_str(close),
+  /* K124 */  be_nested_str(BRY_X3A_X20Fetched_X20),
+  /* K125 */  be_nested_str(cb),
+  /* K126 */  be_nested_str(gen_cb),
+  /* K127 */  be_nested_str(time_dump),
+  /* K128 */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
+  /* K129 */  be_nested_str(year),
+  /* K130 */  be_nested_str(month),
+  /* K131 */  be_nested_str(day),
+  /* K132 */  be_nested_str(hour),
+  /* K133 */  be_nested_str(min),
+  /* K134 */  be_nested_str(sec),
+  /* K135 */  be_nested_str(argument_X20must_X20be_X20a_X20function),
+  /* K136 */  be_nested_str(fast_loop_enabled),
+  /* K137 */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
+  /* K138 */  be_nested_str(scale_uint),
+  /* K139 */  be_nested_str(path),
+  /* K140 */  be_nested_str(startswith),
+  /* K141 */  be_const_int(1),
+  /* K142 */  be_const_int(2147483647),
+  /* K143 */  be_nested_str(_X2E),
+  /* K144 */  be_nested_str(_X2Ebec),
+  /* K145 */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
+  /* K146 */  be_nested_str(exists),
+  /* K147 */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
+  /* K148 */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
+  /* K149 */  be_nested_str(http),
+  /* K150 */  be_nested_str(resp_cmnd_str),
+  /* K151 */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
+  /* K152 */  be_nested_str(urlfetch),
+  /* K153 */  be_nested_str(resp_cmnd_failed),
+  /* K154 */  be_nested_str(resp_cmnd_done),
+};
+
 
 extern const bclass be_class_Tasmota;
 
@@ -13,21 +172,13 @@ be_local_closure(class_Tasmota_cmd,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(cmd_res),
-    /* K1   */  be_nested_str(tasmota),
-    /* K2   */  be_nested_str(global),
-    /* K3   */  be_nested_str(maxlog_level),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str(_cmd),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
@@ -71,37 +222,30 @@ be_local_closure(class_Tasmota_check_not_method,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(function),
-    /* K2   */  be_nested_str(type_error),
-    /* K3   */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
-    /* K4   */  be_nested_str(ismethod),
-    /* K5   */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_check_not_method,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40A0E00,  //  0000  IMPORT	R2	K7
       0x600C0004,  //  0001  GETGBL	R3	G4
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x200C0701,  //  0004  NE	R3	R3	K1
+      0x200C0708,  //  0004  NE	R3	R3	K8
       0x780E0000,  //  0005  JMPF	R3	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0xB006130A,  //  0006  RAISE	1	K9	K10
+      0x8C0C050B,  //  0007  GETMET	R3	R2	K11
       0x5C140200,  //  0008  MOVE	R5	R1
       0x7C0C0400,  //  0009  CALL	R3	2
       0x50100200,  //  000A  LDBOOL	R4	1	0
       0x1C0C0604,  //  000B  EQ	R3	R3	R4
       0x780E0000,  //  000C  JMPF	R3	#000E
-      0xB0060505,  //  000D  RAISE	1	K2	K5
+      0xB006130C,  //  000D  RAISE	1	K9	K12
       0x80000000,  //  000E  RET	0
     })
   )
@@ -116,31 +260,27 @@ be_local_closure(class_Tasmota_remove_driver,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_drivers),
-    /* K1   */  be_nested_str(find),
-    /* K2   */  be_nested_str(pop),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_driver,
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808010D,  //  0000  GETMBR	R2	R0	K13
       0x780A000A,  //  0001  JMPF	R2	#000D
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x8C080501,  //  0003  GETMET	R2	R2	K1
+      0x8808010D,  //  0002  GETMBR	R2	R0	K13
+      0x8C08050E,  //  0003  GETMET	R2	R2	K14
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x4C0C0000,  //  0006  LDNIL	R3
       0x200C0403,  //  0007  NE	R3	R2	R3
       0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C0100,  //  0009  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
+      0x880C010D,  //  0009  GETMBR	R3	R0	K13
+      0x8C0C070F,  //  000A  GETMET	R3	R3	K15
       0x5C140400,  //  000B  MOVE	R5	R2
       0x7C0C0400,  //  000C  CALL	R3	2
       0x80000000,  //  000D  RET	0
@@ -157,75 +297,49 @@ be_local_closure(class_Tasmota_event,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(every_50ms),
-    /* K2   */  be_nested_str(run_deferred),
-    /* K3   */  be_nested_str(every_250ms),
-    /* K4   */  be_nested_str(run_cron),
-    /* K5   */  be_nested_str(mqtt_data),
-    /* K6   */  be_nested_str(cmd),
-    /* K7   */  be_nested_str(exec_cmd),
-    /* K8   */  be_nested_str(tele),
-    /* K9   */  be_nested_str(exec_tele),
-    /* K10  */  be_nested_str(rule),
-    /* K11  */  be_nested_str(exec_rules),
-    /* K12  */  be_nested_str(gc),
-    /* K13  */  be_nested_str(_drivers),
-    /* K14  */  be_const_int(0),
-    /* K15  */  be_nested_str(get),
-    /* K16  */  be_nested_str(function),
-    /* K17  */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K18  */  be_nested_str(_debug_present),
-    /* K19  */  be_nested_str(debug),
-    /* K20  */  be_nested_str(traceback),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_nested_str(save_before_restart),
-    /* K23  */  be_nested_str(persist),
-    /* K24  */  be_nested_str(save),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_event,
     &be_const_str_solidified,
     ( &(const binstruction[108]) {  /* code */
-      0xA41A0000,  //  0000  IMPORT	R6	K0
-      0x1C1C0301,  //  0001  EQ	R7	R1	K1
+      0xA41A0E00,  //  0000  IMPORT	R6	K7
+      0x1C1C0310,  //  0001  EQ	R7	R1	K16
       0x781E0001,  //  0002  JMPF	R7	#0005
-      0x8C1C0102,  //  0003  GETMET	R7	R0	K2
+      0x8C1C0111,  //  0003  GETMET	R7	R0	K17
       0x7C1C0200,  //  0004  CALL	R7	1
-      0x1C1C0303,  //  0005  EQ	R7	R1	K3
+      0x1C1C0312,  //  0005  EQ	R7	R1	K18
       0x781E0001,  //  0006  JMPF	R7	#0009
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
+      0x8C1C0113,  //  0007  GETMET	R7	R0	K19
       0x7C1C0200,  //  0008  CALL	R7	1
       0x501C0000,  //  0009  LDBOOL	R7	0	0
       0x50200000,  //  000A  LDBOOL	R8	0	0
-      0x1C240305,  //  000B  EQ	R9	R1	K5
+      0x1C240314,  //  000B  EQ	R9	R1	K20
       0x78260000,  //  000C  JMPF	R9	#000E
       0x50200200,  //  000D  LDBOOL	R8	1	0
-      0x1C240306,  //  000E  EQ	R9	R1	K6
+      0x1C240315,  //  000E  EQ	R9	R1	K21
       0x78260006,  //  000F  JMPF	R9	#0017
-      0x8C240107,  //  0010  GETMET	R9	R0	K7
+      0x8C240116,  //  0010  GETMET	R9	R0	K22
       0x5C2C0400,  //  0011  MOVE	R11	R2
       0x5C300600,  //  0012  MOVE	R12	R3
       0x5C340800,  //  0013  MOVE	R13	R4
       0x7C240800,  //  0014  CALL	R9	4
       0x80041200,  //  0015  RET	1	R9
       0x7002004E,  //  0016  JMP		#0066
-      0x1C240308,  //  0017  EQ	R9	R1	K8
+      0x1C240317,  //  0017  EQ	R9	R1	K23
       0x78260004,  //  0018  JMPF	R9	#001E
-      0x8C240109,  //  0019  GETMET	R9	R0	K9
+      0x8C240118,  //  0019  GETMET	R9	R0	K24
       0x5C2C0800,  //  001A  MOVE	R11	R4
       0x7C240400,  //  001B  CALL	R9	2
       0x80041200,  //  001C  RET	1	R9
       0x70020047,  //  001D  JMP		#0066
-      0x1C24030A,  //  001E  EQ	R9	R1	K10
+      0x1C240319,  //  001E  EQ	R9	R1	K25
       0x78260007,  //  001F  JMPF	R9	#0028
-      0x8C24010B,  //  0020  GETMET	R9	R0	K11
+      0x8C24011A,  //  0020  GETMET	R9	R0	K26
       0x5C2C0800,  //  0021  MOVE	R11	R4
       0x60300017,  //  0022  GETGBL	R12	G23
       0x5C340600,  //  0023  MOVE	R13	R3
@@ -233,15 +347,15 @@ be_local_closure(class_Tasmota_event,   /* name */
       0x7C240600,  //  0025  CALL	R9	3
       0x80041200,  //  0026  RET	1	R9
       0x7002003D,  //  0027  JMP		#0066
-      0x1C24030C,  //  0028  EQ	R9	R1	K12
+      0x1C24031B,  //  0028  EQ	R9	R1	K27
       0x78260003,  //  0029  JMPF	R9	#002E
-      0x8C24010C,  //  002A  GETMET	R9	R0	K12
+      0x8C24011B,  //  002A  GETMET	R9	R0	K27
       0x7C240200,  //  002B  CALL	R9	1
       0x80041200,  //  002C  RET	1	R9
       0x70020037,  //  002D  JMP		#0066
       0x8824010D,  //  002E  GETMBR	R9	R0	K13
       0x78260035,  //  002F  JMPF	R9	#0066
-      0x5824000E,  //  0030  LDCONST	R9	K14
+      0x5824001C,  //  0030  LDCONST	R9	K28
       0x6028000C,  //  0031  GETGBL	R10	G12
       0x882C010D,  //  0032  GETMBR	R11	R0	K13
       0x7C280200,  //  0033  CALL	R10	1
@@ -249,14 +363,14 @@ be_local_closure(class_Tasmota_event,   /* name */
       0x782A002F,  //  0035  JMPF	R10	#0066
       0x8828010D,  //  0036  GETMBR	R10	R0	K13
       0x94281409,  //  0037  GETIDX	R10	R10	R9
-      0x8C2C0D0F,  //  0038  GETMET	R11	R6	K15
+      0x8C2C0D1D,  //  0038  GETMET	R11	R6	K29
       0x5C341400,  //  0039  MOVE	R13	R10
       0x5C380200,  //  003A  MOVE	R14	R1
       0x7C2C0600,  //  003B  CALL	R11	3
       0x60300004,  //  003C  GETGBL	R12	G4
       0x5C341600,  //  003D  MOVE	R13	R11
       0x7C300200,  //  003E  CALL	R12	1
-      0x1C301910,  //  003F  EQ	R12	R12	K16
+      0x1C301908,  //  003F  EQ	R12	R12	K8
       0x78320022,  //  0040  JMPF	R12	#0064
       0xA8020011,  //  0041  EXBLK	0	#0054
       0x5C301600,  //  0042  MOVE	R12	R11
@@ -281,24 +395,24 @@ be_local_closure(class_Tasmota_event,   /* name */
       0x7002000C,  //  0055  JMP		#0063
       0x60380001,  //  0056  GETGBL	R14	G1
       0x603C0018,  //  0057  GETGBL	R15	G24
-      0x58400011,  //  0058  LDCONST	R16	K17
+      0x5840001E,  //  0058  LDCONST	R16	K30
       0x5C441800,  //  0059  MOVE	R17	R12
       0x5C481A00,  //  005A  MOVE	R18	R13
       0x7C3C0600,  //  005B  CALL	R15	3
       0x7C380200,  //  005C  CALL	R14	1
-      0x88380112,  //  005D  GETMBR	R14	R0	K18
+      0x8838011F,  //  005D  GETMBR	R14	R0	K31
       0x783A0002,  //  005E  JMPF	R14	#0062
-      0xA43A2600,  //  005F  IMPORT	R14	K19
-      0x8C3C1D14,  //  0060  GETMET	R15	R14	K20
+      0xA43A4000,  //  005F  IMPORT	R14	K32
+      0x8C3C1D21,  //  0060  GETMET	R15	R14	K33
       0x7C3C0200,  //  0061  CALL	R15	1
       0x70020000,  //  0062  JMP		#0064
       0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x00241315,  //  0064  ADD	R9	R9	K21
+      0x00241305,  //  0064  ADD	R9	R9	K5
       0x7001FFCA,  //  0065  JMP		#0031
-      0x1C240316,  //  0066  EQ	R9	R1	K22
+      0x1C240322,  //  0066  EQ	R9	R1	K34
       0x78260002,  //  0067  JMPF	R9	#006B
-      0xA4262E00,  //  0068  IMPORT	R9	K23
-      0x8C281318,  //  0069  GETMET	R10	R9	K24
+      0xA4264600,  //  0068  IMPORT	R9	K35
+      0x8C281324,  //  0069  GETMET	R10	R9	K36
       0x7C280200,  //  006A  CALL	R10	1
       0x80040E00,  //  006B  RET	1	R7
     })
@@ -314,39 +428,33 @@ be_local_closure(class_Tasmota_exec_cmd,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(_ccmd),
-    /* K1   */  be_nested_str(json),
-    /* K2   */  be_nested_str(load),
-    /* K3   */  be_nested_str(find_key_i),
-    /* K4   */  be_nested_str(resolvecmnd),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_exec_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x88100125,  //  0000  GETMBR	R4	R0	K37
       0x78120016,  //  0001  JMPF	R4	#0019
-      0xA4120200,  //  0002  IMPORT	R4	K1
-      0x8C140902,  //  0003  GETMET	R5	R4	K2
+      0xA4124C00,  //  0002  IMPORT	R4	K38
+      0x8C140927,  //  0003  GETMET	R5	R4	K39
       0x5C1C0600,  //  0004  MOVE	R7	R3
       0x7C140400,  //  0005  CALL	R5	2
-      0x8C180103,  //  0006  GETMET	R6	R0	K3
-      0x88200100,  //  0007  GETMBR	R8	R0	K0
+      0x8C180128,  //  0006  GETMET	R6	R0	K40
+      0x88200125,  //  0007  GETMBR	R8	R0	K37
       0x5C240200,  //  0008  MOVE	R9	R1
       0x7C180600,  //  0009  CALL	R6	3
       0x4C1C0000,  //  000A  LDNIL	R7
       0x201C0C07,  //  000B  NE	R7	R6	R7
       0x781E000B,  //  000C  JMPF	R7	#0019
-      0x8C1C0104,  //  000D  GETMET	R7	R0	K4
+      0x8C1C0129,  //  000D  GETMET	R7	R0	K41
       0x5C240C00,  //  000E  MOVE	R9	R6
       0x7C1C0400,  //  000F  CALL	R7	2
-      0x881C0100,  //  0010  GETMBR	R7	R0	K0
+      0x881C0125,  //  0010  GETMBR	R7	R0	K37
       0x941C0E06,  //  0011  GETIDX	R7	R7	R6
       0x5C200C00,  //  0012  MOVE	R8	R6
       0x5C240400,  //  0013  MOVE	R9	R2
@@ -370,34 +478,30 @@ be_local_closure(class_Tasmota_set_light,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
-    /* K1   */  be_nested_str(light),
-    /* K2   */  be_nested_str(set),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_set_light,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x600C0001,  //  0000  GETGBL	R3	G1
-      0x58100000,  //  0001  LDCONST	R4	K0
+      0x5810002A,  //  0001  LDCONST	R4	K42
       0x7C0C0200,  //  0002  CALL	R3	1
-      0xA40E0200,  //  0003  IMPORT	R3	K1
+      0xA40E5600,  //  0003  IMPORT	R3	K43
       0x4C100000,  //  0004  LDNIL	R4
       0x20100404,  //  0005  NE	R4	R2	R4
       0x78120005,  //  0006  JMPF	R4	#000D
-      0x8C100702,  //  0007  GETMET	R4	R3	K2
+      0x8C10072C,  //  0007  GETMET	R4	R3	K44
       0x5C180200,  //  0008  MOVE	R6	R1
       0x5C1C0400,  //  0009  MOVE	R7	R2
       0x7C100600,  //  000A  CALL	R4	3
       0x80040800,  //  000B  RET	1	R4
       0x70020003,  //  000C  JMP		#0011
-      0x8C100702,  //  000D  GETMET	R4	R3	K2
+      0x8C10072C,  //  000D  GETMET	R4	R3	K44
       0x5C180200,  //  000E  MOVE	R6	R1
       0x7C100400,  //  000F  CALL	R4	2
       0x80040800,  //  0010  RET	1	R4
@@ -415,59 +519,48 @@ be_local_closure(class_Tasmota_run_cron,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(_crons),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(ccronexpr),
-    /* K3   */  be_nested_str(now),
-    /* K4   */  be_nested_str(size),
-    /* K5   */  be_nested_str(trig),
-    /* K6   */  be_nested_str(next),
-    /* K7   */  be_nested_str(time_reached),
-    /* K8   */  be_nested_str(f),
-    /* K9   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_run_cron,
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804012D,  //  0000  GETMBR	R1	R0	K45
       0x7806001E,  //  0001  JMPF	R1	#0021
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x5804001C,  //  0002  LDCONST	R1	K28
+      0xB80A5C00,  //  0003  GETNGBL	R2	K46
+      0x8C08052F,  //  0004  GETMET	R2	R2	K47
       0x7C080200,  //  0005  CALL	R2	1
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
+      0x880C012D,  //  0006  GETMBR	R3	R0	K45
+      0x8C0C0730,  //  0007  GETMET	R3	R3	K48
       0x7C0C0200,  //  0008  CALL	R3	1
       0x140C0203,  //  0009  LT	R3	R1	R3
       0x780E0015,  //  000A  JMPF	R3	#0021
-      0x880C0100,  //  000B  GETMBR	R3	R0	K0
+      0x880C012D,  //  000B  GETMBR	R3	R0	K45
       0x940C0601,  //  000C  GETIDX	R3	R3	R1
-      0x88100705,  //  000D  GETMBR	R4	R3	K5
-      0x1C100901,  //  000E  EQ	R4	R4	K1
+      0x88100731,  //  000D  GETMBR	R4	R3	K49
+      0x1C10091C,  //  000E  EQ	R4	R4	K28
       0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C100706,  //  0010  GETMET	R4	R3	K6
+      0x8C100732,  //  0010  GETMET	R4	R3	K50
       0x7C100200,  //  0011  CALL	R4	1
-      0x900E0A04,  //  0012  SETMBR	R3	K5	R4
+      0x900E6204,  //  0012  SETMBR	R3	K49	R4
       0x7002000A,  //  0013  JMP		#001F
-      0x8C100707,  //  0014  GETMET	R4	R3	K7
+      0x8C100733,  //  0014  GETMET	R4	R3	K51
       0x7C100200,  //  0015  CALL	R4	1
       0x78120007,  //  0016  JMPF	R4	#001F
-      0x88100708,  //  0017  GETMBR	R4	R3	K8
-      0x8C140706,  //  0018  GETMET	R5	R3	K6
+      0x88100734,  //  0017  GETMBR	R4	R3	K52
+      0x8C140732,  //  0018  GETMET	R5	R3	K50
       0x7C140200,  //  0019  CALL	R5	1
-      0x900E0A05,  //  001A  SETMBR	R3	K5	R5
+      0x900E6205,  //  001A  SETMBR	R3	K49	R5
       0x5C180800,  //  001B  MOVE	R6	R4
       0x5C1C0400,  //  001C  MOVE	R7	R2
       0x5C200A00,  //  001D  MOVE	R8	R5
       0x7C180400,  //  001E  CALL	R6	2
-      0x00040309,  //  001F  ADD	R1	R1	K9
+      0x00040305,  //  001F  ADD	R1	R1	K5
       0x7001FFE4,  //  0020  JMP		#0006
       0x80000000,  //  0021  RET	0
     })
@@ -483,36 +576,30 @@ be_local_closure(class_Tasmota_set_timer,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_timers),
-    /* K2   */  be_nested_str(push),
-    /* K3   */  be_nested_str(Trigger),
-    /* K4   */  be_nested_str(millis),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_set_timer,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x8C100135,  //  0000  GETMET	R4	R0	K53
       0x5C180400,  //  0001  MOVE	R6	R2
       0x7C100400,  //  0002  CALL	R4	2
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x88100136,  //  0003  GETMBR	R4	R0	K54
       0x4C140000,  //  0004  LDNIL	R5
       0x1C100805,  //  0005  EQ	R4	R4	R5
       0x78120002,  //  0006  JMPF	R4	#000A
       0x60100012,  //  0007  GETGBL	R4	G18
       0x7C100000,  //  0008  CALL	R4	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
-      0x88100101,  //  000A  GETMBR	R4	R0	K1
-      0x8C100902,  //  000B  GETMET	R4	R4	K2
-      0xB81A0600,  //  000C  GETNGBL	R6	K3
-      0x8C1C0104,  //  000D  GETMET	R7	R0	K4
+      0x90026C04,  //  0009  SETMBR	R0	K54	R4
+      0x88100136,  //  000A  GETMBR	R4	R0	K54
+      0x8C100937,  //  000B  GETMET	R4	R4	K55
+      0xB81A7000,  //  000C  GETNGBL	R6	K56
+      0x8C1C0139,  //  000D  GETMET	R7	R0	K57
       0x5C240200,  //  000E  MOVE	R9	R1
       0x7C1C0400,  //  000F  CALL	R7	2
       0x5C200400,  //  0010  MOVE	R8	R2
@@ -533,47 +620,40 @@ be_local_closure(class_Tasmota_add_driver,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(instance),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(instance_X20required),
-    /* K3   */  be_nested_str(_drivers),
-    /* K4   */  be_nested_str(find),
-    /* K5   */  be_nested_str(push),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_add_driver,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x20080500,  //  0003  NE	R2	R2	K0
+      0x2008053A,  //  0003  NE	R2	R2	K58
       0x780A0000,  //  0004  JMPF	R2	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0xB006773C,  //  0005  RAISE	1	K59	K60
+      0x8808010D,  //  0006  GETMBR	R2	R0	K13
       0x780A000B,  //  0007  JMPF	R2	#0014
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
-      0x8C080504,  //  0009  GETMET	R2	R2	K4
+      0x8808010D,  //  0008  GETMBR	R2	R0	K13
+      0x8C08050E,  //  0009  GETMET	R2	R2	K14
       0x5C100200,  //  000A  MOVE	R4	R1
       0x7C080400,  //  000B  CALL	R2	2
       0x4C0C0000,  //  000C  LDNIL	R3
       0x1C080403,  //  000D  EQ	R2	R2	R3
       0x780A0003,  //  000E  JMPF	R2	#0013
-      0x88080103,  //  000F  GETMBR	R2	R0	K3
-      0x8C080505,  //  0010  GETMET	R2	R2	K5
+      0x8808010D,  //  000F  GETMBR	R2	R0	K13
+      0x8C080537,  //  0010  GETMET	R2	R2	K55
       0x5C100200,  //  0011  MOVE	R4	R1
       0x7C080400,  //  0012  CALL	R2	2
       0x70020003,  //  0013  JMP		#0018
       0x60080012,  //  0014  GETGBL	R2	G18
       0x7C080000,  //  0015  CALL	R2	0
       0x400C0401,  //  0016  CONNECT	R3	R2	R1
-      0x90020602,  //  0017  SETMBR	R0	K3	R2
+      0x90021A02,  //  0017  SETMBR	R0	K13	R2
       0x80000000,  //  0018  RET	0
     })
   )
@@ -588,36 +668,29 @@ be_local_closure(class_Tasmota_next_cron,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_crons),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(trig),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_next_cron,
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808012D,  //  0000  GETMBR	R2	R0	K45
       0x780A000D,  //  0001  JMPF	R2	#0010
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x580C001C,  //  0002  LDCONST	R3	K28
+      0x8C100530,  //  0003  GETMET	R4	R2	K48
       0x7C100200,  //  0004  CALL	R4	1
       0x14100604,  //  0005  LT	R4	R3	R4
       0x78120008,  //  0006  JMPF	R4	#0010
       0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100903,  //  0008  GETMBR	R4	R4	K3
+      0x8810093D,  //  0008  GETMBR	R4	R4	K61
       0x1C100801,  //  0009  EQ	R4	R4	R1
       0x78120002,  //  000A  JMPF	R4	#000E
       0x94100403,  //  000B  GETIDX	R4	R2	R3
-      0x88100904,  //  000C  GETMBR	R4	R4	K4
+      0x88100931,  //  000C  GETMBR	R4	R4	K49
       0x80040800,  //  000D  RET	1	R4
       0x000C0705,  //  000E  ADD	R3	R3	K5
       0x7001FFF2,  //  000F  JMP		#0003
@@ -635,7 +708,7 @@ be_local_closure(class_Tasmota_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -669,59 +742,40 @@ be_local_closure(class_Tasmota_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str(global),
-    /* K1   */  be_nested_str(ctypes_bytes_dyn),
-    /* K2   */  be_nested_str(_global_addr),
-    /* K3   */  be_nested_str(_global_def),
-    /* K4   */  be_nested_str(introspect),
-    /* K5   */  be_nested_str(_settings_ptr),
-    /* K6   */  be_nested_str(get),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(settings),
-    /* K9   */  be_nested_str(toptr),
-    /* K10  */  be_nested_str(_settings_def),
-    /* K11  */  be_nested_str(wd),
-    /* K12  */  be_nested_str(),
-    /* K13  */  be_nested_str(_debug_present),
-    /* K14  */  be_nested_str(contains),
-    /* K15  */  be_nested_str(debug),
-    /* K16  */  be_nested_str(add_cmd),
-    /* K17  */  be_nested_str(UrlFetch),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x88080102,  //  0001  GETMBR	R2	R0	K2
-      0x880C0103,  //  0002  GETMBR	R3	R0	K3
+      0xB8067C00,  //  0000  GETNGBL	R1	K62
+      0x8808013F,  //  0001  GETMBR	R2	R0	K63
+      0x880C0140,  //  0002  GETMBR	R3	R0	K64
       0x7C040400,  //  0003  CALL	R1	2
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0xA4060800,  //  0005  IMPORT	R1	K4
+      0x90020401,  //  0004  SETMBR	R0	K2	R1
+      0xA4060E00,  //  0005  IMPORT	R1	K7
       0x60080015,  //  0006  GETGBL	R2	G21
-      0x880C0105,  //  0007  GETMBR	R3	R0	K5
+      0x880C0141,  //  0007  GETMBR	R3	R0	K65
       0x54120003,  //  0008  LDINT	R4	4
       0x7C080400,  //  0009  CALL	R2	2
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x58100007,  //  000B  LDCONST	R4	K7
+      0x8C08051D,  //  000A  GETMET	R2	R2	K29
+      0x5810001C,  //  000B  LDCONST	R4	K28
       0x54160003,  //  000C  LDINT	R5	4
       0x7C080600,  //  000D  CALL	R2	3
       0x780A0006,  //  000E  JMPF	R2	#0016
-      0xB80E0200,  //  000F  GETNGBL	R3	K1
-      0x8C100309,  //  0010  GETMET	R4	R1	K9
+      0xB80E7C00,  //  000F  GETNGBL	R3	K62
+      0x8C100343,  //  0010  GETMET	R4	R1	K67
       0x5C180400,  //  0011  MOVE	R6	R2
       0x7C100400,  //  0012  CALL	R4	2
-      0x8814010A,  //  0013  GETMBR	R5	R0	K10
+      0x88140144,  //  0013  GETMBR	R5	R0	K68
       0x7C0C0400,  //  0014  CALL	R3	2
-      0x90021003,  //  0015  SETMBR	R0	K8	R3
-      0x9002170C,  //  0016  SETMBR	R0	K11	K12
-      0xB80E0000,  //  0017  GETNGBL	R3	K0
-      0x8C0C070E,  //  0018  GETMET	R3	R3	K14
-      0x5814000F,  //  0019  LDCONST	R5	K15
+      0x90028403,  //  0015  SETMBR	R0	K66	R3
+      0x90028B46,  //  0016  SETMBR	R0	K69	K70
+      0xB80E0400,  //  0017  GETNGBL	R3	K2
+      0x8C0C0747,  //  0018  GETMET	R3	R3	K71
+      0x58140020,  //  0019  LDCONST	R5	K32
       0x7C0C0400,  //  001A  CALL	R3	2
-      0x90021A03,  //  001B  SETMBR	R0	K13	R3
-      0x8C0C0110,  //  001C  GETMET	R3	R0	K16
-      0x58140011,  //  001D  LDCONST	R5	K17
+      0x90023E03,  //  001B  SETMBR	R0	K31	R3
+      0x8C0C0148,  //  001C  GETMET	R3	R0	K72
+      0x58140049,  //  001D  LDCONST	R5	K73
       0x84180000,  //  001E  CLOSURE	R6	P0
       0x7C0C0600,  //  001F  CALL	R3	3
       0xA0000000,  //  0020  CLOSE	R0
@@ -739,46 +793,36 @@ be_local_closure(class_Tasmota_add_rule,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_rules),
-    /* K2   */  be_nested_str(function),
-    /* K3   */  be_nested_str(push),
-    /* K4   */  be_nested_str(Trigger),
-    /* K5   */  be_nested_str(Rule_Matcher),
-    /* K6   */  be_nested_str(parse),
-    /* K7   */  be_nested_str(value_error),
-    /* K8   */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_add_rule,
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x8C100135,  //  0000  GETMET	R4	R0	K53
       0x5C180400,  //  0001  MOVE	R6	R2
       0x7C100400,  //  0002  CALL	R4	2
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x8810014A,  //  0003  GETMBR	R4	R0	K74
       0x4C140000,  //  0004  LDNIL	R5
       0x1C100805,  //  0005  EQ	R4	R4	R5
       0x78120002,  //  0006  JMPF	R4	#000A
       0x60100012,  //  0007  GETGBL	R4	G18
       0x7C100000,  //  0008  CALL	R4	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x90029404,  //  0009  SETMBR	R0	K74	R4
       0x60100004,  //  000A  GETGBL	R4	G4
       0x5C140400,  //  000B  MOVE	R5	R2
       0x7C100200,  //  000C  CALL	R4	1
-      0x1C100902,  //  000D  EQ	R4	R4	K2
+      0x1C100908,  //  000D  EQ	R4	R4	K8
       0x7812000B,  //  000E  JMPF	R4	#001B
-      0x88100101,  //  000F  GETMBR	R4	R0	K1
-      0x8C100903,  //  0010  GETMET	R4	R4	K3
-      0xB81A0800,  //  0011  GETNGBL	R6	K4
-      0x881C0105,  //  0012  GETMBR	R7	R0	K5
-      0x8C1C0F06,  //  0013  GETMET	R7	R7	K6
+      0x8810014A,  //  000F  GETMBR	R4	R0	K74
+      0x8C100937,  //  0010  GETMET	R4	R4	K55
+      0xB81A7000,  //  0011  GETNGBL	R6	K56
+      0x881C014B,  //  0012  GETMBR	R7	R0	K75
+      0x8C1C0F4C,  //  0013  GETMET	R7	R7	K76
       0x5C240200,  //  0014  MOVE	R9	R1
       0x7C1C0400,  //  0015  CALL	R7	2
       0x5C200400,  //  0016  MOVE	R8	R2
@@ -786,7 +830,7 @@ be_local_closure(class_Tasmota_add_rule,   /* name */
       0x7C180600,  //  0018  CALL	R6	3
       0x7C100400,  //  0019  CALL	R4	2
       0x70020000,  //  001A  JMP		#001C
-      0xB0060F08,  //  001B  RAISE	1	K7	K8
+      0xB006774D,  //  001B  RAISE	1	K59	K77
       0x80000000,  //  001C  RET	0
     })
   )
@@ -801,20 +845,17 @@ be_local_closure(class_Tasmota_try_rule,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(match),
-    /* K1   */  be_nested_str(trigger),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_try_rule,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8C100500,  //  0000  GETMET	R4	R2	K0
+      0x8C10054E,  //  0000  GETMET	R4	R2	K78
       0x5C180200,  //  0001  MOVE	R6	R1
       0x7C100400,  //  0002  CALL	R4	2
       0x4C140000,  //  0003  LDNIL	R5
@@ -825,7 +866,7 @@ be_local_closure(class_Tasmota_try_rule,   /* name */
       0x78160004,  //  0008  JMPF	R5	#000E
       0x5C140600,  //  0009  MOVE	R5	R3
       0x5C180800,  //  000A  MOVE	R6	R4
-      0x881C0501,  //  000B  GETMBR	R7	R2	K1
+      0x881C054F,  //  000B  GETMBR	R7	R2	K79
       0x5C200200,  //  000C  MOVE	R8	R1
       0x7C140600,  //  000D  CALL	R5	3
       0x50140200,  //  000E  LDBOOL	R5	1	0
@@ -845,25 +886,20 @@ be_local_closure(class_Tasmota_find_op,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(_find_op),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(2147483647),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_find_op,
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080150,  //  0000  GETMET	R2	R0	K80
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
-      0x280C0501,  //  0003  GE	R3	R2	K1
+      0x280C051C,  //  0003  GE	R3	R2	K28
       0x780E0011,  //  0004  JMPF	R3	#0017
       0x540E7FFE,  //  0005  LDINT	R3	32767
       0x2C0C0403,  //  0006  AND	R3	R2	R3
@@ -871,15 +907,15 @@ be_local_closure(class_Tasmota_find_op,   /* name */
       0x3C100404,  //  0008  SHR	R4	R2	R4
       0x60140012,  //  0009  GETGBL	R5	G18
       0x7C140000,  //  000A  CALL	R5	0
-      0x04180702,  //  000B  SUB	R6	R3	K2
-      0x401A0206,  //  000C  CONNECT	R6	K1	R6
+      0x04180705,  //  000B  SUB	R6	R3	K5
+      0x401A3806,  //  000C  CONNECT	R6	K28	R6
       0x94180206,  //  000D  GETIDX	R6	R1	R6
       0x40180A06,  //  000E  CONNECT	R6	R5	R6
-      0x04180902,  //  000F  SUB	R6	R4	K2
+      0x04180905,  //  000F  SUB	R6	R4	K5
       0x40180606,  //  0010  CONNECT	R6	R3	R6
       0x94180206,  //  0011  GETIDX	R6	R1	R6
       0x40180A06,  //  0012  CONNECT	R6	R5	R6
-      0x40180903,  //  0013  CONNECT	R6	R4	K3
+      0x40180951,  //  0013  CONNECT	R6	R4	K81
       0x94180206,  //  0014  GETIDX	R6	R1	R6
       0x40180A06,  //  0015  CONNECT	R6	R5	R6
       0x80040A00,  //  0016  RET	1	R5
@@ -904,23 +940,20 @@ be_local_closure(class_Tasmota_remove_cmd,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_ccmd),
-    /* K1   */  be_nested_str(remove),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080125,  //  0000  GETMBR	R2	R0	K37
       0x780A0003,  //  0001  JMPF	R2	#0006
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x8C080501,  //  0003  GETMET	R2	R2	K1
+      0x88080125,  //  0002  GETMBR	R2	R0	K37
+      0x8C080552,  //  0003  GETMET	R2	R2	K82
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x80000000,  //  0006  RET	0
@@ -937,24 +970,20 @@ be_local_closure(class_Tasmota_gc,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(gc),
-    /* K1   */  be_nested_str(collect),
-    /* K2   */  be_nested_str(allocated),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_gc,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0xA4063600,  //  0000  IMPORT	R1	K27
+      0x8C080353,  //  0001  GETMET	R2	R1	K83
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x8C080354,  //  0003  GETMET	R2	R1	K84
       0x7C080200,  //  0004  CALL	R2	1
       0x80040400,  //  0005  RET	1	R2
     })
@@ -970,24 +999,19 @@ be_local_closure(class_Tasmota_find_list_i,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(toupper),
-    /* K3   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_find_list_i,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x8C140702,  //  0002  GETMET	R5	R3	K2
+      0xA40EAA00,  //  0000  IMPORT	R3	K85
+      0x58100056,  //  0001  LDCONST	R4	K86
+      0x8C140757,  //  0002  GETMET	R5	R3	K87
       0x5C1C0400,  //  0003  MOVE	R7	R2
       0x7C140400,  //  0004  CALL	R5	2
       0x6018000C,  //  0005  GETGBL	R6	G12
@@ -995,13 +1019,13 @@ be_local_closure(class_Tasmota_find_list_i,   /* name */
       0x7C180200,  //  0007  CALL	R6	1
       0x14180806,  //  0008  LT	R6	R4	R6
       0x781A0007,  //  0009  JMPF	R6	#0012
-      0x8C180702,  //  000A  GETMET	R6	R3	K2
+      0x8C180757,  //  000A  GETMET	R6	R3	K87
       0x94200204,  //  000B  GETIDX	R8	R1	R4
       0x7C180400,  //  000C  CALL	R6	2
       0x1C180C05,  //  000D  EQ	R6	R6	R5
       0x781A0000,  //  000E  JMPF	R6	#0010
       0x80040800,  //  000F  RET	1	R4
-      0x00100903,  //  0010  ADD	R4	R4	K3
+      0x00100905,  //  0010  ADD	R4	R4	K5
       0x7001FFF2,  //  0011  JMP		#0005
       0x4C180000,  //  0012  LDNIL	R6
       0x80040C00,  //  0013  RET	1	R6
@@ -1018,32 +1042,28 @@ be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_fl),
-    /* K1   */  be_nested_str(find),
-    /* K2   */  be_nested_str(remove),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_fast_loop,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080158,  //  0000  GETMBR	R2	R0	K88
       0x740A0000,  //  0001  JMPT	R2	#0003
       0x80000400,  //  0002  RET	0
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x88080158,  //  0003  GETMBR	R2	R0	K88
+      0x8C08050E,  //  0004  GETMET	R2	R2	K14
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
       0x4C0C0000,  //  0007  LDNIL	R3
       0x200C0403,  //  0008  NE	R3	R2	R3
       0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  000B  GETMET	R3	R3	K2
+      0x880C0158,  //  000A  GETMBR	R3	R0	K88
+      0x8C0C0752,  //  000B  GETMET	R3	R3	K82
       0x5C140400,  //  000C  MOVE	R5	R2
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80000000,  //  000E  RET	0
@@ -1060,71 +1080,58 @@ be_local_closure(class_Tasmota_exec_rules,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(cmd_res),
-    /* K1   */  be_nested_str(_rules),
-    /* K2   */  be_nested_str(json),
-    /* K3   */  be_nested_str(load),
-    /* K4   */  be_nested_str(log),
-    /* K5   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(try_rule),
-    /* K9   */  be_nested_str(trig),
-    /* K10  */  be_nested_str(f),
-    /* K11  */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_exec_rules,
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x8810014A,  //  0001  GETMBR	R4	R0	K74
       0x74120002,  //  0002  JMPT	R4	#0006
       0x4C100000,  //  0003  LDNIL	R4
       0x20100604,  //  0004  NE	R4	R3	R4
       0x78120029,  //  0005  JMPF	R4	#0030
-      0xA4120400,  //  0006  IMPORT	R4	K2
+      0xA4124C00,  //  0006  IMPORT	R4	K38
       0x4C140000,  //  0007  LDNIL	R5
       0x90020005,  //  0008  SETMBR	R0	K0	R5
       0x50140000,  //  0009  LDBOOL	R5	0	0
-      0x8C180903,  //  000A  GETMET	R6	R4	K3
+      0x8C180927,  //  000A  GETMET	R6	R4	K39
       0x5C200200,  //  000B  MOVE	R8	R1
       0x7C180400,  //  000C  CALL	R6	2
       0x4C1C0000,  //  000D  LDNIL	R7
       0x1C1C0C07,  //  000E  EQ	R7	R6	R7
       0x781E0004,  //  000F  JMPF	R7	#0015
-      0x8C1C0104,  //  0010  GETMET	R7	R0	K4
-      0x00260A01,  //  0011  ADD	R9	K5	R1
-      0x58280006,  //  0012  LDCONST	R10	K6
+      0x8C1C0159,  //  0010  GETMET	R7	R0	K89
+      0x0026B401,  //  0011  ADD	R9	K90	R1
+      0x5828005B,  //  0012  LDCONST	R10	K91
       0x7C1C0600,  //  0013  CALL	R7	3
       0x5C180200,  //  0014  MOVE	R6	R1
       0x780A0014,  //  0015  JMPF	R2	#002B
-      0x881C0101,  //  0016  GETMBR	R7	R0	K1
+      0x881C014A,  //  0016  GETMBR	R7	R0	K74
       0x781E0012,  //  0017  JMPF	R7	#002B
-      0x581C0007,  //  0018  LDCONST	R7	K7
+      0x581C001C,  //  0018  LDCONST	R7	K28
       0x6020000C,  //  0019  GETGBL	R8	G12
-      0x88240101,  //  001A  GETMBR	R9	R0	K1
+      0x8824014A,  //  001A  GETMBR	R9	R0	K74
       0x7C200200,  //  001B  CALL	R8	1
       0x14200E08,  //  001C  LT	R8	R7	R8
       0x7822000C,  //  001D  JMPF	R8	#002B
-      0x88200101,  //  001E  GETMBR	R8	R0	K1
+      0x8820014A,  //  001E  GETMBR	R8	R0	K74
       0x94201007,  //  001F  GETIDX	R8	R8	R7
-      0x8C240108,  //  0020  GETMET	R9	R0	K8
+      0x8C24015C,  //  0020  GETMET	R9	R0	K92
       0x5C2C0C00,  //  0021  MOVE	R11	R6
-      0x88301109,  //  0022  GETMBR	R12	R8	K9
-      0x8834110A,  //  0023  GETMBR	R13	R8	K10
+      0x88301131,  //  0022  GETMBR	R12	R8	K49
+      0x88341134,  //  0023  GETMBR	R13	R8	K52
       0x7C240800,  //  0024  CALL	R9	4
       0x74260001,  //  0025  JMPT	R9	#0028
       0x74160000,  //  0026  JMPT	R5	#0028
       0x50140001,  //  0027  LDBOOL	R5	0	1
       0x50140200,  //  0028  LDBOOL	R5	1	0
-      0x001C0F0B,  //  0029  ADD	R7	R7	K11
+      0x001C0F5D,  //  0029  ADD	R7	R7	K93
       0x7001FFED,  //  002A  JMP		#0019
       0x4C1C0000,  //  002B  LDNIL	R7
       0x201C0607,  //  002C  NE	R7	R3	R7
@@ -1146,48 +1153,39 @@ be_local_closure(class_Tasmota_run_deferred,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(_timers),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(time_reached),
-    /* K4   */  be_nested_str(trig),
-    /* K5   */  be_nested_str(f),
-    /* K6   */  be_nested_str(remove),
-    /* K7   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_run_deferred,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040136,  //  0000  GETMBR	R1	R0	K54
       0x78060015,  //  0001  JMPF	R1	#0018
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x8C080502,  //  0004  GETMET	R2	R2	K2
+      0x5804001C,  //  0002  LDCONST	R1	K28
+      0x88080136,  //  0003  GETMBR	R2	R0	K54
+      0x8C080530,  //  0004  GETMET	R2	R2	K48
       0x7C080200,  //  0005  CALL	R2	1
       0x14080202,  //  0006  LT	R2	R1	R2
       0x780A000F,  //  0007  JMPF	R2	#0018
-      0x88080100,  //  0008  GETMBR	R2	R0	K0
+      0x88080136,  //  0008  GETMBR	R2	R0	K54
       0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C0C0103,  //  000A  GETMET	R3	R0	K3
-      0x88140504,  //  000B  GETMBR	R5	R2	K4
+      0x8C0C0133,  //  000A  GETMET	R3	R0	K51
+      0x88140531,  //  000B  GETMBR	R5	R2	K49
       0x7C0C0400,  //  000C  CALL	R3	2
       0x780E0007,  //  000D  JMPF	R3	#0016
-      0x880C0505,  //  000E  GETMBR	R3	R2	K5
-      0x88100100,  //  000F  GETMBR	R4	R0	K0
-      0x8C100906,  //  0010  GETMET	R4	R4	K6
+      0x880C0534,  //  000E  GETMBR	R3	R2	K52
+      0x88100136,  //  000F  GETMBR	R4	R0	K54
+      0x8C100952,  //  0010  GETMET	R4	R4	K82
       0x5C180200,  //  0011  MOVE	R6	R1
       0x7C100400,  //  0012  CALL	R4	2
       0x5C100600,  //  0013  MOVE	R4	R3
       0x7C100000,  //  0014  CALL	R4	0
       0x70020000,  //  0015  JMP		#0017
-      0x00040307,  //  0016  ADD	R1	R1	K7
+      0x0004035D,  //  0016  ADD	R1	R1	K93
       0x7001FFEA,  //  0017  JMP		#0003
       0x80000000,  //  0018  RET	0
     })
@@ -1203,54 +1201,39 @@ be_local_closure(class_Tasmota_compile,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(endswith),
-    /* K2   */  be_nested_str(_X2Ebe),
-    /* K3   */  be_nested_str(BRY_X3A_X20file_X20_X27_X25s_X27_X20does_X20not_X20have_X20_X27_X2Ebe_X27_X20extension),
-    /* K4   */  be_nested_str(find),
-    /* K5   */  be_nested_str(_X23),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str(BRY_X3A_X20cannot_X20compile_X20file_X20in_X20read_X2Donly_X20archive),
-    /* K8   */  be_nested_str(file),
-    /* K9   */  be_nested_str(BRY_X3A_X20empty_X20compiled_X20file),
-    /* K10  */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_X27_X25s_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29),
-    /* K11  */  be_nested_str(c),
-    /* K12  */  be_nested_str(save),
-    /* K13  */  be_nested_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_compile,
     &be_const_str_solidified,
     ( &(const binstruction[84]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40AAA00,  //  0000  IMPORT	R2	K85
+      0x8C0C055E,  //  0001  GETMET	R3	R2	K94
       0x5C140200,  //  0002  MOVE	R5	R1
-      0x58180002,  //  0003  LDCONST	R6	K2
+      0x5818005F,  //  0003  LDCONST	R6	K95
       0x7C0C0600,  //  0004  CALL	R3	3
       0x740E0007,  //  0005  JMPT	R3	#000E
       0x600C0001,  //  0006  GETGBL	R3	G1
       0x60100018,  //  0007  GETGBL	R4	G24
-      0x58140003,  //  0008  LDCONST	R5	K3
+      0x58140060,  //  0008  LDCONST	R5	K96
       0x5C180200,  //  0009  MOVE	R6	R1
       0x7C100400,  //  000A  CALL	R4	2
       0x7C0C0200,  //  000B  CALL	R3	1
       0x500C0000,  //  000C  LDBOOL	R3	0	0
       0x80040600,  //  000D  RET	1	R3
-      0x8C0C0504,  //  000E  GETMET	R3	R2	K4
+      0x8C0C050E,  //  000E  GETMET	R3	R2	K14
       0x5C140200,  //  000F  MOVE	R5	R1
-      0x58180005,  //  0010  LDCONST	R6	K5
+      0x58180061,  //  0010  LDCONST	R6	K97
       0x7C0C0600,  //  0011  CALL	R3	3
-      0x240C0706,  //  0012  GT	R3	R3	K6
+      0x240C071C,  //  0012  GT	R3	R3	K28
       0x780E0006,  //  0013  JMPF	R3	#001B
       0x600C0001,  //  0014  GETGBL	R3	G1
       0x60100018,  //  0015  GETGBL	R4	G24
-      0x58140007,  //  0016  LDCONST	R5	K7
+      0x58140062,  //  0016  LDCONST	R5	K98
       0x7C100200,  //  0017  CALL	R4	1
       0x7C0C0200,  //  0018  CALL	R3	1
       0x500C0000,  //  0019  LDBOOL	R3	0	0
@@ -1259,7 +1242,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0xA8020011,  //  001C  EXBLK	0	#002F
       0x6010000D,  //  001D  GETGBL	R4	G13
       0x5C140200,  //  001E  MOVE	R5	R1
-      0x58180008,  //  001F  LDCONST	R6	K8
+      0x58180063,  //  001F  LDCONST	R6	K99
       0x7C100400,  //  0020  CALL	R4	2
       0x5C0C0800,  //  0021  MOVE	R3	R4
       0x4C100000,  //  0022  LDNIL	R4
@@ -1267,7 +1250,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x78120007,  //  0024  JMPF	R4	#002D
       0x60100001,  //  0025  GETGBL	R4	G1
       0x60140018,  //  0026  GETGBL	R5	G24
-      0x58180009,  //  0027  LDCONST	R6	K9
+      0x58180064,  //  0027  LDCONST	R6	K100
       0x7C140200,  //  0028  CALL	R5	1
       0x7C100200,  //  0029  CALL	R4	1
       0x50100000,  //  002A  LDBOOL	R4	0	0
@@ -1279,7 +1262,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x7002000A,  //  0030  JMP		#003C
       0x60180001,  //  0031  GETGBL	R6	G1
       0x601C0018,  //  0032  GETGBL	R7	G24
-      0x5820000A,  //  0033  LDCONST	R8	K10
+      0x58200065,  //  0033  LDCONST	R8	K101
       0x5C240200,  //  0034  MOVE	R9	R1
       0x5C280800,  //  0035  MOVE	R10	R4
       0x5C2C0A00,  //  0036  MOVE	R11	R5
@@ -1289,9 +1272,9 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x80040C00,  //  003A  RET	1	R6
       0x70020000,  //  003B  JMP		#003D
       0xB0080000,  //  003C  RAISE	2	R0	R0
-      0x0010030B,  //  003D  ADD	R4	R1	K11
+      0x00100366,  //  003D  ADD	R4	R1	K102
       0xA8020005,  //  003E  EXBLK	0	#0045
-      0x8C14010C,  //  003F  GETMET	R5	R0	K12
+      0x8C140124,  //  003F  GETMET	R5	R0	K36
       0x5C1C0800,  //  0040  MOVE	R7	R4
       0x5C200600,  //  0041  MOVE	R8	R3
       0x7C140600,  //  0042  CALL	R5	3
@@ -1301,7 +1284,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x70020009,  //  0046  JMP		#0051
       0x60180001,  //  0047  GETGBL	R6	G1
       0x601C0018,  //  0048  GETGBL	R7	G24
-      0x5820000D,  //  0049  LDCONST	R8	K13
+      0x58200067,  //  0049  LDCONST	R8	K103
       0x5C240800,  //  004A  MOVE	R9	R4
       0x5C280A00,  //  004B  MOVE	R10	R5
       0x7C1C0600,  //  004C  CALL	R7	3
@@ -1325,35 +1308,28 @@ be_local_closure(class_Tasmota_remove_timer,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_timers),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(remove),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_timer,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080136,  //  0000  GETMBR	R2	R0	K54
       0x780A000E,  //  0001  JMPF	R2	#0011
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x580C001C,  //  0002  LDCONST	R3	K28
+      0x8C100530,  //  0003  GETMET	R4	R2	K48
       0x7C100200,  //  0004  CALL	R4	1
       0x14100604,  //  0005  LT	R4	R3	R4
       0x78120009,  //  0006  JMPF	R4	#0011
       0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100903,  //  0008  GETMBR	R4	R4	K3
+      0x8810093D,  //  0008  GETMBR	R4	R4	K61
       0x1C100801,  //  0009  EQ	R4	R4	R1
       0x78120003,  //  000A  JMPF	R4	#000F
-      0x8C100504,  //  000B  GETMET	R4	R2	K4
+      0x8C100552,  //  000B  GETMET	R4	R2	K82
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
       0x70020000,  //  000E  JMP		#0010
@@ -1373,49 +1349,41 @@ be_local_closure(class_Tasmota_remove_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(_rules),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(trig),
-    /* K3   */  be_nested_str(rule),
-    /* K4   */  be_nested_str(id),
-    /* K5   */  be_nested_str(remove),
-    /* K6   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_rule,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C014A,  //  0000  GETMBR	R3	R0	K74
       0x780E0017,  //  0001  JMPF	R3	#001A
-      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x580C001C,  //  0002  LDCONST	R3	K28
       0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x8814014A,  //  0004  GETMBR	R5	R0	K74
       0x7C100200,  //  0005  CALL	R4	1
       0x14100604,  //  0006  LT	R4	R3	R4
       0x78120011,  //  0007  JMPF	R4	#001A
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x8810014A,  //  0008  GETMBR	R4	R0	K74
       0x94100803,  //  0009  GETIDX	R4	R4	R3
-      0x88100902,  //  000A  GETMBR	R4	R4	K2
-      0x88100903,  //  000B  GETMBR	R4	R4	K3
+      0x88100931,  //  000A  GETMBR	R4	R4	K49
+      0x88100919,  //  000B  GETMBR	R4	R4	K25
       0x1C100801,  //  000C  EQ	R4	R4	R1
       0x78120009,  //  000D  JMPF	R4	#0018
-      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x8810014A,  //  000E  GETMBR	R4	R0	K74
       0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x88100904,  //  0010  GETMBR	R4	R4	K4
+      0x8810093D,  //  0010  GETMBR	R4	R4	K61
       0x1C100802,  //  0011  EQ	R4	R4	R2
       0x78120004,  //  0012  JMPF	R4	#0018
-      0x88100100,  //  0013  GETMBR	R4	R0	K0
-      0x8C100905,  //  0014  GETMET	R4	R4	K5
+      0x8810014A,  //  0013  GETMBR	R4	R0	K74
+      0x8C100952,  //  0014  GETMET	R4	R4	K82
       0x5C180600,  //  0015  MOVE	R6	R3
       0x7C100400,  //  0016  CALL	R4	2
       0x70020000,  //  0017  JMP		#0019
-      0x000C0706,  //  0018  ADD	R3	R3	K6
+      0x000C0705,  //  0018  ADD	R3	R3	K5
       0x7001FFE8,  //  0019  JMP		#0003
       0x80000000,  //  001A  RET	0
     })
@@ -1431,66 +1399,53 @@ be_local_closure(class_Tasmota_exec_tele,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(_rules),
-    /* K1   */  be_nested_str(json),
-    /* K2   */  be_nested_str(load),
-    /* K3   */  be_nested_str(log),
-    /* K4   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str(Tele),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(try_rule),
-    /* K9   */  be_nested_str(trig),
-    /* K10  */  be_nested_str(f),
-    /* K11  */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_exec_tele,
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808014A,  //  0000  GETMBR	R2	R0	K74
       0x780A0024,  //  0001  JMPF	R2	#0027
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0xA40A4C00,  //  0002  IMPORT	R2	K38
+      0x8C0C0527,  //  0003  GETMET	R3	R2	K39
       0x5C140200,  //  0004  MOVE	R5	R1
       0x7C0C0400,  //  0005  CALL	R3	2
       0x50100000,  //  0006  LDBOOL	R4	0	0
       0x4C140000,  //  0007  LDNIL	R5
       0x1C140605,  //  0008  EQ	R5	R3	R5
       0x78160004,  //  0009  JMPF	R5	#000F
-      0x8C140103,  //  000A  GETMET	R5	R0	K3
-      0x001E0801,  //  000B  ADD	R7	K4	R1
-      0x58200005,  //  000C  LDCONST	R8	K5
+      0x8C140159,  //  000A  GETMET	R5	R0	K89
+      0x001EB401,  //  000B  ADD	R7	K90	R1
+      0x5820005B,  //  000C  LDCONST	R8	K91
       0x7C140600,  //  000D  CALL	R5	3
       0x5C0C0200,  //  000E  MOVE	R3	R1
       0x60140013,  //  000F  GETGBL	R5	G19
       0x7C140000,  //  0010  CALL	R5	0
-      0x98160C03,  //  0011  SETIDX	R5	K6	R3
+      0x9816D003,  //  0011  SETIDX	R5	K104	R3
       0x5C0C0A00,  //  0012  MOVE	R3	R5
-      0x58140007,  //  0013  LDCONST	R5	K7
+      0x5814001C,  //  0013  LDCONST	R5	K28
       0x6018000C,  //  0014  GETGBL	R6	G12
-      0x881C0100,  //  0015  GETMBR	R7	R0	K0
+      0x881C014A,  //  0015  GETMBR	R7	R0	K74
       0x7C180200,  //  0016  CALL	R6	1
       0x14180A06,  //  0017  LT	R6	R5	R6
       0x781A000C,  //  0018  JMPF	R6	#0026
-      0x88180100,  //  0019  GETMBR	R6	R0	K0
+      0x8818014A,  //  0019  GETMBR	R6	R0	K74
       0x94180C05,  //  001A  GETIDX	R6	R6	R5
-      0x8C1C0108,  //  001B  GETMET	R7	R0	K8
+      0x8C1C015C,  //  001B  GETMET	R7	R0	K92
       0x5C240600,  //  001C  MOVE	R9	R3
-      0x88280D09,  //  001D  GETMBR	R10	R6	K9
-      0x882C0D0A,  //  001E  GETMBR	R11	R6	K10
+      0x88280D31,  //  001D  GETMBR	R10	R6	K49
+      0x882C0D34,  //  001E  GETMBR	R11	R6	K52
       0x7C1C0800,  //  001F  CALL	R7	4
       0x741E0001,  //  0020  JMPT	R7	#0023
       0x74120000,  //  0021  JMPT	R4	#0023
       0x50100001,  //  0022  LDBOOL	R4	0	1
       0x50100200,  //  0023  LDBOOL	R4	1	0
-      0x00140B0B,  //  0024  ADD	R5	R5	K11
+      0x00140B5D,  //  0024  ADD	R5	R5	K93
       0x7001FFED,  //  0025  JMP		#0014
       0x80040800,  //  0026  RET	1	R4
       0x50080000,  //  0027  LDBOOL	R2	0	0
@@ -1508,41 +1463,35 @@ be_local_closure(class_Tasmota_add_cmd,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_ccmd),
-    /* K2   */  be_nested_str(function),
-    /* K3   */  be_nested_str(value_error),
-    /* K4   */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_add_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x8C0C0135,  //  0000  GETMET	R3	R0	K53
       0x5C140400,  //  0001  MOVE	R5	R2
       0x7C0C0400,  //  0002  CALL	R3	2
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x880C0125,  //  0003  GETMBR	R3	R0	K37
       0x4C100000,  //  0004  LDNIL	R4
       0x1C0C0604,  //  0005  EQ	R3	R3	R4
       0x780E0002,  //  0006  JMPF	R3	#000A
       0x600C0013,  //  0007  GETGBL	R3	G19
       0x7C0C0000,  //  0008  CALL	R3	0
-      0x90020203,  //  0009  SETMBR	R0	K1	R3
+      0x90024A03,  //  0009  SETMBR	R0	K37	R3
       0x600C0004,  //  000A  GETGBL	R3	G4
       0x5C100400,  //  000B  MOVE	R4	R2
       0x7C0C0200,  //  000C  CALL	R3	1
-      0x1C0C0702,  //  000D  EQ	R3	R3	K2
+      0x1C0C0708,  //  000D  EQ	R3	R3	K8
       0x780E0002,  //  000E  JMPF	R3	#0012
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
+      0x880C0125,  //  000F  GETMBR	R3	R0	K37
       0x980C0202,  //  0010  SETIDX	R3	R1	R2
       0x70020000,  //  0011  JMP		#0013
-      0xB0060704,  //  0012  RAISE	1	K3	K4
+      0xB006774D,  //  0012  RAISE	1	K59	K77
       0x80000000,  //  0013  RET	0
     })
   )
@@ -1557,52 +1506,46 @@ be_local_closure(class_Tasmota_wire_scan,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(i2c_enabled),
-    /* K1   */  be_nested_str(wire1),
-    /* K2   */  be_nested_str(enabled),
-    /* K3   */  be_nested_str(detect),
-    /* K4   */  be_nested_str(wire2),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_wire_scan,
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x200C0403,  //  0001  NE	R3	R2	R3
       0x780E0005,  //  0002  JMPF	R3	#0009
-      0x8C0C0100,  //  0003  GETMET	R3	R0	K0
+      0x8C0C0169,  //  0003  GETMET	R3	R0	K105
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
       0x740E0001,  //  0006  JMPT	R3	#0009
       0x4C0C0000,  //  0007  LDNIL	R3
       0x80040600,  //  0008  RET	1	R3
-      0x880C0101,  //  0009  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
+      0x880C016A,  //  0009  GETMBR	R3	R0	K106
+      0x8C0C076B,  //  000A  GETMET	R3	R3	K107
       0x7C0C0200,  //  000B  CALL	R3	1
       0x780E0006,  //  000C  JMPF	R3	#0014
-      0x880C0101,  //  000D  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
+      0x880C016A,  //  000D  GETMBR	R3	R0	K106
+      0x8C0C076C,  //  000E  GETMET	R3	R3	K108
       0x5C140200,  //  000F  MOVE	R5	R1
       0x7C0C0400,  //  0010  CALL	R3	2
       0x780E0001,  //  0011  JMPF	R3	#0014
-      0x880C0101,  //  0012  GETMBR	R3	R0	K1
+      0x880C016A,  //  0012  GETMBR	R3	R0	K106
       0x80040600,  //  0013  RET	1	R3
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x8C0C0702,  //  0015  GETMET	R3	R3	K2
+      0x880C016D,  //  0014  GETMBR	R3	R0	K109
+      0x8C0C076B,  //  0015  GETMET	R3	R3	K107
       0x7C0C0200,  //  0016  CALL	R3	1
       0x780E0006,  //  0017  JMPF	R3	#001F
-      0x880C0104,  //  0018  GETMBR	R3	R0	K4
-      0x8C0C0703,  //  0019  GETMET	R3	R3	K3
+      0x880C016D,  //  0018  GETMBR	R3	R0	K109
+      0x8C0C076C,  //  0019  GETMET	R3	R3	K108
       0x5C140200,  //  001A  MOVE	R5	R1
       0x7C0C0400,  //  001B  CALL	R3	2
       0x780E0001,  //  001C  JMPF	R3	#001F
-      0x880C0104,  //  001D  GETMBR	R3	R0	K4
+      0x880C016D,  //  001D  GETMBR	R3	R0	K109
       0x80040600,  //  001E  RET	1	R3
       0x4C0C0000,  //  001F  LDNIL	R3
       0x80040600,  //  0020  RET	1	R3
@@ -1619,24 +1562,18 @@ be_local_closure(class_Tasmota_find_key_i,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(toupper),
-    /* K2   */  be_nested_str(keys),
-    /* K3   */  be_nested_str(_X3F),
-    /* K4   */  be_nested_str(stop_iteration),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_find_key_i,
     &be_const_str_solidified,
     ( &(const binstruction[30]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100701,  //  0001  GETMET	R4	R3	K1
+      0xA40EAA00,  //  0000  IMPORT	R3	K85
+      0x8C100757,  //  0001  GETMET	R4	R3	K87
       0x5C180400,  //  0002  MOVE	R6	R2
       0x7C100400,  //  0003  CALL	R4	2
       0x6014000F,  //  0004  GETGBL	R5	G15
@@ -1645,23 +1582,23 @@ be_local_closure(class_Tasmota_find_key_i,   /* name */
       0x7C140400,  //  0007  CALL	R5	2
       0x78160013,  //  0008  JMPF	R5	#001D
       0x60140010,  //  0009  GETGBL	R5	G16
-      0x8C180302,  //  000A  GETMET	R6	R1	K2
+      0x8C18036E,  //  000A  GETMET	R6	R1	K110
       0x7C180200,  //  000B  CALL	R6	1
       0x7C140200,  //  000C  CALL	R5	1
       0xA802000B,  //  000D  EXBLK	0	#001A
       0x5C180A00,  //  000E  MOVE	R6	R5
       0x7C180000,  //  000F  CALL	R6	0
-      0x8C1C0701,  //  0010  GETMET	R7	R3	K1
+      0x8C1C0757,  //  0010  GETMET	R7	R3	K87
       0x5C240C00,  //  0011  MOVE	R9	R6
       0x7C1C0400,  //  0012  CALL	R7	2
       0x1C1C0E04,  //  0013  EQ	R7	R7	R4
       0x741E0001,  //  0014  JMPT	R7	#0017
-      0x1C1C0503,  //  0015  EQ	R7	R2	K3
+      0x1C1C056F,  //  0015  EQ	R7	R2	K111
       0x781E0001,  //  0016  JMPF	R7	#0019
       0xA8040001,  //  0017  EXBLK	1	1
       0x80040C00,  //  0018  RET	1	R6
       0x7001FFF3,  //  0019  JMP		#000E
-      0x58140004,  //  001A  LDCONST	R5	K4
+      0x58140070,  //  001A  LDCONST	R5	K112
       0xAC140200,  //  001B  CATCH	R5	1	0
       0xB0080000,  //  001C  RAISE	2	R0	R0
       0x80000000,  //  001D  RET	0
@@ -1678,60 +1615,42 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(split),
-    /* K2   */  be_nested_str(_X2F),
-    /* K3   */  be_nested_str(pop),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str(index_X2Ehtml),
-    /* K6   */  be_nested_str(webclient),
-    /* K7   */  be_nested_str(set_follow_redirects),
-    /* K8   */  be_nested_str(begin),
-    /* K9   */  be_nested_str(GET),
-    /* K10  */  be_nested_str(status_X3A_X20),
-    /* K11  */  be_nested_str(connection_error),
-    /* K12  */  be_nested_str(write_file),
-    /* K13  */  be_nested_str(close),
-    /* K14  */  be_nested_str(log),
-    /* K15  */  be_nested_str(BRY_X3A_X20Fetched_X20),
-    /* K16  */  be_const_int(3),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_urlfetch,
     &be_const_str_solidified,
     ( &(const binstruction[48]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E000D,  //  0002  JMPF	R3	#0011
-      0xA40E0000,  //  0003  IMPORT	R3	K0
-      0x8C100701,  //  0004  GETMET	R4	R3	K1
+      0xA40EAA00,  //  0003  IMPORT	R3	K85
+      0x8C100771,  //  0004  GETMET	R4	R3	K113
       0x5C180200,  //  0005  MOVE	R6	R1
-      0x581C0002,  //  0006  LDCONST	R7	K2
+      0x581C0072,  //  0006  LDCONST	R7	K114
       0x7C100600,  //  0007  CALL	R4	3
-      0x8C100903,  //  0008  GETMET	R4	R4	K3
+      0x8C10090F,  //  0008  GETMET	R4	R4	K15
       0x7C100200,  //  0009  CALL	R4	1
       0x5C080800,  //  000A  MOVE	R2	R4
       0x6010000C,  //  000B  GETGBL	R4	G12
       0x5C140400,  //  000C  MOVE	R5	R2
       0x7C100200,  //  000D  CALL	R4	1
-      0x1C100904,  //  000E  EQ	R4	R4	K4
+      0x1C10091C,  //  000E  EQ	R4	R4	K28
       0x78120000,  //  000F  JMPF	R4	#0011
-      0x58080005,  //  0010  LDCONST	R2	K5
-      0xB80E0C00,  //  0011  GETNGBL	R3	K6
+      0x58080073,  //  0010  LDCONST	R2	K115
+      0xB80EE800,  //  0011  GETNGBL	R3	K116
       0x7C0C0000,  //  0012  CALL	R3	0
-      0x8C100707,  //  0013  GETMET	R4	R3	K7
+      0x8C100775,  //  0013  GETMET	R4	R3	K117
       0x50180200,  //  0014  LDBOOL	R6	1	0
       0x7C100400,  //  0015  CALL	R4	2
-      0x8C100708,  //  0016  GETMET	R4	R3	K8
+      0x8C100776,  //  0016  GETMET	R4	R3	K118
       0x5C180200,  //  0017  MOVE	R6	R1
       0x7C100400,  //  0018  CALL	R4	2
-      0x8C100709,  //  0019  GETMET	R4	R3	K9
+      0x8C100777,  //  0019  GETMET	R4	R3	K119
       0x7C100200,  //  001A  CALL	R4	1
       0x541600C7,  //  001B  LDINT	R5	200
       0x20140805,  //  001C  NE	R5	R4	R5
@@ -1739,19 +1658,19 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
       0x60140008,  //  001E  GETGBL	R5	G8
       0x5C180800,  //  001F  MOVE	R6	R4
       0x7C140200,  //  0020  CALL	R5	1
-      0x00161405,  //  0021  ADD	R5	K10	R5
-      0xB0061605,  //  0022  RAISE	1	K11	R5
-      0x8C14070C,  //  0023  GETMET	R5	R3	K12
+      0x0016F005,  //  0021  ADD	R5	K120	R5
+      0xB006F205,  //  0022  RAISE	1	K121	R5
+      0x8C14077A,  //  0023  GETMET	R5	R3	K122
       0x5C1C0400,  //  0024  MOVE	R7	R2
       0x7C140400,  //  0025  CALL	R5	2
-      0x8C18070D,  //  0026  GETMET	R6	R3	K13
+      0x8C18077B,  //  0026  GETMET	R6	R3	K123
       0x7C180200,  //  0027  CALL	R6	1
-      0x8C18010E,  //  0028  GETMET	R6	R0	K14
+      0x8C180159,  //  0028  GETMET	R6	R0	K89
       0x60200008,  //  0029  GETGBL	R8	G8
       0x5C240A00,  //  002A  MOVE	R9	R5
       0x7C200200,  //  002B  CALL	R8	1
-      0x00221E08,  //  002C  ADD	R8	K15	R8
-      0x58240010,  //  002D  LDCONST	R9	K16
+      0x0022F808,  //  002C  ADD	R8	K124	R8
+      0x5824005B,  //  002D  LDCONST	R9	K91
       0x7C180600,  //  002E  CALL	R6	3
       0x80040800,  //  002F  RET	1	R4
     })
@@ -1767,25 +1686,21 @@ be_local_closure(class_Tasmota_fast_loop,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_fl),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_fast_loop,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040158,  //  0000  GETMBR	R1	R0	K88
       0x5C080200,  //  0001  MOVE	R2	R1
       0x740A0000,  //  0002  JMPT	R2	#0004
       0x80000400,  //  0003  RET	0
-      0x58080001,  //  0004  LDCONST	R2	K1
+      0x58080056,  //  0004  LDCONST	R2	K86
       0x600C000C,  //  0005  GETGBL	R3	G12
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C0C0200,  //  0007  CALL	R3	1
@@ -1793,7 +1708,7 @@ be_local_closure(class_Tasmota_fast_loop,   /* name */
       0x780E0003,  //  0009  JMPF	R3	#000E
       0x940C0202,  //  000A  GETIDX	R3	R1	R2
       0x7C0C0000,  //  000B  CALL	R3	0
-      0x00080502,  //  000C  ADD	R2	R2	K2
+      0x0008055D,  //  000C  ADD	R2	R2	K93
       0x7001FFF6,  //  000D  JMP		#0005
       0x80000000,  //  000E  RET	0
     })
@@ -1809,21 +1724,18 @@ be_local_closure(class_Tasmota_gen_cb,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(cb),
-    /* K1   */  be_nested_str(gen_cb),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_gen_cb,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40AFA00,  //  0000  IMPORT	R2	K125
+      0x8C0C057E,  //  0001  GETMET	R3	R2	K126
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x80040600,  //  0004  RET	1	R3
@@ -1840,36 +1752,27 @@ be_local_closure(class_Tasmota_time_str,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str(time_dump),
-    /* K1   */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
-    /* K2   */  be_nested_str(year),
-    /* K3   */  be_nested_str(month),
-    /* K4   */  be_nested_str(day),
-    /* K5   */  be_nested_str(hour),
-    /* K6   */  be_nested_str(min),
-    /* K7   */  be_nested_str(sec),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_time_str,
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08017F,  //  0000  GETMET	R2	R0	K127
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x600C0018,  //  0003  GETGBL	R3	G24
-      0x58100001,  //  0004  LDCONST	R4	K1
-      0x94140502,  //  0005  GETIDX	R5	R2	K2
-      0x94180503,  //  0006  GETIDX	R6	R2	K3
-      0x941C0504,  //  0007  GETIDX	R7	R2	K4
-      0x94200505,  //  0008  GETIDX	R8	R2	K5
-      0x94240506,  //  0009  GETIDX	R9	R2	K6
-      0x94280507,  //  000A  GETIDX	R10	R2	K7
+      0x58100080,  //  0004  LDCONST	R4	K128
+      0x94140581,  //  0005  GETIDX	R5	R2	K129
+      0x94180582,  //  0006  GETIDX	R6	R2	K130
+      0x941C0583,  //  0007  GETIDX	R7	R2	K131
+      0x94200584,  //  0008  GETIDX	R8	R2	K132
+      0x94240585,  //  0009  GETIDX	R9	R2	K133
+      0x94280586,  //  000A  GETIDX	R10	R2	K134
       0x7C0C0E00,  //  000B  CALL	R3	7
       0x80040600,  //  000C  RET	1	R3
     })
@@ -1885,46 +1788,36 @@ be_local_closure(class_Tasmota_add_fast_loop,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_fl),
-    /* K2   */  be_nested_str(function),
-    /* K3   */  be_nested_str(value_error),
-    /* K4   */  be_nested_str(argument_X20must_X20be_X20a_X20function),
-    /* K5   */  be_nested_str(global),
-    /* K6   */  be_nested_str(fast_loop_enabled),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str(push),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_add_fast_loop,
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080135,  //  0000  GETMET	R2	R0	K53
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x88080158,  //  0003  GETMBR	R2	R0	K88
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C080403,  //  0005  EQ	R2	R2	R3
       0x780A0002,  //  0006  JMPF	R2	#000A
       0x60080012,  //  0007  GETGBL	R2	G18
       0x7C080000,  //  0008  CALL	R2	0
-      0x90020202,  //  0009  SETMBR	R0	K1	R2
+      0x9002B002,  //  0009  SETMBR	R0	K88	R2
       0x60080004,  //  000A  GETGBL	R2	G4
       0x5C0C0200,  //  000B  MOVE	R3	R1
       0x7C080200,  //  000C  CALL	R2	1
-      0x20080502,  //  000D  NE	R2	R2	K2
+      0x20080508,  //  000D  NE	R2	R2	K8
       0x780A0000,  //  000E  JMPF	R2	#0010
-      0xB0060704,  //  000F  RAISE	1	K3	K4
-      0x88080105,  //  0010  GETMBR	R2	R0	K5
-      0x900A0D07,  //  0011  SETMBR	R2	K6	K7
-      0x88080101,  //  0012  GETMBR	R2	R0	K1
-      0x8C080508,  //  0013  GETMET	R2	R2	K8
+      0xB0067787,  //  000F  RAISE	1	K59	K135
+      0x88080102,  //  0010  GETMBR	R2	R0	K2
+      0x900B1105,  //  0011  SETMBR	R2	K136	K5
+      0x88080158,  //  0012  GETMBR	R2	R0	K88
+      0x8C080537,  //  0013  GETMET	R2	R2	K55
       0x5C100200,  //  0014  MOVE	R4	R1
       0x7C080400,  //  0015  CALL	R2	2
       0x80000000,  //  0016  RET	0
@@ -1941,33 +1834,29 @@ be_local_closure(class_Tasmota_get_light,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
-    /* K1   */  be_nested_str(light),
-    /* K2   */  be_nested_str(get),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_get_light,
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
       0x60080001,  //  0000  GETGBL	R2	G1
-      0x580C0000,  //  0001  LDCONST	R3	K0
+      0x580C0089,  //  0001  LDCONST	R3	K137
       0x7C080200,  //  0002  CALL	R2	1
-      0xA40A0200,  //  0003  IMPORT	R2	K1
+      0xA40A5600,  //  0003  IMPORT	R2	K43
       0x4C0C0000,  //  0004  LDNIL	R3
       0x200C0203,  //  0005  NE	R3	R1	R3
       0x780E0004,  //  0006  JMPF	R3	#000C
-      0x8C0C0502,  //  0007  GETMET	R3	R2	K2
+      0x8C0C051D,  //  0007  GETMET	R3	R2	K29
       0x5C140200,  //  0008  MOVE	R5	R1
       0x7C0C0400,  //  0009  CALL	R3	2
       0x80040600,  //  000A  RET	1	R3
       0x70020002,  //  000B  JMP		#000F
-      0x8C0C0502,  //  000C  GETMET	R3	R2	K2
+      0x8C0C051D,  //  000C  GETMET	R3	R2	K29
       0x7C0C0200,  //  000D  CALL	R3	1
       0x80040600,  //  000E  RET	1	R3
       0x80000000,  //  000F  RET	0
@@ -1984,43 +1873,36 @@ be_local_closure(class_Tasmota_add_cron,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_crons),
-    /* K2   */  be_nested_str(ccronexpr),
-    /* K3   */  be_nested_str(next),
-    /* K4   */  be_nested_str(push),
-    /* K5   */  be_nested_str(Trigger),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_add_cron,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x8C100135,  //  0000  GETMET	R4	R0	K53
       0x5C180400,  //  0001  MOVE	R6	R2
       0x7C100400,  //  0002  CALL	R4	2
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x8810012D,  //  0003  GETMBR	R4	R0	K45
       0x4C140000,  //  0004  LDNIL	R5
       0x1C100805,  //  0005  EQ	R4	R4	R5
       0x78120002,  //  0006  JMPF	R4	#000A
       0x60100012,  //  0007  GETGBL	R4	G18
       0x7C100000,  //  0008  CALL	R4	0
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
-      0xB8120400,  //  000A  GETNGBL	R4	K2
+      0x90025A04,  //  0009  SETMBR	R0	K45	R4
+      0xB8125C00,  //  000A  GETNGBL	R4	K46
       0x60140008,  //  000B  GETGBL	R5	G8
       0x5C180200,  //  000C  MOVE	R6	R1
       0x7C140200,  //  000D  CALL	R5	1
       0x7C100200,  //  000E  CALL	R4	1
-      0x8C140903,  //  000F  GETMET	R5	R4	K3
+      0x8C140932,  //  000F  GETMET	R5	R4	K50
       0x7C140200,  //  0010  CALL	R5	1
-      0x88180101,  //  0011  GETMBR	R6	R0	K1
-      0x8C180D04,  //  0012  GETMET	R6	R6	K4
-      0xB8220A00,  //  0013  GETNGBL	R8	K5
+      0x8818012D,  //  0011  GETMBR	R6	R0	K45
+      0x8C180D37,  //  0012  GETMET	R6	R6	K55
+      0xB8227000,  //  0013  GETNGBL	R8	K56
       0x5C240A00,  //  0014  MOVE	R9	R5
       0x5C280400,  //  0015  MOVE	R10	R2
       0x5C2C0600,  //  0016  MOVE	R11	R3
@@ -2041,20 +1923,13 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
   be_nested_proto(
     17,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(tasmota),
-    /* K2   */  be_nested_str(scale_uint),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_const_int(3),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_hs2rgb,
     &be_const_str_solidified,
     ( &(const binstruction[68]) {  /* code */
@@ -2067,7 +1942,7 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
       0x541600FE,  //  0006  LDINT	R5	255
       0x541A0167,  //  0007  LDINT	R6	360
       0x10040206,  //  0008  MOD	R1	R1	R6
-      0x24180500,  //  0009  GT	R6	R2	K0
+      0x2418051C,  //  0009  GT	R6	R2	K28
       0x781A0031,  //  000A  JMPF	R6	#003D
       0x541A003B,  //  000B  LDINT	R6	60
       0x0C180206,  //  000C  DIV	R6	R1	R6
@@ -2076,27 +1951,27 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
       0x542200FE,  //  000F  LDINT	R8	255
       0x04201002,  //  0010  SUB	R8	R8	R2
       0xB8260200,  //  0011  GETNGBL	R9	K1
-      0x8C241302,  //  0012  GETMET	R9	R9	K2
+      0x8C24138A,  //  0012  GETMET	R9	R9	K138
       0x5C2C0E00,  //  0013  MOVE	R11	R7
-      0x58300000,  //  0014  LDCONST	R12	K0
+      0x5830001C,  //  0014  LDCONST	R12	K28
       0x5436003B,  //  0015  LDINT	R13	60
       0x543A00FE,  //  0016  LDINT	R14	255
       0x5C3C1000,  //  0017  MOVE	R15	R8
       0x7C240C00,  //  0018  CALL	R9	6
       0xB82A0200,  //  0019  GETNGBL	R10	K1
-      0x8C281502,  //  001A  GETMET	R10	R10	K2
+      0x8C28158A,  //  001A  GETMET	R10	R10	K138
       0x5C300E00,  //  001B  MOVE	R12	R7
-      0x58340000,  //  001C  LDCONST	R13	K0
+      0x5834001C,  //  001C  LDCONST	R13	K28
       0x543A003B,  //  001D  LDINT	R14	60
       0x5C3C1000,  //  001E  MOVE	R15	R8
       0x544200FE,  //  001F  LDINT	R16	255
       0x7C280C00,  //  0020  CALL	R10	6
-      0x1C2C0D00,  //  0021  EQ	R11	R6	K0
+      0x1C2C0D1C,  //  0021  EQ	R11	R6	K28
       0x782E0002,  //  0022  JMPF	R11	#0026
       0x5C141400,  //  0023  MOVE	R5	R10
       0x5C101000,  //  0024  MOVE	R4	R8
       0x70020016,  //  0025  JMP		#003D
-      0x1C2C0D03,  //  0026  EQ	R11	R6	K3
+      0x1C2C0D05,  //  0026  EQ	R11	R6	K5
       0x782E0002,  //  0027  JMPF	R11	#002B
       0x5C0C1200,  //  0028  MOVE	R3	R9
       0x5C101000,  //  0029  MOVE	R4	R8
@@ -2106,7 +1981,7 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
       0x5C0C1000,  //  002D  MOVE	R3	R8
       0x5C101400,  //  002E  MOVE	R4	R10
       0x7002000C,  //  002F  JMP		#003D
-      0x1C2C0D05,  //  0030  EQ	R11	R6	K5
+      0x1C2C0D5B,  //  0030  EQ	R11	R6	K91
       0x782E0002,  //  0031  JMPF	R11	#0035
       0x5C0C1000,  //  0032  MOVE	R3	R8
       0x5C141200,  //  0033  MOVE	R5	R9
@@ -2139,35 +2014,28 @@ be_local_closure(class_Tasmota_remove_cron,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_crons),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(remove),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_remove_cron,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808012D,  //  0000  GETMBR	R2	R0	K45
       0x780A000E,  //  0001  JMPF	R2	#0011
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x580C001C,  //  0002  LDCONST	R3	K28
+      0x8C100530,  //  0003  GETMET	R4	R2	K48
       0x7C100200,  //  0004  CALL	R4	1
       0x14100604,  //  0005  LT	R4	R3	R4
       0x78120009,  //  0006  JMPF	R4	#0011
       0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100903,  //  0008  GETMBR	R4	R4	K3
+      0x8810093D,  //  0008  GETMBR	R4	R4	K61
       0x1C100801,  //  0009  EQ	R4	R4	R1
       0x78120003,  //  000A  JMPF	R4	#000F
-      0x8C100504,  //  000B  GETMET	R4	R2	K4
+      0x8C100552,  //  000B  GETMET	R4	R2	K82
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
       0x70020000,  //  000E  JMP		#0010
@@ -2187,7 +2055,7 @@ be_local_closure(class_Tasmota_load,   /* name */
   be_nested_proto(
     26,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -2453,28 +2321,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(path),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(startswith),
-    /* K4   */  be_nested_str(_X2F),
-    /* K5   */  be_nested_str(find),
-    /* K6   */  be_nested_str(_X23),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_const_int(2147483647),
-    /* K9   */  be_nested_str(_X2E),
-    /* K10  */  be_nested_str(_X2Ebe),
-    /* K11  */  be_nested_str(endswith),
-    /* K12  */  be_nested_str(_X2Ebec),
-    /* K13  */  be_nested_str(c),
-    /* K14  */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
-    /* K15  */  be_nested_str(exists),
-    /* K16  */  be_nested_str(wd),
-    /* K17  */  be_nested_str(),
-    /* K18  */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
-    /* K19  */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_load,
     &be_const_str_solidified,
     ( &(const binstruction[164]) {  /* code */
@@ -2484,72 +2331,72 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x84140003,  //  0003  CLOSURE	R5	P3
       0x84180004,  //  0004  CLOSURE	R6	P4
       0x841C0005,  //  0005  CLOSURE	R7	P5
-      0xA4220000,  //  0006  IMPORT	R8	K0
-      0xA4260200,  //  0007  IMPORT	R9	K1
+      0xA422AA00,  //  0006  IMPORT	R8	K85
+      0xA4271600,  //  0007  IMPORT	R9	K139
       0x6028000C,  //  0008  GETGBL	R10	G12
       0x5C2C0200,  //  0009  MOVE	R11	R1
       0x7C280200,  //  000A  CALL	R10	1
-      0x1C281502,  //  000B  EQ	R10	R10	K2
+      0x1C28151C,  //  000B  EQ	R10	R10	K28
       0x782A0002,  //  000C  JMPF	R10	#0010
       0x50280000,  //  000D  LDBOOL	R10	0	0
       0xA0000000,  //  000E  CLOSE	R0
       0x80041400,  //  000F  RET	1	R10
-      0x8C281103,  //  0010  GETMET	R10	R8	K3
+      0x8C28118C,  //  0010  GETMET	R10	R8	K140
       0x5C300200,  //  0011  MOVE	R12	R1
-      0x58340004,  //  0012  LDCONST	R13	K4
+      0x58340072,  //  0012  LDCONST	R13	K114
       0x7C280600,  //  0013  CALL	R10	3
       0x742A0000,  //  0014  JMPT	R10	#0016
-      0x00060801,  //  0015  ADD	R1	K4	R1
-      0x8C281105,  //  0016  GETMET	R10	R8	K5
+      0x0006E401,  //  0015  ADD	R1	K114	R1
+      0x8C28110E,  //  0016  GETMET	R10	R8	K14
       0x5C300200,  //  0017  MOVE	R12	R1
-      0x58340006,  //  0018  LDCONST	R13	K6
+      0x58340061,  //  0018  LDCONST	R13	K97
       0x7C280600,  //  0019  CALL	R10	3
-      0x242C1502,  //  001A  GT	R11	R10	K2
+      0x242C151C,  //  001A  GT	R11	R10	K28
       0x782E0003,  //  001B  JMPF	R11	#0020
-      0x04301507,  //  001C  SUB	R12	R10	K7
-      0x4032040C,  //  001D  CONNECT	R12	K2	R12
+      0x0430158D,  //  001C  SUB	R12	R10	K141
+      0x4032380C,  //  001D  CONNECT	R12	K28	R12
       0x9430020C,  //  001E  GETIDX	R12	R1	R12
       0x70020000,  //  001F  JMP		#0021
       0x5C300200,  //  0020  MOVE	R12	R1
       0x782E0003,  //  0021  JMPF	R11	#0026
-      0x00341507,  //  0022  ADD	R13	R10	K7
-      0x40341B08,  //  0023  CONNECT	R13	R13	K8
+      0x0034158D,  //  0022  ADD	R13	R10	K141
+      0x40341B8E,  //  0023  CONNECT	R13	R13	K142
       0x9434020D,  //  0024  GETIDX	R13	R1	R13
       0x70020000,  //  0025  JMP		#0027
       0x5C340200,  //  0026  MOVE	R13	R1
-      0x8C381105,  //  0027  GETMET	R14	R8	K5
+      0x8C38110E,  //  0027  GETMET	R14	R8	K14
       0x5C401A00,  //  0028  MOVE	R16	R13
-      0x58440009,  //  0029  LDCONST	R17	K9
+      0x5844008F,  //  0029  LDCONST	R17	K143
       0x7C380600,  //  002A  CALL	R14	3
-      0x14381D02,  //  002B  LT	R14	R14	K2
+      0x14381D1C,  //  002B  LT	R14	R14	K28
       0x783A0001,  //  002C  JMPF	R14	#002F
-      0x0004030A,  //  002D  ADD	R1	R1	K10
-      0x00341B0A,  //  002E  ADD	R13	R13	K10
-      0x8C38110B,  //  002F  GETMET	R14	R8	K11
+      0x0004035F,  //  002D  ADD	R1	R1	K95
+      0x00341B5F,  //  002E  ADD	R13	R13	K95
+      0x8C38115E,  //  002F  GETMET	R14	R8	K94
       0x5C401A00,  //  0030  MOVE	R16	R13
-      0x5844000A,  //  0031  LDCONST	R17	K10
+      0x5844005F,  //  0031  LDCONST	R17	K95
       0x7C380600,  //  0032  CALL	R14	3
-      0x8C3C110B,  //  0033  GETMET	R15	R8	K11
+      0x8C3C115E,  //  0033  GETMET	R15	R8	K94
       0x5C441A00,  //  0034  MOVE	R17	R13
-      0x5848000C,  //  0035  LDCONST	R18	K12
+      0x58480090,  //  0035  LDCONST	R18	K144
       0x7C3C0600,  //  0036  CALL	R15	3
       0x783E0001,  //  0037  JMPF	R15	#003A
       0x5C400200,  //  0038  MOVE	R16	R1
       0x70020000,  //  0039  JMP		#003B
-      0x0040030D,  //  003A  ADD	R16	R1	K13
+      0x00400366,  //  003A  ADD	R16	R1	K102
       0x5C441C00,  //  003B  MOVE	R17	R14
       0x74460007,  //  003C  JMPT	R17	#0045
       0x5C441E00,  //  003D  MOVE	R17	R15
       0x74460005,  //  003E  JMPT	R17	#0045
       0x60440001,  //  003F  GETGBL	R17	G1
-      0x5848000E,  //  0040  LDCONST	R18	K14
+      0x58480091,  //  0040  LDCONST	R18	K145
       0x7C440200,  //  0041  CALL	R17	1
       0x50440000,  //  0042  LDBOOL	R17	0	0
       0xA0000000,  //  0043  CLOSE	R0
       0x80042200,  //  0044  RET	1	R17
       0x50440000,  //  0045  LDBOOL	R17	0	0
       0x783E0008,  //  0046  JMPF	R15	#0050
-      0x8C48130F,  //  0047  GETMET	R18	R9	K15
+      0x8C481392,  //  0047  GETMET	R18	R9	K146
       0x5C502000,  //  0048  MOVE	R20	R16
       0x7C480400,  //  0049  CALL	R18	2
       0x744A0002,  //  004A  JMPT	R18	#004E
@@ -2558,11 +2405,11 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x80042400,  //  004D  RET	1	R18
       0x50440200,  //  004E  LDBOOL	R17	1	0
       0x70020014,  //  004F  JMP		#0065
-      0x8C48130F,  //  0050  GETMET	R18	R9	K15
+      0x8C481392,  //  0050  GETMET	R18	R9	K146
       0x5C500200,  //  0051  MOVE	R20	R1
       0x7C480400,  //  0052  CALL	R18	2
       0x784A0007,  //  0053  JMPF	R18	#005C
-      0x8C48130F,  //  0054  GETMET	R18	R9	K15
+      0x8C481392,  //  0054  GETMET	R18	R9	K146
       0x5C502000,  //  0055  MOVE	R20	R16
       0x7C480400,  //  0056  CALL	R18	2
       0x784A0002,  //  0057  JMPF	R18	#005B
@@ -2570,7 +2417,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x5C4C2000,  //  0059  MOVE	R19	R16
       0x7C480200,  //  005A  CALL	R18	1
       0x70020008,  //  005B  JMP		#0065
-      0x8C48130F,  //  005C  GETMET	R18	R9	K15
+      0x8C481392,  //  005C  GETMET	R18	R9	K146
       0x5C502000,  //  005D  MOVE	R20	R16
       0x7C480400,  //  005E  CALL	R18	2
       0x784A0001,  //  005F  JMPF	R18	#0062
@@ -2580,13 +2427,13 @@ be_local_closure(class_Tasmota_load,   /* name */
       0xA0000000,  //  0063  CLOSE	R0
       0x80042400,  //  0064  RET	1	R18
       0x782E0005,  //  0065  JMPF	R11	#006C
-      0x00481906,  //  0066  ADD	R18	R12	K6
-      0x90022012,  //  0067  SETMBR	R0	K16	R18
+      0x00481961,  //  0066  ADD	R18	R12	K97
+      0x90028A12,  //  0067  SETMBR	R0	K69	R18
       0x5C480400,  //  0068  MOVE	R18	R2
-      0x884C0110,  //  0069  GETMBR	R19	R0	K16
+      0x884C0145,  //  0069  GETMBR	R19	R0	K69
       0x7C480200,  //  006A  CALL	R18	1
       0x70020000,  //  006B  JMP		#006D
-      0x90022111,  //  006C  SETMBR	R0	K16	K17
+      0x90028B46,  //  006C  SETMBR	R0	K69	K70
       0x4C480000,  //  006D  LDNIL	R18
       0x78460025,  //  006E  JMPF	R17	#0095
       0x5C4C0800,  //  006F  MOVE	R19	R4
@@ -2598,7 +2445,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x78560007,  //  0075  JMPF	R21	#007E
       0x60540001,  //  0076  GETGBL	R21	G1
       0x60580018,  //  0077  GETGBL	R22	G24
-      0x585C0012,  //  0078  LDCONST	R23	K18
+      0x585C0093,  //  0078  LDCONST	R23	K147
       0x5C602000,  //  0079  MOVE	R24	R16
       0x7C580400,  //  007A  CALL	R22	2
       0x7C540200,  //  007B  CALL	R21	1
@@ -2609,7 +2456,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x78560007,  //  0080  JMPF	R21	#0089
       0x60540001,  //  0081  GETGBL	R21	G1
       0x60580018,  //  0082  GETGBL	R22	G24
-      0x585C0013,  //  0083  LDCONST	R23	K19
+      0x585C0094,  //  0083  LDCONST	R23	K148
       0x5C602000,  //  0084  MOVE	R24	R16
       0x5C642600,  //  0085  MOVE	R25	R19
       0x7C580600,  //  0086  CALL	R22	3
@@ -2638,7 +2485,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x7C4C0200,  //  009D  CALL	R19	1
       0x782E0002,  //  009E  JMPF	R11	#00A2
       0x5C500600,  //  009F  MOVE	R20	R3
-      0x00541906,  //  00A0  ADD	R21	R12	K6
+      0x00541961,  //  00A0  ADD	R21	R12	K97
       0x7C500200,  //  00A1  CALL	R20	1
       0xA0000000,  //  00A2  CLOSE	R0
       0x80042600,  //  00A3  RET	1	R19
@@ -2655,45 +2502,34 @@ be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(find),
-    /* K2   */  be_nested_str(http),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str(resp_cmnd_str),
-    /* K5   */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
-    /* K6   */  be_nested_str(urlfetch),
-    /* K7   */  be_nested_str(resp_cmnd_failed),
-    /* K8   */  be_nested_str(tasmota),
-    /* K9   */  be_nested_str(resp_cmnd_done),
-    }),
+    &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_urlfetch_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x8C180B01,  //  0001  GETMET	R6	R5	K1
+      0xA416AA00,  //  0000  IMPORT	R5	K85
+      0x8C180B0E,  //  0001  GETMET	R6	R5	K14
       0x5C200600,  //  0002  MOVE	R8	R3
-      0x58240002,  //  0003  LDCONST	R9	K2
+      0x58240095,  //  0003  LDCONST	R9	K149
       0x7C180600,  //  0004  CALL	R6	3
-      0x20180D03,  //  0005  NE	R6	R6	K3
+      0x20180D1C,  //  0005  NE	R6	R6	K28
       0x781A0003,  //  0006  JMPF	R6	#000B
-      0x8C180104,  //  0007  GETMET	R6	R0	K4
-      0x58200005,  //  0008  LDCONST	R8	K5
+      0x8C180196,  //  0007  GETMET	R6	R0	K150
+      0x58200097,  //  0008  LDCONST	R8	K151
       0x7C180400,  //  0009  CALL	R6	2
       0x80000C00,  //  000A  RET	0
       0xA802000A,  //  000B  EXBLK	0	#0017
-      0x8C180106,  //  000C  GETMET	R6	R0	K6
+      0x8C180198,  //  000C  GETMET	R6	R0	K152
       0x5C200600,  //  000D  MOVE	R8	R3
       0x7C180400,  //  000E  CALL	R6	2
-      0x141C0D03,  //  000F  LT	R7	R6	K3
+      0x141C0D1C,  //  000F  LT	R7	R6	K28
       0x781E0003,  //  0010  JMPF	R7	#0015
-      0x8C1C0107,  //  0011  GETMET	R7	R0	K7
+      0x8C1C0199,  //  0011  GETMET	R7	R0	K153
       0x7C1C0200,  //  0012  CALL	R7	1
       0xA8040001,  //  0013  EXBLK	1	1
       0x80000E00,  //  0014  RET	0
@@ -2701,13 +2537,13 @@ be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
       0x70020006,  //  0016  JMP		#001E
       0xAC180002,  //  0017  CATCH	R6	0	2
       0x70020003,  //  0018  JMP		#001D
-      0x8C200107,  //  0019  GETMET	R8	R0	K7
+      0x8C200199,  //  0019  GETMET	R8	R0	K153
       0x7C200200,  //  001A  CALL	R8	1
       0x80001000,  //  001B  RET	0
       0x70020000,  //  001C  JMP		#001E
       0xB0080000,  //  001D  RAISE	2	R0	R0
-      0xB81A1000,  //  001E  GETNGBL	R6	K8
-      0x8C180D09,  //  001F  GETMET	R6	R6	K9
+      0xB81A0200,  //  001E  GETNGBL	R6	K1
+      0x8C180D9A,  //  001F  GETMET	R6	R6	K154
       0x7C180200,  //  0020  CALL	R6	1
       0x80000000,  //  0021  RET	0
     })

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_trigger_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_trigger_class.h
@@ -3,6 +3,18 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'Trigger' ktab size: 8, total: 14 (saved 48 bytes)
+static const bvalue be_ktab_class_Trigger[8] = {
+  /* K0   */  be_nested_str(trig),
+  /* K1   */  be_nested_str(f),
+  /* K2   */  be_nested_str(id),
+  /* K3   */  be_nested_str(o),
+  /* K4   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str(time_reached),
+  /* K7   */  be_nested_str(next),
+};
+
 
 extern const bclass be_class_Trigger;
 
@@ -13,18 +25,13 @@ be_local_closure(class_Trigger_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(trig),
-    /* K1   */  be_nested_str(f),
-    /* K2   */  be_nested_str(id),
-    /* K3   */  be_nested_str(o),
-    }),
+    &be_ktab_class_Trigger,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
@@ -46,36 +53,31 @@ be_local_closure(class_Trigger_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(_X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K1   */  be_nested_str(trig),
-    /* K2   */  be_nested_str(f),
-    /* K3   */  be_nested_str(id),
-    }),
+    &be_ktab_class_Trigger,     /* shared constants */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
+      0x58080004,  //  0001  LDCONST	R2	K4
       0x600C0008,  //  0002  GETGBL	R3	G8
       0x60100006,  //  0003  GETGBL	R4	G6
       0x5C140000,  //  0004  MOVE	R5	R0
       0x7C100200,  //  0005  CALL	R4	1
       0x7C0C0200,  //  0006  CALL	R3	1
       0x60100008,  //  0007  GETGBL	R4	G8
-      0x88140101,  //  0008  GETMBR	R5	R0	K1
+      0x88140100,  //  0008  GETMBR	R5	R0	K0
       0x7C100200,  //  0009  CALL	R4	1
       0x60140008,  //  000A  GETGBL	R5	G8
-      0x88180102,  //  000B  GETMBR	R6	R0	K2
+      0x88180101,  //  000B  GETMBR	R6	R0	K1
       0x7C140200,  //  000C  CALL	R5	1
       0x60180008,  //  000D  GETGBL	R6	G8
-      0x881C0103,  //  000E  GETMBR	R7	R0	K3
+      0x881C0102,  //  000E  GETMBR	R7	R0	K2
       0x7C180200,  //  000F  CALL	R6	1
       0x7C040A00,  //  0010  CALL	R1	5
       0x80040200,  //  0011  RET	1	R1
@@ -92,29 +94,24 @@ be_local_closure(class_Trigger_time_reached,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(o),
-    /* K1   */  be_nested_str(trig),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str(time_reached),
-    }),
+    &be_ktab_class_Trigger,     /* shared constants */
     &be_const_str_time_reached,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x78060007,  //  0001  JMPF	R1	#000A
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x24040302,  //  0003  GT	R1	R1	K2
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x24040305,  //  0003  GT	R1	R1	K5
       0x78060004,  //  0004  JMPF	R1	#000A
-      0x88040100,  //  0005  GETMBR	R1	R0	K0
-      0x8C040303,  //  0006  GETMET	R1	R1	K3
-      0x880C0101,  //  0007  GETMBR	R3	R0	K1
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x8C040306,  //  0006  GETMET	R1	R1	K6
+      0x880C0100,  //  0007  GETMBR	R3	R0	K0
       0x7C040400,  //  0008  CALL	R1	2
       0x80040200,  //  0009  RET	1	R1
       0x50040000,  //  000A  LDBOOL	R1	0	0
@@ -132,23 +129,20 @@ be_local_closure(class_Trigger_next,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(o),
-    /* K1   */  be_nested_str(next),
-    }),
+    &be_ktab_class_Trigger,     /* shared constants */
     &be_const_str_next,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x78060003,  //  0001  JMPF	R1	#0006
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C040301,  //  0003  GETMET	R1	R1	K1
+      0x88040103,  //  0002  GETMBR	R1	R0	K3
+      0x8C040307,  //  0003  GETMET	R1	R1	K7
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
       0x80000000,  //  0006  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zb_coord.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zb_coord.h
@@ -3,6 +3,31 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'zb_coord' ktab size: 21, total: 24 (saved 24 bytes)
+static const bvalue be_ktab_class_zb_coord[21] = {
+  /* K0   */  be_nested_str_weak(init),
+  /* K1   */  be_nested_str_weak(instance),
+  /* K2   */  be_nested_str_weak(value_error),
+  /* K3   */  be_nested_str_weak(instance_X20required),
+  /* K4   */  be_nested_str_weak(_handlers),
+  /* K5   */  be_nested_str_weak(find),
+  /* K6   */  be_nested_str_weak(push),
+  /* K7   */  be_nested_str_weak(introspect),
+  /* K8   */  be_nested_str_weak(toptr),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_nested_str_weak(zcl_frame),
+  /* K11  */  be_nested_str_weak(zcl_attribute_list),
+  /* K12  */  be_nested_str_weak(get),
+  /* K13  */  be_nested_str_weak(function),
+  /* K14  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K15  */  be_nested_str_weak(tasmota),
+  /* K16  */  be_nested_str_weak(_debug_present),
+  /* K17  */  be_nested_str_weak(debug),
+  /* K18  */  be_nested_str_weak(traceback),
+  /* K19  */  be_const_int(1),
+  /* K20  */  be_nested_str_weak(remove),
+};
+
 
 extern const bclass be_class_zb_coord;
 
@@ -13,15 +38,13 @@ be_local_closure(class_zb_coord_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    }),
+    &be_ktab_class_zb_coord,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
@@ -44,47 +67,40 @@ be_local_closure(class_zb_coord_add_handler,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(instance),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(instance_X20required),
-    /* K3   */  be_nested_str_weak(_handlers),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(push),
-    }),
+    &be_ktab_class_zb_coord,     /* shared constants */
     be_str_weak(add_handler),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x20080500,  //  0003  NE	R2	R2	K0
+      0x20080501,  //  0003  NE	R2	R2	K1
       0x780A0000,  //  0004  JMPF	R2	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0xB0060503,  //  0005  RAISE	1	K2	K3
+      0x88080104,  //  0006  GETMBR	R2	R0	K4
       0x780A000B,  //  0007  JMPF	R2	#0014
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
-      0x8C080504,  //  0009  GETMET	R2	R2	K4
+      0x88080104,  //  0008  GETMBR	R2	R0	K4
+      0x8C080505,  //  0009  GETMET	R2	R2	K5
       0x5C100200,  //  000A  MOVE	R4	R1
       0x7C080400,  //  000B  CALL	R2	2
       0x4C0C0000,  //  000C  LDNIL	R3
       0x1C080403,  //  000D  EQ	R2	R2	R3
       0x780A0003,  //  000E  JMPF	R2	#0013
-      0x88080103,  //  000F  GETMBR	R2	R0	K3
-      0x8C080505,  //  0010  GETMET	R2	R2	K5
+      0x88080104,  //  000F  GETMBR	R2	R0	K4
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
       0x5C100200,  //  0011  MOVE	R4	R1
       0x7C080400,  //  0012  CALL	R2	2
       0x70020003,  //  0013  JMP		#0018
       0x60080012,  //  0014  GETGBL	R2	G18
       0x7C080000,  //  0015  CALL	R2	0
       0x400C0401,  //  0016  CONNECT	R3	R2	R1
-      0x90020602,  //  0017  SETMBR	R0	K3	R2
+      0x90020802,  //  0017  SETMBR	R0	K4	R2
       0x80000000,  //  0018  RET	0
     })
   )
@@ -99,70 +115,55 @@ be_local_closure(class_zb_coord_dispatch,   /* name */
   be_nested_proto(
     19,                          /* nstack */
     5,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_handlers),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(toptr),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(zcl_frame),
-    /* K5   */  be_nested_str_weak(zcl_attribute_list),
-    /* K6   */  be_nested_str_weak(get),
-    /* K7   */  be_nested_str_weak(function),
-    /* K8   */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(_debug_present),
-    /* K11  */  be_nested_str_weak(debug),
-    /* K12  */  be_nested_str_weak(traceback),
-    /* K13  */  be_const_int(1),
-    }),
+    &be_ktab_class_zb_coord,     /* shared constants */
     be_str_weak(dispatch),
     &be_const_str_solidified,
     ( &(const binstruction[70]) {  /* code */
-      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x88140104,  //  0000  GETMBR	R5	R0	K4
       0x4C180000,  //  0001  LDNIL	R6
       0x1C140A06,  //  0002  EQ	R5	R5	R6
       0x78160000,  //  0003  JMPF	R5	#0005
       0x80000A00,  //  0004  RET	0
-      0xA4160200,  //  0005  IMPORT	R5	K1
+      0xA4160E00,  //  0005  IMPORT	R5	K7
       0x4C180000,  //  0006  LDNIL	R6
       0x4C1C0000,  //  0007  LDNIL	R7
-      0x8C200B02,  //  0008  GETMET	R8	R5	K2
-      0x58280003,  //  0009  LDCONST	R10	K3
+      0x8C200B08,  //  0008  GETMET	R8	R5	K8
+      0x58280009,  //  0009  LDCONST	R10	K9
       0x7C200400,  //  000A  CALL	R8	2
       0x20240408,  //  000B  NE	R9	R2	R8
       0x78260003,  //  000C  JMPF	R9	#0011
-      0x8C240104,  //  000D  GETMET	R9	R0	K4
+      0x8C24010A,  //  000D  GETMET	R9	R0	K10
       0x5C2C0400,  //  000E  MOVE	R11	R2
       0x7C240400,  //  000F  CALL	R9	2
       0x5C181200,  //  0010  MOVE	R6	R9
       0x20240608,  //  0011  NE	R9	R3	R8
       0x78260003,  //  0012  JMPF	R9	#0017
-      0x8C240105,  //  0013  GETMET	R9	R0	K5
+      0x8C24010B,  //  0013  GETMET	R9	R0	K11
       0x5C2C0600,  //  0014  MOVE	R11	R3
       0x7C240400,  //  0015  CALL	R9	2
       0x5C1C1200,  //  0016  MOVE	R7	R9
-      0x58240003,  //  0017  LDCONST	R9	K3
+      0x58240009,  //  0017  LDCONST	R9	K9
       0x6028000C,  //  0018  GETGBL	R10	G12
-      0x882C0100,  //  0019  GETMBR	R11	R0	K0
+      0x882C0104,  //  0019  GETMBR	R11	R0	K4
       0x7C280200,  //  001A  CALL	R10	1
       0x1428120A,  //  001B  LT	R10	R9	R10
       0x782A0027,  //  001C  JMPF	R10	#0045
-      0x88280100,  //  001D  GETMBR	R10	R0	K0
+      0x88280104,  //  001D  GETMBR	R10	R0	K4
       0x94281409,  //  001E  GETIDX	R10	R10	R9
-      0x8C2C0B06,  //  001F  GETMET	R11	R5	K6
+      0x8C2C0B0C,  //  001F  GETMET	R11	R5	K12
       0x5C341400,  //  0020  MOVE	R13	R10
       0x5C380200,  //  0021  MOVE	R14	R1
       0x7C2C0600,  //  0022  CALL	R11	3
       0x60300004,  //  0023  GETGBL	R12	G4
       0x5C341600,  //  0024  MOVE	R13	R11
       0x7C300200,  //  0025  CALL	R12	1
-      0x1C301907,  //  0026  EQ	R12	R12	K7
+      0x1C30190D,  //  0026  EQ	R12	R12	K13
       0x7832001A,  //  0027  JMPF	R12	#0043
       0xA8020008,  //  0028  EXBLK	0	#0032
       0x5C301600,  //  0029  MOVE	R12	R11
@@ -178,20 +179,20 @@ be_local_closure(class_zb_coord_dispatch,   /* name */
       0x7002000D,  //  0033  JMP		#0042
       0x60380001,  //  0034  GETGBL	R14	G1
       0x603C0018,  //  0035  GETGBL	R15	G24
-      0x58400008,  //  0036  LDCONST	R16	K8
+      0x5840000E,  //  0036  LDCONST	R16	K14
       0x5C441800,  //  0037  MOVE	R17	R12
       0x5C481A00,  //  0038  MOVE	R18	R13
       0x7C3C0600,  //  0039  CALL	R15	3
       0x7C380200,  //  003A  CALL	R14	1
-      0xB83A1200,  //  003B  GETNGBL	R14	K9
-      0x88381D0A,  //  003C  GETMBR	R14	R14	K10
+      0xB83A1E00,  //  003B  GETNGBL	R14	K15
+      0x88381D10,  //  003C  GETMBR	R14	R14	K16
       0x783A0002,  //  003D  JMPF	R14	#0041
-      0xA43A1600,  //  003E  IMPORT	R14	K11
-      0x8C3C1D0C,  //  003F  GETMET	R15	R14	K12
+      0xA43A2200,  //  003E  IMPORT	R14	K17
+      0x8C3C1D12,  //  003F  GETMET	R15	R14	K18
       0x7C3C0200,  //  0040  CALL	R15	1
       0x70020000,  //  0041  JMP		#0043
       0xB0080000,  //  0042  RAISE	2	R0	R0
-      0x0024130D,  //  0043  ADD	R9	R9	K13
+      0x00241313,  //  0043  ADD	R9	R9	K19
       0x7001FFD2,  //  0044  JMP		#0018
       0x80000000,  //  0045  RET	0
     })
@@ -207,31 +208,27 @@ be_local_closure(class_zb_coord_remove_handler,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_handlers),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(remove),
-    }),
+    &be_ktab_class_zb_coord,     /* shared constants */
     be_str_weak(remove_handler),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
       0x780A000A,  //  0001  JMPF	R2	#000D
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x8C080501,  //  0003  GETMET	R2	R2	K1
+      0x88080104,  //  0002  GETMBR	R2	R0	K4
+      0x8C080505,  //  0003  GETMET	R2	R2	K5
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x4C0C0000,  //  0006  LDNIL	R3
       0x200C0403,  //  0007  NE	R3	R2	R3
       0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C0100,  //  0009  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
+      0x880C0104,  //  0009  GETMBR	R3	R0	K4
+      0x8C0C0714,  //  000A  GETMET	R3	R3	K20
       0x5C140400,  //  000B  MOVE	R5	R2
       0x7C0C0400,  //  000C  CALL	R3	2
       0x80000000,  //  000D  RET	0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
@@ -3,6 +3,54 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'zcl_attribute' ktab size: 44, total: 70 (saved 208 bytes)
+static const bvalue be_ktab_class_zcl_attribute[44] = {
+  /* K0   */  be_nested_str_weak(tomap),
+  /* K1   */  be_nested_str_weak(cluster),
+  /* K2   */  be_nested_str_weak(attr_id),
+  /* K3   */  be_nested_str_weak(cmd),
+  /* K4   */  be_nested_str_weak(direction),
+  /* K5   */  be_nested_str_weak(key),
+  /* K6   */  be_nested_str_weak(val),
+  /* K7   */  be_nested_str_weak(_X3Cundefined_X3E),
+  /* K8   */  be_nested_str_weak(key_suffix),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(_X2504X_X2F_X2504X),
+  /* K11  */  be_nested_str_weak(_X2B),
+  /* K12  */  be_nested_str_weak(_X2504X_X25s_X2502X),
+  /* K13  */  be_nested_str_weak(_X3F),
+  /* K14  */  be_nested_str_weak(_X21),
+  /* K15  */  be_nested_str_weak(_cluster),
+  /* K16  */  be_nested_str_weak(_attr_id),
+  /* K17  */  be_nested_str_weak(_iscmd),
+  /* K18  */  be_const_int(0),
+  /* K19  */  be_nested_str_weak(_cmd),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_nested_str_weak(_direction),
+  /* K22  */  be_nested_str_weak(_set_val),
+  /* K23  */  be_nested_str_weak(_set_key),
+  /* K24  */  be_nested_str_weak(setmember),
+  /* K25  */  be_nested_str_weak(introspect),
+  /* K26  */  be_nested_str_weak(json),
+  /* K27  */  be_nested_str_weak(dump),
+  /* K28  */  be_nested_str_weak(key_tostring),
+  /* K29  */  be_nested_str_weak(_X3A),
+  /* K30  */  be_nested_str_weak(get),
+  /* K31  */  be_nested_str_weak(tojson),
+  /* K32  */  be_nested_str_weak(_X28_X25s_X29),
+  /* K33  */  be_nested_str_weak(_X2C_X25s_X3A_X22_X2504X_X2F_X2504X_X22),
+  /* K34  */  be_nested_str_weak(init),
+  /* K35  */  be_nested_str_weak(_init),
+  /* K36  */  be_nested_str_weak(ismapped),
+  /* K37  */  be_nested_str_weak(_deinit),
+  /* K38  */  be_nested_str_weak(cmd_general),
+  /* K39  */  be_nested_str_weak(_cmd_general),
+  /* K40  */  be_nested_str_weak(_get_val),
+  /* K41  */  be_nested_str_weak(tohex),
+  /* K42  */  be_nested_str_weak(_get_key),
+  /* K43  */  be_nested_str_weak(member),
+};
+
 
 extern const bclass be_class_zcl_attribute;
 
@@ -13,21 +61,13 @@ be_local_closure(class_zcl_attribute_tomap,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tomap),
-    /* K1   */  be_nested_str_weak(cluster),
-    /* K2   */  be_nested_str_weak(attr_id),
-    /* K3   */  be_nested_str_weak(cmd),
-    /* K4   */  be_nested_str_weak(direction),
-    /* K5   */  be_nested_str_weak(key),
-    /* K6   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(tomap),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
@@ -62,97 +102,83 @@ be_local_closure(class_zcl_attribute_key_tostring,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_X3Cundefined_X3E),
-    /* K1   */  be_nested_str_weak(key),
-    /* K2   */  be_nested_str_weak(key_suffix),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(attr_id),
-    /* K6   */  be_nested_str_weak(_X2504X_X2F_X2504X),
-    /* K7   */  be_nested_str_weak(_X2B),
-    /* K8   */  be_nested_str_weak(cmd),
-    /* K9   */  be_nested_str_weak(direction),
-    /* K10  */  be_nested_str_weak(_X2504X_X25s_X2502X),
-    /* K11  */  be_nested_str_weak(_X3F),
-    /* K12  */  be_nested_str_weak(_X21),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(key_tostring),
     &be_const_str_solidified,
     ( &(const binstruction[69]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x58040007,  //  0000  LDCONST	R1	K7
+      0x88080105,  //  0001  GETMBR	R2	R0	K5
       0x4C0C0000,  //  0002  LDNIL	R3
       0x200C0403,  //  0003  NE	R3	R2	R3
       0x780E0008,  //  0004  JMPF	R3	#000E
       0x5C040400,  //  0005  MOVE	R1	R2
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x240C0703,  //  0007  GT	R3	R3	K3
+      0x880C0108,  //  0006  GETMBR	R3	R0	K8
+      0x240C0709,  //  0007  GT	R3	R3	K9
       0x780E0003,  //  0008  JMPF	R3	#000D
       0x600C0008,  //  0009  GETGBL	R3	G8
-      0x88100102,  //  000A  GETMBR	R4	R0	K2
+      0x88100108,  //  000A  GETMBR	R4	R0	K8
       0x7C0C0200,  //  000B  CALL	R3	1
       0x00040203,  //  000C  ADD	R1	R1	R3
       0x70020035,  //  000D  JMP		#0044
-      0x880C0104,  //  000E  GETMBR	R3	R0	K4
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
       0x4C100000,  //  000F  LDNIL	R4
       0x200C0604,  //  0010  NE	R3	R3	R4
       0x780E0012,  //  0011  JMPF	R3	#0025
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x880C0102,  //  0012  GETMBR	R3	R0	K2
       0x4C100000,  //  0013  LDNIL	R4
       0x200C0604,  //  0014  NE	R3	R3	R4
       0x780E000E,  //  0015  JMPF	R3	#0025
       0x600C0018,  //  0016  GETGBL	R3	G24
-      0x58100006,  //  0017  LDCONST	R4	K6
-      0x88140104,  //  0018  GETMBR	R5	R0	K4
-      0x88180105,  //  0019  GETMBR	R6	R0	K5
+      0x5810000A,  //  0017  LDCONST	R4	K10
+      0x88140101,  //  0018  GETMBR	R5	R0	K1
+      0x88180102,  //  0019  GETMBR	R6	R0	K2
       0x7C0C0600,  //  001A  CALL	R3	3
       0x5C040600,  //  001B  MOVE	R1	R3
-      0x880C0102,  //  001C  GETMBR	R3	R0	K2
-      0x240C0703,  //  001D  GT	R3	R3	K3
+      0x880C0108,  //  001C  GETMBR	R3	R0	K8
+      0x240C0709,  //  001D  GT	R3	R3	K9
       0x780E0004,  //  001E  JMPF	R3	#0024
       0x600C0008,  //  001F  GETGBL	R3	G8
-      0x88100102,  //  0020  GETMBR	R4	R0	K2
+      0x88100108,  //  0020  GETMBR	R4	R0	K8
       0x7C0C0200,  //  0021  CALL	R3	1
-      0x000E0E03,  //  0022  ADD	R3	K7	R3
+      0x000E1603,  //  0022  ADD	R3	K11	R3
       0x00040203,  //  0023  ADD	R1	R1	R3
       0x7002001E,  //  0024  JMP		#0044
-      0x880C0104,  //  0025  GETMBR	R3	R0	K4
+      0x880C0101,  //  0025  GETMBR	R3	R0	K1
       0x4C100000,  //  0026  LDNIL	R4
       0x200C0604,  //  0027  NE	R3	R3	R4
       0x780E001A,  //  0028  JMPF	R3	#0044
-      0x880C0108,  //  0029  GETMBR	R3	R0	K8
+      0x880C0103,  //  0029  GETMBR	R3	R0	K3
       0x4C100000,  //  002A  LDNIL	R4
       0x200C0604,  //  002B  NE	R3	R3	R4
       0x780E0016,  //  002C  JMPF	R3	#0044
-      0x880C0109,  //  002D  GETMBR	R3	R0	K9
+      0x880C0104,  //  002D  GETMBR	R3	R0	K4
       0x4C100000,  //  002E  LDNIL	R4
       0x200C0604,  //  002F  NE	R3	R3	R4
       0x780E0012,  //  0030  JMPF	R3	#0044
       0x600C0018,  //  0031  GETGBL	R3	G24
-      0x5810000A,  //  0032  LDCONST	R4	K10
-      0x88140104,  //  0033  GETMBR	R5	R0	K4
-      0x88180109,  //  0034  GETMBR	R6	R0	K9
+      0x5810000C,  //  0032  LDCONST	R4	K12
+      0x88140101,  //  0033  GETMBR	R5	R0	K1
+      0x88180104,  //  0034  GETMBR	R6	R0	K4
       0x781A0001,  //  0035  JMPF	R6	#0038
-      0x5818000B,  //  0036  LDCONST	R6	K11
+      0x5818000D,  //  0036  LDCONST	R6	K13
       0x70020000,  //  0037  JMP		#0039
-      0x5818000C,  //  0038  LDCONST	R6	K12
-      0x881C0108,  //  0039  GETMBR	R7	R0	K8
+      0x5818000E,  //  0038  LDCONST	R6	K14
+      0x881C0103,  //  0039  GETMBR	R7	R0	K3
       0x7C0C0800,  //  003A  CALL	R3	4
       0x5C040600,  //  003B  MOVE	R1	R3
-      0x880C0102,  //  003C  GETMBR	R3	R0	K2
-      0x240C0703,  //  003D  GT	R3	R3	K3
+      0x880C0108,  //  003C  GETMBR	R3	R0	K8
+      0x240C0709,  //  003D  GT	R3	R3	K9
       0x780E0004,  //  003E  JMPF	R3	#0044
       0x600C0008,  //  003F  GETGBL	R3	G8
-      0x88100102,  //  0040  GETMBR	R4	R0	K2
+      0x88100108,  //  0040  GETMBR	R4	R0	K8
       0x7C0C0200,  //  0041  CALL	R3	1
-      0x000E0E03,  //  0042  ADD	R3	K7	R3
+      0x000E1603,  //  0042  ADD	R3	K11	R3
       0x00040203,  //  0043  ADD	R1	R1	R3
       0x80040200,  //  0044  RET	1	R1
     })
@@ -168,42 +194,25 @@ be_local_closure(class_zcl_attribute_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cluster),
-    /* K1   */  be_nested_str_weak(_cluster),
-    /* K2   */  be_nested_str_weak(attr_id),
-    /* K3   */  be_nested_str_weak(_attr_id),
-    /* K4   */  be_nested_str_weak(_iscmd),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(cmd),
-    /* K7   */  be_nested_str_weak(_cmd),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(direction),
-    /* K10  */  be_nested_str_weak(_direction),
-    /* K11  */  be_nested_str_weak(val),
-    /* K12  */  be_nested_str_weak(_set_val),
-    /* K13  */  be_nested_str_weak(key),
-    /* K14  */  be_nested_str_weak(_set_key),
-    /* K15  */  be_nested_str_weak(setmember),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[66]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x1C0C0301,  //  0000  EQ	R3	R1	K1
       0x780E0007,  //  0001  JMPF	R3	#000A
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C0C0403,  //  0003  EQ	R3	R2	R3
       0x780E0002,  //  0004  JMPF	R3	#0008
       0x540EFFFE,  //  0005  LDINT	R3	65535
-      0x90020203,  //  0006  SETMBR	R0	K1	R3
+      0x90021E03,  //  0006  SETMBR	R0	K15	R3
       0x70020000,  //  0007  JMP		#0009
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x90021E02,  //  0008  SETMBR	R0	K15	R2
       0x70020036,  //  0009  JMP		#0041
       0x1C0C0302,  //  000A  EQ	R3	R1	K2
       0x780E0008,  //  000B  JMPF	R3	#0015
@@ -211,52 +220,52 @@ be_local_closure(class_zcl_attribute_setmember,   /* name */
       0x1C0C0403,  //  000D  EQ	R3	R2	R3
       0x780E0002,  //  000E  JMPF	R3	#0012
       0x540EFFFE,  //  000F  LDINT	R3	65535
-      0x90020603,  //  0010  SETMBR	R0	K3	R3
+      0x90022003,  //  0010  SETMBR	R0	K16	R3
       0x70020001,  //  0011  JMP		#0014
-      0x90020602,  //  0012  SETMBR	R0	K3	R2
-      0x90020905,  //  0013  SETMBR	R0	K4	K5
+      0x90022002,  //  0012  SETMBR	R0	K16	R2
+      0x90022312,  //  0013  SETMBR	R0	K17	K18
       0x7002002B,  //  0014  JMP		#0041
-      0x1C0C0306,  //  0015  EQ	R3	R1	K6
+      0x1C0C0303,  //  0015  EQ	R3	R1	K3
       0x780E0008,  //  0016  JMPF	R3	#0020
       0x4C0C0000,  //  0017  LDNIL	R3
       0x1C0C0403,  //  0018  EQ	R3	R2	R3
       0x780E0002,  //  0019  JMPF	R3	#001D
       0x540E00FE,  //  001A  LDINT	R3	255
-      0x90020E03,  //  001B  SETMBR	R0	K7	R3
+      0x90022603,  //  001B  SETMBR	R0	K19	R3
       0x70020001,  //  001C  JMP		#001F
-      0x90020E02,  //  001D  SETMBR	R0	K7	R2
-      0x90020908,  //  001E  SETMBR	R0	K4	K8
+      0x90022602,  //  001D  SETMBR	R0	K19	R2
+      0x90022314,  //  001E  SETMBR	R0	K17	K20
       0x70020020,  //  001F  JMP		#0041
-      0x1C0C0309,  //  0020  EQ	R3	R1	K9
+      0x1C0C0304,  //  0020  EQ	R3	R1	K4
       0x780E000B,  //  0021  JMPF	R3	#002E
       0x4C0C0000,  //  0022  LDNIL	R3
       0x1C0C0403,  //  0023  EQ	R3	R2	R3
       0x780E0001,  //  0024  JMPF	R3	#0027
-      0x90021505,  //  0025  SETMBR	R0	K10	K5
+      0x90022B12,  //  0025  SETMBR	R0	K21	K18
       0x70020005,  //  0026  JMP		#002D
       0x780A0001,  //  0027  JMPF	R2	#002A
-      0x580C0008,  //  0028  LDCONST	R3	K8
+      0x580C0014,  //  0028  LDCONST	R3	K20
       0x70020000,  //  0029  JMP		#002B
-      0x580C0005,  //  002A  LDCONST	R3	K5
-      0x90021403,  //  002B  SETMBR	R0	K10	R3
-      0x90020908,  //  002C  SETMBR	R0	K4	K8
+      0x580C0012,  //  002A  LDCONST	R3	K18
+      0x90022A03,  //  002B  SETMBR	R0	K21	R3
+      0x90022314,  //  002C  SETMBR	R0	K17	K20
       0x70020012,  //  002D  JMP		#0041
-      0x1C0C030B,  //  002E  EQ	R3	R1	K11
+      0x1C0C0306,  //  002E  EQ	R3	R1	K6
       0x780E0003,  //  002F  JMPF	R3	#0034
-      0x8C0C010C,  //  0030  GETMET	R3	R0	K12
+      0x8C0C0116,  //  0030  GETMET	R3	R0	K22
       0x5C140400,  //  0031  MOVE	R5	R2
       0x7C0C0400,  //  0032  CALL	R3	2
       0x7002000C,  //  0033  JMP		#0041
-      0x1C0C030D,  //  0034  EQ	R3	R1	K13
+      0x1C0C0305,  //  0034  EQ	R3	R1	K5
       0x780E0003,  //  0035  JMPF	R3	#003A
-      0x8C0C010E,  //  0036  GETMET	R3	R0	K14
+      0x8C0C0117,  //  0036  GETMET	R3	R0	K23
       0x5C140400,  //  0037  MOVE	R5	R2
       0x7C0C0400,  //  0038  CALL	R3	2
       0x70020006,  //  0039  JMP		#0041
       0x600C0003,  //  003A  GETGBL	R3	G3
       0x5C100000,  //  003B  MOVE	R4	R0
       0x7C0C0200,  //  003C  CALL	R3	1
-      0x8C0C070F,  //  003D  GETMET	R3	R3	K15
+      0x8C0C0718,  //  003D  GETMET	R3	R3	K24
       0x5C140200,  //  003E  MOVE	R5	R1
       0x5C180400,  //  003F  MOVE	R6	R2
       0x7C0C0600,  //  0040  CALL	R3	3
@@ -274,77 +283,63 @@ be_local_closure(class_zcl_attribute_tostring,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(dump),
-    /* K3   */  be_nested_str_weak(key_tostring),
-    /* K4   */  be_nested_str_weak(_X3A),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(val),
-    /* K7   */  be_nested_str_weak(tojson),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attr_id),
-    /* K10  */  be_nested_str_weak(key),
-    /* K11  */  be_nested_str_weak(_X28_X25s_X29),
-    /* K12  */  be_nested_str_weak(_X2C_X25s_X3A_X22_X2504X_X2F_X2504X_X22),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
-      0x8C140103,  //  0003  GETMET	R5	R0	K3
+      0xA4063200,  //  0000  IMPORT	R1	K25
+      0xA40A3400,  //  0001  IMPORT	R2	K26
+      0x8C0C051B,  //  0002  GETMET	R3	R2	K27
+      0x8C14011C,  //  0003  GETMET	R5	R0	K28
       0x7C140200,  //  0004  CALL	R5	1
       0x7C0C0400,  //  0005  CALL	R3	2
-      0x000C0704,  //  0006  ADD	R3	R3	K4
-      0x8C100305,  //  0007  GETMET	R4	R1	K5
+      0x000C071D,  //  0006  ADD	R3	R3	K29
+      0x8C10031E,  //  0007  GETMET	R4	R1	K30
       0x88180106,  //  0008  GETMBR	R6	R0	K6
-      0x581C0007,  //  0009  LDCONST	R7	K7
+      0x581C001F,  //  0009  LDCONST	R7	K31
       0x7C100600,  //  000A  CALL	R4	3
       0x4C140000,  //  000B  LDNIL	R5
       0x20100805,  //  000C  NE	R4	R4	R5
       0x78120004,  //  000D  JMPF	R4	#0013
       0x88100106,  //  000E  GETMBR	R4	R0	K6
-      0x8C100907,  //  000F  GETMET	R4	R4	K7
+      0x8C10091F,  //  000F  GETMET	R4	R4	K31
       0x7C100200,  //  0010  CALL	R4	1
       0x000C0604,  //  0011  ADD	R3	R3	R4
       0x70020003,  //  0012  JMP		#0017
-      0x8C100502,  //  0013  GETMET	R4	R2	K2
+      0x8C10051B,  //  0013  GETMET	R4	R2	K27
       0x88180106,  //  0014  GETMBR	R6	R0	K6
       0x7C100400,  //  0015  CALL	R4	2
       0x000C0604,  //  0016  ADD	R3	R3	R4
-      0x88100108,  //  0017  GETMBR	R4	R0	K8
+      0x88100101,  //  0017  GETMBR	R4	R0	K1
       0x4C140000,  //  0018  LDNIL	R5
       0x20100805,  //  0019  NE	R4	R4	R5
       0x78120015,  //  001A  JMPF	R4	#0031
-      0x88100109,  //  001B  GETMBR	R4	R0	K9
+      0x88100102,  //  001B  GETMBR	R4	R0	K2
       0x4C140000,  //  001C  LDNIL	R5
       0x20100805,  //  001D  NE	R4	R4	R5
       0x78120011,  //  001E  JMPF	R4	#0031
-      0x8810010A,  //  001F  GETMBR	R4	R0	K10
+      0x88100105,  //  001F  GETMBR	R4	R0	K5
       0x4C140000,  //  0020  LDNIL	R5
       0x20100805,  //  0021  NE	R4	R4	R5
       0x7812000D,  //  0022  JMPF	R4	#0031
       0x60100018,  //  0023  GETGBL	R4	G24
-      0x5814000B,  //  0024  LDCONST	R5	K11
-      0x8C180103,  //  0025  GETMET	R6	R0	K3
+      0x58140020,  //  0024  LDCONST	R5	K32
+      0x8C18011C,  //  0025  GETMET	R6	R0	K28
       0x7C180200,  //  0026  CALL	R6	1
       0x7C100400,  //  0027  CALL	R4	2
       0x60140018,  //  0028  GETGBL	R5	G24
-      0x5818000C,  //  0029  LDCONST	R6	K12
-      0x8C1C0502,  //  002A  GETMET	R7	R2	K2
+      0x58180021,  //  0029  LDCONST	R6	K33
+      0x8C1C051B,  //  002A  GETMET	R7	R2	K27
       0x5C240800,  //  002B  MOVE	R9	R4
       0x7C1C0400,  //  002C  CALL	R7	2
-      0x88200108,  //  002D  GETMBR	R8	R0	K8
-      0x88240109,  //  002E  GETMBR	R9	R0	K9
+      0x88200101,  //  002D  GETMBR	R8	R0	K1
+      0x88240102,  //  002E  GETMBR	R9	R0	K2
       0x7C140800,  //  002F  CALL	R5	4
       0x000C0605,  //  0030  ADD	R3	R3	R5
       0x80040600,  //  0031  RET	1	R3
@@ -361,29 +356,26 @@ be_local_closure(class_zcl_attribute_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(_init),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080522,  //  0003  GETMET	R2	R2	K34
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x4C080000,  //  0006  LDNIL	R2
       0x1C080202,  //  0007  EQ	R2	R1	R2
       0x780A0001,  //  0008  JMPF	R2	#000B
-      0x8C080101,  //  0009  GETMET	R2	R0	K1
+      0x8C080123,  //  0009  GETMET	R2	R0	K35
       0x7C080200,  //  000A  CALL	R2	1
       0x80000000,  //  000B  RET	0
     })
@@ -399,23 +391,20 @@ be_local_closure(class_zcl_attribute_deinit,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ismapped),
-    /* K1   */  be_nested_str_weak(_deinit),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(deinit),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040124,  //  0000  GETMET	R1	R0	K36
       0x7C040200,  //  0001  CALL	R1	1
       0x74060001,  //  0002  JMPT	R1	#0005
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x8C040125,  //  0003  GETMET	R1	R0	K37
       0x7C040200,  //  0004  CALL	R1	1
       0x80000000,  //  0005  RET	0
     })
@@ -431,37 +420,19 @@ be_local_closure(class_zcl_attribute_member,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cluster),
-    /* K1   */  be_nested_str_weak(_cluster),
-    /* K2   */  be_nested_str_weak(attr_id),
-    /* K3   */  be_nested_str_weak(_attr_id),
-    /* K4   */  be_nested_str_weak(_iscmd),
-    /* K5   */  be_nested_str_weak(cmd),
-    /* K6   */  be_nested_str_weak(_cmd),
-    /* K7   */  be_nested_str_weak(direction),
-    /* K8   */  be_nested_str_weak(_direction),
-    /* K9   */  be_nested_str_weak(cmd_general),
-    /* K10  */  be_nested_str_weak(_cmd_general),
-    /* K11  */  be_nested_str_weak(val),
-    /* K12  */  be_nested_str_weak(_get_val),
-    /* K13  */  be_nested_str_weak(tohex),
-    /* K14  */  be_nested_str_weak(key),
-    /* K15  */  be_nested_str_weak(_get_key),
-    /* K16  */  be_nested_str_weak(member),
-    }),
+    &be_ktab_class_zcl_attribute,     /* shared constants */
     be_str_weak(member),
     &be_const_str_solidified,
     ( &(const binstruction[75]) {  /* code */
-      0x1C080300,  //  0000  EQ	R2	R1	K0
+      0x1C080301,  //  0000  EQ	R2	R1	K1
       0x780A0008,  //  0001  JMPF	R2	#000B
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8808010F,  //  0002  GETMBR	R2	R0	K15
       0x540EFFFE,  //  0003  LDINT	R3	65535
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0001,  //  0005  JMPF	R3	#0008
@@ -472,64 +443,64 @@ be_local_closure(class_zcl_attribute_member,   /* name */
       0x7002003E,  //  000A  JMP		#004A
       0x1C080302,  //  000B  EQ	R2	R1	K2
       0x780A000A,  //  000C  JMPF	R2	#0018
-      0x88080103,  //  000D  GETMBR	R2	R0	K3
+      0x88080110,  //  000D  GETMBR	R2	R0	K16
       0x540EFFFE,  //  000E  LDINT	R3	65535
       0x200C0403,  //  000F  NE	R3	R2	R3
       0x780E0003,  //  0010  JMPF	R3	#0015
-      0x880C0104,  //  0011  GETMBR	R3	R0	K4
+      0x880C0111,  //  0011  GETMBR	R3	R0	K17
       0x740E0001,  //  0012  JMPT	R3	#0015
       0x5C0C0400,  //  0013  MOVE	R3	R2
       0x70020000,  //  0014  JMP		#0016
       0x4C0C0000,  //  0015  LDNIL	R3
       0x80040600,  //  0016  RET	1	R3
       0x70020031,  //  0017  JMP		#004A
-      0x1C080305,  //  0018  EQ	R2	R1	K5
+      0x1C080303,  //  0018  EQ	R2	R1	K3
       0x780A000A,  //  0019  JMPF	R2	#0025
-      0x88080106,  //  001A  GETMBR	R2	R0	K6
+      0x88080113,  //  001A  GETMBR	R2	R0	K19
       0x540E00FE,  //  001B  LDINT	R3	255
       0x200C0403,  //  001C  NE	R3	R2	R3
       0x780E0003,  //  001D  JMPF	R3	#0022
-      0x880C0104,  //  001E  GETMBR	R3	R0	K4
+      0x880C0111,  //  001E  GETMBR	R3	R0	K17
       0x780E0001,  //  001F  JMPF	R3	#0022
       0x5C0C0400,  //  0020  MOVE	R3	R2
       0x70020000,  //  0021  JMP		#0023
       0x4C0C0000,  //  0022  LDNIL	R3
       0x80040600,  //  0023  RET	1	R3
       0x70020024,  //  0024  JMP		#004A
-      0x1C080307,  //  0025  EQ	R2	R1	K7
+      0x1C080304,  //  0025  EQ	R2	R1	K4
       0x780A0002,  //  0026  JMPF	R2	#002A
-      0x88080108,  //  0027  GETMBR	R2	R0	K8
+      0x88080115,  //  0027  GETMBR	R2	R0	K21
       0x80040400,  //  0028  RET	1	R2
       0x7002001F,  //  0029  JMP		#004A
-      0x1C080309,  //  002A  EQ	R2	R1	K9
+      0x1C080326,  //  002A  EQ	R2	R1	K38
       0x780A0002,  //  002B  JMPF	R2	#002F
-      0x8808010A,  //  002C  GETMBR	R2	R0	K10
+      0x88080127,  //  002C  GETMBR	R2	R0	K39
       0x80040400,  //  002D  RET	1	R2
       0x7002001A,  //  002E  JMP		#004A
-      0x1C08030B,  //  002F  EQ	R2	R1	K11
+      0x1C080306,  //  002F  EQ	R2	R1	K6
       0x780A000B,  //  0030  JMPF	R2	#003D
-      0x8C08010C,  //  0031  GETMET	R2	R0	K12
+      0x8C080128,  //  0031  GETMET	R2	R0	K40
       0x7C080200,  //  0032  CALL	R2	1
       0x600C000F,  //  0033  GETGBL	R3	G15
       0x5C100400,  //  0034  MOVE	R4	R2
       0x60140015,  //  0035  GETGBL	R5	G21
       0x7C0C0400,  //  0036  CALL	R3	2
       0x780E0002,  //  0037  JMPF	R3	#003B
-      0x8C0C050D,  //  0038  GETMET	R3	R2	K13
+      0x8C0C0529,  //  0038  GETMET	R3	R2	K41
       0x7C0C0200,  //  0039  CALL	R3	1
       0x5C080600,  //  003A  MOVE	R2	R3
       0x80040400,  //  003B  RET	1	R2
       0x7002000C,  //  003C  JMP		#004A
-      0x1C08030E,  //  003D  EQ	R2	R1	K14
+      0x1C080305,  //  003D  EQ	R2	R1	K5
       0x780A0003,  //  003E  JMPF	R2	#0043
-      0x8C08010F,  //  003F  GETMET	R2	R0	K15
+      0x8C08012A,  //  003F  GETMET	R2	R0	K42
       0x7C080200,  //  0040  CALL	R2	1
       0x80040400,  //  0041  RET	1	R2
       0x70020006,  //  0042  JMP		#004A
       0x60080003,  //  0043  GETGBL	R2	G3
       0x5C0C0000,  //  0044  MOVE	R3	R0
       0x7C080200,  //  0045  CALL	R2	1
-      0x8C080510,  //  0046  GETMET	R2	R2	K16
+      0x8C08052B,  //  0046  GETMET	R2	R2	K43
       0x5C100200,  //  0047  MOVE	R4	R1
       0x7C080400,  //  0048  CALL	R2	2
       0x80040400,  //  0049  RET	1	R2
@@ -559,6 +530,37 @@ be_local_class(zcl_attribute,
     })),
     be_str_weak(zcl_attribute)
 );
+// compact class 'zcl_attribute_list' ktab size: 27, total: 36 (saved 72 bytes)
+static const bvalue be_ktab_class_zcl_attribute_list[27] = {
+  /* K0   */  be_nested_str_weak(groupaddr),
+  /* K1   */  be_nested_str_weak(_groupaddr),
+  /* K2   */  be_nested_str_weak(src_ep),
+  /* K3   */  be_nested_str_weak(_src_ep),
+  /* K4   */  be_nested_str_weak(lqi),
+  /* K5   */  be_nested_str_weak(_lqi),
+  /* K6   */  be_nested_str_weak(member),
+  /* K7   */  be_nested_str_weak(setmember),
+  /* K8   */  be_nested_str_weak(init),
+  /* K9   */  be_nested_str_weak(_init),
+  /* K10  */  be_nested_str_weak(ismapped),
+  /* K11  */  be_nested_str_weak(_deinit),
+  /* K12  */  be_nested_str_weak(json),
+  /* K13  */  be_nested_str_weak(shortaddr),
+  /* K14  */  be_nested_str_weak(push),
+  /* K15  */  be_nested_str_weak(_X22Device_X22_X3A_X220x_X2504X_X22),
+  /* K16  */  be_nested_str_weak(_X22Group_X22_X3A_X220x_X2504X_X22),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(size),
+  /* K19  */  be_nested_str_weak(tostring),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_nested_str_weak(_X22Endpoint_X22_X3A_X25s),
+  /* K22  */  be_nested_str_weak(_X22LinkQuality_X22_X3A_X25s),
+  /* K23  */  be_nested_str_weak(_X7B),
+  /* K24  */  be_nested_str_weak(concat),
+  /* K25  */  be_nested_str_weak(_X2C),
+  /* K26  */  be_nested_str_weak(_X7D),
+};
+
 
 extern const bclass be_class_zcl_attribute_list;
 
@@ -569,21 +571,13 @@ be_local_closure(class_zcl_attribute_list_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(groupaddr),
-    /* K1   */  be_nested_str_weak(_groupaddr),
-    /* K2   */  be_nested_str_weak(src_ep),
-    /* K3   */  be_nested_str_weak(_src_ep),
-    /* K4   */  be_nested_str_weak(lqi),
-    /* K5   */  be_nested_str_weak(_lqi),
-    /* K6   */  be_nested_str_weak(member),
-    }),
+    &be_ktab_class_zcl_attribute_list,     /* shared constants */
     be_str_weak(member),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
@@ -641,21 +635,13 @@ be_local_closure(class_zcl_attribute_list_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(groupaddr),
-    /* K1   */  be_nested_str_weak(_groupaddr),
-    /* K2   */  be_nested_str_weak(src_ep),
-    /* K3   */  be_nested_str_weak(_src_ep),
-    /* K4   */  be_nested_str_weak(lqi),
-    /* K5   */  be_nested_str_weak(_lqi),
-    /* K6   */  be_nested_str_weak(setmember),
-    }),
+    &be_ktab_class_zcl_attribute_list,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[38]) {  /* code */
@@ -692,7 +678,7 @@ be_local_closure(class_zcl_attribute_list_setmember,   /* name */
       0x600C0003,  //  001E  GETGBL	R3	G3
       0x5C100000,  //  001F  MOVE	R4	R0
       0x7C0C0200,  //  0020  CALL	R3	1
-      0x8C0C0706,  //  0021  GETMET	R3	R3	K6
+      0x8C0C0707,  //  0021  GETMET	R3	R3	K7
       0x5C140200,  //  0022  MOVE	R5	R1
       0x5C180400,  //  0023  MOVE	R6	R2
       0x7C0C0600,  //  0024  CALL	R3	3
@@ -710,29 +696,26 @@ be_local_closure(class_zcl_attribute_list_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(_init),
-    }),
+    &be_ktab_class_zcl_attribute_list,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080508,  //  0003  GETMET	R2	R2	K8
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x4C080000,  //  0006  LDNIL	R2
       0x1C080202,  //  0007  EQ	R2	R1	R2
       0x780A0001,  //  0008  JMPF	R2	#000B
-      0x8C080101,  //  0009  GETMET	R2	R0	K1
+      0x8C080109,  //  0009  GETMET	R2	R0	K9
       0x7C080200,  //  000A  CALL	R2	1
       0x80000000,  //  000B  RET	0
     })
@@ -748,23 +731,20 @@ be_local_closure(class_zcl_attribute_list_deinit,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ismapped),
-    /* K1   */  be_nested_str_weak(_deinit),
-    }),
+    &be_ktab_class_zcl_attribute_list,     /* shared constants */
     be_str_weak(deinit),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
       0x7C040200,  //  0001  CALL	R1	1
       0x74060001,  //  0002  JMPT	R1	#0005
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x8C04010B,  //  0003  GETMET	R1	R0	K11
       0x7C040200,  //  0004  CALL	R1	1
       0x80000000,  //  0005  RET	0
     })
@@ -780,96 +760,77 @@ be_local_closure(class_zcl_attribute_list_tostring,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(shortaddr),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(_X22Device_X22_X3A_X220x_X2504X_X22),
-    /* K4   */  be_nested_str_weak(groupaddr),
-    /* K5   */  be_nested_str_weak(_X22Group_X22_X3A_X220x_X2504X_X22),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(size),
-    /* K8   */  be_nested_str_weak(tostring),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(src_ep),
-    /* K11  */  be_nested_str_weak(_X22Endpoint_X22_X3A_X25s),
-    /* K12  */  be_nested_str_weak(lqi),
-    /* K13  */  be_nested_str_weak(_X22LinkQuality_X22_X3A_X25s),
-    /* K14  */  be_nested_str_weak(_X7B),
-    /* K15  */  be_nested_str_weak(concat),
-    /* K16  */  be_nested_str_weak(_X2C),
-    /* K17  */  be_nested_str_weak(_X7D),
-    }),
+    &be_ktab_class_zcl_attribute_list,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[62]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA4061800,  //  0000  IMPORT	R1	K12
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x4C0C0000,  //  0003  LDNIL	R3
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
+      0x880C010D,  //  0004  GETMBR	R3	R0	K13
       0x4C100000,  //  0005  LDNIL	R4
       0x200C0604,  //  0006  NE	R3	R3	R4
       0x780E0005,  //  0007  JMPF	R3	#000E
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x8C0C050E,  //  0008  GETMET	R3	R2	K14
       0x60140018,  //  0009  GETGBL	R5	G24
-      0x58180003,  //  000A  LDCONST	R6	K3
+      0x5818000F,  //  000A  LDCONST	R6	K15
       0x5C1C0600,  //  000B  MOVE	R7	R3
       0x7C140400,  //  000C  CALL	R5	2
       0x7C0C0400,  //  000D  CALL	R3	2
-      0x880C0104,  //  000E  GETMBR	R3	R0	K4
+      0x880C0100,  //  000E  GETMBR	R3	R0	K0
       0x4C100000,  //  000F  LDNIL	R4
       0x200C0604,  //  0010  NE	R3	R3	R4
       0x780E0005,  //  0011  JMPF	R3	#0018
-      0x8C0C0502,  //  0012  GETMET	R3	R2	K2
+      0x8C0C050E,  //  0012  GETMET	R3	R2	K14
       0x60140018,  //  0013  GETGBL	R5	G24
-      0x58180005,  //  0014  LDCONST	R6	K5
+      0x58180010,  //  0014  LDCONST	R6	K16
       0x5C1C0600,  //  0015  MOVE	R7	R3
       0x7C140400,  //  0016  CALL	R5	2
       0x7C0C0400,  //  0017  CALL	R3	2
-      0x58100006,  //  0018  LDCONST	R4	K6
-      0x8C140107,  //  0019  GETMET	R5	R0	K7
+      0x58100011,  //  0018  LDCONST	R4	K17
+      0x8C140112,  //  0019  GETMET	R5	R0	K18
       0x7C140200,  //  001A  CALL	R5	1
       0x14180805,  //  001B  LT	R6	R4	R5
       0x781A0006,  //  001C  JMPF	R6	#0024
-      0x8C180502,  //  001D  GETMET	R6	R2	K2
+      0x8C18050E,  //  001D  GETMET	R6	R2	K14
       0x94200004,  //  001E  GETIDX	R8	R0	R4
-      0x8C201108,  //  001F  GETMET	R8	R8	K8
+      0x8C201113,  //  001F  GETMET	R8	R8	K19
       0x7C200200,  //  0020  CALL	R8	1
       0x7C180400,  //  0021  CALL	R6	2
-      0x00100909,  //  0022  ADD	R4	R4	K9
+      0x00100914,  //  0022  ADD	R4	R4	K20
       0x7001FFF6,  //  0023  JMP		#001B
-      0x880C010A,  //  0024  GETMBR	R3	R0	K10
+      0x880C0102,  //  0024  GETMBR	R3	R0	K2
       0x4C180000,  //  0025  LDNIL	R6
       0x200C0606,  //  0026  NE	R3	R3	R6
       0x780E0005,  //  0027  JMPF	R3	#002E
-      0x8C180502,  //  0028  GETMET	R6	R2	K2
+      0x8C18050E,  //  0028  GETMET	R6	R2	K14
       0x60200018,  //  0029  GETGBL	R8	G24
-      0x5824000B,  //  002A  LDCONST	R9	K11
+      0x58240015,  //  002A  LDCONST	R9	K21
       0x5C280600,  //  002B  MOVE	R10	R3
       0x7C200400,  //  002C  CALL	R8	2
       0x7C180400,  //  002D  CALL	R6	2
-      0x880C010C,  //  002E  GETMBR	R3	R0	K12
+      0x880C0104,  //  002E  GETMBR	R3	R0	K4
       0x4C180000,  //  002F  LDNIL	R6
       0x200C0606,  //  0030  NE	R3	R3	R6
       0x780E0005,  //  0031  JMPF	R3	#0038
-      0x8C180502,  //  0032  GETMET	R6	R2	K2
+      0x8C18050E,  //  0032  GETMET	R6	R2	K14
       0x60200018,  //  0033  GETGBL	R8	G24
-      0x5824000D,  //  0034  LDCONST	R9	K13
+      0x58240016,  //  0034  LDCONST	R9	K22
       0x5C280600,  //  0035  MOVE	R10	R3
       0x7C200400,  //  0036  CALL	R8	2
       0x7C180400,  //  0037  CALL	R6	2
-      0x8C18050F,  //  0038  GETMET	R6	R2	K15
-      0x58200010,  //  0039  LDCONST	R8	K16
+      0x8C180518,  //  0038  GETMET	R6	R2	K24
+      0x58200019,  //  0039  LDCONST	R8	K25
       0x7C180400,  //  003A  CALL	R6	2
-      0x001A1C06,  //  003B  ADD	R6	K14	R6
-      0x00180D11,  //  003C  ADD	R6	R6	K17
+      0x001A2E06,  //  003B  ADD	R6	K23	R6
+      0x00180D1A,  //  003C  ADD	R6	R6	K26
       0x80040C00,  //  003D  RET	1	R6
     })
   )

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_frame.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_frame.h
@@ -3,6 +3,22 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'zcl_frame' ktab size: 12, total: 16 (saved 32 bytes)
+static const bvalue be_ktab_class_zcl_frame[12] = {
+  /* K0   */  be_nested_str_weak(payload),
+  /* K1   */  be_nested_str_weak(_get_bytes),
+  /* K2   */  be_nested_str_weak(payload_ptr),
+  /* K3   */  be_nested_str_weak(member),
+  /* K4   */  be_nested_str_weak(_set_bytes),
+  /* K5   */  be_nested_str_weak(setmember),
+  /* K6   */  be_nested_str_weak(init),
+  /* K7   */  be_nested_str_weak(no_bytes),
+  /* K8   */  be_nested_str_weak(tomap),
+  /* K9   */  be_nested_str_weak(shortaddr_hex),
+  /* K10  */  be_nested_str_weak(0x_X2504X),
+  /* K11  */  be_nested_str_weak(shortaddr),
+};
+
 
 extern const bclass be_class_zcl_frame;
 
@@ -13,18 +29,13 @@ be_local_closure(class_zcl_frame_member,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(payload),
-    /* K1   */  be_nested_str_weak(_get_bytes),
-    /* K2   */  be_nested_str_weak(payload_ptr),
-    /* K3   */  be_nested_str_weak(member),
-    }),
+    &be_ktab_class_zcl_frame,     /* shared constants */
     be_str_weak(member),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -56,24 +67,19 @@ be_local_closure(class_zcl_frame_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(payload),
-    /* K1   */  be_nested_str_weak(_set_bytes),
-    /* K2   */  be_nested_str_weak(payload_ptr),
-    /* K3   */  be_nested_str_weak(setmember),
-    }),
+    &be_ktab_class_zcl_frame,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0x1C0C0300,  //  0000  EQ	R3	R1	K0
       0x780E0005,  //  0001  JMPF	R3	#0008
-      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
+      0x8C0C0104,  //  0002  GETMET	R3	R0	K4
       0x88140102,  //  0003  GETMBR	R5	R0	K2
       0x5C180400,  //  0004  MOVE	R6	R2
       0x7C0C0600,  //  0005  CALL	R3	3
@@ -82,7 +88,7 @@ be_local_closure(class_zcl_frame_setmember,   /* name */
       0x600C0003,  //  0008  GETGBL	R3	G3
       0x5C100000,  //  0009  MOVE	R4	R0
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x8C0C0703,  //  000B  GETMET	R3	R3	K3
+      0x8C0C0705,  //  000B  GETMET	R3	R3	K5
       0x5C140200,  //  000C  MOVE	R5	R1
       0x5C180400,  //  000D  MOVE	R6	R2
       0x7C0C0600,  //  000E  CALL	R3	3
@@ -101,28 +107,25 @@ be_local_closure(class_zcl_frame_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(no_bytes),
-    }),
+    &be_ktab_class_zcl_frame,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080506,  //  0003  GETMET	R2	R2	K6
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x60080015,  //  0006  GETGBL	R2	G21
       0x7C080000,  //  0007  CALL	R2	0
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x90020E02,  //  0008  SETMBR	R0	K7	R2
       0x80000000,  //  0009  RET	0
     })
   )
@@ -137,34 +140,28 @@ be_local_closure(class_zcl_frame_tomap,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tomap),
-    /* K1   */  be_nested_str_weak(shortaddr_hex),
-    /* K2   */  be_nested_str_weak(0x_X2504X),
-    /* K3   */  be_nested_str_weak(shortaddr),
-    /* K4   */  be_nested_str_weak(payload),
-    }),
+    &be_ktab_class_zcl_frame,     /* shared constants */
     be_str_weak(tomap),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040308,  //  0003  GETMET	R1	R1	K8
       0x7C040200,  //  0004  CALL	R1	1
       0x60080018,  //  0005  GETGBL	R2	G24
-      0x580C0002,  //  0006  LDCONST	R3	K2
-      0x88100103,  //  0007  GETMBR	R4	R0	K3
+      0x580C000A,  //  0006  LDCONST	R3	K10
+      0x8810010B,  //  0007  GETMBR	R4	R0	K11
       0x7C080400,  //  0008  CALL	R2	2
-      0x98060202,  //  0009  SETIDX	R1	K1	R2
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
-      0x98060802,  //  000B  SETIDX	R1	K4	R2
+      0x98061202,  //  0009  SETIDX	R1	K9	R2
+      0x88080100,  //  000A  GETMBR	R2	R0	K0
+      0x98060002,  //  000B  SETIDX	R1	K0	R2
       0x80040200,  //  000C  RET	1	R1
     })
   )
@@ -179,19 +176,17 @@ be_local_closure(class_zcl_frame_tostring,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tomap),
-    }),
+    &be_ktab_class_zcl_frame,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040108,  //  0000  GETMET	R1	R0	K8
       0x7C040200,  //  0001  CALL	R1	1
       0x60080008,  //  0002  GETGBL	R2	G8
       0x5C0C0200,  //  0003  MOVE	R3	R1

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_glob.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_glob.h
@@ -3,6 +3,84 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+// compact class 'LVGL_glob' ktab size: 74, total: 131 (saved 456 bytes)
+static const bvalue be_ktab_class_LVGL_glob[74] = {
+  /* K0   */  be_nested_str_weak(event_cb),
+  /* K1   */  be_nested_str_weak(cb),
+  /* K2   */  be_nested_str_weak(gen_cb),
+  /* K3   */  be_nested_str_weak(push),
+  /* K4   */  be_nested_str_weak(stop_iteration),
+  /* K5   */  be_nested_str_weak(cb_event_closure),
+  /* K6   */  be_nested_str_weak(contains),
+  /* K7   */  be_nested_str_weak(function),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_nested_str_weak(lv_event_cb),
+  /* K11  */  be_nested_str_weak(register_obj),
+  /* K12  */  be_nested_str_weak(add_event_cb),
+  /* K13  */  be_nested_str_weak(lv),
+  /* K14  */  be_nested_str_weak(EVENT_DELETE),
+  /* K15  */  be_const_int(0),
+  /* K16  */  be_nested_str_weak(add_cb_event_closure),
+  /* K17  */  be_nested_str_weak(_p),
+  /* K18  */  be_nested_str_weak(get_event_cb),
+  /* K19  */  be_nested_str_weak(lv_timer_cb),
+  /* K20  */  be_nested_str_weak(timer_cb),
+  /* K21  */  be_const_int(2),
+  /* K22  */  be_nested_str_weak(lv_),
+  /* K23  */  be_nested_str_weak(null_cb),
+  /* K24  */  be_nested_str_weak(cb_do_nothing),
+  /* K25  */  be_nested_str_weak(introspect),
+  /* K26  */  be_nested_str_weak(toptr),
+  /* K27  */  be_const_int(1),
+  /* K28  */  be_nested_str_weak(event),
+  /* K29  */  be_nested_str_weak(lv_event),
+  /* K30  */  be_nested_str_weak(get_target),
+  /* K31  */  be_nested_str_weak(get_object_from_ptr),
+  /* K32  */  be_nested_str_weak(cb_obj),
+  /* K33  */  be_nested_str_weak(remove),
+  /* K34  */  be_nested_str_weak(lv_obj_class),
+  /* K35  */  be_nested_str_weak(get_target_obj),
+  /* K36  */  be_nested_str_weak(instance),
+  /* K37  */  be_nested_str_weak(get_code),
+  /* K38  */  be_nested_str_weak(get),
+  /* K39  */  be_nested_str_weak(before_del),
+  /* K40  */  be_nested_str_weak(widget_event),
+  /* K41  */  be_nested_str_weak(widget_destructor),
+  /* K42  */  be_nested_str_weak(find),
+  /* K43  */  be_nested_str_weak(widget_constructor),
+  /* K44  */  be_nested_str_weak(LVG_X3A_X20call_X20to_X20unsupported_X20callback),
+  /* K45  */  be_nested_str_weak(add_handler),
+  /* K46  */  be_nested_str_weak(lv_extra),
+  /* K47  */  be_nested_str_weak(lv_obj),
+  /* K48  */  be_nested_str_weak(value_error),
+  /* K49  */  be_nested_str_weak(arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj),
+  /* K50  */  be_nested_str_weak(widget_struct_by_class),
+  /* K51  */  be_nested_str_weak(widget_cb),
+  /* K52  */  be_nested_str_weak(widget_struct_default),
+  /* K53  */  be_nested_str_weak(copy),
+  /* K54  */  be_nested_str_weak(base_class),
+  /* K55  */  be_nested_str_weak(_class),
+  /* K56  */  be_nested_str_weak(widget_width_def),
+  /* K57  */  be_nested_str_weak(width_def),
+  /* K58  */  be_nested_str_weak(widget_height_def),
+  /* K59  */  be_nested_str_weak(height_def),
+  /* K60  */  be_nested_str_weak(widget_editable),
+  /* K61  */  be_nested_str_weak(editable),
+  /* K62  */  be_nested_str_weak(widget_group_def),
+  /* K63  */  be_nested_str_weak(group_def),
+  /* K64  */  be_nested_str_weak(widget_instance_size),
+  /* K65  */  be_nested_str_weak(instance_size),
+  /* K66  */  be_nested_str_weak(obj_class_create_obj),
+  /* K67  */  be_nested_str_weak(class_init_obj),
+  /* K68  */  be_nested_str_weak(widget_ctor_cb),
+  /* K69  */  be_nested_str_weak(widget_dtor_cb),
+  /* K70  */  be_nested_str_weak(widget_event_cb),
+  /* K71  */  be_nested_str_weak(constructor_cb),
+  /* K72  */  be_nested_str_weak(destructor_cb),
+  /* K73  */  be_nested_str_weak(deregister_obj),
+};
+
 
 extern const bclass be_class_LVGL_glob;
 
@@ -13,7 +91,7 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -46,13 +124,7 @@ be_local_closure(class_LVGL_glob_get_event_cb,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(event_cb),
-    /* K1   */  be_nested_str_weak(cb),
-    /* K2   */  be_nested_str_weak(gen_cb),
-    /* K3   */  be_nested_str_weak(push),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(get_event_cb),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
@@ -101,65 +173,58 @@ be_local_closure(class_LVGL_glob_add_cb_event_closure,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb_event_closure),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(function),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_const_int(0),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(add_cb_event_closure),
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0105,  //  0000  GETMBR	R3	R0	K5
       0x4C100000,  //  0001  LDNIL	R4
       0x1C0C0604,  //  0002  EQ	R3	R3	R4
       0x780E0002,  //  0003  JMPF	R3	#0007
       0x600C0013,  //  0004  GETGBL	R3	G19
       0x7C0C0000,  //  0005  CALL	R3	0
-      0x90020003,  //  0006  SETMBR	R0	K0	R3
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x90020A03,  //  0006  SETMBR	R0	K5	R3
+      0x880C0105,  //  0007  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0008  GETMET	R3	R3	K6
       0x5C140200,  //  0009  MOVE	R5	R1
       0x7C0C0400,  //  000A  CALL	R3	2
       0x780E001A,  //  000B  JMPF	R3	#0027
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x880C0105,  //  000C  GETMBR	R3	R0	K5
       0x940C0601,  //  000D  GETIDX	R3	R3	R1
       0x60100004,  //  000E  GETGBL	R4	G4
       0x5C140600,  //  000F  MOVE	R5	R3
       0x7C100200,  //  0010  CALL	R4	1
-      0x1C100902,  //  0011  EQ	R4	R4	K2
+      0x1C100907,  //  0011  EQ	R4	R4	K7
       0x78120007,  //  0012  JMPF	R4	#001B
-      0x88100100,  //  0013  GETMBR	R4	R0	K0
+      0x88100105,  //  0013  GETMBR	R4	R0	K5
       0x60140012,  //  0014  GETGBL	R5	G18
       0x7C140000,  //  0015  CALL	R5	0
       0x40180A03,  //  0016  CONNECT	R6	R5	R3
       0x40180A02,  //  0017  CONNECT	R6	R5	R2
       0x98100205,  //  0018  SETIDX	R4	R1	R5
-      0x80060600,  //  0019  RET	1	K3
+      0x80061000,  //  0019  RET	1	K8
       0x7002000A,  //  001A  JMP		#0026
-      0x88100100,  //  001B  GETMBR	R4	R0	K0
+      0x88100105,  //  001B  GETMBR	R4	R0	K5
       0x94100801,  //  001C  GETIDX	R4	R4	R1
-      0x8C100904,  //  001D  GETMET	R4	R4	K4
+      0x8C100903,  //  001D  GETMET	R4	R4	K3
       0x5C180400,  //  001E  MOVE	R6	R2
       0x7C100400,  //  001F  CALL	R4	2
       0x6010000C,  //  0020  GETGBL	R4	G12
-      0x88140100,  //  0021  GETMBR	R5	R0	K0
+      0x88140105,  //  0021  GETMBR	R5	R0	K5
       0x94140A01,  //  0022  GETIDX	R5	R5	R1
       0x7C100200,  //  0023  CALL	R4	1
-      0x04100903,  //  0024  SUB	R4	R4	K3
+      0x04100908,  //  0024  SUB	R4	R4	K8
       0x80040800,  //  0025  RET	1	R4
       0x70020002,  //  0026  JMP		#002A
-      0x880C0100,  //  0027  GETMBR	R3	R0	K0
+      0x880C0105,  //  0027  GETMBR	R3	R0	K5
       0x980C0202,  //  0028  SETIDX	R3	R1	R2
-      0x80060A00,  //  0029  RET	1	K5
+      0x80061200,  //  0029  RET	1	K9
       0x80000000,  //  002A  RET	0
     })
   )
@@ -174,7 +239,7 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     4,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -229,25 +294,7 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb),
-    /* K1   */  be_nested_str_weak(lv_event_cb),
-    /* K2   */  be_nested_str_weak(register_obj),
-    /* K3   */  be_nested_str_weak(add_event_cb),
-    /* K4   */  be_nested_str_weak(lv),
-    /* K5   */  be_nested_str_weak(EVENT_DELETE),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(add_cb_event_closure),
-    /* K8   */  be_nested_str_weak(_p),
-    /* K9   */  be_nested_str_weak(get_event_cb),
-    /* K10  */  be_nested_str_weak(lv_timer_cb),
-    /* K11  */  be_nested_str_weak(timer_cb),
-    /* K12  */  be_nested_str_weak(gen_cb),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(lv_),
-    /* K15  */  be_nested_str_weak(null_cb),
-    /* K16  */  be_nested_str_weak(cb_do_nothing),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(make_cb),
     &be_const_str_solidified,
     ( &(const binstruction[70]) {  /* code */
@@ -256,63 +303,63 @@ be_local_closure(class_LVGL_glob_make_cb,   /* name */
       0x78120001,  //  0002  JMPF	R4	#0005
       0x4C100000,  //  0003  LDNIL	R4
       0x80040800,  //  0004  RET	1	R4
-      0xA4120000,  //  0005  IMPORT	R4	K0
-      0x1C140701,  //  0006  EQ	R5	R3	K1
+      0xA4120200,  //  0005  IMPORT	R4	K1
+      0x1C14070A,  //  0006  EQ	R5	R3	K10
       0x78160016,  //  0007  JMPF	R5	#001F
-      0x8C140102,  //  0008  GETMET	R5	R0	K2
+      0x8C14010B,  //  0008  GETMET	R5	R0	K11
       0x5C1C0400,  //  0009  MOVE	R7	R2
       0x7C140400,  //  000A  CALL	R5	2
       0x78160000,  //  000B  JMPF	R5	#000D
       0x50140001,  //  000C  LDBOOL	R5	0	1
       0x50140200,  //  000D  LDBOOL	R5	1	0
       0x78160005,  //  000E  JMPF	R5	#0015
-      0x8C180503,  //  000F  GETMET	R6	R2	K3
+      0x8C18050C,  //  000F  GETMET	R6	R2	K12
       0x84200000,  //  0010  CLOSURE	R8	P0
-      0xB8260800,  //  0011  GETNGBL	R9	K4
-      0x88241305,  //  0012  GETMBR	R9	R9	K5
-      0x58280006,  //  0013  LDCONST	R10	K6
+      0xB8261A00,  //  0011  GETNGBL	R9	K13
+      0x8824130E,  //  0012  GETMBR	R9	R9	K14
+      0x5828000F,  //  0013  LDCONST	R10	K15
       0x7C180800,  //  0014  CALL	R6	4
-      0x8C180107,  //  0015  GETMET	R6	R0	K7
-      0x88200508,  //  0016  GETMBR	R8	R2	K8
+      0x8C180110,  //  0015  GETMET	R6	R0	K16
+      0x88200511,  //  0016  GETMBR	R8	R2	K17
       0x5C240200,  //  0017  MOVE	R9	R1
       0x7C180600,  //  0018  CALL	R6	3
-      0x8C1C0109,  //  0019  GETMET	R7	R0	K9
+      0x8C1C0112,  //  0019  GETMET	R7	R0	K18
       0x5C240C00,  //  001A  MOVE	R9	R6
       0x7C1C0400,  //  001B  CALL	R7	2
       0xA0000000,  //  001C  CLOSE	R0
       0x80040E00,  //  001D  RET	1	R7
       0x70020024,  //  001E  JMP		#0044
-      0x1C14070A,  //  001F  EQ	R5	R3	K10
+      0x1C140713,  //  001F  EQ	R5	R3	K19
       0x7816000F,  //  0020  JMPF	R5	#0031
-      0x8814010B,  //  0021  GETMBR	R5	R0	K11
+      0x88140114,  //  0021  GETMBR	R5	R0	K20
       0x4C180000,  //  0022  LDNIL	R6
       0x1C140A06,  //  0023  EQ	R5	R5	R6
       0x78160003,  //  0024  JMPF	R5	#0029
-      0x8C14090C,  //  0025  GETMET	R5	R4	K12
+      0x8C140902,  //  0025  GETMET	R5	R4	K2
       0x841C0001,  //  0026  CLOSURE	R7	P1
       0x7C140400,  //  0027  CALL	R5	2
-      0x90021605,  //  0028  SETMBR	R0	K11	R5
-      0x8C140107,  //  0029  GETMET	R5	R0	K7
-      0x881C0508,  //  002A  GETMBR	R7	R2	K8
+      0x90022805,  //  0028  SETMBR	R0	K20	R5
+      0x8C140110,  //  0029  GETMET	R5	R0	K16
+      0x881C0511,  //  002A  GETMBR	R7	R2	K17
       0x5C200200,  //  002B  MOVE	R8	R1
       0x7C140600,  //  002C  CALL	R5	3
-      0x8814010B,  //  002D  GETMBR	R5	R0	K11
+      0x88140114,  //  002D  GETMBR	R5	R0	K20
       0xA0000000,  //  002E  CLOSE	R0
       0x80040A00,  //  002F  RET	1	R5
       0x70020012,  //  0030  JMP		#0044
-      0x40160D0D,  //  0031  CONNECT	R5	K6	K13
+      0x40161F15,  //  0031  CONNECT	R5	K15	K21
       0x94140605,  //  0032  GETIDX	R5	R3	R5
-      0x1C140B0E,  //  0033  EQ	R5	R5	K14
+      0x1C140B16,  //  0033  EQ	R5	R5	K22
       0x7816000B,  //  0034  JMPF	R5	#0041
-      0x8814010F,  //  0035  GETMBR	R5	R0	K15
+      0x88140117,  //  0035  GETMBR	R5	R0	K23
       0x4C180000,  //  0036  LDNIL	R6
       0x1C140A06,  //  0037  EQ	R5	R5	R6
       0x78160003,  //  0038  JMPF	R5	#003D
-      0x8C14090C,  //  0039  GETMET	R5	R4	K12
-      0x881C0110,  //  003A  GETMBR	R7	R0	K16
+      0x8C140902,  //  0039  GETMET	R5	R4	K2
+      0x881C0118,  //  003A  GETMBR	R7	R0	K24
       0x7C140400,  //  003B  CALL	R5	2
-      0x90021E05,  //  003C  SETMBR	R0	K15	R5
-      0x8814010F,  //  003D  GETMBR	R5	R0	K15
+      0x90022E05,  //  003C  SETMBR	R0	K23	R5
+      0x88140117,  //  003D  GETMBR	R5	R0	K23
       0xA0000000,  //  003E  CLOSE	R0
       0x80040A00,  //  003F  RET	1	R5
       0x70020002,  //  0040  JMP		#0044
@@ -334,39 +381,32 @@ be_local_closure(class_LVGL_glob_lvgl_timer_dispatch,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(toptr),
-    /* K2   */  be_nested_str_weak(cb_event_closure),
-    /* K3   */  be_nested_str_weak(function),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(1),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(lvgl_timer_dispatch),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40A3200,  //  0000  IMPORT	R2	K25
+      0x8C0C051A,  //  0001  GETMET	R3	R2	K26
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x88100105,  //  0004  GETMBR	R4	R0	K5
       0x94100803,  //  0005  GETIDX	R4	R4	R3
       0x60140004,  //  0006  GETGBL	R5	G4
       0x5C180800,  //  0007  MOVE	R6	R4
       0x7C140200,  //  0008  CALL	R5	1
-      0x1C140B03,  //  0009  EQ	R5	R5	K3
+      0x1C140B07,  //  0009  EQ	R5	R5	K7
       0x78160003,  //  000A  JMPF	R5	#000F
       0x5C140800,  //  000B  MOVE	R5	R4
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C140200,  //  000D  CALL	R5	1
       0x7002000A,  //  000E  JMP		#001A
-      0x58140004,  //  000F  LDCONST	R5	K4
+      0x5814000F,  //  000F  LDCONST	R5	K15
       0x6018000C,  //  0010  GETGBL	R6	G12
       0x5C1C0800,  //  0011  MOVE	R7	R4
       0x7C180200,  //  0012  CALL	R6	1
@@ -375,7 +415,7 @@ be_local_closure(class_LVGL_glob_lvgl_timer_dispatch,   /* name */
       0x94180805,  //  0015  GETIDX	R6	R4	R5
       0x5C1C0600,  //  0016  MOVE	R7	R3
       0x7C180200,  //  0017  CALL	R6	1
-      0x00140B05,  //  0018  ADD	R5	R5	K5
+      0x00140B1B,  //  0018  ADD	R5	R5	K27
       0x7001FFF5,  //  0019  JMP		#0010
       0x80000000,  //  001A  RET	0
     })
@@ -391,57 +431,46 @@ be_local_closure(class_LVGL_glob_lvgl_event_dispatch,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(toptr),
-    /* K2   */  be_nested_str_weak(event),
-    /* K3   */  be_nested_str_weak(_p),
-    /* K4   */  be_nested_str_weak(lv),
-    /* K5   */  be_nested_str_weak(lv_event),
-    /* K6   */  be_nested_str_weak(get_target),
-    /* K7   */  be_nested_str_weak(get_object_from_ptr),
-    /* K8   */  be_nested_str_weak(cb_event_closure),
-    /* K9   */  be_nested_str_weak(function),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(lvgl_event_dispatch),
     &be_const_str_solidified,
     ( &(const binstruction[42]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100701,  //  0001  GETMET	R4	R3	K1
+      0xA40E3200,  //  0000  IMPORT	R3	K25
+      0x8C10071A,  //  0001  GETMET	R4	R3	K26
       0x5C180400,  //  0002  MOVE	R6	R2
       0x7C100400,  //  0003  CALL	R4	2
-      0x88140102,  //  0004  GETMBR	R5	R0	K2
+      0x8814011C,  //  0004  GETMBR	R5	R0	K28
       0x78160002,  //  0005  JMPF	R5	#0009
-      0x88140102,  //  0006  GETMBR	R5	R0	K2
-      0x90160604,  //  0007  SETMBR	R5	K3	R4
+      0x8814011C,  //  0006  GETMBR	R5	R0	K28
+      0x90162204,  //  0007  SETMBR	R5	K17	R4
       0x70020004,  //  0008  JMP		#000E
-      0xB8160800,  //  0009  GETNGBL	R5	K4
-      0x8C140B05,  //  000A  GETMET	R5	R5	K5
+      0xB8161A00,  //  0009  GETNGBL	R5	K13
+      0x8C140B1D,  //  000A  GETMET	R5	R5	K29
       0x5C1C0800,  //  000B  MOVE	R7	R4
       0x7C140400,  //  000C  CALL	R5	2
-      0x90020405,  //  000D  SETMBR	R0	K2	R5
-      0x88140102,  //  000E  GETMBR	R5	R0	K2
-      0x8C140B06,  //  000F  GETMET	R5	R5	K6
+      0x90023805,  //  000D  SETMBR	R0	K28	R5
+      0x8814011C,  //  000E  GETMBR	R5	R0	K28
+      0x8C140B1E,  //  000F  GETMET	R5	R5	K30
       0x7C140200,  //  0010  CALL	R5	1
-      0x8C180107,  //  0011  GETMET	R6	R0	K7
+      0x8C18011F,  //  0011  GETMET	R6	R0	K31
       0x5C200A00,  //  0012  MOVE	R8	R5
       0x7C180400,  //  0013  CALL	R6	2
-      0x881C0108,  //  0014  GETMBR	R7	R0	K8
+      0x881C0105,  //  0014  GETMBR	R7	R0	K5
       0x941C0E05,  //  0015  GETIDX	R7	R7	R5
       0x60200004,  //  0016  GETGBL	R8	G4
       0x5C240E00,  //  0017  MOVE	R9	R7
       0x7C200200,  //  0018  CALL	R8	1
-      0x1C201109,  //  0019  EQ	R8	R8	K9
+      0x1C201107,  //  0019  EQ	R8	R8	K7
       0x78220004,  //  001A  JMPF	R8	#0020
       0x5C200E00,  //  001B  MOVE	R8	R7
       0x5C240C00,  //  001C  MOVE	R9	R6
-      0x88280102,  //  001D  GETMBR	R10	R0	K2
+      0x8828011C,  //  001D  GETMBR	R10	R0	K28
       0x7C200400,  //  001E  CALL	R8	2
       0x70020008,  //  001F  JMP		#0029
       0x6020000C,  //  0020  GETGBL	R8	G12
@@ -451,7 +480,7 @@ be_local_closure(class_LVGL_glob_lvgl_event_dispatch,   /* name */
       0x78220003,  //  0024  JMPF	R8	#0029
       0x94200E01,  //  0025  GETIDX	R8	R7	R1
       0x5C240C00,  //  0026  MOVE	R9	R6
-      0x88280102,  //  0027  GETMBR	R10	R0	K2
+      0x8828011C,  //  0027  GETMBR	R10	R0	K28
       0x7C200400,  //  0028  CALL	R8	2
       0x80000000,  //  0029  RET	0
     })
@@ -467,34 +496,30 @@ be_local_closure(class_LVGL_glob_deregister_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb_obj),
-    /* K1   */  be_nested_str_weak(remove),
-    /* K2   */  be_nested_str_weak(cb_event_closure),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(deregister_obj),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080120,  //  0000  GETMBR	R2	R0	K32
       0x4C0C0000,  //  0001  LDNIL	R3
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0003,  //  0003  JMPF	R2	#0008
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x88080120,  //  0004  GETMBR	R2	R0	K32
+      0x8C080521,  //  0005  GETMET	R2	R2	K33
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x88080105,  //  0008  GETMBR	R2	R0	K5
       0x4C0C0000,  //  0009  LDNIL	R3
       0x20080403,  //  000A  NE	R2	R2	R3
       0x780A0003,  //  000B  JMPF	R2	#0010
-      0x88080102,  //  000C  GETMBR	R2	R0	K2
-      0x8C080501,  //  000D  GETMET	R2	R2	K1
+      0x88080105,  //  000C  GETMBR	R2	R0	K5
+      0x8C080521,  //  000D  GETMET	R2	R2	K33
       0x5C100200,  //  000E  MOVE	R4	R1
       0x7C080400,  //  000F  CALL	R2	2
       0x80000000,  //  0010  RET	0
@@ -511,37 +536,33 @@ be_local_closure(class_LVGL_glob_register_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb_obj),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(_p),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(register_obj),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080120,  //  0000  GETMBR	R2	R0	K32
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C080403,  //  0002  EQ	R2	R2	R3
       0x780A0002,  //  0003  JMPF	R2	#0007
       0x60080013,  //  0004  GETGBL	R2	G19
       0x7C080000,  //  0005  CALL	R2	0
-      0x90020002,  //  0006  SETMBR	R0	K0	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080501,  //  0008  GETMET	R2	R2	K1
-      0x88100302,  //  0009  GETMBR	R4	R1	K2
+      0x90024002,  //  0006  SETMBR	R0	K32	R2
+      0x88080120,  //  0007  GETMBR	R2	R0	K32
+      0x8C080506,  //  0008  GETMET	R2	R2	K6
+      0x88100311,  //  0009  GETMBR	R4	R1	K17
       0x7C080400,  //  000A  CALL	R2	2
       0x780A0002,  //  000B  JMPF	R2	#000F
       0x50080200,  //  000C  LDBOOL	R2	1	0
       0x80040400,  //  000D  RET	1	R2
       0x70020004,  //  000E  JMP		#0014
-      0x88080100,  //  000F  GETMBR	R2	R0	K0
-      0x880C0302,  //  0010  GETMBR	R3	R1	K2
+      0x88080120,  //  000F  GETMBR	R2	R0	K32
+      0x880C0311,  //  0010  GETMBR	R3	R1	K17
       0x98080601,  //  0011  SETIDX	R2	R3	R1
       0x50080000,  //  0012  LDBOOL	R2	0	0
       0x80040400,  //  0013  RET	1	R2
@@ -559,74 +580,59 @@ be_local_closure(class_LVGL_glob_widget_event_impl,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(lv_obj_class),
-    /* K3   */  be_nested_str_weak(lv_event),
-    /* K4   */  be_nested_str_weak(toptr),
-    /* K5   */  be_nested_str_weak(get_target_obj),
-    /* K6   */  be_nested_str_weak(get_object_from_ptr),
-    /* K7   */  be_nested_str_weak(_p),
-    /* K8   */  be_nested_str_weak(instance),
-    /* K9   */  be_nested_str_weak(get_code),
-    /* K10  */  be_nested_str_weak(EVENT_DELETE),
-    /* K11  */  be_nested_str_weak(get),
-    /* K12  */  be_nested_str_weak(before_del),
-    /* K13  */  be_nested_str_weak(widget_event),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(widget_event_impl),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0xA40E3200,  //  0000  IMPORT	R3	K25
+      0xB8121A00,  //  0001  GETNGBL	R4	K13
+      0x8C100922,  //  0002  GETMET	R4	R4	K34
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
-      0xB8160200,  //  0005  GETNGBL	R5	K1
-      0x8C140B03,  //  0006  GETMET	R5	R5	K3
-      0x8C1C0704,  //  0007  GETMET	R7	R3	K4
+      0xB8161A00,  //  0005  GETNGBL	R5	K13
+      0x8C140B1D,  //  0006  GETMET	R5	R5	K29
+      0x8C1C071A,  //  0007  GETMET	R7	R3	K26
       0x5C240400,  //  0008  MOVE	R9	R2
       0x7C1C0400,  //  0009  CALL	R7	2
       0x7C140400,  //  000A  CALL	R5	2
-      0x8C180B05,  //  000B  GETMET	R6	R5	K5
+      0x8C180B23,  //  000B  GETMET	R6	R5	K35
       0x7C180200,  //  000C  CALL	R6	1
-      0x8C1C0106,  //  000D  GETMET	R7	R0	K6
-      0x88240D07,  //  000E  GETMBR	R9	R6	K7
+      0x8C1C011F,  //  000D  GETMET	R7	R0	K31
+      0x88240D11,  //  000E  GETMBR	R9	R6	K17
       0x7C1C0400,  //  000F  CALL	R7	2
       0x60200004,  //  0010  GETGBL	R8	G4
       0x5C240E00,  //  0011  MOVE	R9	R7
       0x7C200200,  //  0012  CALL	R8	1
-      0x1C201108,  //  0013  EQ	R8	R8	K8
+      0x1C201124,  //  0013  EQ	R8	R8	K36
       0x78220018,  //  0014  JMPF	R8	#002E
-      0x8C200B09,  //  0015  GETMET	R8	R5	K9
+      0x8C200B25,  //  0015  GETMET	R8	R5	K37
       0x7C200200,  //  0016  CALL	R8	1
-      0xB8260200,  //  0017  GETNGBL	R9	K1
-      0x8824130A,  //  0018  GETMBR	R9	R9	K10
+      0xB8261A00,  //  0017  GETNGBL	R9	K13
+      0x8824130E,  //  0018  GETMBR	R9	R9	K14
       0x1C201009,  //  0019  EQ	R8	R8	R9
       0x78220009,  //  001A  JMPF	R8	#0025
-      0x8C20070B,  //  001B  GETMET	R8	R3	K11
+      0x8C200726,  //  001B  GETMET	R8	R3	K38
       0x5C280E00,  //  001C  MOVE	R10	R7
-      0x582C000C,  //  001D  LDCONST	R11	K12
+      0x582C0027,  //  001D  LDCONST	R11	K39
       0x7C200600,  //  001E  CALL	R8	3
       0x78220004,  //  001F  JMPF	R8	#0025
-      0x8C200F0C,  //  0020  GETMET	R8	R7	K12
+      0x8C200F27,  //  0020  GETMET	R8	R7	K39
       0x5C280800,  //  0021  MOVE	R10	R4
       0x5C2C0A00,  //  0022  MOVE	R11	R5
       0x7C200600,  //  0023  CALL	R8	3
       0x70020008,  //  0024  JMP		#002E
-      0x8C20070B,  //  0025  GETMET	R8	R3	K11
+      0x8C200726,  //  0025  GETMET	R8	R3	K38
       0x5C280E00,  //  0026  MOVE	R10	R7
-      0x582C000D,  //  0027  LDCONST	R11	K13
+      0x582C0028,  //  0027  LDCONST	R11	K40
       0x7C200600,  //  0028  CALL	R8	3
       0x78220003,  //  0029  JMPF	R8	#002E
-      0x8C200F0D,  //  002A  GETMET	R8	R7	K13
+      0x8C200F28,  //  002A  GETMET	R8	R7	K40
       0x5C280800,  //  002B  MOVE	R10	R4
       0x5C2C0A00,  //  002C  MOVE	R11	R5
       0x7C200600,  //  002D  CALL	R8	3
@@ -644,43 +650,35 @@ be_local_closure(class_LVGL_glob_widget_dtor_impl,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(lv_obj_class),
-    /* K3   */  be_nested_str_weak(get_object_from_ptr),
-    /* K4   */  be_nested_str_weak(instance),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(widget_destructor),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(widget_dtor_impl),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0xA40E3200,  //  0000  IMPORT	R3	K25
+      0xB8121A00,  //  0001  GETNGBL	R4	K13
+      0x8C100922,  //  0002  GETMET	R4	R4	K34
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x8C14011F,  //  0005  GETMET	R5	R0	K31
       0x5C1C0400,  //  0006  MOVE	R7	R2
       0x7C140400,  //  0007  CALL	R5	2
       0x60180004,  //  0008  GETGBL	R6	G4
       0x5C1C0A00,  //  0009  MOVE	R7	R5
       0x7C180200,  //  000A  CALL	R6	1
-      0x1C180D04,  //  000B  EQ	R6	R6	K4
+      0x1C180D24,  //  000B  EQ	R6	R6	K36
       0x781A0007,  //  000C  JMPF	R6	#0015
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x8C180726,  //  000D  GETMET	R6	R3	K38
       0x5C200A00,  //  000E  MOVE	R8	R5
-      0x58240006,  //  000F  LDCONST	R9	K6
+      0x58240029,  //  000F  LDCONST	R9	K41
       0x7C180600,  //  0010  CALL	R6	3
       0x781A0002,  //  0011  JMPF	R6	#0015
-      0x8C180B06,  //  0012  GETMET	R6	R5	K6
+      0x8C180B29,  //  0012  GETMET	R6	R5	K41
       0x5C200800,  //  0013  MOVE	R8	R4
       0x7C180400,  //  0014  CALL	R6	2
       0x80000000,  //  0015  RET	0
@@ -697,52 +695,42 @@ be_local_closure(class_LVGL_glob_widget_ctor_impl,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(lv_obj_class),
-    /* K3   */  be_nested_str_weak(get_object_from_ptr),
-    /* K4   */  be_nested_str_weak(cb_obj),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(instance),
-    /* K7   */  be_nested_str_weak(get),
-    /* K8   */  be_nested_str_weak(widget_constructor),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(widget_ctor_impl),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0xA40E3200,  //  0000  IMPORT	R3	K25
+      0xB8121A00,  //  0001  GETNGBL	R4	K13
+      0x8C100922,  //  0002  GETMET	R4	R4	K34
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x8C14011F,  //  0005  GETMET	R5	R0	K31
       0x5C1C0400,  //  0006  MOVE	R7	R2
       0x7C140400,  //  0007  CALL	R5	2
-      0x88180104,  //  0008  GETMBR	R6	R0	K4
-      0x8C180D05,  //  0009  GETMET	R6	R6	K5
+      0x88180120,  //  0008  GETMBR	R6	R0	K32
+      0x8C180D2A,  //  0009  GETMET	R6	R6	K42
       0x5C200A00,  //  000A  MOVE	R8	R5
       0x7C180400,  //  000B  CALL	R6	2
       0x781A0001,  //  000C  JMPF	R6	#000F
-      0x88180104,  //  000D  GETMBR	R6	R0	K4
+      0x88180120,  //  000D  GETMBR	R6	R0	K32
       0x94140C05,  //  000E  GETIDX	R5	R6	R5
       0x60180004,  //  000F  GETGBL	R6	G4
       0x5C1C0A00,  //  0010  MOVE	R7	R5
       0x7C180200,  //  0011  CALL	R6	1
-      0x1C180D06,  //  0012  EQ	R6	R6	K6
+      0x1C180D24,  //  0012  EQ	R6	R6	K36
       0x781A0007,  //  0013  JMPF	R6	#001C
-      0x8C180707,  //  0014  GETMET	R6	R3	K7
+      0x8C180726,  //  0014  GETMET	R6	R3	K38
       0x5C200A00,  //  0015  MOVE	R8	R5
-      0x58240008,  //  0016  LDCONST	R9	K8
+      0x5824002B,  //  0016  LDCONST	R9	K43
       0x7C180600,  //  0017  CALL	R6	3
       0x781A0002,  //  0018  JMPF	R6	#001C
-      0x8C180B08,  //  0019  GETMET	R6	R5	K8
+      0x8C180B2B,  //  0019  GETMET	R6	R5	K43
       0x5C200800,  //  001A  MOVE	R8	R4
       0x7C180400,  //  001B  CALL	R6	2
       0x80000000,  //  001C  RET	0
@@ -759,20 +747,18 @@ be_local_closure(class_LVGL_glob__anonymous_,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     0,                          /* argc */
-    0,                          /* varg */
+    8,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(LVG_X3A_X20call_X20to_X20unsupported_X20callback),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(_anonymous_),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x60000001,  //  0000  GETGBL	R0	G1
-      0x58040000,  //  0001  LDCONST	R1	K0
+      0x5804002C,  //  0001  LDCONST	R1	K44
       0x7C000200,  //  0002  CALL	R0	1
       0x80000000,  //  0003  RET	0
     })
@@ -788,7 +774,7 @@ be_local_closure(class_LVGL_glob_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -821,19 +807,15 @@ be_local_closure(class_LVGL_glob_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb),
-    /* K1   */  be_nested_str_weak(add_handler),
-    /* K2   */  be_nested_str_weak(lv_extra),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0x8C08032D,  //  0001  GETMET	R2	R1	K45
       0x84100000,  //  0002  CLOSURE	R4	P0
       0x7C080400,  //  0003  CALL	R2	2
-      0xA40A0400,  //  0004  IMPORT	R2	K2
+      0xA40A5C00,  //  0004  IMPORT	R2	K46
       0xA0000000,  //  0005  CLOSE	R0
       0x80000000,  //  0006  RET	0
     })
@@ -849,25 +831,22 @@ be_local_closure(class_LVGL_glob_get_object_from_ptr,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb_obj),
-    /* K1   */  be_nested_str_weak(find),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(get_object_from_ptr),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080120,  //  0000  GETMBR	R2	R0	K32
       0x4C0C0000,  //  0001  LDNIL	R3
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0004,  //  0003  JMPF	R2	#0009
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x88080120,  //  0004  GETMBR	R2	R0	K32
+      0x8C08052A,  //  0005  GETMET	R2	R2	K42
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
       0x80040400,  //  0008  RET	1	R2
@@ -885,128 +864,100 @@ be_local_closure(class_LVGL_glob_create_custom_widget,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(lv_obj),
-    /* K3   */  be_nested_str_weak(value_error),
-    /* K4   */  be_nested_str_weak(arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj),
-    /* K5   */  be_nested_str_weak(widget_struct_by_class),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(widget_cb),
-    /* K8   */  be_nested_str_weak(widget_struct_default),
-    /* K9   */  be_nested_str_weak(copy),
-    /* K10  */  be_nested_str_weak(base_class),
-    /* K11  */  be_nested_str_weak(_class),
-    /* K12  */  be_nested_str_weak(contains),
-    /* K13  */  be_nested_str_weak(widget_width_def),
-    /* K14  */  be_nested_str_weak(width_def),
-    /* K15  */  be_nested_str_weak(widget_height_def),
-    /* K16  */  be_nested_str_weak(height_def),
-    /* K17  */  be_nested_str_weak(widget_editable),
-    /* K18  */  be_nested_str_weak(editable),
-    /* K19  */  be_nested_str_weak(widget_group_def),
-    /* K20  */  be_nested_str_weak(group_def),
-    /* K21  */  be_nested_str_weak(widget_instance_size),
-    /* K22  */  be_nested_str_weak(instance_size),
-    /* K23  */  be_nested_str_weak(obj_class_create_obj),
-    /* K24  */  be_nested_str_weak(_p),
-    /* K25  */  be_nested_str_weak(register_obj),
-    /* K26  */  be_nested_str_weak(class_init_obj),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(create_custom_widget),
     &be_const_str_solidified,
     ( &(const binstruction[86]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA40E3200,  //  0000  IMPORT	R3	K25
       0x6010000F,  //  0001  GETGBL	R4	G15
       0x5C140200,  //  0002  MOVE	R5	R1
-      0xB81A0200,  //  0003  GETNGBL	R6	K1
-      0x88180D02,  //  0004  GETMBR	R6	R6	K2
+      0xB81A1A00,  //  0003  GETNGBL	R6	K13
+      0x88180D2F,  //  0004  GETMBR	R6	R6	K47
       0x7C100400,  //  0005  CALL	R4	2
       0x74120000,  //  0006  JMPT	R4	#0008
-      0xB0060704,  //  0007  RAISE	1	K3	K4
-      0x88100105,  //  0008  GETMBR	R4	R0	K5
+      0xB0066131,  //  0007  RAISE	1	K48	K49
+      0x88100132,  //  0008  GETMBR	R4	R0	K50
       0x4C140000,  //  0009  LDNIL	R5
       0x1C100805,  //  000A  EQ	R4	R4	R5
       0x78120002,  //  000B  JMPF	R4	#000F
       0x60100013,  //  000C  GETGBL	R4	G19
       0x7C100000,  //  000D  CALL	R4	0
-      0x90020A04,  //  000E  SETMBR	R0	K5	R4
+      0x90026404,  //  000E  SETMBR	R0	K50	R4
       0x60100005,  //  000F  GETGBL	R4	G5
       0x5C140200,  //  0010  MOVE	R5	R1
       0x7C100200,  //  0011  CALL	R4	1
-      0x88140105,  //  0012  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0013  GETMET	R5	R5	K6
+      0x88140132,  //  0012  GETMBR	R5	R0	K50
+      0x8C140B2A,  //  0013  GETMET	R5	R5	K42
       0x5C1C0800,  //  0014  MOVE	R7	R4
       0x7C140400,  //  0015  CALL	R5	2
       0x4C180000,  //  0016  LDNIL	R6
       0x1C180A06,  //  0017  EQ	R6	R5	R6
       0x781A002F,  //  0018  JMPF	R6	#0049
-      0x8C180107,  //  0019  GETMET	R6	R0	K7
+      0x8C180133,  //  0019  GETMET	R6	R0	K51
       0x7C180200,  //  001A  CALL	R6	1
-      0x88180108,  //  001B  GETMBR	R6	R0	K8
-      0x8C180D09,  //  001C  GETMET	R6	R6	K9
+      0x88180134,  //  001B  GETMBR	R6	R0	K52
+      0x8C180D35,  //  001C  GETMET	R6	R6	K53
       0x7C180200,  //  001D  CALL	R6	1
       0x5C140C00,  //  001E  MOVE	R5	R6
       0x60180003,  //  001F  GETGBL	R6	G3
       0x5C1C0200,  //  0020  MOVE	R7	R1
       0x7C180200,  //  0021  CALL	R6	1
-      0x88180D0B,  //  0022  GETMBR	R6	R6	K11
-      0x90161406,  //  0023  SETMBR	R5	K10	R6
-      0x8C18070C,  //  0024  GETMET	R6	R3	K12
+      0x88180D37,  //  0022  GETMBR	R6	R6	K55
+      0x90166C06,  //  0023  SETMBR	R5	K54	R6
+      0x8C180706,  //  0024  GETMET	R6	R3	K6
       0x5C200200,  //  0025  MOVE	R8	R1
-      0x5824000D,  //  0026  LDCONST	R9	K13
+      0x58240038,  //  0026  LDCONST	R9	K56
       0x7C180600,  //  0027  CALL	R6	3
       0x781A0001,  //  0028  JMPF	R6	#002B
-      0x8818030D,  //  0029  GETMBR	R6	R1	K13
-      0x90161C06,  //  002A  SETMBR	R5	K14	R6
-      0x8C18070C,  //  002B  GETMET	R6	R3	K12
+      0x88180338,  //  0029  GETMBR	R6	R1	K56
+      0x90167206,  //  002A  SETMBR	R5	K57	R6
+      0x8C180706,  //  002B  GETMET	R6	R3	K6
       0x5C200200,  //  002C  MOVE	R8	R1
-      0x5824000F,  //  002D  LDCONST	R9	K15
+      0x5824003A,  //  002D  LDCONST	R9	K58
       0x7C180600,  //  002E  CALL	R6	3
       0x781A0001,  //  002F  JMPF	R6	#0032
-      0x8818030F,  //  0030  GETMBR	R6	R1	K15
-      0x90162006,  //  0031  SETMBR	R5	K16	R6
-      0x8C18070C,  //  0032  GETMET	R6	R3	K12
+      0x8818033A,  //  0030  GETMBR	R6	R1	K58
+      0x90167606,  //  0031  SETMBR	R5	K59	R6
+      0x8C180706,  //  0032  GETMET	R6	R3	K6
       0x5C200200,  //  0033  MOVE	R8	R1
-      0x58240011,  //  0034  LDCONST	R9	K17
+      0x5824003C,  //  0034  LDCONST	R9	K60
       0x7C180600,  //  0035  CALL	R6	3
       0x781A0001,  //  0036  JMPF	R6	#0039
-      0x88180311,  //  0037  GETMBR	R6	R1	K17
-      0x90162406,  //  0038  SETMBR	R5	K18	R6
-      0x8C18070C,  //  0039  GETMET	R6	R3	K12
+      0x8818033C,  //  0037  GETMBR	R6	R1	K60
+      0x90167A06,  //  0038  SETMBR	R5	K61	R6
+      0x8C180706,  //  0039  GETMET	R6	R3	K6
       0x5C200200,  //  003A  MOVE	R8	R1
-      0x58240013,  //  003B  LDCONST	R9	K19
+      0x5824003E,  //  003B  LDCONST	R9	K62
       0x7C180600,  //  003C  CALL	R6	3
       0x781A0001,  //  003D  JMPF	R6	#0040
-      0x88180313,  //  003E  GETMBR	R6	R1	K19
-      0x90162806,  //  003F  SETMBR	R5	K20	R6
-      0x8C18070C,  //  0040  GETMET	R6	R3	K12
+      0x8818033E,  //  003E  GETMBR	R6	R1	K62
+      0x90167E06,  //  003F  SETMBR	R5	K63	R6
+      0x8C180706,  //  0040  GETMET	R6	R3	K6
       0x5C200200,  //  0041  MOVE	R8	R1
-      0x58240015,  //  0042  LDCONST	R9	K21
+      0x58240040,  //  0042  LDCONST	R9	K64
       0x7C180600,  //  0043  CALL	R6	3
       0x781A0001,  //  0044  JMPF	R6	#0047
-      0x88180315,  //  0045  GETMBR	R6	R1	K21
-      0x90162C06,  //  0046  SETMBR	R5	K22	R6
-      0x88180105,  //  0047  GETMBR	R6	R0	K5
+      0x88180340,  //  0045  GETMBR	R6	R1	K64
+      0x90168206,  //  0046  SETMBR	R5	K65	R6
+      0x88180132,  //  0047  GETMBR	R6	R0	K50
       0x98180805,  //  0048  SETIDX	R6	R4	R5
-      0xB81A0200,  //  0049  GETNGBL	R6	K1
-      0x8C180D17,  //  004A  GETMET	R6	R6	K23
+      0xB81A1A00,  //  0049  GETNGBL	R6	K13
+      0x8C180D42,  //  004A  GETMET	R6	R6	K66
       0x5C200A00,  //  004B  MOVE	R8	R5
       0x5C240400,  //  004C  MOVE	R9	R2
       0x7C180600,  //  004D  CALL	R6	3
-      0x881C0D18,  //  004E  GETMBR	R7	R6	K24
-      0x90063007,  //  004F  SETMBR	R1	K24	R7
-      0x8C1C0119,  //  0050  GETMET	R7	R0	K25
+      0x881C0D11,  //  004E  GETMBR	R7	R6	K17
+      0x90062207,  //  004F  SETMBR	R1	K17	R7
+      0x8C1C010B,  //  0050  GETMET	R7	R0	K11
       0x5C240200,  //  0051  MOVE	R9	R1
       0x7C1C0400,  //  0052  CALL	R7	2
-      0x8C1C031A,  //  0053  GETMET	R7	R1	K26
+      0x8C1C0343,  //  0053  GETMET	R7	R1	K67
       0x7C1C0200,  //  0054  CALL	R7	1
       0x80000000,  //  0055  RET	0
     })
@@ -1022,7 +973,7 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1104,78 +1055,62 @@ be_local_closure(class_LVGL_glob_widget_cb,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb),
-    /* K1   */  be_nested_str_weak(widget_ctor_cb),
-    /* K2   */  be_nested_str_weak(gen_cb),
-    /* K3   */  be_nested_str_weak(widget_dtor_cb),
-    /* K4   */  be_nested_str_weak(widget_event_cb),
-    /* K5   */  be_nested_str_weak(widget_struct_default),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(lv_obj_class),
-    /* K8   */  be_nested_str_weak(lv_obj),
-    /* K9   */  be_nested_str_weak(_class),
-    /* K10  */  be_nested_str_weak(copy),
-    /* K11  */  be_nested_str_weak(base_class),
-    /* K12  */  be_nested_str_weak(constructor_cb),
-    /* K13  */  be_nested_str_weak(destructor_cb),
-    /* K14  */  be_nested_str_weak(event_cb),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(widget_cb),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0xA4060200,  //  0000  IMPORT	R1	K1
+      0x88080144,  //  0001  GETMBR	R2	R0	K68
       0x4C0C0000,  //  0002  LDNIL	R3
       0x1C080403,  //  0003  EQ	R2	R2	R3
       0x780A0003,  //  0004  JMPF	R2	#0009
       0x8C080302,  //  0005  GETMET	R2	R1	K2
       0x84100000,  //  0006  CLOSURE	R4	P0
       0x7C080400,  //  0007  CALL	R2	2
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x90028802,  //  0008  SETMBR	R0	K68	R2
+      0x88080145,  //  0009  GETMBR	R2	R0	K69
       0x4C0C0000,  //  000A  LDNIL	R3
       0x1C080403,  //  000B  EQ	R2	R2	R3
       0x780A0003,  //  000C  JMPF	R2	#0011
       0x8C080302,  //  000D  GETMET	R2	R1	K2
       0x84100001,  //  000E  CLOSURE	R4	P1
       0x7C080400,  //  000F  CALL	R2	2
-      0x90020602,  //  0010  SETMBR	R0	K3	R2
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x90028A02,  //  0010  SETMBR	R0	K69	R2
+      0x88080146,  //  0011  GETMBR	R2	R0	K70
       0x4C0C0000,  //  0012  LDNIL	R3
       0x1C080403,  //  0013  EQ	R2	R2	R3
       0x780A0003,  //  0014  JMPF	R2	#0019
       0x8C080302,  //  0015  GETMET	R2	R1	K2
       0x84100002,  //  0016  CLOSURE	R4	P2
       0x7C080400,  //  0017  CALL	R2	2
-      0x90020802,  //  0018  SETMBR	R0	K4	R2
-      0x88080105,  //  0019  GETMBR	R2	R0	K5
+      0x90028C02,  //  0018  SETMBR	R0	K70	R2
+      0x88080134,  //  0019  GETMBR	R2	R0	K52
       0x4C0C0000,  //  001A  LDNIL	R3
       0x1C080403,  //  001B  EQ	R2	R2	R3
       0x780A0016,  //  001C  JMPF	R2	#0034
-      0xB80A0C00,  //  001D  GETNGBL	R2	K6
-      0x8C080507,  //  001E  GETMET	R2	R2	K7
-      0xB8120C00,  //  001F  GETNGBL	R4	K6
-      0x88100908,  //  0020  GETMBR	R4	R4	K8
-      0x88100909,  //  0021  GETMBR	R4	R4	K9
+      0xB80A1A00,  //  001D  GETNGBL	R2	K13
+      0x8C080522,  //  001E  GETMET	R2	R2	K34
+      0xB8121A00,  //  001F  GETNGBL	R4	K13
+      0x8810092F,  //  0020  GETMBR	R4	R4	K47
+      0x88100937,  //  0021  GETMBR	R4	R4	K55
       0x7C080400,  //  0022  CALL	R2	2
-      0x8C08050A,  //  0023  GETMET	R2	R2	K10
+      0x8C080535,  //  0023  GETMET	R2	R2	K53
       0x7C080200,  //  0024  CALL	R2	1
-      0x90020A02,  //  0025  SETMBR	R0	K5	R2
-      0x88080105,  //  0026  GETMBR	R2	R0	K5
-      0xB80E0C00,  //  0027  GETNGBL	R3	K6
-      0x880C0708,  //  0028  GETMBR	R3	R3	K8
-      0x880C0709,  //  0029  GETMBR	R3	R3	K9
-      0x900A1603,  //  002A  SETMBR	R2	K11	R3
-      0x88080105,  //  002B  GETMBR	R2	R0	K5
-      0x880C0101,  //  002C  GETMBR	R3	R0	K1
-      0x900A1803,  //  002D  SETMBR	R2	K12	R3
-      0x88080105,  //  002E  GETMBR	R2	R0	K5
-      0x880C0103,  //  002F  GETMBR	R3	R0	K3
-      0x900A1A03,  //  0030  SETMBR	R2	K13	R3
-      0x88080105,  //  0031  GETMBR	R2	R0	K5
-      0x880C0104,  //  0032  GETMBR	R3	R0	K4
-      0x900A1C03,  //  0033  SETMBR	R2	K14	R3
+      0x90026802,  //  0025  SETMBR	R0	K52	R2
+      0x88080134,  //  0026  GETMBR	R2	R0	K52
+      0xB80E1A00,  //  0027  GETNGBL	R3	K13
+      0x880C072F,  //  0028  GETMBR	R3	R3	K47
+      0x880C0737,  //  0029  GETMBR	R3	R3	K55
+      0x900A6C03,  //  002A  SETMBR	R2	K54	R3
+      0x88080134,  //  002B  GETMBR	R2	R0	K52
+      0x880C0144,  //  002C  GETMBR	R3	R0	K68
+      0x900A8E03,  //  002D  SETMBR	R2	K71	R3
+      0x88080134,  //  002E  GETMBR	R2	R0	K52
+      0x880C0145,  //  002F  GETMBR	R3	R0	K69
+      0x900A9003,  //  0030  SETMBR	R2	K72	R3
+      0x88080134,  //  0031  GETMBR	R2	R0	K52
+      0x880C0146,  //  0032  GETMBR	R3	R0	K70
+      0x900A0003,  //  0033  SETMBR	R2	K0	R3
       0xA0000000,  //  0034  CLOSE	R0
       0x80000000,  //  0035  RET	0
     })
@@ -1191,23 +1126,19 @@ be_local_closure(class_LVGL_glob_remove_cb,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(_p),
-    /* K2   */  be_nested_str_weak(deregister_obj),
-    }),
+    &be_ktab_class_LVGL_glob,     /* shared constants */
     be_str_weak(remove_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0xA40A3200,  //  0000  IMPORT	R2	K25
+      0x880C0311,  //  0001  GETMBR	R3	R1	K17
+      0x8C100149,  //  0002  GETMET	R4	R0	K73
       0x5C180600,  //  0003  MOVE	R6	R3
       0x7C100400,  //  0004  CALL	R4	2
       0x80000000,  //  0005  RET	0

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -3,6 +3,75 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_lvh_root;
+// compact class 'lvh_root' ktab size: 64, total: 95 (saved 248 bytes)
+static const bvalue be_ktab_class_lvh_root[64] = {
+  /* K0   */  be_nested_str_weak(_text_rule_formula),
+  /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
+  /* K2   */  be_nested_str_weak(_X29),
+  /* K3   */  be_nested_str_weak(_text_rule_function),
+  /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+  /* K5   */  be_nested_str_weak(_text_rule),
+  /* K6   */  be_nested_str_weak(_val_rule_function),
+  /* K7   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+  /* K8   */  be_nested_str_weak(val),
+  /* K9   */  be_nested_str_weak(int),
+  /* K10  */  be_nested_str_weak(lv),
+  /* K11  */  be_nested_str_weak(font_embedded),
+  /* K12  */  be_nested_str_weak(robotocondensed),
+  /* K13  */  be_nested_str_weak(montserrat),
+  /* K14  */  be_nested_str_weak(HSP_X3A_X20Unsupported_X20font_X3A),
+  /* K15  */  be_nested_str_weak(string),
+  /* K16  */  be_nested_str_weak(split),
+  /* K17  */  be_nested_str_weak(_X3A),
+  /* K18  */  be_const_int(1),
+  /* K19  */  be_nested_str_weak(_X2D),
+  /* K20  */  be_const_int(0),
+  /* K21  */  be_const_int(2),
+  /* K22  */  be_nested_str_weak(concat),
+  /* K23  */  be_nested_str_weak(endswith),
+  /* K24  */  be_nested_str_weak(_X2Ettf),
+  /* K25  */  be_nested_str_weak(load_freetype_font),
+  /* K26  */  be_nested_str_weak(load_font),
+  /* K27  */  be_nested_str_weak(_val_rule_formula),
+  /* K28  */  be_nested_str_weak(_val),
+  /* K29  */  be_nested_str_weak(set_val),
+  /* K30  */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+  /* K31  */  be_nested_str_weak(_text_rule_format),
+  /* K32  */  be_nested_str_weak(),
+  /* K33  */  be_nested_str_weak(text),
+  /* K34  */  be_nested_str_weak(_meta),
+  /* K35  */  be_nested_str_weak(set_text),
+  /* K36  */  be_nested_str_weak(_page),
+  /* K37  */  be_nested_str_weak(_parent_lvh),
+  /* K38  */  be_nested_str_weak(_lv_class),
+  /* K39  */  be_nested_str_weak(_lv_obj),
+  /* K40  */  be_nested_str_weak(post_init),
+  /* K41  */  be_nested_str_weak(delete),
+  /* K42  */  be_const_class(be_class_lvh_root),
+  /* K43  */  be_nested_str_weak(resize),
+  /* K44  */  be_nested_str_weak(remove_val_rule),
+  /* K45  */  be_nested_str_weak(_val_rule),
+  /* K46  */  be_nested_str_weak(tasmota),
+  /* K47  */  be_nested_str_weak(add_rule),
+  /* K48  */  be_const_int(0),
+  /* K49  */  be_nested_str_weak(_digit2part),
+  /* K50  */  be_nested_str_weak(_digit2state),
+  /* K51  */  be_nested_str_weak(invalid_X20style_X20suffix_X20_X2502i),
+  /* K52  */  be_nested_str_weak(value_error),
+  /* K53  */  be_nested_str_weak(remove_rule),
+  /* K54  */  be_nested_str_weak(color),
+  /* K55  */  be_nested_str_weak(type_error),
+  /* K56  */  be_nested_str_weak(you_X20cannot_X20assign_X20to_X20_X27delete_X27),
+  /* K57  */  be_nested_str_weak(get_text),
+  /* K58  */  be_nested_str_weak(_X23),
+  /* K59  */  be_nested_str_weak(introspect),
+  /* K60  */  be_nested_str_weak(COLOR_),
+  /* K61  */  be_nested_str_weak(toupper),
+  /* K62  */  be_nested_str_weak(get),
+  /* K63  */  be_nested_str_weak(remove_text_rule),
+};
+
 
 extern const bclass be_class_lvh_root;
 
@@ -13,13 +82,13 @@ be_local_closure(class_lvh_root_get_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -38,15 +107,13 @@ be_local_closure(class_lvh_root_get_text_rule_formula,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_text_rule_formula),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -65,19 +132,13 @@ be_local_closure(class_lvh_root_set_text_rule_formula,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_text_rule_function),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_text_rule_formula),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
@@ -123,19 +184,17 @@ be_local_closure(class_lvh_root_get_text_rule,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_text_rule),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -150,13 +209,13 @@ be_local_closure(class_lvh_root_set_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -174,17 +233,13 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_function),
-    /* K1   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K2   */  be_nested_str_weak(val),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(val_rule_matched),
     &be_const_str_solidified,
     ( &(const binstruction[36]) {  /* code */
@@ -196,7 +251,7 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
       0x780E0001,  //  0005  JMPF	R3	#0008
       0x500C0000,  //  0006  LDBOOL	R3	0	0
       0x80040600,  //  0007  RET	1	R3
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x880C0106,  //  0008  GETMBR	R3	R0	K6
       0x4C100000,  //  0009  LDNIL	R4
       0x20100604,  //  000A  NE	R4	R3	R4
       0x78120011,  //  000B  JMPF	R4	#001E
@@ -211,7 +266,7 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
       0x70020007,  //  0014  JMP		#001D
       0x60180001,  //  0015  GETGBL	R6	G1
       0x601C0018,  //  0016  GETGBL	R7	G24
-      0x58200001,  //  0017  LDCONST	R8	K1
+      0x58200007,  //  0017  LDCONST	R8	K7
       0x5C240800,  //  0018  MOVE	R9	R4
       0x5C280A00,  //  0019  MOVE	R10	R5
       0x7C1C0600,  //  001A  CALL	R7	3
@@ -221,7 +276,7 @@ be_local_closure(class_lvh_root_val_rule_matched,   /* name */
       0x60100009,  //  001E  GETGBL	R4	G9
       0x5C140400,  //  001F  MOVE	R5	R2
       0x7C100200,  //  0020  CALL	R4	1
-      0x90020404,  //  0021  SETMBR	R0	K2	R4
+      0x90021004,  //  0021  SETMBR	R0	K8	R4
       0x50100000,  //  0022  LDBOOL	R4	0	0
       0x80040800,  //  0023  RET	1	R4
     })
@@ -237,32 +292,13 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(font_embedded),
-    /* K3   */  be_nested_str_weak(robotocondensed),
-    /* K4   */  be_nested_str_weak(montserrat),
-    /* K5   */  be_nested_str_weak(HSP_X3A_X20Unsupported_X20font_X3A),
-    /* K6   */  be_nested_str_weak(string),
-    /* K7   */  be_nested_str_weak(split),
-    /* K8   */  be_nested_str_weak(_X3A),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(_X2D),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(concat),
-    /* K14  */  be_nested_str_weak(endswith),
-    /* K15  */  be_nested_str_weak(_X2Ettf),
-    /* K16  */  be_nested_str_weak(load_freetype_font),
-    /* K17  */  be_nested_str_weak(load_font),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(parse_font),
     &be_const_str_solidified,
     ( &(const binstruction[148]) {  /* code */
@@ -270,12 +306,12 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0x600C0004,  //  0001  GETGBL	R3	G4
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x1C0C0700,  //  0004  EQ	R3	R3	K0
+      0x1C0C0709,  //  0004  EQ	R3	R3	K9
       0x780E0020,  //  0005  JMPF	R3	#0027
       0xA8020007,  //  0006  EXBLK	0	#000F
-      0xB80E0200,  //  0007  GETNGBL	R3	K1
-      0x8C0C0702,  //  0008  GETMET	R3	R3	K2
-      0x58140003,  //  0009  LDCONST	R5	K3
+      0xB80E1400,  //  0007  GETNGBL	R3	K10
+      0x8C0C070B,  //  0008  GETMET	R3	R3	K11
+      0x5814000C,  //  0009  LDCONST	R5	K12
       0x5C180200,  //  000A  MOVE	R6	R1
       0x7C0C0600,  //  000B  CALL	R3	3
       0x5C080600,  //  000C  MOVE	R2	R3
@@ -284,9 +320,9 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0xAC0C0000,  //  000F  CATCH	R3	0	0
       0x70020013,  //  0010  JMP		#0025
       0xA8020007,  //  0011  EXBLK	0	#001A
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x58140004,  //  0014  LDCONST	R5	K4
+      0xB80E1400,  //  0012  GETNGBL	R3	K10
+      0x8C0C070B,  //  0013  GETMET	R3	R3	K11
+      0x5814000D,  //  0014  LDCONST	R5	K13
       0x5C180200,  //  0015  MOVE	R6	R1
       0x7C0C0600,  //  0016  CALL	R3	3
       0x5C080600,  //  0017  MOVE	R2	R3
@@ -295,7 +331,7 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0xAC0C0000,  //  001A  CATCH	R3	0	0
       0x70020006,  //  001B  JMP		#0023
       0x600C0001,  //  001C  GETGBL	R3	G1
-      0x58100005,  //  001D  LDCONST	R4	K5
+      0x5810000E,  //  001D  LDCONST	R4	K14
       0x5C140200,  //  001E  MOVE	R5	R1
       0x7C0C0400,  //  001F  CALL	R3	2
       0x4C0C0000,  //  0020  LDNIL	R3
@@ -308,28 +344,28 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0x600C0004,  //  0027  GETGBL	R3	G4
       0x5C100200,  //  0028  MOVE	R4	R1
       0x7C0C0200,  //  0029  CALL	R3	1
-      0x1C0C0706,  //  002A  EQ	R3	R3	K6
+      0x1C0C070F,  //  002A  EQ	R3	R3	K15
       0x780E005D,  //  002B  JMPF	R3	#008A
-      0xA40E0C00,  //  002C  IMPORT	R3	K6
-      0x8C100707,  //  002D  GETMET	R4	R3	K7
+      0xA40E1E00,  //  002C  IMPORT	R3	K15
+      0x8C100710,  //  002D  GETMET	R4	R3	K16
       0x5C180200,  //  002E  MOVE	R6	R1
-      0x581C0008,  //  002F  LDCONST	R7	K8
-      0x58200009,  //  0030  LDCONST	R8	K9
+      0x581C0011,  //  002F  LDCONST	R7	K17
+      0x58200012,  //  0030  LDCONST	R8	K18
       0x7C100800,  //  0031  CALL	R4	4
-      0x8C140707,  //  0032  GETMET	R5	R3	K7
+      0x8C140710,  //  0032  GETMET	R5	R3	K16
       0x5C1C0200,  //  0033  MOVE	R7	R1
-      0x5820000A,  //  0034  LDCONST	R8	K10
+      0x58200013,  //  0034  LDCONST	R8	K19
       0x7C140600,  //  0035  CALL	R5	3
       0x5C180200,  //  0036  MOVE	R6	R1
-      0x581C000B,  //  0037  LDCONST	R7	K11
+      0x581C0014,  //  0037  LDCONST	R7	K20
       0x50200000,  //  0038  LDBOOL	R8	0	0
       0x6024000C,  //  0039  GETGBL	R9	G12
       0x5C280800,  //  003A  MOVE	R10	R4
       0x7C240200,  //  003B  CALL	R9	1
-      0x24241309,  //  003C  GT	R9	R9	K9
+      0x24241312,  //  003C  GT	R9	R9	K18
       0x78260003,  //  003D  JMPF	R9	#0042
       0x6024000C,  //  003E  GETGBL	R9	G12
-      0x9428090B,  //  003F  GETIDX	R10	R4	K11
+      0x94280914,  //  003F  GETIDX	R10	R4	K20
       0x7C240200,  //  0040  CALL	R9	1
       0x74260000,  //  0041  JMPT	R9	#0043
       0x50240001,  //  0042  LDBOOL	R9	0	1
@@ -337,7 +373,7 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0x6028000C,  //  0044  GETGBL	R10	G12
       0x5C2C0A00,  //  0045  MOVE	R11	R5
       0x7C280200,  //  0046  CALL	R10	1
-      0x2828150C,  //  0047  GE	R10	R10	K12
+      0x28281515,  //  0047  GE	R10	R10	K21
       0x782A000B,  //  0048  JMPF	R10	#0055
       0x60280009,  //  0049  GETGBL	R10	G9
       0x542DFFFE,  //  004A  LDINT	R11	-1
@@ -345,51 +381,51 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0x7C280200,  //  004C  CALL	R10	1
       0x5C1C1400,  //  004D  MOVE	R7	R10
       0x5429FFFD,  //  004E  LDINT	R10	-2
-      0x402A160A,  //  004F  CONNECT	R10	K11	R10
+      0x402A280A,  //  004F  CONNECT	R10	K20	R10
       0x94280A0A,  //  0050  GETIDX	R10	R5	R10
-      0x8C28150D,  //  0051  GETMET	R10	R10	K13
-      0x5830000A,  //  0052  LDCONST	R12	K10
+      0x8C281516,  //  0051  GETMET	R10	R10	K22
+      0x58300013,  //  0052  LDCONST	R12	K19
       0x7C280400,  //  0053  CALL	R10	2
       0x5C181400,  //  0054  MOVE	R6	R10
-      0x8C28070E,  //  0055  GETMET	R10	R3	K14
+      0x8C280717,  //  0055  GETMET	R10	R3	K23
       0x5C300C00,  //  0056  MOVE	R12	R6
-      0x5834000F,  //  0057  LDCONST	R13	K15
+      0x58340018,  //  0057  LDCONST	R13	K24
       0x50380200,  //  0058  LDBOOL	R14	1	0
       0x7C280800,  //  0059  CALL	R10	4
       0x782A0006,  //  005A  JMPF	R10	#0062
-      0x8C280707,  //  005B  GETMET	R10	R3	K7
+      0x8C280710,  //  005B  GETMET	R10	R3	K16
       0x5C300C00,  //  005C  MOVE	R12	R6
-      0x58340008,  //  005D  LDCONST	R13	K8
+      0x58340011,  //  005D  LDCONST	R13	K17
       0x7C280600,  //  005E  CALL	R10	3
       0x542DFFFE,  //  005F  LDINT	R11	-1
       0x9418140B,  //  0060  GETIDX	R6	R10	R11
       0x50200200,  //  0061  LDBOOL	R8	1	0
       0x78220007,  //  0062  JMPF	R8	#006B
-      0xB82A0200,  //  0063  GETNGBL	R10	K1
-      0x8C281510,  //  0064  GETMET	R10	R10	K16
+      0xB82A1400,  //  0063  GETNGBL	R10	K10
+      0x8C281519,  //  0064  GETMET	R10	R10	K25
       0x5C300C00,  //  0065  MOVE	R12	R6
       0x5C340E00,  //  0066  MOVE	R13	R7
-      0x5838000B,  //  0067  LDCONST	R14	K11
+      0x58380014,  //  0067  LDCONST	R14	K20
       0x7C280800,  //  0068  CALL	R10	4
       0x5C081400,  //  0069  MOVE	R2	R10
       0x7002001E,  //  006A  JMP		#008A
       0x78260005,  //  006B  JMPF	R9	#0072
-      0xB82A0200,  //  006C  GETNGBL	R10	K1
-      0x8C281511,  //  006D  GETMET	R10	R10	K17
+      0xB82A1400,  //  006C  GETNGBL	R10	K10
+      0x8C28151A,  //  006D  GETMET	R10	R10	K26
       0x5C300200,  //  006E  MOVE	R12	R1
       0x7C280400,  //  006F  CALL	R10	2
       0x5C081400,  //  0070  MOVE	R2	R10
       0x70020017,  //  0071  JMP		#008A
-      0x24280F0B,  //  0072  GT	R10	R7	K11
+      0x24280F14,  //  0072  GT	R10	R7	K20
       0x782A0015,  //  0073  JMPF	R10	#008A
       0x6028000C,  //  0074  GETGBL	R10	G12
       0x5C2C0C00,  //  0075  MOVE	R11	R6
       0x7C280200,  //  0076  CALL	R10	1
-      0x2428150B,  //  0077  GT	R10	R10	K11
+      0x24281514,  //  0077  GT	R10	R10	K20
       0x782A0010,  //  0078  JMPF	R10	#008A
       0xA8020007,  //  0079  EXBLK	0	#0082
-      0xB82A0200,  //  007A  GETNGBL	R10	K1
-      0x8C281502,  //  007B  GETMET	R10	R10	K2
+      0xB82A1400,  //  007A  GETNGBL	R10	K10
+      0x8C28150B,  //  007B  GETMET	R10	R10	K11
       0x5C300C00,  //  007C  MOVE	R12	R6
       0x5C340E00,  //  007D  MOVE	R13	R7
       0x7C280600,  //  007E  CALL	R10	3
@@ -399,7 +435,7 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0xAC280000,  //  0082  CATCH	R10	0	0
       0x70020004,  //  0083  JMP		#0089
       0x60280001,  //  0084  GETGBL	R10	G1
-      0x582C0005,  //  0085  LDCONST	R11	K5
+      0x582C000E,  //  0085  LDCONST	R11	K14
       0x5C300200,  //  0086  MOVE	R12	R1
       0x7C280400,  //  0087  CALL	R10	2
       0x70020000,  //  0088  JMP		#008A
@@ -410,7 +446,7 @@ be_local_closure(class_lvh_root_parse_font,   /* name */
       0x80040400,  //  008D  RET	1	R2
       0x70020003,  //  008E  JMP		#0093
       0x600C0001,  //  008F  GETGBL	R3	G1
-      0x58100005,  //  0090  LDCONST	R4	K5
+      0x5810000E,  //  0090  LDCONST	R4	K14
       0x5C140200,  //  0091  MOVE	R5	R1
       0x7C0C0400,  //  0092  CALL	R3	2
       0x80000000,  //  0093  RET	0
@@ -427,19 +463,17 @@ be_local_closure(class_lvh_root_get_val_rule_formula,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_val_rule_formula),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011B,  //  0000  GETMBR	R1	R0	K27
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -454,25 +488,22 @@ be_local_closure(class_lvh_root_post_config,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(set_val),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(post_config),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011C,  //  0000  GETMBR	R1	R0	K28
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060002,  //  0003  JMPF	R1	#0007
-      0x8C040101,  //  0004  GETMET	R1	R0	K1
-      0x880C0100,  //  0005  GETMBR	R3	R0	K0
+      0x8C04011D,  //  0004  GETMET	R1	R0	K29
+      0x880C011C,  //  0005  GETMBR	R3	R0	K28
       0x7C040400,  //  0006  CALL	R1	2
       0x80000000,  //  0007  RET	0
     })
@@ -488,34 +519,26 @@ be_local_closure(class_lvh_root_text_rule_matched,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int),
-    /* K1   */  be_nested_str_weak(_text_rule_function),
-    /* K2   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K3   */  be_nested_str_weak(_text_rule_format),
-    /* K4   */  be_nested_str_weak(string),
-    /* K5   */  be_nested_str_weak(),
-    /* K6   */  be_nested_str_weak(text),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(text_rule_matched),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x1C080509,  //  0003  EQ	R2	R2	K9
       0x780A0003,  //  0004  JMPF	R2	#0009
       0x6008000A,  //  0005  GETGBL	R2	G10
       0x5C0C0200,  //  0006  MOVE	R3	R1
       0x7C080200,  //  0007  CALL	R2	1
       0x5C040400,  //  0008  MOVE	R1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
       0x4C0C0000,  //  000A  LDNIL	R3
       0x200C0403,  //  000B  NE	R3	R2	R3
       0x780E0011,  //  000C  JMPF	R3	#001F
@@ -530,18 +553,18 @@ be_local_closure(class_lvh_root_text_rule_matched,   /* name */
       0x70020007,  //  0015  JMP		#001E
       0x60140001,  //  0016  GETGBL	R5	G1
       0x60180018,  //  0017  GETGBL	R6	G24
-      0x581C0002,  //  0018  LDCONST	R7	K2
+      0x581C001E,  //  0018  LDCONST	R7	K30
       0x5C200600,  //  0019  MOVE	R8	R3
       0x5C240800,  //  001A  MOVE	R9	R4
       0x7C180600,  //  001B  CALL	R6	3
       0x7C140200,  //  001C  CALL	R5	1
       0x70020000,  //  001D  JMP		#001F
       0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x880C0103,  //  001F  GETMBR	R3	R0	K3
+      0x880C011F,  //  001F  GETMBR	R3	R0	K31
       0x60100004,  //  0020  GETGBL	R4	G4
       0x5C140600,  //  0021  MOVE	R5	R3
       0x7C100200,  //  0022  CALL	R4	1
-      0x1C100904,  //  0023  EQ	R4	R4	K4
+      0x1C10090F,  //  0023  EQ	R4	R4	K15
       0x78120005,  //  0024  JMPF	R4	#002B
       0x60100018,  //  0025  GETGBL	R4	G24
       0x5C140600,  //  0026  MOVE	R5	R3
@@ -549,8 +572,8 @@ be_local_closure(class_lvh_root_text_rule_matched,   /* name */
       0x7C100400,  //  0028  CALL	R4	2
       0x5C0C0800,  //  0029  MOVE	R3	R4
       0x70020000,  //  002A  JMP		#002C
-      0x580C0005,  //  002B  LDCONST	R3	K5
-      0x90020C03,  //  002C  SETMBR	R0	K6	R3
+      0x580C0020,  //  002B  LDCONST	R3	K32
+      0x90024203,  //  002C  SETMBR	R0	K33	R3
       0x50100000,  //  002D  LDBOOL	R4	0	0
       0x80040800,  //  002E  RET	1	R4
     })
@@ -566,19 +589,17 @@ be_local_closure(class_lvh_root_get_meta,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_meta),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_meta),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040122,  //  0000  GETMBR	R1	R0	K34
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -593,19 +614,17 @@ be_local_closure(class_lvh_root_set_value_str,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_value_str),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080123,  //  0000  GETMET	R2	R0	K35
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x80000000,  //  0003  RET	0
@@ -622,37 +641,31 @@ be_local_closure(class_lvh_root_init,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_parent_lvh),
-    /* K2   */  be_nested_str_weak(_lv_class),
-    /* K3   */  be_nested_str_weak(_lv_obj),
-    /* K4   */  be_nested_str_weak(post_init),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x90020002,  //  0000  SETMBR	R0	K0	R2
-      0x90020205,  //  0001  SETMBR	R0	K1	R5
+      0x90024802,  //  0000  SETMBR	R0	K36	R2
+      0x90024A05,  //  0001  SETMBR	R0	K37	R5
       0x4C180000,  //  0002  LDNIL	R6
       0x1C180806,  //  0003  EQ	R6	R4	R6
       0x781A0007,  //  0004  JMPF	R6	#000D
-      0x88180102,  //  0005  GETMBR	R6	R0	K2
+      0x88180126,  //  0005  GETMBR	R6	R0	K38
       0x781A0005,  //  0006  JMPF	R6	#000D
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x88180126,  //  0007  GETMBR	R6	R0	K38
       0x5C1C0C00,  //  0008  MOVE	R7	R6
       0x5C200200,  //  0009  MOVE	R8	R1
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x90020607,  //  000B  SETMBR	R0	K3	R7
+      0x90024E07,  //  000B  SETMBR	R0	K39	R7
       0x70020000,  //  000C  JMP		#000E
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0x8C180104,  //  000E  GETMET	R6	R0	K4
+      0x90024E04,  //  000D  SETMBR	R0	K39	R4
+      0x8C180128,  //  000E  GETMET	R6	R0	K40
       0x7C180200,  //  000F  CALL	R6	1
       0x80000000,  //  0010  RET	0
     })
@@ -668,19 +681,17 @@ be_local_closure(class_lvh_root_get_delete,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(delete),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_delete),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040129,  //  0000  GETMET	R1	R0	K41
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -696,39 +707,34 @@ be_local_closure(class_lvh_root_remove_trailing_zeroes,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_root),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(resize),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(remove_trailing_zeroes),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804002A,  //  0000  LDCONST	R1	K42
       0x6008000C,  //  0001  GETGBL	R2	G12
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C080200,  //  0003  CALL	R2	1
-      0x580C0001,  //  0004  LDCONST	R3	K1
+      0x580C0014,  //  0004  LDCONST	R3	K20
       0x14100602,  //  0005  LT	R4	R3	R2
       0x78120007,  //  0006  JMPF	R4	#000F
       0x5411FFFE,  //  0007  LDINT	R4	-1
       0x04100803,  //  0008  SUB	R4	R4	R3
       0x94100004,  //  0009  GETIDX	R4	R0	R4
-      0x20100901,  //  000A  NE	R4	R4	K1
+      0x20100914,  //  000A  NE	R4	R4	K20
       0x78120000,  //  000B  JMPF	R4	#000D
       0x70020001,  //  000C  JMP		#000F
-      0x000C0702,  //  000D  ADD	R3	R3	K2
+      0x000C0712,  //  000D  ADD	R3	R3	K18
       0x7001FFF5,  //  000E  JMP		#0005
-      0x24100701,  //  000F  GT	R4	R3	K1
+      0x24100714,  //  000F  GT	R4	R3	K20
       0x78120005,  //  0010  JMPF	R4	#0017
-      0x8C100103,  //  0011  GETMET	R4	R0	K3
+      0x8C10012B,  //  0011  GETMET	R4	R0	K43
       0x6018000C,  //  0012  GETGBL	R6	G12
       0x5C1C0000,  //  0013  MOVE	R7	R0
       0x7C180200,  //  0014  CALL	R6	1
@@ -748,7 +754,7 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -779,24 +785,19 @@ be_local_closure(class_lvh_root_set_val_rule,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_val_rule),
-    /* K1   */  be_nested_str_weak(_val_rule),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_val_rule),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08012C,  //  0000  GETMET	R2	R0	K44
       0x7C080200,  //  0001  CALL	R2	1
       0x60080008,  //  0002  GETGBL	R2	G8
       0x5C0C0200,  //  0003  MOVE	R3	R1
       0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x90025A02,  //  0005  SETMBR	R0	K45	R2
+      0xB80A5C00,  //  0006  GETNGBL	R2	K46
+      0x8C08052F,  //  0007  GETMET	R2	R2	K47
+      0x8810012D,  //  0008  GETMBR	R4	R0	K45
       0x84140000,  //  0009  CLOSURE	R5	P0
       0x5C180000,  //  000A  MOVE	R6	R0
       0x7C080800,  //  000B  CALL	R2	4
@@ -815,19 +816,17 @@ be_local_closure(class_lvh_root_get_val_rule,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_val_rule),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804012D,  //  0000  GETMBR	R1	R0	K45
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -842,53 +841,47 @@ be_local_closure(class_lvh_root_digits_to_style,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(_digit2part),
-    /* K2   */  be_nested_str_weak(_digit2state),
-    /* K3   */  be_nested_str_weak(invalid_X20style_X20suffix_X20_X2502i),
-    /* K4   */  be_nested_str_weak(value_error),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(digits_to_style),
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80060000,  //  0003  RET	1	K0
+      0x80066000,  //  0003  RET	1	K48
       0x540A0009,  //  0004  LDINT	R2	10
       0x0C080202,  //  0005  DIV	R2	R1	R2
       0x540E0009,  //  0006  LDINT	R3	10
       0x10080403,  //  0007  MOD	R2	R2	R3
       0x540E0009,  //  0008  LDINT	R3	10
       0x100C0203,  //  0009  MOD	R3	R1	R3
-      0x58100000,  //  000A  LDCONST	R4	K0
-      0x28140500,  //  000B  GE	R5	R2	K0
+      0x58100030,  //  000A  LDCONST	R4	K48
+      0x28140530,  //  000B  GE	R5	R2	K48
       0x78160008,  //  000C  JMPF	R5	#0016
       0x6014000C,  //  000D  GETGBL	R5	G12
-      0x88180101,  //  000E  GETMBR	R6	R0	K1
+      0x88180131,  //  000E  GETMBR	R6	R0	K49
       0x7C140200,  //  000F  CALL	R5	1
       0x14140405,  //  0010  LT	R5	R2	R5
       0x78160003,  //  0011  JMPF	R5	#0016
-      0x88140101,  //  0012  GETMBR	R5	R0	K1
+      0x88140131,  //  0012  GETMBR	R5	R0	K49
       0x94140A02,  //  0013  GETIDX	R5	R5	R2
       0x30100805,  //  0014  OR	R4	R4	R5
       0x70020000,  //  0015  JMP		#0017
       0x4C100000,  //  0016  LDNIL	R4
-      0x28140700,  //  0017  GE	R5	R3	K0
+      0x28140730,  //  0017  GE	R5	R3	K48
       0x78160008,  //  0018  JMPF	R5	#0022
       0x6014000C,  //  0019  GETGBL	R5	G12
-      0x88180102,  //  001A  GETMBR	R6	R0	K2
+      0x88180132,  //  001A  GETMBR	R6	R0	K50
       0x7C140200,  //  001B  CALL	R5	1
       0x14140605,  //  001C  LT	R5	R3	R5
       0x78160003,  //  001D  JMPF	R5	#0022
-      0x88140102,  //  001E  GETMBR	R5	R0	K2
+      0x88140132,  //  001E  GETMBR	R5	R0	K50
       0x94140A03,  //  001F  GETIDX	R5	R5	R3
       0x30100805,  //  0020  OR	R4	R4	R5
       0x70020000,  //  0021  JMP		#0023
@@ -897,10 +890,10 @@ be_local_closure(class_lvh_root_digits_to_style,   /* name */
       0x1C140805,  //  0024  EQ	R5	R4	R5
       0x78160004,  //  0025  JMPF	R5	#002B
       0x60140018,  //  0026  GETGBL	R5	G24
-      0x58180003,  //  0027  LDCONST	R6	K3
+      0x58180033,  //  0027  LDCONST	R6	K51
       0x5C1C0200,  //  0028  MOVE	R7	R1
       0x7C140400,  //  0029  CALL	R5	2
-      0xB0060805,  //  002A  RAISE	1	K4	R5
+      0xB0066805,  //  002A  RAISE	1	K52	R5
       0x80040800,  //  002B  RET	1	R4
     })
   )
@@ -915,22 +908,20 @@ be_local_closure(class_lvh_root_set_text_rule_format,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_format),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_text_rule_format),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x90023E02,  //  0003  SETMBR	R0	K31	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -945,27 +936,23 @@ be_local_closure(class_lvh_root_remove_val_rule,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(remove_val_rule),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804012D,  //  0000  GETMBR	R1	R0	K45
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060004,  //  0003  JMPF	R1	#0009
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8065C00,  //  0004  GETNGBL	R1	K46
+      0x8C040335,  //  0005  GETMET	R1	R1	K53
+      0x880C012D,  //  0006  GETMBR	R3	R0	K45
       0x5C100000,  //  0007  MOVE	R4	R0
       0x7C040600,  //  0008  CALL	R1	3
       0x80000000,  //  0009  RET	0
@@ -982,13 +969,13 @@ be_local_closure(class_lvh_root_delete,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(delete),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -1006,19 +993,17 @@ be_local_closure(class_lvh_root_get_obj,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_obj),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040127,  //  0000  GETMBR	R1	R0	K39
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1033,26 +1018,22 @@ be_local_closure(class_lvh_root_is_color_attribute,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(endswith),
-    /* K2   */  be_nested_str_weak(color),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(is_color_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40A1E00,  //  0000  IMPORT	R2	K15
+      0x8C0C0517,  //  0001  GETMET	R3	R2	K23
       0x60140008,  //  0002  GETGBL	R5	G8
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C140200,  //  0004  CALL	R5	1
-      0x58180002,  //  0005  LDCONST	R6	K2
+      0x58180036,  //  0005  LDCONST	R6	K54
       0x7C0C0600,  //  0006  CALL	R3	3
       0x80040600,  //  0007  RET	1	R3
     })
@@ -1068,19 +1049,17 @@ be_local_closure(class_lvh_root_set_meta,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_meta),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_meta),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90024401,  //  0000  SETMBR	R0	K34	R1
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1095,20 +1074,17 @@ be_local_closure(class_lvh_root_set_delete,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(type_error),
-    /* K1   */  be_nested_str_weak(you_X20cannot_X20assign_X20to_X20_X27delete_X27),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_delete),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0xB0060101,  //  0000  RAISE	1	K0	K1
+      0xB0066F38,  //  0000  RAISE	1	K55	K56
       0x80000000,  //  0001  RET	0
     })
   )
@@ -1123,19 +1099,17 @@ be_local_closure(class_lvh_root_get_value_str,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_text),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_value_str),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040139,  //  0000  GETMET	R1	R0	K57
       0x7C040200,  //  0001  CALL	R1	1
       0x80040200,  //  0002  RET	1	R1
     })
@@ -1151,7 +1125,7 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1255,59 +1229,48 @@ be_local_closure(class_lvh_root_parse_color,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_root),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_X23),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(color),
-    /* K5   */  be_nested_str_weak(string),
-    /* K6   */  be_nested_str_weak(introspect),
-    /* K7   */  be_nested_str_weak(COLOR_),
-    /* K8   */  be_nested_str_weak(toupper),
-    /* K9   */  be_nested_str_weak(get),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(parse_color),
     &be_const_str_solidified,
     ( &(const binstruction[40]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5804002A,  //  0000  LDCONST	R1	K42
       0x84080000,  //  0001  CLOSURE	R2	P0
       0x600C0008,  //  0002  GETGBL	R3	G8
       0x5C100000,  //  0003  MOVE	R4	R0
       0x7C0C0200,  //  0004  CALL	R3	1
       0x5C000600,  //  0005  MOVE	R0	R3
-      0x940C0101,  //  0006  GETIDX	R3	R0	K1
-      0x1C0C0702,  //  0007  EQ	R3	R3	K2
+      0x940C0114,  //  0006  GETIDX	R3	R0	K20
+      0x1C0C073A,  //  0007  EQ	R3	R3	K58
       0x780E0007,  //  0008  JMPF	R3	#0011
-      0xB80E0600,  //  0009  GETNGBL	R3	K3
-      0x8C0C0704,  //  000A  GETMET	R3	R3	K4
+      0xB80E1400,  //  0009  GETNGBL	R3	K10
+      0x8C0C0736,  //  000A  GETMET	R3	R3	K54
       0x5C140400,  //  000B  MOVE	R5	R2
       0x5C180000,  //  000C  MOVE	R6	R0
       0x7C140200,  //  000D  CALL	R5	1
       0x7C0C0400,  //  000E  CALL	R3	2
       0x80040600,  //  000F  RET	1	R3
       0x70020011,  //  0010  JMP		#0023
-      0xA40E0A00,  //  0011  IMPORT	R3	K5
-      0xA4120C00,  //  0012  IMPORT	R4	K6
-      0x8C140708,  //  0013  GETMET	R5	R3	K8
+      0xA40E1E00,  //  0011  IMPORT	R3	K15
+      0xA4127600,  //  0012  IMPORT	R4	K59
+      0x8C14073D,  //  0013  GETMET	R5	R3	K61
       0x5C1C0000,  //  0014  MOVE	R7	R0
       0x7C140400,  //  0015  CALL	R5	2
-      0x00160E05,  //  0016  ADD	R5	K7	R5
-      0x8C180909,  //  0017  GETMET	R6	R4	K9
-      0xB8220600,  //  0018  GETNGBL	R8	K3
+      0x00167805,  //  0016  ADD	R5	K60	R5
+      0x8C18093E,  //  0017  GETMET	R6	R4	K62
+      0xB8221400,  //  0018  GETNGBL	R8	K10
       0x5C240A00,  //  0019  MOVE	R9	R5
       0x7C180600,  //  001A  CALL	R6	3
       0x4C1C0000,  //  001B  LDNIL	R7
       0x201C0C07,  //  001C  NE	R7	R6	R7
       0x781E0004,  //  001D  JMPF	R7	#0023
-      0xB81E0600,  //  001E  GETNGBL	R7	K3
-      0x8C1C0F04,  //  001F  GETMET	R7	R7	K4
+      0xB81E1400,  //  001E  GETNGBL	R7	K10
+      0x8C1C0F36,  //  001F  GETMET	R7	R7	K54
       0x5C240C00,  //  0020  MOVE	R9	R6
       0x7C1C0400,  //  0021  CALL	R7	2
       0x80040E00,  //  0022  RET	1	R7
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x58140001,  //  0025  LDCONST	R5	K1
+      0xB80E1400,  //  0023  GETNGBL	R3	K10
+      0x8C0C0736,  //  0024  GETMET	R3	R3	K54
+      0x58140014,  //  0025  LDCONST	R5	K20
       0x7C0C0400,  //  0026  CALL	R3	2
       0x80040600,  //  0027  RET	1	R3
     })
@@ -1323,19 +1286,17 @@ be_local_closure(class_lvh_root_get_text_rule_format,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_format),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_text_rule_format),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8804011F,  //  0000  GETMBR	R1	R0	K31
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1350,27 +1311,23 @@ be_local_closure(class_lvh_root_remove_text_rule,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(remove_text_rule),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060004,  //  0003  JMPF	R1	#0009
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8065C00,  //  0004  GETNGBL	R1	K46
+      0x8C040335,  //  0005  GETMET	R1	R1	K53
+      0x880C0105,  //  0006  GETMBR	R3	R0	K5
       0x5C100000,  //  0007  MOVE	R4	R0
       0x7C040600,  //  0008  CALL	R1	3
       0x80000000,  //  0009  RET	0
@@ -1387,27 +1344,21 @@ be_local_closure(class_lvh_root_set_val_rule_formula,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_val_rule_function),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_val_rule_formula),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x90023602,  //  0003  SETMBR	R0	K27	R2
+      0x8808011B,  //  0004  GETMBR	R2	R0	K27
       0x000A0202,  //  0005  ADD	R2	K1	R2
       0x00080502,  //  0006  ADD	R2	R2	K2
       0xA8020007,  //  0007  EXBLK	0	#0010
@@ -1416,7 +1367,7 @@ be_local_closure(class_lvh_root_set_val_rule_formula,   /* name */
       0x7C0C0200,  //  000A  CALL	R3	1
       0x5C100600,  //  000B  MOVE	R4	R3
       0x7C100000,  //  000C  CALL	R4	0
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x90020C04,  //  000D  SETMBR	R0	K6	R4
       0xA8040001,  //  000E  EXBLK	1	1
       0x7002000B,  //  000F  JMP		#001C
       0xAC0C0002,  //  0010  CATCH	R3	0	2
@@ -1445,7 +1396,7 @@ be_local_closure(class_lvh_root_set_text_rule,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -1476,24 +1427,19 @@ be_local_closure(class_lvh_root_set_text_rule,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_text_rule),
-    /* K1   */  be_nested_str_weak(_text_rule),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_rule),
-    }),
+    &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(set_text_rule),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08013F,  //  0000  GETMET	R2	R0	K63
       0x7C080200,  //  0001  CALL	R2	1
       0x60080008,  //  0002  GETGBL	R2	G8
       0x5C0C0200,  //  0003  MOVE	R3	R1
       0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x90020A02,  //  0005  SETMBR	R0	K5	R2
+      0xB80A5C00,  //  0006  GETNGBL	R2	K46
+      0x8C08052F,  //  0007  GETMET	R2	R2	K47
+      0x88100105,  //  0008  GETMBR	R4	R0	K5
       0x84140000,  //  0009  CLOSURE	R5	P0
       0x5C180000,  //  000A  MOVE	R6	R0
       0x7C080800,  //  000B  CALL	R2	4
@@ -1608,6 +1554,149 @@ be_local_class(lvh_root,
     })),
     be_str_weak(lvh_root)
 );
+// compact class 'lvh_obj' ktab size: 139, total: 284 (saved 1160 bytes)
+static const bvalue be_ktab_class_lvh_obj[139] = {
+  /* K0   */  be_nested_str_weak(_lv_part2_selector),
+  /* K1   */  be_nested_str_weak(_lv_obj),
+  /* K2   */  be_nested_str_weak(set_style_pad_bottom),
+  /* K3   */  be_nested_str_weak(lv),
+  /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+  /* K5   */  be_nested_str_weak(string),
+  /* K6   */  be_nested_str_weak(toupper),
+  /* K7   */  be_nested_str_weak(TRUE),
+  /* K8   */  be_nested_str_weak(FALSE),
+  /* K9   */  be_nested_str_weak(add_state),
+  /* K10  */  be_nested_str_weak(STATE_CHECKED),
+  /* K11  */  be_nested_str_weak(clear_state),
+  /* K12  */  be_nested_str_weak(set_style_pad_left),
+  /* K13  */  be_nested_str_weak(get_style_pad_top),
+  /* K14  */  be_nested_str_weak(get_style_line_width),
+  /* K15  */  be_nested_str_weak(has_flag),
+  /* K16  */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
+  /* K17  */  be_nested_str_weak(_lv_label),
+  /* K18  */  be_nested_str_weak(get_text),
+  /* K19  */  be_nested_str_weak(set_style_line_width),
+  /* K20  */  be_nested_str_weak(check_label),
+  /* K21  */  be_nested_str_weak(set_text),
+  /* K22  */  be_const_int(0),
+  /* K23  */  be_nested_str_weak(left),
+  /* K24  */  be_nested_str_weak(TEXT_ALIGN_LEFT),
+  /* K25  */  be_const_int(1),
+  /* K26  */  be_nested_str_weak(center),
+  /* K27  */  be_nested_str_weak(TEXT_ALIGN_CENTER),
+  /* K28  */  be_const_int(2),
+  /* K29  */  be_nested_str_weak(right),
+  /* K30  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
+  /* K31  */  be_nested_str_weak(set_style_text_align),
+  /* K32  */  be_nested_str_weak(get_value_color),
+  /* K33  */  be_nested_str_weak(get_style_pad_right),
+  /* K34  */  be_nested_str_weak(get_style_text_color),
+  /* K35  */  be_nested_str_weak(_action),
+  /* K36  */  be_nested_str_weak(),
+  /* K37  */  be_nested_str_weak(get_y),
+  /* K38  */  be_nested_str_weak(set_style_pad_all),
+  /* K39  */  be_nested_str_weak(introspect),
+  /* K40  */  be_nested_str_weak(contains),
+  /* K41  */  be_nested_str_weak(label),
+  /* K42  */  be_nested_str_weak(get_obj),
+  /* K43  */  be_nested_str_weak(set_align),
+  /* K44  */  be_nested_str_weak(ALIGN_CENTER),
+  /* K45  */  be_nested_str_weak(set_text_color),
+  /* K46  */  be_nested_str_weak(OBJ_FLAG_FLEX_IN_NEW_TRACK),
+  /* K47  */  be_nested_str_weak(remove_val_rule),
+  /* K48  */  be_nested_str_weak(remove_text_rule),
+  /* K49  */  be_nested_str_weak(del),
+  /* K50  */  be_nested_str_weak(_page),
+  /* K51  */  be_nested_str_weak(remove_obj),
+  /* K52  */  be_nested_str_weak(id),
+  /* K53  */  be_nested_str_weak(get_x),
+  /* K54  */  be_nested_str_weak(set_style_pad_top),
+  /* K55  */  be_nested_str_weak(set_enabled),
+  /* K56  */  be_nested_str_weak(add_flag),
+  /* K57  */  be_nested_str_weak(clear_flag),
+  /* K58  */  be_nested_str_weak(_oh),
+  /* K59  */  be_nested_str_weak(get_code),
+  /* K60  */  be_nested_str_weak(action),
+  /* K61  */  be_nested_str_weak(EVENT_CLICKED),
+  /* K62  */  be_nested_str_weak(tasmota),
+  /* K63  */  be_nested_str_weak(set_timer),
+  /* K64  */  be_nested_str_weak(_event_map),
+  /* K65  */  be_nested_str_weak(find),
+  /* K66  */  be_nested_str_weak(json),
+  /* K67  */  be_nested_str_weak(EVENT_VALUE_CHANGED),
+  /* K68  */  be_nested_str_weak(val),
+  /* K69  */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
+  /* K70  */  be_nested_str_weak(dump),
+  /* K71  */  be_nested_str_weak(text),
+  /* K72  */  be_nested_str_weak(_X2C_X22text_X22_X3A),
+  /* K73  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
+  /* K74  */  be_nested_str_weak(_page_id),
+  /* K75  */  be_nested_str_weak(init),
+  /* K76  */  be_nested_str_weak(has_state),
+  /* K77  */  be_nested_str_weak(STATE_DISABLED),
+  /* K78  */  be_nested_str_weak(get_enabled),
+  /* K79  */  be_nested_str_weak(get_long_mode),
+  /* K80  */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
+  /* K81  */  be_nested_str_weak(set_text_font),
+  /* K82  */  be_nested_str_weak(get_text_font),
+  /* K83  */  be_nested_str_weak(_val),
+  /* K84  */  be_nested_str_weak(set_value),
+  /* K85  */  be_nested_str_weak(set_style_text_color),
+  /* K86  */  be_nested_str_weak(parse_color),
+  /* K87  */  be_nested_str_weak(get_style_radius),
+  /* K88  */  be_nested_str_weak(set_style_pad_right),
+  /* K89  */  be_nested_str_weak(expand),
+  /* K90  */  be_nested_str_weak(set_width),
+  /* K91  */  be_nested_str_weak(SIZE_CONTENT),
+  /* K92  */  be_nested_str_weak(break),
+  /* K93  */  be_nested_str_weak(LABEL_LONG_WRAP),
+  /* K94  */  be_nested_str_weak(dots),
+  /* K95  */  be_nested_str_weak(LABEL_LONG_DOT),
+  /* K96  */  be_nested_str_weak(scroll),
+  /* K97  */  be_nested_str_weak(LABEL_LONG_SCROLL),
+  /* K98  */  be_nested_str_weak(loop),
+  /* K99  */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
+  /* K100 */  be_nested_str_weak(crop),
+  /* K101 */  be_nested_str_weak(LABEL_LONG_CLIP),
+  /* K102 */  be_nested_str_weak(set_long_mode),
+  /* K103 */  be_nested_str_weak(startswith),
+  /* K104 */  be_nested_str_weak(set_),
+  /* K105 */  be_nested_str_weak(get_),
+  /* K106 */  be_nested_str_weak(real),
+  /* K107 */  be_nested_str_weak(math),
+  /* K108 */  be_nested_str_weak(round),
+  /* K109 */  be_nested_str_weak(endswith),
+  /* K110 */  be_nested_str_weak(_X25),
+  /* K111 */  be_const_int(0),
+  /* K112 */  be_nested_str_weak(pct),
+  /* K113 */  be_const_int(3),
+  /* K114 */  be_nested_str_weak(byte),
+  /* K115 */  be_const_int(2147483647),
+  /* K116 */  be_nested_str_weak(digits_to_style),
+  /* K117 */  be_nested_str_weak(_attr_ignore),
+  /* K118 */  be_nested_str_weak(get),
+  /* K119 */  be_nested_str_weak(function),
+  /* K120 */  be_nested_str_weak(_attr_map),
+  /* K121 */  be_nested_str_weak(is_color_attribute),
+  /* K122 */  be_nested_str_weak(set_style_),
+  /* K123 */  be_nested_str_weak(HSP_X3A_X20unknown_X20attribute_X3A),
+  /* K124 */  be_nested_str_weak(get_style_text_align),
+  /* K125 */  be_nested_str_weak(get_style_pad_left),
+  /* K126 */  be_nested_str_weak(set_x),
+  /* K127 */  be_nested_str_weak(get_style_),
+  /* K128 */  be_nested_str_weak(undefined),
+  /* K129 */  be_nested_str_weak(set_y),
+  /* K130 */  be_nested_str_weak(set_style_radius),
+  /* K131 */  be_nested_str_weak(keys),
+  /* K132 */  be_nested_str_weak(register_event),
+  /* K133 */  be_nested_str_weak(stop_iteration),
+  /* K134 */  be_nested_str_weak(parse_font),
+  /* K135 */  be_nested_str_weak(set_style_text_font),
+  /* K136 */  be_nested_str_weak(get_style_pad_bottom),
+  /* K137 */  be_nested_str_weak(get_value),
+  /* K138 */  be_nested_str_weak(register_event_cb),
+};
+
 
 extern const bclass be_class_lvh_obj;
 
@@ -1618,19 +1707,13 @@ be_local_closure(class_lvh_obj_set_pad_bottom2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_pad_bottom2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -1662,56 +1745,46 @@ be_local_closure(class_lvh_obj_set_toggle,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(toupper),
-    /* K2   */  be_nested_str_weak(TRUE),
-    /* K3   */  be_nested_str_weak(FALSE),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(add_state),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(STATE_CHECKED),
-    /* K8   */  be_nested_str_weak(clear_state),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_toggle),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40A0A00,  //  0000  IMPORT	R2	K5
       0x600C0004,  //  0001  GETGBL	R3	G4
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x1C0C0700,  //  0004  EQ	R3	R3	K0
+      0x1C0C0705,  //  0004  EQ	R3	R3	K5
       0x780E000C,  //  0005  JMPF	R3	#0013
-      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
+      0x8C0C0506,  //  0006  GETMET	R3	R2	K6
       0x60140008,  //  0007  GETGBL	R5	G8
       0x5C180200,  //  0008  MOVE	R6	R1
       0x7C140200,  //  0009  CALL	R5	1
       0x7C0C0400,  //  000A  CALL	R3	2
       0x5C040600,  //  000B  MOVE	R1	R3
-      0x1C0C0302,  //  000C  EQ	R3	R1	K2
+      0x1C0C0307,  //  000C  EQ	R3	R1	K7
       0x780E0001,  //  000D  JMPF	R3	#0010
       0x50040200,  //  000E  LDBOOL	R1	1	0
       0x70020002,  //  000F  JMP		#0013
-      0x1C0C0303,  //  0010  EQ	R3	R1	K3
+      0x1C0C0308,  //  0010  EQ	R3	R1	K8
       0x780E0000,  //  0011  JMPF	R3	#0013
       0x50040000,  //  0012  LDBOOL	R1	0	0
       0x78060005,  //  0013  JMPF	R1	#001A
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  0015  GETMET	R3	R3	K5
-      0xB8160C00,  //  0016  GETNGBL	R5	K6
-      0x88140B07,  //  0017  GETMBR	R5	R5	K7
+      0x880C0101,  //  0014  GETMBR	R3	R0	K1
+      0x8C0C0709,  //  0015  GETMET	R3	R3	K9
+      0xB8160600,  //  0016  GETNGBL	R5	K3
+      0x88140B0A,  //  0017  GETMBR	R5	R5	K10
       0x7C0C0400,  //  0018  CALL	R3	2
       0x70020004,  //  0019  JMP		#001F
-      0x880C0104,  //  001A  GETMBR	R3	R0	K4
-      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
-      0xB8160C00,  //  001C  GETNGBL	R5	K6
-      0x88140B07,  //  001D  GETMBR	R5	R5	K7
+      0x880C0101,  //  001A  GETMBR	R3	R0	K1
+      0x8C0C070B,  //  001B  GETMET	R3	R3	K11
+      0xB8160600,  //  001C  GETNGBL	R5	K3
+      0x88140B0A,  //  001D  GETMBR	R5	R5	K10
       0x7C0C0400,  //  001E  CALL	R3	2
       0x80000000,  //  001F  RET	0
     })
@@ -1727,19 +1800,13 @@ be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_pad_left2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -1748,7 +1815,7 @@ be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x8C08050C,  //  0005  GETMET	R2	R2	K12
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -1771,19 +1838,13 @@ be_local_closure(class_lvh_obj_get_pad_top,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_top),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_pad_top),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -1792,7 +1853,7 @@ be_local_closure(class_lvh_obj_get_pad_top,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C04030D,  //  0005  GETMET	R1	R1	K13
       0x880C0100,  //  0006  GETMBR	R3	R0	K0
       0xB8120600,  //  0007  GETNGBL	R4	K3
       0x88100904,  //  0008  GETMBR	R4	R4	K4
@@ -1813,21 +1874,18 @@ be_local_closure(class_lvh_obj_get_line_width,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_line_width),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C08050E,  //  0001  GETMET	R2	R2	K14
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -1844,25 +1902,20 @@ be_local_closure(class_lvh_obj_get_adjustable,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_adjustable),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x880C0710,  //  0003  GETMBR	R3	R3	K16
       0x7C040400,  //  0004  CALL	R1	2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -1878,27 +1931,24 @@ be_local_closure(class_lvh_obj_get_text,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_text),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_text),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060001,  //  0003  JMPF	R1	#0006
       0x4C040000,  //  0004  LDNIL	R1
       0x80040200,  //  0005  RET	1	R1
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x8C040301,  //  0007  GETMET	R1	R1	K1
+      0x88040111,  //  0006  GETMBR	R1	R0	K17
+      0x8C040312,  //  0007  GETMET	R1	R1	K18
       0x7C040200,  //  0008  CALL	R1	1
       0x80040200,  //  0009  RET	1	R1
     })
@@ -1914,21 +1964,18 @@ be_local_closure(class_lvh_obj_set_line_width,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_line_width),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x880C0101,  //  0000  GETMBR	R3	R0	K1
+      0x8C0C0713,  //  0001  GETMET	R3	R3	K19
       0x60140009,  //  0002  GETGBL	R5	G9
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C140200,  //  0004  CALL	R5	1
@@ -1948,24 +1995,20 @@ be_local_closure(class_lvh_obj_set_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080114,  //  0000  GETMET	R2	R0	K20
       0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x88080111,  //  0002  GETMBR	R2	R0	K17
+      0x8C080515,  //  0003  GETMET	R2	R2	K21
       0x60100008,  //  0004  GETGBL	R4	G8
       0x5C140200,  //  0005  MOVE	R5	R1
       0x7C100200,  //  0006  CALL	R4	1
@@ -1984,58 +2027,44 @@ be_local_closure(class_lvh_obj_set_align,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(check_label),
-    /* K2   */  be_nested_str_weak(left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(center),
-    /* K7   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(right),
-    /* K10  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K11  */  be_nested_str_weak(_lv_label),
-    /* K12  */  be_nested_str_weak(set_style_text_align),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_align),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C100500,  //  0001  EQ	R4	R2	K0
+      0x1C100516,  //  0001  EQ	R4	R2	K22
       0x78120000,  //  0002  JMPF	R4	#0004
-      0x58080000,  //  0003  LDCONST	R2	K0
-      0x8C100101,  //  0004  GETMET	R4	R0	K1
+      0x58080016,  //  0003  LDCONST	R2	K22
+      0x8C100114,  //  0004  GETMET	R4	R0	K20
       0x7C100200,  //  0005  CALL	R4	1
-      0x1C100300,  //  0006  EQ	R4	R1	K0
+      0x1C100316,  //  0006  EQ	R4	R1	K22
       0x74120001,  //  0007  JMPT	R4	#000A
-      0x1C100302,  //  0008  EQ	R4	R1	K2
+      0x1C100317,  //  0008  EQ	R4	R1	K23
       0x78120002,  //  0009  JMPF	R4	#000D
       0xB8120600,  //  000A  GETNGBL	R4	K3
-      0x880C0904,  //  000B  GETMBR	R3	R4	K4
+      0x880C0918,  //  000B  GETMBR	R3	R4	K24
       0x7002000C,  //  000C  JMP		#001A
-      0x1C100305,  //  000D  EQ	R4	R1	K5
+      0x1C100319,  //  000D  EQ	R4	R1	K25
       0x74120001,  //  000E  JMPT	R4	#0011
-      0x1C100306,  //  000F  EQ	R4	R1	K6
+      0x1C10031A,  //  000F  EQ	R4	R1	K26
       0x78120002,  //  0010  JMPF	R4	#0014
       0xB8120600,  //  0011  GETNGBL	R4	K3
-      0x880C0907,  //  0012  GETMBR	R3	R4	K7
+      0x880C091B,  //  0012  GETMBR	R3	R4	K27
       0x70020005,  //  0013  JMP		#001A
-      0x1C100308,  //  0014  EQ	R4	R1	K8
+      0x1C10031C,  //  0014  EQ	R4	R1	K28
       0x74120001,  //  0015  JMPT	R4	#0018
-      0x1C100309,  //  0016  EQ	R4	R1	K9
+      0x1C10031D,  //  0016  EQ	R4	R1	K29
       0x78120001,  //  0017  JMPF	R4	#001A
       0xB8120600,  //  0018  GETNGBL	R4	K3
-      0x880C090A,  //  0019  GETMBR	R3	R4	K10
-      0x8810010B,  //  001A  GETMBR	R4	R0	K11
-      0x8C10090C,  //  001B  GETMET	R4	R4	K12
+      0x880C091E,  //  0019  GETMBR	R3	R4	K30
+      0x88100111,  //  001A  GETMBR	R4	R0	K17
+      0x8C10091F,  //  001B  GETMET	R4	R4	K31
       0x5C180600,  //  001C  MOVE	R6	R3
       0x5C1C0400,  //  001D  MOVE	R7	R2
       0x7C100600,  //  001E  CALL	R4	3
@@ -2053,19 +2082,17 @@ be_local_closure(class_lvh_obj_get_value_color,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_value_color),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_value_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040120,  //  0000  GETMET	R1	R0	K32
       0x7C040200,  //  0001  CALL	R1	1
       0x80040200,  //  0002  RET	1	R1
     })
@@ -2081,19 +2108,13 @@ be_local_closure(class_lvh_obj_get_pad_right,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_pad_right),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -2102,7 +2123,7 @@ be_local_closure(class_lvh_obj_get_pad_right,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C040321,  //  0005  GETMET	R1	R1	K33
       0x880C0100,  //  0006  GETMBR	R3	R0	K0
       0xB8120600,  //  0007  GETNGBL	R4	K3
       0x88100904,  //  0008  GETMBR	R4	R4	K4
@@ -2123,21 +2144,18 @@ be_local_closure(class_lvh_obj_get_text_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_text_color),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_text_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C080522,  //  0001  GETMET	R2	R2	K34
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -2154,24 +2172,21 @@ be_local_closure(class_lvh_obj_get_action,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    /* K1   */  be_nested_str_weak(),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_action),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040123,  //  0000  GETMBR	R1	R0	K35
       0x78060001,  //  0001  JMPF	R1	#0004
       0x5C080200,  //  0002  MOVE	R2	R1
       0x70020000,  //  0003  JMP		#0005
-      0x58080001,  //  0004  LDCONST	R2	K1
+      0x58080024,  //  0004  LDCONST	R2	K36
       0x80040400,  //  0005  RET	1	R2
     })
   )
@@ -2186,21 +2201,18 @@ be_local_closure(class_lvh_obj_get_value_ofs_y,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_y),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_value_ofs_y),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
+      0x8C040325,  //  0001  GETMET	R1	R1	K37
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -2216,19 +2228,13 @@ be_local_closure(class_lvh_obj_set_pad_all2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_all),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_pad_all2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -2237,7 +2243,7 @@ be_local_closure(class_lvh_obj_set_pad_all2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x8C080526,  //  0005  GETMET	R2	R2	K38
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -2260,50 +2266,39 @@ be_local_closure(class_lvh_obj_check_label,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(_lv_obj),
-    /* K4   */  be_nested_str_weak(set_text),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(label),
-    /* K7   */  be_nested_str_weak(get_obj),
-    /* K8   */  be_nested_str_weak(set_align),
-    /* K9   */  be_nested_str_weak(ALIGN_CENTER),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(check_label),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060013,  //  0003  JMPF	R1	#0018
-      0xA4060200,  //  0004  IMPORT	R1	K1
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x58140004,  //  0007  LDCONST	R5	K4
+      0xA4064E00,  //  0004  IMPORT	R1	K39
+      0x8C080328,  //  0005  GETMET	R2	R1	K40
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x58140015,  //  0007  LDCONST	R5	K21
       0x7C080600,  //  0008  CALL	R2	3
       0x780A0002,  //  0009  JMPF	R2	#000D
-      0x88080103,  //  000A  GETMBR	R2	R0	K3
-      0x90020002,  //  000B  SETMBR	R0	K0	R2
+      0x88080101,  //  000A  GETMBR	R2	R0	K1
+      0x90022202,  //  000B  SETMBR	R0	K17	R2
       0x7002000A,  //  000C  JMP		#0018
-      0xB80A0A00,  //  000D  GETNGBL	R2	K5
-      0x8C080506,  //  000E  GETMET	R2	R2	K6
-      0x8C100107,  //  000F  GETMET	R4	R0	K7
+      0xB80A0600,  //  000D  GETNGBL	R2	K3
+      0x8C080529,  //  000E  GETMET	R2	R2	K41
+      0x8C10012A,  //  000F  GETMET	R4	R0	K42
       0x7C100200,  //  0010  CALL	R4	1
       0x7C080400,  //  0011  CALL	R2	2
-      0x90020002,  //  0012  SETMBR	R0	K0	R2
-      0x88080100,  //  0013  GETMBR	R2	R0	K0
-      0x8C080508,  //  0014  GETMET	R2	R2	K8
-      0xB8120A00,  //  0015  GETNGBL	R4	K5
-      0x88100909,  //  0016  GETMBR	R4	R4	K9
+      0x90022202,  //  0012  SETMBR	R0	K17	R2
+      0x88080111,  //  0013  GETMBR	R2	R0	K17
+      0x8C08052B,  //  0014  GETMET	R2	R2	K43
+      0xB8120600,  //  0015  GETNGBL	R4	K3
+      0x8810092C,  //  0016  GETMBR	R4	R4	K44
       0x7C080400,  //  0017  CALL	R2	2
       0x80000000,  //  0018  RET	0
     })
@@ -2319,19 +2314,17 @@ be_local_closure(class_lvh_obj_set_value_color,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_color),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_value_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08012D,  //  0000  GETMET	R2	R0	K45
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x80000000,  //  0003  RET	0
@@ -2348,25 +2341,20 @@ be_local_closure(class_lvh_obj_get_flex_in_new_track,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_FLEX_IN_NEW_TRACK),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_flex_in_new_track),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x880C072E,  //  0003  GETMBR	R3	R3	K46
       0x7C040400,  //  0004  CALL	R1	2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -2382,46 +2370,37 @@ be_local_closure(class_lvh_obj_delete,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_val_rule),
-    /* K1   */  be_nested_str_weak(remove_text_rule),
-    /* K2   */  be_nested_str_weak(_lv_label),
-    /* K3   */  be_nested_str_weak(del),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(_page),
-    /* K6   */  be_nested_str_weak(remove_obj),
-    /* K7   */  be_nested_str_weak(id),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(delete),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04012F,  //  0000  GETMET	R1	R0	K47
       0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x8C040130,  //  0002  GETMET	R1	R0	K48
       0x7C040200,  //  0003  CALL	R1	1
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x88040111,  //  0004  GETMBR	R1	R0	K17
       0x78060004,  //  0005  JMPF	R1	#000B
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x88040111,  //  0006  GETMBR	R1	R0	K17
+      0x8C040331,  //  0007  GETMET	R1	R1	K49
       0x7C040200,  //  0008  CALL	R1	1
       0x4C040000,  //  0009  LDNIL	R1
-      0x90020401,  //  000A  SETMBR	R0	K2	R1
-      0x88040104,  //  000B  GETMBR	R1	R0	K4
+      0x90022201,  //  000A  SETMBR	R0	K17	R1
+      0x88040101,  //  000B  GETMBR	R1	R0	K1
       0x78060004,  //  000C  JMPF	R1	#0012
-      0x88040104,  //  000D  GETMBR	R1	R0	K4
-      0x8C040303,  //  000E  GETMET	R1	R1	K3
+      0x88040101,  //  000D  GETMBR	R1	R0	K1
+      0x8C040331,  //  000E  GETMET	R1	R1	K49
       0x7C040200,  //  000F  CALL	R1	1
       0x4C040000,  //  0010  LDNIL	R1
-      0x90020801,  //  0011  SETMBR	R0	K4	R1
-      0x88040105,  //  0012  GETMBR	R1	R0	K5
-      0x8C040306,  //  0013  GETMET	R1	R1	K6
-      0x880C0107,  //  0014  GETMBR	R3	R0	K7
+      0x90020201,  //  0011  SETMBR	R0	K1	R1
+      0x88040132,  //  0012  GETMBR	R1	R0	K50
+      0x8C040333,  //  0013  GETMET	R1	R1	K51
+      0x880C0134,  //  0014  GETMBR	R3	R0	K52
       0x7C040400,  //  0015  CALL	R1	2
       0x80000000,  //  0016  RET	0
     })
@@ -2437,21 +2416,18 @@ be_local_closure(class_lvh_obj_get_value_ofs_x,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_x),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_value_ofs_x),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
+      0x8C040335,  //  0001  GETMET	R1	R1	K53
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -2467,19 +2443,13 @@ be_local_closure(class_lvh_obj_set_pad_top2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_top),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_pad_top2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -2488,7 +2458,7 @@ be_local_closure(class_lvh_obj_set_pad_top2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x8C080536,  //  0005  GETMET	R2	R2	K54
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -2511,19 +2481,17 @@ be_local_closure(class_lvh_obj_set_click,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_enabled),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_click),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080137,  //  0000  GETMET	R2	R0	K55
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x80000000,  //  0003  RET	0
@@ -2540,33 +2508,27 @@ be_local_closure(class_lvh_obj_set_adjustable,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
-    /* K4   */  be_nested_str_weak(clear_flag),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_adjustable),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080538,  //  0002  GETMET	R2	R2	K56
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x88100910,  //  0004  GETMBR	R4	R4	K16
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x88080101,  //  0007  GETMBR	R2	R0	K1
+      0x8C080539,  //  0008  GETMET	R2	R2	K57
+      0xB8120600,  //  0009  GETNGBL	R4	K3
+      0x88100910,  //  000A  GETMBR	R4	R4	K16
       0x7C080400,  //  000B  CALL	R2	2
       0x80000000,  //  000C  RET	0
     })
@@ -2582,7 +2544,7 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -2641,80 +2603,57 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(get_code),
-    /* K3   */  be_nested_str_weak(action),
-    /* K4   */  be_nested_str_weak(),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(EVENT_CLICKED),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(set_timer),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(_event_map),
-    /* K11  */  be_nested_str_weak(find),
-    /* K12  */  be_nested_str_weak(json),
-    /* K13  */  be_nested_str_weak(EVENT_VALUE_CHANGED),
-    /* K14  */  be_nested_str_weak(val),
-    /* K15  */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
-    /* K16  */  be_nested_str_weak(dump),
-    /* K17  */  be_nested_str_weak(text),
-    /* K18  */  be_nested_str_weak(_X2C_X22text_X22_X3A),
-    /* K19  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
-    /* K20  */  be_nested_str_weak(_page_id),
-    /* K21  */  be_nested_str_weak(id),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(event_cb),
     &be_const_str_solidified,
     ( &(const binstruction[72]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
+      0x88080132,  //  0000  GETMBR	R2	R0	K50
+      0x8808053A,  //  0001  GETMBR	R2	R2	K58
+      0x8C0C033B,  //  0002  GETMET	R3	R1	K59
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x88100103,  //  0004  GETMBR	R4	R0	K3
-      0x20100904,  //  0005  NE	R4	R4	K4
+      0x8810013C,  //  0004  GETMBR	R4	R0	K60
+      0x20100924,  //  0005  NE	R4	R4	K36
       0x78120008,  //  0006  JMPF	R4	#0010
-      0xB8120A00,  //  0007  GETNGBL	R4	K5
-      0x88100906,  //  0008  GETMBR	R4	R4	K6
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x8810093D,  //  0008  GETMBR	R4	R4	K61
       0x1C100604,  //  0009  EQ	R4	R3	R4
       0x78120004,  //  000A  JMPF	R4	#0010
-      0xB8120E00,  //  000B  GETNGBL	R4	K7
-      0x8C100908,  //  000C  GETMET	R4	R4	K8
-      0x58180009,  //  000D  LDCONST	R6	K9
+      0xB8127C00,  //  000B  GETNGBL	R4	K62
+      0x8C10093F,  //  000C  GETMET	R4	R4	K63
+      0x58180016,  //  000D  LDCONST	R6	K22
       0x841C0000,  //  000E  CLOSURE	R7	P0
       0x7C100600,  //  000F  CALL	R4	3
-      0x8810010A,  //  0010  GETMBR	R4	R0	K10
-      0x8C10090B,  //  0011  GETMET	R4	R4	K11
+      0x88100140,  //  0010  GETMBR	R4	R0	K64
+      0x8C100941,  //  0011  GETMET	R4	R4	K65
       0x5C180600,  //  0012  MOVE	R6	R3
       0x7C100400,  //  0013  CALL	R4	2
       0x4C140000,  //  0014  LDNIL	R5
       0x20140805,  //  0015  NE	R5	R4	R5
       0x7816002E,  //  0016  JMPF	R5	#0046
-      0xA4161800,  //  0017  IMPORT	R5	K12
-      0x58180004,  //  0018  LDCONST	R6	K4
-      0xB81E0A00,  //  0019  GETNGBL	R7	K5
-      0x881C0F0D,  //  001A  GETMBR	R7	R7	K13
+      0xA4168400,  //  0017  IMPORT	R5	K66
+      0x58180024,  //  0018  LDCONST	R6	K36
+      0xB81E0600,  //  0019  GETNGBL	R7	K3
+      0x881C0F43,  //  001A  GETMBR	R7	R7	K67
       0x1C1C0607,  //  001B  EQ	R7	R3	R7
       0x781E001A,  //  001C  JMPF	R7	#0038
       0xA8020015,  //  001D  EXBLK	0	#0034
-      0x881C010E,  //  001E  GETMBR	R7	R0	K14
+      0x881C0144,  //  001E  GETMBR	R7	R0	K68
       0x4C200000,  //  001F  LDNIL	R8
       0x20200E08,  //  0020  NE	R8	R7	R8
       0x78220006,  //  0021  JMPF	R8	#0029
       0x60200018,  //  0022  GETGBL	R8	G24
-      0x5824000F,  //  0023  LDCONST	R9	K15
-      0x8C280B10,  //  0024  GETMET	R10	R5	K16
+      0x58240045,  //  0023  LDCONST	R9	K69
+      0x8C280B46,  //  0024  GETMET	R10	R5	K70
       0x5C300E00,  //  0025  MOVE	R12	R7
       0x7C280400,  //  0026  CALL	R10	2
       0x7C200400,  //  0027  CALL	R8	2
       0x5C181000,  //  0028  MOVE	R6	R8
-      0x88200111,  //  0029  GETMBR	R8	R0	K17
+      0x88200147,  //  0029  GETMBR	R8	R0	K71
       0x4C240000,  //  002A  LDNIL	R9
       0x20241009,  //  002B  NE	R9	R8	R9
       0x78260004,  //  002C  JMPF	R9	#0032
-      0x00180D12,  //  002D  ADD	R6	R6	K18
-      0x8C240B10,  //  002E  GETMET	R9	R5	K16
+      0x00180D48,  //  002D  ADD	R6	R6	K72
+      0x8C240B46,  //  002E  GETMET	R9	R5	K70
       0x5C2C1000,  //  002F  MOVE	R11	R8
       0x7C240400,  //  0030  CALL	R9	2
       0x00180C09,  //  0031  ADD	R6	R6	R9
@@ -2725,16 +2664,16 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
       0x70020000,  //  0036  JMP		#0038
       0xB0080000,  //  0037  RAISE	2	R0	R0
       0x601C0018,  //  0038  GETGBL	R7	G24
-      0x58200013,  //  0039  LDCONST	R8	K19
-      0x88240100,  //  003A  GETMBR	R9	R0	K0
-      0x88241314,  //  003B  GETMBR	R9	R9	K20
-      0x88280115,  //  003C  GETMBR	R10	R0	K21
+      0x58200049,  //  0039  LDCONST	R8	K73
+      0x88240132,  //  003A  GETMBR	R9	R0	K50
+      0x8824134A,  //  003B  GETMBR	R9	R9	K74
+      0x88280134,  //  003C  GETMBR	R10	R0	K52
       0x5C2C0800,  //  003D  MOVE	R11	R4
       0x5C300C00,  //  003E  MOVE	R12	R6
       0x7C1C0A00,  //  003F  CALL	R7	5
-      0xB8220E00,  //  0040  GETNGBL	R8	K7
-      0x8C201108,  //  0041  GETMET	R8	R8	K8
-      0x58280009,  //  0042  LDCONST	R10	K9
+      0xB8227C00,  //  0040  GETNGBL	R8	K62
+      0x8C20113F,  //  0041  GETMET	R8	R8	K63
+      0x58280016,  //  0042  LDCONST	R10	K22
       0x842C0001,  //  0043  CLOSURE	R11	P1
       0x7C200600,  //  0044  CALL	R8	3
       0xA0140000,  //  0045  CLOSE	R5
@@ -2753,22 +2692,20 @@ be_local_closure(class_lvh_obj_init,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     6,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x60180003,  //  0000  GETGBL	R6	G3
       0x5C1C0000,  //  0001  MOVE	R7	R0
       0x7C180200,  //  0002  CALL	R6	1
-      0x8C180D00,  //  0003  GETMET	R6	R6	K0
+      0x8C180D4B,  //  0003  GETMET	R6	R6	K75
       0x5C200200,  //  0004  MOVE	R8	R1
       0x5C240400,  //  0005  MOVE	R9	R2
       0x5C280600,  //  0006  MOVE	R10	R3
@@ -2789,25 +2726,20 @@ be_local_closure(class_lvh_obj_get_enabled,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_DISABLED),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_enabled),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04034C,  //  0001  GETMET	R1	R1	K76
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x880C074D,  //  0003  GETMBR	R3	R3	K77
       0x7C040400,  //  0004  CALL	R1	2
       0x78060000,  //  0005  JMPF	R1	#0007
       0x50040001,  //  0006  LDBOOL	R1	0	1
@@ -2826,19 +2758,17 @@ be_local_closure(class_lvh_obj_get_click,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_enabled),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_click),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04014E,  //  0000  GETMET	R1	R0	K78
       0x7C040200,  //  0001  CALL	R1	1
       0x80040200,  //  0002  RET	1	R1
     })
@@ -2854,25 +2784,22 @@ be_local_closure(class_lvh_obj_get_label_mode,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_long_mode),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_label_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
-      0x8C040301,  //  0005  GETMET	R1	R1	K1
+      0x88040111,  //  0004  GETMBR	R1	R0	K17
+      0x8C04034F,  //  0005  GETMET	R1	R1	K79
       0x7C040200,  //  0006  CALL	R1	1
       0x80040200,  //  0007  RET	1	R1
       0x80000000,  //  0008  RET	0
@@ -2889,25 +2816,20 @@ be_local_closure(class_lvh_obj_get_toggle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_CHECKED),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_toggle),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04034C,  //  0001  GETMET	R1	R1	K76
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x880C070A,  //  0003  GETMBR	R3	R3	K10
       0x7C040400,  //  0004  CALL	R1	2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -2923,25 +2845,20 @@ be_local_closure(class_lvh_obj_get_hidden,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_hidden),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x880C0750,  //  0003  GETMBR	R3	R3	K80
       0x7C040400,  //  0004  CALL	R1	2
       0x80040200,  //  0005  RET	1	R1
     })
@@ -2957,19 +2874,17 @@ be_local_closure(class_lvh_obj_set_value_font,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_font),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_value_font),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080151,  //  0000  GETMET	R2	R0	K81
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x80000000,  //  0003  RET	0
@@ -2986,19 +2901,17 @@ be_local_closure(class_lvh_obj_get_value_font,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_text_font),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_value_font),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040152,  //  0000  GETMET	R1	R0	K82
       0x7C040200,  //  0001  CALL	R1	1
       0x80040200,  //  0002  RET	1	R1
     })
@@ -3014,31 +2927,25 @@ be_local_closure(class_lvh_obj_set_val,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(_val),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(_lv_obj),
-    /* K4   */  be_nested_str_weak(set_value),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
-      0x88140103,  //  0003  GETMBR	R5	R0	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
+      0xA40A4E00,  //  0000  IMPORT	R2	K39
+      0x9002A601,  //  0001  SETMBR	R0	K83	R1
+      0x8C0C0528,  //  0002  GETMET	R3	R2	K40
+      0x88140101,  //  0003  GETMBR	R5	R0	K1
+      0x58180054,  //  0004  LDCONST	R6	K84
       0x7C0C0600,  //  0005  CALL	R3	3
       0x780E0003,  //  0006  JMPF	R3	#000B
-      0x880C0103,  //  0007  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x880C0101,  //  0007  GETMBR	R3	R0	K1
+      0x8C0C0754,  //  0008  GETMET	R3	R3	K84
       0x5C140200,  //  0009  MOVE	R5	R1
       0x7C0C0400,  //  000A  CALL	R3	2
       0x80000000,  //  000B  RET	0
@@ -3055,23 +2962,19 @@ be_local_closure(class_lvh_obj_set_text_color,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_text_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_text_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x8C140102,  //  0002  GETMET	R5	R0	K2
+      0x880C0101,  //  0000  GETMBR	R3	R0	K1
+      0x8C0C0755,  //  0001  GETMET	R3	R3	K85
+      0x8C140156,  //  0002  GETMET	R5	R0	K86
       0x5C1C0200,  //  0003  MOVE	R7	R1
       0x7C140400,  //  0004  CALL	R5	2
       0x5C180400,  //  0005  MOVE	R6	R2
@@ -3090,22 +2993,20 @@ be_local_closure(class_lvh_obj_set_action,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_action),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x90024602,  //  0003  SETMBR	R0	K35	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -3120,19 +3021,13 @@ be_local_closure(class_lvh_obj_get_radius2,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_radius2),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -3141,7 +3036,7 @@ be_local_closure(class_lvh_obj_get_radius2,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C040357,  //  0005  GETMET	R1	R1	K87
       0x880C0100,  //  0006  GETMBR	R3	R0	K0
       0xB8120600,  //  0007  GETNGBL	R4	K3
       0x88100904,  //  0008  GETMBR	R4	R4	K4
@@ -3162,19 +3057,13 @@ be_local_closure(class_lvh_obj_set_pad_right2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_pad_right2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -3183,7 +3072,7 @@ be_local_closure(class_lvh_obj_set_pad_right2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x8C080558,  //  0005  GETMET	R2	R2	K88
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -3206,75 +3095,56 @@ be_local_closure(class_lvh_obj_set_label_mode,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expand),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_width),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(SIZE_CONTENT),
-    /* K5   */  be_nested_str_weak(break),
-    /* K6   */  be_nested_str_weak(LABEL_LONG_WRAP),
-    /* K7   */  be_nested_str_weak(dots),
-    /* K8   */  be_nested_str_weak(LABEL_LONG_DOT),
-    /* K9   */  be_nested_str_weak(scroll),
-    /* K10  */  be_nested_str_weak(LABEL_LONG_SCROLL),
-    /* K11  */  be_nested_str_weak(loop),
-    /* K12  */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
-    /* K13  */  be_nested_str_weak(crop),
-    /* K14  */  be_nested_str_weak(LABEL_LONG_CLIP),
-    /* K15  */  be_nested_str_weak(check_label),
-    /* K16  */  be_nested_str_weak(_lv_label),
-    /* K17  */  be_nested_str_weak(set_long_mode),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_label_mode),
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
-      0x1C0C0300,  //  0001  EQ	R3	R1	K0
+      0x1C0C0359,  //  0001  EQ	R3	R1	K89
       0x780E0005,  //  0002  JMPF	R3	#0009
       0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x8C0C075A,  //  0004  GETMET	R3	R3	K90
       0xB8160600,  //  0005  GETNGBL	R5	K3
-      0x88140B04,  //  0006  GETMBR	R5	R5	K4
+      0x88140B5B,  //  0006  GETMBR	R5	R5	K91
       0x7C0C0400,  //  0007  CALL	R3	2
       0x70020017,  //  0008  JMP		#0021
-      0x1C0C0305,  //  0009  EQ	R3	R1	K5
+      0x1C0C035C,  //  0009  EQ	R3	R1	K92
       0x780E0002,  //  000A  JMPF	R3	#000E
       0xB80E0600,  //  000B  GETNGBL	R3	K3
-      0x88080706,  //  000C  GETMBR	R2	R3	K6
+      0x8808075D,  //  000C  GETMBR	R2	R3	K93
       0x70020012,  //  000D  JMP		#0021
-      0x1C0C0307,  //  000E  EQ	R3	R1	K7
+      0x1C0C035E,  //  000E  EQ	R3	R1	K94
       0x780E0002,  //  000F  JMPF	R3	#0013
       0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x88080708,  //  0011  GETMBR	R2	R3	K8
+      0x8808075F,  //  0011  GETMBR	R2	R3	K95
       0x7002000D,  //  0012  JMP		#0021
-      0x1C0C0309,  //  0013  EQ	R3	R1	K9
+      0x1C0C0360,  //  0013  EQ	R3	R1	K96
       0x780E0002,  //  0014  JMPF	R3	#0018
       0xB80E0600,  //  0015  GETNGBL	R3	K3
-      0x8808070A,  //  0016  GETMBR	R2	R3	K10
+      0x88080761,  //  0016  GETMBR	R2	R3	K97
       0x70020008,  //  0017  JMP		#0021
-      0x1C0C030B,  //  0018  EQ	R3	R1	K11
+      0x1C0C0362,  //  0018  EQ	R3	R1	K98
       0x780E0002,  //  0019  JMPF	R3	#001D
       0xB80E0600,  //  001A  GETNGBL	R3	K3
-      0x8808070C,  //  001B  GETMBR	R2	R3	K12
+      0x88080763,  //  001B  GETMBR	R2	R3	K99
       0x70020003,  //  001C  JMP		#0021
-      0x1C0C030D,  //  001D  EQ	R3	R1	K13
+      0x1C0C0364,  //  001D  EQ	R3	R1	K100
       0x780E0001,  //  001E  JMPF	R3	#0021
       0xB80E0600,  //  001F  GETNGBL	R3	K3
-      0x8808070E,  //  0020  GETMBR	R2	R3	K14
+      0x88080765,  //  0020  GETMBR	R2	R3	K101
       0x4C0C0000,  //  0021  LDNIL	R3
       0x200C0403,  //  0022  NE	R3	R2	R3
       0x780E0005,  //  0023  JMPF	R3	#002A
-      0x8C0C010F,  //  0024  GETMET	R3	R0	K15
+      0x8C0C0114,  //  0024  GETMET	R3	R0	K20
       0x7C0C0200,  //  0025  CALL	R3	1
-      0x880C0110,  //  0026  GETMBR	R3	R0	K16
-      0x8C0C0711,  //  0027  GETMET	R3	R3	K17
+      0x880C0111,  //  0026  GETMBR	R3	R0	K17
+      0x8C0C0766,  //  0027  GETMET	R3	R3	K102
       0x5C140400,  //  0028  MOVE	R5	R2
       0x7C0C0400,  //  0029  CALL	R3	2
       0x80000000,  //  002A  RET	0
@@ -3291,79 +3161,51 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(startswith),
-    /* K3   */  be_nested_str_weak(set_),
-    /* K4   */  be_nested_str_weak(get_),
-    /* K5   */  be_nested_str_weak(real),
-    /* K6   */  be_nested_str_weak(math),
-    /* K7   */  be_nested_str_weak(round),
-    /* K8   */  be_nested_str_weak(endswith),
-    /* K9   */  be_nested_str_weak(_X25),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(lv),
-    /* K12  */  be_nested_str_weak(pct),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(byte),
-    /* K15  */  be_const_int(2147483647),
-    /* K16  */  be_nested_str_weak(digits_to_style),
-    /* K17  */  be_nested_str_weak(_attr_ignore),
-    /* K18  */  be_nested_str_weak(find),
-    /* K19  */  be_nested_str_weak(get),
-    /* K20  */  be_nested_str_weak(function),
-    /* K21  */  be_nested_str_weak(_attr_map),
-    /* K22  */  be_nested_str_weak(is_color_attribute),
-    /* K23  */  be_nested_str_weak(parse_color),
-    /* K24  */  be_nested_str_weak(_lv_obj),
-    /* K25  */  be_nested_str_weak(set_style_),
-    /* K26  */  be_nested_str_weak(HSP_X3A_X20unknown_X20attribute_X3A),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[164]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x8C140702,  //  0002  GETMET	R5	R3	K2
+      0xA40E0A00,  //  0000  IMPORT	R3	K5
+      0xA4124E00,  //  0001  IMPORT	R4	K39
+      0x8C140767,  //  0002  GETMET	R5	R3	K103
       0x5C1C0200,  //  0003  MOVE	R7	R1
-      0x58200003,  //  0004  LDCONST	R8	K3
+      0x58200068,  //  0004  LDCONST	R8	K104
       0x7C140600,  //  0005  CALL	R5	3
       0x74160004,  //  0006  JMPT	R5	#000C
-      0x8C140702,  //  0007  GETMET	R5	R3	K2
+      0x8C140767,  //  0007  GETMET	R5	R3	K103
       0x5C1C0200,  //  0008  MOVE	R7	R1
-      0x58200004,  //  0009  LDCONST	R8	K4
+      0x58200069,  //  0009  LDCONST	R8	K105
       0x7C140600,  //  000A  CALL	R5	3
       0x78160000,  //  000B  JMPF	R5	#000D
       0x80000A00,  //  000C  RET	0
       0x60140004,  //  000D  GETGBL	R5	G4
       0x5C180400,  //  000E  MOVE	R6	R2
       0x7C140200,  //  000F  CALL	R5	1
-      0x1C140B05,  //  0010  EQ	R5	R5	K5
+      0x1C140B6A,  //  0010  EQ	R5	R5	K106
       0x78160006,  //  0011  JMPF	R5	#0019
-      0xA4160C00,  //  0012  IMPORT	R5	K6
+      0xA416D600,  //  0012  IMPORT	R5	K107
       0x60180009,  //  0013  GETGBL	R6	G9
-      0x8C1C0B07,  //  0014  GETMET	R7	R5	K7
+      0x8C1C0B6C,  //  0014  GETMET	R7	R5	K108
       0x5C240400,  //  0015  MOVE	R9	R2
       0x7C1C0400,  //  0016  CALL	R7	2
       0x7C180200,  //  0017  CALL	R6	1
       0x5C080C00,  //  0018  MOVE	R2	R6
-      0x8C140708,  //  0019  GETMET	R5	R3	K8
+      0x8C14076D,  //  0019  GETMET	R5	R3	K109
       0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x58200009,  //  001B  LDCONST	R8	K9
+      0x5820006E,  //  001B  LDCONST	R8	K110
       0x7C140600,  //  001C  CALL	R5	3
       0x78160009,  //  001D  JMPF	R5	#0028
       0x5415FFFD,  //  001E  LDINT	R5	-2
-      0x40161405,  //  001F  CONNECT	R5	K10	R5
+      0x4016DE05,  //  001F  CONNECT	R5	K111	R5
       0x94040205,  //  0020  GETIDX	R1	R1	R5
-      0xB8161600,  //  0021  GETNGBL	R5	K11
-      0x8C140B0C,  //  0022  GETMET	R5	R5	K12
+      0xB8160600,  //  0021  GETNGBL	R5	K3
+      0x8C140B70,  //  0022  GETMET	R5	R5	K112
       0x601C0009,  //  0023  GETGBL	R7	G9
       0x5C200400,  //  0024  MOVE	R8	R2
       0x7C1C0200,  //  0025  CALL	R7	1
@@ -3373,13 +3215,13 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
       0x6018000C,  //  0029  GETGBL	R6	G12
       0x5C1C0200,  //  002A  MOVE	R7	R1
       0x7C180200,  //  002B  CALL	R6	1
-      0x28180D0D,  //  002C  GE	R6	R6	K13
+      0x28180D71,  //  002C  GE	R6	R6	K113
       0x781A001F,  //  002D  JMPF	R6	#004E
-      0x8C18070E,  //  002E  GETMET	R6	R3	K14
+      0x8C180772,  //  002E  GETMET	R6	R3	K114
       0x5421FFFE,  //  002F  LDINT	R8	-1
       0x94200208,  //  0030  GETIDX	R8	R1	R8
       0x7C180400,  //  0031  CALL	R6	2
-      0x8C1C070E,  //  0032  GETMET	R7	R3	K14
+      0x8C1C0772,  //  0032  GETMET	R7	R3	K114
       0x5425FFFD,  //  0033  LDINT	R9	-2
       0x94240209,  //  0034  GETIDX	R9	R1	R9
       0x7C1C0400,  //  0035  CALL	R7	2
@@ -3397,32 +3239,32 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
       0x7822000B,  //  0041  JMPF	R8	#004E
       0x60200009,  //  0042  GETGBL	R8	G9
       0x5425FFFD,  //  0043  LDINT	R9	-2
-      0x4024130F,  //  0044  CONNECT	R9	R9	K15
+      0x40241373,  //  0044  CONNECT	R9	R9	K115
       0x94240209,  //  0045  GETIDX	R9	R1	R9
       0x7C200200,  //  0046  CALL	R8	1
       0x5425FFFC,  //  0047  LDINT	R9	-3
-      0x40261409,  //  0048  CONNECT	R9	K10	R9
+      0x4026DE09,  //  0048  CONNECT	R9	K111	R9
       0x94040209,  //  0049  GETIDX	R1	R1	R9
-      0x8C240110,  //  004A  GETMET	R9	R0	K16
+      0x8C240174,  //  004A  GETMET	R9	R0	K116
       0x5C2C1000,  //  004B  MOVE	R11	R8
       0x7C240400,  //  004C  CALL	R9	2
       0x5C141200,  //  004D  MOVE	R5	R9
-      0x88180111,  //  004E  GETMBR	R6	R0	K17
-      0x8C180D12,  //  004F  GETMET	R6	R6	K18
+      0x88180175,  //  004E  GETMBR	R6	R0	K117
+      0x8C180D41,  //  004F  GETMET	R6	R6	K65
       0x5C200200,  //  0050  MOVE	R8	R1
       0x7C180400,  //  0051  CALL	R6	2
       0x4C1C0000,  //  0052  LDNIL	R7
       0x20180C07,  //  0053  NE	R6	R6	R7
       0x781A0000,  //  0054  JMPF	R6	#0056
       0x80000C00,  //  0055  RET	0
-      0x8C180913,  //  0056  GETMET	R6	R4	K19
+      0x8C180976,  //  0056  GETMET	R6	R4	K118
       0x5C200000,  //  0057  MOVE	R8	R0
-      0x00260601,  //  0058  ADD	R9	K3	R1
+      0x0026D001,  //  0058  ADD	R9	K104	R1
       0x7C180600,  //  0059  CALL	R6	3
       0x601C0004,  //  005A  GETGBL	R7	G4
       0x5C200C00,  //  005B  MOVE	R8	R6
       0x7C1C0200,  //  005C  CALL	R7	1
-      0x1C1C0F14,  //  005D  EQ	R7	R7	K20
+      0x1C1C0F77,  //  005D  EQ	R7	R7	K119
       0x781E000A,  //  005E  JMPF	R7	#006A
       0x5C1C0C00,  //  005F  MOVE	R7	R6
       0x5C200000,  //  0060  MOVE	R8	R0
@@ -3432,64 +3274,64 @@ be_local_closure(class_lvh_obj_setmember,   /* name */
       0x782A0001,  //  0064  JMPF	R10	#0067
       0x5C280A00,  //  0065  MOVE	R10	R5
       0x70020000,  //  0066  JMP		#0068
-      0x5828000A,  //  0067  LDCONST	R10	K10
+      0x5828006F,  //  0067  LDCONST	R10	K111
       0x7C1C0600,  //  0068  CALL	R7	3
       0x80000E00,  //  0069  RET	0
-      0x881C0115,  //  006A  GETMBR	R7	R0	K21
-      0x8C1C0F12,  //  006B  GETMET	R7	R7	K18
+      0x881C0178,  //  006A  GETMBR	R7	R0	K120
+      0x8C1C0F41,  //  006B  GETMET	R7	R7	K65
       0x5C240200,  //  006C  MOVE	R9	R1
       0x5C280200,  //  006D  MOVE	R10	R1
       0x7C1C0600,  //  006E  CALL	R7	3
       0x5C040E00,  //  006F  MOVE	R1	R7
-      0x8C1C0116,  //  0070  GETMET	R7	R0	K22
+      0x8C1C0179,  //  0070  GETMET	R7	R0	K121
       0x5C240200,  //  0071  MOVE	R9	R1
       0x7C1C0400,  //  0072  CALL	R7	2
       0x781E0003,  //  0073  JMPF	R7	#0078
-      0x8C1C0117,  //  0074  GETMET	R7	R0	K23
+      0x8C1C0156,  //  0074  GETMET	R7	R0	K86
       0x5C240400,  //  0075  MOVE	R9	R2
       0x7C1C0400,  //  0076  CALL	R7	2
       0x5C080E00,  //  0077  MOVE	R2	R7
       0x4C1C0000,  //  0078  LDNIL	R7
       0x1C1C0A07,  //  0079  EQ	R7	R5	R7
       0x781E000E,  //  007A  JMPF	R7	#008A
-      0x8C1C0913,  //  007B  GETMET	R7	R4	K19
-      0x88240118,  //  007C  GETMBR	R9	R0	K24
-      0x002A0601,  //  007D  ADD	R10	K3	R1
+      0x8C1C0976,  //  007B  GETMET	R7	R4	K118
+      0x88240101,  //  007C  GETMBR	R9	R0	K1
+      0x002AD001,  //  007D  ADD	R10	K104	R1
       0x7C1C0600,  //  007E  CALL	R7	3
       0x5C180E00,  //  007F  MOVE	R6	R7
       0x601C0004,  //  0080  GETGBL	R7	G4
       0x5C200C00,  //  0081  MOVE	R8	R6
       0x7C1C0200,  //  0082  CALL	R7	1
-      0x1C1C0F14,  //  0083  EQ	R7	R7	K20
+      0x1C1C0F77,  //  0083  EQ	R7	R7	K119
       0x781E0004,  //  0084  JMPF	R7	#008A
       0x5C1C0C00,  //  0085  MOVE	R7	R6
-      0x88200118,  //  0086  GETMBR	R8	R0	K24
+      0x88200101,  //  0086  GETMBR	R8	R0	K1
       0x5C240400,  //  0087  MOVE	R9	R2
       0x7C1C0400,  //  0088  CALL	R7	2
       0x80040E00,  //  0089  RET	1	R7
-      0x8C1C0913,  //  008A  GETMET	R7	R4	K19
-      0x88240118,  //  008B  GETMBR	R9	R0	K24
-      0x002A3201,  //  008C  ADD	R10	K25	R1
+      0x8C1C0976,  //  008A  GETMET	R7	R4	K118
+      0x88240101,  //  008B  GETMBR	R9	R0	K1
+      0x002AF401,  //  008C  ADD	R10	K122	R1
       0x7C1C0600,  //  008D  CALL	R7	3
       0x5C180E00,  //  008E  MOVE	R6	R7
       0x601C0004,  //  008F  GETGBL	R7	G4
       0x5C200C00,  //  0090  MOVE	R8	R6
       0x7C1C0200,  //  0091  CALL	R7	1
-      0x1C1C0F14,  //  0092  EQ	R7	R7	K20
+      0x1C1C0F77,  //  0092  EQ	R7	R7	K119
       0x781E000A,  //  0093  JMPF	R7	#009F
       0x5C1C0C00,  //  0094  MOVE	R7	R6
-      0x88200118,  //  0095  GETMBR	R8	R0	K24
+      0x88200101,  //  0095  GETMBR	R8	R0	K1
       0x5C240400,  //  0096  MOVE	R9	R2
       0x4C280000,  //  0097  LDNIL	R10
       0x20280A0A,  //  0098  NE	R10	R5	R10
       0x782A0001,  //  0099  JMPF	R10	#009C
       0x5C280A00,  //  009A  MOVE	R10	R5
       0x70020000,  //  009B  JMP		#009D
-      0x5828000A,  //  009C  LDCONST	R10	K10
+      0x5828006F,  //  009C  LDCONST	R10	K111
       0x7C1C0600,  //  009D  CALL	R7	3
       0x80040E00,  //  009E  RET	1	R7
       0x601C0001,  //  009F  GETGBL	R7	G1
-      0x5820001A,  //  00A0  LDCONST	R8	K26
+      0x5820007B,  //  00A0  LDCONST	R8	K123
       0x5C240200,  //  00A1  MOVE	R9	R1
       0x7C1C0400,  //  00A2  CALL	R7	2
       0x80000000,  //  00A3  RET	0
@@ -3506,33 +3348,27 @@ be_local_closure(class_lvh_obj_set_enabled,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(clear_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_DISABLED),
-    /* K4   */  be_nested_str_weak(add_state),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_enabled),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C08050B,  //  0002  GETMET	R2	R2	K11
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x8810094D,  //  0004  GETMBR	R4	R4	K77
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x88080101,  //  0007  GETMBR	R2	R0	K1
+      0x8C080509,  //  0008  GETMET	R2	R2	K9
+      0xB8120600,  //  0009  GETNGBL	R4	K3
+      0x8810094D,  //  000A  GETMBR	R4	R4	K77
       0x7C080400,  //  000B  CALL	R2	2
       0x80000000,  //  000C  RET	0
     })
@@ -3548,57 +3384,46 @@ be_local_closure(class_lvh_obj_get_align,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(get_style_text_align),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_nested_str_weak(left),
-    /* K6   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K7   */  be_nested_str_weak(center),
-    /* K8   */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K9   */  be_nested_str_weak(right),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_align),
     &be_const_str_solidified,
     ( &(const binstruction[33]) {  /* code */
-      0x1C080300,  //  0000  EQ	R2	R1	K0
+      0x1C080316,  //  0000  EQ	R2	R1	K22
       0x780A0000,  //  0001  JMPF	R2	#0003
-      0x58040000,  //  0002  LDCONST	R1	K0
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x58040016,  //  0002  LDCONST	R1	K22
+      0x88080111,  //  0003  GETMBR	R2	R0	K17
       0x4C0C0000,  //  0004  LDNIL	R3
       0x1C080403,  //  0005  EQ	R2	R2	R3
       0x780A0001,  //  0006  JMPF	R2	#0009
       0x4C080000,  //  0007  LDNIL	R2
       0x80040400,  //  0008  RET	1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x8C080502,  //  000A  GETMET	R2	R2	K2
+      0x88080111,  //  0009  GETMBR	R2	R0	K17
+      0x8C08057C,  //  000A  GETMET	R2	R2	K124
       0x5C100200,  //  000B  MOVE	R4	R1
       0x7C080400,  //  000C  CALL	R2	2
       0xB80E0600,  //  000D  GETNGBL	R3	K3
-      0x880C0704,  //  000E  GETMBR	R3	R3	K4
+      0x880C0718,  //  000E  GETMBR	R3	R3	K24
       0x1C0C0403,  //  000F  EQ	R3	R2	R3
       0x780E0001,  //  0010  JMPF	R3	#0013
-      0x80060A00,  //  0011  RET	1	K5
+      0x80062E00,  //  0011  RET	1	K23
       0x7002000C,  //  0012  JMP		#0020
       0xB80E0600,  //  0013  GETNGBL	R3	K3
-      0x880C0706,  //  0014  GETMBR	R3	R3	K6
+      0x880C071B,  //  0014  GETMBR	R3	R3	K27
       0x1C0C0403,  //  0015  EQ	R3	R2	R3
       0x780E0001,  //  0016  JMPF	R3	#0019
-      0x80060E00,  //  0017  RET	1	K7
+      0x80063400,  //  0017  RET	1	K26
       0x70020006,  //  0018  JMP		#0020
       0xB80E0600,  //  0019  GETNGBL	R3	K3
-      0x880C0708,  //  001A  GETMBR	R3	R3	K8
+      0x880C071E,  //  001A  GETMBR	R3	R3	K30
       0x1C0C0403,  //  001B  EQ	R3	R2	R3
       0x780E0001,  //  001C  JMPF	R3	#001F
-      0x80061200,  //  001D  RET	1	K9
+      0x80063A00,  //  001D  RET	1	K29
       0x70020000,  //  001E  JMP		#0020
       0x80040400,  //  001F  RET	1	R2
       0x80000000,  //  0020  RET	0
@@ -3615,19 +3440,13 @@ be_local_closure(class_lvh_obj_get_pad_left,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_pad_left),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -3636,7 +3455,7 @@ be_local_closure(class_lvh_obj_get_pad_left,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C04037D,  //  0005  GETMET	R1	R1	K125
       0x880C0100,  //  0006  GETMBR	R3	R0	K0
       0xB8120600,  //  0007  GETNGBL	R4	K3
       0x88100904,  //  0008  GETMBR	R4	R4	K4
@@ -3657,24 +3476,20 @@ be_local_closure(class_lvh_obj_set_value_ofs_x,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_x),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_value_ofs_x),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080114,  //  0000  GETMET	R2	R0	K20
       0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x88080111,  //  0002  GETMBR	R2	R0	K17
+      0x8C08057E,  //  0003  GETMET	R2	R2	K126
       0x60100009,  //  0004  GETGBL	R4	G9
       0x5C140200,  //  0005  MOVE	R5	R1
       0x7C100200,  //  0006  CALL	R4	1
@@ -3693,33 +3508,27 @@ be_local_closure(class_lvh_obj_set_flex_in_new_track,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_FLEX_IN_NEW_TRACK),
-    /* K4   */  be_nested_str_weak(clear_flag),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_flex_in_new_track),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080538,  //  0002  GETMET	R2	R2	K56
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x8810092E,  //  0004  GETMBR	R4	R4	K46
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x88080101,  //  0007  GETMBR	R2	R0	K1
+      0x8C080539,  //  0008  GETMET	R2	R2	K57
+      0xB8120600,  //  0009  GETNGBL	R4	K3
+      0x8810092E,  //  000A  GETMBR	R4	R4	K46
       0x7C080400,  //  000B  CALL	R2	2
       0x80000000,  //  000C  RET	0
     })
@@ -3735,45 +3544,26 @@ be_local_closure(class_lvh_obj_member,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(startswith),
-    /* K3   */  be_nested_str_weak(set_),
-    /* K4   */  be_nested_str_weak(get_),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(byte),
-    /* K7   */  be_const_int(2147483647),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(digits_to_style),
-    /* K10  */  be_nested_str_weak(_attr_ignore),
-    /* K11  */  be_nested_str_weak(find),
-    /* K12  */  be_nested_str_weak(get),
-    /* K13  */  be_nested_str_weak(function),
-    /* K14  */  be_nested_str_weak(_attr_map),
-    /* K15  */  be_nested_str_weak(_lv_obj),
-    /* K16  */  be_nested_str_weak(get_style_),
-    /* K17  */  be_nested_str_weak(undefined),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(member),
     &be_const_str_solidified,
     ( &(const binstruction[125]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100502,  //  0002  GETMET	R4	R2	K2
+      0xA40A0A00,  //  0000  IMPORT	R2	K5
+      0xA40E4E00,  //  0001  IMPORT	R3	K39
+      0x8C100567,  //  0002  GETMET	R4	R2	K103
       0x5C180200,  //  0003  MOVE	R6	R1
-      0x581C0003,  //  0004  LDCONST	R7	K3
+      0x581C0068,  //  0004  LDCONST	R7	K104
       0x7C100600,  //  0005  CALL	R4	3
       0x74120004,  //  0006  JMPT	R4	#000C
-      0x8C100502,  //  0007  GETMET	R4	R2	K2
+      0x8C100567,  //  0007  GETMET	R4	R2	K103
       0x5C180200,  //  0008  MOVE	R6	R1
-      0x581C0004,  //  0009  LDCONST	R7	K4
+      0x581C0069,  //  0009  LDCONST	R7	K105
       0x7C100600,  //  000A  CALL	R4	3
       0x78120000,  //  000B  JMPF	R4	#000D
       0x80000800,  //  000C  RET	0
@@ -3781,13 +3571,13 @@ be_local_closure(class_lvh_obj_member,   /* name */
       0x6014000C,  //  000E  GETGBL	R5	G12
       0x5C180200,  //  000F  MOVE	R6	R1
       0x7C140200,  //  0010  CALL	R5	1
-      0x28140B05,  //  0011  GE	R5	R5	K5
+      0x28140B71,  //  0011  GE	R5	R5	K113
       0x7816001F,  //  0012  JMPF	R5	#0033
-      0x8C140506,  //  0013  GETMET	R5	R2	K6
+      0x8C140572,  //  0013  GETMET	R5	R2	K114
       0x541DFFFE,  //  0014  LDINT	R7	-1
       0x941C0207,  //  0015  GETIDX	R7	R1	R7
       0x7C140400,  //  0016  CALL	R5	2
-      0x8C180506,  //  0017  GETMET	R6	R2	K6
+      0x8C180572,  //  0017  GETMET	R6	R2	K114
       0x5421FFFD,  //  0018  LDINT	R8	-2
       0x94200208,  //  0019  GETIDX	R8	R1	R8
       0x7C180400,  //  001A  CALL	R6	2
@@ -3805,32 +3595,32 @@ be_local_closure(class_lvh_obj_member,   /* name */
       0x781E000B,  //  0026  JMPF	R7	#0033
       0x601C0009,  //  0027  GETGBL	R7	G9
       0x5421FFFD,  //  0028  LDINT	R8	-2
-      0x40201107,  //  0029  CONNECT	R8	R8	K7
+      0x40201173,  //  0029  CONNECT	R8	R8	K115
       0x94200208,  //  002A  GETIDX	R8	R1	R8
       0x7C1C0200,  //  002B  CALL	R7	1
       0x5421FFFC,  //  002C  LDINT	R8	-3
-      0x40221008,  //  002D  CONNECT	R8	K8	R8
+      0x40222C08,  //  002D  CONNECT	R8	K22	R8
       0x94040208,  //  002E  GETIDX	R1	R1	R8
-      0x8C200109,  //  002F  GETMET	R8	R0	K9
+      0x8C200174,  //  002F  GETMET	R8	R0	K116
       0x5C280E00,  //  0030  MOVE	R10	R7
       0x7C200400,  //  0031  CALL	R8	2
       0x5C101000,  //  0032  MOVE	R4	R8
-      0x8814010A,  //  0033  GETMBR	R5	R0	K10
-      0x8C140B0B,  //  0034  GETMET	R5	R5	K11
+      0x88140175,  //  0033  GETMBR	R5	R0	K117
+      0x8C140B41,  //  0034  GETMET	R5	R5	K65
       0x5C1C0200,  //  0035  MOVE	R7	R1
       0x7C140400,  //  0036  CALL	R5	2
       0x4C180000,  //  0037  LDNIL	R6
       0x20140A06,  //  0038  NE	R5	R5	R6
       0x78160000,  //  0039  JMPF	R5	#003B
       0x80000A00,  //  003A  RET	0
-      0x8C14070C,  //  003B  GETMET	R5	R3	K12
+      0x8C140776,  //  003B  GETMET	R5	R3	K118
       0x5C1C0000,  //  003C  MOVE	R7	R0
-      0x00220801,  //  003D  ADD	R8	K4	R1
+      0x0022D201,  //  003D  ADD	R8	K105	R1
       0x7C140600,  //  003E  CALL	R5	3
       0x60180004,  //  003F  GETGBL	R6	G4
       0x5C1C0A00,  //  0040  MOVE	R7	R5
       0x7C180200,  //  0041  CALL	R6	1
-      0x1C180D0D,  //  0042  EQ	R6	R6	K13
+      0x1C180D77,  //  0042  EQ	R6	R6	K119
       0x781A0009,  //  0043  JMPF	R6	#004E
       0x5C180A00,  //  0044  MOVE	R6	R5
       0x5C1C0000,  //  0045  MOVE	R7	R0
@@ -3839,11 +3629,11 @@ be_local_closure(class_lvh_obj_member,   /* name */
       0x78220001,  //  0048  JMPF	R8	#004B
       0x5C200800,  //  0049  MOVE	R8	R4
       0x70020000,  //  004A  JMP		#004C
-      0x58200008,  //  004B  LDCONST	R8	K8
+      0x58200016,  //  004B  LDCONST	R8	K22
       0x7C180400,  //  004C  CALL	R6	2
       0x80040C00,  //  004D  RET	1	R6
-      0x8818010E,  //  004E  GETMBR	R6	R0	K14
-      0x8C180D0B,  //  004F  GETMET	R6	R6	K11
+      0x88180178,  //  004E  GETMBR	R6	R0	K120
+      0x8C180D41,  //  004F  GETMET	R6	R6	K65
       0x5C200200,  //  0050  MOVE	R8	R1
       0x5C240200,  //  0051  MOVE	R9	R1
       0x7C180600,  //  0052  CALL	R6	3
@@ -3851,42 +3641,42 @@ be_local_closure(class_lvh_obj_member,   /* name */
       0x4C180000,  //  0054  LDNIL	R6
       0x1C180806,  //  0055  EQ	R6	R4	R6
       0x781A000D,  //  0056  JMPF	R6	#0065
-      0x8C18070C,  //  0057  GETMET	R6	R3	K12
-      0x8820010F,  //  0058  GETMBR	R8	R0	K15
-      0x00260801,  //  0059  ADD	R9	K4	R1
+      0x8C180776,  //  0057  GETMET	R6	R3	K118
+      0x88200101,  //  0058  GETMBR	R8	R0	K1
+      0x0026D201,  //  0059  ADD	R9	K105	R1
       0x7C180600,  //  005A  CALL	R6	3
       0x5C140C00,  //  005B  MOVE	R5	R6
       0x60180004,  //  005C  GETGBL	R6	G4
       0x5C1C0A00,  //  005D  MOVE	R7	R5
       0x7C180200,  //  005E  CALL	R6	1
-      0x1C180D0D,  //  005F  EQ	R6	R6	K13
+      0x1C180D77,  //  005F  EQ	R6	R6	K119
       0x781A0003,  //  0060  JMPF	R6	#0065
       0x5C180A00,  //  0061  MOVE	R6	R5
-      0x881C010F,  //  0062  GETMBR	R7	R0	K15
+      0x881C0101,  //  0062  GETMBR	R7	R0	K1
       0x7C180200,  //  0063  CALL	R6	1
       0x80040C00,  //  0064  RET	1	R6
-      0x8C18070C,  //  0065  GETMET	R6	R3	K12
-      0x8820010F,  //  0066  GETMBR	R8	R0	K15
-      0x00262001,  //  0067  ADD	R9	K16	R1
+      0x8C180776,  //  0065  GETMET	R6	R3	K118
+      0x88200101,  //  0066  GETMBR	R8	R0	K1
+      0x0026FE01,  //  0067  ADD	R9	K127	R1
       0x7C180600,  //  0068  CALL	R6	3
       0x5C140C00,  //  0069  MOVE	R5	R6
       0x60180004,  //  006A  GETGBL	R6	G4
       0x5C1C0A00,  //  006B  MOVE	R7	R5
       0x7C180200,  //  006C  CALL	R6	1
-      0x1C180D0D,  //  006D  EQ	R6	R6	K13
+      0x1C180D77,  //  006D  EQ	R6	R6	K119
       0x781A0009,  //  006E  JMPF	R6	#0079
       0x5C180A00,  //  006F  MOVE	R6	R5
-      0x881C010F,  //  0070  GETMBR	R7	R0	K15
+      0x881C0101,  //  0070  GETMBR	R7	R0	K1
       0x4C200000,  //  0071  LDNIL	R8
       0x20200808,  //  0072  NE	R8	R4	R8
       0x78220001,  //  0073  JMPF	R8	#0076
       0x5C200800,  //  0074  MOVE	R8	R4
       0x70020000,  //  0075  JMP		#0077
-      0x58200008,  //  0076  LDCONST	R8	K8
+      0x58200016,  //  0076  LDCONST	R8	K22
       0x7C180400,  //  0077  CALL	R6	2
       0x80040C00,  //  0078  RET	1	R6
       0x6018000B,  //  0079  GETGBL	R6	G11
-      0x581C0011,  //  007A  LDCONST	R7	K17
+      0x581C0080,  //  007A  LDCONST	R7	K128
       0x7C180200,  //  007B  CALL	R6	1
       0x80040C00,  //  007C  RET	1	R6
     })
@@ -3902,13 +3692,13 @@ be_local_closure(class_lvh_obj_get_text_font,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_text_font),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -3926,24 +3716,20 @@ be_local_closure(class_lvh_obj_set_value_ofs_y,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_y),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_value_ofs_y),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080114,  //  0000  GETMET	R2	R0	K20
       0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x88080111,  //  0002  GETMBR	R2	R0	K17
+      0x8C080581,  //  0003  GETMET	R2	R2	K129
       0x60100009,  //  0004  GETGBL	R4	G9
       0x5C140200,  //  0005  MOVE	R5	R1
       0x7C100200,  //  0006  CALL	R4	1
@@ -3962,19 +3748,13 @@ be_local_closure(class_lvh_obj_set_radius2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_radius2),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
@@ -3983,7 +3763,7 @@ be_local_closure(class_lvh_obj_set_radius2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x8C080582,  //  0005  GETMET	R2	R2	K130
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -4006,33 +3786,27 @@ be_local_closure(class_lvh_obj_set_hidden,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
-    /* K4   */  be_nested_str_weak(clear_flag),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_hidden),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080538,  //  0002  GETMET	R2	R2	K56
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x88100950,  //  0004  GETMBR	R4	R4	K80
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x88080101,  //  0007  GETMBR	R2	R0	K1
+      0x8C080539,  //  0008  GETMET	R2	R2	K57
+      0xB8120600,  //  0009  GETNGBL	R4	K3
+      0x88100950,  //  000A  GETMBR	R4	R4	K80
       0x7C080400,  //  000B  CALL	R2	2
       0x80000000,  //  000C  RET	0
     })
@@ -4048,39 +3822,32 @@ be_local_closure(class_lvh_obj_register_event_cb,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(_event_map),
-    /* K3   */  be_nested_str_weak(keys),
-    /* K4   */  be_nested_str_weak(register_event),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(register_event_cb),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x88040132,  //  0000  GETMBR	R1	R0	K50
+      0x8804033A,  //  0001  GETMBR	R1	R1	K58
       0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x880C0140,  //  0003  GETMBR	R3	R0	K64
+      0x8C0C0783,  //  0004  GETMET	R3	R3	K131
       0x7C0C0200,  //  0005  CALL	R3	1
       0x7C080200,  //  0006  CALL	R2	1
       0xA8020006,  //  0007  EXBLK	0	#000F
       0x5C0C0400,  //  0008  MOVE	R3	R2
       0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100304,  //  000A  GETMET	R4	R1	K4
+      0x8C100384,  //  000A  GETMET	R4	R1	K132
       0x5C180000,  //  000B  MOVE	R6	R0
       0x5C1C0600,  //  000C  MOVE	R7	R3
       0x7C100600,  //  000D  CALL	R4	3
       0x7001FFF8,  //  000E  JMP		#0008
-      0x58080005,  //  000F  LDCONST	R2	K5
+      0x58080085,  //  000F  LDCONST	R2	K133
       0xAC080200,  //  0010  CATCH	R2	1	0
       0xB0080000,  //  0011  RAISE	2	R0	R0
       0x80000000,  //  0012  RET	0
@@ -4097,31 +3864,26 @@ be_local_closure(class_lvh_obj_set_text_font,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_font),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_text_font),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(set_text_font),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080186,  //  0000  GETMET	R2	R0	K134
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0004,  //  0005  JMPF	R3	#000B
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x8C0C0787,  //  0007  GETMET	R3	R3	K135
       0x5C140400,  //  0008  MOVE	R5	R2
-      0x58180003,  //  0009  LDCONST	R6	K3
+      0x5818006F,  //  0009  LDCONST	R6	K111
       0x7C0C0600,  //  000A  CALL	R3	3
       0x80000000,  //  000B  RET	0
     })
@@ -4137,19 +3899,13 @@ be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_pad_bottom),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
@@ -4158,7 +3914,7 @@ be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C040388,  //  0005  GETMET	R1	R1	K136
       0x880C0100,  //  0006  GETMBR	R3	R0	K0
       0xB8120600,  //  0007  GETNGBL	R4	K3
       0x88100904,  //  0008  GETMBR	R4	R4	K4
@@ -4179,13 +3935,13 @@ be_local_closure(class_lvh_obj_get_pad_all,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_pad_all),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -4203,21 +3959,18 @@ be_local_closure(class_lvh_obj_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_value),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(get_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040389,  //  0001  GETMET	R1	R1	K137
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -4233,19 +3986,17 @@ be_local_closure(class_lvh_obj_post_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(register_event_cb),
-    }),
+    &be_ktab_class_lvh_obj,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C04018A,  //  0000  GETMET	R1	R0	K138
       0x7C040200,  //  0001  CALL	R1	1
       0x80000000,  //  0002  RET	0
     })
@@ -4533,6 +4284,36 @@ be_local_class(lvh_label,
     })),
     be_str_weak(lvh_label)
 );
+// compact class 'lvh_arc' ktab size: 26, total: 49 (saved 184 bytes)
+static const bvalue be_ktab_class_lvh_arc[26] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(get_mode),
+  /* K2   */  be_nested_str_weak(_label_angle),
+  /* K3   */  be_nested_str_weak(_lv_label),
+  /* K4   */  be_nested_str_weak(rotate_obj_to_angle),
+  /* K5   */  be_nested_str_weak(set_range),
+  /* K6   */  be_nested_str_weak(get_max),
+  /* K7   */  be_nested_str_weak(refresh_label_to_angle),
+  /* K8   */  be_nested_str_weak(get_arc_line_width),
+  /* K9   */  be_nested_str_weak(lv),
+  /* K10  */  be_nested_str_weak(PART_INDICATOR),
+  /* K11  */  be_nested_str_weak(STATE_DEFAULT),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(ARC_MODE_NORMAL),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str_weak(ARC_MODE_REVERSE),
+  /* K16  */  be_const_int(2),
+  /* K17  */  be_nested_str_weak(ARC_MODE_SYMMETRICAL),
+  /* K18  */  be_nested_str_weak(set_mode),
+  /* K19  */  be_nested_str_weak(set_style_arc_width),
+  /* K20  */  be_nested_str_weak(get_min_value),
+  /* K21  */  be_nested_str_weak(get_max_value),
+  /* K22  */  be_nested_str_weak(set_val),
+  /* K23  */  be_nested_str_weak(post_config),
+  /* K24  */  be_nested_str_weak(get_min),
+  /* K25  */  be_nested_str_weak(set_text),
+};
+
 
 extern const bclass be_class_lvh_arc;
 
@@ -4543,16 +4324,13 @@ be_local_closure(class_lvh_arc_get_type,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_mode),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(get_type),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -4573,33 +4351,28 @@ be_local_closure(class_lvh_arc_refresh_label_to_angle,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_label_angle),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(rotate_obj_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(refresh_label_to_angle),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060008,  //  0003  JMPF	R1	#000D
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x88040103,  //  0004  GETMBR	R1	R0	K3
       0x4C080000,  //  0005  LDNIL	R2
       0x20040202,  //  0006  NE	R1	R1	R2
       0x78060004,  //  0007  JMPF	R1	#000D
-      0x88040102,  //  0008  GETMBR	R1	R0	K2
-      0x8C040303,  //  0009  GETMET	R1	R1	K3
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x88100100,  //  000B  GETMBR	R4	R0	K0
+      0x88040100,  //  0008  GETMBR	R1	R0	K0
+      0x8C040304,  //  0009  GETMET	R1	R1	K4
+      0x880C0103,  //  000A  GETMBR	R3	R0	K3
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
       0x7C040600,  //  000C  CALL	R1	3
       0x80000000,  //  000D  RET	0
     })
@@ -4615,30 +4388,25 @@ be_local_closure(class_lvh_arc_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_max),
-    /* K3   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_min),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
       0x60100009,  //  0002  GETGBL	R4	G9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
-      0x8C140102,  //  0005  GETMET	R5	R0	K2
+      0x8C140106,  //  0005  GETMET	R5	R0	K6
       0x7C140200,  //  0006  CALL	R5	1
       0x7C080600,  //  0007  CALL	R2	3
-      0x8C080103,  //  0008  GETMET	R2	R0	K3
+      0x8C080107,  //  0008  GETMET	R2	R0	K7
       0x7C080200,  //  0009  CALL	R2	1
       0x80000000,  //  000A  RET	0
     })
@@ -4654,28 +4422,22 @@ be_local_closure(class_lvh_arc_get_line_width1,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_arc_line_width),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_INDICATOR),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(get_line_width1),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0xB8120400,  //  0004  GETNGBL	R4	K2
-      0x88100904,  //  0005  GETMBR	R4	R4	K4
+      0x8C040308,  //  0001  GETMET	R1	R1	K8
+      0xB80E1200,  //  0002  GETNGBL	R3	K9
+      0x880C070A,  //  0003  GETMBR	R3	R3	K10
+      0xB8121200,  //  0004  GETNGBL	R4	K9
+      0x8810090B,  //  0005  GETMBR	R4	R4	K11
       0x300C0604,  //  0006  OR	R3	R3	R4
       0x7C040400,  //  0007  CALL	R1	2
       0x80040200,  //  0008  RET	1	R1
@@ -4692,46 +4454,36 @@ be_local_closure(class_lvh_arc_set_type,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(ARC_MODE_NORMAL),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(ARC_MODE_REVERSE),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(ARC_MODE_SYMMETRICAL),
-    /* K7   */  be_nested_str_weak(_lv_obj),
-    /* K8   */  be_nested_str_weak(set_mode),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_type),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
-      0x1C0C0300,  //  0001  EQ	R3	R1	K0
+      0x1C0C030C,  //  0001  EQ	R3	R1	K12
       0x780E0002,  //  0002  JMPF	R3	#0006
-      0xB80E0200,  //  0003  GETNGBL	R3	K1
-      0x88080702,  //  0004  GETMBR	R2	R3	K2
+      0xB80E1200,  //  0003  GETNGBL	R3	K9
+      0x8808070D,  //  0004  GETMBR	R2	R3	K13
       0x70020008,  //  0005  JMP		#000F
-      0x1C0C0303,  //  0006  EQ	R3	R1	K3
+      0x1C0C030E,  //  0006  EQ	R3	R1	K14
       0x780E0002,  //  0007  JMPF	R3	#000B
-      0xB80E0200,  //  0008  GETNGBL	R3	K1
-      0x88080704,  //  0009  GETMBR	R2	R3	K4
+      0xB80E1200,  //  0008  GETNGBL	R3	K9
+      0x8808070F,  //  0009  GETMBR	R2	R3	K15
       0x70020003,  //  000A  JMP		#000F
-      0x1C0C0305,  //  000B  EQ	R3	R1	K5
+      0x1C0C0310,  //  000B  EQ	R3	R1	K16
       0x780E0001,  //  000C  JMPF	R3	#000F
-      0xB80E0200,  //  000D  GETNGBL	R3	K1
-      0x88080706,  //  000E  GETMBR	R2	R3	K6
+      0xB80E1200,  //  000D  GETNGBL	R3	K9
+      0x88080711,  //  000E  GETMBR	R2	R3	K17
       0x4C0C0000,  //  000F  LDNIL	R3
       0x200C0403,  //  0010  NE	R3	R2	R3
       0x780E0003,  //  0011  JMPF	R3	#0016
-      0x880C0107,  //  0012  GETMBR	R3	R0	K7
-      0x8C0C0708,  //  0013  GETMET	R3	R3	K8
+      0x880C0100,  //  0012  GETMBR	R3	R0	K0
+      0x8C0C0712,  //  0013  GETMET	R3	R3	K18
       0x5C140400,  //  0014  MOVE	R5	R2
       0x7C0C0400,  //  0015  CALL	R3	2
       0x80000000,  //  0016  RET	0
@@ -4748,31 +4500,25 @@ be_local_closure(class_lvh_arc_set_line_width1,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_arc_width),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_INDICATOR),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_line_width1),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080513,  //  0001  GETMET	R2	R2	K19
       0x60100009,  //  0002  GETGBL	R4	G9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
-      0xB8160400,  //  0005  GETNGBL	R5	K2
-      0x88140B03,  //  0006  GETMBR	R5	R5	K3
-      0xB81A0400,  //  0007  GETNGBL	R6	K2
-      0x88180D04,  //  0008  GETMBR	R6	R6	K4
+      0xB8161200,  //  0005  GETNGBL	R5	K9
+      0x88140B0A,  //  0006  GETMBR	R5	R5	K10
+      0xB81A1200,  //  0007  GETNGBL	R6	K9
+      0x88180D0B,  //  0008  GETMBR	R6	R6	K11
       0x30140A06,  //  0009  OR	R5	R5	R6
       0x7C080600,  //  000A  CALL	R2	3
       0x80000000,  //  000B  RET	0
@@ -4789,21 +4535,18 @@ be_local_closure(class_lvh_arc_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_min_value),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(get_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040314,  //  0001  GETMET	R1	R1	K20
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -4819,21 +4562,18 @@ be_local_closure(class_lvh_arc_set_line_width,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_arc_width),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C0C0713,  //  0001  GETMET	R3	R3	K19
       0x60140009,  //  0002  GETGBL	R5	G9
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C140200,  //  0004  CALL	R5	1
@@ -4853,21 +4593,18 @@ be_local_closure(class_lvh_arc_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_max_value),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(get_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040315,  //  0001  GETMET	R1	R1	K21
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -4883,24 +4620,21 @@ be_local_closure(class_lvh_arc_set_label_to_angle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_label_angle),
-    /* K1   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_label_to_angle),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x90020402,  //  0003  SETMBR	R0	K2	R2
+      0x8C080107,  //  0004  GETMET	R2	R0	K7
       0x7C080200,  //  0005  CALL	R2	1
       0x80000000,  //  0006  RET	0
     })
@@ -4916,26 +4650,23 @@ be_local_closure(class_lvh_arc_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_val),
-    /* K1   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080516,  //  0003  GETMET	R2	R2	K22
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080101,  //  0006  GETMET	R2	R0	K1
+      0x8C080107,  //  0006  GETMET	R2	R0	K7
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -4951,25 +4682,22 @@ be_local_closure(class_lvh_arc_post_config,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(post_config),
-    /* K1   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(post_config),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040317,  //  0003  GETMET	R1	R1	K23
       0x7C040200,  //  0004  CALL	R1	1
-      0x8C040101,  //  0005  GETMET	R1	R0	K1
+      0x8C040107,  //  0005  GETMET	R1	R0	K7
       0x7C040200,  //  0006  CALL	R1	1
       0x80000000,  //  0007  RET	0
     })
@@ -4985,21 +4713,18 @@ be_local_closure(class_lvh_arc_get_line_width,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_arc_line_width),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(get_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080508,  //  0001  GETMET	R2	R2	K8
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -5016,30 +4741,25 @@ be_local_closure(class_lvh_arc_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_min),
-    /* K3   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_max),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
+      0x8C100118,  //  0002  GETMET	R4	R0	K24
       0x7C100200,  //  0003  CALL	R4	1
       0x60140009,  //  0004  GETGBL	R5	G9
       0x5C180200,  //  0005  MOVE	R6	R1
       0x7C140200,  //  0006  CALL	R5	1
       0x7C080600,  //  0007  CALL	R2	3
-      0x8C080103,  //  0008  GETMET	R2	R0	K3
+      0x8C080107,  //  0008  GETMET	R2	R0	K7
       0x7C080200,  //  0009  CALL	R2	1
       0x80000000,  //  000A  RET	0
     })
@@ -5055,26 +4775,23 @@ be_local_closure(class_lvh_arc_set_text,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text),
-    /* K1   */  be_nested_str_weak(refresh_label_to_angle),
-    }),
+    &be_ktab_class_lvh_arc,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x8C080519,  //  0003  GETMET	R2	R2	K25
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080101,  //  0006  GETMET	R2	R0	K1
+      0x8C080107,  //  0006  GETMET	R2	R0	K7
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -5365,6 +5082,28 @@ be_local_class(lvh_spinner,
     })),
     be_str_weak(lvh_spinner)
 );
+// compact class 'lvh_img' ktab size: 18, total: 24 (saved 48 bytes)
+static const bvalue be_ktab_class_lvh_img[18] = {
+  /* K0   */  be_nested_str_weak(tasmota_logo),
+  /* K1   */  be_nested_str_weak(_lv_obj),
+  /* K2   */  be_nested_str_weak(set_tasmota_logo),
+  /* K3   */  be_nested_str_weak(set_src),
+  /* K4   */  be_nested_str_weak(set_inner_align),
+  /* K5   */  be_nested_str_weak(lv),
+  /* K6   */  be_nested_str_weak(IMAGE_ALIGN_STRETCH),
+  /* K7   */  be_nested_str_weak(set_angle),
+  /* K8   */  be_nested_str_weak(get_angle),
+  /* K9   */  be_nested_str_weak(_raw),
+  /* K10  */  be_nested_str_weak(fromb64),
+  /* K11  */  be_nested_str_weak(lv_image_dsc),
+  /* K12  */  be_nested_str_weak(header_cf),
+  /* K13  */  be_nested_str_weak(COLOR_FORMAT_RAW),
+  /* K14  */  be_nested_str_weak(data_size),
+  /* K15  */  be_nested_str_weak(data),
+  /* K16  */  be_nested_str_weak(_buffer),
+  /* K17  */  be_nested_str_weak(_imd_dsc),
+};
+
 
 extern const bclass be_class_lvh_img;
 
@@ -5375,18 +5114,13 @@ be_local_closure(class_lvh_img_set_src,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_logo),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_tasmota_logo),
-    /* K3   */  be_nested_str_weak(set_src),
-    }),
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(set_src),
     &be_const_str_solidified,
     ( &(const binstruction[11]) {  /* code */
@@ -5414,13 +5148,13 @@ be_local_closure(class_lvh_img_get_auto_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(get_auto_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5438,26 +5172,21 @@ be_local_closure(class_lvh_img_set_auto_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_inner_align),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(IMAGE_ALIGN_STRETCH),
-    }),
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(set_auto_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x78060004,  //  0000  JMPF	R1	#0006
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080504,  //  0002  GETMET	R2	R2	K4
+      0xB8120A00,  //  0003  GETNGBL	R4	K5
+      0x88100906,  //  0004  GETMBR	R4	R4	K6
       0x7C080400,  //  0005  CALL	R2	2
       0x80000000,  //  0006  RET	0
     })
@@ -5473,16 +5202,13 @@ be_local_closure(class_lvh_img_set_angle,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_angle),
-    }),
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(set_angle),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -5490,8 +5216,8 @@ be_local_closure(class_lvh_img_set_angle,   /* name */
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x5C040400,  //  0003  MOVE	R1	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080507,  //  0005  GETMET	R2	R2	K7
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C080400,  //  0007  CALL	R2	2
       0x80000000,  //  0008  RET	0
@@ -5508,21 +5234,18 @@ be_local_closure(class_lvh_img_get_angle,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_angle),
-    }),
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(get_angle),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040308,  //  0001  GETMET	R1	R1	K8
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -5538,52 +5261,39 @@ be_local_closure(class_lvh_img_set_raw,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_raw),
-    /* K1   */  be_nested_str_weak(fromb64),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(lv_image_dsc),
-    /* K4   */  be_nested_str_weak(header_cf),
-    /* K5   */  be_nested_str_weak(COLOR_FORMAT_RAW),
-    /* K6   */  be_nested_str_weak(data_size),
-    /* K7   */  be_nested_str_weak(data),
-    /* K8   */  be_nested_str_weak(_buffer),
-    /* K9   */  be_nested_str_weak(_imd_dsc),
-    /* K10  */  be_nested_str_weak(_lv_obj),
-    /* K11  */  be_nested_str_weak(set_src),
-    }),
+    &be_ktab_class_lvh_img,     /* shared constants */
     be_str_weak(set_raw),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0x60080015,  //  0000  GETGBL	R2	G21
       0x7C080000,  //  0001  CALL	R2	0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x8C08050A,  //  0002  GETMET	R2	R2	K10
       0x5C100200,  //  0003  MOVE	R4	R1
       0x7C080400,  //  0004  CALL	R2	2
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x90021202,  //  0005  SETMBR	R0	K9	R2
+      0xB80A0A00,  //  0006  GETNGBL	R2	K5
+      0x8C08050B,  //  0007  GETMET	R2	R2	K11
       0x7C080200,  //  0008  CALL	R2	1
-      0xB80E0400,  //  0009  GETNGBL	R3	K2
-      0x880C0705,  //  000A  GETMBR	R3	R3	K5
-      0x900A0803,  //  000B  SETMBR	R2	K4	R3
+      0xB80E0A00,  //  0009  GETNGBL	R3	K5
+      0x880C070D,  //  000A  GETMBR	R3	R3	K13
+      0x900A1803,  //  000B  SETMBR	R2	K12	R3
       0x600C000C,  //  000C  GETGBL	R3	G12
-      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x88100109,  //  000D  GETMBR	R4	R0	K9
       0x7C0C0200,  //  000E  CALL	R3	1
-      0x900A0C03,  //  000F  SETMBR	R2	K6	R3
-      0x880C0100,  //  0010  GETMBR	R3	R0	K0
-      0x8C0C0708,  //  0011  GETMET	R3	R3	K8
+      0x900A1C03,  //  000F  SETMBR	R2	K14	R3
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
+      0x8C0C0710,  //  0011  GETMET	R3	R3	K16
       0x7C0C0200,  //  0012  CALL	R3	1
-      0x900A0E03,  //  0013  SETMBR	R2	K7	R3
-      0x90021202,  //  0014  SETMBR	R0	K9	R2
-      0x880C010A,  //  0015  GETMBR	R3	R0	K10
-      0x8C0C070B,  //  0016  GETMET	R3	R3	K11
+      0x900A1E03,  //  0013  SETMBR	R2	K15	R3
+      0x90022202,  //  0014  SETMBR	R0	K17	R2
+      0x880C0101,  //  0015  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  0016  GETMET	R3	R3	K3
       0x5C140400,  //  0017  MOVE	R5	R2
       0x7C0C0400,  //  0018  CALL	R3	2
       0x80000000,  //  0019  RET	0
@@ -5614,6 +5324,19 @@ be_local_class(lvh_img,
     })),
     be_str_weak(lvh_img)
 );
+// compact class 'lvh_qrcode' ktab size: 9, total: 29 (saved 160 bytes)
+static const bvalue be_ktab_class_lvh_qrcode[9] = {
+  /* K0   */  be_nested_str_weak(qr_text),
+  /* K1   */  be_nested_str_weak(_update),
+  /* K2   */  be_nested_str_weak(_lv_obj),
+  /* K3   */  be_nested_str_weak(set_light_color),
+  /* K4   */  be_nested_str_weak(parse_color),
+  /* K5   */  be_nested_str_weak(set_size),
+  /* K6   */  be_nested_str_weak(set_dark_color),
+  /* K7   */  be_nested_str_weak(post_config),
+  /* K8   */  be_nested_str_weak(update),
+};
+
 
 extern const bclass be_class_lvh_qrcode;
 
@@ -5624,13 +5347,13 @@ be_local_closure(class_lvh_qrcode_get_qr_dark_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_qr_dark_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5648,16 +5371,13 @@ be_local_closure(class_lvh_qrcode_set_qr_text,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(qr_text),
-    /* K1   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_qr_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -5681,28 +5401,23 @@ be_local_closure(class_lvh_qrcode_set_light_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_light_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_light_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080503,  //  0001  GETMET	R2	R2	K3
+      0x8C100104,  //  0002  GETMET	R4	R0	K4
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080103,  //  0006  GETMET	R2	R0	K3
+      0x8C080101,  //  0006  GETMET	R2	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -5718,13 +5433,13 @@ be_local_closure(class_lvh_qrcode_get_dark_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_dark_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5742,28 +5457,23 @@ be_local_closure(class_lvh_qrcode_set_qr_light_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_light_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_qr_light_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080503,  //  0001  GETMET	R2	R2	K3
+      0x8C100104,  //  0002  GETMET	R4	R0	K4
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080103,  //  0006  GETMET	R2	R0	K3
+      0x8C080101,  //  0006  GETMET	R2	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -5779,13 +5489,13 @@ be_local_closure(class_lvh_qrcode_get_qr_light_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_qr_light_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5803,25 +5513,21 @@ be_local_closure(class_lvh_qrcode_set_qr_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_size),
-    /* K2   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_qr_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x8C080102,  //  0004  GETMET	R2	R0	K2
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
       0x7C080200,  //  0005  CALL	R2	1
       0x80000000,  //  0006  RET	0
     })
@@ -5837,13 +5543,13 @@ be_local_closure(class_lvh_qrcode_get_light_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_light_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5861,25 +5567,21 @@ be_local_closure(class_lvh_qrcode_set_size,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_size),
-    /* K2   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080505,  //  0001  GETMET	R2	R2	K5
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x8C080102,  //  0004  GETMET	R2	R0	K2
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
       0x7C080200,  //  0005  CALL	R2	1
       0x80000000,  //  0006  RET	0
     })
@@ -5895,28 +5597,23 @@ be_local_closure(class_lvh_qrcode_set_qr_dark_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_dark_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_qr_dark_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080506,  //  0001  GETMET	R2	R2	K6
+      0x8C100104,  //  0002  GETMET	R4	R0	K4
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080103,  //  0006  GETMET	R2	R0	K3
+      0x8C080101,  //  0006  GETMET	R2	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -5932,13 +5629,13 @@ be_local_closure(class_lvh_qrcode_get_qr_text,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_qr_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -5956,28 +5653,23 @@ be_local_closure(class_lvh_qrcode_set_dark_color,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_dark_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(set_dark_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C080506,  //  0001  GETMET	R2	R2	K6
+      0x8C100104,  //  0002  GETMET	R4	R0	K4
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C100400,  //  0004  CALL	R4	2
       0x7C080400,  //  0005  CALL	R2	2
-      0x8C080103,  //  0006  GETMET	R2	R0	K3
+      0x8C080101,  //  0006  GETMET	R2	R0	K1
       0x7C080200,  //  0007  CALL	R2	1
       0x80000000,  //  0008  RET	0
     })
@@ -5993,13 +5685,13 @@ be_local_closure(class_lvh_qrcode_get_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -6017,23 +5709,20 @@ be_local_closure(class_lvh_qrcode_post_config,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(post_config),
-    /* K1   */  be_nested_str_weak(_update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(post_config),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040307,  //  0003  GETMET	R1	R1	K7
       0x7C040200,  //  0004  CALL	R1	1
       0x8C040101,  //  0005  GETMET	R1	R0	K1
       0x7C040200,  //  0006  CALL	R1	1
@@ -6051,17 +5740,13 @@ be_local_closure(class_lvh_qrcode__update,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(qr_text),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(update),
-    }),
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(_update),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
@@ -6069,8 +5754,8 @@ be_local_closure(class_lvh_qrcode__update,   /* name */
       0x4C080000,  //  0001  LDNIL	R2
       0x20080202,  //  0002  NE	R2	R1	R2
       0x780A0006,  //  0003  JMPF	R2	#000B
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x88080102,  //  0004  GETMBR	R2	R0	K2
+      0x8C080508,  //  0005  GETMET	R2	R2	K8
       0x5C100200,  //  0006  MOVE	R4	R1
       0x6014000C,  //  0007  GETGBL	R5	G12
       0x5C180200,  //  0008  MOVE	R6	R1
@@ -6090,13 +5775,13 @@ be_local_closure(class_lvh_qrcode_get_qr_size,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_qrcode,     /* shared constants */
     be_str_weak(get_qr_size),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -6137,6 +5822,19 @@ be_local_class(lvh_qrcode,
     })),
     be_str_weak(lvh_qrcode)
 );
+// compact class 'lvh_slider' ktab size: 9, total: 14 (saved 40 bytes)
+static const bvalue be_ktab_class_lvh_slider[9] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(set_range),
+  /* K2   */  be_nested_str_weak(get_min),
+  /* K3   */  be_nested_str_weak(get_min_value),
+  /* K4   */  be_nested_str_weak(_val),
+  /* K5   */  be_nested_str_weak(set_value),
+  /* K6   */  be_const_int(0),
+  /* K7   */  be_nested_str_weak(get_max_value),
+  /* K8   */  be_nested_str_weak(get_max),
+};
+
 
 extern const bclass be_class_lvh_slider;
 
@@ -6147,17 +5845,13 @@ be_local_closure(class_lvh_slider_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_min),
-    }),
+    &be_ktab_class_lvh_slider,     /* shared constants */
     be_str_weak(set_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -6183,21 +5877,18 @@ be_local_closure(class_lvh_slider_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_min_value),
-    }),
+    &be_ktab_class_lvh_slider,     /* shared constants */
     be_str_weak(get_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040303,  //  0001  GETMET	R1	R1	K3
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -6213,26 +5904,21 @@ be_local_closure(class_lvh_slider_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_value),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_lvh_slider,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x90020801,  //  0000  SETMBR	R0	K4	R1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080505,  //  0002  GETMET	R2	R2	K5
       0x5C100200,  //  0003  MOVE	R4	R1
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x58140006,  //  0004  LDCONST	R5	K6
       0x7C080600,  //  0005  CALL	R2	3
       0x80000000,  //  0006  RET	0
     })
@@ -6248,21 +5934,18 @@ be_local_closure(class_lvh_slider_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_max_value),
-    }),
+    &be_ktab_class_lvh_slider,     /* shared constants */
     be_str_weak(get_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -6278,17 +5961,13 @@ be_local_closure(class_lvh_slider_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_max),
-    }),
+    &be_ktab_class_lvh_slider,     /* shared constants */
     be_str_weak(set_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
@@ -6297,7 +5976,7 @@ be_local_closure(class_lvh_slider_set_min,   /* name */
       0x60100009,  //  0002  GETGBL	R4	G9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
-      0x8C140102,  //  0005  GETMET	R5	R0	K2
+      0x8C140108,  //  0005  GETMET	R5	R0	K8
       0x7C140200,  //  0006  CALL	R5	1
       0x7C080600,  //  0007  CALL	R2	3
       0x80000000,  //  0008  RET	0
@@ -6325,6 +6004,26 @@ be_local_class(lvh_slider,
     })),
     be_str_weak(lvh_slider)
 );
+// compact class 'lvh_roller' ktab size: 16, total: 20 (saved 32 bytes)
+static const bvalue be_ktab_class_lvh_roller[16] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(set_options),
+  /* K2   */  be_nested_str_weak(lv),
+  /* K3   */  be_nested_str_weak(ROLLER_MODE_NORMAL),
+  /* K4   */  be_nested_str_weak(resize),
+  /* K5   */  be_nested_str_weak(get_selected_str),
+  /* K6   */  be_nested_str_weak(_buffer),
+  /* K7   */  be_nested_str_weak(remove_trailing_zeroes),
+  /* K8   */  be_nested_str_weak(asstring),
+  /* K9   */  be_nested_str_weak(get_options),
+  /* K10  */  be_nested_str_weak(_val),
+  /* K11  */  be_nested_str_weak(set_selected),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(attribute_error),
+  /* K14  */  be_nested_str_weak(set_text_X20unsupported_X20on_X20roller),
+  /* K15  */  be_nested_str_weak(get_selected),
+};
+
 
 extern const bclass be_class_lvh_roller;
 
@@ -6335,18 +6034,13 @@ be_local_closure(class_lvh_roller_set_options,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_options),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(ROLLER_MODE_NORMAL),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(set_options),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
@@ -6370,39 +6064,32 @@ be_local_closure(class_lvh_roller_get_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resize),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_selected_str),
-    /* K3   */  be_nested_str_weak(_buffer),
-    /* K4   */  be_nested_str_weak(remove_trailing_zeroes),
-    /* K5   */  be_nested_str_weak(asstring),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(get_text),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x60040015,  //  0000  GETGBL	R1	G21
       0x7C040000,  //  0001  CALL	R1	0
-      0x8C040300,  //  0002  GETMET	R1	R1	K0
+      0x8C040304,  //  0002  GETMET	R1	R1	K4
       0x540E00FF,  //  0003  LDINT	R3	256
       0x7C040400,  //  0004  CALL	R1	2
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x8C080502,  //  0006  GETMET	R2	R2	K2
-      0x8C100303,  //  0007  GETMET	R4	R1	K3
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x8C080505,  //  0006  GETMET	R2	R2	K5
+      0x8C100306,  //  0007  GETMET	R4	R1	K6
       0x7C100200,  //  0008  CALL	R4	1
       0x541600FF,  //  0009  LDINT	R5	256
       0x7C080600,  //  000A  CALL	R2	3
-      0x8C080104,  //  000B  GETMET	R2	R0	K4
+      0x8C080107,  //  000B  GETMET	R2	R0	K7
       0x5C100200,  //  000C  MOVE	R4	R1
       0x7C080400,  //  000D  CALL	R2	2
       0x5C040400,  //  000E  MOVE	R1	R2
-      0x8C080305,  //  000F  GETMET	R2	R1	K5
+      0x8C080308,  //  000F  GETMET	R2	R1	K8
       0x7C080200,  //  0010  CALL	R2	1
       0x80040400,  //  0011  RET	1	R2
     })
@@ -6418,21 +6105,18 @@ be_local_closure(class_lvh_roller_get_options,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_options),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(get_options),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -6448,26 +6132,21 @@ be_local_closure(class_lvh_roller_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_selected),
-    /* K3   */  be_const_int(0),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x90021401,  //  0000  SETMBR	R0	K10	R1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C08050B,  //  0002  GETMET	R2	R2	K11
       0x5C100200,  //  0003  MOVE	R4	R1
-      0x58140003,  //  0004  LDCONST	R5	K3
+      0x5814000C,  //  0004  LDCONST	R5	K12
       0x7C080600,  //  0005  CALL	R2	3
       0x80000000,  //  0006  RET	0
     })
@@ -6483,20 +6162,17 @@ be_local_closure(class_lvh_roller_set_text,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_error),
-    /* K1   */  be_nested_str_weak(set_text_X20unsupported_X20on_X20roller),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0xB0060101,  //  0000  RAISE	1	K0	K1
+      0xB0061B0E,  //  0000  RAISE	1	K13	K14
       0x80000000,  //  0001  RET	0
     })
   )
@@ -6511,21 +6187,18 @@ be_local_closure(class_lvh_roller_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_selected),
-    }),
+    &be_ktab_class_lvh_roller,     /* shared constants */
     be_str_weak(get_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -6553,6 +6226,16 @@ be_local_class(lvh_roller,
     })),
     be_str_weak(lvh_roller)
 );
+// compact class 'lvh_led' ktab size: 6, total: 8 (saved 16 bytes)
+static const bvalue be_ktab_class_lvh_led[6] = {
+  /* K0   */  be_nested_str_weak(_val),
+  /* K1   */  be_nested_str_weak(_lv_obj),
+  /* K2   */  be_nested_str_weak(set_brightness),
+  /* K3   */  be_nested_str_weak(get_brightness),
+  /* K4   */  be_nested_str_weak(parse_color),
+  /* K5   */  be_nested_str_weak(set_color),
+};
+
 
 extern const bclass be_class_lvh_led;
 
@@ -6563,17 +6246,13 @@ be_local_closure(class_lvh_led_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_brightness),
-    }),
+    &be_ktab_class_lvh_led,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
@@ -6596,13 +6275,13 @@ be_local_closure(class_lvh_led_get_color,   /* name */
   be_nested_proto(
     1,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    &be_ktab_class_lvh_led,     /* shared constants */
     be_str_weak(get_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
@@ -6620,21 +6299,18 @@ be_local_closure(class_lvh_led_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_brightness),
-    }),
+    &be_ktab_class_lvh_led,     /* shared constants */
     be_str_weak(get_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040303,  //  0001  GETMET	R1	R1	K3
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -6650,25 +6326,21 @@ be_local_closure(class_lvh_led_set_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_color),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_color),
-    }),
+    &be_ktab_class_lvh_led,     /* shared constants */
     be_str_weak(set_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080104,  //  0000  GETMET	R2	R0	K4
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x8C0C0705,  //  0004  GETMET	R3	R3	K5
       0x5C140400,  //  0005  MOVE	R5	R2
       0x7C0C0400,  //  0006  CALL	R3	2
       0x80000000,  //  0007  RET	0
@@ -6695,6 +6367,36 @@ be_local_class(lvh_led,
     })),
     be_str_weak(lvh_led)
 );
+// compact class 'lvh_dropdown' ktab size: 26, total: 37 (saved 88 bytes)
+static const bvalue be_ktab_class_lvh_dropdown[26] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(get_selected),
+  /* K2   */  be_nested_str_weak(set_text),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_nested_str_weak(set_dir),
+  /* K6   */  be_nested_str_weak(_dir),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_nested_str_weak(_symbol),
+  /* K9   */  be_nested_str_weak(lv),
+  /* K10  */  be_nested_str_weak(SYMBOL_UP),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(SYMBOL_LEFT),
+  /* K13  */  be_nested_str_weak(SYMBOL_RIGHT),
+  /* K14  */  be_nested_str_weak(SYMBOL_DOWN),
+  /* K15  */  be_nested_str_weak(set_symbol),
+  /* K16  */  be_nested_str_weak(get_dir),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(_val),
+  /* K19  */  be_nested_str_weak(set_selected),
+  /* K20  */  be_nested_str_weak(get_text),
+  /* K21  */  be_nested_str_weak(resize),
+  /* K22  */  be_nested_str_weak(get_selected_str),
+  /* K23  */  be_nested_str_weak(_buffer),
+  /* K24  */  be_nested_str_weak(remove_trailing_zeroes),
+  /* K25  */  be_nested_str_weak(asstring),
+};
+
 
 extern const bclass be_class_lvh_dropdown;
 
@@ -6705,16 +6407,13 @@ be_local_closure(class_lvh_dropdown_get_val,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_selected),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(get_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -6735,21 +6434,18 @@ be_local_closure(class_lvh_dropdown_set_text,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
@@ -6766,28 +6462,13 @@ be_local_closure(class_lvh_dropdown_set_direction,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_const_int(3),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(set_dir),
-    /* K4   */  be_nested_str_weak(_dir),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(_symbol),
-    /* K7   */  be_nested_str_weak(lv),
-    /* K8   */  be_nested_str_weak(SYMBOL_UP),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(SYMBOL_LEFT),
-    /* K11  */  be_nested_str_weak(SYMBOL_RIGHT),
-    /* K12  */  be_nested_str_weak(SYMBOL_DOWN),
-    /* K13  */  be_nested_str_weak(set_symbol),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(set_direction),
     &be_const_str_solidified,
     ( &(const binstruction[40]) {  /* code */
@@ -6795,40 +6476,40 @@ be_local_closure(class_lvh_dropdown_set_direction,   /* name */
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x5C040400,  //  0003  MOVE	R1	R2
-      0x14080300,  //  0004  LT	R2	R1	K0
+      0x14080303,  //  0004  LT	R2	R1	K3
       0x740A0001,  //  0005  JMPT	R2	#0008
-      0x24080301,  //  0006  GT	R2	R1	K1
+      0x24080304,  //  0006  GT	R2	R1	K4
       0x780A0000,  //  0007  JMPF	R2	#0009
-      0x58040000,  //  0008  LDCONST	R1	K0
-      0x88080102,  //  0009  GETMBR	R2	R0	K2
-      0x8C080503,  //  000A  GETMET	R2	R2	K3
-      0x88100104,  //  000B  GETMBR	R4	R0	K4
+      0x58040003,  //  0008  LDCONST	R1	K3
+      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x8C080505,  //  000A  GETMET	R2	R2	K5
+      0x88100106,  //  000B  GETMBR	R4	R0	K6
       0x94100801,  //  000C  GETIDX	R4	R4	R1
       0x7C080400,  //  000D  CALL	R2	2
-      0x1C080305,  //  000E  EQ	R2	R1	K5
+      0x1C080307,  //  000E  EQ	R2	R1	K7
       0x780A0003,  //  000F  JMPF	R2	#0014
-      0xB80A0E00,  //  0010  GETNGBL	R2	K7
-      0x88080508,  //  0011  GETMBR	R2	R2	K8
-      0x90020C02,  //  0012  SETMBR	R0	K6	R2
+      0xB80A1200,  //  0010  GETNGBL	R2	K9
+      0x8808050A,  //  0011  GETMBR	R2	R2	K10
+      0x90021002,  //  0012  SETMBR	R0	K8	R2
       0x7002000E,  //  0013  JMP		#0023
-      0x1C080309,  //  0014  EQ	R2	R1	K9
+      0x1C08030B,  //  0014  EQ	R2	R1	K11
       0x780A0003,  //  0015  JMPF	R2	#001A
-      0xB80A0E00,  //  0016  GETNGBL	R2	K7
-      0x8808050A,  //  0017  GETMBR	R2	R2	K10
-      0x90020C02,  //  0018  SETMBR	R0	K6	R2
+      0xB80A1200,  //  0016  GETNGBL	R2	K9
+      0x8808050C,  //  0017  GETMBR	R2	R2	K12
+      0x90021002,  //  0018  SETMBR	R0	K8	R2
       0x70020008,  //  0019  JMP		#0023
-      0x1C080301,  //  001A  EQ	R2	R1	K1
+      0x1C080304,  //  001A  EQ	R2	R1	K4
       0x780A0003,  //  001B  JMPF	R2	#0020
-      0xB80A0E00,  //  001C  GETNGBL	R2	K7
-      0x8808050B,  //  001D  GETMBR	R2	R2	K11
-      0x90020C02,  //  001E  SETMBR	R0	K6	R2
+      0xB80A1200,  //  001C  GETNGBL	R2	K9
+      0x8808050D,  //  001D  GETMBR	R2	R2	K13
+      0x90021002,  //  001E  SETMBR	R0	K8	R2
       0x70020002,  //  001F  JMP		#0023
-      0xB80A0E00,  //  0020  GETNGBL	R2	K7
-      0x8808050C,  //  0021  GETMBR	R2	R2	K12
-      0x90020C02,  //  0022  SETMBR	R0	K6	R2
-      0x88080102,  //  0023  GETMBR	R2	R0	K2
-      0x8C08050D,  //  0024  GETMET	R2	R2	K13
-      0x88100106,  //  0025  GETMBR	R4	R0	K6
+      0xB80A1200,  //  0020  GETNGBL	R2	K9
+      0x8808050E,  //  0021  GETMBR	R2	R2	K14
+      0x90021002,  //  0022  SETMBR	R0	K8	R2
+      0x88080100,  //  0023  GETMBR	R2	R0	K0
+      0x8C08050F,  //  0024  GETMET	R2	R2	K15
+      0x88100108,  //  0025  GETMBR	R4	R0	K8
       0x7C080400,  //  0026  CALL	R2	2
       0x80000000,  //  0027  RET	0
     })
@@ -6844,37 +6525,31 @@ be_local_closure(class_lvh_dropdown_get_direction,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_dir),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_dir),
-    /* K4   */  be_const_int(1),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(get_direction),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040310,  //  0001  GETMET	R1	R1	K16
       0x7C040200,  //  0002  CALL	R1	1
-      0x58080002,  //  0003  LDCONST	R2	K2
+      0x58080011,  //  0003  LDCONST	R2	K17
       0x600C000C,  //  0004  GETGBL	R3	G12
-      0x88100103,  //  0005  GETMBR	R4	R0	K3
+      0x88100106,  //  0005  GETMBR	R4	R0	K6
       0x7C0C0200,  //  0006  CALL	R3	1
       0x140C0403,  //  0007  LT	R3	R2	R3
       0x780E0006,  //  0008  JMPF	R3	#0010
-      0x880C0103,  //  0009  GETMBR	R3	R0	K3
+      0x880C0106,  //  0009  GETMBR	R3	R0	K6
       0x940C0602,  //  000A  GETIDX	R3	R3	R2
       0x1C0C0203,  //  000B  EQ	R3	R1	R3
       0x780E0000,  //  000C  JMPF	R3	#000E
       0x80040400,  //  000D  RET	1	R2
-      0x00080504,  //  000E  ADD	R2	R2	K4
+      0x00080507,  //  000E  ADD	R2	R2	K7
       0x7001FFF3,  //  000F  JMP		#0004
       0x540DFFFE,  //  0010  LDINT	R3	-1
       0x80040600,  //  0011  RET	1	R3
@@ -6891,22 +6566,19 @@ be_local_closure(class_lvh_dropdown_set_show_selected,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(set_show_selected),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x78060003,  //  0000  JMPF	R1	#0005
       0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
       0x4C100000,  //  0003  LDNIL	R4
       0x7C080400,  //  0004  CALL	R2	2
       0x80000000,  //  0005  RET	0
@@ -6923,23 +6595,19 @@ be_local_closure(class_lvh_dropdown_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_selected),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x90022401,  //  0000  SETMBR	R0	K18	R1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080513,  //  0002  GETMET	R2	R2	K19
       0x5C100200,  //  0003  MOVE	R4	R1
       0x7C080400,  //  0004  CALL	R2	2
       0x80000000,  //  0005  RET	0
@@ -6956,46 +6624,38 @@ be_local_closure(class_lvh_dropdown_get_text,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_text),
-    /* K2   */  be_nested_str_weak(resize),
-    /* K3   */  be_nested_str_weak(get_selected_str),
-    /* K4   */  be_nested_str_weak(_buffer),
-    /* K5   */  be_nested_str_weak(remove_trailing_zeroes),
-    /* K6   */  be_nested_str_weak(asstring),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(get_text),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040314,  //  0001  GETMET	R1	R1	K20
       0x7C040200,  //  0002  CALL	R1	1
       0x4C080000,  //  0003  LDNIL	R2
       0x1C080202,  //  0004  EQ	R2	R1	R2
       0x780A0012,  //  0005  JMPF	R2	#0019
       0x60080015,  //  0006  GETGBL	R2	G21
       0x7C080000,  //  0007  CALL	R2	0
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x8C080515,  //  0008  GETMET	R2	R2	K21
       0x541200FF,  //  0009  LDINT	R4	256
       0x7C080400,  //  000A  CALL	R2	2
       0x880C0100,  //  000B  GETMBR	R3	R0	K0
-      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
-      0x8C140504,  //  000D  GETMET	R5	R2	K4
+      0x8C0C0716,  //  000C  GETMET	R3	R3	K22
+      0x8C140517,  //  000D  GETMET	R5	R2	K23
       0x7C140200,  //  000E  CALL	R5	1
       0x541A00FF,  //  000F  LDINT	R6	256
       0x7C0C0600,  //  0010  CALL	R3	3
-      0x8C0C0105,  //  0011  GETMET	R3	R0	K5
+      0x8C0C0118,  //  0011  GETMET	R3	R0	K24
       0x5C140400,  //  0012  MOVE	R5	R2
       0x7C0C0400,  //  0013  CALL	R3	2
       0x5C080600,  //  0014  MOVE	R2	R3
-      0x8C0C0506,  //  0015  GETMET	R3	R2	K6
+      0x8C0C0519,  //  0015  GETMET	R3	R2	K25
       0x7C0C0200,  //  0016  CALL	R3	1
       0x80040600,  //  0017  RET	1	R3
       0x70020000,  //  0018  JMP		#001A
@@ -7014,21 +6674,18 @@ be_local_closure(class_lvh_dropdown_get_show_selected,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_text),
-    }),
+    &be_ktab_class_lvh_dropdown,     /* shared constants */
     be_str_weak(get_show_selected),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040314,  //  0001  GETMET	R1	R1	K20
       0x7C040200,  //  0002  CALL	R1	1
       0x4C080000,  //  0003  LDNIL	R2
       0x1C080202,  //  0004  EQ	R2	R1	R2
@@ -7143,6 +6800,25 @@ be_local_class(lvh_dropdown_list,
     })),
     be_str_weak(lvh_dropdown_list)
 );
+// compact class 'lvh_bar' ktab size: 15, total: 24 (saved 72 bytes)
+static const bvalue be_ktab_class_lvh_bar[15] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(get_max_value),
+  /* K2   */  be_nested_str_weak(set_range),
+  /* K3   */  be_nested_str_weak(get_min_value),
+  /* K4   */  be_nested_str_weak(post_init),
+  /* K5   */  be_nested_str_weak(_parent_lvh),
+  /* K6   */  be_nested_str_weak(_page),
+  /* K7   */  be_nested_str_weak(_oh),
+  /* K8   */  be_nested_str_weak(lvh_scale),
+  /* K9   */  be_nested_str_weak(get_range_min_value),
+  /* K10  */  be_nested_str_weak(get_range_max_value),
+  /* K11  */  be_nested_str_weak(_val),
+  /* K12  */  be_nested_str_weak(set_value),
+  /* K13  */  be_nested_str_weak(lv),
+  /* K14  */  be_nested_str_weak(ANIM_OFF),
+};
+
 
 extern const bclass be_class_lvh_bar;
 
@@ -7153,16 +6829,13 @@ be_local_closure(class_lvh_bar_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_max_value),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(get_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
@@ -7183,24 +6856,20 @@ be_local_closure(class_lvh_bar_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_min_value),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(set_max),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
       0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x8C100902,  //  0003  GETMET	R4	R4	K2
+      0x8C100903,  //  0003  GETMET	R4	R4	K3
       0x7C100200,  //  0004  CALL	R4	1
       0x60140009,  //  0005  GETGBL	R5	G9
       0x5C180200,  //  0006  MOVE	R6	R1
@@ -7220,48 +6889,38 @@ be_local_closure(class_lvh_bar_post_init,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(post_init),
-    /* K1   */  be_nested_str_weak(_parent_lvh),
-    /* K2   */  be_nested_str_weak(_page),
-    /* K3   */  be_nested_str_weak(_oh),
-    /* K4   */  be_nested_str_weak(lvh_scale),
-    /* K5   */  be_nested_str_weak(_lv_obj),
-    /* K6   */  be_nested_str_weak(get_range_min_value),
-    /* K7   */  be_nested_str_weak(get_range_max_value),
-    /* K8   */  be_nested_str_weak(set_range),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
       0x60040003,  //  0000  GETGBL	R1	G3
       0x5C080000,  //  0001  MOVE	R2	R0
       0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x8C040304,  //  0003  GETMET	R1	R1	K4
       0x7C040200,  //  0004  CALL	R1	1
       0x6004000F,  //  0005  GETGBL	R1	G15
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x880C0102,  //  0007  GETMBR	R3	R0	K2
-      0x880C0703,  //  0008  GETMBR	R3	R3	K3
-      0x880C0704,  //  0009  GETMBR	R3	R3	K4
+      0x88080105,  //  0006  GETMBR	R2	R0	K5
+      0x880C0106,  //  0007  GETMBR	R3	R0	K6
+      0x880C0707,  //  0008  GETMBR	R3	R3	K7
+      0x880C0708,  //  0009  GETMBR	R3	R3	K8
       0x7C040400,  //  000A  CALL	R1	2
       0x7806000C,  //  000B  JMPF	R1	#0019
-      0x88040101,  //  000C  GETMBR	R1	R0	K1
-      0x88040305,  //  000D  GETMBR	R1	R1	K5
-      0x8C040306,  //  000E  GETMET	R1	R1	K6
+      0x88040105,  //  000C  GETMBR	R1	R0	K5
+      0x88040300,  //  000D  GETMBR	R1	R1	K0
+      0x8C040309,  //  000E  GETMET	R1	R1	K9
       0x7C040200,  //  000F  CALL	R1	1
-      0x88080101,  //  0010  GETMBR	R2	R0	K1
-      0x88080505,  //  0011  GETMBR	R2	R2	K5
-      0x8C080507,  //  0012  GETMET	R2	R2	K7
+      0x88080105,  //  0010  GETMBR	R2	R0	K5
+      0x88080500,  //  0011  GETMBR	R2	R2	K0
+      0x8C08050A,  //  0012  GETMET	R2	R2	K10
       0x7C080200,  //  0013  CALL	R2	1
-      0x880C0105,  //  0014  GETMBR	R3	R0	K5
-      0x8C0C0708,  //  0015  GETMET	R3	R3	K8
+      0x880C0100,  //  0014  GETMBR	R3	R0	K0
+      0x8C0C0702,  //  0015  GETMET	R3	R3	K2
       0x5C140200,  //  0016  MOVE	R5	R1
       0x5C180400,  //  0017  MOVE	R6	R2
       0x7C0C0600,  //  0018  CALL	R3	3
@@ -7279,21 +6938,18 @@ be_local_closure(class_lvh_bar_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_min_value),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(get_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040303,  //  0001  GETMET	R1	R1	K3
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -7309,27 +6965,23 @@ be_local_closure(class_lvh_bar_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_max_value),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(set_min),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
       0x60100009,  //  0002  GETGBL	R4	G9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
       0x88140100,  //  0005  GETMBR	R5	R0	K0
-      0x8C140B02,  //  0006  GETMET	R5	R5	K2
+      0x8C140B01,  //  0006  GETMET	R5	R5	K1
       0x7C140200,  //  0007  CALL	R5	1
       0x7C080600,  //  0008  CALL	R2	3
       0x80000000,  //  0009  RET	0
@@ -7346,28 +6998,22 @@ be_local_closure(class_lvh_bar_set_val,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_value),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(ANIM_OFF),
-    }),
+    &be_ktab_class_lvh_bar,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x90021601,  //  0000  SETMBR	R0	K11	R1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C08050C,  //  0002  GETMET	R2	R2	K12
       0x5C100200,  //  0003  MOVE	R4	R1
-      0xB8160600,  //  0004  GETNGBL	R5	K3
-      0x88140B04,  //  0005  GETMBR	R5	R5	K4
+      0xB8161A00,  //  0004  GETNGBL	R5	K13
+      0x88140B0E,  //  0005  GETMBR	R5	R5	K14
       0x7C080600,  //  0006  CALL	R2	3
       0x80000000,  //  0007  RET	0
     })
@@ -7512,6 +7158,23 @@ be_local_class(lvh_line,
     })),
     be_str_weak(lvh_line)
 );
+// compact class 'lvh_scale' ktab size: 13, total: 21 (saved 64 bytes)
+static const bvalue be_ktab_class_lvh_scale[13] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(push),
+  /* K2   */  be_nested_str_weak(),
+  /* K3   */  be_nested_str_weak(_options),
+  /* K4   */  be_nested_str_weak(_options_arr),
+  /* K5   */  be_nested_str_weak(lv),
+  /* K6   */  be_nested_str_weak(str_arr),
+  /* K7   */  be_nested_str_weak(_lv_obj),
+  /* K8   */  be_nested_str_weak(set_text_src),
+  /* K9   */  be_nested_str_weak(HTP_X3A_X20_X27scale_X27_X20needs_X20_X27text_src_X27_X20to_X20be_X20a_X20list_X20of_X20strings),
+  /* K10  */  be_nested_str_weak(get_range_max_value),
+  /* K11  */  be_nested_str_weak(set_range),
+  /* K12  */  be_nested_str_weak(get_range_min_value),
+};
+
 
 extern const bclass be_class_lvh_scale;
 
@@ -7522,24 +7185,13 @@ be_local_closure(class_lvh_scale_set_text_src,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(_options),
-    /* K4   */  be_nested_str_weak(_options_arr),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(str_arr),
-    /* K7   */  be_nested_str_weak(_lv_obj),
-    /* K8   */  be_nested_str_weak(set_text_src),
-    /* K9   */  be_nested_str_weak(HTP_X3A_X20_X27scale_X27_X20needs_X20_X27text_src_X27_X20to_X20be_X20a_X20list_X20of_X20strings),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(set_text_src),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
@@ -7590,21 +7242,18 @@ be_local_closure(class_lvh_scale_get_max,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_range_max_value),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(get_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x8C04030A,  //  0001  GETMET	R1	R1	K10
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -7620,27 +7269,23 @@ be_local_closure(class_lvh_scale_set_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_range_max_value),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(set_min),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C08050B,  //  0001  GETMET	R2	R2	K11
       0x60100009,  //  0002  GETGBL	R4	G9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
-      0x88140100,  //  0005  GETMBR	R5	R0	K0
-      0x8C140B02,  //  0006  GETMET	R5	R5	K2
+      0x88140107,  //  0005  GETMBR	R5	R0	K7
+      0x8C140B0A,  //  0006  GETMET	R5	R5	K10
       0x7C140200,  //  0007  CALL	R5	1
       0x7C080600,  //  0008  CALL	R2	3
       0x80000000,  //  0009  RET	0
@@ -7657,19 +7302,17 @@ be_local_closure(class_lvh_scale_get_text_src,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_options),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(get_text_src),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -7684,24 +7327,20 @@ be_local_closure(class_lvh_scale_set_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_range),
-    /* K2   */  be_nested_str_weak(get_range_min_value),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(set_max),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x8C100902,  //  0003  GETMET	R4	R4	K2
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C08050B,  //  0001  GETMET	R2	R2	K11
+      0x88100107,  //  0002  GETMBR	R4	R0	K7
+      0x8C10090C,  //  0003  GETMET	R4	R4	K12
       0x7C100200,  //  0004  CALL	R4	1
       0x60140009,  //  0005  GETGBL	R5	G9
       0x5C180200,  //  0006  MOVE	R6	R1
@@ -7721,21 +7360,18 @@ be_local_closure(class_lvh_scale_get_min,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_range_min_value),
-    }),
+    &be_ktab_class_lvh_scale,     /* shared constants */
     be_str_weak(get_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x8C04030C,  //  0001  GETMET	R1	R1	K12
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -7765,6 +7401,52 @@ be_local_class(lvh_scale,
     })),
     be_str_weak(lvh_scale)
 );
+// compact class 'lvh_scale_section' ktab size: 42, total: 57 (saved 120 bytes)
+static const bvalue be_ktab_class_lvh_scale_section[42] = {
+  /* K0   */  be_nested_str_weak(string),
+  /* K1   */  be_nested_str_weak(introspect),
+  /* K2   */  be_nested_str_weak(startswith),
+  /* K3   */  be_nested_str_weak(set_),
+  /* K4   */  be_nested_str_weak(get_),
+  /* K5   */  be_nested_str_weak(endswith),
+  /* K6   */  be_nested_str_weak(_X25),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(lv),
+  /* K9   */  be_nested_str_weak(pct),
+  /* K10  */  be_const_int(3),
+  /* K11  */  be_nested_str_weak(byte),
+  /* K12  */  be_const_int(2147483647),
+  /* K13  */  be_nested_str_weak(value_error),
+  /* K14  */  be_nested_str_weak(only_X20modifiers_X20_X2710_X27_X20or_X20_X2730_X27_X20allowed),
+  /* K15  */  be_nested_str_weak(_attr_ignore),
+  /* K16  */  be_nested_str_weak(find),
+  /* K17  */  be_nested_str_weak(_style),
+  /* K18  */  be_nested_str_weak(_style10),
+  /* K19  */  be_nested_str_weak(_style30),
+  /* K20  */  be_nested_str_weak(get),
+  /* K21  */  be_nested_str_weak(function),
+  /* K22  */  be_nested_str_weak(is_color_attribute),
+  /* K23  */  be_nested_str_weak(parse_color),
+  /* K24  */  be_nested_str_weak(_X20for_X20),
+  /* K25  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
+  /* K26  */  be_nested_str_weak(_lv_obj),
+  /* K27  */  be_nested_str_weak(_min),
+  /* K28  */  be_nested_str_weak(_max),
+  /* K29  */  be_nested_str_weak(_parent_lvh),
+  /* K30  */  be_nested_str_weak(_page),
+  /* K31  */  be_nested_str_weak(_oh),
+  /* K32  */  be_nested_str_weak(lvh_scale),
+  /* K33  */  be_nested_str_weak(add_section),
+  /* K34  */  be_nested_str_weak(style),
+  /* K35  */  be_nested_str_weak(set_style),
+  /* K36  */  be_nested_str_weak(PART_MAIN),
+  /* K37  */  be_nested_str_weak(PART_INDICATOR),
+  /* K38  */  be_nested_str_weak(PART_ITEMS),
+  /* K39  */  be_nested_str_weak(HSP_X3A_X20_X27scale_section_X27_X20should_X20have_X20a_X20parent_X20of_X20type_X20_X27scale_X27),
+  /* K40  */  be_nested_str_weak(set_range),
+  /* K41  */  be_nested_str_weak(del),
+};
+
 
 extern const bclass be_class_lvh_scale_section;
 
@@ -7775,40 +7457,13 @@ be_local_closure(class_lvh_scale_section_setmember,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(startswith),
-    /* K3   */  be_nested_str_weak(set_),
-    /* K4   */  be_nested_str_weak(get_),
-    /* K5   */  be_nested_str_weak(endswith),
-    /* K6   */  be_nested_str_weak(_X25),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(lv),
-    /* K9   */  be_nested_str_weak(pct),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(byte),
-    /* K12  */  be_const_int(2147483647),
-    /* K13  */  be_nested_str_weak(value_error),
-    /* K14  */  be_nested_str_weak(only_X20modifiers_X20_X2710_X27_X20or_X20_X2730_X27_X20allowed),
-    /* K15  */  be_nested_str_weak(_attr_ignore),
-    /* K16  */  be_nested_str_weak(find),
-    /* K17  */  be_nested_str_weak(_style),
-    /* K18  */  be_nested_str_weak(_style10),
-    /* K19  */  be_nested_str_weak(_style30),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_nested_str_weak(function),
-    /* K22  */  be_nested_str_weak(is_color_attribute),
-    /* K23  */  be_nested_str_weak(parse_color),
-    /* K24  */  be_nested_str_weak(_X20for_X20),
-    /* K25  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[141]) {  /* code */
@@ -7966,85 +7621,65 @@ be_local_closure(class_lvh_scale_section_post_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(_min),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_max),
-    /* K4   */  be_nested_str_weak(_parent_lvh),
-    /* K5   */  be_nested_str_weak(_page),
-    /* K6   */  be_nested_str_weak(_oh),
-    /* K7   */  be_nested_str_weak(lvh_scale),
-    /* K8   */  be_nested_str_weak(add_section),
-    /* K9   */  be_nested_str_weak(_style),
-    /* K10  */  be_nested_str_weak(lv),
-    /* K11  */  be_nested_str_weak(style),
-    /* K12  */  be_nested_str_weak(set_style),
-    /* K13  */  be_nested_str_weak(PART_MAIN),
-    /* K14  */  be_nested_str_weak(_style10),
-    /* K15  */  be_nested_str_weak(PART_INDICATOR),
-    /* K16  */  be_nested_str_weak(_style30),
-    /* K17  */  be_nested_str_weak(PART_ITEMS),
-    /* K18  */  be_nested_str_weak(HSP_X3A_X20_X27scale_section_X27_X20should_X20have_X20a_X20parent_X20of_X20type_X20_X27scale_X27),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[51]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x90020302,  //  0002  SETMBR	R0	K1	K2
-      0x90020702,  //  0003  SETMBR	R0	K3	K2
+      0x90023401,  //  0001  SETMBR	R0	K26	R1
+      0x90023707,  //  0002  SETMBR	R0	K27	K7
+      0x90023907,  //  0003  SETMBR	R0	K28	K7
       0x6004000F,  //  0004  GETGBL	R1	G15
-      0x88080104,  //  0005  GETMBR	R2	R0	K4
-      0x880C0105,  //  0006  GETMBR	R3	R0	K5
-      0x880C0706,  //  0007  GETMBR	R3	R3	K6
-      0x880C0707,  //  0008  GETMBR	R3	R3	K7
+      0x8808011D,  //  0005  GETMBR	R2	R0	K29
+      0x880C011E,  //  0006  GETMBR	R3	R0	K30
+      0x880C071F,  //  0007  GETMBR	R3	R3	K31
+      0x880C0720,  //  0008  GETMBR	R3	R3	K32
       0x7C040400,  //  0009  CALL	R1	2
       0x78060023,  //  000A  JMPF	R1	#002F
-      0x88040104,  //  000B  GETMBR	R1	R0	K4
-      0x88040300,  //  000C  GETMBR	R1	R1	K0
-      0x8C040308,  //  000D  GETMET	R1	R1	K8
+      0x8804011D,  //  000B  GETMBR	R1	R0	K29
+      0x8804031A,  //  000C  GETMBR	R1	R1	K26
+      0x8C040321,  //  000D  GETMET	R1	R1	K33
       0x7C040200,  //  000E  CALL	R1	1
-      0x90020001,  //  000F  SETMBR	R0	K0	R1
-      0xB8061400,  //  0010  GETNGBL	R1	K10
-      0x8C04030B,  //  0011  GETMET	R1	R1	K11
+      0x90023401,  //  000F  SETMBR	R0	K26	R1
+      0xB8061000,  //  0010  GETNGBL	R1	K8
+      0x8C040322,  //  0011  GETMET	R1	R1	K34
       0x7C040200,  //  0012  CALL	R1	1
-      0x90021201,  //  0013  SETMBR	R0	K9	R1
-      0x88040100,  //  0014  GETMBR	R1	R0	K0
-      0x8C04030C,  //  0015  GETMET	R1	R1	K12
-      0xB80E1400,  //  0016  GETNGBL	R3	K10
-      0x880C070D,  //  0017  GETMBR	R3	R3	K13
-      0x88100109,  //  0018  GETMBR	R4	R0	K9
+      0x90022201,  //  0013  SETMBR	R0	K17	R1
+      0x8804011A,  //  0014  GETMBR	R1	R0	K26
+      0x8C040323,  //  0015  GETMET	R1	R1	K35
+      0xB80E1000,  //  0016  GETNGBL	R3	K8
+      0x880C0724,  //  0017  GETMBR	R3	R3	K36
+      0x88100111,  //  0018  GETMBR	R4	R0	K17
       0x7C040600,  //  0019  CALL	R1	3
-      0xB8061400,  //  001A  GETNGBL	R1	K10
-      0x8C04030B,  //  001B  GETMET	R1	R1	K11
+      0xB8061000,  //  001A  GETNGBL	R1	K8
+      0x8C040322,  //  001B  GETMET	R1	R1	K34
       0x7C040200,  //  001C  CALL	R1	1
-      0x90021C01,  //  001D  SETMBR	R0	K14	R1
-      0x88040100,  //  001E  GETMBR	R1	R0	K0
-      0x8C04030C,  //  001F  GETMET	R1	R1	K12
-      0xB80E1400,  //  0020  GETNGBL	R3	K10
-      0x880C070F,  //  0021  GETMBR	R3	R3	K15
-      0x8810010E,  //  0022  GETMBR	R4	R0	K14
+      0x90022401,  //  001D  SETMBR	R0	K18	R1
+      0x8804011A,  //  001E  GETMBR	R1	R0	K26
+      0x8C040323,  //  001F  GETMET	R1	R1	K35
+      0xB80E1000,  //  0020  GETNGBL	R3	K8
+      0x880C0725,  //  0021  GETMBR	R3	R3	K37
+      0x88100112,  //  0022  GETMBR	R4	R0	K18
       0x7C040600,  //  0023  CALL	R1	3
-      0xB8061400,  //  0024  GETNGBL	R1	K10
-      0x8C04030B,  //  0025  GETMET	R1	R1	K11
+      0xB8061000,  //  0024  GETNGBL	R1	K8
+      0x8C040322,  //  0025  GETMET	R1	R1	K34
       0x7C040200,  //  0026  CALL	R1	1
-      0x90022001,  //  0027  SETMBR	R0	K16	R1
-      0x88040100,  //  0028  GETMBR	R1	R0	K0
-      0x8C04030C,  //  0029  GETMET	R1	R1	K12
-      0xB80E1400,  //  002A  GETNGBL	R3	K10
-      0x880C0711,  //  002B  GETMBR	R3	R3	K17
-      0x88100110,  //  002C  GETMBR	R4	R0	K16
+      0x90022601,  //  0027  SETMBR	R0	K19	R1
+      0x8804011A,  //  0028  GETMBR	R1	R0	K26
+      0x8C040323,  //  0029  GETMET	R1	R1	K35
+      0xB80E1000,  //  002A  GETNGBL	R3	K8
+      0x880C0726,  //  002B  GETMBR	R3	R3	K38
+      0x88100113,  //  002C  GETMBR	R4	R0	K19
       0x7C040600,  //  002D  CALL	R1	3
       0x70020002,  //  002E  JMP		#0032
       0x60040001,  //  002F  GETGBL	R1	G1
-      0x58080012,  //  0030  LDCONST	R2	K18
+      0x58080027,  //  0030  LDCONST	R2	K39
       0x7C040200,  //  0031  CALL	R1	1
       0x80000000,  //  0032  RET	0
     })
@@ -8060,27 +7695,24 @@ be_local_closure(class_lvh_scale_section_set_min,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_max),
-    /* K1   */  be_nested_str_weak(set_range),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(set_min),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x880C011C,  //  0003  GETMBR	R3	R0	K28
       0x14100602,  //  0004  LT	R4	R3	R2
       0x78120000,  //  0005  JMPF	R4	#0007
       0x5C0C0400,  //  0006  MOVE	R3	R2
-      0x8C100101,  //  0007  GETMET	R4	R0	K1
+      0x8C100128,  //  0007  GETMET	R4	R0	K40
       0x5C180400,  //  0008  MOVE	R6	R2
       0x5C1C0600,  //  0009  MOVE	R7	R3
       0x7C100600,  //  000A  CALL	R4	3
@@ -8098,27 +7730,24 @@ be_local_closure(class_lvh_scale_section_set_max,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_min),
-    /* K1   */  be_nested_str_weak(set_range),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(set_max),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8808011B,  //  0000  GETMBR	R2	R0	K27
       0x600C0009,  //  0001  GETGBL	R3	G9
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x24100403,  //  0004  GT	R4	R2	R3
       0x78120000,  //  0005  JMPF	R4	#0007
       0x5C080600,  //  0006  MOVE	R2	R3
-      0x8C100101,  //  0007  GETMET	R4	R0	K1
+      0x8C100128,  //  0007  GETMET	R4	R0	K40
       0x5C180400,  //  0008  MOVE	R6	R2
       0x5C1C0600,  //  0009  MOVE	R7	R3
       0x7C100600,  //  000A  CALL	R4	3
@@ -8136,25 +7765,20 @@ be_local_closure(class_lvh_scale_section_set_range,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_min),
-    /* K1   */  be_nested_str_weak(_max),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(set_range),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(set_range),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
+      0x90023601,  //  0000  SETMBR	R0	K27	R1
+      0x90023802,  //  0001  SETMBR	R0	K28	R2
+      0x880C011A,  //  0002  GETMBR	R3	R0	K26
+      0x8C0C0728,  //  0003  GETMET	R3	R3	K40
       0x5C140200,  //  0004  MOVE	R5	R1
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C0C0600,  //  0006  CALL	R3	3
@@ -8172,36 +7796,31 @@ be_local_closure(class_lvh_scale_section_delete,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_style),
-    /* K1   */  be_nested_str_weak(del),
-    /* K2   */  be_nested_str_weak(_style10),
-    /* K3   */  be_nested_str_weak(_style30),
-    }),
+    &be_ktab_class_lvh_scale_section,     /* shared constants */
     be_str_weak(delete),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
+      0x8C040329,  //  0001  GETMET	R1	R1	K41
       0x7C040200,  //  0002  CALL	R1	1
       0x4C040000,  //  0003  LDNIL	R1
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0x88040102,  //  0005  GETMBR	R1	R0	K2
-      0x8C040301,  //  0006  GETMET	R1	R1	K1
+      0x90022201,  //  0004  SETMBR	R0	K17	R1
+      0x88040112,  //  0005  GETMBR	R1	R0	K18
+      0x8C040329,  //  0006  GETMET	R1	R1	K41
       0x7C040200,  //  0007  CALL	R1	1
       0x4C040000,  //  0008  LDNIL	R1
-      0x90020401,  //  0009  SETMBR	R0	K2	R1
-      0x88040103,  //  000A  GETMBR	R1	R0	K3
-      0x8C040301,  //  000B  GETMET	R1	R1	K1
+      0x90022401,  //  0009  SETMBR	R0	K18	R1
+      0x88040113,  //  000A  GETMBR	R1	R0	K19
+      0x8C040329,  //  000B  GETMET	R1	R1	K41
       0x7C040200,  //  000C  CALL	R1	1
       0x4C040000,  //  000D  LDNIL	R1
-      0x90020601,  //  000E  SETMBR	R0	K3	R1
+      0x90022601,  //  000E  SETMBR	R0	K19	R1
       0x80000000,  //  000F  RET	0
     })
   )
@@ -8233,6 +7852,31 @@ be_local_class(lvh_scale_section,
     })),
     be_str_weak(lvh_scale_section)
 );
+// compact class 'lvh_scale_line' ktab size: 21, total: 29 (saved 64 bytes)
+static const bvalue be_ktab_class_lvh_scale_line[21] = {
+  /* K0   */  be_nested_str_weak(set_val),
+  /* K1   */  be_nested_str_weak(_parent_lvh),
+  /* K2   */  be_nested_str_weak(_lv_obj),
+  /* K3   */  be_nested_str_weak(set_line_needle_value),
+  /* K4   */  be_nested_str_weak(_needle_length),
+  /* K5   */  be_nested_str_weak(_val),
+  /* K6   */  be_nested_str_weak(get_points_num),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_nested_str_weak(get_points),
+  /* K9   */  be_nested_str_weak(_lv_points),
+  /* K10  */  be_nested_str_weak(setbytes),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str_weak(set_points),
+  /* K13  */  be_nested_str_weak(_page),
+  /* K14  */  be_nested_str_weak(_oh),
+  /* K15  */  be_nested_str_weak(lvh_scale),
+  /* K16  */  be_nested_str_weak(HSP_X3A_X20_X27scale_line_X27_X20should_X20have_X20a_X20parent_X20of_X20type_X20_X27scale_X27),
+  /* K17  */  be_nested_str_weak(lv),
+  /* K18  */  be_nested_str_weak(point_arr),
+  /* K19  */  be_nested_str_weak(point),
+  /* K20  */  be_nested_str_weak(post_init),
+};
+
 
 extern const bclass be_class_lvh_scale_line;
 
@@ -8243,27 +7887,13 @@ be_local_closure(class_lvh_scale_line_set_val,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_val),
-    /* K1   */  be_nested_str_weak(_parent_lvh),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(set_line_needle_value),
-    /* K4   */  be_nested_str_weak(_needle_length),
-    /* K5   */  be_nested_str_weak(_val),
-    /* K6   */  be_nested_str_weak(get_points_num),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(get_points),
-    /* K9   */  be_nested_str_weak(_lv_points),
-    /* K10  */  be_nested_str_weak(setbytes),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(set_points),
-    }),
+    &be_ktab_class_lvh_scale_line,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
@@ -8317,58 +7947,45 @@ be_local_closure(class_lvh_scale_line_post_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_parent_lvh),
-    /* K1   */  be_nested_str_weak(_page),
-    /* K2   */  be_nested_str_weak(_oh),
-    /* K3   */  be_nested_str_weak(lvh_scale),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20_X27scale_line_X27_X20should_X20have_X20a_X20parent_X20of_X20type_X20_X27scale_X27),
-    /* K5   */  be_nested_str_weak(_needle_length),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_lv_points),
-    /* K8   */  be_nested_str_weak(lv),
-    /* K9   */  be_nested_str_weak(point_arr),
-    /* K10  */  be_nested_str_weak(point),
-    /* K11  */  be_nested_str_weak(post_init),
-    }),
+    &be_ktab_class_lvh_scale_line,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[31]) {  /* code */
       0x6004000F,  //  0000  GETGBL	R1	G15
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x880C0702,  //  0003  GETMBR	R3	R3	K2
-      0x880C0703,  //  0004  GETMBR	R3	R3	K3
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x880C010D,  //  0002  GETMBR	R3	R0	K13
+      0x880C070E,  //  0003  GETMBR	R3	R3	K14
+      0x880C070F,  //  0004  GETMBR	R3	R3	K15
       0x7C040400,  //  0005  CALL	R1	2
       0x74060002,  //  0006  JMPT	R1	#000A
       0x60040001,  //  0007  GETGBL	R1	G1
-      0x58080004,  //  0008  LDCONST	R2	K4
+      0x58080010,  //  0008  LDCONST	R2	K16
       0x7C040200,  //  0009  CALL	R1	1
-      0x90020B06,  //  000A  SETMBR	R0	K5	K6
-      0xB8061000,  //  000B  GETNGBL	R1	K8
-      0x8C040309,  //  000C  GETMET	R1	R1	K9
+      0x9002090B,  //  000A  SETMBR	R0	K4	K11
+      0xB8062200,  //  000B  GETNGBL	R1	K17
+      0x8C040312,  //  000C  GETMET	R1	R1	K18
       0x600C0012,  //  000D  GETGBL	R3	G18
       0x7C0C0000,  //  000E  CALL	R3	0
-      0xB8121000,  //  000F  GETNGBL	R4	K8
-      0x8C10090A,  //  0010  GETMET	R4	R4	K10
+      0xB8122200,  //  000F  GETNGBL	R4	K17
+      0x8C100913,  //  0010  GETMET	R4	R4	K19
       0x7C100200,  //  0011  CALL	R4	1
       0x40100604,  //  0012  CONNECT	R4	R3	R4
-      0xB8121000,  //  0013  GETNGBL	R4	K8
-      0x8C10090A,  //  0014  GETMET	R4	R4	K10
+      0xB8122200,  //  0013  GETNGBL	R4	K17
+      0x8C100913,  //  0014  GETMET	R4	R4	K19
       0x7C100200,  //  0015  CALL	R4	1
       0x40100604,  //  0016  CONNECT	R4	R3	R4
       0x7C040400,  //  0017  CALL	R1	2
-      0x90020E01,  //  0018  SETMBR	R0	K7	R1
+      0x90021201,  //  0018  SETMBR	R0	K9	R1
       0x60040003,  //  0019  GETGBL	R1	G3
       0x5C080000,  //  001A  MOVE	R2	R0
       0x7C040200,  //  001B  CALL	R1	1
-      0x8C04030B,  //  001C  GETMET	R1	R1	K11
+      0x8C040314,  //  001C  GETMET	R1	R1	K20
       0x7C040200,  //  001D  CALL	R1	1
       0x80000000,  //  001E  RET	0
     })
@@ -8384,19 +8001,17 @@ be_local_closure(class_lvh_scale_line_get_needle_length,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_needle_length),
-    }),
+    &be_ktab_class_lvh_scale_line,     /* shared constants */
     be_str_weak(get_needle_length),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -8411,30 +8026,26 @@ be_local_closure(class_lvh_scale_line_set_needle_length,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_needle_length),
-    /* K1   */  be_nested_str_weak(_val),
-    /* K2   */  be_nested_str_weak(set_val),
-    }),
+    &be_ktab_class_lvh_scale_line,     /* shared constants */
     be_str_weak(set_needle_length),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
       0x60080009,  //  0000  GETGBL	R2	G9
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x90020802,  //  0003  SETMBR	R0	K4	R2
+      0x88080105,  //  0004  GETMBR	R2	R0	K5
       0x4C0C0000,  //  0005  LDNIL	R3
       0x20080403,  //  0006  NE	R2	R2	R3
       0x780A0002,  //  0007  JMPF	R2	#000B
-      0x8C080102,  //  0008  GETMET	R2	R0	K2
-      0x88100101,  //  0009  GETMBR	R4	R0	K1
+      0x8C080100,  //  0008  GETMET	R2	R0	K0
+      0x88100105,  //  0009  GETMBR	R4	R0	K5
       0x7C080400,  //  000A  CALL	R2	2
       0x80000000,  //  000B  RET	0
     })
@@ -8460,6 +8071,16 @@ be_local_class(lvh_scale_line,
     })),
     be_str_weak(lvh_scale_line)
 );
+// compact class 'lvh_spangroup' ktab size: 6, total: 8 (saved 16 bytes)
+static const bvalue be_ktab_class_lvh_spangroup[6] = {
+  /* K0   */  be_nested_str_weak(_lv_obj),
+  /* K1   */  be_nested_str_weak(set_mode),
+  /* K2   */  be_nested_str_weak(lv),
+  /* K3   */  be_nested_str_weak(SPAN_MODE_BREAK),
+  /* K4   */  be_nested_str_weak(refr_mode),
+  /* K5   */  be_nested_str_weak(post_init),
+};
+
 
 extern const bclass be_class_lvh_spangroup;
 
@@ -8470,20 +8091,13 @@ be_local_closure(class_lvh_spangroup_post_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_mode),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(SPAN_MODE_BREAK),
-    /* K4   */  be_nested_str_weak(refr_mode),
-    /* K5   */  be_nested_str_weak(post_init),
-    }),
+    &be_ktab_class_lvh_spangroup,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
@@ -8514,21 +8128,18 @@ be_local_closure(class_lvh_spangroup_refr_mode,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(refr_mode),
-    }),
+    &be_ktab_class_lvh_spangroup,     /* shared constants */
     be_str_weak(refr_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x8C040304,  //  0001  GETMET	R1	R1	K4
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
@@ -8552,6 +8163,40 @@ be_local_class(lvh_spangroup,
     })),
     be_str_weak(lvh_spangroup)
 );
+// compact class 'lvh_span' ktab size: 30, total: 36 (saved 48 bytes)
+static const bvalue be_ktab_class_lvh_span[30] = {
+  /* K0   */  be_nested_str_weak(string),
+  /* K1   */  be_nested_str_weak(introspect),
+  /* K2   */  be_nested_str_weak(startswith),
+  /* K3   */  be_nested_str_weak(set_),
+  /* K4   */  be_nested_str_weak(get_),
+  /* K5   */  be_nested_str_weak(endswith),
+  /* K6   */  be_nested_str_weak(_X25),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(lv),
+  /* K9   */  be_nested_str_weak(pct),
+  /* K10  */  be_nested_str_weak(_attr_ignore),
+  /* K11  */  be_nested_str_weak(find),
+  /* K12  */  be_nested_str_weak(get),
+  /* K13  */  be_nested_str_weak(function),
+  /* K14  */  be_nested_str_weak(_style),
+  /* K15  */  be_nested_str_weak(is_color_attribute),
+  /* K16  */  be_nested_str_weak(parse_color),
+  /* K17  */  be_nested_str_weak(_parent_lvh),
+  /* K18  */  be_nested_str_weak(refr_mode),
+  /* K19  */  be_nested_str_weak(_X20for_X20),
+  /* K20  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
+  /* K21  */  be_nested_str_weak(_lv_obj),
+  /* K22  */  be_nested_str_weak(_page),
+  /* K23  */  be_nested_str_weak(_oh),
+  /* K24  */  be_nested_str_weak(lvh_spangroup),
+  /* K25  */  be_nested_str_weak(new_span),
+  /* K26  */  be_nested_str_weak(get_style),
+  /* K27  */  be_nested_str_weak(parse_font),
+  /* K28  */  be_nested_str_weak(set_text_font),
+  /* K29  */  be_nested_str_weak(set_text),
+};
+
 
 extern const bclass be_class_lvh_span;
 
@@ -8562,35 +8207,13 @@ be_local_closure(class_lvh_span_setmember,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(startswith),
-    /* K3   */  be_nested_str_weak(set_),
-    /* K4   */  be_nested_str_weak(get_),
-    /* K5   */  be_nested_str_weak(endswith),
-    /* K6   */  be_nested_str_weak(_X25),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(lv),
-    /* K9   */  be_nested_str_weak(pct),
-    /* K10  */  be_nested_str_weak(_attr_ignore),
-    /* K11  */  be_nested_str_weak(find),
-    /* K12  */  be_nested_str_weak(get),
-    /* K13  */  be_nested_str_weak(function),
-    /* K14  */  be_nested_str_weak(_style),
-    /* K15  */  be_nested_str_weak(is_color_attribute),
-    /* K16  */  be_nested_str_weak(parse_color),
-    /* K17  */  be_nested_str_weak(_parent_lvh),
-    /* K18  */  be_nested_str_weak(refr_mode),
-    /* K19  */  be_nested_str_weak(_X20for_X20),
-    /* K20  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
-    }),
+    &be_ktab_class_lvh_span,     /* shared constants */
     be_str_weak(setmember),
     &be_const_str_solidified,
     ( &(const binstruction[92]) {  /* code */
@@ -8699,43 +8322,34 @@ be_local_closure(class_lvh_span_post_init,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(_parent_lvh),
-    /* K2   */  be_nested_str_weak(_page),
-    /* K3   */  be_nested_str_weak(_oh),
-    /* K4   */  be_nested_str_weak(lvh_spangroup),
-    /* K5   */  be_nested_str_weak(new_span),
-    /* K6   */  be_nested_str_weak(_style),
-    /* K7   */  be_nested_str_weak(get_style),
-    }),
+    &be_ktab_class_lvh_span,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
       0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90022A01,  //  0001  SETMBR	R0	K21	R1
       0x6004000F,  //  0002  GETGBL	R1	G15
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
-      0x880C0102,  //  0004  GETMBR	R3	R0	K2
-      0x880C0703,  //  0005  GETMBR	R3	R3	K3
-      0x880C0704,  //  0006  GETMBR	R3	R3	K4
+      0x88080111,  //  0003  GETMBR	R2	R0	K17
+      0x880C0116,  //  0004  GETMBR	R3	R0	K22
+      0x880C0717,  //  0005  GETMBR	R3	R3	K23
+      0x880C0718,  //  0006  GETMBR	R3	R3	K24
       0x7C040400,  //  0007  CALL	R1	2
       0x78060008,  //  0008  JMPF	R1	#0012
-      0x88040101,  //  0009  GETMBR	R1	R0	K1
-      0x88040300,  //  000A  GETMBR	R1	R1	K0
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x88040111,  //  0009  GETMBR	R1	R0	K17
+      0x88040315,  //  000A  GETMBR	R1	R1	K21
+      0x8C040319,  //  000B  GETMET	R1	R1	K25
       0x7C040200,  //  000C  CALL	R1	1
-      0x90020001,  //  000D  SETMBR	R0	K0	R1
-      0x88040100,  //  000E  GETMBR	R1	R0	K0
-      0x8C040307,  //  000F  GETMET	R1	R1	K7
+      0x90022A01,  //  000D  SETMBR	R0	K21	R1
+      0x88040115,  //  000E  GETMBR	R1	R0	K21
+      0x8C04031A,  //  000F  GETMET	R1	R1	K26
       0x7C040200,  //  0010  CALL	R1	1
-      0x90020C01,  //  0011  SETMBR	R0	K6	R1
+      0x90021C01,  //  0011  SETMBR	R0	K14	R1
       0x80000000,  //  0012  RET	0
     })
   )
@@ -8750,34 +8364,28 @@ be_local_closure(class_lvh_span_set_text_font,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parse_font),
-    /* K1   */  be_nested_str_weak(_style),
-    /* K2   */  be_nested_str_weak(set_text_font),
-    /* K3   */  be_nested_str_weak(_parent_lvh),
-    /* K4   */  be_nested_str_weak(refr_mode),
-    }),
+    &be_ktab_class_lvh_span,     /* shared constants */
     be_str_weak(set_text_font),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C08011B,  //  0000  GETMET	R2	R0	K27
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x200C0403,  //  0004  NE	R3	R2	R3
       0x780E0006,  //  0005  JMPF	R3	#000D
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x880C010E,  //  0006  GETMBR	R3	R0	K14
+      0x8C0C071C,  //  0007  GETMET	R3	R3	K28
       0x5C140400,  //  0008  MOVE	R5	R2
       0x7C0C0400,  //  0009  CALL	R3	2
-      0x880C0103,  //  000A  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  000B  GETMET	R3	R3	K4
+      0x880C0111,  //  000A  GETMBR	R3	R0	K17
+      0x8C0C0712,  //  000B  GETMET	R3	R3	K18
       0x7C0C0200,  //  000C  CALL	R3	1
       0x80000000,  //  000D  RET	0
     })
@@ -8793,21 +8401,18 @@ be_local_closure(class_lvh_span_set_text,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_text),
-    }),
+    &be_ktab_class_lvh_span,     /* shared constants */
     be_str_weak(set_text),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080115,  //  0000  GETMBR	R2	R0	K21
+      0x8C08051D,  //  0001  GETMET	R2	R2	K29
       0x60100008,  //  0002  GETGBL	R4	G8
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C100200,  //  0004  CALL	R4	1
@@ -8837,6 +8442,34 @@ be_local_class(lvh_span,
     })),
     be_str_weak(lvh_span)
 );
+// compact class 'lvh_chart' ktab size: 24, total: 54 (saved 240 bytes)
+static const bvalue be_ktab_class_lvh_chart[24] = {
+  /* K0   */  be_nested_str_weak(_y_min),
+  /* K1   */  be_nested_str_weak(_lv_obj),
+  /* K2   */  be_nested_str_weak(set_next_value),
+  /* K3   */  be_nested_str_weak(_ser1),
+  /* K4   */  be_nested_str_weak(add_point2),
+  /* K5   */  be_nested_str_weak(set_range),
+  /* K6   */  be_nested_str_weak(lv),
+  /* K7   */  be_nested_str_weak(CHART_AXIS_PRIMARY_Y),
+  /* K8   */  be_nested_str_weak(_y_max),
+  /* K9   */  be_nested_str_weak(_ser2),
+  /* K10  */  be_nested_str_weak(set_series_color),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str_weak(_h_div),
+  /* K13  */  be_const_int(3),
+  /* K14  */  be_nested_str_weak(_v_div),
+  /* K15  */  be_nested_str_weak(set_update_mode),
+  /* K16  */  be_nested_str_weak(CHART_UPDATE_MODE_SHIFT),
+  /* K17  */  be_nested_str_weak(add_series),
+  /* K18  */  be_nested_str_weak(color),
+  /* K19  */  be_const_int(15615044),
+  /* K20  */  be_const_int(4517444),
+  /* K21  */  be_nested_str_weak(_val),
+  /* K22  */  be_nested_str_weak(add_point),
+  /* K23  */  be_nested_str_weak(set_div_line_count),
+};
+
 
 extern const bclass be_class_lvh_chart;
 
@@ -8847,15 +8480,13 @@ be_local_closure(class_lvh_chart_get_y_min,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_y_min),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(get_y_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
@@ -8874,23 +8505,19 @@ be_local_closure(class_lvh_chart_add_point,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_next_value),
-    /* K2   */  be_nested_str_weak(_ser1),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(add_point),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0x88100103,  //  0002  GETMBR	R4	R0	K3
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C080600,  //  0004  CALL	R2	3
       0x80000000,  //  0005  RET	0
@@ -8907,19 +8534,17 @@ be_local_closure(class_lvh_chart_set_val2,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(add_point2),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_val2),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x8C080104,  //  0000  GETMET	R2	R0	K4
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x80000000,  //  0003  RET	0
@@ -8936,30 +8561,23 @@ be_local_closure(class_lvh_chart_set_y_min,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_y_min),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_range),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(CHART_AXIS_PRIMARY_Y),
-    /* K5   */  be_nested_str_weak(_y_max),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_y_min),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
       0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x88100904,  //  0004  GETMBR	R4	R4	K4
+      0x8C080505,  //  0002  GETMET	R2	R2	K5
+      0xB8120C00,  //  0003  GETNGBL	R4	K6
+      0x88100907,  //  0004  GETMBR	R4	R4	K7
       0x88140100,  //  0005  GETMBR	R5	R0	K0
-      0x88180105,  //  0006  GETMBR	R6	R0	K5
+      0x88180108,  //  0006  GETMBR	R6	R0	K8
       0x7C080800,  //  0007  CALL	R2	4
       0x80000000,  //  0008  RET	0
     })
@@ -8975,23 +8593,19 @@ be_local_closure(class_lvh_chart_add_point2,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_next_value),
-    /* K2   */  be_nested_str_weak(_ser2),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(add_point2),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0x88100109,  //  0002  GETMBR	R4	R0	K9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C080600,  //  0004  CALL	R2	3
       0x80000000,  //  0005  RET	0
@@ -9008,23 +8622,19 @@ be_local_closure(class_lvh_chart_set_series1_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_series_color),
-    /* K2   */  be_nested_str_weak(_ser1),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_series1_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
+      0x88100103,  //  0002  GETMBR	R4	R0	K3
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C080600,  //  0004  CALL	R2	3
       0x80000000,  //  0005  RET	0
@@ -9041,23 +8651,19 @@ be_local_closure(class_lvh_chart_set_series2_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_series_color),
-    /* K2   */  be_nested_str_weak(_ser2),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_series2_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
+      0x88100109,  //  0002  GETMBR	R4	R0	K9
       0x5C140200,  //  0003  MOVE	R5	R1
       0x7C080600,  //  0004  CALL	R2	3
       0x80000000,  //  0005  RET	0
@@ -9074,30 +8680,23 @@ be_local_closure(class_lvh_chart_set_y_max,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_y_max),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_range),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(CHART_AXIS_PRIMARY_Y),
-    /* K5   */  be_nested_str_weak(_y_min),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_y_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021001,  //  0000  SETMBR	R0	K8	R1
       0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x88100904,  //  0004  GETMBR	R4	R4	K4
-      0x88140105,  //  0005  GETMBR	R5	R0	K5
-      0x88180100,  //  0006  GETMBR	R6	R0	K0
+      0x8C080505,  //  0002  GETMET	R2	R2	K5
+      0xB8120C00,  //  0003  GETNGBL	R4	K6
+      0x88100907,  //  0004  GETMBR	R4	R4	K7
+      0x88140100,  //  0005  GETMBR	R5	R0	K0
+      0x88180108,  //  0006  GETMBR	R6	R0	K8
       0x7C080800,  //  0007  CALL	R2	4
       0x80000000,  //  0008  RET	0
     })
@@ -9113,65 +8712,47 @@ be_local_closure(class_lvh_chart_post_init,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_y_min),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_y_max),
-    /* K3   */  be_nested_str_weak(_h_div),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(_v_div),
-    /* K6   */  be_nested_str_weak(_lv_obj),
-    /* K7   */  be_nested_str_weak(set_update_mode),
-    /* K8   */  be_nested_str_weak(lv),
-    /* K9   */  be_nested_str_weak(CHART_UPDATE_MODE_SHIFT),
-    /* K10  */  be_nested_str_weak(_ser1),
-    /* K11  */  be_nested_str_weak(add_series),
-    /* K12  */  be_nested_str_weak(color),
-    /* K13  */  be_const_int(15615044),
-    /* K14  */  be_nested_str_weak(CHART_AXIS_PRIMARY_Y),
-    /* K15  */  be_nested_str_weak(_ser2),
-    /* K16  */  be_const_int(4517444),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(post_init),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x90020101,  //  0000  SETMBR	R0	K0	K1
+      0x9002010B,  //  0000  SETMBR	R0	K0	K11
       0x54060063,  //  0001  LDINT	R1	100
-      0x90020401,  //  0002  SETMBR	R0	K2	R1
-      0x90020704,  //  0003  SETMBR	R0	K3	K4
+      0x90021001,  //  0002  SETMBR	R0	K8	R1
+      0x9002190D,  //  0003  SETMBR	R0	K12	K13
       0x54060004,  //  0004  LDINT	R1	5
-      0x90020A01,  //  0005  SETMBR	R0	K5	R1
-      0x88040106,  //  0006  GETMBR	R1	R0	K6
-      0x8C040307,  //  0007  GETMET	R1	R1	K7
-      0xB80E1000,  //  0008  GETNGBL	R3	K8
-      0x880C0709,  //  0009  GETMBR	R3	R3	K9
+      0x90021C01,  //  0005  SETMBR	R0	K14	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x8C04030F,  //  0007  GETMET	R1	R1	K15
+      0xB80E0C00,  //  0008  GETNGBL	R3	K6
+      0x880C0710,  //  0009  GETMBR	R3	R3	K16
       0x7C040400,  //  000A  CALL	R1	2
-      0x88040106,  //  000B  GETMBR	R1	R0	K6
-      0x8C04030B,  //  000C  GETMET	R1	R1	K11
-      0xB80E1000,  //  000D  GETNGBL	R3	K8
-      0x8C0C070C,  //  000E  GETMET	R3	R3	K12
-      0x5814000D,  //  000F  LDCONST	R5	K13
+      0x88040101,  //  000B  GETMBR	R1	R0	K1
+      0x8C040311,  //  000C  GETMET	R1	R1	K17
+      0xB80E0C00,  //  000D  GETNGBL	R3	K6
+      0x8C0C0712,  //  000E  GETMET	R3	R3	K18
+      0x58140013,  //  000F  LDCONST	R5	K19
       0x7C0C0400,  //  0010  CALL	R3	2
-      0xB8121000,  //  0011  GETNGBL	R4	K8
-      0x8810090E,  //  0012  GETMBR	R4	R4	K14
+      0xB8120C00,  //  0011  GETNGBL	R4	K6
+      0x88100907,  //  0012  GETMBR	R4	R4	K7
       0x7C040600,  //  0013  CALL	R1	3
-      0x90021401,  //  0014  SETMBR	R0	K10	R1
-      0x88040106,  //  0015  GETMBR	R1	R0	K6
-      0x8C04030B,  //  0016  GETMET	R1	R1	K11
-      0xB80E1000,  //  0017  GETNGBL	R3	K8
-      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
-      0x58140010,  //  0019  LDCONST	R5	K16
+      0x90020601,  //  0014  SETMBR	R0	K3	R1
+      0x88040101,  //  0015  GETMBR	R1	R0	K1
+      0x8C040311,  //  0016  GETMET	R1	R1	K17
+      0xB80E0C00,  //  0017  GETNGBL	R3	K6
+      0x8C0C0712,  //  0018  GETMET	R3	R3	K18
+      0x58140014,  //  0019  LDCONST	R5	K20
       0x7C0C0400,  //  001A  CALL	R3	2
-      0xB8121000,  //  001B  GETNGBL	R4	K8
-      0x8810090E,  //  001C  GETMBR	R4	R4	K14
+      0xB8120C00,  //  001B  GETNGBL	R4	K6
+      0x88100907,  //  001C  GETMBR	R4	R4	K7
       0x7C040600,  //  001D  CALL	R1	3
-      0x90021E01,  //  001E  SETMBR	R0	K15	R1
+      0x90021201,  //  001E  SETMBR	R0	K9	R1
       0x80000000,  //  001F  RET	0
     })
   )
@@ -9186,19 +8767,17 @@ be_local_closure(class_lvh_chart_get_y_max,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_y_max),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(get_y_max),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -9213,21 +8792,18 @@ be_local_closure(class_lvh_chart_set_val,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(add_point),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_val),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x90022A01,  //  0000  SETMBR	R0	K21	R1
+      0x8C080116,  //  0001  GETMET	R2	R0	K22
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
@@ -9244,26 +8820,21 @@ be_local_closure(class_lvh_chart_set_v_div_line_count,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_v_div),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_div_line_count),
-    /* K3   */  be_nested_str_weak(_h_div),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_v_div_line_count),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021C01,  //  0000  SETMBR	R0	K14	R1
       0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
-      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x8C080517,  //  0002  GETMET	R2	R2	K23
+      0x8810010C,  //  0003  GETMBR	R4	R0	K12
+      0x8814010E,  //  0004  GETMBR	R5	R0	K14
       0x7C080600,  //  0005  CALL	R2	3
       0x80000000,  //  0006  RET	0
     })
@@ -9279,26 +8850,21 @@ be_local_closure(class_lvh_chart_set_h_div_line_count,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_h_div),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_div_line_count),
-    /* K3   */  be_nested_str_weak(_v_div),
-    }),
+    &be_ktab_class_lvh_chart,     /* shared constants */
     be_str_weak(set_h_div_line_count),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90021801,  //  0000  SETMBR	R0	K12	R1
       0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x8C080517,  //  0002  GETMET	R2	R2	K23
+      0x8810010C,  //  0003  GETMBR	R4	R0	K12
+      0x8814010E,  //  0004  GETMBR	R5	R0	K14
       0x7C080600,  //  0005  CALL	R2	3
       0x80000000,  //  0006  RET	0
     })
@@ -9339,6 +8905,20 @@ be_local_class(lvh_chart,
     })),
     be_str_weak(lvh_chart)
 );
+// compact class 'lvh_btnmatrix' ktab size: 10, total: 11 (saved 8 bytes)
+static const bvalue be_ktab_class_lvh_btnmatrix[10] = {
+  /* K0   */  be_const_int(0),
+  /* K1   */  be_nested_str_weak(push),
+  /* K2   */  be_nested_str_weak(),
+  /* K3   */  be_nested_str_weak(_options),
+  /* K4   */  be_nested_str_weak(_options_arr),
+  /* K5   */  be_nested_str_weak(lv),
+  /* K6   */  be_nested_str_weak(str_arr),
+  /* K7   */  be_nested_str_weak(_lv_obj),
+  /* K8   */  be_nested_str_weak(set_map),
+  /* K9   */  be_nested_str_weak(HTP_X3A_X20_X27btnmatrix_X27_X20needs_X20_X27options_X27_X20to_X20be_X20a_X20list_X20of_X20strings),
+};
+
 
 extern const bclass be_class_lvh_btnmatrix;
 
@@ -9349,24 +8929,13 @@ be_local_closure(class_lvh_btnmatrix_set_options,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(_options),
-    /* K4   */  be_nested_str_weak(_options_arr),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(str_arr),
-    /* K7   */  be_nested_str_weak(_lv_obj),
-    /* K8   */  be_nested_str_weak(set_map),
-    /* K9   */  be_nested_str_weak(HTP_X3A_X20_X27btnmatrix_X27_X20needs_X20_X27options_X27_X20to_X20be_X20a_X20list_X20of_X20strings),
-    }),
+    &be_ktab_class_lvh_btnmatrix,     /* shared constants */
     be_str_weak(set_options),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
@@ -9417,19 +8986,17 @@ be_local_closure(class_lvh_btnmatrix_get_options,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_options),
-    }),
+    &be_ktab_class_lvh_btnmatrix,     /* shared constants */
     be_str_weak(get_options),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -9502,6 +9069,41 @@ be_local_class(lvh_scr,
     })),
     be_str_weak(lvh_scr)
 );
+// compact class 'lvh_page' ktab size: 31, total: 50 (saved 152 bytes)
+static const bvalue be_ktab_class_lvh_page[31] = {
+  /* K0   */  be_nested_str_weak(global),
+  /* K1   */  be_nested_str_weak(_oh),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_nested_str_weak(_page_id),
+  /* K4   */  be_nested_str_weak(_obj_id),
+  /* K5   */  be_nested_str_weak(_lv_scr),
+  /* K6   */  be_nested_str_weak(lv),
+  /* K7   */  be_nested_str_weak(scr_act),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(layer_top),
+  /* K10  */  be_nested_str_weak(obj),
+  /* K11  */  be_nested_str_weak(get_style_bg_color),
+  /* K12  */  be_nested_str_weak(set_style_bg_color),
+  /* K13  */  be_nested_str_weak(lvh_scr),
+  /* K14  */  be_nested_str_weak(p),
+  /* K15  */  be_nested_str_weak(b0),
+  /* K16  */  be_nested_str_weak(_p),
+  /* K17  */  be_nested_str_weak(page_dir_to),
+  /* K18  */  be_nested_str_weak(id),
+  /* K19  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22out_X22_X7D_X7D),
+  /* K20  */  be_nested_str_weak(lvh_page_cur_idx),
+  /* K21  */  be_nested_str_weak(tasmota),
+  /* K22  */  be_nested_str_weak(set_timer),
+  /* K23  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22in_X22_X7D_X7D),
+  /* K24  */  be_nested_str_weak(show_anim),
+  /* K25  */  be_nested_str_weak(find),
+  /* K26  */  be_nested_str_weak(SCR_LOAD_ANIM_NONE),
+  /* K27  */  be_nested_str_weak(screen_load_anim),
+  /* K28  */  be_nested_str_weak(p_X25ib_X25i),
+  /* K29  */  be_nested_str_weak(_page),
+  /* K30  */  be_nested_str_weak(remove),
+};
+
 
 extern const bclass be_class_lvh_page;
 
@@ -9512,30 +9114,13 @@ be_local_closure(class_lvh_page_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(_page_id),
-    /* K4   */  be_nested_str_weak(_obj_id),
-    /* K5   */  be_nested_str_weak(_lv_scr),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(scr_act),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(layer_top),
-    /* K10  */  be_nested_str_weak(obj),
-    /* K11  */  be_nested_str_weak(get_style_bg_color),
-    /* K12  */  be_nested_str_weak(set_style_bg_color),
-    /* K13  */  be_nested_str_weak(lvh_scr),
-    /* K14  */  be_nested_str_weak(p),
-    /* K15  */  be_nested_str_weak(b0),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[66]) {  /* code */
@@ -9618,7 +9203,7 @@ be_local_closure(class_lvh_page_show,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -9675,41 +9260,22 @@ be_local_closure(class_lvh_page_show,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_scr),
-    /* K1   */  be_nested_str_weak(_p),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(scr_act),
-    /* K4   */  be_nested_str_weak(_oh),
-    /* K5   */  be_nested_str_weak(page_dir_to),
-    /* K6   */  be_nested_str_weak(id),
-    /* K7   */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22out_X22_X7D_X7D),
-    /* K8   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(set_timer),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22in_X22_X7D_X7D),
-    /* K13  */  be_nested_str_weak(_page_id),
-    /* K14  */  be_nested_str_weak(show_anim),
-    /* K15  */  be_nested_str_weak(find),
-    /* K16  */  be_nested_str_weak(SCR_LOAD_ANIM_NONE),
-    /* K17  */  be_nested_str_weak(screen_load_anim),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(show),
     &be_const_str_solidified,
     ( &(const binstruction[66]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0105,  //  0000  GETMBR	R3	R0	K5
       0x4C100000,  //  0001  LDNIL	R4
       0x1C0C0604,  //  0002  EQ	R3	R3	R4
       0x780E0001,  //  0003  JMPF	R3	#0006
       0x4C0C0000,  //  0004  LDNIL	R3
       0x80040600,  //  0005  RET	1	R3
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x880C0701,  //  0007  GETMBR	R3	R3	K1
-      0xB8120400,  //  0008  GETNGBL	R4	K2
-      0x8C100903,  //  0009  GETMET	R4	R4	K3
+      0x880C0105,  //  0006  GETMBR	R3	R0	K5
+      0x880C0710,  //  0007  GETMBR	R3	R3	K16
+      0xB8120C00,  //  0008  GETNGBL	R4	K6
+      0x8C100907,  //  0009  GETMET	R4	R4	K7
       0x7C100200,  //  000A  CALL	R4	1
-      0x88100901,  //  000B  GETMBR	R4	R4	K1
+      0x88100910,  //  000B  GETMBR	R4	R4	K16
       0x1C0C0604,  //  000C  EQ	R3	R3	R4
       0x780E0000,  //  000D  JMPF	R3	#000F
       0x80000600,  //  000E  RET	0
@@ -9720,46 +9286,46 @@ be_local_closure(class_lvh_page_show,   /* name */
       0x4C0C0000,  //  0013  LDNIL	R3
       0x1C0C0203,  //  0014  EQ	R3	R1	R3
       0x780E0005,  //  0015  JMPF	R3	#001C
-      0x880C0104,  //  0016  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  0017  GETMET	R3	R3	K5
-      0x8C140106,  //  0018  GETMET	R5	R0	K6
+      0x880C0101,  //  0016  GETMBR	R3	R0	K1
+      0x8C0C0711,  //  0017  GETMET	R3	R3	K17
+      0x8C140112,  //  0018  GETMET	R5	R0	K18
       0x7C140200,  //  0019  CALL	R5	1
       0x7C0C0400,  //  001A  CALL	R3	2
       0x5C040600,  //  001B  MOVE	R1	R3
       0x600C0018,  //  001C  GETGBL	R3	G24
-      0x58100007,  //  001D  LDCONST	R4	K7
-      0x88140104,  //  001E  GETMBR	R5	R0	K4
-      0x88140B08,  //  001F  GETMBR	R5	R5	K8
+      0x58100013,  //  001D  LDCONST	R4	K19
+      0x88140101,  //  001E  GETMBR	R5	R0	K1
+      0x88140B14,  //  001F  GETMBR	R5	R5	K20
       0x7C0C0400,  //  0020  CALL	R3	2
-      0xB8121200,  //  0021  GETNGBL	R4	K9
-      0x8C10090A,  //  0022  GETMET	R4	R4	K10
-      0x5818000B,  //  0023  LDCONST	R6	K11
+      0xB8122A00,  //  0021  GETNGBL	R4	K21
+      0x8C100916,  //  0022  GETMET	R4	R4	K22
+      0x58180008,  //  0023  LDCONST	R6	K8
       0x841C0000,  //  0024  CLOSURE	R7	P0
       0x7C100600,  //  0025  CALL	R4	3
       0x60100018,  //  0026  GETGBL	R4	G24
-      0x5814000C,  //  0027  LDCONST	R5	K12
-      0x8818010D,  //  0028  GETMBR	R6	R0	K13
+      0x58140017,  //  0027  LDCONST	R5	K23
+      0x88180103,  //  0028  GETMBR	R6	R0	K3
       0x7C100400,  //  0029  CALL	R4	2
-      0xB8161200,  //  002A  GETNGBL	R5	K9
-      0x8C140B0A,  //  002B  GETMET	R5	R5	K10
-      0x581C000B,  //  002C  LDCONST	R7	K11
+      0xB8162A00,  //  002A  GETNGBL	R5	K21
+      0x8C140B16,  //  002B  GETMET	R5	R5	K22
+      0x581C0008,  //  002C  LDCONST	R7	K8
       0x84200001,  //  002D  CLOSURE	R8	P1
       0x7C140600,  //  002E  CALL	R5	3
-      0x88140104,  //  002F  GETMBR	R5	R0	K4
-      0x8818010D,  //  0030  GETMBR	R6	R0	K13
-      0x90161006,  //  0031  SETMBR	R5	K8	R6
-      0x8814010E,  //  0032  GETMBR	R5	R0	K14
-      0x8C140B0F,  //  0033  GETMET	R5	R5	K15
+      0x88140101,  //  002F  GETMBR	R5	R0	K1
+      0x88180103,  //  0030  GETMBR	R6	R0	K3
+      0x90162806,  //  0031  SETMBR	R5	K20	R6
+      0x88140118,  //  0032  GETMBR	R5	R0	K24
+      0x8C140B19,  //  0033  GETMET	R5	R5	K25
       0x5C1C0200,  //  0034  MOVE	R7	R1
-      0xB8220400,  //  0035  GETNGBL	R8	K2
-      0x88201110,  //  0036  GETMBR	R8	R8	K16
+      0xB8220C00,  //  0035  GETNGBL	R8	K6
+      0x8820111A,  //  0036  GETMBR	R8	R8	K26
       0x7C140600,  //  0037  CALL	R5	3
-      0xB81A0400,  //  0038  GETNGBL	R6	K2
-      0x8C180D11,  //  0039  GETMET	R6	R6	K17
-      0x88200100,  //  003A  GETMBR	R8	R0	K0
+      0xB81A0C00,  //  0038  GETNGBL	R6	K6
+      0x8C180D1B,  //  0039  GETMET	R6	R6	K27
+      0x88200105,  //  003A  GETMBR	R8	R0	K5
       0x5C240A00,  //  003B  MOVE	R9	R5
       0x5C280400,  //  003C  MOVE	R10	R2
-      0x582C000B,  //  003D  LDCONST	R11	K11
+      0x582C0008,  //  003D  LDCONST	R11	K8
       0x50300000,  //  003E  LDBOOL	R12	0	0
       0x7C180C00,  //  003F  CALL	R6	6
       0xA0000000,  //  0040  CLOSE	R0
@@ -9777,19 +9343,17 @@ be_local_closure(class_lvh_page_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page_id),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(id),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -9804,19 +9368,17 @@ be_local_closure(class_lvh_page_get_scr,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_scr),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(get_scr),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -9831,21 +9393,18 @@ be_local_closure(class_lvh_page_get_obj,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_obj_id),
-    /* K1   */  be_nested_str_weak(find),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(get_obj),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080519,  //  0001  GETMET	R2	R2	K25
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -9862,32 +9421,26 @@ be_local_closure(class_lvh_page_add_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_obj_id),
-    /* K1   */  be_nested_str_weak(p_X25ib_X25i),
-    /* K2   */  be_nested_str_weak(_page),
-    /* K3   */  be_nested_str_weak(id),
-    /* K4   */  be_nested_str_weak(global),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(add_obj),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0104,  //  0000  GETMBR	R3	R0	K4
       0x980C0202,  //  0001  SETIDX	R3	R1	R2
       0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100001,  //  0003  LDCONST	R4	K1
-      0x88140502,  //  0004  GETMBR	R5	R2	K2
-      0x8C140B03,  //  0005  GETMET	R5	R5	K3
+      0x5810001C,  //  0003  LDCONST	R4	K28
+      0x8814051D,  //  0004  GETMBR	R5	R2	K29
+      0x8C140B12,  //  0005  GETMET	R5	R5	K18
       0x7C140200,  //  0006  CALL	R5	1
       0x5C180200,  //  0007  MOVE	R6	R1
       0x7C0C0600,  //  0008  CALL	R3	3
-      0xB8120800,  //  0009  GETNGBL	R4	K4
+      0xB8120000,  //  0009  GETNGBL	R4	K0
       0x90100602,  //  000A  SETMBR	R4	R3	R2
       0x80000000,  //  000B  RET	0
     })
@@ -9903,41 +9456,33 @@ be_local_closure(class_lvh_page_remove_obj,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_obj_id),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_nested_str_weak(p_X25ib_X25i),
-    /* K4   */  be_nested_str_weak(_page),
-    /* K5   */  be_nested_str_weak(id),
-    /* K6   */  be_nested_str_weak(global),
-    }),
+    &be_ktab_class_lvh_page,     /* shared constants */
     be_str_weak(remove_obj),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080519,  //  0001  GETMET	R2	R2	K25
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x880C0100,  //  0004  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  0005  GETMET	R3	R3	K2
+      0x880C0104,  //  0004  GETMBR	R3	R0	K4
+      0x8C0C071E,  //  0005  GETMET	R3	R3	K30
       0x5C140200,  //  0006  MOVE	R5	R1
       0x7C0C0400,  //  0007  CALL	R3	2
       0x780A0009,  //  0008  JMPF	R2	#0013
       0x600C0018,  //  0009  GETGBL	R3	G24
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x88140504,  //  000B  GETMBR	R5	R2	K4
-      0x8C140B05,  //  000C  GETMET	R5	R5	K5
+      0x5810001C,  //  000A  LDCONST	R4	K28
+      0x8814051D,  //  000B  GETMBR	R5	R2	K29
+      0x8C140B12,  //  000C  GETMET	R5	R5	K18
       0x7C140200,  //  000D  CALL	R5	1
       0x5C180200,  //  000E  MOVE	R6	R1
       0x7C0C0600,  //  000F  CALL	R3	3
-      0xB8120C00,  //  0010  GETNGBL	R4	K6
+      0xB8120000,  //  0010  GETNGBL	R4	K0
       0x4C140000,  //  0011  LDNIL	R5
       0x90100605,  //  0012  SETMBR	R4	R3	R5
       0x80000000,  //  0013  RET	0
@@ -9981,6 +9526,132 @@ be_local_class(lvh_page,
     })),
     be_str_weak(lvh_page)
 );
+extern const bclass be_class_HASPmota;
+// compact class 'HASPmota' ktab size: 121, total: 176 (saved 440 bytes)
+static const bvalue be_ktab_class_HASPmota[121] = {
+  /* K0   */  be_nested_str_weak(string),
+  /* K1   */  be_nested_str_weak(json),
+  /* K2   */  be_nested_str_weak(lvh_page_cur_idx),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_nested_str_weak(lvh_page),
+  /* K5   */  be_nested_str_weak(lvh_pages),
+  /* K6   */  be_nested_str_weak(r),
+  /* K7   */  be_nested_str_weak(read),
+  /* K8   */  be_nested_str_weak(close),
+  /* K9   */  be_nested_str_weak(split),
+  /* K10  */  be_nested_str_weak(_X0A),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str_weak(load),
+  /* K13  */  be_nested_str_weak(instance),
+  /* K14  */  be_nested_str_weak(tasmota),
+  /* K15  */  be_nested_str_weak(loglevel),
+  /* K16  */  be_nested_str_weak(log),
+  /* K17  */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
+  /* K18  */  be_nested_str_weak(parse_page),
+  /* K19  */  be_nested_str_weak(parse_obj),
+  /* K20  */  be_nested_str_weak(tr),
+  /* K21  */  be_nested_str_weak(_X20_X09),
+  /* K22  */  be_nested_str_weak(),
+  /* K23  */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
+  /* K24  */  be_const_int(2),
+  /* K25  */  be_nested_str_weak(remove),
+  /* K26  */  be_nested_str_weak(pages_list_sorted),
+  /* K27  */  be_nested_str_weak(prev),
+  /* K28  */  be_nested_str_weak(next),
+  /* K29  */  be_nested_str_weak(back),
+  /* K30  */  be_nested_str_weak(re_page_target),
+  /* K31  */  be_nested_str_weak(match),
+  /* K32  */  be_nested_str_weak(show),
+  /* K33  */  be_nested_str_weak(fix_lv_version),
+  /* K34  */  be_nested_str_weak(re),
+  /* K35  */  be_nested_str_weak(compile),
+  /* K36  */  be_nested_str_weak(p_X5Cd_X2B),
+  /* K37  */  be_nested_str_weak(introspect),
+  /* K38  */  be_nested_str_weak(toptr),
+  /* K39  */  be_nested_str_weak(event),
+  /* K40  */  be_nested_str_weak(_p),
+  /* K41  */  be_nested_str_weak(lv),
+  /* K42  */  be_nested_str_weak(lv_event),
+  /* K43  */  be_nested_str_weak(get_user_data),
+  /* K44  */  be_nested_str_weak(fromptr),
+  /* K45  */  be_nested_str_weak(event_cb),
+  /* K46  */  be_nested_str_weak(keys),
+  /* K47  */  be_nested_str_weak(push),
+  /* K48  */  be_nested_str_weak(stop_iteration),
+  /* K49  */  be_nested_str_weak(sort),
+  /* K50  */  be_nested_str_weak(find),
+  /* K51  */  be_const_class(be_class_HASPmota),
+  /* K52  */  be_nested_str_weak(get),
+  /* K53  */  be_nested_str_weak(version),
+  /* K54  */  be_nested_str_weak(int),
+  /* K55  */  be_nested_str_weak(EVENT_CLICKED),
+  /* K56  */  be_nested_str_weak(page_show),
+  /* K57  */  be_nested_str_weak(_action),
+  /* K58  */  be_nested_str_weak(value_error),
+  /* K59  */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
+  /* K60  */  be_nested_str_weak(cb),
+  /* K61  */  be_nested_str_weak(gen_cb),
+  /* K62  */  be_nested_str_weak(_lv_obj),
+  /* K63  */  be_nested_str_weak(add_event_cb),
+  /* K64  */  be_const_int(0),
+  /* K65  */  be_const_int(1),
+  /* K66  */  be_nested_str_weak(has),
+  /* K67  */  be_nested_str_weak(page),
+  /* K68  */  be_nested_str_weak(contains),
+  /* K69  */  be_nested_str_weak(id),
+  /* K70  */  be_nested_str_weak(get_page_cur),
+  /* K71  */  be_nested_str_weak(path),
+  /* K72  */  be_nested_str_weak(def_templ_name),
+  /* K73  */  be_nested_str_weak(exists),
+  /* K74  */  be_nested_str_weak(file_X20_X27),
+  /* K75  */  be_nested_str_weak(_X27_X20not_X20found),
+  /* K76  */  be_nested_str_weak(io_erorr),
+  /* K77  */  be_nested_str_weak(start),
+  /* K78  */  be_nested_str_weak(dark),
+  /* K79  */  be_nested_str_weak(hres),
+  /* K80  */  be_nested_str_weak(get_hor_res),
+  /* K81  */  be_nested_str_weak(vres),
+  /* K82  */  be_nested_str_weak(get_ver_res),
+  /* K83  */  be_nested_str_weak(scr),
+  /* K84  */  be_nested_str_weak(scr_act),
+  /* K85  */  be_nested_str_weak(r16),
+  /* K86  */  be_nested_str_weak(font_embedded),
+  /* K87  */  be_nested_str_weak(robotocondensed),
+  /* K88  */  be_nested_str_weak(montserrat),
+  /* K89  */  be_nested_str_weak(theme_haspmota_init),
+  /* K90  */  be_nested_str_weak(color),
+  /* K91  */  be_const_int(16711935),
+  /* K92  */  be_const_int(3158064),
+  /* K93  */  be_nested_str_weak(get_disp),
+  /* K94  */  be_nested_str_weak(set_theme),
+  /* K95  */  be_nested_str_weak(set_style_bg_color),
+  /* K96  */  be_const_int(16777215),
+  /* K97  */  be_nested_str_weak(theme_apply),
+  /* K98  */  be_nested_str_weak(layer_top),
+  /* K99  */  be_nested_str_weak(set_style_bg_opa),
+  /* K100 */  be_nested_str_weak(_load),
+  /* K101 */  be_nested_str_weak(global),
+  /* K102 */  be_nested_str_weak(obj),
+  /* K103 */  be_nested_str_weak(berry_run),
+  /* K104 */  be_nested_str_weak(nil),
+  /* K105 */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K106 */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
+  /* K107 */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
+  /* K108 */  be_nested_str_weak(parentid),
+  /* K109 */  be_nested_str_weak(get_obj),
+  /* K110 */  be_nested_str_weak(get_scr),
+  /* K111 */  be_nested_str_weak(lvh_),
+  /* K112 */  be_nested_str_weak(class),
+  /* K113 */  be_nested_str_weak(lvh_obj),
+  /* K114 */  be_nested_str_weak(module),
+  /* K115 */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20),
+  /* K116 */  be_nested_str_weak(add_obj),
+  /* K117 */  be_nested_str_weak(function),
+  /* K118 */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K119 */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
+  /* K120 */  be_nested_str_weak(post_config),
+};
+
 
 extern const bclass be_class_HASPmota;
 
@@ -9991,40 +9662,13 @@ be_local_closure(class_HASPmota__load,   /* name */
   be_nested_proto(
     15,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(lvh_page),
-    /* K5   */  be_nested_str_weak(lvh_pages),
-    /* K6   */  be_nested_str_weak(r),
-    /* K7   */  be_nested_str_weak(read),
-    /* K8   */  be_nested_str_weak(close),
-    /* K9   */  be_nested_str_weak(split),
-    /* K10  */  be_nested_str_weak(_X0A),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(load),
-    /* K13  */  be_nested_str_weak(instance),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(loglevel),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
-    /* K18  */  be_nested_str_weak(parse_page),
-    /* K19  */  be_nested_str_weak(parse_obj),
-    /* K20  */  be_nested_str_weak(tr),
-    /* K21  */  be_nested_str_weak(_X20_X09),
-    /* K22  */  be_nested_str_weak(),
-    /* K23  */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
-    /* K24  */  be_const_int(2),
-    /* K25  */  be_nested_str_weak(remove),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(_load),
     &be_const_str_solidified,
     ( &(const binstruction[85]) {  /* code */
@@ -10126,34 +9770,22 @@ be_local_closure(class_HASPmota_page_show,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lvh_pages),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K2   */  be_nested_str_weak(pages_list_sorted),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(prev),
-    /* K5   */  be_nested_str_weak(next),
-    /* K6   */  be_nested_str_weak(back),
-    /* K7   */  be_nested_str_weak(re_page_target),
-    /* K8   */  be_nested_str_weak(match),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(show),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(page_show),
     &be_const_str_solidified,
     ( &(const binstruction[68]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x880C0105,  //  0001  GETMBR	R3	R0	K5
+      0x88100102,  //  0002  GETMBR	R4	R0	K2
       0x940C0604,  //  0003  GETIDX	R3	R3	R4
-      0x8C100102,  //  0004  GETMET	R4	R0	K2
-      0x88180101,  //  0005  GETMBR	R6	R0	K1
+      0x8C10011A,  //  0004  GETMET	R4	R0	K26
+      0x88180102,  //  0005  GETMBR	R6	R0	K2
       0x7C100400,  //  0006  CALL	R4	2
       0x6014000C,  //  0007  GETGBL	R5	G12
       0x5C180800,  //  0008  MOVE	R6	R4
@@ -10161,10 +9793,10 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x18140B03,  //  000A  LE	R5	R5	K3
       0x78160000,  //  000B  JMPF	R5	#000D
       0x80000A00,  //  000C  RET	0
-      0x1C140304,  //  000D  EQ	R5	R1	K4
+      0x1C14031B,  //  000D  EQ	R5	R1	K27
       0x78160009,  //  000E  JMPF	R5	#0019
       0x60140009,  //  000F  GETGBL	R5	G9
-      0x88180704,  //  0010  GETMBR	R6	R3	K4
+      0x8818071B,  //  0010  GETMBR	R6	R3	K27
       0x7C140200,  //  0011  CALL	R5	1
       0x5C080A00,  //  0012  MOVE	R2	R5
       0x4C140000,  //  0013  LDNIL	R5
@@ -10173,10 +9805,10 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x5415FFFE,  //  0016  LDINT	R5	-1
       0x94080805,  //  0017  GETIDX	R2	R4	R5
       0x70020020,  //  0018  JMP		#003A
-      0x1C140305,  //  0019  EQ	R5	R1	K5
+      0x1C14031C,  //  0019  EQ	R5	R1	K28
       0x78160008,  //  001A  JMPF	R5	#0024
       0x60140009,  //  001B  GETGBL	R5	G9
-      0x88180705,  //  001C  GETMBR	R6	R3	K5
+      0x8818071C,  //  001C  GETMBR	R6	R3	K28
       0x7C140200,  //  001D  CALL	R5	1
       0x5C080A00,  //  001E  MOVE	R2	R5
       0x4C140000,  //  001F  LDNIL	R5
@@ -10184,10 +9816,10 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x78160000,  //  0021  JMPF	R5	#0023
       0x94080903,  //  0022  GETIDX	R2	R4	K3
       0x70020015,  //  0023  JMP		#003A
-      0x1C140306,  //  0024  EQ	R5	R1	K6
+      0x1C14031D,  //  0024  EQ	R5	R1	K29
       0x78160008,  //  0025  JMPF	R5	#002F
       0x60140009,  //  0026  GETGBL	R5	G9
-      0x88180706,  //  0027  GETMBR	R6	R3	K6
+      0x8818071D,  //  0027  GETMBR	R6	R3	K29
       0x7C140200,  //  0028  CALL	R5	1
       0x5C080A00,  //  0029  MOVE	R2	R5
       0x4C140000,  //  002A  LDNIL	R5
@@ -10195,8 +9827,8 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x78160000,  //  002C  JMPF	R5	#002E
       0x58080003,  //  002D  LDCONST	R2	K3
       0x7002000A,  //  002E  JMP		#003A
-      0x88140107,  //  002F  GETMBR	R5	R0	K7
-      0x8C140B08,  //  0030  GETMET	R5	R5	K8
+      0x8814011E,  //  002F  GETMBR	R5	R0	K30
+      0x8C140B1F,  //  0030  GETMET	R5	R5	K31
       0x5C1C0200,  //  0031  MOVE	R7	R1
       0x7C140400,  //  0032  CALL	R5	2
       0x78160005,  //  0033  JMPF	R5	#003A
@@ -10209,11 +9841,11 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x4C140000,  //  003A  LDNIL	R5
       0x20140405,  //  003B  NE	R5	R2	R5
       0x78160005,  //  003C  JMPF	R5	#0043
-      0x24140509,  //  003D  GT	R5	R2	K9
+      0x2414050B,  //  003D  GT	R5	R2	K11
       0x78160003,  //  003E  JMPF	R5	#0043
-      0x88140100,  //  003F  GETMBR	R5	R0	K0
+      0x88140105,  //  003F  GETMBR	R5	R0	K5
       0x94140A02,  //  0040  GETIDX	R5	R5	R2
-      0x8C140B0A,  //  0041  GETMET	R5	R5	K10
+      0x8C140B20,  //  0041  GETMET	R5	R5	K32
       0x7C140200,  //  0042  CALL	R5	1
       0x80000000,  //  0043  RET	0
     })
@@ -10229,29 +9861,23 @@ be_local_closure(class_HASPmota_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fix_lv_version),
-    /* K1   */  be_nested_str_weak(re),
-    /* K2   */  be_nested_str_weak(re_page_target),
-    /* K3   */  be_nested_str_weak(compile),
-    /* K4   */  be_nested_str_weak(p_X5Cd_X2B),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040121,  //  0000  GETMET	R1	R0	K33
       0x7C040200,  //  0001  CALL	R1	1
-      0xA4060200,  //  0002  IMPORT	R1	K1
-      0x8C080303,  //  0003  GETMET	R2	R1	K3
-      0x58100004,  //  0004  LDCONST	R4	K4
+      0xA4064400,  //  0002  IMPORT	R1	K34
+      0x8C080323,  //  0003  GETMET	R2	R1	K35
+      0x58100024,  //  0004  LDCONST	R4	K36
       0x7C080400,  //  0005  CALL	R2	2
-      0x90020402,  //  0006  SETMBR	R0	K2	R2
+      0x90023C02,  //  0006  SETMBR	R0	K30	R2
       0x80000000,  //  0007  RET	0
     })
   )
@@ -10266,60 +9892,48 @@ be_local_closure(class_HASPmota_event_dispatch,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(toptr),
-    /* K2   */  be_nested_str_weak(event),
-    /* K3   */  be_nested_str_weak(_p),
-    /* K4   */  be_nested_str_weak(lv),
-    /* K5   */  be_nested_str_weak(lv_event),
-    /* K6   */  be_nested_str_weak(get_user_data),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(fromptr),
-    /* K9   */  be_nested_str_weak(instance),
-    /* K10  */  be_nested_str_weak(event_cb),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(event_dispatch),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40A4A00,  //  0000  IMPORT	R2	K37
+      0x8C0C0526,  //  0001  GETMET	R3	R2	K38
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x88100127,  //  0004  GETMBR	R4	R0	K39
       0x78120002,  //  0005  JMPF	R4	#0009
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x90120603,  //  0007  SETMBR	R4	K3	R3
+      0x88100127,  //  0006  GETMBR	R4	R0	K39
+      0x90125003,  //  0007  SETMBR	R4	K40	R3
       0x70020004,  //  0008  JMP		#000E
-      0xB8120800,  //  0009  GETNGBL	R4	K4
-      0x8C100905,  //  000A  GETMET	R4	R4	K5
+      0xB8125200,  //  0009  GETNGBL	R4	K41
+      0x8C10092A,  //  000A  GETMET	R4	R4	K42
       0x5C180600,  //  000B  MOVE	R6	R3
       0x7C100400,  //  000C  CALL	R4	2
-      0x90020404,  //  000D  SETMBR	R0	K2	R4
-      0x88100102,  //  000E  GETMBR	R4	R0	K2
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x90024E04,  //  000D  SETMBR	R0	K39	R4
+      0x88100127,  //  000E  GETMBR	R4	R0	K39
+      0x8C10092B,  //  000F  GETMET	R4	R4	K43
       0x7C100200,  //  0010  CALL	R4	1
       0x60140009,  //  0011  GETGBL	R5	G9
       0x5C180800,  //  0012  MOVE	R6	R4
       0x7C140200,  //  0013  CALL	R5	1
-      0x20140B07,  //  0014  NE	R5	R5	K7
+      0x20140B0B,  //  0014  NE	R5	R5	K11
       0x7816000A,  //  0015  JMPF	R5	#0021
-      0x8C140508,  //  0016  GETMET	R5	R2	K8
+      0x8C14052C,  //  0016  GETMET	R5	R2	K44
       0x5C1C0800,  //  0017  MOVE	R7	R4
       0x7C140400,  //  0018  CALL	R5	2
       0x60180004,  //  0019  GETGBL	R6	G4
       0x5C1C0A00,  //  001A  MOVE	R7	R5
       0x7C180200,  //  001B  CALL	R6	1
-      0x1C180D09,  //  001C  EQ	R6	R6	K9
+      0x1C180D0D,  //  001C  EQ	R6	R6	K13
       0x781A0002,  //  001D  JMPF	R6	#0021
-      0x8C180B0A,  //  001E  GETMET	R6	R5	K10
-      0x88200102,  //  001F  GETMBR	R8	R0	K2
+      0x8C180B2D,  //  001E  GETMET	R6	R5	K45
+      0x88200127,  //  001F  GETMBR	R8	R0	K39
       0x7C180400,  //  0020  CALL	R6	2
       0x80000000,  //  0021  RET	0
     })
@@ -10335,49 +9949,39 @@ be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K2   */  be_nested_str_weak(lvh_pages),
-    /* K3   */  be_nested_str_weak(keys),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    /* K6   */  be_nested_str_weak(sort),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_const_int(1),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(pages_list_sorted),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
       0x60080012,  //  0000  GETGBL	R2	G18
       0x7C080000,  //  0001  CALL	R2	0
-      0x1C0C0300,  //  0002  EQ	R3	R1	K0
+      0x1C0C030B,  //  0002  EQ	R3	R1	K11
       0x780E0000,  //  0003  JMPF	R3	#0005
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
       0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x88100105,  //  0006  GETMBR	R4	R0	K5
+      0x8C10092E,  //  0007  GETMET	R4	R4	K46
       0x7C100200,  //  0008  CALL	R4	1
       0x7C0C0200,  //  0009  CALL	R3	1
       0xA8020007,  //  000A  EXBLK	0	#0013
       0x5C100600,  //  000B  MOVE	R4	R3
       0x7C100000,  //  000C  CALL	R4	0
-      0x20140900,  //  000D  NE	R5	R4	K0
+      0x2014090B,  //  000D  NE	R5	R4	K11
       0x78160002,  //  000E  JMPF	R5	#0012
-      0x8C140504,  //  000F  GETMET	R5	R2	K4
+      0x8C14052F,  //  000F  GETMET	R5	R2	K47
       0x5C1C0800,  //  0010  MOVE	R7	R4
       0x7C140400,  //  0011  CALL	R5	2
       0x7001FFF7,  //  0012  JMP		#000B
-      0x580C0005,  //  0013  LDCONST	R3	K5
+      0x580C0030,  //  0013  LDCONST	R3	K48
       0xAC0C0200,  //  0014  CATCH	R3	1	0
       0xB0080000,  //  0015  RAISE	2	R0	R0
-      0x8C0C0106,  //  0016  GETMET	R3	R0	K6
+      0x8C0C0131,  //  0016  GETMET	R3	R0	K49
       0x5C140400,  //  0017  MOVE	R5	R2
       0x7C0C0400,  //  0018  CALL	R3	2
       0x5C080600,  //  0019  MOVE	R2	R3
@@ -10389,7 +9993,7 @@ be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
       0x5C100400,  //  001F  MOVE	R4	R2
       0x7C0C0200,  //  0020  CALL	R3	1
       0x00080402,  //  0021  ADD	R2	R2	R2
-      0x8C100507,  //  0022  GETMET	R4	R2	K7
+      0x8C100532,  //  0022  GETMET	R4	R2	K50
       0x5C180200,  //  0023  MOVE	R6	R1
       0x7C100400,  //  0024  CALL	R4	2
       0x4C140000,  //  0025  LDNIL	R5
@@ -10398,7 +10002,7 @@ be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
       0x4C140000,  //  0028  LDNIL	R5
       0x80040A00,  //  0029  RET	1	R5
       0x00140803,  //  002A  ADD	R5	R4	R3
-      0x04140B08,  //  002B  SUB	R5	R5	K8
+      0x04140B03,  //  002B  SUB	R5	R5	K3
       0x40140805,  //  002C  CONNECT	R5	R4	R5
       0x94080405,  //  002D  GETIDX	R2	R2	R5
       0x80040400,  //  002E  RET	1	R2
@@ -10415,21 +10019,18 @@ be_local_closure(class_HASPmota_get_page_cur,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lvh_pages),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(get_page_cur),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x88080102,  //  0001  GETMBR	R2	R0	K2
       0x94040202,  //  0002  GETIDX	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -10445,37 +10046,30 @@ be_local_closure(class_HASPmota_fix_lv_version,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     0,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_HASPmota),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(get),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(version),
-    /* K5   */  be_nested_str_weak(int),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(fix_lv_version),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x58000000,  //  0000  LDCONST	R0	K0
-      0xA4060200,  //  0001  IMPORT	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
+      0x58000033,  //  0000  LDCONST	R0	K51
+      0xA4064A00,  //  0001  IMPORT	R1	K37
+      0x8C080334,  //  0002  GETMET	R2	R1	K52
+      0xB8125200,  //  0003  GETNGBL	R4	K41
+      0x58140035,  //  0004  LDCONST	R5	K53
       0x7C080600,  //  0005  CALL	R2	3
       0x600C0004,  //  0006  GETGBL	R3	G4
       0x5C100400,  //  0007  MOVE	R4	R2
       0x7C0C0200,  //  0008  CALL	R3	1
-      0x200C0705,  //  0009  NE	R3	R3	K5
+      0x200C0736,  //  0009  NE	R3	R3	K54
       0x780E0002,  //  000A  JMPF	R3	#000E
-      0xB80E0600,  //  000B  GETNGBL	R3	K3
+      0xB80E5200,  //  000B  GETNGBL	R3	K41
       0x54120007,  //  000C  LDINT	R4	8
-      0x900E0804,  //  000D  SETMBR	R3	K4	R4
+      0x900E6A04,  //  000D  SETMBR	R3	K53	R4
       0x80000000,  //  000E  RET	0
     })
   )
@@ -10490,28 +10084,23 @@ be_local_closure(class_HASPmota_do_action,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lv),
-    /* K1   */  be_nested_str_weak(EVENT_CLICKED),
-    /* K2   */  be_nested_str_weak(page_show),
-    /* K3   */  be_nested_str_weak(_action),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(do_action),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0xB80E5200,  //  0000  GETNGBL	R3	K41
+      0x880C0737,  //  0001  GETMBR	R3	R3	K55
       0x200C0403,  //  0002  NE	R3	R2	R3
       0x780E0000,  //  0003  JMPF	R3	#0005
       0x80000600,  //  0004  RET	0
-      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
-      0x88140303,  //  0006  GETMBR	R5	R1	K3
+      0x8C0C0138,  //  0005  GETMET	R3	R0	K56
+      0x88140339,  //  0006  GETMBR	R5	R1	K57
       0x7C0C0400,  //  0007  CALL	R3	2
       0x80000000,  //  0008  RET	0
     })
@@ -10527,46 +10116,36 @@ be_local_closure(class_HASPmota_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(load),
-    /* K2   */  be_nested_str_weak(instance),
-    /* K3   */  be_nested_str_weak(parse_page),
-    /* K4   */  be_nested_str_weak(parse_obj),
-    /* K5   */  be_nested_str_weak(lvh_pages),
-    /* K6   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K7   */  be_nested_str_weak(value_error),
-    /* K8   */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0xA40A0200,  //  0000  IMPORT	R2	K1
+      0x8C0C050C,  //  0001  GETMET	R3	R2	K12
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x60100004,  //  0004  GETGBL	R4	G4
       0x5C140600,  //  0005  MOVE	R5	R3
       0x7C100200,  //  0006  CALL	R4	1
-      0x1C100902,  //  0007  EQ	R4	R4	K2
+      0x1C10090D,  //  0007  EQ	R4	R4	K13
       0x78120009,  //  0008  JMPF	R4	#0013
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x8C100112,  //  0009  GETMET	R4	R0	K18
       0x5C180600,  //  000A  MOVE	R6	R3
       0x7C100400,  //  000B  CALL	R4	2
-      0x8C100104,  //  000C  GETMET	R4	R0	K4
+      0x8C100113,  //  000C  GETMET	R4	R0	K19
       0x5C180600,  //  000D  MOVE	R6	R3
       0x881C0105,  //  000E  GETMBR	R7	R0	K5
-      0x88200106,  //  000F  GETMBR	R8	R0	K6
+      0x88200102,  //  000F  GETMBR	R8	R0	K2
       0x941C0E08,  //  0010  GETIDX	R7	R7	R8
       0x7C100600,  //  0011  CALL	R4	3
       0x70020000,  //  0012  JMP		#0014
-      0xB0060F08,  //  0013  RAISE	1	K7	K8
+      0xB006753B,  //  0013  RAISE	1	K58	K59
       0x80000000,  //  0014  RET	0
     })
   )
@@ -10581,7 +10160,7 @@ be_local_closure(class_HASPmota_register_event,   /* name */
   be_nested_proto(
     13,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
@@ -10612,33 +10191,25 @@ be_local_closure(class_HASPmota_register_event,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(cb),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(event_cb),
-    /* K3   */  be_nested_str_weak(gen_cb),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(add_event_cb),
-    /* K6   */  be_nested_str_weak(toptr),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(register_event),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0xA40E7800,  //  0000  IMPORT	R3	K60
+      0xA4124A00,  //  0001  IMPORT	R4	K37
+      0x8814012D,  //  0002  GETMBR	R5	R0	K45
       0x4C180000,  //  0003  LDNIL	R6
       0x1C140A06,  //  0004  EQ	R5	R5	R6
       0x78160003,  //  0005  JMPF	R5	#000A
-      0x8C140703,  //  0006  GETMET	R5	R3	K3
+      0x8C14073D,  //  0006  GETMET	R5	R3	K61
       0x841C0000,  //  0007  CLOSURE	R7	P0
       0x7C140400,  //  0008  CALL	R5	2
-      0x90020405,  //  0009  SETMBR	R0	K2	R5
-      0x88140304,  //  000A  GETMBR	R5	R1	K4
-      0x8C180B05,  //  000B  GETMET	R6	R5	K5
-      0x88200102,  //  000C  GETMBR	R8	R0	K2
+      0x90025A05,  //  0009  SETMBR	R0	K45	R5
+      0x8814033E,  //  000A  GETMBR	R5	R1	K62
+      0x8C180B3F,  //  000B  GETMET	R6	R5	K63
+      0x8820012D,  //  000C  GETMBR	R8	R0	K45
       0x5C240400,  //  000D  MOVE	R9	R2
-      0x8C280906,  //  000E  GETMET	R10	R4	K6
+      0x8C280926,  //  000E  GETMET	R10	R4	K38
       0x5C300200,  //  000F  MOVE	R12	R1
       0x7C280400,  //  0010  CALL	R10	2
       0x7C180800,  //  0011  CALL	R6	4
@@ -10657,50 +10228,44 @@ be_local_closure(class_HASPmota_page_dir_to,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pages_list_sorted),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(find),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(page_dir_to),
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
+      0x8C08011A,  //  0000  GETMET	R2	R0	K26
+      0x58100040,  //  0001  LDCONST	R4	K64
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C0C0403,  //  0004  EQ	R3	R2	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80060200,  //  0006  RET	1	K1
+      0x80068000,  //  0006  RET	1	K64
       0x600C000C,  //  0007  GETGBL	R3	G12
       0x5C100400,  //  0008  MOVE	R4	R2
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x18100702,  //  000A  LE	R4	R3	K2
+      0x18100741,  //  000A  LE	R4	R3	K65
       0x78120000,  //  000B  JMPF	R4	#000D
-      0x80060200,  //  000C  RET	1	K1
-      0x1C100703,  //  000D  EQ	R4	R3	K3
+      0x80068000,  //  000C  RET	1	K64
+      0x1C100718,  //  000D  EQ	R4	R3	K24
       0x78120000,  //  000E  JMPF	R4	#0010
-      0x80060400,  //  000F  RET	1	K2
-      0x8C100504,  //  0010  GETMET	R4	R2	K4
+      0x80068200,  //  000F  RET	1	K65
+      0x8C100532,  //  0010  GETMET	R4	R2	K50
       0x5C180200,  //  0011  MOVE	R6	R1
       0x7C100400,  //  0012  CALL	R4	2
       0x4C140000,  //  0013  LDNIL	R5
       0x1C140805,  //  0014  EQ	R5	R4	R5
       0x78160000,  //  0015  JMPF	R5	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x00140702,  //  0017  ADD	R5	R3	K2
-      0x0C140B03,  //  0018  DIV	R5	R5	K3
+      0x80068000,  //  0016  RET	1	K64
+      0x00140741,  //  0017  ADD	R5	R3	K65
+      0x0C140B18,  //  0018  DIV	R5	R5	K24
       0x18140805,  //  0019  LE	R5	R4	R5
       0x78160001,  //  001A  JMPF	R5	#001D
-      0x80060400,  //  001B  RET	1	K2
+      0x80068200,  //  001B  RET	1	K65
       0x70020001,  //  001C  JMP		#001F
       0x5415FFFE,  //  001D  LDINT	R5	-1
       0x80040A00,  //  001E  RET	1	R5
@@ -10718,84 +10283,69 @@ be_local_closure(class_HASPmota_parse_page,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(has),
-    /* K1   */  be_nested_str_weak(page),
-    /* K2   */  be_nested_str_weak(int),
-    /* K3   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K4   */  be_nested_str_weak(lvh_pages),
-    /* K5   */  be_nested_str_weak(contains),
-    /* K6   */  be_nested_str_weak(lvh_page),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(id),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(get_page_cur),
-    /* K11  */  be_nested_str_weak(prev),
-    /* K12  */  be_nested_str_weak(next),
-    /* K13  */  be_nested_str_weak(back),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(parse_page),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
+      0x8C080342,  //  0000  GETMET	R2	R1	K66
+      0x58100043,  //  0001  LDCONST	R4	K67
       0x7C080400,  //  0002  CALL	R2	2
       0x780A0030,  //  0003  JMPF	R2	#0035
       0x60080004,  //  0004  GETGBL	R2	G4
-      0x940C0301,  //  0005  GETIDX	R3	R1	K1
+      0x940C0343,  //  0005  GETIDX	R3	R1	K67
       0x7C080200,  //  0006  CALL	R2	1
-      0x1C080502,  //  0007  EQ	R2	R2	K2
+      0x1C080536,  //  0007  EQ	R2	R2	K54
       0x780A002B,  //  0008  JMPF	R2	#0035
       0x60080009,  //  0009  GETGBL	R2	G9
-      0x940C0301,  //  000A  GETIDX	R3	R1	K1
+      0x940C0343,  //  000A  GETIDX	R3	R1	K67
       0x7C080200,  //  000B  CALL	R2	1
-      0x90020602,  //  000C  SETMBR	R0	K3	R2
-      0x880C0104,  //  000D  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  000E  GETMET	R3	R3	K5
+      0x90020402,  //  000C  SETMBR	R0	K2	R2
+      0x880C0105,  //  000D  GETMBR	R3	R0	K5
+      0x8C0C0744,  //  000E  GETMET	R3	R3	K68
       0x5C140400,  //  000F  MOVE	R5	R2
       0x7C0C0400,  //  0010  CALL	R3	2
       0x740E0006,  //  0011  JMPT	R3	#0019
-      0x880C0106,  //  0012  GETMBR	R3	R0	K6
-      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x880C0104,  //  0012  GETMBR	R3	R0	K4
+      0x88100105,  //  0013  GETMBR	R4	R0	K5
       0x5C140600,  //  0014  MOVE	R5	R3
       0x5C180400,  //  0015  MOVE	R6	R2
       0x5C1C0000,  //  0016  MOVE	R7	R0
       0x7C140400,  //  0017  CALL	R5	2
       0x98100405,  //  0018  SETIDX	R4	R2	R5
-      0x8C0C0307,  //  0019  GETMET	R3	R1	K7
-      0x58140008,  //  001A  LDCONST	R5	K8
+      0x8C0C0332,  //  0019  GETMET	R3	R1	K50
+      0x58140045,  //  001A  LDCONST	R5	K69
       0x7C0C0400,  //  001B  CALL	R3	2
-      0x1C0C0709,  //  001C  EQ	R3	R3	K9
+      0x1C0C070B,  //  001C  EQ	R3	R3	K11
       0x780E0016,  //  001D  JMPF	R3	#0035
-      0x8C0C010A,  //  001E  GETMET	R3	R0	K10
+      0x8C0C0146,  //  001E  GETMET	R3	R0	K70
       0x7C0C0200,  //  001F  CALL	R3	1
       0x60100009,  //  0020  GETGBL	R4	G9
-      0x8C140307,  //  0021  GETMET	R5	R1	K7
-      0x581C000B,  //  0022  LDCONST	R7	K11
+      0x8C140332,  //  0021  GETMET	R5	R1	K50
+      0x581C001B,  //  0022  LDCONST	R7	K27
       0x4C200000,  //  0023  LDNIL	R8
       0x7C140600,  //  0024  CALL	R5	3
       0x7C100200,  //  0025  CALL	R4	1
-      0x900E1604,  //  0026  SETMBR	R3	K11	R4
+      0x900E3604,  //  0026  SETMBR	R3	K27	R4
       0x60100009,  //  0027  GETGBL	R4	G9
-      0x8C140307,  //  0028  GETMET	R5	R1	K7
-      0x581C000C,  //  0029  LDCONST	R7	K12
+      0x8C140332,  //  0028  GETMET	R5	R1	K50
+      0x581C001C,  //  0029  LDCONST	R7	K28
       0x4C200000,  //  002A  LDNIL	R8
       0x7C140600,  //  002B  CALL	R5	3
       0x7C100200,  //  002C  CALL	R4	1
-      0x900E1804,  //  002D  SETMBR	R3	K12	R4
+      0x900E3804,  //  002D  SETMBR	R3	K28	R4
       0x60100009,  //  002E  GETGBL	R4	G9
-      0x8C140307,  //  002F  GETMET	R5	R1	K7
-      0x581C000D,  //  0030  LDCONST	R7	K13
+      0x8C140332,  //  002F  GETMET	R5	R1	K50
+      0x581C001D,  //  0030  LDCONST	R7	K29
       0x4C200000,  //  0031  LDNIL	R8
       0x7C140600,  //  0032  CALL	R5	3
       0x7C100200,  //  0033  CALL	R4	1
-      0x900E1A04,  //  0034  SETMBR	R3	K13	R4
+      0x900E3A04,  //  0034  SETMBR	R3	K29	R4
       0x80000000,  //  0035  RET	0
     })
   )
@@ -10810,48 +10360,43 @@ be_local_closure(class_HASPmota_sort,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     1,                          /* argc */
-    4,                          /* varg */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_HASPmota),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(sort),
     &be_const_str_solidified,
     ( &(const binstruction[30]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58040033,  //  0000  LDCONST	R1	K51
       0x60080010,  //  0001  GETGBL	R2	G16
       0x600C000C,  //  0002  GETGBL	R3	G12
       0x5C100000,  //  0003  MOVE	R4	R0
       0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x040C0741,  //  0005  SUB	R3	R3	K65
+      0x400E8203,  //  0006  CONNECT	R3	K65	R3
       0x7C080200,  //  0007  CALL	R2	1
       0xA8020010,  //  0008  EXBLK	0	#001A
       0x5C0C0400,  //  0009  MOVE	R3	R2
       0x7C0C0000,  //  000A  CALL	R3	0
       0x94100003,  //  000B  GETIDX	R4	R0	R3
       0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x24180B0B,  //  000D  GT	R6	R5	K11
       0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x04180B41,  //  000F  SUB	R6	R5	K65
       0x94180006,  //  0010  GETIDX	R6	R0	R6
       0x24180C04,  //  0011  GT	R6	R6	R4
       0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x04180B41,  //  0013  SUB	R6	R5	K65
       0x94180006,  //  0014  GETIDX	R6	R0	R6
       0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x04140B41,  //  0016  SUB	R5	R5	K65
       0x7001FFF4,  //  0017  JMP		#000D
       0x98000A04,  //  0018  SETIDX	R0	R5	R4
       0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
+      0x58080030,  //  001A  LDCONST	R2	K48
       0xAC080200,  //  001B  CATCH	R2	1	0
       0xB0080000,  //  001C  RAISE	2	R0	R0
       0x80040000,  //  001D  RET	1	R0
@@ -10868,152 +10413,118 @@ be_local_closure(class_HASPmota_start,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[33]) {     /* constants */
-    /* K0   */  be_nested_str_weak(path),
-    /* K1   */  be_nested_str_weak(def_templ_name),
-    /* K2   */  be_nested_str_weak(exists),
-    /* K3   */  be_nested_str_weak(file_X20_X27),
-    /* K4   */  be_nested_str_weak(_X27_X20not_X20found),
-    /* K5   */  be_nested_str_weak(io_erorr),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(start),
-    /* K8   */  be_nested_str_weak(dark),
-    /* K9   */  be_nested_str_weak(hres),
-    /* K10  */  be_nested_str_weak(get_hor_res),
-    /* K11  */  be_nested_str_weak(vres),
-    /* K12  */  be_nested_str_weak(get_ver_res),
-    /* K13  */  be_nested_str_weak(scr),
-    /* K14  */  be_nested_str_weak(scr_act),
-    /* K15  */  be_nested_str_weak(r16),
-    /* K16  */  be_nested_str_weak(font_embedded),
-    /* K17  */  be_nested_str_weak(robotocondensed),
-    /* K18  */  be_nested_str_weak(montserrat),
-    /* K19  */  be_nested_str_weak(theme_haspmota_init),
-    /* K20  */  be_const_int(0),
-    /* K21  */  be_nested_str_weak(color),
-    /* K22  */  be_const_int(16711935),
-    /* K23  */  be_const_int(3158064),
-    /* K24  */  be_nested_str_weak(get_disp),
-    /* K25  */  be_nested_str_weak(set_theme),
-    /* K26  */  be_nested_str_weak(set_style_bg_color),
-    /* K27  */  be_const_int(16777215),
-    /* K28  */  be_nested_str_weak(theme_apply),
-    /* K29  */  be_nested_str_weak(layer_top),
-    /* K30  */  be_nested_str_weak(set_style_bg_opa),
-    /* K31  */  be_nested_str_weak(lvh_pages),
-    /* K32  */  be_nested_str_weak(_load),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[105]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA40E8E00,  //  0000  IMPORT	R3	K71
       0x4C100000,  //  0001  LDNIL	R4
       0x1C100404,  //  0002  EQ	R4	R2	R4
       0x78120000,  //  0003  JMPF	R4	#0005
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C100702,  //  0005  GETMET	R4	R3	K2
+      0x88080148,  //  0004  GETMBR	R2	R0	K72
+      0x8C100749,  //  0005  GETMET	R4	R3	K73
       0x5C180400,  //  0006  MOVE	R6	R2
       0x7C100400,  //  0007  CALL	R4	2
       0x74120002,  //  0008  JMPT	R4	#000C
-      0x00120602,  //  0009  ADD	R4	K3	R2
-      0x00100904,  //  000A  ADD	R4	R4	K4
-      0xB0060A04,  //  000B  RAISE	1	K5	R4
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x00129402,  //  0009  ADD	R4	K74	R2
+      0x0010094B,  //  000A  ADD	R4	R4	K75
+      0xB0069804,  //  000B  RAISE	1	K76	R4
+      0xB8125200,  //  000C  GETNGBL	R4	K41
+      0x8C10094D,  //  000D  GETMET	R4	R4	K77
       0x7C100200,  //  000E  CALL	R4	1
       0x60100017,  //  000F  GETGBL	R4	G23
       0x5C140200,  //  0010  MOVE	R5	R1
       0x7C100200,  //  0011  CALL	R4	1
-      0x90021004,  //  0012  SETMBR	R0	K8	R4
-      0xB8120C00,  //  0013  GETNGBL	R4	K6
-      0x8C10090A,  //  0014  GETMET	R4	R4	K10
+      0x90029C04,  //  0012  SETMBR	R0	K78	R4
+      0xB8125200,  //  0013  GETNGBL	R4	K41
+      0x8C100950,  //  0014  GETMET	R4	R4	K80
       0x7C100200,  //  0015  CALL	R4	1
-      0x90021204,  //  0016  SETMBR	R0	K9	R4
-      0xB8120C00,  //  0017  GETNGBL	R4	K6
-      0x8C10090C,  //  0018  GETMET	R4	R4	K12
+      0x90029E04,  //  0016  SETMBR	R0	K79	R4
+      0xB8125200,  //  0017  GETNGBL	R4	K41
+      0x8C100952,  //  0018  GETMET	R4	R4	K82
       0x7C100200,  //  0019  CALL	R4	1
-      0x90021604,  //  001A  SETMBR	R0	K11	R4
-      0xB8120C00,  //  001B  GETNGBL	R4	K6
-      0x8C10090E,  //  001C  GETMET	R4	R4	K14
+      0x9002A204,  //  001A  SETMBR	R0	K81	R4
+      0xB8125200,  //  001B  GETNGBL	R4	K41
+      0x8C100954,  //  001C  GETMET	R4	R4	K84
       0x7C100200,  //  001D  CALL	R4	1
-      0x90021A04,  //  001E  SETMBR	R0	K13	R4
+      0x9002A604,  //  001E  SETMBR	R0	K83	R4
       0xA8020007,  //  001F  EXBLK	0	#0028
-      0xB8120C00,  //  0020  GETNGBL	R4	K6
-      0x8C100910,  //  0021  GETMET	R4	R4	K16
-      0x58180011,  //  0022  LDCONST	R6	K17
+      0xB8125200,  //  0020  GETNGBL	R4	K41
+      0x8C100956,  //  0021  GETMET	R4	R4	K86
+      0x58180057,  //  0022  LDCONST	R6	K87
       0x541E000F,  //  0023  LDINT	R7	16
       0x7C100600,  //  0024  CALL	R4	3
-      0x90021E04,  //  0025  SETMBR	R0	K15	R4
+      0x9002AA04,  //  0025  SETMBR	R0	K85	R4
       0xA8040001,  //  0026  EXBLK	1	1
       0x70020009,  //  0027  JMP		#0032
       0xAC100000,  //  0028  CATCH	R4	0	0
       0x70020006,  //  0029  JMP		#0031
-      0xB8120C00,  //  002A  GETNGBL	R4	K6
-      0x8C100910,  //  002B  GETMET	R4	R4	K16
-      0x58180012,  //  002C  LDCONST	R6	K18
+      0xB8125200,  //  002A  GETNGBL	R4	K41
+      0x8C100956,  //  002B  GETMET	R4	R4	K86
+      0x58180058,  //  002C  LDCONST	R6	K88
       0x541E000D,  //  002D  LDINT	R7	14
       0x7C100600,  //  002E  CALL	R4	3
-      0x90021E04,  //  002F  SETMBR	R0	K15	R4
+      0x9002AA04,  //  002F  SETMBR	R0	K85	R4
       0x70020000,  //  0030  JMP		#0032
       0xB0080000,  //  0031  RAISE	2	R0	R0
-      0xB8120C00,  //  0032  GETNGBL	R4	K6
-      0x8C100913,  //  0033  GETMET	R4	R4	K19
-      0x58180014,  //  0034  LDCONST	R6	K20
-      0xB81E0C00,  //  0035  GETNGBL	R7	K6
-      0x8C1C0F15,  //  0036  GETMET	R7	R7	K21
-      0x58240016,  //  0037  LDCONST	R9	K22
+      0xB8125200,  //  0032  GETNGBL	R4	K41
+      0x8C100959,  //  0033  GETMET	R4	R4	K89
+      0x58180040,  //  0034  LDCONST	R6	K64
+      0xB81E5200,  //  0035  GETNGBL	R7	K41
+      0x8C1C0F5A,  //  0036  GETMET	R7	R7	K90
+      0x5824005B,  //  0037  LDCONST	R9	K91
       0x7C1C0400,  //  0038  CALL	R7	2
-      0xB8220C00,  //  0039  GETNGBL	R8	K6
-      0x8C201115,  //  003A  GETMET	R8	R8	K21
-      0x58280017,  //  003B  LDCONST	R10	K23
+      0xB8225200,  //  0039  GETNGBL	R8	K41
+      0x8C20115A,  //  003A  GETMET	R8	R8	K90
+      0x5828005C,  //  003B  LDCONST	R10	K92
       0x7C200400,  //  003C  CALL	R8	2
-      0x88240108,  //  003D  GETMBR	R9	R0	K8
-      0x8828010F,  //  003E  GETMBR	R10	R0	K15
+      0x8824014E,  //  003D  GETMBR	R9	R0	K78
+      0x88280155,  //  003E  GETMBR	R10	R0	K85
       0x7C100C00,  //  003F  CALL	R4	6
-      0x8814010D,  //  0040  GETMBR	R5	R0	K13
-      0x8C140B18,  //  0041  GETMET	R5	R5	K24
+      0x88140153,  //  0040  GETMBR	R5	R0	K83
+      0x8C140B5D,  //  0041  GETMET	R5	R5	K93
       0x7C140200,  //  0042  CALL	R5	1
-      0x8C140B19,  //  0043  GETMET	R5	R5	K25
+      0x8C140B5E,  //  0043  GETMET	R5	R5	K94
       0x5C1C0800,  //  0044  MOVE	R7	R4
       0x7C140400,  //  0045  CALL	R5	2
-      0x8814010D,  //  0046  GETMBR	R5	R0	K13
-      0x8C140B1A,  //  0047  GETMET	R5	R5	K26
-      0x881C0108,  //  0048  GETMBR	R7	R0	K8
+      0x88140153,  //  0046  GETMBR	R5	R0	K83
+      0x8C140B5F,  //  0047  GETMET	R5	R5	K95
+      0x881C014E,  //  0048  GETMBR	R7	R0	K78
       0x781E0004,  //  0049  JMPF	R7	#004F
-      0xB81E0C00,  //  004A  GETNGBL	R7	K6
-      0x8C1C0F15,  //  004B  GETMET	R7	R7	K21
-      0x58240014,  //  004C  LDCONST	R9	K20
+      0xB81E5200,  //  004A  GETNGBL	R7	K41
+      0x8C1C0F5A,  //  004B  GETMET	R7	R7	K90
+      0x58240040,  //  004C  LDCONST	R9	K64
       0x7C1C0400,  //  004D  CALL	R7	2
       0x70020003,  //  004E  JMP		#0053
-      0xB81E0C00,  //  004F  GETNGBL	R7	K6
-      0x8C1C0F15,  //  0050  GETMET	R7	R7	K21
-      0x5824001B,  //  0051  LDCONST	R9	K27
+      0xB81E5200,  //  004F  GETNGBL	R7	K41
+      0x8C1C0F5A,  //  0050  GETMET	R7	R7	K90
+      0x58240060,  //  0051  LDCONST	R9	K96
       0x7C1C0400,  //  0052  CALL	R7	2
-      0x58200014,  //  0053  LDCONST	R8	K20
+      0x58200040,  //  0053  LDCONST	R8	K64
       0x7C140600,  //  0054  CALL	R5	3
-      0xB8160C00,  //  0055  GETNGBL	R5	K6
-      0x8C140B1C,  //  0056  GETMET	R5	R5	K28
-      0xB81E0C00,  //  0057  GETNGBL	R7	K6
-      0x8C1C0F1D,  //  0058  GETMET	R7	R7	K29
+      0xB8165200,  //  0055  GETNGBL	R5	K41
+      0x8C140B61,  //  0056  GETMET	R5	R5	K97
+      0xB81E5200,  //  0057  GETNGBL	R7	K41
+      0x8C1C0F62,  //  0058  GETMET	R7	R7	K98
       0x7C1C0200,  //  0059  CALL	R7	1
       0x7C140400,  //  005A  CALL	R5	2
-      0xB8160C00,  //  005B  GETNGBL	R5	K6
-      0x8C140B1D,  //  005C  GETMET	R5	R5	K29
+      0xB8165200,  //  005B  GETNGBL	R5	K41
+      0x8C140B62,  //  005C  GETMET	R5	R5	K98
       0x7C140200,  //  005D  CALL	R5	1
-      0x8C140B1E,  //  005E  GETMET	R5	R5	K30
-      0x581C0014,  //  005F  LDCONST	R7	K20
-      0x58200014,  //  0060  LDCONST	R8	K20
+      0x8C140B63,  //  005E  GETMET	R5	R5	K99
+      0x581C0040,  //  005F  LDCONST	R7	K64
+      0x58200040,  //  0060  LDCONST	R8	K64
       0x7C140600,  //  0061  CALL	R5	3
       0x60140013,  //  0062  GETGBL	R5	G19
       0x7C140000,  //  0063  CALL	R5	0
-      0x90023E05,  //  0064  SETMBR	R0	K31	R5
-      0x8C140120,  //  0065  GETMET	R5	R0	K32
+      0x90020A05,  //  0064  SETMBR	R0	K5	R5
+      0x8C140164,  //  0065  GETMET	R5	R0	K100
       0x5C1C0400,  //  0066  MOVE	R7	R2
       0x7C140400,  //  0067  CALL	R5	2
       0x80000000,  //  0068  RET	0
@@ -11030,69 +10541,38 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
   be_nested_proto(
     22,                          /* nstack */
     3,                          /* argc */
-    2,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(id),
-    /* K4   */  be_nested_str_weak(obj),
-    /* K5   */  be_nested_str_weak(get_page_cur),
-    /* K6   */  be_nested_str_weak(berry_run),
-    /* K7   */  be_nested_str_weak(nil),
-    /* K8   */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
-    /* K11  */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
-    /* K12  */  be_nested_str_weak(parentid),
-    /* K13  */  be_nested_str_weak(get_obj),
-    /* K14  */  be_nested_str_weak(_lv_obj),
-    /* K15  */  be_nested_str_weak(get_scr),
-    /* K16  */  be_nested_str_weak(get),
-    /* K17  */  be_nested_str_weak(lvh_),
-    /* K18  */  be_nested_str_weak(class),
-    /* K19  */  be_nested_str_weak(lvh_obj),
-    /* K20  */  be_nested_str_weak(module),
-    /* K21  */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20),
-    /* K22  */  be_nested_str_weak(add_obj),
-    /* K23  */  be_nested_str_weak(function),
-    /* K24  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K25  */  be_const_int(0),
-    /* K26  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
-    /* K27  */  be_nested_str_weak(keys),
-    /* K28  */  be_nested_str_weak(stop_iteration),
-    /* K29  */  be_nested_str_weak(post_config),
-    }),
+    &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(parse_obj),
     &be_const_str_solidified,
     ( &(const binstruction[215]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
+      0xA40ECA00,  //  0000  IMPORT	R3	K101
+      0xA4124A00,  //  0001  IMPORT	R4	K37
       0x60140009,  //  0002  GETGBL	R5	G9
-      0x8C180302,  //  0003  GETMET	R6	R1	K2
-      0x58200003,  //  0004  LDCONST	R8	K3
+      0x8C180332,  //  0003  GETMET	R6	R1	K50
+      0x58200045,  //  0004  LDCONST	R8	K69
       0x7C180400,  //  0005  CALL	R6	2
       0x7C140200,  //  0006  CALL	R5	1
       0x60180008,  //  0007  GETGBL	R6	G8
-      0x8C1C0302,  //  0008  GETMET	R7	R1	K2
-      0x58240004,  //  0009  LDCONST	R9	K4
+      0x8C1C0332,  //  0008  GETMET	R7	R1	K50
+      0x58240066,  //  0009  LDCONST	R9	K102
       0x7C1C0400,  //  000A  CALL	R7	2
       0x7C180200,  //  000B  CALL	R6	1
       0x4C1C0000,  //  000C  LDNIL	R7
-      0x8C200105,  //  000D  GETMET	R8	R0	K5
+      0x8C200146,  //  000D  GETMET	R8	R0	K70
       0x7C200200,  //  000E  CALL	R8	1
       0x60240008,  //  000F  GETGBL	R9	G8
-      0x8C280302,  //  0010  GETMET	R10	R1	K2
-      0x58300006,  //  0011  LDCONST	R12	K6
+      0x8C280332,  //  0010  GETMET	R10	R1	K50
+      0x58300067,  //  0011  LDCONST	R12	K103
       0x7C280400,  //  0012  CALL	R10	2
       0x7C240200,  //  0013  CALL	R9	1
       0x4C280000,  //  0014  LDNIL	R10
-      0x202C1307,  //  0015  NE	R11	R9	K7
+      0x202C1368,  //  0015  NE	R11	R9	K104
       0x782E0012,  //  0016  JMPF	R11	#002A
       0xA8020005,  //  0017  EXBLK	0	#001E
       0x602C000D,  //  0018  GETGBL	R11	G13
@@ -11105,7 +10585,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020008,  //  001F  JMP		#0029
       0x60340001,  //  0020  GETGBL	R13	G1
       0x60380018,  //  0021  GETGBL	R14	G24
-      0x583C0008,  //  0022  LDCONST	R15	K8
+      0x583C0069,  //  0022  LDCONST	R15	K105
       0x5C401200,  //  0023  MOVE	R16	R9
       0x5C441600,  //  0024  MOVE	R17	R11
       0x5C481800,  //  0025  MOVE	R18	R12
@@ -11113,12 +10593,12 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x7C340200,  //  0027  CALL	R13	1
       0x70020000,  //  0028  JMP		#002A
       0xB0080000,  //  0029  RAISE	2	R0	R0
-      0x202C0D07,  //  002A  NE	R11	R6	K7
+      0x202C0D68,  //  002A  NE	R11	R6	K104
       0x782E006A,  //  002B  JMPF	R11	#0097
       0x4C2C0000,  //  002C  LDNIL	R11
       0x202C0A0B,  //  002D  NE	R11	R5	R11
       0x782E0067,  //  002E  JMPF	R11	#0097
-      0x142C0B09,  //  002F  LT	R11	R5	K9
+      0x142C0B41,  //  002F  LT	R11	R5	K65
       0x742E0002,  //  0030  JMPT	R11	#0034
       0x542E00FD,  //  0031  LDINT	R11	254
       0x242C0A0B,  //  0032  GT	R11	R5	R11
@@ -11127,44 +10607,44 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60300008,  //  0035  GETGBL	R12	G8
       0x5C340A00,  //  0036  MOVE	R13	R5
       0x7C300200,  //  0037  CALL	R12	1
-      0x0032140C,  //  0038  ADD	R12	K10	R12
-      0x0030190B,  //  0039  ADD	R12	R12	K11
+      0x0032D40C,  //  0038  ADD	R12	K106	R12
+      0x0030196B,  //  0039  ADD	R12	R12	K107
       0x00301806,  //  003A  ADD	R12	R12	R6
       0x7C2C0200,  //  003B  CALL	R11	1
       0x80001600,  //  003C  RET	0
       0x4C2C0000,  //  003D  LDNIL	R11
       0x60300009,  //  003E  GETGBL	R12	G9
-      0x8C340302,  //  003F  GETMET	R13	R1	K2
-      0x583C000C,  //  0040  LDCONST	R15	K12
+      0x8C340332,  //  003F  GETMET	R13	R1	K50
+      0x583C006C,  //  0040  LDCONST	R15	K108
       0x7C340400,  //  0041  CALL	R13	2
       0x7C300200,  //  0042  CALL	R12	1
       0x4C340000,  //  0043  LDNIL	R13
       0x4C380000,  //  0044  LDNIL	R14
       0x2038180E,  //  0045  NE	R14	R12	R14
       0x783A0007,  //  0046  JMPF	R14	#004F
-      0x8C38110D,  //  0047  GETMET	R14	R8	K13
+      0x8C38116D,  //  0047  GETMET	R14	R8	K109
       0x5C401800,  //  0048  MOVE	R16	R12
       0x7C380400,  //  0049  CALL	R14	2
       0x5C341C00,  //  004A  MOVE	R13	R14
       0x4C380000,  //  004B  LDNIL	R14
       0x20381A0E,  //  004C  NE	R14	R13	R14
       0x783A0000,  //  004D  JMPF	R14	#004F
-      0x882C1B0E,  //  004E  GETMBR	R11	R13	K14
+      0x882C1B3E,  //  004E  GETMBR	R11	R13	K62
       0x4C380000,  //  004F  LDNIL	R14
       0x1C38160E,  //  0050  EQ	R14	R11	R14
       0x783A0002,  //  0051  JMPF	R14	#0055
-      0x8C38110F,  //  0052  GETMET	R14	R8	K15
+      0x8C38116E,  //  0052  GETMET	R14	R8	K110
       0x7C380200,  //  0053  CALL	R14	1
       0x5C2C1C00,  //  0054  MOVE	R11	R14
-      0x8C380910,  //  0055  GETMET	R14	R4	K16
+      0x8C380934,  //  0055  GETMET	R14	R4	K52
       0x5C400000,  //  0056  MOVE	R16	R0
-      0x00462206,  //  0057  ADD	R17	K17	R6
+      0x0046DE06,  //  0057  ADD	R17	K111	R6
       0x7C380600,  //  0058  CALL	R14	3
       0x4C3C0000,  //  0059  LDNIL	R15
       0x4C400000,  //  005A  LDNIL	R16
       0x1C401C10,  //  005B  EQ	R16	R14	R16
       0x78420010,  //  005C  JMPF	R16	#006E
-      0x8C400910,  //  005D  GETMET	R16	R4	K16
+      0x8C400934,  //  005D  GETMET	R16	R4	K52
       0x5C480600,  //  005E  MOVE	R18	R3
       0x5C4C0C00,  //  005F  MOVE	R19	R6
       0x7C400600,  //  0060  CALL	R16	3
@@ -11174,17 +10654,17 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60440004,  //  0064  GETGBL	R17	G4
       0x5C482000,  //  0065  MOVE	R18	R16
       0x7C440200,  //  0066  CALL	R17	1
-      0x1C442312,  //  0067  EQ	R17	R17	K18
+      0x1C442370,  //  0067  EQ	R17	R17	K112
       0x78460004,  //  0068  JMPF	R17	#006E
       0x5C442000,  //  0069  MOVE	R17	R16
       0x5C481600,  //  006A  MOVE	R18	R11
       0x7C440200,  //  006B  CALL	R17	1
       0x5C3C2200,  //  006C  MOVE	R15	R17
-      0x88380113,  //  006D  GETMBR	R14	R0	K19
+      0x88380171,  //  006D  GETMBR	R14	R0	K113
       0x4C400000,  //  006E  LDNIL	R16
       0x1C401C10,  //  006F  EQ	R16	R14	R16
       0x7842000F,  //  0070  JMPF	R16	#0081
-      0x8C400914,  //  0071  GETMET	R16	R4	K20
+      0x8C400972,  //  0071  GETMET	R16	R4	K114
       0x5C480C00,  //  0072  MOVE	R18	R6
       0x7C400400,  //  0073  CALL	R16	2
       0x4C440000,  //  0074  LDNIL	R17
@@ -11193,13 +10673,13 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60440004,  //  0077  GETGBL	R17	G4
       0x5C482000,  //  0078  MOVE	R18	R16
       0x7C440200,  //  0079  CALL	R17	1
-      0x1C442312,  //  007A  EQ	R17	R17	K18
+      0x1C442370,  //  007A  EQ	R17	R17	K112
       0x78460004,  //  007B  JMPF	R17	#0081
       0x5C442000,  //  007C  MOVE	R17	R16
       0x5C481600,  //  007D  MOVE	R18	R11
       0x7C440200,  //  007E  CALL	R17	1
       0x5C3C2200,  //  007F  MOVE	R15	R17
-      0x88380113,  //  0080  GETMBR	R14	R0	K19
+      0x88380171,  //  0080  GETMBR	R14	R0	K113
       0x4C400000,  //  0081  LDNIL	R16
       0x1C401C10,  //  0082  EQ	R16	R14	R16
       0x78420006,  //  0083  JMPF	R16	#008B
@@ -11207,7 +10687,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60440008,  //  0085  GETGBL	R17	G8
       0x5C480C00,  //  0086  MOVE	R18	R6
       0x7C440200,  //  0087  CALL	R17	1
-      0x00462A11,  //  0088  ADD	R17	K21	R17
+      0x0046E611,  //  0088  ADD	R17	K115	R17
       0x7C400200,  //  0089  CALL	R16	1
       0x80002000,  //  008A  RET	0
       0x5C401C00,  //  008B  MOVE	R16	R14
@@ -11218,7 +10698,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x5C541A00,  //  0090  MOVE	R21	R13
       0x7C400A00,  //  0091  CALL	R16	5
       0x5C1C2000,  //  0092  MOVE	R7	R16
-      0x8C401116,  //  0093  GETMET	R16	R8	K22
+      0x8C401174,  //  0093  GETMET	R16	R8	K116
       0x5C480A00,  //  0094  MOVE	R18	R5
       0x5C4C0E00,  //  0095  MOVE	R19	R7
       0x7C400600,  //  0096  CALL	R16	3
@@ -11231,7 +10711,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60300004,  //  009D  GETGBL	R12	G4
       0x5C341600,  //  009E  MOVE	R13	R11
       0x7C300200,  //  009F  CALL	R12	1
-      0x1C301917,  //  00A0  EQ	R12	R12	K23
+      0x1C301975,  //  00A0  EQ	R12	R12	K117
       0x78320002,  //  00A1  JMPF	R12	#00A5
       0x5C301600,  //  00A2  MOVE	R12	R11
       0x5C340E00,  //  00A3  MOVE	R13	R7
@@ -11242,7 +10722,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020008,  //  00A8  JMP		#00B2
       0x60340001,  //  00A9  GETGBL	R13	G1
       0x60380018,  //  00AA  GETGBL	R14	G24
-      0x583C0018,  //  00AB  LDCONST	R15	K24
+      0x583C0076,  //  00AB  LDCONST	R15	K118
       0x5C401200,  //  00AC  MOVE	R16	R9
       0x5C441600,  //  00AD  MOVE	R17	R11
       0x5C481800,  //  00AE  MOVE	R18	R12
@@ -11254,24 +10734,24 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x1C2C0A0B,  //  00B4  EQ	R11	R5	R11
       0x782E0000,  //  00B5  JMPF	R11	#00B7
       0x80001600,  //  00B6  RET	0
-      0x1C2C0B19,  //  00B7  EQ	R11	R5	K25
+      0x1C2C0B0B,  //  00B7  EQ	R11	R5	K11
       0x782E0005,  //  00B8  JMPF	R11	#00BF
-      0x202C0D07,  //  00B9  NE	R11	R6	K7
+      0x202C0D68,  //  00B9  NE	R11	R6	K104
       0x782E0003,  //  00BA  JMPF	R11	#00BF
       0x602C0001,  //  00BB  GETGBL	R11	G1
-      0x5830001A,  //  00BC  LDCONST	R12	K26
+      0x58300077,  //  00BC  LDCONST	R12	K119
       0x7C2C0200,  //  00BD  CALL	R11	1
       0x80001600,  //  00BE  RET	0
-      0x1C2C0B19,  //  00BF  EQ	R11	R5	K25
+      0x1C2C0B0B,  //  00BF  EQ	R11	R5	K11
       0x782E0005,  //  00C0  JMPF	R11	#00C7
-      0x8C2C0105,  //  00C1  GETMET	R11	R0	K5
+      0x8C2C0146,  //  00C1  GETMET	R11	R0	K70
       0x7C2C0200,  //  00C2  CALL	R11	1
-      0x8C2C170D,  //  00C3  GETMET	R11	R11	K13
-      0x58340019,  //  00C4  LDCONST	R13	K25
+      0x8C2C176D,  //  00C3  GETMET	R11	R11	K109
+      0x5834000B,  //  00C4  LDCONST	R13	K11
       0x7C2C0400,  //  00C5  CALL	R11	2
       0x5C1C1600,  //  00C6  MOVE	R7	R11
       0x602C0010,  //  00C7  GETGBL	R11	G16
-      0x8C30031B,  //  00C8  GETMET	R12	R1	K27
+      0x8C30032E,  //  00C8  GETMET	R12	R1	K46
       0x7C300200,  //  00C9  CALL	R12	1
       0x7C2C0200,  //  00CA  CALL	R11	1
       0xA8020004,  //  00CB  EXBLK	0	#00D1
@@ -11280,10 +10760,10 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x9434020C,  //  00CE  GETIDX	R13	R1	R12
       0x901C180D,  //  00CF  SETMBR	R7	R12	R13
       0x7001FFFA,  //  00D0  JMP		#00CC
-      0x582C001C,  //  00D1  LDCONST	R11	K28
+      0x582C0030,  //  00D1  LDCONST	R11	K48
       0xAC2C0200,  //  00D2  CATCH	R11	1	0
       0xB0080000,  //  00D3  RAISE	2	R0	R0
-      0x8C2C0F1D,  //  00D4  GETMET	R11	R7	K29
+      0x8C2C0F78,  //  00D4  GETMET	R11	R7	K120
       0x7C2C0200,  //  00D5  CALL	R11	1
       0x80000000,  //  00D6  RET	0
     })


### PR DESCRIPTION
## Description:

Berry, special optimization when doing solidification yields 24KB Flash size reduction with standard Tasmota 32 firmware.

Normally each function or class methods holds its own `ktab` (constant tables) containing numbers and strings. Each ktab entry consumes 8 bytes. Constant table size is max 256 (bigger is possible but increases code size). ktab appear to consume a lot of flash.
Within a same class, it appears that some strings and values are often repeated, for example method names and variable names.

This optimization scans each class during solidification, and tries to create a consolidated single constant table that is shared among all methods. Berry code is then scanned to update the constant numbers to the new index in the shared table.

As a result, this avoids a lot of duplication of constant values (`bvalue`), but has no functional impact, nor any performance impact.

This is a first version. It could be improved to also include modules, and have a smart approach when the consolidated table is more than 256 entries (in such case, the optimization stops).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
