### PR TITLE
Berry `zigbee.started()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Berry `file.savecode()` (#21884)
 - Berry `solidify.nocompact()` and reduce size of Matter UI (#21885)
 - Berry `zigbee.find()`
+- Berry `zigbee.started()`
 
 ### Breaking Changed
 - Berry `energy` module support for 8 phases and move to pseudo-arrays (#21887)

--- a/lib/libesp32/berry_tasmota/src/be_zigbee.c
+++ b/lib/libesp32/berry_tasmota/src/be_zigbee.c
@@ -49,6 +49,7 @@ static int zd_member(bvm *vm) {
   be_return(vm);
 }
 
+extern int zc_started(struct bvm *vm);
 extern int zc_info(struct bvm *vm);
 extern int zc_item(struct bvm *vm);
 extern int zc_find(struct bvm *vm);
@@ -111,6 +112,8 @@ class be_class_zb_coord_ntv (scope: global, name: zb_coord_ntv, strings: weak) {
   zcl_attribute, class(be_class_zcl_attribute)
   zcl_attribute_list, class(be_class_zcl_attribute_list)
   zb_device, class(be_class_zb_device)
+
+  started, func(zc_started)
 
   info, func(zc_info)
   item, func(zc_item)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -2426,7 +2426,7 @@ void ZigbeeShow(bool json)
                       zigbee.major_rel, zigbee.minor_rel,
                       zigbee.maint_rel, zigbee.revision);
       WSContentSend_P(HTTP_BTN_ZB_BUTTONS);
-    } else {
+    } else if (zigbee.state_machine) {      // show buttons only if the state machine is still running. If not running anymore, it means aborted
       uint32_t grey = WebColor(COL_FORM);
       WSContentSend_P(HTTP_BTN_ZB_BUTTONS_DISABLED, grey, grey);
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -75,6 +75,21 @@ extern "C" {
 
 extern "C" {
   // Zigbee Coordinator `zc`
+
+  // `zigbee.started() -> bool or nil`
+  // Returns `true` if Zigbee sucessfully started, `false` if not yet started
+  // or `nil` if not configured or aborted
+  int zc_started(struct bvm *vm);
+  int zc_started(struct bvm *vm) {
+    // return `nil` if `zigbee.active` is false (i.e. no GPIO configured)
+    // or aborted, `zigbee.init_phase` is `true` but `zigbee.state_machine` is `false`
+    if (!zigbee.active || (!zigbee.state_machine && zigbee.init_phase)) {
+      be_return_nil(vm);
+    }
+    be_pushbool(vm, !zigbee.init_phase);
+    be_return(vm);
+  }
+
   int zc_info(struct bvm *vm);
   int zc_info(struct bvm *vm) {
     int32_t top = be_top(vm); // Get the number of arguments


### PR DESCRIPTION
## Description:

Added `zigbee.started() -> bool or nil`:
- returns `true` if zigbee sucessfully started, then all other zigbee methods are available. This state is final and does not change.
- returns `false` if zigbee is still in initialization process. This state eventually changes to `true` or `nil`
- returns `nil` if zigbee is not configured (no GPIO) or if initialization failes. This state is final and indicates a fatal error.

Other change:
- Zigbee buttons are not displayed on front page if initialization failed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
