### PR TITLE
Avoid random content in bvalue

### DIFF
--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -307,7 +307,7 @@ static int exp2const(bfuncinfo *finfo, bexpdesc *e)
 {
     int idx = findconst(finfo, e); /* does the constant already exist? */
     if (idx == -1) { /* if not add it */
-        bvalue k;
+        bvalue k = {};
         switch (e->type) {
         case ETINT:
             k.type = BE_INT;
@@ -882,7 +882,7 @@ void be_code_index(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k)
 void be_code_class(bfuncinfo *finfo, bexpdesc *dst, bclass *c)
 {
     int src;
-    bvalue var;
+    bvalue var = {};
     var_setclass(&var, c);  /* new var of CLASS type */
     src = newconst(finfo, &var);  /* allocate a new constant and return kreg */
     if (dst->type == ETLOCAL) {  /* if target is a local variable, just assign */
@@ -965,7 +965,7 @@ void be_code_raise(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2)
 
 void be_code_implicit_class(bfuncinfo *finfo, bexpdesc *e, bclass *c)
 {
-    bvalue k;
+    bvalue k = {};
     k.type = BE_CLASS;
     k.v.p = c;
     int idx = newconst(finfo, &k);  /* create new constant */


### PR DESCRIPTION
## Description:

Fix for #21845, some `bvalue` are not initialized and may contain random values. This is an issue when a constant is initialized with 32 bits, but also contains space for 64 bits pointers. This patch force all zeroes in the `bvalue`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
