### PR TITLE
Zigbee avoid disabling console serial on ESP32 and improved log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Matter fail to report Shutter status if no shutter is configured in Tasmota
 - Matter fix Waterleak broken after Berry solidification optimisation #21885
 - Berry avoid `readbytes()` from crashing when file is too large
+- Zigbee avoid disabling console serial on ESP32 and improved log messages
 
 ### Removed
 - Berry remove reuse of methods for interface-like code reuse #21500

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_9_serial.ino
@@ -298,13 +298,25 @@ void ZigbeeInitSerial(void)
   if (PinUsed(GPIO_ZIGBEE_RX) && PinUsed(GPIO_ZIGBEE_TX)) {
 		AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ZIGBEE "GPIOs Rx:%d Tx:%d"), Pin(GPIO_ZIGBEE_RX), Pin(GPIO_ZIGBEE_TX));
     // if TasmotaGlobal.seriallog_level is 0, we allow GPIO 13/15 to switch to Hardware Serial
-    ZigbeeSerial = new TasmotaSerial(Pin(GPIO_ZIGBEE_RX), Pin(GPIO_ZIGBEE_TX), TasmotaGlobal.seriallog_level ? 1 : 2, 0, 256);   // set a receive buffer of 256 bytes
+    int32_t uart_num = TasmotaGlobal.seriallog_level ? 1 : 2;
+    ZigbeeSerial = new TasmotaSerial(Pin(GPIO_ZIGBEE_RX), Pin(GPIO_ZIGBEE_TX), uart_num, 0, 256);   // set a receive buffer of 256 bytes
+    if (ZigbeeSerial == nullptr) {
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Failed to allocate TasmotaSerial - aborting Zigbee"));
+      return;
+    }
+    if (!ZigbeeSerial->isValid()) {
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Invalid Serial GPIOs - aborting Zigbee"));
+      delete ZigbeeSerial;
+      return;
+    }
     ZigbeeSerial->begin(115200);
+#ifdef ESP8266
     if (ZigbeeSerial->hardwareSerial()) {
       ClaimSerial();
 		}
+#endif // ESP8266
 #ifdef ESP32
-    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Serial UART%d"), ZigbeeSerial->getUart());
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Using Hardware Serial UART%d"), ZigbeeSerial->getUart());
 #endif  // ESP32
     zigbee_buffer = new SBuffer(ZIGBEE_BUFFER_SIZE);
 


### PR DESCRIPTION
## Description:

Zigbee would mistakenly disable serial logging on ESP32.
Improved handling of Serial errors.
Improved logging for ESP32 for Zigbee serial.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
