### PR TITLE
Zigbee extend timeout for MCU reboot from 5s to 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Matter fixed UI bug when no endpoints configured
+- Zigbee extend timeout for MCU reboot from 5s to 10s
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
@@ -453,7 +453,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_CALL(&ZNP_Reset_Device, 0)         // LOW = reset
     ZI_WAIT(100)                          // wait for .1 second
     ZI_CALL(&ZNP_Reset_Device, 1)         // HIGH = release reset
-    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
+    ZI_WAIT_RECV_FUNC(10000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
     ZI_WAIT(100)
     ZI_LOG(LOG_LEVEL_DEBUG, kCheckingDeviceConfiguration)     // Log Debug: checking device configuration
     ZI_SEND(ZBS_VERSION)                      // check ZNP software version
@@ -925,7 +925,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_CALL(&EZ_Reset_Device, 1)         // HIGH = release reset
 
     // wait for device to start
-    ZI_WAIT_UNTIL(5000, ZBR_RSTACK)     // wait for RSTACK message
+    ZI_WAIT_UNTIL(10000, ZBR_RSTACK)     // wait for RSTACK message
 
     // Init device and probe version
     ZI_SEND(ZBS_VERSION)                ZI_WAIT_RECV_FUNC(5000, ZBR_VERSION, &EZ_ReceiveCheckVersion)       // check EXT PAN ID


### PR DESCRIPTION
## Description:

Zigbee MCU CC2652P7 now takes 7s to boot, which breaks the timeout - now extended to 10s.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
