### PR TITLE
Berry `file.write()` raises an exception on failure (ex: disk full)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Berry `light.get` for separate RGB/CT (#21818)
 - Berry `bytes` setters and getters with negative offsets (#21835)
+- Berry `file.write()` raises an exception on failure (ex: disk full)
 
 ### Removed
 - Berry internal: remove class from closure to simplify code (#21839)

--- a/lib/libesp32/berry/src/be_filelib.c
+++ b/lib/libesp32/berry/src/be_filelib.c
@@ -26,7 +26,10 @@ static int i_write(bvm *vm)
         } else {
             data = be_tobytes(vm, 2, &size);
         }
-        be_fwrite(fh, data, size);
+        size_t bw = be_fwrite(fh, data, size);
+        if (bw != size) {
+            be_raise(vm, "io_error", "write failed");
+        }
     }
     be_return_nil(vm);
 }


### PR DESCRIPTION
## Description:

Berry `file.write()` would not raise any error if the filesystem is full. Now an exception is raised.

From upstream https://github.com/berry-lang/berry/pull/442

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
