### PR TITLE
Berry add `file.savecode()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Analog GPIO ``ADC Voltage`` with ``AdcParam<x> 11,<start_range>,<end_range>,<lowest_voltage>,<highest_voltage>`` provide energy monitoring with dc voltage 
 - Analog GPIO ``ADC Current`` with ``AdcParam<x> 12,<start_range>,<end_range>,<lowest_current>,<highest_current>`` provide energy monitoring with dc voltage
 - Berry add new type "addr" to ctypes mapping
+- Berry add `file.savecode()`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -297,6 +297,13 @@ static void save_global_info(bvm *vm, void *fp)
     }
 }
 
+void be_bytecode_save_to_fs(bvm *vm, void *fp, bproto *proto)
+{
+    save_header(fp);
+    save_global_info(vm, fp);
+    save_proto(vm, fp, proto);
+}
+
 void be_bytecode_save(bvm *vm, const char *filename, bproto *proto)
 {
     void *fp = be_fopen(filename, "wb");
@@ -304,9 +311,7 @@ void be_bytecode_save(bvm *vm, const char *filename, bproto *proto)
         bytecode_error(vm, be_pushfstring(vm,
             "can not open file '%s'.", filename));
     } else {
-        save_header(fp);
-        save_global_info(vm, fp);
-        save_proto(vm, fp, proto);
+        be_bytecode_save_to_fs(vm, fp, proto);
         be_fclose(fp);
     }
 }

--- a/lib/libesp32/berry/src/be_bytecode.h
+++ b/lib/libesp32/berry/src/be_bytecode.h
@@ -11,6 +11,7 @@
 #include "be_object.h"
 
 void be_bytecode_save(bvm *vm, const char *filename, bproto *proto);
+void be_bytecode_save_to_fs(bvm *vm, void *fp, bproto *proto);
 bclosure* be_bytecode_load(bvm *vm, const char *filename);
 bclosure* be_bytecode_load_from_fs(bvm *vm, void *fp);
 bbool be_bytecode_check(const char *path);


### PR DESCRIPTION
## Description:

Add `file.savecode()` function to save pre-compiled Berry bytecode (.bec files) from native Berry code. This allows to generate .bec files in CI.

From upstream https://github.com/berry-lang/berry/pull/441

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
