### PR TITLE
BearSSL panic on ESP8266 in rare conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Matter fixed UI bug when no endpoints configured
 - Zigbee extend timeout for MCU reboot from 5s to 10s
 - Matter fix when Rules are disabled
+- BearSSL panic on ESP8266 in rare conditions
 
 ### Removed
 

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/ec_prime_i15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/ec_prime_i15.c
@@ -465,7 +465,7 @@ run_code(jacobian *P1, const jacobian *P2,
 	memcpy(t[P1x], P1->c, 3 * I15_LEN * sizeof(uint16_t));
 	memcpy(t[P2x], P2->c, 3 * I15_LEN * sizeof(uint16_t));
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Run formulas.

--- a/lib/lib_ssl/bearssl-esp8266/src/rsa/rsa_i15_priv.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/rsa/rsa_i15_priv.c
@@ -141,7 +141,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	mp = mq + 2 * fwlen;
 	memmove(mp, t1, fwlen * sizeof *t1);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Compute s2 = x^dq mod q.
@@ -152,7 +152,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	r &= br_i15_modpow_opt(s2, sk->dq, sk->dqlen, mq, q0i,
 		mq + 3 * fwlen, TLEN - 3 * fwlen);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * Compute s1 = x^dq mod q.
@@ -184,7 +184,7 @@ br_rsa_i15_private(unsigned char *x, const br_rsa_private_key *sk)
 	br_i15_decode_reduce(t1, sk->iq, sk->iqlen, mp);
 	br_i15_montymul(t2, s1, t1, mp, p0i);
 
-	optimistic_yield(10000);
+	stack_thunk_yield();
 
 	/*
 	 * h is now in t2. We compute the final result:

--- a/lib/lib_ssl/bearssl-esp8266/src/t_inner.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/t_inner.h
@@ -2598,16 +2598,16 @@ br_cpuid(uint32_t mask_eax, uint32_t mask_ebx,
 
   #define _debugBearSSL (0)
   #ifdef ESP8266
-    extern void optimistic_yield(uint32_t);
+    extern void stack_thunk_yield(void);
   #else
-    #define optimistic_yield(ignored)
+    #define stack_thunk_yield(ignored)
   #endif
   #ifdef __cplusplus
   }
   #endif
 
 #else
-  #define optimistic_yield(ignored)
+  #define stack_thunk_yield(ignored)
 #endif
 
 #ifdef ESP32

--- a/lib/lib_ssl/tls_mini/src/StackThunk_light.h
+++ b/lib/lib_ssl/tls_mini/src/StackThunk_light.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+extern void stack_thunk_yield();
+
 extern void stack_thunk_light_add_ref();
 extern void stack_thunk_light_del_ref();
 extern void stack_thunk_light_repaint();


### PR DESCRIPTION
## Description:

Fix BearSSL that could crash on ESP8266 on rare conditions.

Application of upstream fixes: https://github.com/earlephilhower/bearssl-esp8266/pull/19 and https://github.com/esp8266/Arduino/compare/master...mcspr:esp8266-Arduino:bssl/9170-thunk

No functional change, no code size change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
