### PR TITLE
Berry `zigbee.find()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Berry new type "addr" to ctypes mapping (#21883)
 - Berry `file.savecode()` (#21884)
 - Berry `solidify.nocompact()` and reduce size of Matter UI (#21885)
+- Berry `zigbee.find()`
 
 ### Breaking Changed
 - Berry `energy` module support for 8 phases and move to pseudo-arrays (#21887)

--- a/lib/libesp32/berry_tasmota/src/be_zigbee.c
+++ b/lib/libesp32/berry_tasmota/src/be_zigbee.c
@@ -51,6 +51,7 @@ static int zd_member(bvm *vm) {
 
 extern int zc_info(struct bvm *vm);
 extern int zc_item(struct bvm *vm);
+extern int zc_find(struct bvm *vm);
 extern int32_t zc_size(void* d);               BE_FUNC_CTYPE_DECLARE(zc_size, "i", ".");
 extern int zc_iter(bvm *vm);
 extern void zc_abort(void);                    BE_FUNC_CTYPE_DECLARE(zc_abort, "", ".");
@@ -113,6 +114,7 @@ class be_class_zb_coord_ntv (scope: global, name: zb_coord_ntv, strings: weak) {
 
   info, func(zc_info)
   item, func(zc_item)
+  find, func(zc_find)
   size, ctype_func(zc_size)
   iter, func(zc_iter)
 


### PR DESCRIPTION
## Description:

Berry Zigbee, add `zigbee.find(shortaddr:int | friendlyname:str) -> instance of zb_device` as an alternative to `zigbee[shortaddr:int | friendlyname:str]`, but `find` returns `nil` when the device does not exist, instead of an exception.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
