### PR TITLE
Berry avoid `readbytes()` from crashing when file is too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - LVGL Added OpenHASP icons to font `montserrat-28`
 - Matter fail to report Shutter status if no shutter is configured in Tasmota
 - Matter fix Waterleak broken after Berry solidification optimisation #21885
+- Berry avoid `readbytes()` from crashing when file is too large
 
 ### Removed
 - Berry remove reuse of methods for interface-like code reuse #21500


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #21657

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
