### PR TITLE
Add NeoPool `NPSetOption<x>` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Matter improve internal `inspect`for superclasses (#21824)
 - Matter support for split lights (`SetOption68 1` and `SetOption37 128`) (#21834)
 - Berry `webserver_async` (#21836)
+- NeoPool add `NPSetOption<x>` command to enabled/disable data validation/connection statistics
 
 ### Breaking Changed
 


### PR DESCRIPTION
## Description:

Add commands to control measurement validation/transmission statistics:
- `NPSetOption0 {0|1}`
(only available on ESP32 or if NEOPOOL_RANGE_CHECKS is defined)
Disable(0)/Enable(1) sensor data min/max validation and correction ()

- `NPSetOption1 {0|1}`
(only available on ESP32 or if NEOPOOL_CONNSTAT is defined)
Disable(0)/Enable(1) modbus connection statistics


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
