### PR TITLE
Xsns 102 ld2410

### DIFF
--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -193,7 +193,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t neopool_outputsensitive : 1;  // bit 11 (v13.2.0.1) - SetOption157 - (NeoPool) Output sensitive data (1)
     uint32_t mqtt_disable_modbus : 1;      // bit 12 (v13.3.0.5) - SetOption158 - (MQTT) Disable publish ModbusReceived MQTT messages (1), you must use event trigger rules instead
     uint32_t counter_both_edges : 1;       // bit 13 (v13.3.0.5) - SetOption159 - (Counter) Enable counting on both rising and falling edge (1)
-    uint32_t spare14 : 1;                  // bit 14
+    uint32_t ld2410_use_pin : 1;           // bit 14 (development) - SetOption160 - (LD2410) Disable generate moving event by sensor report - use LD2410 out pin for events (1)
     uint32_t spare15 : 1;                  // bit 15
     uint32_t spare16 : 1;                  // bit 16
     uint32_t spare17 : 1;                  // bit 17

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Ontfout"
 #define D_DEWPOINT "Dou punt"
 #define D_DISABLED "Gedeaktiveer"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Afstand"
 #define D_DNS_SERVER "DNS"
 #define D_DO "Opgeloste suurstof"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Премахване на дефекти"
 #define D_DEWPOINT "Температура на оросяване"
 #define D_DISABLED "Забранено"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Разстояние"
 #define D_DNS_SERVER "Сървър на DNS"
 #define D_DO "Разтворен кислород"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Depuració"
 #define D_DEWPOINT "Punt de rossada"
 #define D_DISABLED "Deshabilitat"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distancia"
 #define D_DNS_SERVER "Servidor DNS"
 #define D_DO "Oxígen dissolt"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Zablokováno"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distance"
 #define D_DNS_SERVER "Server DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "debug"
 #define D_DEWPOINT "Taupunkt"
 #define D_DISABLED "deaktiviert"
-#define D_MOVING_DISTANCE "Abstand bewegt"
-#define D_STATIC_DISTANCE "Abstand fix"
-#define D_DETECT_DISTANCE "Abstandsfeststellung"
 #define D_DISTANCE "Abstand"
 #define D_DNS_SERVER "DNS-Server"
 #define D_DO "gelöster Sauerstoff"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Abstand bewegt"
+#define D_STATIC_DISTANCE "Abstand fix"
+#define D_DETECT_DISTANCE "Abstandsfeststellung"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -1273,10 +1273,10 @@
 #define D_MOVING_DISTANCE "Abstand bewegt"
 #define D_STATIC_DISTANCE "Abstand fix"
 #define D_DETECT_DISTANCE "Abstandsfeststellung"
-#define D_MOVING_ENERGY_T "Moving target"
-#define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
-#define D_LD2410_LIGHT "Light sensor"
+#define D_MOVING_ENERGY_T "Bewegliches Ziel"
+#define D_STATIC_ENERGY_T "Statisches Ziel"
+#define D_LD2410_PIN_STATE "Zustand des Ausgangspins"
+#define D_LD2410_LIGHT "Lichtsensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Ανενεργό"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Απόσταση"
 #define D_DNS_SERVER "Διακομιστής DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -1276,7 +1276,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Disabled"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distance"
 #define D_DNS_SERVER "DNS Server"
 #define D_DO "Disolved Oxygen"
@@ -1272,6 +1269,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Punto de Rocío"
 #define D_DISABLED "Deshabilitado"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distancia"
 #define D_DNS_SERVER "Servidor DNS"
 #define D_DO "Oxígeno Disuelto"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Point de rosée"
 #define D_DISABLED "Désactivé"
-#define D_MOVING_DISTANCE "Distance mobile"
-#define D_STATIC_DISTANCE "Distance fixe"
-#define D_DETECT_DISTANCE "Distance détectée"
 #define D_DISTANCE "Distance"
 #define D_DNS_SERVER "Serveur DNS"
 #define D_DO "Oxygène dissout"
@@ -1272,6 +1269,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Distance mobile"
+#define D_STATIC_DISTANCE "Distance fixe"
+#define D_DETECT_DISTANCE "Distance détectée"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -1274,10 +1274,10 @@
 #define D_MOVING_DISTANCE "Distance mobile"
 #define D_STATIC_DISTANCE "Distance fixe"
 #define D_DETECT_DISTANCE "Distance détectée"
-#define D_MOVING_ENERGY_T "Moving target"
-#define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
-#define D_LD2410_LIGHT "Light sensor"
+#define D_MOVING_ENERGY_T "Cible mouvante"
+#define D_STATIC_ENERGY_T "Cible statique"
+#define D_LD2410_PIN_STATE "État de la broche de sortie"
+#define D_LD2410_LIGHT "Capteur de lumière"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debugearje"
 #define D_DEWPOINT "Dauwpunt"
 #define D_DISABLED "Útsetten"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Ôfstân"
 #define D_DNS_SERVER "DNS Server"
 #define D_DO "Oploste soerstof"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "באגים"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "מבוטל"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "מרחק"
 #define D_DNS_SERVER "DNS שרת"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Harmatpont"
 #define D_DISABLED "Letiltva"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Távolság"
 #define D_DNS_SERVER "DNS szerver"
 #define D_DO "Oldott oxygén"
@@ -1274,6 +1271,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -1278,7 +1278,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -87,9 +87,6 @@
 #define D_DEBUG                "Debug"
 #define D_DEWPOINT             "Punto rugiada" //
 #define D_DISABLED             "Disabilitato/a"
-#define D_MOVING_DISTANCE      "Distanza in movimento"
-#define D_STATIC_DISTANCE      "Distanza statica"
-#define D_DETECT_DISTANCE      "Rileva distanza"
 #define D_DISTANCE             "Distanza"
 #define D_DNS_SERVER           "Server DNS"
 #define D_DO                   "Ossigeno dissolto"
@@ -1272,6 +1269,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX              "Pipsolar - TX"
 #define D_SENSOR_PIPSOLAR_RX              "Pipsolar - RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE      "Distanza in movimento"
+#define D_STATIC_DISTANCE      "Distanza statica"
+#define D_DETECT_DISTANCE      "Rileva distanza"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Importa"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -1275,9 +1275,9 @@
 #define D_STATIC_DISTANCE      "Distanza statica"
 #define D_DETECT_DISTANCE      "Rileva distanza"
 #define D_MOVING_ENERGY_T "Moving target"
-#define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
-#define D_LD2410_LIGHT "Light sensor"
+#define D_STATIC_ENERGY_T "Target statico"
+#define D_LD2410_PIN_STATE "Stato pin di uscita"
+#define D_LD2410_LIGHT "Sensore di luce"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Importa"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "디버그"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "사용안함"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "거리"
 #define D_DNS_SERVER "DNS 서버"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dauwpunt"
 #define D_DISABLED "Uitgeschakeld"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Afstand"
 #define D_DNS_SERVER "DNS Server"
 #define D_DO "Opgelost zuurstof"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Punkt rosy"
 #define D_DISABLED "Wyłączony"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Odległość"
 #define D_DNS_SERVER "Serwer DNS"
 #define D_DO "Rozpuszczalność tlenu"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Depurar"
 #define D_DEWPOINT "Ponto de orvalho"
 #define D_DISABLED "Desabilitado"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distância"
 #define D_DNS_SERVER "Servidor DNS"
 #define D_DO "Oxigênio dissolvido"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Depurar"
 #define D_DEWPOINT "Ponto de Condensação"
 #define D_DISABLED "Disabilitado"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distância"
 #define D_DNS_SERVER "Servidor DNS"
 #define D_DO "Oxigénio Dissolvido"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Depanare"
 #define D_DEWPOINT "Punct de rouă"
 #define D_DISABLED "Dezactivat"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distanță"
 #define D_DNS_SERVER "Server DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -1276,7 +1276,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -88,9 +88,6 @@
 #define D_DEBUG "Отладка"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Блокирован"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Расстояние"
 #define D_DNS_SERVER "DNS Сервер"
 #define D_DO "Disolved Oxygen"
@@ -1272,6 +1269,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -89,9 +89,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Zablokované"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Vzdialenosť"
 #define D_DNS_SERVER "Server DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Debug"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Inaktiverad"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Distans"
 #define D_DNS_SERVER "DNS-server"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Hata Ayıklama"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "Etkin Değil"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Mesage"
 #define D_DNS_SERVER "DNS Sunucu"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Налагодження"
 #define D_DEWPOINT "Tочка роси"
 #define D_DISABLED "Вимкнено"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Відстань"
 #define D_DNS_SERVER "Сервер DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "Tìm lỗi"
 #define D_DEWPOINT "Điểm sương"
 #define D_DISABLED "Vô hiệu hóa"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "Khoảng cách"
 #define D_DNS_SERVER "Máy chủ DNS"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "调试"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "禁用"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "距离"
 #define D_DNS_SERVER "DNS服务器"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -1275,7 +1275,7 @@
 #define D_DETECT_DISTANCE "Detect Distance"
 #define D_MOVING_ENERGY_T "Moving target"
 #define D_STATIC_ENERGY_T "Static target"
-#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_PIN_STATE "Output pin state"
 #define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -87,9 +87,6 @@
 #define D_DEBUG "偵錯"
 #define D_DEWPOINT "Dew point"
 #define D_DISABLED "已停用"
-#define D_MOVING_DISTANCE "Moving Distance"
-#define D_STATIC_DISTANCE "Static Distance"
-#define D_DETECT_DISTANCE "Detect Distance"
 #define D_DISTANCE "距離"
 #define D_DNS_SERVER "DNS伺服器"
 #define D_DO "Disolved Oxygen"
@@ -1271,6 +1268,15 @@
 // ixrv92_pipsolar.ino
 #define D_SENSOR_PIPSOLAR_TX             "Pipsolar TX"
 #define D_SENSOR_PIPSOLAR_RX             "Pipsolar RX"
+
+// xsns_102_ld2410.ino
+#define D_MOVING_DISTANCE "Moving Distance"
+#define D_STATIC_DISTANCE "Static Distance"
+#define D_DETECT_DISTANCE "Detect Distance"
+#define D_MOVING_ENERGY_T "Moving target"
+#define D_STATIC_ENERGY_T "Static target"
+#define D_LD2410_PIN_STATE "Out port state"
+#define D_LD2410_LIGHT "Light sensor"
 
 // xsns_115_wooliis.ino
 #define D_IMPORT                          "Import"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -877,7 +877,7 @@
 //#define USE_VINDRIKTNING                         // Add support for IKEA VINDRIKTNING particle concentration sensor (+0k6 code)
 //  #define VINDRIKTNING_SHOW_PM1                  // Display undocumented/supposed PM1.0 values
 //  #define VINDRIKTNING_SHOW_PM10                 // Display undocumented/supposed PM10 values
-#define USE_LD2410                               // Add support for HLK-LD2410 24GHz smart wave motion sensor (+2k8 code)
+//#define USE_LD2410                               // Add support for HLK-LD2410 24GHz smart wave motion sensor (+3k7 code)
 //#define USE_LOX_O2                               // Add support for LuminOx LOX O2 Sensor (+0k8 code)
 //#define USE_GM861                                // Add support for GM861 1D and 2D Bar Code Reader (+1k3 code)
 //  #define GM861_DECODE_AIM                       // Decode AIM-id (+0k3 code)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -877,7 +877,7 @@
 //#define USE_VINDRIKTNING                         // Add support for IKEA VINDRIKTNING particle concentration sensor (+0k6 code)
 //  #define VINDRIKTNING_SHOW_PM1                  // Display undocumented/supposed PM1.0 values
 //  #define VINDRIKTNING_SHOW_PM10                 // Display undocumented/supposed PM10 values
-//#define USE_LD2410                               // Add support for HLK-LD2410 24GHz smart wave motion sensor (+2k8 code)
+#define USE_LD2410                               // Add support for HLK-LD2410 24GHz smart wave motion sensor (+2k8 code)
 //#define USE_LOX_O2                               // Add support for LuminOx LOX O2 Sensor (+0k8 code)
 //#define USE_GM861                                // Add support for GM861 1D and 2D Bar Code Reader (+1k3 code)
 //  #define GM861_DECODE_AIM                       // Decode AIM-id (+0k3 code)

--- a/tasmota/tasmota_xsns_sensor/xsns_102_ld2410.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_102_ld2410.ino
@@ -5,8 +5,7 @@
 
   SPDX-License-Identifier: GPL-3.0-only
 */
-#define USE_LD2410
-#define USE_WEBSERVER
+
 #ifdef USE_LD2410
 /*********************************************************************************************\
  * HLK-LD2410 24GHz smart wave motion sensor

--- a/tasmota/tasmota_xsns_sensor/xsns_102_ld2410.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_102_ld2410.ino
@@ -9,7 +9,12 @@
 #ifdef USE_LD2410
 /*********************************************************************************************\
  * HLK-LD2410 24GHz smart wave motion sensor
- *
+ * 
+ * Attention!
+ * This module works with HLK-LD2410, HLK-LD2410B (md5sum-as tested), HLK-LD2410C (md5sum-as tested) devices. 
+ * The module does not support HLK-LD2410S (md5sum-as tested) and is not guaranteed to work with other devices.
+ * 
+ * 
  * LD2410Duration 0                            - Set factory default settings
  * LD2410Duration 1..65535                     - Set no-one duration in seconds (default 5)
  * LD2410MovingSens 50,50,40,30,20,15,15,15,15 - Set moving distance sensitivity for up to 9 gates (at 0.75 meter interval)


### PR DESCRIPTION
## Description:

Added new features:
- command **LD2410EngineeringStart**. Starting engineering mode for tuning moving and static sensitivity
- command **LD2410EngineeringEnd**. Stop engineering mode
- commang LD2410Get. Get last  received moving/static target energy
- add Setoption160 - Disable generate moving event by sensor report - use LD2410 out pin for events (1 for disable)
- added output to main web page engineering statistics when receive engineering reports
![Снимок экрана от 2024-08-01 01-37-31](https://github.com/user-attachments/assets/9b657d44-d90f-41d9-ab2f-462c57580c9f) ![Снимок экрана от 2024-07-31 22-36-27](https://github.com/user-attachments/assets/f2954b24-903f-41ba-b9ed-6bd8e538682c)

Refactoring language header files - add/move defines for xsns_102_ld2410.ino module
_UPD: check with Tasmota core ESP32 V.3.0.2_

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
