### PR TITLE
Zigbee loads device data early before MCU startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 platform update from 2024.07.11 to 2024.08.10 (#21893)
 - ESP32 Framework (Arduino Core) from v3.0.2 to v3.0.4 (#21893)
 - Refactored Analog driver to better support multiple channels
+- Zigbee loads device data early before MCU startup
 
 ### Fixed
 - Berry `light.get` for separate RGB/CT (#21818)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1_headers.ino
@@ -69,7 +69,7 @@ public:
 #endif // USE_ZIGBEE_EEPROM
   {}
 
-  bool active = true;                 // is Zigbee active for this device, i.e. GPIOs configured
+  bool active = false;                // is Zigbee active for this device, i.e. GPIOs configured
   bool state_machine = false;		      // the state machine is running
   bool state_waiting = false;         // the state machine is waiting for external event or timeout
   bool state_no_timeout = false;      // the current wait loop does not generate a timeout but only continues running

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
@@ -425,7 +425,27 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_RECV_UNEXPECTED(&ZNP_Recv_Default)
+
+    ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "Loading Zigbee data")
+    ZI_CALL(&Z_Prepare_Storage, 0)
+    ZI_CALL(&Z_Load_Devices, 0)
+    ZI_CALL(&Z_Load_Data, 0)
+    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
+    ZI_CALL(&Z_ZbAutoload, 0)
+#ifndef USE_ZIGBEE_DEBUG
     ZI_WAIT(15500)                             // wait for 15 seconds for Tasmota to stabilize
+#else
+    ZI_WAIT(30000)                             // wait for cumulated 5 minutes
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+#endif
 
     //ZI_MQTT_STATE(ZIGBEE_STATUS_BOOT, "Booting")
     ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "rebooting ZNP device")
@@ -532,11 +552,6 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     // Correctly configured and running, enable all Tasmota features
     // ======================================================================
   ZI_LABEL(ZIGBEE_LABEL_READY)
-    ZI_CALL(&Z_Prepare_Storage, 0)
-    ZI_CALL(&Z_Load_Devices, 0)
-    ZI_CALL(&Z_Load_Data, 0)
-    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
-    ZI_CALL(&Z_ZbAutoload, 0)
     ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
     ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
     ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
@@ -881,7 +896,27 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_RECV_UNEXPECTED(&EZ_Recv_Default)
+    
+    ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "Loading Zigbee data")
+    ZI_CALL(&Z_Prepare_Storage, 0)
+    ZI_CALL(&Z_Load_Devices, 0)
+    ZI_CALL(&Z_Load_Data, 0)
+    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
+    ZI_CALL(&Z_ZbAutoload, 0)
+#ifndef USE_ZIGBEE_DEBUG
     ZI_WAIT(15500)                             // wait for 15 seconds for Tasmota to stabilize
+#else
+    ZI_WAIT(30000)                             // wait for cumulated 5 minutes
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+    ZI_WAIT(30000)
+#endif
 
     // Hardware reset
     ZI_LOG(LOG_LEVEL_INFO, kResettingDevice)     // Log Debug: resetting EZSP device
@@ -978,12 +1013,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_LOG(LOG_LEVEL_INFO, kZigbeeGroup0)
     ZI_SEND(ZBS_SET_MCAST_ENTRY)        ZI_WAIT_RECV(2500, ZBR_SET_MCAST_ENTRY)
 
-  // ZI_LABEL(ZIGBEE_LABEL_READY)
-    ZI_CALL(&Z_Prepare_Storage, 0)
-    ZI_CALL(&Z_Load_Devices, 0)
-    ZI_CALL(&Z_Load_Data, 0)
-    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
-    ZI_CALL(&Z_ZbAutoload, 0)
+  ZI_LABEL(ZIGBEE_LABEL_READY)
     ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
     ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
     ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
@@ -1088,6 +1118,7 @@ void ZigbeeStateMachine_Run(void) {
     }
     if (zigbee.pc < 0) {
       zigbee.state_machine = false;
+      zigbee.active = false;
       return;
     }
 
@@ -1133,6 +1164,7 @@ void ZigbeeStateMachine_Run(void) {
         zigbee.state_machine = false;
         if (cur_d8) {
           AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_ZIGBEE "Stopping (%d)"), cur_d8);
+          zigbee.active = false;
         }
         break;
       case ZGB_INSTR_CALL:

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -83,7 +83,7 @@ extern "C" {
   int zc_started(struct bvm *vm) {
     // return `nil` if `zigbee.active` is false (i.e. no GPIO configured)
     // or aborted, `zigbee.init_phase` is `true` but `zigbee.state_machine` is `false`
-    if (!zigbee.active || (!zigbee.state_machine && zigbee.init_phase)) {
+    if (!zigbee.active) {
       be_return_nil(vm);
     }
     be_pushbool(vm, !zigbee.init_phase);
@@ -117,7 +117,7 @@ extern "C" {
   // implement item() and find()
   int zc_item_or_find(struct bvm *vm, bbool raise_if_unknown) {
     int32_t top = be_top(vm); // Get the number of arguments
-    if (zigbee.init_phase) {
+    if (!zigbee.active) {
       be_raise(vm, "internal_error", "zigbee not started");
     }
     if (top >= 2 && (be_isint(vm, 2) || be_isstring(vm, 2))) {
@@ -189,7 +189,7 @@ extern "C" {
 
   int zc_iter(bvm *vm);
   int zc_iter(bvm *vm) {
-    if (zigbee.init_phase) {
+    if (!zigbee.active) {
       be_raise(vm, "internal_error", "zigbee not started");
     }
     be_pushntvclosure(vm, zc_iter_closure, 1);


### PR DESCRIPTION
## Description:

Zigbee improvements to prepare for Matter-Zigbee mapping:
- Zigbee devices data is now loaded at startup, available to be consulted by Berry and Matter. Previously it was only loaded after succesful initialization of Zigbee MCU. No functional change
- Hence some commands are available from start: `ZbInfo`, `ZbStatus`, `ZbName`...
- new `USE_ZIGBEE_DEBUG` to delay initialization of Zigbee MCU by 5 minutes. It makes easier testing without an actual Zigbee MCU
- Zigbee buttons are removed from main UI page if Zigbee initialization of MCU failed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
