### PR TITLE
Berry Zigbee improvements to prepare Matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Command ``SetOption69 1`` to enable Serial Bridge inverted Receive (#22000)
 - Zigbee Koenkk firmware 20240710 for Sonoff Zigbee ZBPro
+- Berry Zigbee improvements to prepare Matter
 
 ### Breaking Changed
 - Berry make `energy` modules changes from #21887 backwards compatible

--- a/lib/libesp32/berry_tasmota/src/be_zigbee.c
+++ b/lib/libesp32/berry_tasmota/src/be_zigbee.c
@@ -49,6 +49,8 @@ static int zd_member(bvm *vm) {
   be_return(vm);
 }
 
+extern int zd_info(bvm *vm);
+
 extern int zc_started(struct bvm *vm);
 extern int zc_info(struct bvm *vm);
 extern int zc_item(struct bvm *vm);
@@ -99,6 +101,8 @@ class be_class_zb_device (scope: global, name: zb_device, strings: weak) {
   init, ctype_func(zd_init)
 
   member, func(zd_member)
+
+  info, func(zd_info)
 
   tostring, closure(class_zb_device_tostring_closure)
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -587,6 +587,11 @@ void Z_Devices::jsonAppend(uint16_t shortaddr, const Z_attribute_list &attr_list
 // internal function to publish device information with respect to all `SetOption`s
 //
 void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_list &attr_list, bool include_time) const {
+#ifdef USE_BERRY
+    // Publish to Berry
+    callBerryZigbeeDispatcher("attributes_final", nullptr, &attr_list, shortaddr);
+#endif // USE_BERRY
+
   const char * local_friendfly_name;     // friendlyname publish can depend on the source endpoint
   local_friendfly_name = ep_names.getEPName(attr_list.src_ep);    // check if this ep has a specific name
   if (local_friendfly_name == nullptr) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -26,6 +26,9 @@
 #include "be_func.h"
 
 extern "C" {
+  extern const bclass be_class_zcl_attribute_list;
+  extern const bclass be_class_zcl_attribute;
+  extern const bclass be_class_zcl_attribute_ntv;
   extern const bclass be_class_zb_device;
 
   // Zigbee Device `zd`
@@ -118,7 +121,11 @@ extern "C" {
   int zc_item_or_find(struct bvm *vm, bbool raise_if_unknown) {
     int32_t top = be_top(vm); // Get the number of arguments
     if (!zigbee.active) {
-      be_raise(vm, "internal_error", "zigbee not started");
+      if (raise_if_unknown) {
+        be_raise(vm, "internal_error", "zigbee not started");
+      } else {
+        be_return_nil(vm);
+      }
     }
     if (top >= 2 && (be_isint(vm, 2) || be_isstring(vm, 2))) {
       const Z_Device & device = be_isint(vm, 2) ? zigbee_devices.findShortAddr(be_toint(vm, 2))
@@ -235,6 +242,27 @@ extern "C" {
     return ret;
   }
 
+  int zd_info(bvm *vm);
+  int zd_info(bvm *vm) {
+    if (!zigbee.active) {
+      be_raise(vm, "internal_error", "zigbee not started");
+    }
+    be_getmember(vm, 1, "_p");
+    const class Z_Device* device = (const class Z_Device*) be_tocomptr(vm, -1);
+    // call ZbInfo
+    static Z_attribute_list attr_list;
+    attr_list.reset();
+    if (device != nullptr) {
+      device->jsonDumpSingleDevice(attr_list, 3, false);   // don't add Device/Name
+      be_pushntvclass(vm, &be_class_zcl_attribute_list);
+     be_pushcomptr(vm, &attr_list);
+      be_call(vm, 1);
+      be_pop(vm, 1);
+      be_return(vm);
+    } else {
+      be_return_nil(vm);
+    }
+  }
 }
 
 /*********************************************************************************************\
@@ -346,10 +374,6 @@ extern "C" {
  *
 \*********************************************************************************************/
 extern "C" {
-  extern const bclass be_class_zcl_attribute_list;
-  extern const bclass be_class_zcl_attribute;
-  extern const bclass be_class_zcl_attribute_ntv;
-
   void zat_zcl_attribute(struct bvm *vm, const Z_attribute *attr);
 
   // Pushes the Z_attribute_list on the stack as a simple list


### PR DESCRIPTION
## Description:

Berry Zigbee improvements to prepare for Zigbee-Matter bridging:
- add `<device>.info()` equivalent of running `ZbInfo <device>` and getting the `attribute_list`
- `zigbee.find(<device>)` now returns `nil` if zigbee failed to start, instead of raising an exception
- add Zigbee event `attributes_final` triggered just before final and consolidated attributes are sent to MQTT. Zigbee typically waits for 350ms before sending attributes, so it can consolidate multiple sensors (like temperature+humidity+pressure) in a single MQTT message

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
