### PR TITLE
Berry add new type "addr" to ctypes mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file.
 - NeoPool command `NPSetOption<x>` to enabled/disable data validation/connection statistics (#21850)
 - Analog GPIO ``ADC Input`` with ``AdcParam<x> 1,<start_range>,<end_range>,<margin>,1`` provide direct light control 
 - Analog GPIO ``ADC Voltage`` with ``AdcParam<x> 11,<start_range>,<end_range>,<lowest_voltage>,<highest_voltage>`` provide energy monitoring with dc voltage 
-- Analog GPIO ``ADC Current`` with ``AdcParam<x> 12,<start_range>,<end_range>,<lowest_current>,<highest_current>`` provide energy monitoring with dc voltage 
+- Analog GPIO ``ADC Current`` with ``AdcParam<x> 12,<start_range>,<end_range>,<lowest_current>,<highest_current>`` provide energy monitoring with dc voltage
+- Berry add new type "addr" to ctypes mapping
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/include/be_ctypes.h
+++ b/lib/libesp32/berry_tasmota/include/be_ctypes.h
@@ -33,6 +33,10 @@ enum {
     ctypes_ptr32  =   9,
     ctypes_ptr64  =  -9,
 
+    // address (no acces to the value)
+    ctypes_addr   =  15,
+
+    // special
     ctypes_bf     =   0,    //bif-field
 };
 
@@ -51,17 +55,6 @@ typedef struct be_ctypes_structure_t {
     const char **instance_mapping;  /* array of instance class names for automatic instanciation of class */
     const be_ctypes_structure_item_t * items;
 } be_ctypes_structure_t;
-
-typedef struct be_ctypes_class_t {
-    const char * name;
-    const be_ctypes_structure_t * definitions;
-} be_ctypes_class_t;
-
-typedef struct be_ctypes_classes_t {
-    uint16_t  size;
-    const char **instance_mapping;  /* array of instance class names for automatic instanciation of class */
-    const be_ctypes_class_t * classes;
-} be_ctypes_classes_t;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
## Description:

Add a new type "addr" to the ctypes mapping of C structures, allows to get the address of the data (not the value) and pass it to a class constructor. Will be used by energy driver.

Remove duplicate definitions as well.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
