### PR TITLE
Crash when calling TasmotaSerial destructor when initialized with incorrect arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee extend timeout for MCU reboot from 5s to 10s (#22009)
 - Matter fix when Rules are disabled (#22016)
 - BearSSL panic on ESP8266 in rare conditions (#22017)
+- Crash when calling TasmotaSerial destructor when initialized with incorrect arguments
 
 ### Removed
 

--- a/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
+++ b/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
@@ -123,7 +123,9 @@ void TasmotaSerial::end(void) {
 }
 
 TasmotaSerial::~TasmotaSerial(void) {
-  end();
+  if (m_valid) {
+    end();
+  }
 }
 
 bool TasmotaSerial::isValidGPIOpin(int pin) {


### PR DESCRIPTION
## Description:

In cases TasmotaSerial is started with incompatible GPIO numbers, the object is not in valid state `m_valid` is `false`. In such case, calling the destructor would crash.

Added a test to make the destructor do nothing in such case.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
