### PR TITLE
Matter Zigbee support for sensors: Temperature, Humidity, Pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Command ``SetOption69 1`` to enable Serial Bridge inverted Receive (#22000)
 - Zigbee Koenkk firmware 20240710 for Sonoff Zigbee ZBPro
 - Berry Zigbee improvements to prepare Matter
+- Matter Zigbee support for sensors: Temperature, Humidity, Pressure
 
 ### Breaking Changed
 - Berry make `energy` modules changes from #21887 backwards compatible

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -55,6 +55,7 @@ be_extern_native_module(TFL);
 be_extern_native_module(mdns);
 #ifdef USE_ZIGBEE
 be_extern_native_module(zigbee);
+be_extern_native_module(matter_zigbee);
 #endif // USE_ZIGBEE
 #ifdef USE_BERRY_CAM
 be_extern_native_module(cam);
@@ -171,6 +172,7 @@ BERRY_LOCAL const bntvmodule_t* const be_module_table[] = {
 #endif // USE_WEBSERVER
 #ifdef USE_ZIGBEE
     &be_native_module(zigbee),
+    &be_native_module(matter_zigbee),
 #endif // USE_ZIGBEE
     &be_native_module(flash),
     &be_native_module(partition_core),

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -233,6 +233,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_0.h"
 #include "solidify/solidified_Matter_z_Commissioning.h"
 #include "solidify/solidified_Matter_z_Autoconf.h"
+#include "solidify/solidified_Matter_z_Zigbee.h"
 #include "solidify/solidified_Matter_Base38.h"
 #include "solidify/solidified_Matter_UI.h"
 #include "solidify/solidified_Matter_Profiler.h"
@@ -295,6 +296,9 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Sensor_Air_Quality.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Sensor_Rain.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Sensor_Waterleak.h"
+#include "solidify/solidified_Matter_Plugin_9_Zigbee_Temperature.h"
+#include "solidify/solidified_Matter_Plugin_9_Zigbee_Pressure.h"
+#include "solidify/solidified_Matter_Plugin_9_Zigbee_Humidity.h"
 #include "solidify/solidified_Matter_Plugin_z_All.h"
 #include "solidify/solidified_Matter_zz_Device.h"
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -35,6 +35,7 @@ class Matter_Plugin
   static var UPDATE_TIME = 5000             # default is every 5 seconds
   static var VIRTUAL = false                # set to true only for virtual devices
   static var BRIDGE = false                 # set to true only for bridged devices (ESP8266 or OpenBK)
+  static var ZIGBEE = false                 # set to true only when mapped to a zigbee device
   var update_next                           # next timestamp for update
   # Configuration of the plugin: clusters and type
   static var CLUSTERS = matter.consolidate_clusters(_class, {

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
@@ -55,6 +55,12 @@ class Matter_Plugin_Device : Matter_Plugin
   #############################################################
   # Constructor
   def init(device, endpoint, arguments)
+    # Zigbee code, activated only when `ZIGBEE` is true
+    # attribute `zigbee_mapper` needs to be defined for classes with `ZIGBEE` true
+    if self.ZIGBEE
+      self.zigbee_mapper = device.create_zb_mapper(self)  # needs to exist before `parse_configuration()` is called
+    end
+
     super(self).init(device, endpoint, arguments)
 
     if self.BRIDGE
@@ -64,6 +70,17 @@ class Matter_Plugin_Device : Matter_Plugin
     end
   end
 
+  #############################################################
+  # parse_configuration
+  #
+  # Parse configuration map, handling case of Zigbee configuration
+  def parse_configuration(config)
+    # super(self).parse_configuration(config)   # not necessary because the superclass does nothing
+    if self.ZIGBEE && self.zigbee_mapper
+      self.zigbee_mapper.parse_configuration(config)
+    end
+  end
+  
   #############################################################
   # read an attribute
   #

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor.be
@@ -57,6 +57,7 @@ class Matter_Plugin_Sensor : Matter_Plugin_Device
   #
   # Parse configuration map
   def parse_configuration(config)
+    super(self).parse_configuration(config)
     self.tasmota_sensor_filter = config.find(self.ARG#-'filter'-#)
     if self.tasmota_sensor_filter
       self.tasmota_sensor_matcher = tasmota.Rule_Matcher.parse(self.tasmota_sensor_filter)
@@ -166,6 +167,32 @@ class Matter_Plugin_Sensor : Matter_Plugin_Device
   end
   #############################################################
   #############################################################
+
+  #############################################################
+  # For Zigbee devices
+  #############################################################
+  #############################################################
+  # attributes_refined
+  #
+  # Filtered to only events for this endpoint
+  #
+  # Can be called only if `self.ZIGBEE` is true
+  def zigbee_received(frame, attr_list)
+    import math
+    log(f"MTR: zigbee_received Ox{self.zigbee_mapper.shortaddr:04X} {attr_list=} {type(attr_list)=}", 3)
+    var idx = 0
+    while (idx < size(attr_list))
+      var entry = attr_list[idx]
+      if (entry.key == self.ZIGBEE_NAME)
+        var val = self.pre_value(entry.val)
+        var update_list = { self.JSON_NAME : val }   # Matter temperature is 1/100th of degrees
+        self.update_virtual(update_list)
+        log(f"MTR: [{self.endpoint:02X}] {self.JSON_NAME} updated {update_list}", 3)
+        return nil
+      end
+      idx += 1
+    end
+  end
 
 end
 matter.Plugin_Sensor = Matter_Plugin_Sensor

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Humidity.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Humidity.be
@@ -1,0 +1,38 @@
+#
+# Matter_Plugin_9_Zigbee_Humidity.be - implements the behavior for a Zigbee Humidity sensor
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Zigbee_Humidity,weak
+
+class Matter_Plugin_Zigbee_Humidity : Matter_Plugin_Sensor_Humidity
+  static var ZIGBEE = true
+  static var TYPE = "z_humidity"                    # name of the plug-in in json
+  static var DISPLAY_NAME = "Zig Humidity"          # display name of the plug-in
+  static var ZIGBEE_NAME = "Humidity"               # name of zigbee attribute with sensor reported
+  static var ARG  = "zigbee_device"                 # zigbee device
+  static var ARG_TYPE = / x -> str(x)               # function to convert argument to the right type
+  static var ARG_HINT = "Device"                    # Hint for entering the Argument (inside 'placeholder')
+  static var VIRTUAL = true                         # virtual device, necessary for Zigbee mapping
+  var zigbee_mapper                                 # required for zigbee device
+
+end
+matter.Plugin_Zigbee_Humidity = Matter_Plugin_Zigbee_Humidity

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Pressure.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Pressure.be
@@ -1,0 +1,38 @@
+#
+# Matter_Plugin_9_Zigbee_Pressure.be - implements the behavior for a Zigbee Pressure sensor
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Zigbee_Pressure,weak
+
+class Matter_Plugin_Zigbee_Pressure : Matter_Plugin_Sensor_Pressure
+  static var ZIGBEE = true
+  static var TYPE = "z_pressure"                    # name of the plug-in in json
+  static var DISPLAY_NAME = "Zig Pressure"          # display name of the plug-in
+  static var ZIGBEE_NAME = "Pressure"               # name of zigbee attribute with sensor reported
+  static var ARG  = "zigbee_device"                 # zigbee device
+  static var ARG_TYPE = / x -> str(x)               # function to convert argument to the right type
+  static var ARG_HINT = "Device"                    # Hint for entering the Argument (inside 'placeholder')
+  static var VIRTUAL = true                         # virtual device, necessary for Zigbee mapping
+  var zigbee_mapper                                 # required for zigbee device
+
+end
+matter.Plugin_Zigbee_Pressure = Matter_Plugin_Zigbee_Pressure

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Temperature.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Zigbee_Temperature.be
@@ -1,0 +1,38 @@
+#
+# Matter_Plugin_9_Zigbee_Temperature.be - implements the behavior for a Zigbee Temperature sensor
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Zigbee_Temperature,weak
+
+class Matter_Plugin_Zigbee_Temperature : Matter_Plugin_Sensor_Temp
+  static var ZIGBEE = true
+  static var TYPE = "z_temp"                        # name of the plug-in in json
+  static var DISPLAY_NAME = "Zig Temperature"       # display name of the plug-in
+  static var ZIGBEE_NAME = "Temperature"            # name of zigbee attribute with sensor reported
+  static var ARG  = "zigbee_device"                 # zigbee device
+  static var ARG_TYPE = / x -> str(x)               # function to convert argument to the right type
+  static var ARG_HINT = "Device"                    # Hint for entering the Argument (inside 'placeholder')
+  static var VIRTUAL = true                         # virtual device, necessary for Zigbee mapping
+  var zigbee_mapper                                 # required for zigbee device
+
+end
+matter.Plugin_Zigbee_Temperature = Matter_Plugin_Zigbee_Temperature

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -32,11 +32,13 @@ import matter
 # WebUI for the partition manager
 #################################################################################
 class Matter_UI
-  static var _CLASSES_TYPES = "|relay|light0|light1|light2|light3|shutter|shutter+tilt"
+  static var _CLASSES_TYPES_STD =
+                              "|relay|light0|light1|light2|light3|shutter|shutter+tilt"
                               "|gensw_btn"
                               "|temperature|pressure|illuminance|humidity|occupancy|onoff|contact|flow|rain|waterleak"
                               "|airquality"
-                              "|-virtual|v_relay|v_light0|v_light1|v_light2|v_light3"
+  static var _CLASSES_TYPES_VIRTUAL = 
+                              "-virtual|v_relay|v_light0|v_light1|v_light2|v_light3"
                               "|v_fan"
                               "|v_temp|v_pressure|v_illuminance|v_humidity|v_occupancy|v_contact|v_flow|v_rain|v_waterleak"
                               "|v_airquality"
@@ -438,7 +440,11 @@ class Matter_UI
 
     
     # Add new endpoint section
-    self.show_plugins_hints_js(self._CLASSES_TYPES)
+    if self.device.zigbee
+      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self.device.zigbee._CLASSES_TYPES, self._CLASSES_TYPES_VIRTUAL)
+    else
+      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self._CLASSES_TYPES_VIRTUAL)
+    end
 
     webserver.content_send("<p></p><fieldset><legend><b>&nbsp;Add to Configuration&nbsp;</b></legend><p></p>"
                            "<p><b>Add local sensor or device</b></p>"
@@ -453,9 +459,13 @@ class Matter_UI
                            "<tr>"
                            "<td style='font-size:smaller;'><input type='text' name='nam' size='1' value='' placeholder='(optional)' title=''></td>"
                            "<td style='font-size:smaller;'><select id='pi' name='pi' onchange='otm(\"arg\",this.value)'>")
-    self.plugin_option('', self._CLASSES_TYPES)
+    if self.device.zigbee
+      self.plugin_option('', self._CLASSES_TYPES_STD, self.device.zigbee._CLASSES_TYPES, self._CLASSES_TYPES_VIRTUAL)
+    else
+      self.plugin_option('', self._CLASSES_TYPES_STD, self._CLASSES_TYPES_VIRTUAL)
+    end
     webserver.content_send("</select></td>"
-                          "<td style='font-size:smaller;'><input type='text' id='arg' name='arg' size='1' value=''></td>"
+                           "<td style='font-size:smaller;'><input type='text' id='arg' name='arg' size='1' value=''></td>"
                            "</tr></table>"
                            
                            "<div style='display: block;'></div>"
@@ -509,6 +519,8 @@ class Matter_UI
         webserver.content_send("<option value=''></option>")
       elif typ == '-virtual'
         webserver.content_send("<option value='' disabled>--- Virtual Devices ---</option>")
+      elif typ == '-zigbee'
+        webserver.content_send("<option value='' disabled>--- Zigbee Devices ---</option>")
       else
         var nam = self.device.get_plugin_class_displayname(typ)
         webserver.content_send(format("<option value='%s'%s>%s</option>", typ, (typ == cur) ? " selected" : "", nam))

--- a/lib/libesp32/berry_matter/src/embedded/Matter_z_Zigbee.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_z_Zigbee.be
@@ -1,0 +1,174 @@
+#
+# Matter_z_Zigbee.be - implements common Zigbee handling
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# IMPORTANT: this class is included in build only if `#define USE_ZIGBEE` is defined in `C`
+#
+# This is managed in matter_module with includes
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+#@ solidify:Matter_Zigbee_Mapper,weak
+##########################################################################################
+# Matter_Zigbee_Mapper
+#
+# Class used to enrich Matter plug-in and do the mapping.
+# This helps avoiding duplication of code
+##########################################################################################
+class Matter_Zigbee_Mapper
+  var pi                                            # plug-in for this mapper
+  var device_arg                                    # contains the device shortaddr (int) or device name (str) as per configuration JSON
+                                                    # we need to store it, because the zigbee subsystem is not initialized when Matter starts
+                                                    # hence lookup needs to be postponed
+  var zigbee_device                                 # zigbee device
+  var shortaddr                                     # shortaddr to facilitatefiltering
+
+  def init(pi)
+    self.pi = pi
+  end
+
+  #############################################################
+  # parse_configuration
+  #
+  # Parse configuration map
+  def parse_configuration(config)
+    import zigbee
+    import string
+    self.device_arg = config.find(self.pi.ARG #-'zigbee_device'-#, nil)
+    # we accept hex integers
+    if (type(self.device_arg) == 'string')
+      if string.startswith(self.device_arg, "0x") || string.startswith(self.device_arg, "0X")
+        self.device_arg = int(self.device_arg)
+      end
+    end
+    if (self.device_arg != nil)
+      tasmota.set_timer(100, /-> self.probe_zb_values())         # delayed on purpose to make sure all matter is initialized
+    end
+  end
+
+  #############################################################
+  # read_zb_info
+  #
+  # Run the equivalent of `ZbInfo` and return the atttribute_list
+  #
+  # Return nil if something went wrong
+  def read_zb_info()
+    if self.resolve_zb_device()
+      import zigbee
+      var device = zigbee.find(self.shortaddr)
+      if (device != nil)
+        var info = device.info()
+        return info
+      end
+    end
+  end
+
+  #############################################################
+  # probe_zb_values
+  #
+  # Probe stored values so we don't need to wait for the sensor
+  # to send a new value
+  #
+  # It is virtually equivalent to doing `ZbInfo` and parsing
+  # the last known value
+  def probe_zb_values()
+    var info = self.read_zb_info()
+    if (info != nil)
+      log(f"MTR: Read information for zigbee device 0x{self.shortaddr:%04X}", 3)
+      # handle it like if it was attributes received
+      self.pi.zigbee_received(nil, info)
+    end
+  end
+  
+  #############################################################
+  # resolve_zb_device
+  #
+  # Lazily resolve the device id
+  # return true if found, false if not found or zigbee not started
+  def resolve_zb_device()
+    import zigbee
+    if (self.device_arg == nil)   return false    end
+    if (self.shortaddr != nil)    return true     end
+
+    self.zigbee_device = zigbee.find(self.device_arg)
+    if self.zigbee_device
+      self.shortaddr = self.zigbee_device.shortaddr
+      return true
+    else
+      log(f"MTR: cannot find zigbee device '{self.device_arg}'", 3)
+      return false
+    end
+  end
+
+end
+
+##########################################################################################
+# Matter_Zigbee
+#
+# Helper class for managing mapping between Matter and Zigbee
+##########################################################################################
+class Matter_Zigbee
+  static var Matter_Zigbee_Mapper = Matter_Zigbee_Mapper
+  var device                          # reference to the main Device instance
+  # UI
+  static var _CLASSES_TYPES = # Zigbee
+                              "-zigbee|z_temp|z_pressure|z_humidity"
+
+  #############################################################
+  def init(device)
+    import zigbee
+    self.device = device
+    zigbee.add_handler(self)          # listen to all events received
+  end
+
+  #############################################################
+  # attributes_refined
+  #
+  # Called by Zigbee mapping whenever a new event is received
+  def attributes_final(event_type, frame, attr_list, shortaddr)
+    # iterate on all applicable endpoint
+    # log(f"MTR: attributes_final received '{attr_list}' for 0x{shortaddr:04X}", 3)
+    var plugins = self.device.plugins
+    var idx = 0
+    while (idx < size(plugins))
+      var pi = plugins[idx]
+      if (pi.ZIGBEE && pi.zigbee_mapper)          # first test always works, while second works only if `zigbee` arrtibute exists
+        if (pi.zigbee_mapper.resolve_zb_device())    # resolve if this wan't done before
+          if (pi.zigbee_mapper.shortaddr == shortaddr)
+            pi.zigbee_received(frame, attr_list)
+          end
+        end
+      end
+      idx += 1
+    end
+  end
+
+end
+
+#@ solidify:matter_zigbee,weak
+matter_zigbee = module('matter_zigbee')
+matter_zigbee.Matter_Zigbee = Matter_Zigbee
+
+def matter_zigbee_init(m)
+  return m.Matter_Zigbee
+end
+matter_zigbee.init = matter_zigbee_init
+

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -39,6 +39,7 @@ class Matter_Device
   var commissioning                   # `matter.Commissioning()` object
   var autoconf                        # `matter.Autoconf()` objects
   var sessions                        # `matter.Session_Store()` objet
+  var zigbee                          # `Mattter_Zigbee()` object, only set if compiled with zigbee, `nil` otherwise
   var ui
   var tick                            # increment at each tick, avoids to repeat too frequently some actions
   # Events
@@ -82,6 +83,7 @@ class Matter_Device
     self.sessions.load_fabrics()
     self.message_handler = matter.MessageHandler(self)
     self.events = matter.EventHandler(self)
+    self.zigbee = self.init_zigbee()
     self.ui = matter.UI(self)
 
     self.commissioning.init_basic_commissioning()
@@ -998,6 +1000,30 @@ class Matter_Device
       tasmota.publish_result(mtr_info, "")
     end
   end
+
+  #####################################################################
+  # Zigbee support
+  #
+  # Returns true if zigbee module is present
+  #####################################################################
+  def is_zigbee_present()
+    import introspect
+    return (introspect.module('matter_zigbee') != nil)
+  end
+  #
+  def init_zigbee()
+    if self.is_zigbee_present()
+      import matter_zigbee
+      return matter_zigbee(self)
+    end
+  end
+  #
+  def create_zb_mapper(pi)
+    if self.zigbee
+      return self.zigbee.Matter_Zigbee_Mapper(pi)
+    end
+  end
+
 
 end
 matter.Device = Matter_Device

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -6,50 +6,50 @@
 extern const bclass be_class_Matter_Plugin;
 // compact class 'Matter_Plugin' ktab size: 61, total: 104 (saved 344 bytes)
 static const bvalue be_ktab_class_Matter_Plugin[61] = {
-  /* K0   */  be_nested_str_weak(),
-  /* K1   */  be_nested_str_weak(json),
-  /* K2   */  be_nested_str_weak(node_label),
-  /* K3   */  be_nested_str_weak(_X2C_X22Name_X22_X3A_X25s),
-  /* K4   */  be_nested_str_weak(dump),
+  /* K0   */  be_nested_str_weak(json),
+  /* K1   */  be_nested_str_weak(node_label),
+  /* K2   */  be_nested_str_weak(_X2C_X22Name_X22_X3A_X25s),
+  /* K3   */  be_nested_str_weak(dump),
+  /* K4   */  be_nested_str_weak(),
   /* K5   */  be_nested_str_weak(append_state_json),
   /* K6   */  be_nested_str_weak(_X7B_X22Ep_X22_X3A_X25i_X25s_X25s_X7D),
   /* K7   */  be_nested_str_weak(endpoint),
-  /* K8   */  be_nested_str_weak(CLUSTERS),
-  /* K9   */  be_nested_str_weak(find),
-  /* K10  */  be_const_class(be_class_Matter_Plugin),
-  /* K11  */  be_nested_str_weak(ARG),
-  /* K12  */  be_nested_str_weak(msg),
-  /* K13  */  be_nested_str_weak(device),
-  /* K14  */  be_nested_str_weak(message_handler),
-  /* K15  */  be_nested_str_weak(im),
-  /* K16  */  be_nested_str_weak(send_ack_now),
-  /* K17  */  be_nested_str_weak(k2l),
-  /* K18  */  be_nested_str_weak(parse_configuration),
-  /* K19  */  be_nested_str_weak(name),
-  /* K20  */  be_nested_str_weak(ARG_TYPE),
-  /* K21  */  be_nested_str_weak(update_next),
-  /* K22  */  be_nested_str_weak(matter),
-  /* K23  */  be_nested_str_weak(jitter),
-  /* K24  */  be_nested_str_weak(UPDATE_TIME),
-  /* K25  */  be_nested_str_weak(tasmota),
-  /* K26  */  be_nested_str_weak(time_reached),
-  /* K27  */  be_nested_str_weak(tick),
-  /* K28  */  be_nested_str_weak(update_shadow),
-  /* K29  */  be_nested_str_weak(millis),
-  /* K30  */  be_nested_str_weak(events),
-  /* K31  */  be_nested_str_weak(publish_event),
-  /* K32  */  be_nested_str_weak(attribute_updated),
-  /* K33  */  be_const_int(0),
-  /* K34  */  be_const_int(2),
-  /* K35  */  be_nested_str_weak(get),
-  /* K36  */  be_const_int(1),
-  /* K37  */  be_nested_str_weak(UPDATE_COMMANDS),
-  /* K38  */  be_nested_str_weak(_X25s_X3A_X25s),
-  /* K39  */  be_nested_str_weak(_X25s_X2C_X25s_X3A_X25s),
-  /* K40  */  be_nested_str_weak(publish_command),
-  /* K41  */  be_nested_str_weak(MtrReceived),
-  /* K42  */  be_nested_str_weak(contains),
-  /* K43  */  be_nested_str_weak(BRIDGE),
+  /* K8   */  be_nested_str_weak(tick),
+  /* K9   */  be_nested_str_weak(device),
+  /* K10  */  be_nested_str_weak(update_shadow),
+  /* K11  */  be_nested_str_weak(msg),
+  /* K12  */  be_nested_str_weak(message_handler),
+  /* K13  */  be_nested_str_weak(im),
+  /* K14  */  be_nested_str_weak(send_ack_now),
+  /* K15  */  be_nested_str_weak(CLUSTERS),
+  /* K16  */  be_nested_str_weak(find),
+  /* K17  */  be_nested_str_weak(attribute_updated),
+  /* K18  */  be_nested_str_weak(update_next),
+  /* K19  */  be_nested_str_weak(matter),
+  /* K20  */  be_nested_str_weak(jitter),
+  /* K21  */  be_nested_str_weak(UPDATE_TIME),
+  /* K22  */  be_nested_str_weak(tasmota),
+  /* K23  */  be_nested_str_weak(time_reached),
+  /* K24  */  be_nested_str_weak(millis),
+  /* K25  */  be_const_class(be_class_Matter_Plugin),
+  /* K26  */  be_nested_str_weak(ARG),
+  /* K27  */  be_nested_str_weak(ARG_TYPE),
+  /* K28  */  be_nested_str_weak(parse_configuration),
+  /* K29  */  be_nested_str_weak(name),
+  /* K30  */  be_nested_str_weak(BRIDGE),
+  /* K31  */  be_nested_str_weak(UPDATE_COMMANDS),
+  /* K32  */  be_nested_str_weak(k2l),
+  /* K33  */  be_nested_str_weak(events),
+  /* K34  */  be_nested_str_weak(publish_event),
+  /* K35  */  be_const_int(0),
+  /* K36  */  be_const_int(2),
+  /* K37  */  be_nested_str_weak(get),
+  /* K38  */  be_const_int(1),
+  /* K39  */  be_nested_str_weak(_X25s_X3A_X25s),
+  /* K40  */  be_nested_str_weak(_X25s_X2C_X25s_X3A_X25s),
+  /* K41  */  be_nested_str_weak(publish_command),
+  /* K42  */  be_nested_str_weak(MtrReceived),
+  /* K43  */  be_nested_str_weak(contains),
   /* K44  */  be_nested_str_weak(TLV),
   /* K45  */  be_nested_str_weak(cluster),
   /* K46  */  be_nested_str_weak(attribute),
@@ -73,30 +73,6 @@ static const bvalue be_ktab_class_Matter_Plugin[61] = {
 extern const bclass be_class_Matter_Plugin;
 
 /********************************************************************
-** Solidified function: append_state_json
-********************************************************************/
-be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(append_state_json),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80060000,  //  0000  RET	1	K0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: state_json
 ********************************************************************/
 be_local_closure(class_Matter_Plugin_state_json,   /* name */
@@ -113,17 +89,17 @@ be_local_closure(class_Matter_Plugin_state_json,   /* name */
     be_str_weak(state_json),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0xA4060200,  //  0000  IMPORT	R1	K1
-      0x88080102,  //  0001  GETMBR	R2	R0	K2
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
       0x780A0006,  //  0002  JMPF	R2	#000A
       0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0003,  //  0004  LDCONST	R3	K3
-      0x8C100304,  //  0005  GETMET	R4	R1	K4
-      0x88180102,  //  0006  GETMBR	R6	R0	K2
+      0x580C0002,  //  0004  LDCONST	R3	K2
+      0x8C100303,  //  0005  GETMET	R4	R1	K3
+      0x88180101,  //  0006  GETMBR	R6	R0	K1
       0x7C100400,  //  0007  CALL	R4	2
       0x7C080400,  //  0008  CALL	R2	2
       0x70020000,  //  0009  JMP		#000B
-      0x58080000,  //  000A  LDCONST	R2	K0
+      0x58080004,  //  000A  LDCONST	R2	K4
       0x8C0C0105,  //  000B  GETMET	R3	R0	K5
       0x7C0C0200,  //  000C  CALL	R3	1
       0x780E0007,  //  000D  JMPF	R3	#0016
@@ -145,113 +121,11 @@ be_local_closure(class_Matter_Plugin_state_json,   /* name */
 
 
 /********************************************************************
-** Solidified function: timed_request
+** Solidified function: update_shadow_lazy
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_timed_request,   /* name */
+be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_attribute_list_bytes
-********************************************************************/
-be_local_closure(class_Matter_Plugin_get_attribute_list_bytes,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(get_attribute_list_bytes),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88080108,  //  0000  GETMBR	R2	R0	K8
-      0x8C080509,  //  0001  GETMET	R2	R2	K9
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x4C140000,  //  0003  LDNIL	R5
-      0x7C080600,  //  0004  CALL	R2	3
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_sensors
-********************************************************************/
-be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(parse_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_virtual
-********************************************************************/
-be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(update_virtual),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_name
-********************************************************************/
-be_local_closure(class_Matter_Plugin_get_name,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -260,46 +134,20 @@ be_local_closure(class_Matter_Plugin_get_name,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(get_name),
+    be_str_weak(update_shadow_lazy),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: ui_conf_to_string
-********************************************************************/
-be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(ui_conf_to_string),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x5808000A,  //  0000  LDCONST	R2	K10
-      0x880C010B,  //  0001  GETMBR	R3	R0	K11
-      0x780E0006,  //  0002  JMPF	R3	#000A
-      0x60100008,  //  0003  GETGBL	R4	G8
-      0x8C140309,  //  0004  GETMET	R5	R1	K9
-      0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200000,  //  0006  LDCONST	R8	K0
-      0x7C140600,  //  0007  CALL	R5	3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x70020000,  //  0009  JMP		#000B
-      0x58100000,  //  000A  LDCONST	R4	K0
-      0x80040800,  //  000B  RET	1	R4
+    ( &(const binstruction[11]) {  /* code */
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
+      0x88080109,  //  0001  GETMBR	R2	R0	K9
+      0x88080508,  //  0002  GETMBR	R2	R2	K8
+      0x20040202,  //  0003  NE	R1	R1	R2
+      0x78060004,  //  0004  JMPF	R1	#000A
+      0x8C04010A,  //  0005  GETMET	R1	R0	K10
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040109,  //  0007  GETMBR	R1	R0	K9
+      0x88040308,  //  0008  GETMBR	R1	R1	K8
+      0x90021001,  //  0009  SETMBR	R0	K8	R1
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -323,18 +171,18 @@ be_local_closure(class_Matter_Plugin_ack_request,   /* name */
     be_str_weak(ack_request),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x8808030C,  //  0000  GETMBR	R2	R1	K12
+      0x8808030B,  //  0000  GETMBR	R2	R1	K11
       0x4C0C0000,  //  0001  LDNIL	R3
       0x200C0403,  //  0002  NE	R3	R2	R3
       0x780E0005,  //  0003  JMPF	R3	#000A
-      0x880C010D,  //  0004  GETMBR	R3	R0	K13
-      0x880C070E,  //  0005  GETMBR	R3	R3	K14
-      0x880C070F,  //  0006  GETMBR	R3	R3	K15
-      0x8C0C0710,  //  0007  GETMET	R3	R3	K16
+      0x880C0109,  //  0004  GETMBR	R3	R0	K9
+      0x880C070C,  //  0005  GETMBR	R3	R3	K12
+      0x880C070D,  //  0006  GETMBR	R3	R3	K13
+      0x8C0C070E,  //  0007  GETMET	R3	R3	K14
       0x5C140400,  //  0008  MOVE	R5	R2
       0x7C0C0400,  //  0009  CALL	R3	2
       0x4C0C0000,  //  000A  LDNIL	R3
-      0x90061803,  //  000B  SETMBR	R1	K12	R3
+      0x90061603,  //  000B  SETMBR	R1	K11	R3
       0x80000000,  //  000C  RET	0
     })
   )
@@ -343,12 +191,12 @@ be_local_closure(class_Matter_Plugin_ack_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_cluster_list_sorted
+** Solidified function: get_attribute_list_bytes
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
+be_local_closure(class_Matter_Plugin_get_attribute_list_bytes,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -356,14 +204,15 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(get_cluster_list_sorted),
+    be_str_weak(get_attribute_list_bytes),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8804010D,  //  0000  GETMBR	R1	R0	K13
-      0x8C040311,  //  0001  GETMET	R1	R1	K17
-      0x880C0108,  //  0002  GETMBR	R3	R0	K8
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8808010F,  //  0000  GETMBR	R2	R0	K15
+      0x8C080510,  //  0001  GETMET	R2	R2	K16
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x4C140000,  //  0003  LDNIL	R5
+      0x7C080600,  //  0004  CALL	R2	3
+      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
@@ -371,11 +220,11 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: write_attribute
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_init,   /* name */
+be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    5,                          /* nstack */
     4,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -384,20 +233,11 @@ be_local_closure(class_Matter_Plugin_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(init),
+    be_str_weak(write_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x90021A01,  //  0000  SETMBR	R0	K13	R1
-      0x90020E02,  //  0001  SETMBR	R0	K7	R2
-      0x8C100112,  //  0002  GETMET	R4	R0	K18
-      0x5C180600,  //  0003  MOVE	R6	R3
-      0x7C100400,  //  0004  CALL	R4	2
-      0x8C100709,  //  0005  GETMET	R4	R3	K9
-      0x58180013,  //  0006  LDCONST	R6	K19
-      0x581C0000,  //  0007  LDCONST	R7	K0
-      0x7C100600,  //  0008  CALL	R4	3
-      0x90020404,  //  0009  SETMBR	R0	K2	R4
-      0x80000000,  //  000A  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -405,32 +245,54 @@ be_local_closure(class_Matter_Plugin_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: ui_string_to_conf
+** Solidified function: attribute_updated
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
+be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    12,                          /* varg */
+    10,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(ui_string_to_conf),
+    be_str_weak(attribute_updated),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x580C000A,  //  0000  LDCONST	R3	K10
-      0x8810010B,  //  0001  GETMBR	R4	R0	K11
-      0x88140114,  //  0002  GETMBR	R5	R0	K20
-      0x780A0004,  //  0003  JMPF	R2	#0009
-      0x78120003,  //  0004  JMPF	R4	#0009
-      0x5C180A00,  //  0005  MOVE	R6	R5
-      0x5C1C0400,  //  0006  MOVE	R7	R2
-      0x7C180200,  //  0007  CALL	R6	1
-      0x98040806,  //  0008  SETIDX	R1	R4	R6
-      0x80040200,  //  0009  RET	1	R1
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88100109,  //  0000  GETMBR	R4	R0	K9
+      0x8C100911,  //  0001  GETMET	R4	R4	K17
+      0x88180107,  //  0002  GETMBR	R6	R0	K7
+      0x5C1C0200,  //  0003  MOVE	R7	R1
+      0x5C200400,  //  0004  MOVE	R8	R2
+      0x5C240600,  //  0005  MOVE	R9	R3
+      0x7C100A00,  //  0006  CALL	R4	5
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: append_state_json
+********************************************************************/
+be_local_closure(class_Matter_Plugin_append_state_json,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(append_state_json),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80060800,  //  0000  RET	1	K4
     })
   )
 );
@@ -454,33 +316,33 @@ be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
     be_str_weak(every_250ms),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x88040112,  //  0000  GETMBR	R1	R0	K18
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060005,  //  0003  JMPF	R1	#000A
-      0xB8062C00,  //  0004  GETNGBL	R1	K22
-      0x8C040317,  //  0005  GETMET	R1	R1	K23
-      0x880C0118,  //  0006  GETMBR	R3	R0	K24
+      0xB8062600,  //  0004  GETNGBL	R1	K19
+      0x8C040314,  //  0005  GETMET	R1	R1	K20
+      0x880C0115,  //  0006  GETMBR	R3	R0	K21
       0x7C040400,  //  0007  CALL	R1	2
-      0x90022A01,  //  0008  SETMBR	R0	K21	R1
+      0x90022401,  //  0008  SETMBR	R0	K18	R1
       0x70020010,  //  0009  JMP		#001B
-      0xB8063200,  //  000A  GETNGBL	R1	K25
-      0x8C04031A,  //  000B  GETMET	R1	R1	K26
-      0x880C0115,  //  000C  GETMBR	R3	R0	K21
+      0xB8062C00,  //  000A  GETNGBL	R1	K22
+      0x8C040317,  //  000B  GETMET	R1	R1	K23
+      0x880C0112,  //  000C  GETMBR	R3	R0	K18
       0x7C040400,  //  000D  CALL	R1	2
       0x7806000B,  //  000E  JMPF	R1	#001B
-      0x8804011B,  //  000F  GETMBR	R1	R0	K27
-      0x8808010D,  //  0010  GETMBR	R2	R0	K13
-      0x8808051B,  //  0011  GETMBR	R2	R2	K27
+      0x88040108,  //  000F  GETMBR	R1	R0	K8
+      0x88080109,  //  0010  GETMBR	R2	R0	K9
+      0x88080508,  //  0011  GETMBR	R2	R2	K8
       0x20040202,  //  0012  NE	R1	R1	R2
       0x78060001,  //  0013  JMPF	R1	#0016
-      0x8C04011C,  //  0014  GETMET	R1	R0	K28
+      0x8C04010A,  //  0014  GETMET	R1	R0	K10
       0x7C040200,  //  0015  CALL	R1	1
-      0xB8063200,  //  0016  GETNGBL	R1	K25
-      0x8C04031D,  //  0017  GETMET	R1	R1	K29
-      0x880C0118,  //  0018  GETMBR	R3	R0	K24
+      0xB8062C00,  //  0016  GETNGBL	R1	K22
+      0x8C040318,  //  0017  GETMET	R1	R1	K24
+      0x880C0115,  //  0018  GETMBR	R3	R0	K21
       0x7C040400,  //  0019  CALL	R1	2
-      0x90022A01,  //  001A  SETMBR	R0	K21	R1
+      0x90022401,  //  001A  SETMBR	R0	K18	R1
       0x80000000,  //  001B  RET	0
     })
   )
@@ -489,12 +351,12 @@ be_local_closure(class_Matter_Plugin_every_250ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: publish_event
+** Solidified function: invoke_request
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_publish_event,   /* name */
+be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
-    7,                          /* argc */
+    5,                          /* nstack */
+    4,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -502,47 +364,11 @@ be_local_closure(class_Matter_Plugin_publish_event,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(publish_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x881C010D,  //  0000  GETMBR	R7	R0	K13
-      0x881C0F1E,  //  0001  GETMBR	R7	R7	K30
-      0x8C1C0F1F,  //  0002  GETMET	R7	R7	K31
-      0x88240107,  //  0003  GETMBR	R9	R0	K7
-      0x5C280200,  //  0004  MOVE	R10	R1
-      0x5C2C0400,  //  0005  MOVE	R11	R2
-      0x50300200,  //  0006  LDBOOL	R12	1	0
-      0x5C340600,  //  0007  MOVE	R13	R3
-      0x5C380800,  //  0008  MOVE	R14	R4
-      0x5C3C0A00,  //  0009  MOVE	R15	R5
-      0x5C400C00,  //  000A  MOVE	R16	R6
-      0x7C1C1200,  //  000B  CALL	R7	9
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_event
-********************************************************************/
-be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(subscribe_event),
+    be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -550,11 +376,44 @@ be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_configuration
+** Solidified function: ui_string_to_conf
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
+be_local_closure(class_Matter_Plugin_ui_string_to_conf,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    8,                          /* nstack */
+    3,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(ui_string_to_conf),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x580C0019,  //  0000  LDCONST	R3	K25
+      0x8810011A,  //  0001  GETMBR	R4	R0	K26
+      0x8814011B,  //  0002  GETMBR	R5	R0	K27
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0x78120003,  //  0004  JMPF	R4	#0009
+      0x5C180A00,  //  0005  MOVE	R6	R5
+      0x5C1C0400,  //  0006  MOVE	R7	R2
+      0x7C180200,  //  0007  CALL	R6	1
+      0x98040806,  //  0008  SETIDX	R1	R4	R6
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_name
+********************************************************************/
+be_local_closure(class_Matter_Plugin_set_name,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -563,150 +422,18 @@ be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(parse_configuration),
+    be_str_weak(set_name),
     &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _parse_update_virtual
-********************************************************************/
-be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    7,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(_parse_update_virtual),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8C1C0309,  //  0000  GETMET	R7	R1	K9
-      0x5C240400,  //  0001  MOVE	R9	R2
-      0x7C1C0400,  //  0002  CALL	R7	2
-      0x4C200000,  //  0003  LDNIL	R8
-      0x20200E08,  //  0004  NE	R8	R7	R8
-      0x7822000A,  //  0005  JMPF	R8	#0011
-      0x5C200800,  //  0006  MOVE	R8	R4
-      0x5C240E00,  //  0007  MOVE	R9	R7
-      0x7C200200,  //  0008  CALL	R8	1
-      0x5C1C1000,  //  0009  MOVE	R7	R8
-      0x20200E03,  //  000A  NE	R8	R7	R3
-      0x78220003,  //  000B  JMPF	R8	#0010
-      0x8C200120,  //  000C  GETMET	R8	R0	K32
-      0x5C280A00,  //  000D  MOVE	R10	R5
-      0x5C2C0C00,  //  000E  MOVE	R11	R6
-      0x7C200600,  //  000F  CALL	R8	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x80040600,  //  0011  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_attribute
-********************************************************************/
-be_local_closure(class_Matter_Plugin_subscribe_attribute,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(subscribe_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: contains_attribute
-********************************************************************/
-be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(contains_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x880C0108,  //  0000  GETMBR	R3	R0	K8
-      0x8C0C0709,  //  0001  GETMET	R3	R3	K9
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x78120010,  //  0006  JMPF	R4	#0018
-      0x58100021,  //  0007  LDCONST	R4	K33
-      0x6014000C,  //  0008  GETGBL	R5	G12
-      0x5C180600,  //  0009  MOVE	R6	R3
-      0x7C140200,  //  000A  CALL	R5	1
-      0x0C140B22,  //  000B  DIV	R5	R5	K34
-      0x14180805,  //  000C  LT	R6	R4	R5
-      0x781A0009,  //  000D  JMPF	R6	#0018
-      0x8C180723,  //  000E  GETMET	R6	R3	K35
-      0x08200922,  //  000F  MUL	R8	R4	K34
-      0x5425FFFD,  //  0010  LDINT	R9	-2
-      0x7C180600,  //  0011  CALL	R6	3
-      0x1C180C02,  //  0012  EQ	R6	R6	R2
-      0x781A0001,  //  0013  JMPF	R6	#0016
-      0x50180200,  //  0014  LDBOOL	R6	1	0
-      0x80040C00,  //  0015  RET	1	R6
-      0x00100924,  //  0016  ADD	R4	R4	K36
-      0x7001FFF3,  //  0017  JMP		#000C
-      0x50100000,  //  0018  LDBOOL	R4	0	0
-      0x80040800,  //  0019  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_clusters
-********************************************************************/
-be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(get_clusters),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040108,  //  0000  GETMBR	R1	R0	K8
-      0x80040200,  //  0001  RET	1	R1
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x20080202,  //  0001  NE	R2	R1	R2
+      0x780A0003,  //  0002  JMPF	R2	#0007
+      0x8C080111,  //  0003  GETMET	R2	R0	K17
+      0x54120038,  //  0004  LDINT	R4	57
+      0x54160004,  //  0005  LDINT	R5	5
+      0x7C080600,  //  0006  CALL	R2	3
+      0x90020201,  //  0007  SETMBR	R0	K1	R1
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -741,11 +468,94 @@ be_local_closure(class_Matter_Plugin__X3Clambda_X3E,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_shadow_lazy
+** Solidified function: parse_configuration
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
+be_local_closure(class_Matter_Plugin_parse_configuration,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: timed_request
+********************************************************************/
+be_local_closure(class_Matter_Plugin_timed_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Plugin_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x90021201,  //  0000  SETMBR	R0	K9	R1
+      0x90020E02,  //  0001  SETMBR	R0	K7	R2
+      0x8C10011C,  //  0002  GETMET	R4	R0	K28
+      0x5C180600,  //  0003  MOVE	R6	R3
+      0x7C100400,  //  0004  CALL	R4	2
+      0x8C100710,  //  0005  GETMET	R4	R3	K16
+      0x5818001D,  //  0006  LDCONST	R6	K29
+      0x581C0004,  //  0007  LDCONST	R7	K4
+      0x7C100600,  //  0008  CALL	R4	3
+      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_local_device
+********************************************************************/
+be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -754,20 +564,14 @@ be_local_closure(class_Matter_Plugin_update_shadow_lazy,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(update_shadow_lazy),
+    be_str_weak(is_local_device),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x8804011B,  //  0000  GETMBR	R1	R0	K27
-      0x8808010D,  //  0001  GETMBR	R2	R0	K13
-      0x8808051B,  //  0002  GETMBR	R2	R2	K27
-      0x20040202,  //  0003  NE	R1	R1	R2
-      0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C04011C,  //  0005  GETMET	R1	R0	K28
-      0x7C040200,  //  0006  CALL	R1	1
-      0x8804010D,  //  0007  GETMBR	R1	R0	K13
-      0x8804031B,  //  0008  GETMBR	R1	R1	K27
-      0x90023601,  //  0009  SETMBR	R0	K27	R1
-      0x80000000,  //  000A  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8804011E,  //  0000  GETMBR	R1	R0	K30
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x50040001,  //  0002  LDBOOL	R1	0	1
+      0x50040200,  //  0003  LDBOOL	R1	1	0
+      0x80040200,  //  0004  RET	1	R1
     })
   )
 );
@@ -791,7 +595,7 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
     be_str_weak(consolidate_update_commands),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040125,  //  0000  GETMBR	R1	R0	K37
+      0x8804011F,  //  0000  GETMBR	R1	R0	K31
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -800,11 +604,74 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
 
 
 /********************************************************************
-** Solidified function: publish_command
+** Solidified function: get_cluster_list_sorted
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_publish_command,   /* name */
+be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(get_cluster_list_sorted),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x8C040320,  //  0001  GETMET	R1	R1	K32
+      0x880C010F,  //  0002  GETMBR	R3	R0	K15
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ui_conf_to_string
+********************************************************************/
+be_local_closure(class_Matter_Plugin_ui_conf_to_string,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(ui_conf_to_string),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x58080019,  //  0000  LDCONST	R2	K25
+      0x880C011A,  //  0001  GETMBR	R3	R0	K26
+      0x780E0006,  //  0002  JMPF	R3	#000A
+      0x60100008,  //  0003  GETGBL	R4	G8
+      0x8C140310,  //  0004  GETMET	R5	R1	K16
+      0x5C1C0600,  //  0005  MOVE	R7	R3
+      0x58200004,  //  0006  LDCONST	R8	K4
+      0x7C140600,  //  0007  CALL	R5	3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x70020000,  //  0009  JMP		#000B
+      0x58100004,  //  000A  LDCONST	R4	K4
+      0x80040800,  //  000B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: publish_event
+********************************************************************/
+be_local_closure(class_Matter_Plugin_publish_event,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
     7,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -813,55 +680,22 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(publish_command),
+    be_str_weak(publish_event),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0xA41E0200,  //  0000  IMPORT	R7	K1
-      0x60200018,  //  0001  GETGBL	R8	G24
-      0x58240026,  //  0002  LDCONST	R9	K38
-      0x8C280F04,  //  0003  GETMET	R10	R7	K4
-      0x5C300200,  //  0004  MOVE	R12	R1
-      0x7C280400,  //  0005  CALL	R10	2
-      0x8C2C0F04,  //  0006  GETMET	R11	R7	K4
-      0x5C340400,  //  0007  MOVE	R13	R2
-      0x7C2C0400,  //  0008  CALL	R11	2
-      0x7C200600,  //  0009  CALL	R8	3
-      0x4C240000,  //  000A  LDNIL	R9
-      0x20240609,  //  000B  NE	R9	R3	R9
-      0x7826000A,  //  000C  JMPF	R9	#0018
-      0x60240018,  //  000D  GETGBL	R9	G24
-      0x58280027,  //  000E  LDCONST	R10	K39
-      0x5C2C1000,  //  000F  MOVE	R11	R8
-      0x8C300F04,  //  0010  GETMET	R12	R7	K4
-      0x5C380600,  //  0011  MOVE	R14	R3
-      0x7C300400,  //  0012  CALL	R12	2
-      0x8C340F04,  //  0013  GETMET	R13	R7	K4
-      0x5C3C0800,  //  0014  MOVE	R15	R4
-      0x7C340400,  //  0015  CALL	R13	2
-      0x7C240800,  //  0016  CALL	R9	4
-      0x5C201200,  //  0017  MOVE	R8	R9
-      0x4C240000,  //  0018  LDNIL	R9
-      0x20240A09,  //  0019  NE	R9	R5	R9
-      0x7826000A,  //  001A  JMPF	R9	#0026
-      0x60240018,  //  001B  GETGBL	R9	G24
-      0x58280027,  //  001C  LDCONST	R10	K39
-      0x5C2C1000,  //  001D  MOVE	R11	R8
-      0x8C300F04,  //  001E  GETMET	R12	R7	K4
-      0x5C380A00,  //  001F  MOVE	R14	R5
-      0x7C300400,  //  0020  CALL	R12	2
-      0x8C340F04,  //  0021  GETMET	R13	R7	K4
-      0x5C3C0C00,  //  0022  MOVE	R15	R6
-      0x7C340400,  //  0023  CALL	R13	2
-      0x7C240800,  //  0024  CALL	R9	4
-      0x5C201200,  //  0025  MOVE	R8	R9
-      0xB8262C00,  //  0026  GETNGBL	R9	K22
-      0x8C241328,  //  0027  GETMET	R9	R9	K40
-      0x582C0029,  //  0028  LDCONST	R11	K41
-      0x88300107,  //  0029  GETMBR	R12	R0	K7
-      0x88340102,  //  002A  GETMBR	R13	R0	K2
-      0x5C381000,  //  002B  MOVE	R14	R8
-      0x7C240A00,  //  002C  CALL	R9	5
-      0x80000000,  //  002D  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x881C0109,  //  0000  GETMBR	R7	R0	K9
+      0x881C0F21,  //  0001  GETMBR	R7	R7	K33
+      0x8C1C0F22,  //  0002  GETMET	R7	R7	K34
+      0x88240107,  //  0003  GETMBR	R9	R0	K7
+      0x5C280200,  //  0004  MOVE	R10	R1
+      0x5C2C0400,  //  0005  MOVE	R11	R2
+      0x50300200,  //  0006  LDBOOL	R12	1	0
+      0x5C340600,  //  0007  MOVE	R13	R3
+      0x5C380800,  //  0008  MOVE	R14	R4
+      0x5C3C0A00,  //  0009  MOVE	R15	R5
+      0x5C400C00,  //  000A  MOVE	R16	R6
+      0x7C1C1200,  //  000B  CALL	R7	9
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -869,11 +703,11 @@ be_local_closure(class_Matter_Plugin_publish_command,   /* name */
 
 
 /********************************************************************
-** Solidified function: contains_cluster
+** Solidified function: update_virtual
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
+be_local_closure(class_Matter_Plugin_update_virtual,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    2,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -882,14 +716,10 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(contains_cluster),
+    be_str_weak(update_virtual),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080108,  //  0000  GETMBR	R2	R0	K8
-      0x8C08052A,  //  0001  GETMET	R2	R2	K42
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -897,12 +727,12 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_name
+** Solidified function: _parse_update_virtual
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_set_name,   /* name */
+be_local_closure(class_Matter_Plugin__parse_update_virtual,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    12,                          /* nstack */
+    7,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -910,18 +740,128 @@ be_local_closure(class_Matter_Plugin_set_name,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(set_name),
+    be_str_weak(_parse_update_virtual),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080102,  //  0000  GETMBR	R2	R0	K2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0003,  //  0002  JMPF	R2	#0007
-      0x8C080120,  //  0003  GETMET	R2	R0	K32
-      0x54120038,  //  0004  LDINT	R4	57
-      0x54160004,  //  0005  LDINT	R5	5
-      0x7C080600,  //  0006  CALL	R2	3
-      0x90020401,  //  0007  SETMBR	R0	K2	R1
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x8C1C0310,  //  0000  GETMET	R7	R1	K16
+      0x5C240400,  //  0001  MOVE	R9	R2
+      0x7C1C0400,  //  0002  CALL	R7	2
+      0x4C200000,  //  0003  LDNIL	R8
+      0x20200E08,  //  0004  NE	R8	R7	R8
+      0x7822000A,  //  0005  JMPF	R8	#0011
+      0x5C200800,  //  0006  MOVE	R8	R4
+      0x5C240E00,  //  0007  MOVE	R9	R7
+      0x7C200200,  //  0008  CALL	R8	1
+      0x5C1C1000,  //  0009  MOVE	R7	R8
+      0x20200E03,  //  000A  NE	R8	R7	R3
+      0x78220003,  //  000B  JMPF	R8	#0010
+      0x8C200111,  //  000C  GETMET	R8	R0	K17
+      0x5C280A00,  //  000D  MOVE	R10	R5
+      0x5C2C0C00,  //  000E  MOVE	R11	R6
+      0x7C200600,  //  000F  CALL	R8	3
+      0x80040E00,  //  0010  RET	1	R7
+      0x80040600,  //  0011  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x88040308,  //  0001  GETMBR	R1	R1	K8
+      0x90021001,  //  0002  SETMBR	R0	K8	R1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: contains_attribute
+********************************************************************/
+be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(contains_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x880C010F,  //  0000  GETMBR	R3	R0	K15
+      0x8C0C0710,  //  0001  GETMET	R3	R3	K16
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100604,  //  0005  NE	R4	R3	R4
+      0x78120010,  //  0006  JMPF	R4	#0018
+      0x58100023,  //  0007  LDCONST	R4	K35
+      0x6014000C,  //  0008  GETGBL	R5	G12
+      0x5C180600,  //  0009  MOVE	R6	R3
+      0x7C140200,  //  000A  CALL	R5	1
+      0x0C140B24,  //  000B  DIV	R5	R5	K36
+      0x14180805,  //  000C  LT	R6	R4	R5
+      0x781A0009,  //  000D  JMPF	R6	#0018
+      0x8C180725,  //  000E  GETMET	R6	R3	K37
+      0x08200924,  //  000F  MUL	R8	R4	K36
+      0x5425FFFD,  //  0010  LDINT	R9	-2
+      0x7C180600,  //  0011  CALL	R6	3
+      0x1C180C02,  //  0012  EQ	R6	R6	R2
+      0x781A0001,  //  0013  JMPF	R6	#0016
+      0x50180200,  //  0014  LDBOOL	R6	1	0
+      0x80040C00,  //  0015  RET	1	R6
+      0x00100926,  //  0016  ADD	R4	R4	K38
+      0x7001FFF3,  //  0017  JMP		#000C
+      0x50100000,  //  0018  LDBOOL	R4	0	0
+      0x80040800,  //  0019  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_name
+********************************************************************/
+be_local_closure(class_Matter_Plugin_get_name,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(get_name),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -954,12 +894,12 @@ be_local_closure(class_Matter_Plugin_get_endpoint,   /* name */
 
 
 /********************************************************************
-** Solidified function: write_attribute
+** Solidified function: subscribe_event
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
+be_local_closure(class_Matter_Plugin_subscribe_event,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
+    6,                          /* nstack */
+    5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -967,122 +907,11 @@ be_local_closure(class_Matter_Plugin_write_attribute,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(write_attribute),
+    be_str_weak(subscribe_event),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(class_Matter_Plugin_update_shadow,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8804010D,  //  0000  GETMBR	R1	R0	K13
-      0x8804031B,  //  0001  GETMBR	R1	R1	K27
-      0x90023601,  //  0002  SETMBR	R0	K27	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(class_Matter_Plugin_invoke_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(class_Matter_Plugin_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8810010D,  //  0000  GETMBR	R4	R0	K13
-      0x8C100920,  //  0001  GETMET	R4	R4	K32
-      0x88180107,  //  0002  GETMBR	R6	R0	K7
-      0x5C1C0200,  //  0003  MOVE	R7	R1
-      0x5C200400,  //  0004  MOVE	R8	R2
-      0x5C240600,  //  0005  MOVE	R9	R3
-      0x7C100A00,  //  0006  CALL	R4	5
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_local_device
-********************************************************************/
-be_local_closure(class_Matter_Plugin_is_local_device,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin,     /* shared constants */
-    be_str_weak(is_local_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8804012B,  //  0000  GETMBR	R1	R0	K43
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x50040001,  //  0002  LDBOOL	R1	0	1
-      0x50040200,  //  0003  LDBOOL	R1	1	0
-      0x80040200,  //  0004  RET	1	R1
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
     })
   )
 );
@@ -1115,6 +944,152 @@ be_local_closure(class_Matter_Plugin_read_event,   /* name */
 
 
 /********************************************************************
+** Solidified function: parse_sensors
+********************************************************************/
+be_local_closure(class_Matter_Plugin_parse_sensors,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(parse_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: publish_command
+********************************************************************/
+be_local_closure(class_Matter_Plugin_publish_command,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    7,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(publish_command),
+    &be_const_str_solidified,
+    ( &(const binstruction[46]) {  /* code */
+      0xA41E0000,  //  0000  IMPORT	R7	K0
+      0x60200018,  //  0001  GETGBL	R8	G24
+      0x58240027,  //  0002  LDCONST	R9	K39
+      0x8C280F03,  //  0003  GETMET	R10	R7	K3
+      0x5C300200,  //  0004  MOVE	R12	R1
+      0x7C280400,  //  0005  CALL	R10	2
+      0x8C2C0F03,  //  0006  GETMET	R11	R7	K3
+      0x5C340400,  //  0007  MOVE	R13	R2
+      0x7C2C0400,  //  0008  CALL	R11	2
+      0x7C200600,  //  0009  CALL	R8	3
+      0x4C240000,  //  000A  LDNIL	R9
+      0x20240609,  //  000B  NE	R9	R3	R9
+      0x7826000A,  //  000C  JMPF	R9	#0018
+      0x60240018,  //  000D  GETGBL	R9	G24
+      0x58280028,  //  000E  LDCONST	R10	K40
+      0x5C2C1000,  //  000F  MOVE	R11	R8
+      0x8C300F03,  //  0010  GETMET	R12	R7	K3
+      0x5C380600,  //  0011  MOVE	R14	R3
+      0x7C300400,  //  0012  CALL	R12	2
+      0x8C340F03,  //  0013  GETMET	R13	R7	K3
+      0x5C3C0800,  //  0014  MOVE	R15	R4
+      0x7C340400,  //  0015  CALL	R13	2
+      0x7C240800,  //  0016  CALL	R9	4
+      0x5C201200,  //  0017  MOVE	R8	R9
+      0x4C240000,  //  0018  LDNIL	R9
+      0x20240A09,  //  0019  NE	R9	R5	R9
+      0x7826000A,  //  001A  JMPF	R9	#0026
+      0x60240018,  //  001B  GETGBL	R9	G24
+      0x58280028,  //  001C  LDCONST	R10	K40
+      0x5C2C1000,  //  001D  MOVE	R11	R8
+      0x8C300F03,  //  001E  GETMET	R12	R7	K3
+      0x5C380A00,  //  001F  MOVE	R14	R5
+      0x7C300400,  //  0020  CALL	R12	2
+      0x8C340F03,  //  0021  GETMET	R13	R7	K3
+      0x5C3C0C00,  //  0022  MOVE	R15	R6
+      0x7C340400,  //  0023  CALL	R13	2
+      0x7C240800,  //  0024  CALL	R9	4
+      0x5C201200,  //  0025  MOVE	R8	R9
+      0xB8262600,  //  0026  GETNGBL	R9	K19
+      0x8C241329,  //  0027  GETMET	R9	R9	K41
+      0x582C002A,  //  0028  LDCONST	R11	K42
+      0x88300107,  //  0029  GETMBR	R12	R0	K7
+      0x88340101,  //  002A  GETMBR	R13	R0	K1
+      0x5C381000,  //  002B  MOVE	R14	R8
+      0x7C240A00,  //  002C  CALL	R9	5
+      0x80000000,  //  002D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_clusters
+********************************************************************/
+be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(get_clusters),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x8804010F,  //  0000  GETMBR	R1	R0	K15
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: contains_cluster
+********************************************************************/
+be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(contains_cluster),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8808010F,  //  0000  GETMBR	R2	R0	K15
+      0x8C08052B,  //  0001  GETMET	R2	R2	K43
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
@@ -1131,14 +1106,14 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
     be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[169]) {  /* code */
-      0xB8122C00,  //  0000  GETNGBL	R4	K22
+      0xB8122600,  //  0000  GETNGBL	R4	K19
       0x8810092C,  //  0001  GETMBR	R4	R4	K44
       0x8814052D,  //  0002  GETMBR	R5	R2	K45
       0x8818052E,  //  0003  GETMBR	R6	R2	K46
       0x541E001C,  //  0004  LDINT	R7	29
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0050,  //  0006  JMPF	R7	#0058
-      0x1C1C0D21,  //  0007  EQ	R7	R6	K33
+      0x1C1C0D23,  //  0007  EQ	R7	R6	K35
       0x781E001B,  //  0008  JMPF	R7	#0025
       0x8C1C092F,  //  0009  GETMET	R7	R4	K47
       0x7C1C0200,  //  000A  CALL	R7	1
@@ -1153,12 +1128,12 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x8C2C0F32,  //  0013  GETMET	R11	R7	K50
       0x7C2C0200,  //  0014  CALL	R11	1
       0x8C301733,  //  0015  GETMET	R12	R11	K51
-      0x58380021,  //  0016  LDCONST	R14	K33
+      0x58380023,  //  0016  LDCONST	R14	K35
       0x883C0934,  //  0017  GETMBR	R15	R4	K52
       0x5C401400,  //  0018  MOVE	R16	R10
       0x7C300800,  //  0019  CALL	R12	4
       0x8C301733,  //  001A  GETMET	R12	R11	K51
-      0x58380024,  //  001B  LDCONST	R14	K36
+      0x58380026,  //  001B  LDCONST	R14	K38
       0x883C0934,  //  001C  GETMBR	R15	R4	K52
       0x9440100A,  //  001D  GETIDX	R16	R8	R10
       0x7C300800,  //  001E  CALL	R12	4
@@ -1168,7 +1143,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0xB0080000,  //  0022  RAISE	2	R0	R0
       0x80040E00,  //  0023  RET	1	R7
       0x70020032,  //  0024  JMP		#0058
-      0x1C1C0D24,  //  0025  EQ	R7	R6	K36
+      0x1C1C0D26,  //  0025  EQ	R7	R6	K38
       0x781E0013,  //  0026  JMPF	R7	#003B
       0x8C1C092F,  //  0027  GETMET	R7	R4	K47
       0x7C1C0200,  //  0028  CALL	R7	1
@@ -1190,7 +1165,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0xB0080000,  //  0038  RAISE	2	R0	R0
       0x80040E00,  //  0039  RET	1	R7
       0x7002001C,  //  003A  JMP		#0058
-      0x1C1C0D22,  //  003B  EQ	R7	R6	K34
+      0x1C1C0D24,  //  003B  EQ	R7	R6	K36
       0x781E0003,  //  003C  JMPF	R7	#0041
       0x8C1C092F,  //  003D  GETMET	R7	R4	K47
       0x7C1C0200,  //  003E  CALL	R7	1
@@ -1207,7 +1182,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x781E0005,  //  0049  JMPF	R7	#0050
       0x8C1C0739,  //  004A  GETMET	R7	R3	K57
       0x88240937,  //  004B  GETMBR	R9	R4	K55
-      0x58280021,  //  004C  LDCONST	R10	K33
+      0x58280023,  //  004C  LDCONST	R10	K35
       0x7C1C0600,  //  004D  CALL	R7	3
       0x80040E00,  //  004E  RET	1	R7
       0x70020007,  //  004F  JMP		#0058
@@ -1216,7 +1191,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x781E0004,  //  0052  JMPF	R7	#0058
       0x8C1C0739,  //  0053  GETMET	R7	R3	K57
       0x88240937,  //  0054  GETMBR	R9	R4	K55
-      0x58280024,  //  0055  LDCONST	R10	K36
+      0x58280026,  //  0055  LDCONST	R10	K38
       0x7C1C0600,  //  0056  CALL	R7	3
       0x80040E00,  //  0057  RET	1	R7
       0x541EFFF7,  //  0058  LDINT	R7	65528
@@ -1241,19 +1216,19 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x5C281000,  //  006B  MOVE	R10	R8
       0x7C240200,  //  006C  CALL	R9	1
       0x70020000,  //  006D  JMP		#006F
-      0x58240021,  //  006E  LDCONST	R9	K33
-      0x58280021,  //  006F  LDCONST	R10	K33
+      0x58240023,  //  006E  LDCONST	R9	K35
+      0x58280023,  //  006F  LDCONST	R10	K35
       0x142C1409,  //  0070  LT	R11	R10	R9
       0x782E0009,  //  0071  JMPF	R11	#007C
       0x8C2C0F33,  //  0072  GETMET	R11	R7	K51
       0x4C340000,  //  0073  LDNIL	R13
       0x88380934,  //  0074  GETMBR	R14	R4	K52
-      0x8C3C1123,  //  0075  GETMET	R15	R8	K35
-      0x08441522,  //  0076  MUL	R17	R10	K34
+      0x8C3C1125,  //  0075  GETMET	R15	R8	K37
+      0x08441524,  //  0076  MUL	R17	R10	K36
       0x5449FFFD,  //  0077  LDINT	R18	-2
       0x7C3C0600,  //  0078  CALL	R15	3
       0x7C2C0800,  //  0079  CALL	R11	4
-      0x00281524,  //  007A  ADD	R10	R10	K36
+      0x00281526,  //  007A  ADD	R10	R10	K38
       0x7001FFF3,  //  007B  JMP		#0070
       0x80040E00,  //  007C  RET	1	R7
       0x70020028,  //  007D  JMP		#00A7
@@ -1275,9 +1250,9 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x1C1C0C07,  //  008D  EQ	R7	R6	R7
       0x781E000A,  //  008E  JMPF	R7	#009A
       0x881C013B,  //  008F  GETMBR	R7	R0	K59
-      0x8C1C0F09,  //  0090  GETMET	R7	R7	K9
+      0x8C1C0F10,  //  0090  GETMET	R7	R7	K16
       0x5C240A00,  //  0091  MOVE	R9	R5
-      0x58280021,  //  0092  LDCONST	R10	K33
+      0x58280023,  //  0092  LDCONST	R10	K35
       0x7C1C0600,  //  0093  CALL	R7	3
       0x8C200739,  //  0094  GETMET	R8	R3	K57
       0x88280937,  //  0095  GETMBR	R10	R4	K55
@@ -1289,9 +1264,9 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x1C1C0C07,  //  009B  EQ	R7	R6	R7
       0x781E0009,  //  009C  JMPF	R7	#00A7
       0x881C013C,  //  009D  GETMBR	R7	R0	K60
-      0x8C1C0F09,  //  009E  GETMET	R7	R7	K9
+      0x8C1C0F10,  //  009E  GETMET	R7	R7	K16
       0x5C240A00,  //  009F  MOVE	R9	R5
-      0x58280024,  //  00A0  LDCONST	R10	K36
+      0x58280026,  //  00A0  LDCONST	R10	K38
       0x7C1C0600,  //  00A1  CALL	R7	3
       0x8C200739,  //  00A2  GETMET	R8	R3	K57
       0x88280937,  //  00A3  GETMBR	R10	R4	K55
@@ -1307,56 +1282,74 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
 
 
 /********************************************************************
+** Solidified function: subscribe_attribute
+********************************************************************/
+be_local_closure(class_Matter_Plugin_subscribe_attribute,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin,     /* shared constants */
+    be_str_weak(subscribe_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin
 ********************************************************************/
 be_local_class(Matter_Plugin,
     5,
     NULL,
-    be_nested_map(51,
+    be_nested_map(52,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(FEATURE_MAPS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(258, -1), be_const_int(5) },
-        { be_const_key_int(49, 2), be_const_int(4) },
-        { be_const_key_int(514, -1), be_const_int(2) },
-    }))    ) } )) },
-        { be_const_key_weak(append_state_json, -1), be_const_closure(class_Matter_Plugin_append_state_json_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_init_closure) },
-        { be_const_key_weak(state_json, -1), be_const_closure(class_Matter_Plugin_state_json_closure) },
-        { be_const_key_weak(read_attribute, 10), be_const_closure(class_Matter_Plugin_read_attribute_closure) },
-        { be_const_key_weak(timed_request, -1), be_const_closure(class_Matter_Plugin_timed_request_closure) },
-        { be_const_key_weak(get_attribute_list_bytes, -1), be_const_closure(class_Matter_Plugin_get_attribute_list_bytes_closure) },
-        { be_const_key_weak(read_event, 39), be_const_closure(class_Matter_Plugin_read_event_closure) },
-        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_update_virtual_closure) },
-        { be_const_key_weak(is_local_device, -1), be_const_closure(class_Matter_Plugin_is_local_device_closure) },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(class_Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(state_json, 38), be_const_closure(class_Matter_Plugin_state_json_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(device, -1), be_const_var(1) },
         { be_const_key_weak(ack_request, -1), be_const_closure(class_Matter_Plugin_ack_request_closure) },
-        { be_const_key_weak(get_cluster_list_sorted, -1), be_const_closure(class_Matter_Plugin_get_cluster_list_sorted_closure) },
-        { be_const_key_weak(ui_conf_to_string, 34), be_const_static_closure(class_Matter_Plugin_ui_conf_to_string_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(class_Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(UPDATE_COMMANDS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(get_attribute_list_bytes, -1), be_const_closure(class_Matter_Plugin_get_attribute_list_bytes_closure) },
+        { be_const_key_weak(is_local_device, -1), be_const_closure(class_Matter_Plugin_is_local_device_closure) },
+        { be_const_key_weak(write_attribute, -1), be_const_closure(class_Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(BRIDGE, -1), be_const_bool(0) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(CLUSTERS, 51), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(29, -1), be_const_bytes_instance(0000000100020003FFF8FFF9FFFAFFFBFFFCFFFD) },
+    }))    ) } )) },
+        { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(0,
     ( (struct bvalue*) &(const bvalue[]) {
     }))    ) } )) },
-        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(class_Matter_Plugin_ui_string_to_conf_closure) },
-        { be_const_key_weak(update_next, 48), be_const_var(0) },
-        { be_const_key_weak(device, -1), be_const_var(1) },
-        { be_const_key_weak(publish_event, -1), be_const_closure(class_Matter_Plugin_publish_event_closure) },
-        { be_const_key_weak(subscribe_event, -1), be_const_closure(class_Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
-        { be_const_key_weak(parse_configuration, 30), be_const_closure(class_Matter_Plugin_parse_configuration_closure) },
-        { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(class_Matter_Plugin_update_shadow_lazy_closure) },
-        { be_const_key_weak(consolidate_update_commands, 12), be_const_closure(class_Matter_Plugin_consolidate_update_commands_closure) },
-        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(class_Matter_Plugin_subscribe_attribute_closure) },
-        { be_const_key_weak(contains_attribute, 38), be_const_closure(class_Matter_Plugin_contains_attribute_closure) },
+        { be_const_key_weak(every_250ms, 0), be_const_closure(class_Matter_Plugin_every_250ms_closure) },
         { be_const_key_weak(get_clusters, -1), be_const_closure(class_Matter_Plugin_get_clusters_closure) },
+        { be_const_key_weak(publish_command, -1), be_const_closure(class_Matter_Plugin_publish_command_closure) },
+        { be_const_key_weak(set_name, -1), be_const_closure(class_Matter_Plugin_set_name_closure) },
         { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(class_Matter_Plugin__X3Clambda_X3E_closure) },
-        { be_const_key_weak(get_name, 23), be_const_closure(class_Matter_Plugin_get_name_closure) },
-        { be_const_key_weak(write_attribute, 47), be_const_closure(class_Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
-        { be_const_key_weak(tick, -1), be_const_var(3) },
-        { be_const_key_weak(CLUSTER_REVISIONS, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_update_virtual_closure) },
+        { be_const_key_weak(timed_request, -1), be_const_closure(class_Matter_Plugin_timed_request_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_init_closure) },
+        { be_const_key_weak(update_shadow_lazy, 36), be_const_closure(class_Matter_Plugin_update_shadow_lazy_closure) },
+        { be_const_key_weak(VIRTUAL, 9), be_const_bool(0) },
+        { be_const_key_weak(COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(29, -1), be_const_nil() },
+    }))    ) } )) },
+        { be_const_key_weak(ZIGBEE, -1), be_const_bool(0) },
+        { be_const_key_weak(CLUSTER_REVISIONS, 21), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(25,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(8, -1), be_const_int(5) },
@@ -1385,31 +1378,39 @@ be_local_class(Matter_Plugin,
         { be_const_key_int(6, -1), be_const_int(5) },
         { be_const_key_int(1024, -1), be_const_int(3) },
     }))    ) } )) },
-        { be_const_key_weak(get_endpoint, 24), be_const_closure(class_Matter_Plugin_get_endpoint_closure) },
-        { be_const_key_weak(COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(29, -1), be_const_nil() },
-    }))    ) } )) },
+        { be_const_key_weak(consolidate_update_commands, 34), be_const_closure(class_Matter_Plugin_consolidate_update_commands_closure) },
+        { be_const_key_weak(ui_conf_to_string, -1), be_const_static_closure(class_Matter_Plugin_ui_conf_to_string_closure) },
+        { be_const_key_weak(_parse_update_virtual, 2), be_const_closure(class_Matter_Plugin__parse_update_virtual_closure) },
+        { be_const_key_weak(update_next, 17), be_const_var(0) },
         { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(_Not_X20used_) },
-        { be_const_key_weak(set_name, -1), be_const_closure(class_Matter_Plugin_set_name_closure) },
-        { be_const_key_weak(contains_cluster, -1), be_const_closure(class_Matter_Plugin_contains_cluster_closure) },
-        { be_const_key_weak(publish_command, -1), be_const_closure(class_Matter_Plugin_publish_command_closure) },
         { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_update_shadow_closure) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_invoke_request_closure) },
-        { be_const_key_weak(parse_sensors, 21), be_const_closure(class_Matter_Plugin_parse_sensors_closure) },
-        { be_const_key_weak(CLUSTERS, 14), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
+        { be_const_key_weak(attribute_updated, 27), be_const_closure(class_Matter_Plugin_attribute_updated_closure) },
+        { be_const_key_weak(node_label, -1), be_const_var(4) },
+        { be_const_key_weak(parse_configuration, 30), be_const_closure(class_Matter_Plugin_parse_configuration_closure) },
+        { be_const_key_weak(get_cluster_list_sorted, -1), be_const_closure(class_Matter_Plugin_get_cluster_list_sorted_closure) },
+        { be_const_key_weak(get_name, -1), be_const_closure(class_Matter_Plugin_get_name_closure) },
+        { be_const_key_weak(endpoint, 6), be_const_var(2) },
+        { be_const_key_weak(get_endpoint, -1), be_const_closure(class_Matter_Plugin_get_endpoint_closure) },
+        { be_const_key_weak(FEATURE_MAPS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(29, -1), be_const_bytes_instance(0000000100020003FFF8FFF9FFFAFFFBFFFCFFFD) },
+        { be_const_key_int(258, -1), be_const_int(5) },
+        { be_const_key_int(49, 2), be_const_int(4) },
+        { be_const_key_int(514, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(VIRTUAL, -1), be_const_bool(0) },
-        { be_const_key_weak(DISPLAY_NAME, 4), be_nested_str_weak() },
-        { be_const_key_weak(node_label, 9), be_const_var(4) },
-        { be_const_key_weak(_parse_update_virtual, -1), be_const_closure(class_Matter_Plugin__parse_update_virtual_closure) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(class_Matter_Plugin_every_250ms_closure) },
-        { be_const_key_weak(endpoint, -1), be_const_var(2) },
-        { be_const_key_weak(BRIDGE, 0), be_const_bool(0) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
+        { be_const_key_weak(subscribe_event, -1), be_const_closure(class_Matter_Plugin_subscribe_event_closure) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
+        { be_const_key_weak(read_event, -1), be_const_closure(class_Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(publish_event, 22), be_const_closure(class_Matter_Plugin_publish_event_closure) },
+        { be_const_key_weak(parse_sensors, -1), be_const_closure(class_Matter_Plugin_parse_sensors_closure) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak() },
+        { be_const_key_weak(ui_string_to_conf, 14), be_const_static_closure(class_Matter_Plugin_ui_string_to_conf_closure) },
+        { be_const_key_weak(contains_attribute, 13), be_const_closure(class_Matter_Plugin_contains_attribute_closure) },
+        { be_const_key_weak(tick, -1), be_const_var(3) },
+        { be_const_key_weak(contains_cluster, -1), be_const_closure(class_Matter_Plugin_contains_cluster_closure) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_read_attribute_closure) },
+        { be_const_key_weak(append_state_json, -1), be_const_closure(class_Matter_Plugin_append_state_json_closure) },
     })),
     be_str_weak(Matter_Plugin)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
@@ -211,134 +211,205 @@ be_local_class(GetOptionReader,
     })),
     be_str_weak(GetOptionReader)
 );
-// compact class 'Matter_Plugin_Device' ktab size: 122, total: 158 (saved 288 bytes)
-static const bvalue be_ktab_class_Matter_Plugin_Device[122] = {
-  /* K0   */  be_nested_str_weak(http_remote),
-  /* K1   */  be_nested_str_weak(add_schedule),
-  /* K2   */  be_nested_str_weak(UPDATE_CMD),
-  /* K3   */  be_nested_str_weak(UPDATE_TIME),
+// compact class 'Matter_Plugin_Device' ktab size: 126, total: 164 (saved 304 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Device[126] = {
+  /* K0   */  be_nested_str_weak(BRIDGE),
+  /* K1   */  be_nested_str_weak(http_remote),
+  /* K2   */  be_nested_str_weak(scheduler),
+  /* K3   */  be_nested_str_weak(every_250ms),
   /* K4   */  be_nested_str_weak(webserver),
   /* K5   */  be_nested_str_weak(web_values_prefix),
   /* K6   */  be_nested_str_weak(content_send),
   /* K7   */  be_nested_str_weak(_X26lt_X3B_X2D_X2D_X20_X28),
   /* K8   */  be_nested_str_weak(DISPLAY_NAME),
   /* K9   */  be_nested_str_weak(_X29_X20_X2D_X2D_X26gt_X3B),
-  /* K10  */  be_nested_str_weak(BRIDGE),
-  /* K11  */  be_nested_str_weak(scheduler),
-  /* K12  */  be_nested_str_weak(every_250ms),
-  /* K13  */  be_nested_str_weak(_X3Cb_X3EOn_X3C_X2Fb_X3E),
-  /* K14  */  be_nested_str_weak(Off),
-  /* K15  */  be_nested_str_weak(),
-  /* K16  */  be_nested_str_weak(matter),
-  /* K17  */  be_nested_str_weak(TLV),
-  /* K18  */  be_nested_str_weak(cluster),
-  /* K19  */  be_nested_str_weak(command),
-  /* K20  */  be_const_int(3),
-  /* K21  */  be_const_int(0),
-  /* K22  */  be_const_int(1),
-  /* K23  */  be_nested_str_weak(Matter_TLV_struct),
-  /* K24  */  be_nested_str_weak(add_TLV),
-  /* K25  */  be_nested_str_weak(U2),
-  /* K26  */  be_nested_str_weak(invoke_request),
-  /* K27  */  be_nested_str_weak(tick),
+  /* K10  */  be_nested_str_weak(json),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(_X20),
+  /* K13  */  be_const_int(0),
+  /* K14  */  be_nested_str_weak(call_sync),
+  /* K15  */  be_nested_str_weak(SYNC_TIMEOUT),
+  /* K16  */  be_nested_str_weak(device_is_alive),
+  /* K17  */  be_nested_str_weak(load),
+  /* K18  */  be_const_int(1),
+  /* K19  */  be_nested_str_weak(log),
+  /* K20  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+  /* K21  */  be_const_int(3),
+  /* K22  */  be_nested_str_weak(ZIGBEE),
+  /* K23  */  be_nested_str_weak(zigbee_mapper),
+  /* K24  */  be_nested_str_weak(create_zb_mapper),
+  /* K25  */  be_nested_str_weak(init),
+  /* K26  */  be_nested_str_weak(find),
+  /* K27  */  be_nested_str_weak(ARG_HTTP),
   /* K28  */  be_nested_str_weak(device),
-  /* K29  */  be_nested_str_weak(call_remote_sync),
-  /* K30  */  be_nested_str_weak(parse_http_response),
-  /* K31  */  be_nested_str_weak(json),
-  /* K32  */  be_const_int(2),
-  /* K33  */  be_nested_str_weak(_X20),
-  /* K34  */  be_nested_str_weak(call_sync),
-  /* K35  */  be_nested_str_weak(SYNC_TIMEOUT),
-  /* K36  */  be_nested_str_weak(device_is_alive),
-  /* K37  */  be_nested_str_weak(load),
-  /* K38  */  be_nested_str_weak(log),
-  /* K39  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
-  /* K40  */  be_nested_str_weak(parse_status_response_and_call_method),
-  /* K41  */  be_nested_str_weak(parse_status),
-  /* K42  */  be_nested_str_weak(get_name),
-  /* K43  */  be_nested_str_weak(PREFIX),
-  /* K44  */  be_nested_str_weak(html_escape),
-  /* K45  */  be_nested_str_weak(attribute),
-  /* K46  */  be_nested_str_weak(set),
-  /* K47  */  be_nested_str_weak(U1),
-  /* K48  */  be_nested_str_weak(Matter_TLV_array),
-  /* K49  */  be_nested_str_weak(TYPES),
-  /* K50  */  be_nested_str_weak(keys),
-  /* K51  */  be_nested_str_weak(add_struct),
-  /* K52  */  be_nested_str_weak(stop_iteration),
-  /* K53  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
-  /* K54  */  be_nested_str_weak(find),
-  /* K55  */  be_nested_str_weak(get_admin_vendor),
-  /* K56  */  be_nested_str_weak(disable_bridge_mode),
-  /* K57  */  be_nested_str_weak(string),
-  /* K58  */  be_nested_str_weak(get_info),
-  /* K59  */  be_nested_str_weak(name),
-  /* K60  */  be_nested_str_weak(set_or_nil),
-  /* K61  */  be_nested_str_weak(UTF1),
-  /* K62  */  be_nested_str_weak(tasmota),
-  /* K63  */  be_nested_str_weak(cmd),
-  /* K64  */  be_nested_str_weak(DeviceName),
-  /* K65  */  be_nested_str_weak(version),
-  /* K66  */  be_nested_str_weak(_X28),
-  /* K67  */  be_nested_str_weak(NULL),
-  /* K68  */  be_nested_str_weak(Status_X202),
-  /* K69  */  be_nested_str_weak(StatusFWR),
-  /* K70  */  be_nested_str_weak(Version),
-  /* K71  */  be_nested_str_weak(mac),
-  /* K72  */  be_nested_str_weak(wifi),
-  /* K73  */  be_nested_str_weak(BOOL),
-  /* K74  */  be_nested_str_weak(reachable),
-  /* K75  */  be_nested_str_weak(read_attribute),
-  /* K76  */  be_nested_str_weak(init),
-  /* K77  */  be_nested_str_weak(ARG_HTTP),
-  /* K78  */  be_nested_str_weak(register_http_remote),
-  /* K79  */  be_nested_str_weak(PROBE_TIMEOUT),
-  /* K80  */  be_nested_str_weak(register_cmd_cb),
-  /* K81  */  be_nested_str_weak(introspect),
-  /* K82  */  be_nested_str_weak(get),
-  /* K83  */  be_nested_str_weak(JSON_NAME),
-  /* K84  */  be_nested_str_weak(contains),
-  /* K85  */  be_nested_str_weak(shadow_value),
-  /* K86  */  be_nested_str_weak(dump),
-  /* K87  */  be_nested_str_weak(null),
-  /* K88  */  be_nested_str_weak(_X2C_X22_X25s_X22_X3A_X25s),
-  /* K89  */  be_nested_str_weak(shadow_onoff),
-  /* K90  */  be_nested_str_weak(Power),
-  /* K91  */  be_nested_str_weak(shadow_bri),
-  /* K92  */  be_nested_str_weak(Bri),
-  /* K93  */  be_nested_str_weak(shadow_ct),
-  /* K94  */  be_nested_str_weak(CT),
-  /* K95  */  be_nested_str_weak(shadow_hue),
-  /* K96  */  be_nested_str_weak(Hue),
-  /* K97  */  be_nested_str_weak(shadow_sat),
-  /* K98  */  be_nested_str_weak(Sat),
-  /* K99  */  be_nested_str_weak(shadow_shutter_pos),
-  /* K100 */  be_nested_str_weak(ShutterPos),
-  /* K101 */  be_nested_str_weak(shadow_shutter_target),
-  /* K102 */  be_nested_str_weak(ShutterTarget),
-  /* K103 */  be_nested_str_weak(shadow_shutter_tilt),
-  /* K104 */  be_nested_str_weak(ShutterTilt),
-  /* K105 */  be_nested_str_weak(shadow_contact),
-  /* K106 */  be_nested_str_weak(Contact),
-  /* K107 */  be_nested_str_weak(shadow_occupancy),
-  /* K108 */  be_nested_str_weak(Occupancy),
-  /* K109 */  be_nested_str_weak(shadow_air_quality),
-  /* K110 */  be_nested_str_weak(AirQuality),
-  /* K111 */  be_nested_str_weak(shadow_co2),
-  /* K112 */  be_nested_str_weak(CO2),
-  /* K113 */  be_nested_str_weak(shadow_pm1),
-  /* K114 */  be_nested_str_weak(PM1),
-  /* K115 */  be_nested_str_weak(shadow_pm2_5),
-  /* K116 */  be_nested_str_weak(PM2_X2E5),
-  /* K117 */  be_nested_str_weak(shadow_pm10),
-  /* K118 */  be_nested_str_weak(PM10),
-  /* K119 */  be_nested_str_weak(shadow_tvoc),
-  /* K120 */  be_nested_str_weak(TVOC),
-  /* K121 */  be_nested_str_weak(attribute_updated),
+  /* K29  */  be_nested_str_weak(register_http_remote),
+  /* K30  */  be_nested_str_weak(PROBE_TIMEOUT),
+  /* K31  */  be_nested_str_weak(register_cmd_cb),
+  /* K32  */  be_nested_str_weak(matter),
+  /* K33  */  be_nested_str_weak(TLV),
+  /* K34  */  be_nested_str_weak(cluster),
+  /* K35  */  be_nested_str_weak(attribute),
+  /* K36  */  be_nested_str_weak(set),
+  /* K37  */  be_nested_str_weak(U2),
+  /* K38  */  be_nested_str_weak(U1),
+  /* K39  */  be_nested_str_weak(Matter_TLV_array),
+  /* K40  */  be_nested_str_weak(TYPES),
+  /* K41  */  be_nested_str_weak(keys),
+  /* K42  */  be_nested_str_weak(add_struct),
+  /* K43  */  be_nested_str_weak(add_TLV),
+  /* K44  */  be_nested_str_weak(stop_iteration),
+  /* K45  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
+  /* K46  */  be_nested_str_weak(get_admin_vendor),
+  /* K47  */  be_nested_str_weak(disable_bridge_mode),
+  /* K48  */  be_nested_str_weak(string),
+  /* K49  */  be_nested_str_weak(get_info),
+  /* K50  */  be_nested_str_weak(name),
+  /* K51  */  be_nested_str_weak(set_or_nil),
+  /* K52  */  be_nested_str_weak(UTF1),
+  /* K53  */  be_nested_str_weak(tasmota),
+  /* K54  */  be_nested_str_weak(cmd),
+  /* K55  */  be_nested_str_weak(DeviceName),
+  /* K56  */  be_nested_str_weak(get_name),
+  /* K57  */  be_nested_str_weak(version),
+  /* K58  */  be_nested_str_weak(_X28),
+  /* K59  */  be_nested_str_weak(NULL),
+  /* K60  */  be_nested_str_weak(Status_X202),
+  /* K61  */  be_nested_str_weak(StatusFWR),
+  /* K62  */  be_nested_str_weak(Version),
+  /* K63  */  be_nested_str_weak(mac),
+  /* K64  */  be_nested_str_weak(wifi),
+  /* K65  */  be_nested_str_weak(),
+  /* K66  */  be_nested_str_weak(BOOL),
+  /* K67  */  be_nested_str_weak(reachable),
+  /* K68  */  be_nested_str_weak(read_attribute),
+  /* K69  */  be_nested_str_weak(parse_configuration),
+  /* K70  */  be_nested_str_weak(_X3Cb_X3EOn_X3C_X2Fb_X3E),
+  /* K71  */  be_nested_str_weak(Off),
+  /* K72  */  be_nested_str_weak(command),
+  /* K73  */  be_nested_str_weak(Matter_TLV_struct),
+  /* K74  */  be_nested_str_weak(invoke_request),
+  /* K75  */  be_nested_str_weak(tick),
+  /* K76  */  be_nested_str_weak(call_remote_sync),
+  /* K77  */  be_nested_str_weak(UPDATE_CMD),
+  /* K78  */  be_nested_str_weak(parse_http_response),
+  /* K79  */  be_nested_str_weak(PREFIX),
+  /* K80  */  be_nested_str_weak(html_escape),
+  /* K81  */  be_nested_str_weak(add_schedule),
+  /* K82  */  be_nested_str_weak(UPDATE_TIME),
+  /* K83  */  be_nested_str_weak(introspect),
+  /* K84  */  be_nested_str_weak(get),
+  /* K85  */  be_nested_str_weak(JSON_NAME),
+  /* K86  */  be_nested_str_weak(contains),
+  /* K87  */  be_nested_str_weak(shadow_value),
+  /* K88  */  be_nested_str_weak(dump),
+  /* K89  */  be_nested_str_weak(null),
+  /* K90  */  be_nested_str_weak(_X2C_X22_X25s_X22_X3A_X25s),
+  /* K91  */  be_nested_str_weak(shadow_onoff),
+  /* K92  */  be_nested_str_weak(Power),
+  /* K93  */  be_nested_str_weak(shadow_bri),
+  /* K94  */  be_nested_str_weak(Bri),
+  /* K95  */  be_nested_str_weak(shadow_ct),
+  /* K96  */  be_nested_str_weak(CT),
+  /* K97  */  be_nested_str_weak(shadow_hue),
+  /* K98  */  be_nested_str_weak(Hue),
+  /* K99  */  be_nested_str_weak(shadow_sat),
+  /* K100 */  be_nested_str_weak(Sat),
+  /* K101 */  be_nested_str_weak(shadow_shutter_pos),
+  /* K102 */  be_nested_str_weak(ShutterPos),
+  /* K103 */  be_nested_str_weak(shadow_shutter_target),
+  /* K104 */  be_nested_str_weak(ShutterTarget),
+  /* K105 */  be_nested_str_weak(shadow_shutter_tilt),
+  /* K106 */  be_nested_str_weak(ShutterTilt),
+  /* K107 */  be_nested_str_weak(shadow_contact),
+  /* K108 */  be_nested_str_weak(Contact),
+  /* K109 */  be_nested_str_weak(shadow_occupancy),
+  /* K110 */  be_nested_str_weak(Occupancy),
+  /* K111 */  be_nested_str_weak(shadow_air_quality),
+  /* K112 */  be_nested_str_weak(AirQuality),
+  /* K113 */  be_nested_str_weak(shadow_co2),
+  /* K114 */  be_nested_str_weak(CO2),
+  /* K115 */  be_nested_str_weak(shadow_pm1),
+  /* K116 */  be_nested_str_weak(PM1),
+  /* K117 */  be_nested_str_weak(shadow_pm2_5),
+  /* K118 */  be_nested_str_weak(PM2_X2E5),
+  /* K119 */  be_nested_str_weak(shadow_pm10),
+  /* K120 */  be_nested_str_weak(PM10),
+  /* K121 */  be_nested_str_weak(shadow_tvoc),
+  /* K122 */  be_nested_str_weak(TVOC),
+  /* K123 */  be_nested_str_weak(parse_status_response_and_call_method),
+  /* K124 */  be_nested_str_weak(parse_status),
+  /* K125 */  be_nested_str_weak(attribute_updated),
 };
 
 
 extern const bclass be_class_Matter_Plugin_Device;
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060003,  //  0001  JMPF	R1	#0006
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x70020004,  //  0005  JMP		#000B
+      0x60040003,  //  0006  GETGBL	R1	G3
+      0x5C080000,  //  0007  MOVE	R2	R0
+      0x7C040200,  //  0008  CALL	R1	1
+      0x8C040303,  //  0009  GETMET	R1	R1	K3
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_values
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(web_values),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xA4060800,  //  0000  IMPORT	R1	K4
+      0x8C080105,  //  0001  GETMET	R2	R0	K5
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080306,  //  0003  GETMET	R2	R1	K6
+      0x88100108,  //  0004  GETMBR	R4	R0	K8
+      0x00120E04,  //  0005  ADD	R4	K7	R4
+      0x00100909,  //  0006  ADD	R4	R4	K9
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: parse_status
@@ -358,6 +429,611 @@ be_local_closure(class_Matter_Plugin_Device_parse_status,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
       0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: call_remote_sync
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(call_remote_sync),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x780E0028,  //  0001  JMPF	R3	#002B
+      0xA40E1400,  //  0002  IMPORT	R3	K10
+      0x5810000B,  //  0003  LDCONST	R4	K11
+      0x4C140000,  //  0004  LDNIL	R5
+      0x20140405,  //  0005  NE	R5	R2	R5
+      0x78160005,  //  0006  JMPF	R5	#000D
+      0x0014030C,  //  0007  ADD	R5	R1	K12
+      0x60180008,  //  0008  GETGBL	R6	G8
+      0x5C1C0400,  //  0009  MOVE	R7	R2
+      0x7C180200,  //  000A  CALL	R6	1
+      0x00140A06,  //  000B  ADD	R5	R5	R6
+      0x5C040A00,  //  000C  MOVE	R1	R5
+      0x2414090D,  //  000D  GT	R5	R4	K13
+      0x78160015,  //  000E  JMPF	R5	#0025
+      0x88140101,  //  000F  GETMBR	R5	R0	K1
+      0x8C140B0E,  //  0010  GETMET	R5	R5	K14
+      0x5C1C0200,  //  0011  MOVE	R7	R1
+      0x8820010F,  //  0012  GETMBR	R8	R0	K15
+      0x7C140600,  //  0013  CALL	R5	3
+      0x4C180000,  //  0014  LDNIL	R6
+      0x20180A06,  //  0015  NE	R6	R5	R6
+      0x781A0007,  //  0016  JMPF	R6	#001F
+      0x88180101,  //  0017  GETMBR	R6	R0	K1
+      0x8C180D10,  //  0018  GETMET	R6	R6	K16
+      0x50200200,  //  0019  LDBOOL	R8	1	0
+      0x7C180400,  //  001A  CALL	R6	2
+      0x8C180711,  //  001B  GETMET	R6	R3	K17
+      0x5C200A00,  //  001C  MOVE	R8	R5
+      0x7C180400,  //  001D  CALL	R6	2
+      0x80040C00,  //  001E  RET	1	R6
+      0x04100912,  //  001F  SUB	R4	R4	K18
+      0xB81A2600,  //  0020  GETNGBL	R6	K19
+      0x581C0014,  //  0021  LDCONST	R7	K20
+      0x58200015,  //  0022  LDCONST	R8	K21
+      0x7C180400,  //  0023  CALL	R6	2
+      0x7001FFE7,  //  0024  JMP		#000D
+      0x88140101,  //  0025  GETMBR	R5	R0	K1
+      0x8C140B10,  //  0026  GETMET	R5	R5	K16
+      0x501C0000,  //  0027  LDBOOL	R7	0	0
+      0x7C140400,  //  0028  CALL	R5	2
+      0x4C140000,  //  0029  LDNIL	R5
+      0x80040A00,  //  002A  RET	1	R5
+      0x80000000,  //  002B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x88100116,  //  0000  GETMBR	R4	R0	K22
+      0x78120003,  //  0001  JMPF	R4	#0006
+      0x8C100318,  //  0002  GETMET	R4	R1	K24
+      0x5C180000,  //  0003  MOVE	R6	R0
+      0x7C100400,  //  0004  CALL	R4	2
+      0x90022E04,  //  0005  SETMBR	R0	K23	R4
+      0x60100003,  //  0006  GETGBL	R4	G3
+      0x5C140000,  //  0007  MOVE	R5	R0
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C100919,  //  0009  GETMET	R4	R4	K25
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x5C1C0400,  //  000B  MOVE	R7	R2
+      0x5C200600,  //  000C  MOVE	R8	R3
+      0x7C100800,  //  000D  CALL	R4	4
+      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x7812000A,  //  000F  JMPF	R4	#001B
+      0x8C10071A,  //  0010  GETMET	R4	R3	K26
+      0x8818011B,  //  0011  GETMBR	R6	R0	K27
+      0x7C100400,  //  0012  CALL	R4	2
+      0x8814011C,  //  0013  GETMBR	R5	R0	K28
+      0x8C140B1D,  //  0014  GETMET	R5	R5	K29
+      0x5C1C0800,  //  0015  MOVE	R7	R4
+      0x8820011E,  //  0016  GETMBR	R8	R0	K30
+      0x7C140600,  //  0017  CALL	R5	3
+      0x90020205,  //  0018  SETMBR	R0	K1	R5
+      0x8C14011F,  //  0019  GETMET	R5	R0	K31
+      0x7C140200,  //  001A  CALL	R5	1
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[244]) {  /* code */
+      0xB8124000,  //  0000  GETNGBL	R4	K32
+      0x88100921,  //  0001  GETMBR	R4	R4	K33
+      0x88140522,  //  0002  GETMBR	R5	R2	K34
+      0x88180523,  //  0003  GETMBR	R6	R2	K35
+      0x1C1C0B15,  //  0004  EQ	R7	R5	K21
+      0x781E000F,  //  0005  JMPF	R7	#0016
+      0x1C1C0D0D,  //  0006  EQ	R7	R6	K13
+      0x781E0005,  //  0007  JMPF	R7	#000E
+      0x8C1C0724,  //  0008  GETMET	R7	R3	K36
+      0x88240925,  //  0009  GETMBR	R9	R4	K37
+      0x5828000D,  //  000A  LDCONST	R10	K13
+      0x7C1C0600,  //  000B  CALL	R7	3
+      0x80040E00,  //  000C  RET	1	R7
+      0x70020006,  //  000D  JMP		#0015
+      0x1C1C0D12,  //  000E  EQ	R7	R6	K18
+      0x781E0004,  //  000F  JMPF	R7	#0015
+      0x8C1C0724,  //  0010  GETMET	R7	R3	K36
+      0x88240926,  //  0011  GETMBR	R9	R4	K38
+      0x5828000D,  //  0012  LDCONST	R10	K13
+      0x7C1C0600,  //  0013  CALL	R7	3
+      0x80040E00,  //  0014  RET	1	R7
+      0x700200D4,  //  0015  JMP		#00EB
+      0x541E0003,  //  0016  LDINT	R7	4
+      0x1C1C0A07,  //  0017  EQ	R7	R5	R7
+      0x781E0004,  //  0018  JMPF	R7	#001E
+      0x1C1C0D0D,  //  0019  EQ	R7	R6	K13
+      0x781E0001,  //  001A  JMPF	R7	#001D
+      0x4C1C0000,  //  001B  LDNIL	R7
+      0x80040E00,  //  001C  RET	1	R7
+      0x700200CC,  //  001D  JMP		#00EB
+      0x541E0004,  //  001E  LDINT	R7	5
+      0x1C1C0A07,  //  001F  EQ	R7	R5	R7
+      0x781E0000,  //  0020  JMPF	R7	#0022
+      0x700200C8,  //  0021  JMP		#00EB
+      0x541E001C,  //  0022  LDINT	R7	29
+      0x1C1C0A07,  //  0023  EQ	R7	R5	R7
+      0x781E0034,  //  0024  JMPF	R7	#005A
+      0x1C1C0D0D,  //  0025  EQ	R7	R6	K13
+      0x781E0031,  //  0026  JMPF	R7	#0059
+      0x8C1C0927,  //  0027  GETMET	R7	R4	K39
+      0x7C1C0200,  //  0028  CALL	R7	1
+      0x88200128,  //  0029  GETMBR	R8	R0	K40
+      0x60240010,  //  002A  GETGBL	R9	G16
+      0x8C281129,  //  002B  GETMET	R10	R8	K41
+      0x7C280200,  //  002C  CALL	R10	1
+      0x7C240200,  //  002D  CALL	R9	1
+      0xA802000E,  //  002E  EXBLK	0	#003E
+      0x5C281200,  //  002F  MOVE	R10	R9
+      0x7C280000,  //  0030  CALL	R10	0
+      0x8C2C0F2A,  //  0031  GETMET	R11	R7	K42
+      0x7C2C0200,  //  0032  CALL	R11	1
+      0x8C30172B,  //  0033  GETMET	R12	R11	K43
+      0x5838000D,  //  0034  LDCONST	R14	K13
+      0x883C0925,  //  0035  GETMBR	R15	R4	K37
+      0x5C401400,  //  0036  MOVE	R16	R10
+      0x7C300800,  //  0037  CALL	R12	4
+      0x8C30172B,  //  0038  GETMET	R12	R11	K43
+      0x58380012,  //  0039  LDCONST	R14	K18
+      0x883C0925,  //  003A  GETMBR	R15	R4	K37
+      0x9440100A,  //  003B  GETIDX	R16	R8	R10
+      0x7C300800,  //  003C  CALL	R12	4
+      0x7001FFF0,  //  003D  JMP		#002F
+      0x5824002C,  //  003E  LDCONST	R9	K44
+      0xAC240200,  //  003F  CATCH	R9	1	0
+      0xB0080000,  //  0040  RAISE	2	R0	R0
+      0x8824012D,  //  0041  GETMBR	R9	R0	K45
+      0x8C24131A,  //  0042  GETMET	R9	R9	K26
+      0x8C2C032E,  //  0043  GETMET	R11	R1	K46
+      0x7C2C0200,  //  0044  CALL	R11	1
+      0x7C240400,  //  0045  CALL	R9	2
+      0x4C280000,  //  0046  LDNIL	R10
+      0x1C24120A,  //  0047  EQ	R9	R9	R10
+      0x7826000E,  //  0048  JMPF	R9	#0058
+      0x8824011C,  //  0049  GETMBR	R9	R0	K28
+      0x8824132F,  //  004A  GETMBR	R9	R9	K47
+      0x7426000B,  //  004B  JMPT	R9	#0058
+      0x8C240F2A,  //  004C  GETMET	R9	R7	K42
+      0x7C240200,  //  004D  CALL	R9	1
+      0x8C28132B,  //  004E  GETMET	R10	R9	K43
+      0x5830000D,  //  004F  LDCONST	R12	K13
+      0x88340925,  //  0050  GETMBR	R13	R4	K37
+      0x543A0012,  //  0051  LDINT	R14	19
+      0x7C280800,  //  0052  CALL	R10	4
+      0x8C28132B,  //  0053  GETMET	R10	R9	K43
+      0x58300012,  //  0054  LDCONST	R12	K18
+      0x88340925,  //  0055  GETMBR	R13	R4	K37
+      0x58380012,  //  0056  LDCONST	R14	K18
+      0x7C280800,  //  0057  CALL	R10	4
+      0x80040E00,  //  0058  RET	1	R7
+      0x70020090,  //  0059  JMP		#00EB
+      0x541E0038,  //  005A  LDINT	R7	57
+      0x1C1C0A07,  //  005B  EQ	R7	R5	R7
+      0x781E008D,  //  005C  JMPF	R7	#00EB
+      0xA41E6000,  //  005D  IMPORT	R7	K48
+      0x1C200D15,  //  005E  EQ	R8	R6	K21
+      0x78220018,  //  005F  JMPF	R8	#0079
+      0x88200100,  //  0060  GETMBR	R8	R0	K0
+      0x7822000B,  //  0061  JMPF	R8	#006E
+      0x88200101,  //  0062  GETMBR	R8	R0	K1
+      0x8C201131,  //  0063  GETMET	R8	R8	K49
+      0x7C200200,  //  0064  CALL	R8	1
+      0x8C20111A,  //  0065  GETMET	R8	R8	K26
+      0x58280032,  //  0066  LDCONST	R10	K50
+      0x7C200400,  //  0067  CALL	R8	2
+      0x8C240733,  //  0068  GETMET	R9	R3	K51
+      0x882C0934,  //  0069  GETMBR	R11	R4	K52
+      0x5C301000,  //  006A  MOVE	R12	R8
+      0x7C240600,  //  006B  CALL	R9	3
+      0x80041200,  //  006C  RET	1	R9
+      0x70020009,  //  006D  JMP		#0078
+      0x8C200724,  //  006E  GETMET	R8	R3	K36
+      0x88280934,  //  006F  GETMBR	R10	R4	K52
+      0xB82E6A00,  //  0070  GETNGBL	R11	K53
+      0x8C2C1736,  //  0071  GETMET	R11	R11	K54
+      0x58340037,  //  0072  LDCONST	R13	K55
+      0x50380200,  //  0073  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0074  CALL	R11	3
+      0x942C1737,  //  0075  GETIDX	R11	R11	K55
+      0x7C200600,  //  0076  CALL	R8	3
+      0x80041000,  //  0077  RET	1	R8
+      0x70020071,  //  0078  JMP		#00EB
+      0x54220004,  //  0079  LDINT	R8	5
+      0x1C200C08,  //  007A  EQ	R8	R6	R8
+      0x78220006,  //  007B  JMPF	R8	#0083
+      0x8C200724,  //  007C  GETMET	R8	R3	K36
+      0x88280934,  //  007D  GETMBR	R10	R4	K52
+      0x8C2C0138,  //  007E  GETMET	R11	R0	K56
+      0x7C2C0200,  //  007F  CALL	R11	1
+      0x7C200600,  //  0080  CALL	R8	3
+      0x80041000,  //  0081  RET	1	R8
+      0x70020067,  //  0082  JMP		#00EB
+      0x54220009,  //  0083  LDINT	R8	10
+      0x1C200C08,  //  0084  EQ	R8	R6	R8
+      0x78220033,  //  0085  JMPF	R8	#00BA
+      0x88200100,  //  0086  GETMBR	R8	R0	K0
+      0x7822001B,  //  0087  JMPF	R8	#00A4
+      0x88200101,  //  0088  GETMBR	R8	R0	K1
+      0x8C201131,  //  0089  GETMET	R8	R8	K49
+      0x7C200200,  //  008A  CALL	R8	1
+      0x8C20111A,  //  008B  GETMET	R8	R8	K26
+      0x58280039,  //  008C  LDCONST	R10	K57
+      0x7C200400,  //  008D  CALL	R8	2
+      0x7822000E,  //  008E  JMPF	R8	#009E
+      0x8C240F1A,  //  008F  GETMET	R9	R7	K26
+      0x5C2C1000,  //  0090  MOVE	R11	R8
+      0x5830003A,  //  0091  LDCONST	R12	K58
+      0x7C240600,  //  0092  CALL	R9	3
+      0x2428130D,  //  0093  GT	R10	R9	K13
+      0x782A0002,  //  0094  JMPF	R10	#0098
+      0x04281312,  //  0095  SUB	R10	R9	K18
+      0x402A1A0A,  //  0096  CONNECT	R10	K13	R10
+      0x9420100A,  //  0097  GETIDX	R8	R8	R10
+      0x8C280724,  //  0098  GETMET	R10	R3	K36
+      0x88300934,  //  0099  GETMBR	R12	R4	K52
+      0x5C341000,  //  009A  MOVE	R13	R8
+      0x7C280600,  //  009B  CALL	R10	3
+      0x80041400,  //  009C  RET	1	R10
+      0x70020004,  //  009D  JMP		#00A3
+      0x8C240724,  //  009E  GETMET	R9	R3	K36
+      0x882C093B,  //  009F  GETMBR	R11	R4	K59
+      0x4C300000,  //  00A0  LDNIL	R12
+      0x7C240600,  //  00A1  CALL	R9	3
+      0x80041200,  //  00A2  RET	1	R9
+      0x70020014,  //  00A3  JMP		#00B9
+      0xB8226A00,  //  00A4  GETNGBL	R8	K53
+      0x8C201136,  //  00A5  GETMET	R8	R8	K54
+      0x5828003C,  //  00A6  LDCONST	R10	K60
+      0x502C0200,  //  00A7  LDBOOL	R11	1	0
+      0x7C200600,  //  00A8  CALL	R8	3
+      0x9420113D,  //  00A9  GETIDX	R8	R8	K61
+      0x9420113E,  //  00AA  GETIDX	R8	R8	K62
+      0x8C240F1A,  //  00AB  GETMET	R9	R7	K26
+      0x5C2C1000,  //  00AC  MOVE	R11	R8
+      0x5830003A,  //  00AD  LDCONST	R12	K58
+      0x7C240600,  //  00AE  CALL	R9	3
+      0x2428130D,  //  00AF  GT	R10	R9	K13
+      0x782A0002,  //  00B0  JMPF	R10	#00B4
+      0x04281312,  //  00B1  SUB	R10	R9	K18
+      0x402A1A0A,  //  00B2  CONNECT	R10	K13	R10
+      0x9420100A,  //  00B3  GETIDX	R8	R8	R10
+      0x8C280724,  //  00B4  GETMET	R10	R3	K36
+      0x88300934,  //  00B5  GETMBR	R12	R4	K52
+      0x5C341000,  //  00B6  MOVE	R13	R8
+      0x7C280600,  //  00B7  CALL	R10	3
+      0x80041400,  //  00B8  RET	1	R10
+      0x70020030,  //  00B9  JMP		#00EB
+      0x5422000E,  //  00BA  LDINT	R8	15
+      0x1C200C08,  //  00BB  EQ	R8	R6	R8
+      0x74220002,  //  00BC  JMPT	R8	#00C0
+      0x54220011,  //  00BD  LDINT	R8	18
+      0x1C200C08,  //  00BE  EQ	R8	R6	R8
+      0x78220019,  //  00BF  JMPF	R8	#00DA
+      0x88200100,  //  00C0  GETMBR	R8	R0	K0
+      0x7822000B,  //  00C1  JMPF	R8	#00CE
+      0x88200101,  //  00C2  GETMBR	R8	R0	K1
+      0x8C201131,  //  00C3  GETMET	R8	R8	K49
+      0x7C200200,  //  00C4  CALL	R8	1
+      0x8C20111A,  //  00C5  GETMET	R8	R8	K26
+      0x5828003F,  //  00C6  LDCONST	R10	K63
+      0x7C200400,  //  00C7  CALL	R8	2
+      0x8C240733,  //  00C8  GETMET	R9	R3	K51
+      0x882C0934,  //  00C9  GETMBR	R11	R4	K52
+      0x5C301000,  //  00CA  MOVE	R12	R8
+      0x7C240600,  //  00CB  CALL	R9	3
+      0x80041200,  //  00CC  RET	1	R9
+      0x7002000A,  //  00CD  JMP		#00D9
+      0x8C200724,  //  00CE  GETMET	R8	R3	K36
+      0x88280934,  //  00CF  GETMBR	R10	R4	K52
+      0xB82E6A00,  //  00D0  GETNGBL	R11	K53
+      0x8C2C1740,  //  00D1  GETMET	R11	R11	K64
+      0x7C2C0200,  //  00D2  CALL	R11	1
+      0x8C2C171A,  //  00D3  GETMET	R11	R11	K26
+      0x5834003F,  //  00D4  LDCONST	R13	K63
+      0x58380041,  //  00D5  LDCONST	R14	K65
+      0x7C2C0600,  //  00D6  CALL	R11	3
+      0x7C200600,  //  00D7  CALL	R8	3
+      0x80041000,  //  00D8  RET	1	R8
+      0x70020010,  //  00D9  JMP		#00EB
+      0x54220010,  //  00DA  LDINT	R8	17
+      0x1C200C08,  //  00DB  EQ	R8	R6	R8
+      0x7822000D,  //  00DC  JMPF	R8	#00EB
+      0x88200100,  //  00DD  GETMBR	R8	R0	K0
+      0x78220006,  //  00DE  JMPF	R8	#00E6
+      0x8C200724,  //  00DF  GETMET	R8	R3	K36
+      0x88280942,  //  00E0  GETMBR	R10	R4	K66
+      0x882C0101,  //  00E1  GETMBR	R11	R0	K1
+      0x882C1743,  //  00E2  GETMBR	R11	R11	K67
+      0x7C200600,  //  00E3  CALL	R8	3
+      0x80041000,  //  00E4  RET	1	R8
+      0x70020004,  //  00E5  JMP		#00EB
+      0x8C200724,  //  00E6  GETMET	R8	R3	K36
+      0x88280942,  //  00E7  GETMBR	R10	R4	K66
+      0x582C0012,  //  00E8  LDCONST	R11	K18
+      0x7C200600,  //  00E9  CALL	R8	3
+      0x80041000,  //  00EA  RET	1	R8
+      0x601C0003,  //  00EB  GETGBL	R7	G3
+      0x5C200000,  //  00EC  MOVE	R8	R0
+      0x7C1C0200,  //  00ED  CALL	R7	1
+      0x8C1C0F44,  //  00EE  GETMET	R7	R7	K68
+      0x5C240200,  //  00EF  MOVE	R9	R1
+      0x5C280400,  //  00F0  MOVE	R10	R2
+      0x5C2C0600,  //  00F1  MOVE	R11	R3
+      0x7C1C0800,  //  00F2  CALL	R7	4
+      0x80040E00,  //  00F3  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_configuration
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_parse_configuration,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080116,  //  0000  GETMBR	R2	R0	K22
+      0x780A0005,  //  0001  JMPF	R2	#0008
+      0x88080117,  //  0002  GETMBR	R2	R0	K23
+      0x780A0003,  //  0003  JMPF	R2	#0008
+      0x88080117,  //  0004  GETMBR	R2	R0	K23
+      0x8C080545,  //  0005  GETMET	R2	R2	K69
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_value_onoff
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(web_value_onoff),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x20080202,  //  0001  NE	R2	R1	R2
+      0x780A0004,  //  0002  JMPF	R2	#0008
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x58080046,  //  0004  LDCONST	R2	K70
+      0x70020000,  //  0005  JMP		#0007
+      0x58080047,  //  0006  LDCONST	R2	K71
+      0x70020000,  //  0007  JMP		#0009
+      0x58080041,  //  0008  LDCONST	R2	K65
+      0x80040400,  //  0009  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[51]) {  /* code */
+      0xB8124000,  //  0000  GETNGBL	R4	K32
+      0x88100921,  //  0001  GETMBR	R4	R4	K33
+      0x88140722,  //  0002  GETMBR	R5	R3	K34
+      0x88180748,  //  0003  GETMBR	R6	R3	K72
+      0x1C1C0B15,  //  0004  EQ	R7	R5	K21
+      0x781E0016,  //  0005  JMPF	R7	#001D
+      0x1C1C0D0D,  //  0006  EQ	R7	R6	K13
+      0x781E0002,  //  0007  JMPF	R7	#000B
+      0x501C0200,  //  0008  LDBOOL	R7	1	0
+      0x80040E00,  //  0009  RET	1	R7
+      0x70020010,  //  000A  JMP		#001C
+      0x1C1C0D12,  //  000B  EQ	R7	R6	K18
+      0x781E0009,  //  000C  JMPF	R7	#0017
+      0x8C1C0949,  //  000D  GETMET	R7	R4	K73
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x8C200F2B,  //  000F  GETMET	R8	R7	K43
+      0x5828000D,  //  0010  LDCONST	R10	K13
+      0x882C0925,  //  0011  GETMBR	R11	R4	K37
+      0x5830000D,  //  0012  LDCONST	R12	K13
+      0x7C200800,  //  0013  CALL	R8	4
+      0x900E910D,  //  0014  SETMBR	R3	K72	K13
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020004,  //  0016  JMP		#001C
+      0x541E003F,  //  0017  LDINT	R7	64
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0001,  //  0019  JMPF	R7	#001C
+      0x501C0200,  //  001A  LDBOOL	R7	1	0
+      0x80040E00,  //  001B  RET	1	R7
+      0x70020014,  //  001C  JMP		#0032
+      0x541E0003,  //  001D  LDINT	R7	4
+      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
+      0x781E0002,  //  001F  JMPF	R7	#0023
+      0x501C0200,  //  0020  LDBOOL	R7	1	0
+      0x80040E00,  //  0021  RET	1	R7
+      0x7002000E,  //  0022  JMP		#0032
+      0x541E0004,  //  0023  LDINT	R7	5
+      0x1C1C0A07,  //  0024  EQ	R7	R5	R7
+      0x781E0002,  //  0025  JMPF	R7	#0029
+      0x501C0200,  //  0026  LDBOOL	R7	1	0
+      0x80040E00,  //  0027  RET	1	R7
+      0x70020008,  //  0028  JMP		#0032
+      0x601C0003,  //  0029  GETGBL	R7	G3
+      0x5C200000,  //  002A  MOVE	R8	R0
+      0x7C1C0200,  //  002B  CALL	R7	1
+      0x8C1C0F4A,  //  002C  GETMET	R7	R7	K74
+      0x5C240200,  //  002D  MOVE	R9	R1
+      0x5C280400,  //  002E  MOVE	R10	R2
+      0x5C2C0600,  //  002F  MOVE	R11	R3
+      0x7C1C0800,  //  0030  CALL	R7	4
+      0x80040E00,  //  0031  RET	1	R7
+      0x80000000,  //  0032  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x7806000D,  //  0001  JMPF	R1	#0010
+      0x8804014B,  //  0002  GETMBR	R1	R0	K75
+      0x8808011C,  //  0003  GETMBR	R2	R0	K28
+      0x8808054B,  //  0004  GETMBR	R2	R2	K75
+      0x20040202,  //  0005  NE	R1	R1	R2
+      0x78060008,  //  0006  JMPF	R1	#0010
+      0x8C04014C,  //  0007  GETMET	R1	R0	K76
+      0x880C014D,  //  0008  GETMBR	R3	R0	K77
+      0x7C040400,  //  0009  CALL	R1	2
+      0x78060004,  //  000A  JMPF	R1	#0010
+      0x8C08014E,  //  000B  GETMET	R2	R0	K78
+      0x58100012,  //  000C  LDCONST	R4	K18
+      0x5C140200,  //  000D  MOVE	R5	R1
+      0x8818014D,  //  000E  GETMBR	R6	R0	K77
+      0x7C080800,  //  000F  CALL	R2	4
+      0x8804011C,  //  0010  GETMBR	R1	R0	K28
+      0x8804034B,  //  0011  GETMBR	R1	R1	K75
+      0x90029601,  //  0012  SETMBR	R0	K75	R1
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_values_prefix
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(web_values_prefix),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xA4060800,  //  0000  IMPORT	R1	K4
+      0x8C080138,  //  0001  GETMET	R2	R0	K56
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C0C0306,  //  0003  GETMET	R3	R1	K6
+      0x60140018,  //  0004  GETGBL	R5	G24
+      0x8818014F,  //  0005  GETMBR	R6	R0	K79
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0x8C1C0350,  //  0007  GETMET	R7	R1	K80
+      0x5C240400,  //  0008  MOVE	R9	R2
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x70020000,  //  000A  JMP		#000C
+      0x581C0041,  //  000B  LDCONST	R7	K65
+      0x7C140400,  //  000C  CALL	R5	2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -408,685 +1084,14 @@ be_local_closure(class_Matter_Plugin_Device_register_cmd_cb,   /* name */
     be_str_weak(register_cmd_cb),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C040351,  //  0001  GETMET	R1	R1	K81
+      0x880C014D,  //  0002  GETMBR	R3	R0	K77
+      0x88100152,  //  0003  GETMBR	R4	R0	K82
       0x84140000,  //  0004  CLOSURE	R5	P0
       0x7C040800,  //  0005  CALL	R1	4
       0xA0000000,  //  0006  CLOSE	R0
       0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_values
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_web_values,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(web_values),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080105,  //  0001  GETMET	R2	R0	K5
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080306,  //  0003  GETMET	R2	R1	K6
-      0x88100108,  //  0004  GETMBR	R4	R0	K8
-      0x00120E04,  //  0005  ADD	R4	K7	R4
-      0x00100909,  //  0006  ADD	R4	R4	K9
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_every_250ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8804010A,  //  0000  GETMBR	R1	R0	K10
-      0x78060003,  //  0001  JMPF	R1	#0006
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C04030B,  //  0003  GETMET	R1	R1	K11
-      0x7C040200,  //  0004  CALL	R1	1
-      0x70020004,  //  0005  JMP		#000B
-      0x60040003,  //  0006  GETGBL	R1	G3
-      0x5C080000,  //  0007  MOVE	R2	R0
-      0x7C040200,  //  0008  CALL	R1	1
-      0x8C04030C,  //  0009  GETMET	R1	R1	K12
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_value_onoff
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_web_value_onoff,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(web_value_onoff),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0004,  //  0002  JMPF	R2	#0008
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x5808000D,  //  0004  LDCONST	R2	K13
-      0x70020000,  //  0005  JMP		#0007
-      0x5808000E,  //  0006  LDCONST	R2	K14
-      0x70020000,  //  0007  JMP		#0009
-      0x5808000F,  //  0008  LDCONST	R2	K15
-      0x80040400,  //  0009  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_invoke_request,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
-      0xB8122000,  //  0000  GETNGBL	R4	K16
-      0x88100911,  //  0001  GETMBR	R4	R4	K17
-      0x88140712,  //  0002  GETMBR	R5	R3	K18
-      0x88180713,  //  0003  GETMBR	R6	R3	K19
-      0x1C1C0B14,  //  0004  EQ	R7	R5	K20
-      0x781E0016,  //  0005  JMPF	R7	#001D
-      0x1C1C0D15,  //  0006  EQ	R7	R6	K21
-      0x781E0002,  //  0007  JMPF	R7	#000B
-      0x501C0200,  //  0008  LDBOOL	R7	1	0
-      0x80040E00,  //  0009  RET	1	R7
-      0x70020010,  //  000A  JMP		#001C
-      0x1C1C0D16,  //  000B  EQ	R7	R6	K22
-      0x781E0009,  //  000C  JMPF	R7	#0017
-      0x8C1C0917,  //  000D  GETMET	R7	R4	K23
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x8C200F18,  //  000F  GETMET	R8	R7	K24
-      0x58280015,  //  0010  LDCONST	R10	K21
-      0x882C0919,  //  0011  GETMBR	R11	R4	K25
-      0x58300015,  //  0012  LDCONST	R12	K21
-      0x7C200800,  //  0013  CALL	R8	4
-      0x900E2715,  //  0014  SETMBR	R3	K19	K21
-      0x80040E00,  //  0015  RET	1	R7
-      0x70020004,  //  0016  JMP		#001C
-      0x541E003F,  //  0017  LDINT	R7	64
-      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
-      0x781E0001,  //  0019  JMPF	R7	#001C
-      0x501C0200,  //  001A  LDBOOL	R7	1	0
-      0x80040E00,  //  001B  RET	1	R7
-      0x70020014,  //  001C  JMP		#0032
-      0x541E0003,  //  001D  LDINT	R7	4
-      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
-      0x781E0002,  //  001F  JMPF	R7	#0023
-      0x501C0200,  //  0020  LDBOOL	R7	1	0
-      0x80040E00,  //  0021  RET	1	R7
-      0x7002000E,  //  0022  JMP		#0032
-      0x541E0004,  //  0023  LDINT	R7	5
-      0x1C1C0A07,  //  0024  EQ	R7	R5	R7
-      0x781E0002,  //  0025  JMPF	R7	#0029
-      0x501C0200,  //  0026  LDBOOL	R7	1	0
-      0x80040E00,  //  0027  RET	1	R7
-      0x70020008,  //  0028  JMP		#0032
-      0x601C0003,  //  0029  GETGBL	R7	G3
-      0x5C200000,  //  002A  MOVE	R8	R0
-      0x7C1C0200,  //  002B  CALL	R7	1
-      0x8C1C0F1A,  //  002C  GETMET	R7	R7	K26
-      0x5C240200,  //  002D  MOVE	R9	R1
-      0x5C280400,  //  002E  MOVE	R10	R2
-      0x5C2C0600,  //  002F  MOVE	R11	R3
-      0x7C1C0800,  //  0030  CALL	R7	4
-      0x80040E00,  //  0031  RET	1	R7
-      0x80000000,  //  0032  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x8804010A,  //  0000  GETMBR	R1	R0	K10
-      0x7806000D,  //  0001  JMPF	R1	#0010
-      0x8804011B,  //  0002  GETMBR	R1	R0	K27
-      0x8808011C,  //  0003  GETMBR	R2	R0	K28
-      0x8808051B,  //  0004  GETMBR	R2	R2	K27
-      0x20040202,  //  0005  NE	R1	R1	R2
-      0x78060008,  //  0006  JMPF	R1	#0010
-      0x8C04011D,  //  0007  GETMET	R1	R0	K29
-      0x880C0102,  //  0008  GETMBR	R3	R0	K2
-      0x7C040400,  //  0009  CALL	R1	2
-      0x78060004,  //  000A  JMPF	R1	#0010
-      0x8C08011E,  //  000B  GETMET	R2	R0	K30
-      0x58100016,  //  000C  LDCONST	R4	K22
-      0x5C140200,  //  000D  MOVE	R5	R1
-      0x88180102,  //  000E  GETMBR	R6	R0	K2
-      0x7C080800,  //  000F  CALL	R2	4
-      0x8804011C,  //  0010  GETMBR	R1	R0	K28
-      0x8804031B,  //  0011  GETMBR	R1	R1	K27
-      0x90023601,  //  0012  SETMBR	R0	K27	R1
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: call_remote_sync
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(call_remote_sync),
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x880C010A,  //  0000  GETMBR	R3	R0	K10
-      0x780E0028,  //  0001  JMPF	R3	#002B
-      0xA40E3E00,  //  0002  IMPORT	R3	K31
-      0x58100020,  //  0003  LDCONST	R4	K32
-      0x4C140000,  //  0004  LDNIL	R5
-      0x20140405,  //  0005  NE	R5	R2	R5
-      0x78160005,  //  0006  JMPF	R5	#000D
-      0x00140321,  //  0007  ADD	R5	R1	K33
-      0x60180008,  //  0008  GETGBL	R6	G8
-      0x5C1C0400,  //  0009  MOVE	R7	R2
-      0x7C180200,  //  000A  CALL	R6	1
-      0x00140A06,  //  000B  ADD	R5	R5	R6
-      0x5C040A00,  //  000C  MOVE	R1	R5
-      0x24140915,  //  000D  GT	R5	R4	K21
-      0x78160015,  //  000E  JMPF	R5	#0025
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x8C140B22,  //  0010  GETMET	R5	R5	K34
-      0x5C1C0200,  //  0011  MOVE	R7	R1
-      0x88200123,  //  0012  GETMBR	R8	R0	K35
-      0x7C140600,  //  0013  CALL	R5	3
-      0x4C180000,  //  0014  LDNIL	R6
-      0x20180A06,  //  0015  NE	R6	R5	R6
-      0x781A0007,  //  0016  JMPF	R6	#001F
-      0x88180100,  //  0017  GETMBR	R6	R0	K0
-      0x8C180D24,  //  0018  GETMET	R6	R6	K36
-      0x50200200,  //  0019  LDBOOL	R8	1	0
-      0x7C180400,  //  001A  CALL	R6	2
-      0x8C180725,  //  001B  GETMET	R6	R3	K37
-      0x5C200A00,  //  001C  MOVE	R8	R5
-      0x7C180400,  //  001D  CALL	R6	2
-      0x80040C00,  //  001E  RET	1	R6
-      0x04100916,  //  001F  SUB	R4	R4	K22
-      0xB81A4C00,  //  0020  GETNGBL	R6	K38
-      0x581C0027,  //  0021  LDCONST	R7	K39
-      0x58200014,  //  0022  LDCONST	R8	K20
-      0x7C180400,  //  0023  CALL	R6	2
-      0x7001FFE7,  //  0024  JMP		#000D
-      0x88140100,  //  0025  GETMBR	R5	R0	K0
-      0x8C140B24,  //  0026  GETMET	R5	R5	K36
-      0x501C0000,  //  0027  LDBOOL	R7	0	0
-      0x7C140400,  //  0028  CALL	R5	2
-      0x4C140000,  //  0029  LDNIL	R5
-      0x80040A00,  //  002A  RET	1	R5
-      0x80000000,  //  002B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_http_response
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(parse_http_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8810010A,  //  0000  GETMBR	R4	R0	K10
-      0x7812000A,  //  0001  JMPF	R4	#000D
-      0x8810011C,  //  0002  GETMBR	R4	R0	K28
-      0x8810091B,  //  0003  GETMBR	R4	R4	K27
-      0x90023604,  //  0004  SETMBR	R0	K27	R4
-      0x88100100,  //  0005  GETMBR	R4	R0	K0
-      0x8C100928,  //  0006  GETMET	R4	R4	K40
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x5C1C0400,  //  0008  MOVE	R7	R2
-      0x5C200600,  //  0009  MOVE	R8	R3
-      0x5C240000,  //  000A  MOVE	R9	R0
-      0x88280129,  //  000B  GETMBR	R10	R0	K41
-      0x7C100C00,  //  000C  CALL	R4	6
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_values_prefix
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_web_values_prefix,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(web_values_prefix),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C08012A,  //  0001  GETMET	R2	R0	K42
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C0C0306,  //  0003  GETMET	R3	R1	K6
-      0x60140018,  //  0004  GETGBL	R5	G24
-      0x8818012B,  //  0005  GETMBR	R6	R0	K43
-      0x780A0003,  //  0006  JMPF	R2	#000B
-      0x8C1C032C,  //  0007  GETMET	R7	R1	K44
-      0x5C240400,  //  0008  MOVE	R9	R2
-      0x7C1C0400,  //  0009  CALL	R7	2
-      0x70020000,  //  000A  JMP		#000C
-      0x581C000F,  //  000B  LDCONST	R7	K15
-      0x7C140400,  //  000C  CALL	R5	2
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[244]) {  /* code */
-      0xB8122000,  //  0000  GETNGBL	R4	K16
-      0x88100911,  //  0001  GETMBR	R4	R4	K17
-      0x88140512,  //  0002  GETMBR	R5	R2	K18
-      0x8818052D,  //  0003  GETMBR	R6	R2	K45
-      0x1C1C0B14,  //  0004  EQ	R7	R5	K20
-      0x781E000F,  //  0005  JMPF	R7	#0016
-      0x1C1C0D15,  //  0006  EQ	R7	R6	K21
-      0x781E0005,  //  0007  JMPF	R7	#000E
-      0x8C1C072E,  //  0008  GETMET	R7	R3	K46
-      0x88240919,  //  0009  GETMBR	R9	R4	K25
-      0x58280015,  //  000A  LDCONST	R10	K21
-      0x7C1C0600,  //  000B  CALL	R7	3
-      0x80040E00,  //  000C  RET	1	R7
-      0x70020006,  //  000D  JMP		#0015
-      0x1C1C0D16,  //  000E  EQ	R7	R6	K22
-      0x781E0004,  //  000F  JMPF	R7	#0015
-      0x8C1C072E,  //  0010  GETMET	R7	R3	K46
-      0x8824092F,  //  0011  GETMBR	R9	R4	K47
-      0x58280015,  //  0012  LDCONST	R10	K21
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x700200D4,  //  0015  JMP		#00EB
-      0x541E0003,  //  0016  LDINT	R7	4
-      0x1C1C0A07,  //  0017  EQ	R7	R5	R7
-      0x781E0004,  //  0018  JMPF	R7	#001E
-      0x1C1C0D15,  //  0019  EQ	R7	R6	K21
-      0x781E0001,  //  001A  JMPF	R7	#001D
-      0x4C1C0000,  //  001B  LDNIL	R7
-      0x80040E00,  //  001C  RET	1	R7
-      0x700200CC,  //  001D  JMP		#00EB
-      0x541E0004,  //  001E  LDINT	R7	5
-      0x1C1C0A07,  //  001F  EQ	R7	R5	R7
-      0x781E0000,  //  0020  JMPF	R7	#0022
-      0x700200C8,  //  0021  JMP		#00EB
-      0x541E001C,  //  0022  LDINT	R7	29
-      0x1C1C0A07,  //  0023  EQ	R7	R5	R7
-      0x781E0034,  //  0024  JMPF	R7	#005A
-      0x1C1C0D15,  //  0025  EQ	R7	R6	K21
-      0x781E0031,  //  0026  JMPF	R7	#0059
-      0x8C1C0930,  //  0027  GETMET	R7	R4	K48
-      0x7C1C0200,  //  0028  CALL	R7	1
-      0x88200131,  //  0029  GETMBR	R8	R0	K49
-      0x60240010,  //  002A  GETGBL	R9	G16
-      0x8C281132,  //  002B  GETMET	R10	R8	K50
-      0x7C280200,  //  002C  CALL	R10	1
-      0x7C240200,  //  002D  CALL	R9	1
-      0xA802000E,  //  002E  EXBLK	0	#003E
-      0x5C281200,  //  002F  MOVE	R10	R9
-      0x7C280000,  //  0030  CALL	R10	0
-      0x8C2C0F33,  //  0031  GETMET	R11	R7	K51
-      0x7C2C0200,  //  0032  CALL	R11	1
-      0x8C301718,  //  0033  GETMET	R12	R11	K24
-      0x58380015,  //  0034  LDCONST	R14	K21
-      0x883C0919,  //  0035  GETMBR	R15	R4	K25
-      0x5C401400,  //  0036  MOVE	R16	R10
-      0x7C300800,  //  0037  CALL	R12	4
-      0x8C301718,  //  0038  GETMET	R12	R11	K24
-      0x58380016,  //  0039  LDCONST	R14	K22
-      0x883C0919,  //  003A  GETMBR	R15	R4	K25
-      0x9440100A,  //  003B  GETIDX	R16	R8	R10
-      0x7C300800,  //  003C  CALL	R12	4
-      0x7001FFF0,  //  003D  JMP		#002F
-      0x58240034,  //  003E  LDCONST	R9	K52
-      0xAC240200,  //  003F  CATCH	R9	1	0
-      0xB0080000,  //  0040  RAISE	2	R0	R0
-      0x88240135,  //  0041  GETMBR	R9	R0	K53
-      0x8C241336,  //  0042  GETMET	R9	R9	K54
-      0x8C2C0337,  //  0043  GETMET	R11	R1	K55
-      0x7C2C0200,  //  0044  CALL	R11	1
-      0x7C240400,  //  0045  CALL	R9	2
-      0x4C280000,  //  0046  LDNIL	R10
-      0x1C24120A,  //  0047  EQ	R9	R9	R10
-      0x7826000E,  //  0048  JMPF	R9	#0058
-      0x8824011C,  //  0049  GETMBR	R9	R0	K28
-      0x88241338,  //  004A  GETMBR	R9	R9	K56
-      0x7426000B,  //  004B  JMPT	R9	#0058
-      0x8C240F33,  //  004C  GETMET	R9	R7	K51
-      0x7C240200,  //  004D  CALL	R9	1
-      0x8C281318,  //  004E  GETMET	R10	R9	K24
-      0x58300015,  //  004F  LDCONST	R12	K21
-      0x88340919,  //  0050  GETMBR	R13	R4	K25
-      0x543A0012,  //  0051  LDINT	R14	19
-      0x7C280800,  //  0052  CALL	R10	4
-      0x8C281318,  //  0053  GETMET	R10	R9	K24
-      0x58300016,  //  0054  LDCONST	R12	K22
-      0x88340919,  //  0055  GETMBR	R13	R4	K25
-      0x58380016,  //  0056  LDCONST	R14	K22
-      0x7C280800,  //  0057  CALL	R10	4
-      0x80040E00,  //  0058  RET	1	R7
-      0x70020090,  //  0059  JMP		#00EB
-      0x541E0038,  //  005A  LDINT	R7	57
-      0x1C1C0A07,  //  005B  EQ	R7	R5	R7
-      0x781E008D,  //  005C  JMPF	R7	#00EB
-      0xA41E7200,  //  005D  IMPORT	R7	K57
-      0x1C200D14,  //  005E  EQ	R8	R6	K20
-      0x78220018,  //  005F  JMPF	R8	#0079
-      0x8820010A,  //  0060  GETMBR	R8	R0	K10
-      0x7822000B,  //  0061  JMPF	R8	#006E
-      0x88200100,  //  0062  GETMBR	R8	R0	K0
-      0x8C20113A,  //  0063  GETMET	R8	R8	K58
-      0x7C200200,  //  0064  CALL	R8	1
-      0x8C201136,  //  0065  GETMET	R8	R8	K54
-      0x5828003B,  //  0066  LDCONST	R10	K59
-      0x7C200400,  //  0067  CALL	R8	2
-      0x8C24073C,  //  0068  GETMET	R9	R3	K60
-      0x882C093D,  //  0069  GETMBR	R11	R4	K61
-      0x5C301000,  //  006A  MOVE	R12	R8
-      0x7C240600,  //  006B  CALL	R9	3
-      0x80041200,  //  006C  RET	1	R9
-      0x70020009,  //  006D  JMP		#0078
-      0x8C20072E,  //  006E  GETMET	R8	R3	K46
-      0x8828093D,  //  006F  GETMBR	R10	R4	K61
-      0xB82E7C00,  //  0070  GETNGBL	R11	K62
-      0x8C2C173F,  //  0071  GETMET	R11	R11	K63
-      0x58340040,  //  0072  LDCONST	R13	K64
-      0x50380200,  //  0073  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0074  CALL	R11	3
-      0x942C1740,  //  0075  GETIDX	R11	R11	K64
-      0x7C200600,  //  0076  CALL	R8	3
-      0x80041000,  //  0077  RET	1	R8
-      0x70020071,  //  0078  JMP		#00EB
-      0x54220004,  //  0079  LDINT	R8	5
-      0x1C200C08,  //  007A  EQ	R8	R6	R8
-      0x78220006,  //  007B  JMPF	R8	#0083
-      0x8C20072E,  //  007C  GETMET	R8	R3	K46
-      0x8828093D,  //  007D  GETMBR	R10	R4	K61
-      0x8C2C012A,  //  007E  GETMET	R11	R0	K42
-      0x7C2C0200,  //  007F  CALL	R11	1
-      0x7C200600,  //  0080  CALL	R8	3
-      0x80041000,  //  0081  RET	1	R8
-      0x70020067,  //  0082  JMP		#00EB
-      0x54220009,  //  0083  LDINT	R8	10
-      0x1C200C08,  //  0084  EQ	R8	R6	R8
-      0x78220033,  //  0085  JMPF	R8	#00BA
-      0x8820010A,  //  0086  GETMBR	R8	R0	K10
-      0x7822001B,  //  0087  JMPF	R8	#00A4
-      0x88200100,  //  0088  GETMBR	R8	R0	K0
-      0x8C20113A,  //  0089  GETMET	R8	R8	K58
-      0x7C200200,  //  008A  CALL	R8	1
-      0x8C201136,  //  008B  GETMET	R8	R8	K54
-      0x58280041,  //  008C  LDCONST	R10	K65
-      0x7C200400,  //  008D  CALL	R8	2
-      0x7822000E,  //  008E  JMPF	R8	#009E
-      0x8C240F36,  //  008F  GETMET	R9	R7	K54
-      0x5C2C1000,  //  0090  MOVE	R11	R8
-      0x58300042,  //  0091  LDCONST	R12	K66
-      0x7C240600,  //  0092  CALL	R9	3
-      0x24281315,  //  0093  GT	R10	R9	K21
-      0x782A0002,  //  0094  JMPF	R10	#0098
-      0x04281316,  //  0095  SUB	R10	R9	K22
-      0x402A2A0A,  //  0096  CONNECT	R10	K21	R10
-      0x9420100A,  //  0097  GETIDX	R8	R8	R10
-      0x8C28072E,  //  0098  GETMET	R10	R3	K46
-      0x8830093D,  //  0099  GETMBR	R12	R4	K61
-      0x5C341000,  //  009A  MOVE	R13	R8
-      0x7C280600,  //  009B  CALL	R10	3
-      0x80041400,  //  009C  RET	1	R10
-      0x70020004,  //  009D  JMP		#00A3
-      0x8C24072E,  //  009E  GETMET	R9	R3	K46
-      0x882C0943,  //  009F  GETMBR	R11	R4	K67
-      0x4C300000,  //  00A0  LDNIL	R12
-      0x7C240600,  //  00A1  CALL	R9	3
-      0x80041200,  //  00A2  RET	1	R9
-      0x70020014,  //  00A3  JMP		#00B9
-      0xB8227C00,  //  00A4  GETNGBL	R8	K62
-      0x8C20113F,  //  00A5  GETMET	R8	R8	K63
-      0x58280044,  //  00A6  LDCONST	R10	K68
-      0x502C0200,  //  00A7  LDBOOL	R11	1	0
-      0x7C200600,  //  00A8  CALL	R8	3
-      0x94201145,  //  00A9  GETIDX	R8	R8	K69
-      0x94201146,  //  00AA  GETIDX	R8	R8	K70
-      0x8C240F36,  //  00AB  GETMET	R9	R7	K54
-      0x5C2C1000,  //  00AC  MOVE	R11	R8
-      0x58300042,  //  00AD  LDCONST	R12	K66
-      0x7C240600,  //  00AE  CALL	R9	3
-      0x24281315,  //  00AF  GT	R10	R9	K21
-      0x782A0002,  //  00B0  JMPF	R10	#00B4
-      0x04281316,  //  00B1  SUB	R10	R9	K22
-      0x402A2A0A,  //  00B2  CONNECT	R10	K21	R10
-      0x9420100A,  //  00B3  GETIDX	R8	R8	R10
-      0x8C28072E,  //  00B4  GETMET	R10	R3	K46
-      0x8830093D,  //  00B5  GETMBR	R12	R4	K61
-      0x5C341000,  //  00B6  MOVE	R13	R8
-      0x7C280600,  //  00B7  CALL	R10	3
-      0x80041400,  //  00B8  RET	1	R10
-      0x70020030,  //  00B9  JMP		#00EB
-      0x5422000E,  //  00BA  LDINT	R8	15
-      0x1C200C08,  //  00BB  EQ	R8	R6	R8
-      0x74220002,  //  00BC  JMPT	R8	#00C0
-      0x54220011,  //  00BD  LDINT	R8	18
-      0x1C200C08,  //  00BE  EQ	R8	R6	R8
-      0x78220019,  //  00BF  JMPF	R8	#00DA
-      0x8820010A,  //  00C0  GETMBR	R8	R0	K10
-      0x7822000B,  //  00C1  JMPF	R8	#00CE
-      0x88200100,  //  00C2  GETMBR	R8	R0	K0
-      0x8C20113A,  //  00C3  GETMET	R8	R8	K58
-      0x7C200200,  //  00C4  CALL	R8	1
-      0x8C201136,  //  00C5  GETMET	R8	R8	K54
-      0x58280047,  //  00C6  LDCONST	R10	K71
-      0x7C200400,  //  00C7  CALL	R8	2
-      0x8C24073C,  //  00C8  GETMET	R9	R3	K60
-      0x882C093D,  //  00C9  GETMBR	R11	R4	K61
-      0x5C301000,  //  00CA  MOVE	R12	R8
-      0x7C240600,  //  00CB  CALL	R9	3
-      0x80041200,  //  00CC  RET	1	R9
-      0x7002000A,  //  00CD  JMP		#00D9
-      0x8C20072E,  //  00CE  GETMET	R8	R3	K46
-      0x8828093D,  //  00CF  GETMBR	R10	R4	K61
-      0xB82E7C00,  //  00D0  GETNGBL	R11	K62
-      0x8C2C1748,  //  00D1  GETMET	R11	R11	K72
-      0x7C2C0200,  //  00D2  CALL	R11	1
-      0x8C2C1736,  //  00D3  GETMET	R11	R11	K54
-      0x58340047,  //  00D4  LDCONST	R13	K71
-      0x5838000F,  //  00D5  LDCONST	R14	K15
-      0x7C2C0600,  //  00D6  CALL	R11	3
-      0x7C200600,  //  00D7  CALL	R8	3
-      0x80041000,  //  00D8  RET	1	R8
-      0x70020010,  //  00D9  JMP		#00EB
-      0x54220010,  //  00DA  LDINT	R8	17
-      0x1C200C08,  //  00DB  EQ	R8	R6	R8
-      0x7822000D,  //  00DC  JMPF	R8	#00EB
-      0x8820010A,  //  00DD  GETMBR	R8	R0	K10
-      0x78220006,  //  00DE  JMPF	R8	#00E6
-      0x8C20072E,  //  00DF  GETMET	R8	R3	K46
-      0x88280949,  //  00E0  GETMBR	R10	R4	K73
-      0x882C0100,  //  00E1  GETMBR	R11	R0	K0
-      0x882C174A,  //  00E2  GETMBR	R11	R11	K74
-      0x7C200600,  //  00E3  CALL	R8	3
-      0x80041000,  //  00E4  RET	1	R8
-      0x70020004,  //  00E5  JMP		#00EB
-      0x8C20072E,  //  00E6  GETMET	R8	R3	K46
-      0x88280949,  //  00E7  GETMBR	R10	R4	K73
-      0x582C0016,  //  00E8  LDCONST	R11	K22
-      0x7C200600,  //  00E9  CALL	R8	3
-      0x80041000,  //  00EA  RET	1	R8
-      0x601C0003,  //  00EB  GETGBL	R7	G3
-      0x5C200000,  //  00EC  MOVE	R8	R0
-      0x7C1C0200,  //  00ED  CALL	R7	1
-      0x8C1C0F4B,  //  00EE  GETMET	R7	R7	K75
-      0x5C240200,  //  00EF  MOVE	R9	R1
-      0x5C280400,  //  00F0  MOVE	R10	R2
-      0x5C2C0600,  //  00F1  MOVE	R11	R3
-      0x7C1C0800,  //  00F2  CALL	R7	4
-      0x80040E00,  //  00F3  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Device_init,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C10094C,  //  0003  GETMET	R4	R4	K76
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x5C200600,  //  0006  MOVE	R8	R3
-      0x7C100800,  //  0007  CALL	R4	4
-      0x8810010A,  //  0008  GETMBR	R4	R0	K10
-      0x7812000A,  //  0009  JMPF	R4	#0015
-      0x8C100736,  //  000A  GETMET	R4	R3	K54
-      0x8818014D,  //  000B  GETMBR	R6	R0	K77
-      0x7C100400,  //  000C  CALL	R4	2
-      0x8814011C,  //  000D  GETMBR	R5	R0	K28
-      0x8C140B4E,  //  000E  GETMET	R5	R5	K78
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x8820014F,  //  0010  GETMBR	R8	R0	K79
-      0x7C140600,  //  0011  CALL	R5	3
-      0x90020005,  //  0012  SETMBR	R0	K0	R5
-      0x8C140150,  //  0013  GETMET	R5	R0	K80
-      0x7C140200,  //  0014  CALL	R5	1
-      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -1167,101 +1172,138 @@ be_local_closure(class_Matter_Plugin_Device_append_state_json,   /* name */
     be_str_weak(append_state_json),
     &be_const_str_solidified,
     ( &(const binstruction[95]) {  /* code */
-      0xA406A200,  //  0000  IMPORT	R1	K81
-      0xA40A3E00,  //  0001  IMPORT	R2	K31
-      0x580C000F,  //  0002  LDCONST	R3	K15
+      0xA406A600,  //  0000  IMPORT	R1	K83
+      0xA40A1400,  //  0001  IMPORT	R2	K10
+      0x580C0041,  //  0002  LDCONST	R3	K65
       0x84100000,  //  0003  CLOSURE	R4	P0
-      0x8C140352,  //  0004  GETMET	R5	R1	K82
+      0x8C140354,  //  0004  GETMET	R5	R1	K84
       0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x58200053,  //  0006  LDCONST	R8	K83
+      0x58200055,  //  0006  LDCONST	R8	K85
       0x7C140600,  //  0007  CALL	R5	3
       0x78160013,  //  0008  JMPF	R5	#001D
-      0x8C180354,  //  0009  GETMET	R6	R1	K84
+      0x8C180356,  //  0009  GETMET	R6	R1	K86
       0x5C200000,  //  000A  MOVE	R8	R0
-      0x58240055,  //  000B  LDCONST	R9	K85
+      0x58240057,  //  000B  LDCONST	R9	K87
       0x7C180600,  //  000C  CALL	R6	3
       0x781A000E,  //  000D  JMPF	R6	#001D
-      0x88180155,  //  000E  GETMBR	R6	R0	K85
+      0x88180157,  //  000E  GETMBR	R6	R0	K87
       0x4C1C0000,  //  000F  LDNIL	R7
       0x20180C07,  //  0010  NE	R6	R6	R7
       0x781A0003,  //  0011  JMPF	R6	#0016
-      0x8C180556,  //  0012  GETMET	R6	R2	K86
-      0x88200155,  //  0013  GETMBR	R8	R0	K85
+      0x8C180558,  //  0012  GETMET	R6	R2	K88
+      0x88200157,  //  0013  GETMBR	R8	R0	K87
       0x7C180400,  //  0014  CALL	R6	2
       0x70020000,  //  0015  JMP		#0017
-      0x58180057,  //  0016  LDCONST	R6	K87
+      0x58180059,  //  0016  LDCONST	R6	K89
       0x601C0018,  //  0017  GETGBL	R7	G24
-      0x58200058,  //  0018  LDCONST	R8	K88
+      0x5820005A,  //  0018  LDCONST	R8	K90
       0x5C240A00,  //  0019  MOVE	R9	R5
       0x5C280C00,  //  001A  MOVE	R10	R6
       0x7C1C0600,  //  001B  CALL	R7	3
       0x000C0607,  //  001C  ADD	R3	R3	R7
       0x5C180800,  //  001D  MOVE	R6	R4
-      0x581C0059,  //  001E  LDCONST	R7	K89
-      0x5820005A,  //  001F  LDCONST	R8	K90
+      0x581C005B,  //  001E  LDCONST	R7	K91
+      0x5820005C,  //  001F  LDCONST	R8	K92
       0x7C180400,  //  0020  CALL	R6	2
       0x5C180800,  //  0021  MOVE	R6	R4
-      0x581C005B,  //  0022  LDCONST	R7	K91
-      0x5820005C,  //  0023  LDCONST	R8	K92
+      0x581C005D,  //  0022  LDCONST	R7	K93
+      0x5820005E,  //  0023  LDCONST	R8	K94
       0x7C180400,  //  0024  CALL	R6	2
       0x5C180800,  //  0025  MOVE	R6	R4
-      0x581C005D,  //  0026  LDCONST	R7	K93
-      0x5820005E,  //  0027  LDCONST	R8	K94
+      0x581C005F,  //  0026  LDCONST	R7	K95
+      0x58200060,  //  0027  LDCONST	R8	K96
       0x7C180400,  //  0028  CALL	R6	2
       0x5C180800,  //  0029  MOVE	R6	R4
-      0x581C005F,  //  002A  LDCONST	R7	K95
-      0x58200060,  //  002B  LDCONST	R8	K96
+      0x581C0061,  //  002A  LDCONST	R7	K97
+      0x58200062,  //  002B  LDCONST	R8	K98
       0x7C180400,  //  002C  CALL	R6	2
       0x5C180800,  //  002D  MOVE	R6	R4
-      0x581C0061,  //  002E  LDCONST	R7	K97
-      0x58200062,  //  002F  LDCONST	R8	K98
+      0x581C0063,  //  002E  LDCONST	R7	K99
+      0x58200064,  //  002F  LDCONST	R8	K100
       0x7C180400,  //  0030  CALL	R6	2
       0x5C180800,  //  0031  MOVE	R6	R4
-      0x581C0063,  //  0032  LDCONST	R7	K99
-      0x58200064,  //  0033  LDCONST	R8	K100
+      0x581C0065,  //  0032  LDCONST	R7	K101
+      0x58200066,  //  0033  LDCONST	R8	K102
       0x7C180400,  //  0034  CALL	R6	2
       0x5C180800,  //  0035  MOVE	R6	R4
-      0x581C0065,  //  0036  LDCONST	R7	K101
-      0x58200066,  //  0037  LDCONST	R8	K102
+      0x581C0067,  //  0036  LDCONST	R7	K103
+      0x58200068,  //  0037  LDCONST	R8	K104
       0x7C180400,  //  0038  CALL	R6	2
       0x5C180800,  //  0039  MOVE	R6	R4
-      0x581C0067,  //  003A  LDCONST	R7	K103
-      0x58200068,  //  003B  LDCONST	R8	K104
+      0x581C0069,  //  003A  LDCONST	R7	K105
+      0x5820006A,  //  003B  LDCONST	R8	K106
       0x7C180400,  //  003C  CALL	R6	2
       0x5C180800,  //  003D  MOVE	R6	R4
-      0x581C0069,  //  003E  LDCONST	R7	K105
-      0x5820006A,  //  003F  LDCONST	R8	K106
+      0x581C006B,  //  003E  LDCONST	R7	K107
+      0x5820006C,  //  003F  LDCONST	R8	K108
       0x7C180400,  //  0040  CALL	R6	2
       0x5C180800,  //  0041  MOVE	R6	R4
-      0x581C006B,  //  0042  LDCONST	R7	K107
-      0x5820006C,  //  0043  LDCONST	R8	K108
+      0x581C006D,  //  0042  LDCONST	R7	K109
+      0x5820006E,  //  0043  LDCONST	R8	K110
       0x7C180400,  //  0044  CALL	R6	2
       0x5C180800,  //  0045  MOVE	R6	R4
-      0x581C006D,  //  0046  LDCONST	R7	K109
-      0x5820006E,  //  0047  LDCONST	R8	K110
+      0x581C006F,  //  0046  LDCONST	R7	K111
+      0x58200070,  //  0047  LDCONST	R8	K112
       0x7C180400,  //  0048  CALL	R6	2
       0x5C180800,  //  0049  MOVE	R6	R4
-      0x581C006F,  //  004A  LDCONST	R7	K111
-      0x58200070,  //  004B  LDCONST	R8	K112
+      0x581C0071,  //  004A  LDCONST	R7	K113
+      0x58200072,  //  004B  LDCONST	R8	K114
       0x7C180400,  //  004C  CALL	R6	2
       0x5C180800,  //  004D  MOVE	R6	R4
-      0x581C0071,  //  004E  LDCONST	R7	K113
-      0x58200072,  //  004F  LDCONST	R8	K114
+      0x581C0073,  //  004E  LDCONST	R7	K115
+      0x58200074,  //  004F  LDCONST	R8	K116
       0x7C180400,  //  0050  CALL	R6	2
       0x5C180800,  //  0051  MOVE	R6	R4
-      0x581C0073,  //  0052  LDCONST	R7	K115
-      0x58200074,  //  0053  LDCONST	R8	K116
+      0x581C0075,  //  0052  LDCONST	R7	K117
+      0x58200076,  //  0053  LDCONST	R8	K118
       0x7C180400,  //  0054  CALL	R6	2
       0x5C180800,  //  0055  MOVE	R6	R4
-      0x581C0075,  //  0056  LDCONST	R7	K117
-      0x58200076,  //  0057  LDCONST	R8	K118
+      0x581C0077,  //  0056  LDCONST	R7	K119
+      0x58200078,  //  0057  LDCONST	R8	K120
       0x7C180400,  //  0058  CALL	R6	2
       0x5C180800,  //  0059  MOVE	R6	R4
-      0x581C0077,  //  005A  LDCONST	R7	K119
-      0x58200078,  //  005B  LDCONST	R8	K120
+      0x581C0079,  //  005A  LDCONST	R7	K121
+      0x5820007A,  //  005B  LDCONST	R8	K122
       0x7C180400,  //  005C  CALL	R6	2
       0xA0000000,  //  005D  CLOSE	R0
       0x80040600,  //  005E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_response
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Device_parse_http_response,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Device,     /* shared constants */
+    be_str_weak(parse_http_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x7812000A,  //  0001  JMPF	R4	#000D
+      0x8810011C,  //  0002  GETMBR	R4	R0	K28
+      0x8810094B,  //  0003  GETMBR	R4	R4	K75
+      0x90029604,  //  0004  SETMBR	R0	K75	R4
+      0x88100101,  //  0005  GETMBR	R4	R0	K1
+      0x8C10097B,  //  0006  GETMET	R4	R4	K123
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x5C200600,  //  0009  MOVE	R8	R3
+      0x5C240000,  //  000A  MOVE	R9	R0
+      0x8828017C,  //  000B  GETMBR	R10	R0	K124
+      0x7C100C00,  //  000C  CALL	R4	6
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -1285,7 +1327,7 @@ be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
     be_str_weak(_parse_sensor_entry),
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8C1C0336,  //  0000  GETMET	R7	R1	K54
+      0x8C1C031A,  //  0000  GETMET	R7	R1	K26
       0x5C240400,  //  0001  MOVE	R9	R2
       0x7C1C0400,  //  0002  CALL	R7	2
       0x4C200000,  //  0003  LDNIL	R8
@@ -1297,7 +1339,7 @@ be_local_closure(class_Matter_Plugin_Device__parse_sensor_entry,   /* name */
       0x5C1C1000,  //  0009  MOVE	R7	R8
       0x20200E03,  //  000A  NE	R8	R7	R3
       0x78220003,  //  000B  JMPF	R8	#0010
-      0x8C200179,  //  000C  GETMET	R8	R0	K121
+      0x8C20017D,  //  000C  GETMET	R8	R0	K125
       0x5C280A00,  //  000D  MOVE	R10	R5
       0x5C2C0C00,  //  000E  MOVE	R11	R6
       0x7C200600,  //  000F  CALL	R8	3
@@ -1316,23 +1358,42 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Device,
     1,
     &be_class_Matter_Plugin,
-    be_nested_map(24,
+    be_nested_map(25,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(ARG_HTTP, -1), be_nested_str_weak(url) },
+        { be_const_key_weak(every_250ms, 10), be_const_closure(class_Matter_Plugin_Device_every_250ms_closure) },
         { be_const_key_weak(_parse_sensor_entry, -1), be_const_closure(class_Matter_Plugin_Device__parse_sensor_entry_closure) },
-        { be_const_key_weak(TYPES, 14), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(web_values, -1), be_const_closure(class_Matter_Plugin_Device_web_values_closure) },
+        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Device_parse_status_closure) },
+        { be_const_key_weak(call_remote_sync, 7), be_const_closure(class_Matter_Plugin_Device_call_remote_sync_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Device_init_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Device_invoke_request_closure) },
+        { be_const_key_weak(PREFIX, -1), be_nested_str_weak(_X7C_X20_X3Ci_X3E_X25s_X3C_X2Fi_X3E_X20) },
+        { be_const_key_weak(http_remote, -1), be_const_var(0) },
+        { be_const_key_weak(UPDATE_CMD, -1), be_nested_str_weak(Status_X2011) },
+        { be_const_key_weak(web_value_onoff, -1), be_const_closure(class_Matter_Plugin_Device_web_value_onoff_closure) },
+        { be_const_key_weak(GetOptionReader, -1), be_const_class(be_class_GetOptionReader) },
+        { be_const_key_weak(read_attribute, 6), be_const_closure(class_Matter_Plugin_Device_read_attribute_closure) },
+        { be_const_key_weak(NON_BRIDGE_VENDOR, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(2,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(4631),
+        be_const_int(4993),
+    }))    ) } )) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Device_update_shadow_closure) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(19, -1), be_const_int(1) },
     }))    ) } )) },
-        { be_const_key_weak(parse_status, 12), be_const_closure(class_Matter_Plugin_Device_parse_status_closure) },
-        { be_const_key_weak(http_remote, -1), be_const_var(0) },
-        { be_const_key_weak(register_cmd_cb, 6), be_const_closure(class_Matter_Plugin_Device_register_cmd_cb_closure) },
-        { be_const_key_weak(GetOptionReader, 16), be_const_class(be_class_GetOptionReader) },
-        { be_const_key_weak(append_state_json, 19), be_const_closure(class_Matter_Plugin_Device_append_state_json_closure) },
-        { be_const_key_weak(web_values, 22), be_const_closure(class_Matter_Plugin_Device_web_values_closure) },
-        { be_const_key_weak(PREFIX, -1), be_nested_str_weak(_X7C_X20_X3Ci_X3E_X25s_X3C_X2Fi_X3E_X20) },
-        { be_const_key_weak(CLUSTERS, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(register_cmd_cb, -1), be_const_closure(class_Matter_Plugin_Device_register_cmd_cb_closure) },
+        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Device_web_values_prefix_closure) },
+        { be_const_key_weak(PROBE_TIMEOUT, 13), be_const_int(1700) },
+        { be_const_key_weak(parse_configuration, 16), be_const_closure(class_Matter_Plugin_Device_parse_configuration_closure) },
+        { be_const_key_weak(ARG_HTTP, -1), be_nested_str_weak(url) },
+        { be_const_key_weak(append_state_json, -1), be_const_closure(class_Matter_Plugin_Device_append_state_json_closure) },
+        { be_const_key_weak(parse_http_response, -1), be_const_closure(class_Matter_Plugin_Device_parse_http_response_closure) },
+        { be_const_key_weak(SYNC_TIMEOUT, -1), be_const_int(500) },
+        { be_const_key_weak(CLUSTERS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(5, -1), be_const_bytes_instance(000000010002000300040005FFF8FFF9FFFAFFFBFFFCFFFD) },
@@ -1340,24 +1401,6 @@ be_local_class(Matter_Plugin_Device,
         { be_const_key_int(57, -1), be_const_bytes_instance(00030005000A000F00110012FFF8FFF9FFFAFFFBFFFCFFFD) },
         { be_const_key_int(3, -1), be_const_bytes_instance(00000001FFF8FFF9FFFAFFFBFFFCFFFD) },
         { be_const_key_int(4, 1), be_const_bytes_instance(0000FFF8FFF9FFFAFFFBFFFCFFFD) },
-    }))    ) } )) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Plugin_Device_invoke_request_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Device_init_closure) },
-        { be_const_key_weak(PROBE_TIMEOUT, 20), be_const_int(1700) },
-        { be_const_key_weak(SYNC_TIMEOUT, -1), be_const_int(500) },
-        { be_const_key_weak(UPDATE_CMD, -1), be_nested_str_weak(Status_X2011) },
-        { be_const_key_weak(parse_http_response, -1), be_const_closure(class_Matter_Plugin_Device_parse_http_response_closure) },
-        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Device_web_values_prefix_closure) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(class_Matter_Plugin_Device_read_attribute_closure) },
-        { be_const_key_weak(call_remote_sync, 21), be_const_closure(class_Matter_Plugin_Device_call_remote_sync_closure) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(class_Matter_Plugin_Device_update_shadow_closure) },
-        { be_const_key_weak(web_value_onoff, -1), be_const_closure(class_Matter_Plugin_Device_web_value_onoff_closure) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(class_Matter_Plugin_Device_every_250ms_closure) },
-        { be_const_key_weak(NON_BRIDGE_VENDOR, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(2,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(4631),
-        be_const_int(4993),
     }))    ) } )) },
     })),
     be_str_weak(Matter_Plugin_Device)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor.h
@@ -3,48 +3,112 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'Matter_Plugin_Sensor' ktab size: 36, total: 53 (saved 136 bytes)
-static const bvalue be_ktab_class_Matter_Plugin_Sensor[36] = {
-  /* K0   */  be_nested_str_weak(contains),
-  /* K1   */  be_nested_str_weak(TempUnit),
-  /* K2   */  be_nested_str_weak(temp_unit),
-  /* K3   */  be_nested_str_weak(PressureUnit),
-  /* K4   */  be_nested_str_weak(pressure_unit),
-  /* K5   */  be_nested_str_weak(tasmota_sensor_matcher),
-  /* K6   */  be_nested_str_weak(pre_value),
-  /* K7   */  be_nested_str_weak(match),
-  /* K8   */  be_nested_str_weak(shadow_value),
-  /* K9   */  be_nested_str_weak(value_changed),
-  /* K10  */  be_nested_str_weak(tasmota_sensor_filter),
-  /* K11  */  be_nested_str_weak(find),
-  /* K12  */  be_nested_str_weak(ARG),
-  /* K13  */  be_nested_str_weak(tasmota),
-  /* K14  */  be_nested_str_weak(Rule_Matcher),
-  /* K15  */  be_nested_str_weak(parse),
-  /* K16  */  be_nested_str_weak(TEMP_C),
-  /* K17  */  be_nested_str_weak(PRESSURE_HPA),
-  /* K18  */  be_nested_str_weak(VIRTUAL),
-  /* K19  */  be_nested_str_weak(JSON_NAME),
-  /* K20  */  be_nested_str_weak(init),
-  /* K21  */  be_nested_str_weak(add_read_sensors_schedule),
-  /* K22  */  be_nested_str_weak(UPDATE_TIME),
-  /* K23  */  be_nested_str_weak(string),
-  /* K24  */  be_nested_str_weak(webserver),
-  /* K25  */  be_nested_str_weak(html_escape),
-  /* K26  */  be_nested_str_weak(split),
-  /* K27  */  be_nested_str_weak(_X23),
-  /* K28  */  be_const_int(0),
-  /* K29  */  be_nested_str_weak(),
-  /* K30  */  be_nested_str_weak(get_name),
-  /* K31  */  be_nested_str_weak(filter_name_html),
-  /* K32  */  be_nested_str_weak(content_send),
-  /* K33  */  be_nested_str_weak(PREFIX),
-  /* K34  */  be_nested_str_weak(bool),
-  /* K35  */  be_nested_str_weak(update_virtual),
+// compact class 'Matter_Plugin_Sensor' ktab size: 49, total: 70 (saved 168 bytes)
+static const bvalue be_ktab_class_Matter_Plugin_Sensor[49] = {
+  /* K0   */  be_nested_str_weak(find),
+  /* K1   */  be_nested_str_weak(JSON_NAME),
+  /* K2   */  be_nested_str_weak(bool),
+  /* K3   */  be_nested_str_weak(shadow_value),
+  /* K4   */  be_nested_str_weak(value_changed),
+  /* K5   */  be_nested_str_weak(update_virtual),
+  /* K6   */  be_nested_str_weak(contains),
+  /* K7   */  be_nested_str_weak(TempUnit),
+  /* K8   */  be_nested_str_weak(temp_unit),
+  /* K9   */  be_nested_str_weak(PressureUnit),
+  /* K10  */  be_nested_str_weak(pressure_unit),
+  /* K11  */  be_nested_str_weak(tasmota_sensor_matcher),
+  /* K12  */  be_nested_str_weak(pre_value),
+  /* K13  */  be_nested_str_weak(match),
+  /* K14  */  be_nested_str_weak(tasmota_sensor_filter),
+  /* K15  */  be_nested_str_weak(string),
+  /* K16  */  be_nested_str_weak(webserver),
+  /* K17  */  be_nested_str_weak(html_escape),
+  /* K18  */  be_nested_str_weak(split),
+  /* K19  */  be_nested_str_weak(_X23),
+  /* K20  */  be_const_int(0),
+  /* K21  */  be_nested_str_weak(),
+  /* K22  */  be_nested_str_weak(init),
+  /* K23  */  be_nested_str_weak(add_read_sensors_schedule),
+  /* K24  */  be_nested_str_weak(UPDATE_TIME),
+  /* K25  */  be_nested_str_weak(get_name),
+  /* K26  */  be_nested_str_weak(filter_name_html),
+  /* K27  */  be_nested_str_weak(content_send),
+  /* K28  */  be_nested_str_weak(PREFIX),
+  /* K29  */  be_nested_str_weak(parse_configuration),
+  /* K30  */  be_nested_str_weak(ARG),
+  /* K31  */  be_nested_str_weak(tasmota),
+  /* K32  */  be_nested_str_weak(Rule_Matcher),
+  /* K33  */  be_nested_str_weak(parse),
+  /* K34  */  be_nested_str_weak(TEMP_C),
+  /* K35  */  be_nested_str_weak(PRESSURE_HPA),
+  /* K36  */  be_nested_str_weak(VIRTUAL),
+  /* K37  */  be_nested_str_weak(math),
+  /* K38  */  be_nested_str_weak(log),
+  /* K39  */  be_nested_str_weak(MTR_X3A_X20zigbee_received_X20Ox_X2504X_X20attr_list_X3D_X25s_X20type_X28attr_list_X29_X3D_X25s),
+  /* K40  */  be_nested_str_weak(zigbee_mapper),
+  /* K41  */  be_nested_str_weak(shortaddr),
+  /* K42  */  be_const_int(3),
+  /* K43  */  be_nested_str_weak(key),
+  /* K44  */  be_nested_str_weak(ZIGBEE_NAME),
+  /* K45  */  be_nested_str_weak(val),
+  /* K46  */  be_nested_str_weak(MTR_X3A_X20_X5B_X2502X_X5D_X20_X25s_X20updated_X20_X25s),
+  /* K47  */  be_nested_str_weak(endpoint),
+  /* K48  */  be_const_int(1),
 };
 
 
 extern const bclass be_class_Matter_Plugin_Sensor;
+
+/********************************************************************
+** Solidified function: update_virtual
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
+    be_str_weak(update_virtual),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x200C0403,  //  0004  NE	R3	R2	R3
+      0x780E000E,  //  0005  JMPF	R3	#0015
+      0x600C0004,  //  0006  GETGBL	R3	G4
+      0x5C100400,  //  0007  MOVE	R4	R2
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x1C0C0702,  //  0009  EQ	R3	R3	K2
+      0x780E0003,  //  000A  JMPF	R3	#000F
+      0x600C0009,  //  000B  GETGBL	R3	G9
+      0x5C100400,  //  000C  MOVE	R4	R2
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x5C080600,  //  000E  MOVE	R2	R3
+      0x880C0103,  //  000F  GETMBR	R3	R0	K3
+      0x200C0602,  //  0010  NE	R3	R3	R2
+      0x780E0002,  //  0011  JMPF	R3	#0015
+      0x8C0C0104,  //  0012  GETMET	R3	R0	K4
+      0x7C0C0200,  //  0013  CALL	R3	1
+      0x90020602,  //  0014  SETMBR	R0	K3	R2
+      0x600C0003,  //  0015  GETGBL	R3	G3
+      0x5C100000,  //  0016  MOVE	R4	R0
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x8C0C0705,  //  0018  GETMET	R3	R3	K5
+      0x5C140200,  //  0019  MOVE	R5	R1
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: parse_status
@@ -66,24 +130,24 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
       0x540E0009,  //  0000  LDINT	R3	10
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E001E,  //  0002  JMPF	R3	#0022
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x58140001,  //  0004  LDCONST	R5	K1
+      0x8C0C0306,  //  0003  GETMET	R3	R1	K6
+      0x58140007,  //  0004  LDCONST	R5	K7
       0x7C0C0400,  //  0005  CALL	R3	2
       0x780E0001,  //  0006  JMPF	R3	#0009
-      0x940C0301,  //  0007  GETIDX	R3	R1	K1
-      0x90020403,  //  0008  SETMBR	R0	K2	R3
-      0x8C0C0300,  //  0009  GETMET	R3	R1	K0
-      0x58140003,  //  000A  LDCONST	R5	K3
+      0x940C0307,  //  0007  GETIDX	R3	R1	K7
+      0x90021003,  //  0008  SETMBR	R0	K8	R3
+      0x8C0C0306,  //  0009  GETMET	R3	R1	K6
+      0x58140009,  //  000A  LDCONST	R5	K9
       0x7C0C0400,  //  000B  CALL	R3	2
       0x780E0001,  //  000C  JMPF	R3	#000F
-      0x940C0303,  //  000D  GETIDX	R3	R1	K3
-      0x90020803,  //  000E  SETMBR	R0	K4	R3
-      0x880C0105,  //  000F  GETMBR	R3	R0	K5
+      0x940C0309,  //  000D  GETIDX	R3	R1	K9
+      0x90021403,  //  000E  SETMBR	R0	K10	R3
+      0x880C010B,  //  000F  GETMBR	R3	R0	K11
       0x780E0010,  //  0010  JMPF	R3	#0022
-      0x8C0C0106,  //  0011  GETMET	R3	R0	K6
+      0x8C0C010C,  //  0011  GETMET	R3	R0	K12
       0x6014000A,  //  0012  GETGBL	R5	G10
-      0x88180105,  //  0013  GETMBR	R6	R0	K5
-      0x8C180D07,  //  0014  GETMET	R6	R6	K7
+      0x8818010B,  //  0013  GETMBR	R6	R0	K11
+      0x8C180D0D,  //  0014  GETMET	R6	R6	K13
       0x5C200200,  //  0015  MOVE	R8	R1
       0x7C180400,  //  0016  CALL	R6	2
       0x7C140200,  //  0017  CALL	R5	1
@@ -91,53 +155,13 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_status,   /* name */
       0x4C100000,  //  0019  LDNIL	R4
       0x20100604,  //  001A  NE	R4	R3	R4
       0x78120005,  //  001B  JMPF	R4	#0022
-      0x88100108,  //  001C  GETMBR	R4	R0	K8
+      0x88100103,  //  001C  GETMBR	R4	R0	K3
       0x20100604,  //  001D  NE	R4	R3	R4
       0x78120002,  //  001E  JMPF	R4	#0022
-      0x8C100109,  //  001F  GETMET	R4	R0	K9
+      0x8C100104,  //  001F  GETMET	R4	R0	K4
       0x7C100200,  //  0020  CALL	R4	1
-      0x90021003,  //  0021  SETMBR	R0	K8	R3
+      0x90020603,  //  0021  SETMBR	R0	K3	R3
       0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_configuration
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
-    be_str_weak(parse_configuration),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x8C08030B,  //  0000  GETMET	R2	R1	K11
-      0x8810010C,  //  0001  GETMBR	R4	R0	K12
-      0x7C080400,  //  0002  CALL	R2	2
-      0x90021402,  //  0003  SETMBR	R0	K10	R2
-      0x8808010A,  //  0004  GETMBR	R2	R0	K10
-      0x780A0005,  //  0005  JMPF	R2	#000C
-      0xB80A1A00,  //  0006  GETNGBL	R2	K13
-      0x8808050E,  //  0007  GETMBR	R2	R2	K14
-      0x8C08050F,  //  0008  GETMET	R2	R2	K15
-      0x8810010A,  //  0009  GETMBR	R4	R0	K10
-      0x7C080400,  //  000A  CALL	R2	2
-      0x90020A02,  //  000B  SETMBR	R0	K5	R2
-      0x88080110,  //  000C  GETMBR	R2	R0	K16
-      0x90020402,  //  000D  SETMBR	R0	K2	R2
-      0x88080111,  //  000E  GETMBR	R2	R0	K17
-      0x90020802,  //  000F  SETMBR	R0	K4	R2
-      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -169,12 +193,12 @@ be_local_closure(class_Matter_Plugin_Sensor_pre_value,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_sensors
+** Solidified function: filter_name_html
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
+be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
+    9,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -182,42 +206,22 @@ be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
-    be_str_weak(parse_sensors),
+    be_str_weak(filter_name_html),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x88080112,  //  0000  GETMBR	R2	R0	K18
-      0x740A001D,  //  0001  JMPT	R2	#0020
-      0x88080105,  //  0002  GETMBR	R2	R0	K5
-      0x780A001B,  //  0003  JMPF	R2	#0020
-      0x88080105,  //  0004  GETMBR	R2	R0	K5
-      0x8C080507,  //  0005  GETMET	R2	R2	K7
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x600C000F,  //  0008  GETGBL	R3	G15
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x60140013,  //  000A  GETGBL	R5	G19
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E0003,  //  000C  JMPF	R3	#0011
-      0x8C0C050B,  //  000D  GETMET	R3	R2	K11
-      0x88140113,  //  000E  GETMBR	R5	R0	K19
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x5C080600,  //  0010  MOVE	R2	R3
-      0x8C0C0106,  //  0011  GETMET	R3	R0	K6
-      0x6014000A,  //  0012  GETGBL	R5	G10
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C140200,  //  0014  CALL	R5	1
-      0x7C0C0400,  //  0015  CALL	R3	2
-      0x5C080600,  //  0016  MOVE	R2	R3
-      0x4C0C0000,  //  0017  LDNIL	R3
-      0x200C0403,  //  0018  NE	R3	R2	R3
-      0x780E0005,  //  0019  JMPF	R3	#0020
-      0x880C0108,  //  001A  GETMBR	R3	R0	K8
-      0x200C0403,  //  001B  NE	R3	R2	R3
-      0x780E0002,  //  001C  JMPF	R3	#0020
-      0x8C0C0109,  //  001D  GETMET	R3	R0	K9
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x90021002,  //  001F  SETMBR	R0	K8	R2
-      0x80000000,  //  0020  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x8804010E,  //  0000  GETMBR	R1	R0	K14
+      0x78060009,  //  0001  JMPF	R1	#000C
+      0xA4061E00,  //  0002  IMPORT	R1	K15
+      0xA40A2000,  //  0003  IMPORT	R2	K16
+      0x8C0C0511,  //  0004  GETMET	R3	R2	K17
+      0x8C140312,  //  0005  GETMET	R5	R1	K18
+      0x881C010E,  //  0006  GETMBR	R7	R0	K14
+      0x58200013,  //  0007  LDCONST	R8	K19
+      0x7C140600,  //  0008  CALL	R5	3
+      0x94140B14,  //  0009  GETIDX	R5	R5	K20
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x80040600,  //  000B  RET	1	R3
+      0x80062A00,  //  000C  RET	1	K21
     })
   )
 );
@@ -268,51 +272,15 @@ be_local_closure(class_Matter_Plugin_Sensor_init,   /* name */
       0x60100003,  //  0000  GETGBL	R4	G3
       0x5C140000,  //  0001  MOVE	R5	R0
       0x7C100200,  //  0002  CALL	R4	1
-      0x8C100914,  //  0003  GETMET	R4	R4	K20
+      0x8C100916,  //  0003  GETMET	R4	R4	K22
       0x5C180200,  //  0004  MOVE	R6	R1
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x5C200600,  //  0006  MOVE	R8	R3
       0x7C100800,  //  0007  CALL	R4	4
-      0x8C100315,  //  0008  GETMET	R4	R1	K21
-      0x88180116,  //  0009  GETMBR	R6	R0	K22
+      0x8C100317,  //  0008  GETMET	R4	R1	K23
+      0x88180118,  //  0009  GETMBR	R6	R0	K24
       0x7C100400,  //  000A  CALL	R4	2
       0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: filter_name_html
-********************************************************************/
-be_local_closure(class_Matter_Plugin_Sensor_filter_name_html,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
-    be_str_weak(filter_name_html),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8804010A,  //  0000  GETMBR	R1	R0	K10
-      0x78060009,  //  0001  JMPF	R1	#000C
-      0xA4062E00,  //  0002  IMPORT	R1	K23
-      0xA40A3000,  //  0003  IMPORT	R2	K24
-      0x8C0C0519,  //  0004  GETMET	R3	R2	K25
-      0x8C14031A,  //  0005  GETMET	R5	R1	K26
-      0x881C010A,  //  0006  GETMBR	R7	R0	K10
-      0x5820001B,  //  0007  LDCONST	R8	K27
-      0x7C140600,  //  0008  CALL	R5	3
-      0x94140B1C,  //  0009  GETIDX	R5	R5	K28
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x80040600,  //  000B  RET	1	R3
-      0x80063A00,  //  000C  RET	1	K29
     })
   )
 );
@@ -336,23 +304,23 @@ be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0xA4063000,  //  0000  IMPORT	R1	K24
-      0x8C08011E,  //  0001  GETMET	R2	R0	K30
+      0xA4062000,  //  0000  IMPORT	R1	K16
+      0x8C080119,  //  0001  GETMET	R2	R0	K25
       0x7C080200,  //  0002  CALL	R2	1
       0x5C0C0400,  //  0003  MOVE	R3	R2
       0x740E0002,  //  0004  JMPT	R3	#0008
-      0x8C0C011F,  //  0005  GETMET	R3	R0	K31
+      0x8C0C011A,  //  0005  GETMET	R3	R0	K26
       0x7C0C0200,  //  0006  CALL	R3	1
       0x5C080600,  //  0007  MOVE	R2	R3
-      0x8C0C0320,  //  0008  GETMET	R3	R1	K32
+      0x8C0C031B,  //  0008  GETMET	R3	R1	K27
       0x60140018,  //  0009  GETGBL	R5	G24
-      0x88180121,  //  000A  GETMBR	R6	R0	K33
+      0x8818011C,  //  000A  GETMBR	R6	R0	K28
       0x780A0003,  //  000B  JMPF	R2	#0010
-      0x8C1C0319,  //  000C  GETMET	R7	R1	K25
+      0x8C1C0311,  //  000C  GETMET	R7	R1	K17
       0x5C240400,  //  000D  MOVE	R9	R2
       0x7C1C0400,  //  000E  CALL	R7	2
       0x70020000,  //  000F  JMP		#0011
-      0x581C001D,  //  0010  LDCONST	R7	K29
+      0x581C0015,  //  0010  LDCONST	R7	K21
       0x7C140400,  //  0011  CALL	R5	2
       0x7C0C0400,  //  0012  CALL	R3	2
       0x80000000,  //  0013  RET	0
@@ -363,11 +331,11 @@ be_local_closure(class_Matter_Plugin_Sensor_web_values_prefix,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_virtual
+** Solidified function: parse_configuration
 ********************************************************************/
-be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
+be_local_closure(class_Matter_Plugin_Sensor_parse_configuration,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -376,37 +344,159 @@ be_local_closure(class_Matter_Plugin_Sensor_update_virtual,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
-    be_str_weak(update_virtual),
+    be_str_weak(parse_configuration),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x8C08030B,  //  0000  GETMET	R2	R1	K11
-      0x88100113,  //  0001  GETMBR	R4	R0	K19
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x200C0403,  //  0004  NE	R3	R2	R3
-      0x780E000E,  //  0005  JMPF	R3	#0015
-      0x600C0004,  //  0006  GETGBL	R3	G4
-      0x5C100400,  //  0007  MOVE	R4	R2
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x1C0C0722,  //  0009  EQ	R3	R3	K34
-      0x780E0003,  //  000A  JMPF	R3	#000F
-      0x600C0009,  //  000B  GETGBL	R3	G9
-      0x5C100400,  //  000C  MOVE	R4	R2
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x5C080600,  //  000E  MOVE	R2	R3
-      0x880C0108,  //  000F  GETMBR	R3	R0	K8
-      0x200C0602,  //  0010  NE	R3	R3	R2
-      0x780E0002,  //  0011  JMPF	R3	#0015
-      0x8C0C0109,  //  0012  GETMET	R3	R0	K9
-      0x7C0C0200,  //  0013  CALL	R3	1
-      0x90021002,  //  0014  SETMBR	R0	K8	R2
-      0x600C0003,  //  0015  GETGBL	R3	G3
-      0x5C100000,  //  0016  MOVE	R4	R0
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x8C0C0723,  //  0018  GETMET	R3	R3	K35
-      0x5C140200,  //  0019  MOVE	R5	R1
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x80000000,  //  001B  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051D,  //  0003  GETMET	R2	R2	K29
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080300,  //  0006  GETMET	R2	R1	K0
+      0x8810011E,  //  0007  GETMBR	R4	R0	K30
+      0x7C080400,  //  0008  CALL	R2	2
+      0x90021C02,  //  0009  SETMBR	R0	K14	R2
+      0x8808010E,  //  000A  GETMBR	R2	R0	K14
+      0x780A0005,  //  000B  JMPF	R2	#0012
+      0xB80A3E00,  //  000C  GETNGBL	R2	K31
+      0x88080520,  //  000D  GETMBR	R2	R2	K32
+      0x8C080521,  //  000E  GETMET	R2	R2	K33
+      0x8810010E,  //  000F  GETMBR	R4	R0	K14
+      0x7C080400,  //  0010  CALL	R2	2
+      0x90021602,  //  0011  SETMBR	R0	K11	R2
+      0x88080122,  //  0012  GETMBR	R2	R0	K34
+      0x90021002,  //  0013  SETMBR	R0	K8	R2
+      0x88080123,  //  0014  GETMBR	R2	R0	K35
+      0x90021402,  //  0015  SETMBR	R0	K10	R2
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_sensors
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Sensor_parse_sensors,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
+    be_str_weak(parse_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x88080124,  //  0000  GETMBR	R2	R0	K36
+      0x740A001D,  //  0001  JMPT	R2	#0020
+      0x8808010B,  //  0002  GETMBR	R2	R0	K11
+      0x780A001B,  //  0003  JMPF	R2	#0020
+      0x8808010B,  //  0004  GETMBR	R2	R0	K11
+      0x8C08050D,  //  0005  GETMET	R2	R2	K13
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x600C000F,  //  0008  GETGBL	R3	G15
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x60140013,  //  000A  GETGBL	R5	G19
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x780E0003,  //  000C  JMPF	R3	#0011
+      0x8C0C0500,  //  000D  GETMET	R3	R2	K0
+      0x88140101,  //  000E  GETMBR	R5	R0	K1
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x5C080600,  //  0010  MOVE	R2	R3
+      0x8C0C010C,  //  0011  GETMET	R3	R0	K12
+      0x6014000A,  //  0012  GETGBL	R5	G10
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C140200,  //  0014  CALL	R5	1
+      0x7C0C0400,  //  0015  CALL	R3	2
+      0x5C080600,  //  0016  MOVE	R2	R3
+      0x4C0C0000,  //  0017  LDNIL	R3
+      0x200C0403,  //  0018  NE	R3	R2	R3
+      0x780E0005,  //  0019  JMPF	R3	#0020
+      0x880C0103,  //  001A  GETMBR	R3	R0	K3
+      0x200C0403,  //  001B  NE	R3	R2	R3
+      0x780E0002,  //  001C  JMPF	R3	#0020
+      0x8C0C0104,  //  001D  GETMET	R3	R0	K4
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x90020602,  //  001F  SETMBR	R0	K3	R2
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: zigbee_received
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Sensor_zigbee_received,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Plugin_Sensor,     /* shared constants */
+    be_str_weak(zigbee_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0xA40E4A00,  //  0000  IMPORT	R3	K37
+      0xB8124C00,  //  0001  GETNGBL	R4	K38
+      0x60140018,  //  0002  GETGBL	R5	G24
+      0x58180027,  //  0003  LDCONST	R6	K39
+      0x881C0128,  //  0004  GETMBR	R7	R0	K40
+      0x881C0F29,  //  0005  GETMBR	R7	R7	K41
+      0x5C200400,  //  0006  MOVE	R8	R2
+      0x60240004,  //  0007  GETGBL	R9	G4
+      0x5C280400,  //  0008  MOVE	R10	R2
+      0x7C240200,  //  0009  CALL	R9	1
+      0x7C140800,  //  000A  CALL	R5	4
+      0x5818002A,  //  000B  LDCONST	R6	K42
+      0x7C100400,  //  000C  CALL	R4	2
+      0x58100014,  //  000D  LDCONST	R4	K20
+      0x6014000C,  //  000E  GETGBL	R5	G12
+      0x5C180400,  //  000F  MOVE	R6	R2
+      0x7C140200,  //  0010  CALL	R5	1
+      0x14140805,  //  0011  LT	R5	R4	R5
+      0x7816001B,  //  0012  JMPF	R5	#002F
+      0x94140404,  //  0013  GETIDX	R5	R2	R4
+      0x88180B2B,  //  0014  GETMBR	R6	R5	K43
+      0x881C012C,  //  0015  GETMBR	R7	R0	K44
+      0x1C180C07,  //  0016  EQ	R6	R6	R7
+      0x781A0014,  //  0017  JMPF	R6	#002D
+      0x8C18010C,  //  0018  GETMET	R6	R0	K12
+      0x88200B2D,  //  0019  GETMBR	R8	R5	K45
+      0x7C180400,  //  001A  CALL	R6	2
+      0x601C0013,  //  001B  GETGBL	R7	G19
+      0x7C1C0000,  //  001C  CALL	R7	0
+      0x88200101,  //  001D  GETMBR	R8	R0	K1
+      0x981C1006,  //  001E  SETIDX	R7	R8	R6
+      0x8C200105,  //  001F  GETMET	R8	R0	K5
+      0x5C280E00,  //  0020  MOVE	R10	R7
+      0x7C200400,  //  0021  CALL	R8	2
+      0xB8224C00,  //  0022  GETNGBL	R8	K38
+      0x60240018,  //  0023  GETGBL	R9	G24
+      0x5828002E,  //  0024  LDCONST	R10	K46
+      0x882C012F,  //  0025  GETMBR	R11	R0	K47
+      0x88300101,  //  0026  GETMBR	R12	R0	K1
+      0x5C340E00,  //  0027  MOVE	R13	R7
+      0x7C240800,  //  0028  CALL	R9	4
+      0x5828002A,  //  0029  LDCONST	R10	K42
+      0x7C200400,  //  002A  CALL	R8	2
+      0x4C200000,  //  002B  LDNIL	R8
+      0x80041000,  //  002C  RET	1	R8
+      0x00100930,  //  002D  ADD	R4	R4	K48
+      0x7001FFDE,  //  002E  JMP		#000E
+      0x80000000,  //  002F  RET	0
     })
   )
 );
@@ -420,32 +510,33 @@ extern const bclass be_class_Matter_Plugin_Device;
 be_local_class(Matter_Plugin_Sensor,
     5,
     &be_class_Matter_Plugin_Device,
-    be_nested_map(24,
+    be_nested_map(25,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
-        { be_const_key_weak(TEMP_C, -1), be_nested_str_weak(C) },
-        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
-        { be_const_key_weak(shadow_value, 19), be_const_var(2) },
-        { be_const_key_weak(PRESSURE_MMHG, -1), be_nested_str_weak(mmHg) },
-        { be_const_key_weak(parse_status, -1), be_const_closure(class_Matter_Plugin_Sensor_parse_status_closure) },
-        { be_const_key_weak(TEMP_F, -1), be_nested_str_weak(F) },
-        { be_const_key_weak(update_virtual, -1), be_const_closure(class_Matter_Plugin_Sensor_update_virtual_closure) },
-        { be_const_key_weak(pre_value, 7), be_const_closure(class_Matter_Plugin_Sensor_pre_value_closure) },
-        { be_const_key_weak(ARG_HINT, 14), be_nested_str_weak(Filter_X20pattern) },
-        { be_const_key_weak(tasmota_sensor_filter, 6), be_const_var(0) },
-        { be_const_key_weak(UPDATE_CMD, -1), be_nested_str_weak(Status_X2010) },
-        { be_const_key_weak(parse_sensors, -1), be_const_closure(class_Matter_Plugin_Sensor_parse_sensors_closure) },
-        { be_const_key_weak(parse_configuration, 20), be_const_closure(class_Matter_Plugin_Sensor_parse_configuration_closure) },
-        { be_const_key_weak(PRESSURE_INHG, -1), be_nested_str_weak(inHg) },
-        { be_const_key_weak(ARG, 11), be_nested_str_weak(filter) },
-        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Sensor_web_values_prefix_closure) },
-        { be_const_key_weak(filter_name_html, 16), be_const_closure(class_Matter_Plugin_Sensor_filter_name_html_closure) },
-        { be_const_key_weak(PRESSURE_HPA, -1), be_nested_str_weak(hPa) },
-        { be_const_key_weak(init, 5), be_const_closure(class_Matter_Plugin_Sensor_init_closure) },
-        { be_const_key_weak(value_changed, 21), be_const_closure(class_Matter_Plugin_Sensor_value_changed_closure) },
-        { be_const_key_weak(pressure_unit, -1), be_const_var(4) },
-        { be_const_key_weak(temp_unit, -1), be_const_var(3) },
         { be_const_key_weak(JSON_NAME, -1), be_nested_str_weak() },
+        { be_const_key_weak(pre_value, -1), be_const_closure(class_Matter_Plugin_Sensor_pre_value_closure) },
+        { be_const_key_weak(zigbee_received, -1), be_const_closure(class_Matter_Plugin_Sensor_zigbee_received_closure) },
+        { be_const_key_weak(parse_status, 2), be_const_closure(class_Matter_Plugin_Sensor_parse_status_closure) },
+        { be_const_key_weak(TEMP_C, -1), be_nested_str_weak(C) },
+        { be_const_key_weak(temp_unit, 23), be_const_var(3) },
+        { be_const_key_weak(UPDATE_TIME, 10), be_const_int(5000) },
+        { be_const_key_weak(TEMP_F, -1), be_nested_str_weak(F) },
+        { be_const_key_weak(pressure_unit, -1), be_const_var(4) },
+        { be_const_key_weak(UPDATE_CMD, -1), be_nested_str_weak(Status_X2010) },
+        { be_const_key_weak(tasmota_sensor_filter, 1), be_const_var(0) },
+        { be_const_key_weak(value_changed, 7), be_const_closure(class_Matter_Plugin_Sensor_value_changed_closure) },
+        { be_const_key_weak(PRESSURE_INHG, -1), be_nested_str_weak(inHg) },
+        { be_const_key_weak(parse_configuration, 22), be_const_closure(class_Matter_Plugin_Sensor_parse_configuration_closure) },
+        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
+        { be_const_key_weak(update_virtual, 14), be_const_closure(class_Matter_Plugin_Sensor_update_virtual_closure) },
+        { be_const_key_weak(PRESSURE_MMHG, -1), be_nested_str_weak(mmHg) },
+        { be_const_key_weak(web_values_prefix, -1), be_const_closure(class_Matter_Plugin_Sensor_web_values_prefix_closure) },
+        { be_const_key_weak(shadow_value, -1), be_const_var(2) },
+        { be_const_key_weak(filter_name_html, 13), be_const_closure(class_Matter_Plugin_Sensor_filter_name_html_closure) },
+        { be_const_key_weak(ARG_HINT, 12), be_nested_str_weak(Filter_X20pattern) },
+        { be_const_key_weak(parse_sensors, -1), be_const_closure(class_Matter_Plugin_Sensor_parse_sensors_closure) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak(filter) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Plugin_Sensor_init_closure) },
+        { be_const_key_weak(PRESSURE_HPA, -1), be_nested_str_weak(hPa) },
     })),
     be_str_weak(Matter_Plugin_Sensor)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Humidity.h
@@ -1,0 +1,58 @@
+/* Solidification of Matter_Plugin_9_Zigbee_Humidity.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Zigbee_Humidity;
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Zigbee_Humidity__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040008,  //  0000  GETGBL	R1	G8
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Zigbee_Humidity
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
+be_local_class(Matter_Plugin_Zigbee_Humidity,
+    1,
+    &be_class_Matter_Plugin_Sensor_Humidity,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(ARG, 2), be_nested_str_weak(zigbee_device) },
+        { be_const_key_weak(ARG_TYPE, 8), be_const_static_closure(class_Matter_Plugin_Zigbee_Humidity__X3Clambda_X3E_closure) },
+        { be_const_key_weak(ARG_HINT, 7), be_nested_str_weak(Device) },
+        { be_const_key_weak(ZIGBEE, 6), be_const_bool(1) },
+        { be_const_key_weak(ZIGBEE_NAME, -1), be_nested_str_weak(Humidity) },
+        { be_const_key_weak(VIRTUAL, -1), be_const_bool(1) },
+        { be_const_key_weak(zigbee_mapper, -1), be_const_var(0) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Zig_X20Humidity) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(z_humidity) },
+    })),
+    be_str_weak(Matter_Plugin_Zigbee_Humidity)
+);
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Pressure.h
@@ -1,0 +1,58 @@
+/* Solidification of Matter_Plugin_9_Zigbee_Pressure.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Zigbee_Pressure;
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Zigbee_Pressure__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040008,  //  0000  GETGBL	R1	G8
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Zigbee_Pressure
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
+be_local_class(Matter_Plugin_Zigbee_Pressure,
+    1,
+    &be_class_Matter_Plugin_Sensor_Pressure,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(ARG, 2), be_nested_str_weak(zigbee_device) },
+        { be_const_key_weak(ARG_TYPE, 8), be_const_static_closure(class_Matter_Plugin_Zigbee_Pressure__X3Clambda_X3E_closure) },
+        { be_const_key_weak(ARG_HINT, 7), be_nested_str_weak(Device) },
+        { be_const_key_weak(ZIGBEE, 6), be_const_bool(1) },
+        { be_const_key_weak(ZIGBEE_NAME, -1), be_nested_str_weak(Pressure) },
+        { be_const_key_weak(VIRTUAL, -1), be_const_bool(1) },
+        { be_const_key_weak(zigbee_mapper, -1), be_const_var(0) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Zig_X20Pressure) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(z_pressure) },
+    })),
+    be_str_weak(Matter_Plugin_Zigbee_Pressure)
+);
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Temperature.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_9_Zigbee_Temperature.h
@@ -1,0 +1,58 @@
+/* Solidification of Matter_Plugin_9_Zigbee_Temperature.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Zigbee_Temperature;
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(class_Matter_Plugin_Zigbee_Temperature__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040008,  //  0000  GETGBL	R1	G8
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Zigbee_Temperature
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Sensor_Temp;
+be_local_class(Matter_Plugin_Zigbee_Temperature,
+    1,
+    &be_class_Matter_Plugin_Sensor_Temp,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(ARG, 2), be_nested_str_weak(zigbee_device) },
+        { be_const_key_weak(ARG_TYPE, 8), be_const_static_closure(class_Matter_Plugin_Zigbee_Temperature__X3Clambda_X3E_closure) },
+        { be_const_key_weak(ARG_HINT, 7), be_nested_str_weak(Device) },
+        { be_const_key_weak(ZIGBEE, 6), be_const_bool(1) },
+        { be_const_key_weak(ZIGBEE_NAME, -1), be_nested_str_weak(Temperature) },
+        { be_const_key_weak(VIRTUAL, -1), be_const_bool(1) },
+        { be_const_key_weak(zigbee_mapper, -1), be_const_var(0) },
+        { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Zig_X20Temperature) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(z_temp) },
+    })),
+    be_str_weak(Matter_Plugin_Zigbee_Temperature)
+);
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -4,324 +4,253 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_UI;
-// compact class 'Matter_UI' ktab size: 229, total: 359 (saved 1040 bytes)
-static const bvalue be_ktab_class_Matter_UI[229] = {
-  /* K0   */  be_const_class(be_class_Matter_UI),
-  /* K1   */  be_nested_str_weak(keys),
-  /* K2   */  be_nested_str_weak(contains),
-  /* K3   */  be_nested_str_weak(stop_iteration),
-  /* K4   */  be_nested_str_weak(webserver),
-  /* K5   */  be_nested_str_weak(check_privileged_access),
-  /* K6   */  be_nested_str_weak(content_start),
-  /* K7   */  be_nested_str_weak(Matter_X20Advanced_X20Configuration),
-  /* K8   */  be_nested_str_weak(content_send_style),
-  /* K9   */  be_nested_str_weak(matter_enabled),
-  /* K10  */  be_nested_str_weak(show_passcode_form),
-  /* K11  */  be_nested_str_weak(show_fabric_info),
-  /* K12  */  be_nested_str_weak(web_add_config_button),
-  /* K13  */  be_nested_str_weak(content_stop),
-  /* K14  */  be_nested_str_weak(Matter),
-  /* K15  */  be_nested_str_weak(show_enable),
-  /* K16  */  be_nested_str_weak(show_plugins_configuration),
-  /* K17  */  be_nested_str_weak(content_send),
-  /* K18  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3D_X27butmat_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27mattera_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X20name_X3D_X27_X27_X3EAdvanced_X20Configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-  /* K19  */  be_nested_str_weak(content_button),
-  /* K20  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-  /* K21  */  be_nested_str_weak(),
-  /* K22  */  be_nested_str_weak(device),
-  /* K23  */  be_nested_str_weak(get_plugin_class_displayname),
-  /* K24  */  be_nested_str_weak(tasmota),
-  /* K25  */  be_nested_str_weak(get_option),
-  /* K26  */  be_nested_str_weak(matter),
-  /* K27  */  be_nested_str_weak(MATTER_OPTION),
-  /* K28  */  be_const_int(0),
-  /* K29  */  be_nested_str_weak(POWER),
-  /* K30  */  be_const_int(1),
-  /* K31  */  be_nested_str_weak(HSBColor),
-  /* K32  */  be_nested_str_weak(CT),
-  /* K33  */  be_nested_str_weak(Dimmer),
-  /* K34  */  be_nested_str_weak(push),
-  /* K35  */  be_nested_str_weak(type),
-  /* K36  */  be_nested_str_weak(light0),
-  /* K37  */  be_nested_str_weak(relay),
-  /* K38  */  be_nested_str_weak(light1),
-  /* K39  */  be_nested_str_weak(light2),
-  /* K40  */  be_nested_str_weak(light3),
-  /* K41  */  be_nested_str_weak(autoconf),
-  /* K42  */  be_nested_str_weak(autoconf_sensors_list),
-  /* K43  */  be_nested_str_weak(sessions),
-  /* K44  */  be_nested_str_weak(count_active_fabrics),
-  /* K45  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27text_X2Dalign_X3Aright_X3Bfont_X2Dsize_X3A11px_X3Bcolor_X3A_X23aaa_X3Bpadding_X3A0px_X3B_X27_X3E_X25s_X3C_X2Fdiv_X3E),
-  /* K46  */  be_nested_str_weak(Matter_X3A_X20No_X20active_X20association),
-  /* K47  */  be_nested_str_weak(Matter_X3A_X20),
-  /* K48  */  be_nested_str_weak(_X20active_X20association),
-  /* K49  */  be_nested_str_weak(s),
-  /* K50  */  be_nested_str_weak(show_bridge_status),
-  /* K51  */  be_nested_str_weak(commissioning),
-  /* K52  */  be_nested_str_weak(is_root_commissioning_open),
-  /* K53  */  be_nested_str_weak(show_commissioning_info),
-  /* K54  */  be_nested_str_weak(Matter_X20Create_X20new_X20endpoint),
-  /* K55  */  be_nested_str_weak(arg),
-  /* K56  */  be_nested_str_weak(url),
-  /* K57  */  be_nested_str_weak(show_remote_autoconf),
-  /* K58  */  be_nested_str_weak(string),
-  /* K59  */  be_nested_str_weak(introspect),
-  /* K60  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCurrent_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K61  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Cp_X3E_X3Cb_X3ELocal_X20sensors_X20and_X20devices_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-  /* K62  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X23_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K63  */  be_nested_str_weak(plugins_config),
-  /* K64  */  be_nested_str_weak(remove),
-  /* K65  */  be_nested_str_weak(0),
-  /* K66  */  be_nested_str_weak(k2l_num),
-  /* K67  */  be_nested_str_weak(find),
-  /* K68  */  be_nested_str_weak(http_),
-  /* K69  */  be_nested_str_weak(plugins_classes),
-  /* K70  */  be_nested_str_weak(ui_conf_to_string),
-  /* K71  */  be_nested_str_weak(ARG_HINT),
-  /* K72  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
-  /* K73  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
-  /* K74  */  be_nested_str_weak(html_escape),
-  /* K75  */  be_nested_str_weak(name),
-  /* K76  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
-  /* K77  */  be_nested_str_weak(plugin_name),
-  /* K78  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
-  /* K79  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20title_X3D_X27Delete_X20Endpoint_X20_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X20_X25i_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K80  */  be_nested_str_weak(_X3C_X2Ftable_X3E),
-  /* K81  */  be_nested_str_weak(_X3Cp_X3E_X26lt_X3Bnone_X26gt_X3B_X3C_X2Fp_X3E),
-  /* K82  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K83  */  be_nested_str_weak(sort_distinct),
-  /* K84  */  be_nested_str_weak(get_plugin_remote_info),
-  /* K85  */  be_nested_str_weak(_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E),
-  /* K86  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K87  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2722_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
-  /* K88  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
-  /* K89  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
-  /* K90  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
-  /* K91  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K92  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K93  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
-  /* K94  */  be_nested_str_weak(show_plugins_hints_js),
-  /* K95  */  be_nested_str_weak(_CLASSES_TYPES),
-  /* K96  */  be_nested_str_long(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BAdd_X20to_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20local_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X20title_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20id_X3D_X27pi_X27_X20name_X3D_X27pi_X27_X20onchange_X3D_X27otm_X28_X22arg_X22_X2Cthis_X2Evalue_X29_X27_X3E),
-  /* K97  */  be_nested_str_weak(plugin_option),
-  /* K98  */  be_nested_str_long(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X27_X20name_X3D_X27arg_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20name_X3D_X27addep_X27_X20class_X3D_X27button_X20bgrn_X27_X3ECreate_X20new_X20endpoint_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20Tasmota_X20or_X20OpenBK_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatteradd_X27_X20method_X3D_X27get_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X2730_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3Ehttp_X3A_X2F_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27url_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X20required_X20placeholder_X3D_X27IP_X20or_X20domain_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2710_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20class_X3D_X27button_X20bgrn_X27_X3EAuto_X2Dconfigure_X20remote_X20Tasmota_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20all_X20and_X20Auto_X2Ddiscover_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
-  /* K99  */  be_nested_str_weak(commissioning_open),
-  /* K100 */  be_nested_str_weak(millis),
-  /* K101 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCommissioning_X20open_X20for_X20_X25i_X20min_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K102 */  be_nested_str_weak(compute_manual_pairing_code),
-  /* K103 */  be_nested_str_weak(_X3Cp_X3EManual_X20pairing_X20code_X3A_X3Cbr_X3E_X3Cb_X3E_X25s_X2D_X25s_X2D_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Chr_X3E),
-  /* K104 */  be_const_int(3),
-  /* K105 */  be_const_int(2147483647),
-  /* K106 */  be_nested_str_weak(_X3Cdiv_X3E_X3Ccenter_X3E),
-  /* K107 */  be_nested_str_weak(compute_qrcode_content),
-  /* K108 */  be_nested_str_weak(show_qrcode),
-  /* K109 */  be_nested_str_weak(_X3Cp_X3E_X20_X25s_X3C_X2Fp_X3E),
-  /* K110 */  be_nested_str_weak(_X3C_X2Fdiv_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K111 */  be_nested_str_weak(json),
-  /* K112 */  be_nested_str_weak(Plugin_Device),
-  /* K113 */  be_nested_str_weak(PROBE_TIMEOUT),
-  /* K114 */  be_nested_str_weak(HTTP_remote),
-  /* K115 */  be_nested_str_weak(call_sync),
-  /* K116 */  be_nested_str_weak(Status_X2010),
-  /* K117 */  be_nested_str_weak(load),
-  /* K118 */  be_nested_str_weak(StatusSNS),
-  /* K119 */  be_nested_str_weak(Status_X2011),
-  /* K120 */  be_nested_str_weak(StatusSTS),
-  /* K121 */  be_nested_str_weak(log),
-  /* K122 */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status10_X3D_X25s_X20satus11_X3D_X25s),
-  /* K123 */  be_nested_str_weak(generate_config_from_status),
-  /* K124 */  be_nested_str_weak(_CLASSES_TYPES2),
-  /* K125 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-  /* K126 */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
-  /* K127 */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K128 */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
-  /* K129 */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
-  /* K130 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
-  /* K131 */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
-  /* K132 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E),
-  /* K133 */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-  /* K134 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
-  /* K135 */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
-  /* K136 */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-  /* K137 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BFabrics_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3EAssociated_X20fabrics_X3A_X3C_X2Fp_X3E),
-  /* K138 */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3ENone_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-  /* K139 */  be_nested_str_weak(fabrics),
-  /* K140 */  be_nested_str_weak(persistables),
-  /* K141 */  be_nested_str_weak(_X3Chr_X3E),
-  /* K142 */  be_nested_str_weak(fabric_label),
-  /* K143 */  be_nested_str_weak(_X3CNo_X20label_X3E),
-  /* K144 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X3C_X2Fb_X3E_X20_X28_X25s_X29_X26nbsp_X3B_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K145 */  be_nested_str_weak(get_fabric_index),
-  /* K146 */  be_nested_str_weak(get_admin_vendor_name),
-  /* K147 */  be_nested_str_weak(get_fabric_id),
-  /* K148 */  be_nested_str_weak(copy),
-  /* K149 */  be_nested_str_weak(reverse),
-  /* K150 */  be_nested_str_weak(get_device_id),
-  /* K151 */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
-  /* K152 */  be_nested_str_weak(tohex),
-  /* K153 */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
-  /* K154 */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22Are_X20you_X20sure_X3F_X22_X29_X3B_X27_X3E),
-  /* K155 */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25i_X27_X3E),
-  /* K156 */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K157 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K158 */  be_nested_str_weak(has_arg),
-  /* K159 */  be_nested_str_weak(mtc0),
-  /* K160 */  be_nested_str_weak(stop_basic_commissioning),
-  /* K161 */  be_nested_str_weak(mtc1),
-  /* K162 */  be_nested_str_weak(start_root_basic_commissioning),
-  /* K163 */  be_nested_str_weak(split),
-  /* K164 */  be_nested_str_weak(_X7C),
-  /* K165 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X3E_X3C_X2Foption_X3E),
-  /* K166 */  be_nested_str_weak(_X2Dvirtual),
-  /* K167 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Virtual_X20Devices_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
-  /* K168 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
-  /* K169 */  be_nested_str_weak(_X20selected),
-  /* K170 */  be_nested_str_weak(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27matterc_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3E),
-  /* K171 */  be_nested_str_weak(_LOGO),
-  /* K172 */  be_nested_str_weak(_X20Configure_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-  /* K173 */  be_nested_str_weak(add_driver),
-  /* K174 */  be_nested_str_weak(plugins),
-  /* K175 */  be_nested_str_weak(BRIDGE),
-  /* K176 */  be_nested_str_weak(http_remote),
-  /* K177 */  be_nested_str_weak(addr),
-  /* K178 */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-  /* K179 */  be_nested_str_weak(_STYLESHEET),
-  /* K180 */  be_nested_str_weak(k2l),
-  /* K181 */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
-  /* K182 */  be_nested_str_weak(web_last_seen),
-  /* K183 */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
-  /* K184 */  be_nested_str_weak(web_values),
-  /* K185 */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
-  /* K186 */  be_nested_str_weak(on),
-  /* K187 */  be_nested_str_weak(_X2Fmatterc),
-  /* K188 */  be_nested_str_weak(HTTP_GET),
-  /* K189 */  be_nested_str_weak(HTTP_POST),
-  /* K190 */  be_nested_str_weak(_X2Fmattera),
-  /* K191 */  be_nested_str_weak(_X2Fmatteradd),
-  /* K192 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Advanced_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E_X3Cp_X3EPasscode_X3A_X3C_X2Fp_X3E),
-  /* K193 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X271_X27_X20max_X3D_X2799999998_X27_X20name_X3D_X27passcode_X27_X20value_X3D_X27_X25i_X27_X3E),
-  /* K194 */  be_nested_str_weak(root_passcode),
-  /* K195 */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
-  /* K196 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X274095_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
-  /* K197 */  be_nested_str_weak(root_discriminator),
-  /* K198 */  be_nested_str_weak(ipv4only),
-  /* K199 */  be_nested_str_weak(_X20checked),
-  /* K200 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
-  /* K201 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K202 */  be_nested_str_weak(_X20),
-  /* K203 */  be_nested_str_weak(_XE2_X96_X84),
-  /* K204 */  be_nested_str_weak(_XE2_X96_X80),
-  /* K205 */  be_nested_str_weak(_XE2_X96_X88),
-  /* K206 */  be_nested_str_weak(QRCode),
-  /* K207 */  be_nested_str_weak(encode_str),
-  /* K208 */  be_nested_str_weak(bitmap),
-  /* K209 */  be_nested_str_weak(size),
-  /* K210 */  be_nested_str_weak(_X3Cstyle_X3E_X2Eqr_X7Bfont_X2Dfamily_X3Amonospace_X3B_X20margin_X3A0_X3B_X20padding_X3A0_X3B_X20white_X2Dspace_X3Apre_X3B_X20font_X2Dsize_X3A18px_X3B_X20color_X3A_X23fff_X3B_X20line_X2Dheight_X3A100_X25_X3B_X7D_X3C_X2Fstyle_X3E),
-  /* K211 */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27transform_X3Ascale_X28_X2E8_X2C1_X29_X3B_X20display_X3Ainline_X2Dblock_X3B_X27_X3E),
-  /* K212 */  be_nested_str_weak(_X3Cdiv_X20class_X3D_X27qr_X27_X3E),
-  /* K213 */  be_nested_str_weak(_X3C_X2Fdiv_X3E),
-  /* K214 */  be_const_int(2),
-  /* K215 */  be_nested_str_weak(_X3Cdiv_X20class_X3D_X27qr_X27_X20style_X3D_X27background_X2Dcolor_X3A_X23000_X3B_X27_X3E),
-  /* K216 */  be_nested_str_weak(_X2F_X3Cdiv_X3E),
-  /* K217 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X20style_X3D_X27width_X3A320px_X3B_X27_X3ECheck_X20the_X20_X3Ca_X20href_X3D_X27https_X3A_X2F_X2Ftasmota_X2Egithub_X2Eio_X2Fdocs_X2FMatter_X2F_X27_X20target_X3D_X27_blank_X27_X3EMatter_X20documentation_X3C_X2Fa_X3E_X2E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E),
-  /* K218 */  be_nested_str_weak(checked),
-  /* K219 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20id_X3D_X27menable_X27_X20type_X3D_X27checkbox_X27_X20name_X3D_X27menable_X27_X20_X25s_X3E),
-  /* K220 */  be_nested_str_weak(_X3Clabel_X20for_X3D_X27menable_X27_X3E_X3Cb_X3EMatter_X20enable_X3C_X2Fb_X3E_X3C_X2Flabel_X3E_X3C_X2Fp_X3E),
-  /* K221 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20id_X3D_X27comm_X27_X20type_X3D_X27checkbox_X27_X20name_X3D_X27comm_X27_X20_X25s_X3E),
-  /* K222 */  be_nested_str_weak(_X3Clabel_X20for_X3D_X27comm_X27_X3E_X3Cb_X3ECommissioning_X20open_X3C_X2Fb_X3E_X3C_X2Flabel_X3E_X3C_X2Fp_X3E),
-  /* K223 */  be_nested_str_weak(disable_bridge_mode),
-  /* K224 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27nobridge_X27_X25s_X3E_X3Cb_X3EForce_X20Static_X20endpoints_X3C_X2Fb_X3E_X20_X28non_X2Dbridge_X29_X3C_X2Fp_X3E),
-  /* K225 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27save_X27_X20class_X3D_X27button_X20bgrn_X27_X3ESave_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K226 */  be_nested_str_weak(_X3Cscript_X20type_X3D_X27text_X2Fjavascript_X27_X3Evar_X20hm_X3D_X25s_X3Bvar_X20hl_X3D_X25s_X3B_X3C_X2Fscript_X3E),
-  /* K227 */  be_nested_str_weak(dump),
-  /* K228 */  be_nested_str_weak(_ADD_ENDPOINT_JS),
+// compact class 'Matter_UI' ktab size: 234, total: 364 (saved 1040 bytes)
+static const bvalue be_ktab_class_Matter_UI[234] = {
+  /* K0   */  be_nested_str_weak(webserver),
+  /* K1   */  be_nested_str_weak(device),
+  /* K2   */  be_nested_str_weak(commissioning),
+  /* K3   */  be_nested_str_weak(commissioning_open),
+  /* K4   */  be_nested_str_weak(tasmota),
+  /* K5   */  be_nested_str_weak(millis),
+  /* K6   */  be_const_int(0),
+  /* K7   */  be_nested_str_weak(content_send),
+  /* K8   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCommissioning_X20open_X20for_X20_X25i_X20min_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K9   */  be_nested_str_weak(compute_manual_pairing_code),
+  /* K10  */  be_nested_str_weak(_X3Cp_X3EManual_X20pairing_X20code_X3A_X3Cbr_X3E_X3Cb_X3E_X25s_X2D_X25s_X2D_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Chr_X3E),
+  /* K11  */  be_const_int(3),
+  /* K12  */  be_const_int(2147483647),
+  /* K13  */  be_nested_str_weak(_X3Cdiv_X3E_X3Ccenter_X3E),
+  /* K14  */  be_nested_str_weak(compute_qrcode_content),
+  /* K15  */  be_nested_str_weak(show_qrcode),
+  /* K16  */  be_nested_str_weak(_X3Cp_X3E_X20_X25s_X3C_X2Fp_X3E),
+  /* K17  */  be_nested_str_weak(_X3C_X2Fdiv_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K18  */  be_nested_str_weak(contains),
+  /* K19  */  be_nested_str_weak(POWER),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_nested_str_weak(HSBColor),
+  /* K22  */  be_nested_str_weak(CT),
+  /* K23  */  be_nested_str_weak(Dimmer),
+  /* K24  */  be_nested_str_weak(push),
+  /* K25  */  be_nested_str_weak(type),
+  /* K26  */  be_nested_str_weak(light0),
+  /* K27  */  be_nested_str_weak(relay),
+  /* K28  */  be_nested_str_weak(stop_iteration),
+  /* K29  */  be_nested_str_weak(light1),
+  /* K30  */  be_nested_str_weak(light2),
+  /* K31  */  be_nested_str_weak(light3),
+  /* K32  */  be_nested_str_weak(autoconf),
+  /* K33  */  be_nested_str_weak(autoconf_sensors_list),
+  /* K34  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BFabrics_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3EAssociated_X20fabrics_X3A_X3C_X2Fp_X3E),
+  /* K35  */  be_nested_str_weak(sessions),
+  /* K36  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3ENone_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+  /* K37  */  be_nested_str_weak(fabrics),
+  /* K38  */  be_nested_str_weak(persistables),
+  /* K39  */  be_nested_str_weak(_X3Chr_X3E),
+  /* K40  */  be_nested_str_weak(fabric_label),
+  /* K41  */  be_nested_str_weak(_X3CNo_X20label_X3E),
+  /* K42  */  be_nested_str_weak(html_escape),
+  /* K43  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X3C_X2Fb_X3E_X20_X28_X25s_X29_X26nbsp_X3B_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K44  */  be_nested_str_weak(get_fabric_index),
+  /* K45  */  be_nested_str_weak(get_admin_vendor_name),
+  /* K46  */  be_nested_str_weak(get_fabric_id),
+  /* K47  */  be_nested_str_weak(copy),
+  /* K48  */  be_nested_str_weak(reverse),
+  /* K49  */  be_nested_str_weak(get_device_id),
+  /* K50  */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
+  /* K51  */  be_nested_str_weak(tohex),
+  /* K52  */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
+  /* K53  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22Are_X20you_X20sure_X3F_X22_X29_X3B_X27_X3E),
+  /* K54  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25i_X27_X3E),
+  /* K55  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K56  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K57  */  be_nested_str_weak(_X20),
+  /* K58  */  be_nested_str_weak(_XE2_X96_X84),
+  /* K59  */  be_nested_str_weak(_XE2_X96_X80),
+  /* K60  */  be_nested_str_weak(_XE2_X96_X88),
+  /* K61  */  be_nested_str_weak(matter),
+  /* K62  */  be_nested_str_weak(QRCode),
+  /* K63  */  be_nested_str_weak(encode_str),
+  /* K64  */  be_nested_str_weak(bitmap),
+  /* K65  */  be_nested_str_weak(size),
+  /* K66  */  be_nested_str_weak(_X3Cstyle_X3E_X2Eqr_X7Bfont_X2Dfamily_X3Amonospace_X3B_X20margin_X3A0_X3B_X20padding_X3A0_X3B_X20white_X2Dspace_X3Apre_X3B_X20font_X2Dsize_X3A18px_X3B_X20color_X3A_X23fff_X3B_X20line_X2Dheight_X3A100_X25_X3B_X7D_X3C_X2Fstyle_X3E),
+  /* K67  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27transform_X3Ascale_X28_X2E8_X2C1_X29_X3B_X20display_X3Ainline_X2Dblock_X3B_X27_X3E),
+  /* K68  */  be_nested_str_weak(_X3Cdiv_X20class_X3D_X27qr_X27_X3E),
+  /* K69  */  be_nested_str_weak(),
+  /* K70  */  be_nested_str_weak(_X3C_X2Fdiv_X3E),
+  /* K71  */  be_const_int(2),
+  /* K72  */  be_nested_str_weak(_X3Cdiv_X20class_X3D_X27qr_X27_X20style_X3D_X27background_X2Dcolor_X3A_X23000_X3B_X27_X3E),
+  /* K73  */  be_nested_str_weak(_X2F_X3Cdiv_X3E),
+  /* K74  */  be_nested_str_weak(matter_enabled),
+  /* K75  */  be_nested_str_weak(count_active_fabrics),
+  /* K76  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27text_X2Dalign_X3Aright_X3Bfont_X2Dsize_X3A11px_X3Bcolor_X3A_X23aaa_X3Bpadding_X3A0px_X3B_X27_X3E_X25s_X3C_X2Fdiv_X3E),
+  /* K77  */  be_nested_str_weak(Matter_X3A_X20No_X20active_X20association),
+  /* K78  */  be_nested_str_weak(Matter_X3A_X20),
+  /* K79  */  be_nested_str_weak(_X20active_X20association),
+  /* K80  */  be_nested_str_weak(s),
+  /* K81  */  be_nested_str_weak(show_bridge_status),
+  /* K82  */  be_nested_str_weak(is_root_commissioning_open),
+  /* K83  */  be_nested_str_weak(show_commissioning_info),
+  /* K84  */  be_nested_str_weak(check_privileged_access),
+  /* K85  */  be_nested_str_weak(content_start),
+  /* K86  */  be_nested_str_weak(Matter),
+  /* K87  */  be_nested_str_weak(content_send_style),
+  /* K88  */  be_nested_str_weak(show_enable),
+  /* K89  */  be_nested_str_weak(show_plugins_configuration),
+  /* K90  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3D_X27butmat_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27mattera_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X20name_X3D_X27_X27_X3EAdvanced_X20Configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+  /* K91  */  be_nested_str_weak(content_button),
+  /* K92  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+  /* K93  */  be_nested_str_weak(content_stop),
+  /* K94  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Advanced_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E_X3Cp_X3EPasscode_X3A_X3C_X2Fp_X3E),
+  /* K95  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X271_X27_X20max_X3D_X2799999998_X27_X20name_X3D_X27passcode_X27_X20value_X3D_X27_X25i_X27_X3E),
+  /* K96  */  be_nested_str_weak(root_passcode),
+  /* K97  */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
+  /* K98  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X274095_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
+  /* K99  */  be_nested_str_weak(root_discriminator),
+  /* K100 */  be_nested_str_weak(ipv4only),
+  /* K101 */  be_nested_str_weak(_X20checked),
+  /* K102 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
+  /* K103 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K104 */  be_nested_str_weak(json),
+  /* K105 */  be_nested_str_weak(string),
+  /* K106 */  be_nested_str_weak(split),
+  /* K107 */  be_nested_str_weak(_X7C),
+  /* K108 */  be_nested_str_weak(plugins_classes),
+  /* K109 */  be_nested_str_weak(find),
+  /* K110 */  be_nested_str_weak(ARG_HINT),
+  /* K111 */  be_nested_str_weak(_X3Cscript_X20type_X3D_X27text_X2Fjavascript_X27_X3Evar_X20hm_X3D_X25s_X3Bvar_X20hl_X3D_X25s_X3B_X3C_X2Fscript_X3E),
+  /* K112 */  be_nested_str_weak(dump),
+  /* K113 */  be_nested_str_weak(_ADD_ENDPOINT_JS),
+  /* K114 */  be_nested_str_weak(get_option),
+  /* K115 */  be_nested_str_weak(MATTER_OPTION),
+  /* K116 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X20style_X3D_X27width_X3A320px_X3B_X27_X3ECheck_X20the_X20_X3Ca_X20href_X3D_X27https_X3A_X2F_X2Ftasmota_X2Egithub_X2Eio_X2Fdocs_X2FMatter_X2F_X27_X20target_X3D_X27_blank_X27_X3EMatter_X20documentation_X3C_X2Fa_X3E_X2E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E),
+  /* K117 */  be_nested_str_weak(checked),
+  /* K118 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20id_X3D_X27menable_X27_X20type_X3D_X27checkbox_X27_X20name_X3D_X27menable_X27_X20_X25s_X3E),
+  /* K119 */  be_nested_str_weak(_X3Clabel_X20for_X3D_X27menable_X27_X3E_X3Cb_X3EMatter_X20enable_X3C_X2Fb_X3E_X3C_X2Flabel_X3E_X3C_X2Fp_X3E),
+  /* K120 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20id_X3D_X27comm_X27_X20type_X3D_X27checkbox_X27_X20name_X3D_X27comm_X27_X20_X25s_X3E),
+  /* K121 */  be_nested_str_weak(_X3Clabel_X20for_X3D_X27comm_X27_X3E_X3Cb_X3ECommissioning_X20open_X3C_X2Fb_X3E_X3C_X2Flabel_X3E_X3C_X2Fp_X3E),
+  /* K122 */  be_nested_str_weak(disable_bridge_mode),
+  /* K123 */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27nobridge_X27_X25s_X3E_X3Cb_X3EForce_X20Static_X20endpoints_X3C_X2Fb_X3E_X20_X28non_X2Dbridge_X29_X3C_X2Fp_X3E),
+  /* K124 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27save_X27_X20class_X3D_X27button_X20bgrn_X27_X3ESave_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K125 */  be_const_class(be_class_Matter_UI),
+  /* K126 */  be_nested_str_weak(keys),
+  /* K127 */  be_nested_str_weak(has_arg),
+  /* K128 */  be_nested_str_weak(mtc0),
+  /* K129 */  be_nested_str_weak(stop_basic_commissioning),
+  /* K130 */  be_nested_str_weak(mtc1),
+  /* K131 */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K132 */  be_nested_str_weak(introspect),
+  /* K133 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCurrent_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K134 */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Cp_X3E_X3Cb_X3ELocal_X20sensors_X20and_X20devices_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+  /* K135 */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X23_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K136 */  be_nested_str_weak(plugins_config),
+  /* K137 */  be_nested_str_weak(remove),
+  /* K138 */  be_nested_str_weak(0),
+  /* K139 */  be_nested_str_weak(k2l_num),
+  /* K140 */  be_nested_str_weak(http_),
+  /* K141 */  be_nested_str_weak(ui_conf_to_string),
+  /* K142 */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
+  /* K143 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
+  /* K144 */  be_nested_str_weak(name),
+  /* K145 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
+  /* K146 */  be_nested_str_weak(plugin_name),
+  /* K147 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
+  /* K148 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20title_X3D_X27Delete_X20Endpoint_X20_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X20_X25i_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K149 */  be_nested_str_weak(_X3C_X2Ftable_X3E),
+  /* K150 */  be_nested_str_weak(_X3Cp_X3E_X26lt_X3Bnone_X26gt_X3B_X3C_X2Fp_X3E),
+  /* K151 */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K152 */  be_nested_str_weak(url),
+  /* K153 */  be_nested_str_weak(sort_distinct),
+  /* K154 */  be_nested_str_weak(get_plugin_remote_info),
+  /* K155 */  be_nested_str_weak(_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E),
+  /* K156 */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K157 */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2722_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
+  /* K158 */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
+  /* K159 */  be_nested_str_weak(_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
+  /* K160 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
+  /* K161 */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K162 */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K163 */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
+  /* K164 */  be_nested_str_weak(zigbee),
+  /* K165 */  be_nested_str_weak(show_plugins_hints_js),
+  /* K166 */  be_nested_str_weak(_CLASSES_TYPES_STD),
+  /* K167 */  be_nested_str_weak(_CLASSES_TYPES),
+  /* K168 */  be_nested_str_weak(_CLASSES_TYPES_VIRTUAL),
+  /* K169 */  be_nested_str_long(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BAdd_X20to_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20local_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X20title_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20id_X3D_X27pi_X27_X20name_X3D_X27pi_X27_X20onchange_X3D_X27otm_X28_X22arg_X22_X2Cthis_X2Evalue_X29_X27_X3E),
+  /* K170 */  be_nested_str_weak(plugin_option),
+  /* K171 */  be_nested_str_long(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X27_X20name_X3D_X27arg_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20name_X3D_X27addep_X27_X20class_X3D_X27button_X20bgrn_X27_X3ECreate_X20new_X20endpoint_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20Tasmota_X20or_X20OpenBK_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatteradd_X27_X20method_X3D_X27get_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X2730_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3Ehttp_X3A_X2F_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27url_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X20required_X20placeholder_X3D_X27IP_X20or_X20domain_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2710_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20class_X3D_X27button_X20bgrn_X27_X3EAuto_X2Dconfigure_X20remote_X20Tasmota_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20all_X20and_X20Auto_X2Ddiscover_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
+  /* K172 */  be_nested_str_weak(plugins),
+  /* K173 */  be_nested_str_weak(BRIDGE),
+  /* K174 */  be_nested_str_weak(http_remote),
+  /* K175 */  be_nested_str_weak(addr),
+  /* K176 */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+  /* K177 */  be_nested_str_weak(_STYLESHEET),
+  /* K178 */  be_nested_str_weak(k2l),
+  /* K179 */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
+  /* K180 */  be_nested_str_weak(web_last_seen),
+  /* K181 */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
+  /* K182 */  be_nested_str_weak(web_values),
+  /* K183 */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K184 */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
+  /* K185 */  be_nested_str_weak(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27matterc_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3E),
+  /* K186 */  be_nested_str_weak(_LOGO),
+  /* K187 */  be_nested_str_weak(_X20Configure_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+  /* K188 */  be_nested_str_weak(get_plugin_class_displayname),
+  /* K189 */  be_nested_str_weak(Matter_X20Advanced_X20Configuration),
+  /* K190 */  be_nested_str_weak(show_passcode_form),
+  /* K191 */  be_nested_str_weak(show_fabric_info),
+  /* K192 */  be_nested_str_weak(web_add_config_button),
+  /* K193 */  be_nested_str_weak(Matter_X20Create_X20new_X20endpoint),
+  /* K194 */  be_nested_str_weak(arg),
+  /* K195 */  be_nested_str_weak(show_remote_autoconf),
+  /* K196 */  be_nested_str_weak(on),
+  /* K197 */  be_nested_str_weak(_X2Fmatterc),
+  /* K198 */  be_nested_str_weak(HTTP_GET),
+  /* K199 */  be_nested_str_weak(HTTP_POST),
+  /* K200 */  be_nested_str_weak(_X2Fmattera),
+  /* K201 */  be_nested_str_weak(_X2Fmatteradd),
+  /* K202 */  be_nested_str_weak(add_driver),
+  /* K203 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X3E_X3C_X2Foption_X3E),
+  /* K204 */  be_nested_str_weak(_X2Dvirtual),
+  /* K205 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Virtual_X20Devices_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
+  /* K206 */  be_nested_str_weak(_X2Dzigbee),
+  /* K207 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Zigbee_X20Devices_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
+  /* K208 */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
+  /* K209 */  be_nested_str_weak(_X20selected),
+  /* K210 */  be_nested_str_weak(Plugin_Device),
+  /* K211 */  be_nested_str_weak(PROBE_TIMEOUT),
+  /* K212 */  be_nested_str_weak(HTTP_remote),
+  /* K213 */  be_nested_str_weak(call_sync),
+  /* K214 */  be_nested_str_weak(Status_X2010),
+  /* K215 */  be_nested_str_weak(load),
+  /* K216 */  be_nested_str_weak(StatusSNS),
+  /* K217 */  be_nested_str_weak(Status_X2011),
+  /* K218 */  be_nested_str_weak(StatusSTS),
+  /* K219 */  be_nested_str_weak(log),
+  /* K220 */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status10_X3D_X25s_X20satus11_X3D_X25s),
+  /* K221 */  be_nested_str_weak(generate_config_from_status),
+  /* K222 */  be_nested_str_weak(_CLASSES_TYPES2),
+  /* K223 */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+  /* K224 */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
+  /* K225 */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+  /* K226 */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
+  /* K227 */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
+  /* K228 */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
+  /* K229 */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
+  /* K230 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E),
+  /* K231 */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
+  /* K232 */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
+  /* K233 */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
 };
 
 
 extern const bclass be_class_Matter_UI;
 
 /********************************************************************
-** Solidified function: equal_map
+** Solidified function: show_commissioning_info
 ********************************************************************/
-be_local_closure(class_Matter_UI_equal_map,   /* name */
+be_local_closure(class_Matter_UI_show_commissioning_info,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(equal_map),
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C0010,  //  0001  GETGBL	R3	G16
-      0x8C100101,  //  0002  GETMET	R4	R0	K1
-      0x7C100200,  //  0003  CALL	R4	1
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020010,  //  0005  EXBLK	0	#0017
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140302,  //  0008  GETMET	R5	R1	K2
-      0x5C1C0800,  //  0009  MOVE	R7	R4
-      0x7C140400,  //  000A  CALL	R5	2
-      0x74160002,  //  000B  JMPT	R5	#000F
-      0x50140000,  //  000C  LDBOOL	R5	0	0
-      0xA8040001,  //  000D  EXBLK	1	1
-      0x80040A00,  //  000E  RET	1	R5
-      0x94140204,  //  000F  GETIDX	R5	R1	R4
-      0x94180004,  //  0010  GETIDX	R6	R0	R4
-      0x20140A06,  //  0011  NE	R5	R5	R6
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x50140000,  //  0013  LDBOOL	R5	0	0
-      0xA8040001,  //  0014  EXBLK	1	1
-      0x80040A00,  //  0015  RET	1	R5
-      0x7001FFEE,  //  0016  JMP		#0006
-      0x580C0003,  //  0017  LDCONST	R3	K3
-      0xAC0C0200,  //  0018  CATCH	R3	1	0
-      0xB0080000,  //  0019  RAISE	2	R0	R0
-      0x600C0010,  //  001A  GETGBL	R3	G16
-      0x8C100301,  //  001B  GETMET	R4	R1	K1
-      0x7C100200,  //  001C  CALL	R4	1
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x8C140102,  //  0021  GETMET	R5	R0	K2
-      0x5C1C0800,  //  0022  MOVE	R7	R4
-      0x7C140400,  //  0023  CALL	R5	2
-      0x74160002,  //  0024  JMPT	R5	#0028
-      0x50140000,  //  0025  LDBOOL	R5	0	0
-      0xA8040001,  //  0026  EXBLK	1	1
-      0x80040A00,  //  0027  RET	1	R5
-      0x94140204,  //  0028  GETIDX	R5	R1	R4
-      0x94180004,  //  0029  GETIDX	R6	R0	R4
-      0x20140A06,  //  002A  NE	R5	R5	R6
-      0x78160002,  //  002B  JMPF	R5	#002F
-      0x50140000,  //  002C  LDBOOL	R5	0	0
-      0xA8040001,  //  002D  EXBLK	1	1
-      0x80040A00,  //  002E  RET	1	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C0003,  //  0030  LDCONST	R3	K3
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x500C0200,  //  0033  LDBOOL	R3	1	0
-      0x80040600,  //  0034  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: page_part_mgr_adv
-********************************************************************/
-be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -330,144 +259,70 @@ be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(page_part_mgr_adv),
+    be_str_weak(show_commissioning_info),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080305,  //  0001  GETMET	R2	R1	K5
-      0x7C080200,  //  0002  CALL	R2	1
-      0x740A0001,  //  0003  JMPT	R2	#0006
-      0x4C080000,  //  0004  LDNIL	R2
-      0x80040400,  //  0005  RET	1	R2
-      0x8C080306,  //  0006  GETMET	R2	R1	K6
-      0x58100007,  //  0007  LDCONST	R4	K7
-      0x7C080400,  //  0008  CALL	R2	2
-      0x8C080308,  //  0009  GETMET	R2	R1	K8
-      0x7C080200,  //  000A  CALL	R2	1
-      0x8C080109,  //  000B  GETMET	R2	R0	K9
-      0x7C080200,  //  000C  CALL	R2	1
-      0x780A0003,  //  000D  JMPF	R2	#0012
-      0x8C08010A,  //  000E  GETMET	R2	R0	K10
-      0x7C080200,  //  000F  CALL	R2	1
-      0x8C08010B,  //  0010  GETMET	R2	R0	K11
-      0x7C080200,  //  0011  CALL	R2	1
-      0x8C08010C,  //  0012  GETMET	R2	R0	K12
-      0x7C080200,  //  0013  CALL	R2	1
-      0x8C08030D,  //  0014  GETMET	R2	R1	K13
-      0x7C080200,  //  0015  CALL	R2	1
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: page_part_mgr
-********************************************************************/
-be_local_closure(class_Matter_UI_page_part_mgr,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(page_part_mgr),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080305,  //  0001  GETMET	R2	R1	K5
-      0x7C080200,  //  0002  CALL	R2	1
-      0x740A0001,  //  0003  JMPT	R2	#0006
-      0x4C080000,  //  0004  LDNIL	R2
-      0x80040400,  //  0005  RET	1	R2
-      0x8C080306,  //  0006  GETMET	R2	R1	K6
-      0x5810000E,  //  0007  LDCONST	R4	K14
-      0x7C080400,  //  0008  CALL	R2	2
-      0x8C080308,  //  0009  GETMET	R2	R1	K8
-      0x7C080200,  //  000A  CALL	R2	1
-      0x8C08010F,  //  000B  GETMET	R2	R0	K15
-      0x7C080200,  //  000C  CALL	R2	1
-      0x8C080109,  //  000D  GETMET	R2	R0	K9
-      0x7C080200,  //  000E  CALL	R2	1
-      0x780A0001,  //  000F  JMPF	R2	#0012
-      0x8C080110,  //  0010  GETMET	R2	R0	K16
-      0x7C080200,  //  0011  CALL	R2	1
-      0x8C080311,  //  0012  GETMET	R2	R1	K17
-      0x58100012,  //  0013  LDCONST	R4	K18
-      0x7C080400,  //  0014  CALL	R2	2
-      0x8C080313,  //  0015  GETMET	R2	R1	K19
-      0x88100314,  //  0016  GETMBR	R4	R1	K20
-      0x7C080400,  //  0017  CALL	R2	2
-      0x8C08030D,  //  0018  GETMET	R2	R1	K13
-      0x7C080200,  //  0019  CALL	R2	1
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: plugin_name
-********************************************************************/
-be_local_closure(class_Matter_UI_plugin_name,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    11,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(plugin_name),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x1C0C0315,  //  0000  EQ	R3	R1	K21
-      0x780E0000,  //  0001  JMPF	R3	#0003
-      0x80062A00,  //  0002  RET	1	K21
-      0x880C0116,  //  0003  GETMBR	R3	R0	K22
-      0x8C0C0717,  //  0004  GETMET	R3	R3	K23
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x80040600,  //  0007  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: matter_enabled
-********************************************************************/
-be_local_closure(class_Matter_UI_matter_enabled,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(matter_enabled),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60040017,  //  0000  GETGBL	R1	G23
-      0xB80A3000,  //  0001  GETNGBL	R2	K24
-      0x8C080519,  //  0002  GETMET	R2	R2	K25
-      0xB8123400,  //  0003  GETNGBL	R4	K26
-      0x8810091B,  //  0004  GETMBR	R4	R4	K27
-      0x7C080400,  //  0005  CALL	R2	2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80040200,  //  0007  RET	1	R1
+    ( &(const binstruction[61]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080502,  //  0002  GETMBR	R2	R2	K2
+      0x88080503,  //  0003  GETMBR	R2	R2	K3
+      0xB80E0800,  //  0004  GETNGBL	R3	K4
+      0x8C0C0705,  //  0005  GETMET	R3	R3	K5
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x04080403,  //  0007  SUB	R2	R2	R3
+      0x540E03E7,  //  0008  LDINT	R3	1000
+      0x0C080403,  //  0009  DIV	R2	R2	R3
+      0x140C0506,  //  000A  LT	R3	R2	K6
+      0x780E0000,  //  000B  JMPF	R3	#000D
+      0x58080006,  //  000C  LDCONST	R2	K6
+      0x540E001D,  //  000D  LDINT	R3	30
+      0x000C0403,  //  000E  ADD	R3	R2	R3
+      0x5412003B,  //  000F  LDINT	R4	60
+      0x0C0C0604,  //  0010  DIV	R3	R3	R4
+      0x8C100307,  //  0011  GETMET	R4	R1	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x5C200600,  //  0014  MOVE	R8	R3
+      0x7C180400,  //  0015  CALL	R6	2
+      0x7C100400,  //  0016  CALL	R4	2
+      0x88100101,  //  0017  GETMBR	R4	R0	K1
+      0x88100902,  //  0018  GETMBR	R4	R4	K2
+      0x8C100909,  //  0019  GETMET	R4	R4	K9
+      0x7C100200,  //  001A  CALL	R4	1
+      0x8C140307,  //  001B  GETMET	R5	R1	K7
+      0x601C0018,  //  001C  GETGBL	R7	G24
+      0x5820000A,  //  001D  LDCONST	R8	K10
+      0x40260D0B,  //  001E  CONNECT	R9	K6	K11
+      0x94240809,  //  001F  GETIDX	R9	R4	R9
+      0x542A0003,  //  0020  LDINT	R10	4
+      0x542E0005,  //  0021  LDINT	R11	6
+      0x4028140B,  //  0022  CONNECT	R10	R10	R11
+      0x9428080A,  //  0023  GETIDX	R10	R4	R10
+      0x542E0006,  //  0024  LDINT	R11	7
+      0x402C170C,  //  0025  CONNECT	R11	R11	K12
+      0x942C080B,  //  0026  GETIDX	R11	R4	R11
+      0x7C1C0800,  //  0027  CALL	R7	4
+      0x7C140400,  //  0028  CALL	R5	2
+      0x8C140307,  //  0029  GETMET	R5	R1	K7
+      0x581C000D,  //  002A  LDCONST	R7	K13
+      0x7C140400,  //  002B  CALL	R5	2
+      0x88140101,  //  002C  GETMBR	R5	R0	K1
+      0x88140B02,  //  002D  GETMBR	R5	R5	K2
+      0x8C140B0E,  //  002E  GETMET	R5	R5	K14
+      0x7C140200,  //  002F  CALL	R5	1
+      0x8C18010F,  //  0030  GETMET	R6	R0	K15
+      0x5C200A00,  //  0031  MOVE	R8	R5
+      0x7C180400,  //  0032  CALL	R6	2
+      0x8C180307,  //  0033  GETMET	R6	R1	K7
+      0x60200018,  //  0034  GETGBL	R8	G24
+      0x58240010,  //  0035  LDCONST	R9	K16
+      0x5C280A00,  //  0036  MOVE	R10	R5
+      0x7C200400,  //  0037  CALL	R8	2
+      0x7C180400,  //  0038  CALL	R6	2
+      0x8C180307,  //  0039  GETMET	R6	R1	K7
+      0x58200011,  //  003A  LDCONST	R8	K17
+      0x7C180400,  //  003B  CALL	R6	2
+      0x80000000,  //  003C  RET	0
     })
   )
 );
@@ -493,895 +348,101 @@ be_local_closure(class_Matter_UI_generate_config_from_status,   /* name */
     ( &(const binstruction[97]) {  /* code */
       0x600C0012,  //  0000  GETGBL	R3	G18
       0x7C0C0000,  //  0001  CALL	R3	0
-      0x5810001C,  //  0002  LDCONST	R4	K28
-      0x8C140502,  //  0003  GETMET	R5	R2	K2
-      0x581C001D,  //  0004  LDCONST	R7	K29
+      0x58100006,  //  0002  LDCONST	R4	K6
+      0x8C140512,  //  0003  GETMET	R5	R2	K18
+      0x581C0013,  //  0004  LDCONST	R7	K19
       0x7C140400,  //  0005  CALL	R5	2
       0x78160001,  //  0006  JMPF	R5	#0009
-      0x5810001E,  //  0007  LDCONST	R4	K30
+      0x58100014,  //  0007  LDCONST	R4	K20
       0x7002000E,  //  0008  JMP		#0018
-      0x5814001E,  //  0009  LDCONST	R5	K30
+      0x58140014,  //  0009  LDCONST	R5	K20
       0x50180200,  //  000A  LDBOOL	R6	1	0
       0x781A000B,  //  000B  JMPF	R6	#0018
-      0x8C180502,  //  000C  GETMET	R6	R2	K2
+      0x8C180512,  //  000C  GETMET	R6	R2	K18
       0x60200008,  //  000D  GETGBL	R8	G8
       0x5C240A00,  //  000E  MOVE	R9	R5
       0x7C200200,  //  000F  CALL	R8	1
-      0x00223A08,  //  0010  ADD	R8	K29	R8
+      0x00222608,  //  0010  ADD	R8	K19	R8
       0x7C180400,  //  0011  CALL	R6	2
       0x781A0002,  //  0012  JMPF	R6	#0016
       0x5C100A00,  //  0013  MOVE	R4	R5
-      0x00140B1E,  //  0014  ADD	R5	R5	K30
+      0x00140B14,  //  0014  ADD	R5	R5	K20
       0x70020000,  //  0015  JMP		#0017
       0x70020000,  //  0016  JMP		#0018
       0x7001FFF1,  //  0017  JMP		#000A
       0x4C140000,  //  0018  LDNIL	R5
       0x4C180000,  //  0019  LDNIL	R6
       0x4C1C0000,  //  001A  LDNIL	R7
-      0x8C200502,  //  001B  GETMET	R8	R2	K2
-      0x5828001F,  //  001C  LDCONST	R10	K31
+      0x8C200512,  //  001B  GETMET	R8	R2	K18
+      0x58280015,  //  001C  LDCONST	R10	K21
       0x7C200400,  //  001D  CALL	R8	2
       0x78220002,  //  001E  JMPF	R8	#0022
       0x5C1C0800,  //  001F  MOVE	R7	R4
-      0x0410091E,  //  0020  SUB	R4	R4	K30
+      0x04100914,  //  0020  SUB	R4	R4	K20
       0x7002000C,  //  0021  JMP		#002F
-      0x8C200502,  //  0022  GETMET	R8	R2	K2
-      0x58280020,  //  0023  LDCONST	R10	K32
+      0x8C200512,  //  0022  GETMET	R8	R2	K18
+      0x58280016,  //  0023  LDCONST	R10	K22
       0x7C200400,  //  0024  CALL	R8	2
       0x78220002,  //  0025  JMPF	R8	#0029
       0x5C180800,  //  0026  MOVE	R6	R4
-      0x0410091E,  //  0027  SUB	R4	R4	K30
+      0x04100914,  //  0027  SUB	R4	R4	K20
       0x70020005,  //  0028  JMP		#002F
-      0x8C200502,  //  0029  GETMET	R8	R2	K2
-      0x58280021,  //  002A  LDCONST	R10	K33
+      0x8C200512,  //  0029  GETMET	R8	R2	K18
+      0x58280017,  //  002A  LDCONST	R10	K23
       0x7C200400,  //  002B  CALL	R8	2
       0x78220001,  //  002C  JMPF	R8	#002F
       0x5C140800,  //  002D  MOVE	R5	R4
-      0x0410091E,  //  002E  SUB	R4	R4	K30
+      0x04100914,  //  002E  SUB	R4	R4	K20
       0x60200010,  //  002F  GETGBL	R8	G16
-      0x40263C04,  //  0030  CONNECT	R9	K30	R4
+      0x40262804,  //  0030  CONNECT	R9	K20	R4
       0x7C200200,  //  0031  CALL	R8	1
       0xA8020008,  //  0032  EXBLK	0	#003C
       0x5C241000,  //  0033  MOVE	R9	R8
       0x7C240000,  //  0034  CALL	R9	0
-      0x8C280722,  //  0035  GETMET	R10	R3	K34
+      0x8C280718,  //  0035  GETMET	R10	R3	K24
       0x60300013,  //  0036  GETGBL	R12	G19
       0x7C300000,  //  0037  CALL	R12	0
-      0x98324724,  //  0038  SETIDX	R12	K35	K36
-      0x98324A09,  //  0039  SETIDX	R12	K37	R9
+      0x9832331A,  //  0038  SETIDX	R12	K25	K26
+      0x98323609,  //  0039  SETIDX	R12	K27	R9
       0x7C280400,  //  003A  CALL	R10	2
       0x7001FFF6,  //  003B  JMP		#0033
-      0x58200003,  //  003C  LDCONST	R8	K3
+      0x5820001C,  //  003C  LDCONST	R8	K28
       0xAC200200,  //  003D  CATCH	R8	1	0
       0xB0080000,  //  003E  RAISE	2	R0	R0
       0x4C200000,  //  003F  LDNIL	R8
       0x20200A08,  //  0040  NE	R8	R5	R8
       0x78220005,  //  0041  JMPF	R8	#0048
-      0x8C200722,  //  0042  GETMET	R8	R3	K34
+      0x8C200718,  //  0042  GETMET	R8	R3	K24
       0x60280013,  //  0043  GETGBL	R10	G19
       0x7C280000,  //  0044  CALL	R10	0
-      0x982A4726,  //  0045  SETIDX	R10	K35	K38
-      0x982A4A05,  //  0046  SETIDX	R10	K37	R5
+      0x982A331D,  //  0045  SETIDX	R10	K25	K29
+      0x982A3605,  //  0046  SETIDX	R10	K27	R5
       0x7C200400,  //  0047  CALL	R8	2
       0x4C200000,  //  0048  LDNIL	R8
       0x20200C08,  //  0049  NE	R8	R6	R8
       0x78220005,  //  004A  JMPF	R8	#0051
-      0x8C200722,  //  004B  GETMET	R8	R3	K34
+      0x8C200718,  //  004B  GETMET	R8	R3	K24
       0x60280013,  //  004C  GETGBL	R10	G19
       0x7C280000,  //  004D  CALL	R10	0
-      0x982A4727,  //  004E  SETIDX	R10	K35	K39
-      0x982A4A06,  //  004F  SETIDX	R10	K37	R6
+      0x982A331E,  //  004E  SETIDX	R10	K25	K30
+      0x982A3606,  //  004F  SETIDX	R10	K27	R6
       0x7C200400,  //  0050  CALL	R8	2
       0x4C200000,  //  0051  LDNIL	R8
       0x20200E08,  //  0052  NE	R8	R7	R8
       0x78220005,  //  0053  JMPF	R8	#005A
-      0x8C200722,  //  0054  GETMET	R8	R3	K34
+      0x8C200718,  //  0054  GETMET	R8	R3	K24
       0x60280013,  //  0055  GETGBL	R10	G19
       0x7C280000,  //  0056  CALL	R10	0
-      0x982A4728,  //  0057  SETIDX	R10	K35	K40
-      0x982A4A07,  //  0058  SETIDX	R10	K37	R7
+      0x982A331F,  //  0057  SETIDX	R10	K25	K31
+      0x982A3607,  //  0058  SETIDX	R10	K27	R7
       0x7C200400,  //  0059  CALL	R8	2
-      0x88200116,  //  005A  GETMBR	R8	R0	K22
-      0x88201129,  //  005B  GETMBR	R8	R8	K41
-      0x8C20112A,  //  005C  GETMET	R8	R8	K42
+      0x88200101,  //  005A  GETMBR	R8	R0	K1
+      0x88201120,  //  005B  GETMBR	R8	R8	K32
+      0x8C201121,  //  005C  GETMET	R8	R8	K33
       0x5C280200,  //  005D  MOVE	R10	R1
       0x7C200400,  //  005E  CALL	R8	2
       0x000C0608,  //  005F  ADD	R3	R3	R8
       0x80040600,  //  0060  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_sensor
-********************************************************************/
-be_local_closure(class_Matter_UI_web_sensor,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(web_sensor),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080109,  //  0001  GETMET	R2	R0	K9
-      0x7C080200,  //  0002  CALL	R2	1
-      0x780A002C,  //  0003  JMPF	R2	#0031
-      0x88080116,  //  0004  GETMBR	R2	R0	K22
-      0x8808052B,  //  0005  GETMBR	R2	R2	K43
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x20080403,  //  0007  NE	R2	R2	R3
-      0x780A0004,  //  0008  JMPF	R2	#000E
-      0x88080116,  //  0009  GETMBR	R2	R0	K22
-      0x8808052B,  //  000A  GETMBR	R2	R2	K43
-      0x8C08052C,  //  000B  GETMET	R2	R2	K44
-      0x7C080200,  //  000C  CALL	R2	1
-      0x70020000,  //  000D  JMP		#000F
-      0x5808001C,  //  000E  LDCONST	R2	K28
-      0x1C0C051C,  //  000F  EQ	R3	R2	K28
-      0x780E0006,  //  0010  JMPF	R3	#0018
-      0x8C0C0311,  //  0011  GETMET	R3	R1	K17
-      0x60140018,  //  0012  GETGBL	R5	G24
-      0x5818002D,  //  0013  LDCONST	R6	K45
-      0x581C002E,  //  0014  LDCONST	R7	K46
-      0x7C140400,  //  0015  CALL	R5	2
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x7002000F,  //  0017  JMP		#0028
-      0x240C051E,  //  0018  GT	R3	R2	K30
-      0x8C100311,  //  0019  GETMET	R4	R1	K17
-      0x60180018,  //  001A  GETGBL	R6	G24
-      0x581C002D,  //  001B  LDCONST	R7	K45
-      0x60200008,  //  001C  GETGBL	R8	G8
-      0x5C240400,  //  001D  MOVE	R9	R2
-      0x7C200200,  //  001E  CALL	R8	1
-      0x00225E08,  //  001F  ADD	R8	K47	R8
-      0x00201130,  //  0020  ADD	R8	R8	K48
-      0x780E0001,  //  0021  JMPF	R3	#0024
-      0x58240031,  //  0022  LDCONST	R9	K49
-      0x70020000,  //  0023  JMP		#0025
-      0x58240015,  //  0024  LDCONST	R9	K21
-      0x00201009,  //  0025  ADD	R8	R8	R9
-      0x7C180400,  //  0026  CALL	R6	2
-      0x7C100400,  //  0027  CALL	R4	2
-      0x8C0C0132,  //  0028  GETMET	R3	R0	K50
-      0x7C0C0200,  //  0029  CALL	R3	1
-      0x880C0116,  //  002A  GETMBR	R3	R0	K22
-      0x880C0733,  //  002B  GETMBR	R3	R3	K51
-      0x8C0C0734,  //  002C  GETMET	R3	R3	K52
-      0x7C0C0200,  //  002D  CALL	R3	1
-      0x780E0001,  //  002E  JMPF	R3	#0031
-      0x8C0C0135,  //  002F  GETMET	R3	R0	K53
-      0x7C0C0200,  //  0030  CALL	R3	1
-      0x80000000,  //  0031  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: page_part_mgr_add
-********************************************************************/
-be_local_closure(class_Matter_UI_page_part_mgr_add,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(page_part_mgr_add),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080305,  //  0001  GETMET	R2	R1	K5
-      0x7C080200,  //  0002  CALL	R2	1
-      0x740A0001,  //  0003  JMPT	R2	#0006
-      0x4C080000,  //  0004  LDNIL	R2
-      0x80040400,  //  0005  RET	1	R2
-      0x8C080306,  //  0006  GETMET	R2	R1	K6
-      0x58100036,  //  0007  LDCONST	R4	K54
-      0x7C080400,  //  0008  CALL	R2	2
-      0x8C080308,  //  0009  GETMET	R2	R1	K8
-      0x7C080200,  //  000A  CALL	R2	1
-      0x8C080337,  //  000B  GETMET	R2	R1	K55
-      0x58100038,  //  000C  LDCONST	R4	K56
-      0x7C080400,  //  000D  CALL	R2	2
-      0x8C0C0109,  //  000E  GETMET	R3	R0	K9
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x780E0002,  //  0010  JMPF	R3	#0014
-      0x8C0C0139,  //  0011  GETMET	R3	R0	K57
-      0x5C140400,  //  0012  MOVE	R5	R2
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x8C0C0313,  //  0014  GETMET	R3	R1	K19
-      0x88140314,  //  0015  GETMBR	R5	R1	K20
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x8C0C030D,  //  0017  GETMET	R3	R1	K13
-      0x7C0C0200,  //  0018  CALL	R3	1
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_plugins_configuration
-********************************************************************/
-be_local_closure(class_Matter_UI_show_plugins_configuration,   /* name */
-  be_nested_proto(
-    29,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_plugins_configuration),
-    &be_const_str_solidified,
-    ( &(const binstruction[322]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0xA40A7400,  //  0001  IMPORT	R2	K58
-      0xA40E7600,  //  0002  IMPORT	R3	K59
-      0x8C100311,  //  0003  GETMET	R4	R1	K17
-      0x5818003C,  //  0004  LDCONST	R6	K60
-      0x7C100400,  //  0005  CALL	R4	2
-      0x8C100311,  //  0006  GETMET	R4	R1	K17
-      0x5818003D,  //  0007  LDCONST	R6	K61
-      0x7C100400,  //  0008  CALL	R4	2
-      0x8C100311,  //  0009  GETMET	R4	R1	K17
-      0x5818003E,  //  000A  LDCONST	R6	K62
-      0x7C100400,  //  000B  CALL	R4	2
-      0x88100116,  //  000C  GETMBR	R4	R0	K22
-      0x8810093F,  //  000D  GETMBR	R4	R4	K63
-      0x8C100940,  //  000E  GETMET	R4	R4	K64
-      0x58180041,  //  000F  LDCONST	R6	K65
-      0x7C100400,  //  0010  CALL	R4	2
-      0x88100116,  //  0011  GETMBR	R4	R0	K22
-      0x8C100942,  //  0012  GETMET	R4	R4	K66
-      0x88180116,  //  0013  GETMBR	R6	R0	K22
-      0x88180D3F,  //  0014  GETMBR	R6	R6	K63
-      0x7C100400,  //  0015  CALL	R4	2
-      0x5814001C,  //  0016  LDCONST	R5	K28
-      0x50180000,  //  0017  LDBOOL	R6	0	0
-      0x601C000C,  //  0018  GETGBL	R7	G12
-      0x5C200800,  //  0019  MOVE	R8	R4
-      0x7C1C0200,  //  001A  CALL	R7	1
-      0x141C0A07,  //  001B  LT	R7	R5	R7
-      0x781E005D,  //  001C  JMPF	R7	#007B
-      0x941C0805,  //  001D  GETIDX	R7	R4	R5
-      0x88200116,  //  001E  GETMBR	R8	R0	K22
-      0x8820113F,  //  001F  GETMBR	R8	R8	K63
-      0x8C201143,  //  0020  GETMET	R8	R8	K67
-      0x60280008,  //  0021  GETGBL	R10	G8
-      0x5C2C0E00,  //  0022  MOVE	R11	R7
-      0x7C280200,  //  0023  CALL	R10	1
-      0x7C200400,  //  0024  CALL	R8	2
-      0x8C241143,  //  0025  GETMET	R9	R8	K67
-      0x582C0023,  //  0026  LDCONST	R11	K35
-      0x7C240400,  //  0027  CALL	R9	2
-      0x5C281200,  //  0028  MOVE	R10	R9
-      0x742A0001,  //  0029  JMPT	R10	#002C
-      0x00140B1E,  //  002A  ADD	R5	R5	K30
-      0x7001FFEB,  //  002B  JMP		#0018
-      0x8C280543,  //  002C  GETMET	R10	R2	K67
-      0x5C301200,  //  002D  MOVE	R12	R9
-      0x58340044,  //  002E  LDCONST	R13	K68
-      0x7C280600,  //  002F  CALL	R10	3
-      0x1C28151C,  //  0030  EQ	R10	R10	K28
-      0x782A0001,  //  0031  JMPF	R10	#0034
-      0x00140B1E,  //  0032  ADD	R5	R5	K30
-      0x7001FFE3,  //  0033  JMP		#0018
-      0x88280116,  //  0034  GETMBR	R10	R0	K22
-      0x88281545,  //  0035  GETMBR	R10	R10	K69
-      0x8C281543,  //  0036  GETMET	R10	R10	K67
-      0x5C301200,  //  0037  MOVE	R12	R9
-      0x7C280400,  //  0038  CALL	R10	2
-      0x582C0015,  //  0039  LDCONST	R11	K21
-      0x58300015,  //  003A  LDCONST	R12	K21
-      0x4C340000,  //  003B  LDNIL	R13
-      0x2034140D,  //  003C  NE	R13	R10	R13
-      0x78360005,  //  003D  JMPF	R13	#0044
-      0x8C341546,  //  003E  GETMET	R13	R10	K70
-      0x5C3C1400,  //  003F  MOVE	R15	R10
-      0x5C401000,  //  0040  MOVE	R16	R8
-      0x7C340600,  //  0041  CALL	R13	3
-      0x5C2C1A00,  //  0042  MOVE	R11	R13
-      0x88301547,  //  0043  GETMBR	R12	R10	K71
-      0x50180200,  //  0044  LDBOOL	R6	1	0
-      0x8C340311,  //  0045  GETMET	R13	R1	K17
-      0x603C0018,  //  0046  GETGBL	R15	G24
-      0x58400048,  //  0047  LDCONST	R16	K72
-      0x5C440E00,  //  0048  MOVE	R17	R7
-      0x7C3C0400,  //  0049  CALL	R15	2
-      0x7C340400,  //  004A  CALL	R13	2
-      0x8C340311,  //  004B  GETMET	R13	R1	K17
-      0x603C0018,  //  004C  GETGBL	R15	G24
-      0x58400049,  //  004D  LDCONST	R16	K73
-      0x5C440E00,  //  004E  MOVE	R17	R7
-      0x8C48034A,  //  004F  GETMET	R18	R1	K74
-      0x8C501143,  //  0050  GETMET	R20	R8	K67
-      0x5858004B,  //  0051  LDCONST	R22	K75
-      0x585C0015,  //  0052  LDCONST	R23	K21
-      0x7C500600,  //  0053  CALL	R20	3
-      0x7C480400,  //  0054  CALL	R18	2
-      0x7C3C0600,  //  0055  CALL	R15	3
-      0x7C340400,  //  0056  CALL	R13	2
-      0x8C340311,  //  0057  GETMET	R13	R1	K17
-      0x603C0018,  //  0058  GETGBL	R15	G24
-      0x5840004C,  //  0059  LDCONST	R16	K76
-      0x8C44014D,  //  005A  GETMET	R17	R0	K77
-      0x8C4C1143,  //  005B  GETMET	R19	R8	K67
-      0x58540023,  //  005C  LDCONST	R21	K35
-      0x58580015,  //  005D  LDCONST	R22	K21
-      0x7C4C0600,  //  005E  CALL	R19	3
-      0x7C440400,  //  005F  CALL	R17	2
-      0x7C3C0400,  //  0060  CALL	R15	2
-      0x7C340400,  //  0061  CALL	R13	2
-      0x8C340311,  //  0062  GETMET	R13	R1	K17
-      0x603C0018,  //  0063  GETGBL	R15	G24
-      0x5840004E,  //  0064  LDCONST	R16	K78
-      0x5C440E00,  //  0065  MOVE	R17	R7
-      0x8C48034A,  //  0066  GETMET	R18	R1	K74
-      0x5C501600,  //  0067  MOVE	R20	R11
-      0x7C480400,  //  0068  CALL	R18	2
-      0x8C4C034A,  //  0069  GETMET	R19	R1	K74
-      0x5C541800,  //  006A  MOVE	R21	R12
-      0x7C4C0400,  //  006B  CALL	R19	2
-      0x8C50034A,  //  006C  GETMET	R20	R1	K74
-      0x5C581800,  //  006D  MOVE	R22	R12
-      0x7C500400,  //  006E  CALL	R20	2
-      0x7C3C0A00,  //  006F  CALL	R15	5
-      0x7C340400,  //  0070  CALL	R13	2
-      0x8C340311,  //  0071  GETMET	R13	R1	K17
-      0x603C0018,  //  0072  GETGBL	R15	G24
-      0x5840004F,  //  0073  LDCONST	R16	K79
-      0x5C440E00,  //  0074  MOVE	R17	R7
-      0x5C480E00,  //  0075  MOVE	R18	R7
-      0x5C4C0E00,  //  0076  MOVE	R19	R7
-      0x7C3C0800,  //  0077  CALL	R15	4
-      0x7C340400,  //  0078  CALL	R13	2
-      0x00140B1E,  //  0079  ADD	R5	R5	K30
-      0x7001FF9C,  //  007A  JMP		#0018
-      0x8C1C0311,  //  007B  GETMET	R7	R1	K17
-      0x58240050,  //  007C  LDCONST	R9	K80
-      0x7C1C0400,  //  007D  CALL	R7	2
-      0x5C1C0C00,  //  007E  MOVE	R7	R6
-      0x741E0002,  //  007F  JMPT	R7	#0083
-      0x8C1C0311,  //  0080  GETMET	R7	R1	K17
-      0x58240051,  //  0081  LDCONST	R9	K81
-      0x7C1C0400,  //  0082  CALL	R7	2
-      0x8C1C0311,  //  0083  GETMET	R7	R1	K17
-      0x58240052,  //  0084  LDCONST	R9	K82
-      0x7C1C0400,  //  0085  CALL	R7	2
-      0x601C0012,  //  0086  GETGBL	R7	G18
-      0x7C1C0000,  //  0087  CALL	R7	0
-      0x60200010,  //  0088  GETGBL	R8	G16
-      0x88240116,  //  0089  GETMBR	R9	R0	K22
-      0x8824133F,  //  008A  GETMBR	R9	R9	K63
-      0x7C200200,  //  008B  CALL	R8	1
-      0xA802000B,  //  008C  EXBLK	0	#0099
-      0x5C241000,  //  008D  MOVE	R9	R8
-      0x7C240000,  //  008E  CALL	R9	0
-      0x8C281343,  //  008F  GETMET	R10	R9	K67
-      0x58300038,  //  0090  LDCONST	R12	K56
-      0x7C280400,  //  0091  CALL	R10	2
-      0x4C2C0000,  //  0092  LDNIL	R11
-      0x202C140B,  //  0093  NE	R11	R10	R11
-      0x782E0002,  //  0094  JMPF	R11	#0098
-      0x8C2C0F22,  //  0095  GETMET	R11	R7	K34
-      0x5C341400,  //  0096  MOVE	R13	R10
-      0x7C2C0400,  //  0097  CALL	R11	2
-      0x7001FFF3,  //  0098  JMP		#008D
-      0x58200003,  //  0099  LDCONST	R8	K3
-      0xAC200200,  //  009A  CATCH	R8	1	0
-      0xB0080000,  //  009B  RAISE	2	R0	R0
-      0x88200116,  //  009C  GETMBR	R8	R0	K22
-      0x8C201153,  //  009D  GETMET	R8	R8	K83
-      0x5C280E00,  //  009E  MOVE	R10	R7
-      0x7C200400,  //  009F  CALL	R8	2
-      0x60200010,  //  00A0  GETGBL	R8	G16
-      0x5C240E00,  //  00A1  MOVE	R9	R7
-      0x7C200200,  //  00A2  CALL	R8	1
-      0xA8020084,  //  00A3  EXBLK	0	#0129
-      0x5C241000,  //  00A4  MOVE	R9	R8
-      0x7C240000,  //  00A5  CALL	R9	0
-      0x8C28034A,  //  00A6  GETMET	R10	R1	K74
-      0x5C301200,  //  00A7  MOVE	R12	R9
-      0x7C280400,  //  00A8  CALL	R10	2
-      0x8C2C034A,  //  00A9  GETMET	R11	R1	K74
-      0x88340116,  //  00AA  GETMBR	R13	R0	K22
-      0x8C341B54,  //  00AB  GETMET	R13	R13	K84
-      0x5C3C1200,  //  00AC  MOVE	R15	R9
-      0x7C340400,  //  00AD  CALL	R13	2
-      0x8C341B43,  //  00AE  GETMET	R13	R13	K67
-      0x583C004B,  //  00AF  LDCONST	R15	K75
-      0x5C401200,  //  00B0  MOVE	R16	R9
-      0x7C340600,  //  00B1  CALL	R13	3
-      0x7C2C0400,  //  00B2  CALL	R11	2
-      0x8C300311,  //  00B3  GETMET	R12	R1	K17
-      0x60380018,  //  00B4  GETGBL	R14	G24
-      0x583C0055,  //  00B5  LDCONST	R15	K85
-      0x5C401400,  //  00B6  MOVE	R16	R10
-      0x5C441400,  //  00B7  MOVE	R17	R10
-      0x5C481600,  //  00B8  MOVE	R18	R11
-      0x7C380800,  //  00B9  CALL	R14	4
-      0x7C300400,  //  00BA  CALL	R12	2
-      0x8C300311,  //  00BB  GETMET	R12	R1	K17
-      0x58380056,  //  00BC  LDCONST	R14	K86
-      0x7C300400,  //  00BD  CALL	R12	2
-      0x50180000,  //  00BE  LDBOOL	R6	0	0
-      0x5814001C,  //  00BF  LDCONST	R5	K28
-      0x6030000C,  //  00C0  GETGBL	R12	G12
-      0x5C340800,  //  00C1  MOVE	R13	R4
-      0x7C300200,  //  00C2  CALL	R12	1
-      0x14300A0C,  //  00C3  LT	R12	R5	R12
-      0x7832005F,  //  00C4  JMPF	R12	#0125
-      0x94300805,  //  00C5  GETIDX	R12	R4	R5
-      0x88340116,  //  00C6  GETMBR	R13	R0	K22
-      0x88341B3F,  //  00C7  GETMBR	R13	R13	K63
-      0x8C341B43,  //  00C8  GETMET	R13	R13	K67
-      0x603C0008,  //  00C9  GETGBL	R15	G8
-      0x5C401800,  //  00CA  MOVE	R16	R12
-      0x7C3C0200,  //  00CB  CALL	R15	1
-      0x7C340400,  //  00CC  CALL	R13	2
-      0x8C381B43,  //  00CD  GETMET	R14	R13	K67
-      0x58400023,  //  00CE  LDCONST	R16	K35
-      0x7C380400,  //  00CF  CALL	R14	2
-      0x5C3C1C00,  //  00D0  MOVE	R15	R14
-      0x743E0001,  //  00D1  JMPT	R15	#00D4
-      0x00140B1E,  //  00D2  ADD	R5	R5	K30
-      0x7001FFEB,  //  00D3  JMP		#00C0
-      0x8C3C0543,  //  00D4  GETMET	R15	R2	K67
-      0x5C441C00,  //  00D5  MOVE	R17	R14
-      0x58480044,  //  00D6  LDCONST	R18	K68
-      0x7C3C0600,  //  00D7  CALL	R15	3
-      0x203C1F1C,  //  00D8  NE	R15	R15	K28
-      0x783E0001,  //  00D9  JMPF	R15	#00DC
-      0x00140B1E,  //  00DA  ADD	R5	R5	K30
-      0x7001FFE3,  //  00DB  JMP		#00C0
-      0x8C3C1B43,  //  00DC  GETMET	R15	R13	K67
-      0x58440038,  //  00DD  LDCONST	R17	K56
-      0x7C3C0400,  //  00DE  CALL	R15	2
-      0x203C1E09,  //  00DF  NE	R15	R15	R9
-      0x783E0001,  //  00E0  JMPF	R15	#00E3
-      0x00140B1E,  //  00E1  ADD	R5	R5	K30
-      0x7001FFDC,  //  00E2  JMP		#00C0
-      0x883C0116,  //  00E3  GETMBR	R15	R0	K22
-      0x883C1F45,  //  00E4  GETMBR	R15	R15	K69
-      0x8C3C1F43,  //  00E5  GETMET	R15	R15	K67
-      0x5C441C00,  //  00E6  MOVE	R17	R14
-      0x7C3C0400,  //  00E7  CALL	R15	2
-      0x58400015,  //  00E8  LDCONST	R16	K21
-      0x58440015,  //  00E9  LDCONST	R17	K21
-      0x4C480000,  //  00EA  LDNIL	R18
-      0x20481E12,  //  00EB  NE	R18	R15	R18
-      0x784A0005,  //  00EC  JMPF	R18	#00F3
-      0x8C481F46,  //  00ED  GETMET	R18	R15	K70
-      0x5C501E00,  //  00EE  MOVE	R20	R15
-      0x5C541A00,  //  00EF  MOVE	R21	R13
-      0x7C480600,  //  00F0  CALL	R18	3
-      0x5C402400,  //  00F1  MOVE	R16	R18
-      0x88441F47,  //  00F2  GETMBR	R17	R15	K71
-      0x50180200,  //  00F3  LDBOOL	R6	1	0
-      0x8C480311,  //  00F4  GETMET	R18	R1	K17
-      0x60500018,  //  00F5  GETGBL	R20	G24
-      0x58540057,  //  00F6  LDCONST	R21	K87
-      0x5C581800,  //  00F7  MOVE	R22	R12
-      0x7C500400,  //  00F8  CALL	R20	2
-      0x7C480400,  //  00F9  CALL	R18	2
-      0x8C480311,  //  00FA  GETMET	R18	R1	K17
-      0x60500018,  //  00FB  GETGBL	R20	G24
-      0x58540058,  //  00FC  LDCONST	R21	K88
-      0x5C581800,  //  00FD  MOVE	R22	R12
-      0x8C5C034A,  //  00FE  GETMET	R23	R1	K74
-      0x8C641B43,  //  00FF  GETMET	R25	R13	K67
-      0x586C004B,  //  0100  LDCONST	R27	K75
-      0x58700015,  //  0101  LDCONST	R28	K21
-      0x7C640600,  //  0102  CALL	R25	3
-      0x7C5C0400,  //  0103  CALL	R23	2
-      0x7C500600,  //  0104  CALL	R20	3
-      0x7C480400,  //  0105  CALL	R18	2
-      0x8C480311,  //  0106  GETMET	R18	R1	K17
-      0x60500018,  //  0107  GETGBL	R20	G24
-      0x58540059,  //  0108  LDCONST	R21	K89
-      0x8C58014D,  //  0109  GETMET	R22	R0	K77
-      0x8C601B43,  //  010A  GETMET	R24	R13	K67
-      0x58680023,  //  010B  LDCONST	R26	K35
-      0x586C0015,  //  010C  LDCONST	R27	K21
-      0x7C600600,  //  010D  CALL	R24	3
-      0x7C580400,  //  010E  CALL	R22	2
-      0x7C500400,  //  010F  CALL	R20	2
-      0x7C480400,  //  0110  CALL	R18	2
-      0x8C480311,  //  0111  GETMET	R18	R1	K17
-      0x60500018,  //  0112  GETGBL	R20	G24
-      0x5854005A,  //  0113  LDCONST	R21	K90
-      0x5C581800,  //  0114  MOVE	R22	R12
-      0x8C5C034A,  //  0115  GETMET	R23	R1	K74
-      0x5C642000,  //  0116  MOVE	R25	R16
-      0x7C5C0400,  //  0117  CALL	R23	2
-      0x8C60034A,  //  0118  GETMET	R24	R1	K74
-      0x5C682200,  //  0119  MOVE	R26	R17
-      0x7C600400,  //  011A  CALL	R24	2
-      0x7C500800,  //  011B  CALL	R20	4
-      0x7C480400,  //  011C  CALL	R18	2
-      0x8C480311,  //  011D  GETMET	R18	R1	K17
-      0x60500018,  //  011E  GETGBL	R20	G24
-      0x5854005B,  //  011F  LDCONST	R21	K91
-      0x5C581800,  //  0120  MOVE	R22	R12
-      0x7C500400,  //  0121  CALL	R20	2
-      0x7C480400,  //  0122  CALL	R18	2
-      0x00140B1E,  //  0123  ADD	R5	R5	K30
-      0x7001FF9A,  //  0124  JMP		#00C0
-      0x8C300311,  //  0125  GETMET	R12	R1	K17
-      0x5838005C,  //  0126  LDCONST	R14	K92
-      0x7C300400,  //  0127  CALL	R12	2
-      0x7001FF7A,  //  0128  JMP		#00A4
-      0x58200003,  //  0129  LDCONST	R8	K3
-      0xAC200200,  //  012A  CATCH	R8	1	0
-      0xB0080000,  //  012B  RAISE	2	R0	R0
-      0x5C200C00,  //  012C  MOVE	R8	R6
-      0x74220002,  //  012D  JMPT	R8	#0131
-      0x8C200311,  //  012E  GETMET	R8	R1	K17
-      0x58280051,  //  012F  LDCONST	R10	K81
-      0x7C200400,  //  0130  CALL	R8	2
-      0x8C200311,  //  0131  GETMET	R8	R1	K17
-      0x5828005D,  //  0132  LDCONST	R10	K93
-      0x7C200400,  //  0133  CALL	R8	2
-      0x8C20015E,  //  0134  GETMET	R8	R0	K94
-      0x8828015F,  //  0135  GETMBR	R10	R0	K95
-      0x7C200400,  //  0136  CALL	R8	2
-      0x8C200311,  //  0137  GETMET	R8	R1	K17
-      0x58280060,  //  0138  LDCONST	R10	K96
-      0x7C200400,  //  0139  CALL	R8	2
-      0x8C200161,  //  013A  GETMET	R8	R0	K97
-      0x58280015,  //  013B  LDCONST	R10	K21
-      0x882C015F,  //  013C  GETMBR	R11	R0	K95
-      0x7C200600,  //  013D  CALL	R8	3
-      0x8C200311,  //  013E  GETMET	R8	R1	K17
-      0x58280062,  //  013F  LDCONST	R10	K98
-      0x7C200400,  //  0140  CALL	R8	2
-      0x80000000,  //  0141  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_commissioning_info
-********************************************************************/
-be_local_closure(class_Matter_UI_show_commissioning_info,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_commissioning_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x88080116,  //  0001  GETMBR	R2	R0	K22
-      0x88080533,  //  0002  GETMBR	R2	R2	K51
-      0x88080563,  //  0003  GETMBR	R2	R2	K99
-      0xB80E3000,  //  0004  GETNGBL	R3	K24
-      0x8C0C0764,  //  0005  GETMET	R3	R3	K100
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x04080403,  //  0007  SUB	R2	R2	R3
-      0x540E03E7,  //  0008  LDINT	R3	1000
-      0x0C080403,  //  0009  DIV	R2	R2	R3
-      0x140C051C,  //  000A  LT	R3	R2	K28
-      0x780E0000,  //  000B  JMPF	R3	#000D
-      0x5808001C,  //  000C  LDCONST	R2	K28
-      0x540E001D,  //  000D  LDINT	R3	30
-      0x000C0403,  //  000E  ADD	R3	R2	R3
-      0x5412003B,  //  000F  LDINT	R4	60
-      0x0C0C0604,  //  0010  DIV	R3	R3	R4
-      0x8C100311,  //  0011  GETMET	R4	R1	K17
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0065,  //  0013  LDCONST	R7	K101
-      0x5C200600,  //  0014  MOVE	R8	R3
-      0x7C180400,  //  0015  CALL	R6	2
-      0x7C100400,  //  0016  CALL	R4	2
-      0x88100116,  //  0017  GETMBR	R4	R0	K22
-      0x88100933,  //  0018  GETMBR	R4	R4	K51
-      0x8C100966,  //  0019  GETMET	R4	R4	K102
-      0x7C100200,  //  001A  CALL	R4	1
-      0x8C140311,  //  001B  GETMET	R5	R1	K17
-      0x601C0018,  //  001C  GETGBL	R7	G24
-      0x58200067,  //  001D  LDCONST	R8	K103
-      0x40263968,  //  001E  CONNECT	R9	K28	K104
-      0x94240809,  //  001F  GETIDX	R9	R4	R9
-      0x542A0003,  //  0020  LDINT	R10	4
-      0x542E0005,  //  0021  LDINT	R11	6
-      0x4028140B,  //  0022  CONNECT	R10	R10	R11
-      0x9428080A,  //  0023  GETIDX	R10	R4	R10
-      0x542E0006,  //  0024  LDINT	R11	7
-      0x402C1769,  //  0025  CONNECT	R11	R11	K105
-      0x942C080B,  //  0026  GETIDX	R11	R4	R11
-      0x7C1C0800,  //  0027  CALL	R7	4
-      0x7C140400,  //  0028  CALL	R5	2
-      0x8C140311,  //  0029  GETMET	R5	R1	K17
-      0x581C006A,  //  002A  LDCONST	R7	K106
-      0x7C140400,  //  002B  CALL	R5	2
-      0x88140116,  //  002C  GETMBR	R5	R0	K22
-      0x88140B33,  //  002D  GETMBR	R5	R5	K51
-      0x8C140B6B,  //  002E  GETMET	R5	R5	K107
-      0x7C140200,  //  002F  CALL	R5	1
-      0x8C18016C,  //  0030  GETMET	R6	R0	K108
-      0x5C200A00,  //  0031  MOVE	R8	R5
-      0x7C180400,  //  0032  CALL	R6	2
-      0x8C180311,  //  0033  GETMET	R6	R1	K17
-      0x60200018,  //  0034  GETGBL	R8	G24
-      0x5824006D,  //  0035  LDCONST	R9	K109
-      0x5C280A00,  //  0036  MOVE	R10	R5
-      0x7C200400,  //  0037  CALL	R8	2
-      0x7C180400,  //  0038  CALL	R6	2
-      0x8C180311,  //  0039  GETMET	R6	R1	K17
-      0x5820006E,  //  003A  LDCONST	R8	K110
-      0x7C180400,  //  003B  CALL	R6	2
-      0x80000000,  //  003C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_remote_autoconf
-********************************************************************/
-be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
-  be_nested_proto(
-    27,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_remote_autoconf),
-    &be_const_str_solidified,
-    ( &(const binstruction[220]) {  /* code */
-      0xA40A0800,  //  0000  IMPORT	R2	K4
-      0xA40EDE00,  //  0001  IMPORT	R3	K111
-      0x1C100315,  //  0002  EQ	R4	R1	K21
-      0x78120000,  //  0003  JMPF	R4	#0005
-      0x80000800,  //  0004  RET	0
-      0xB8123400,  //  0005  GETNGBL	R4	K26
-      0x88100970,  //  0006  GETMBR	R4	R4	K112
-      0x88100971,  //  0007  GETMBR	R4	R4	K113
-      0xB8163400,  //  0008  GETNGBL	R5	K26
-      0x8C140B72,  //  0009  GETMET	R5	R5	K114
-      0x4C1C0000,  //  000A  LDNIL	R7
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x5C240800,  //  000C  MOVE	R9	R4
-      0x7C140800,  //  000D  CALL	R5	4
-      0x8C180B73,  //  000E  GETMET	R6	R5	K115
-      0x58200074,  //  000F  LDCONST	R8	K116
-      0x5C240800,  //  0010  MOVE	R9	R4
-      0x7C180600,  //  0011  CALL	R6	3
-      0x4C1C0000,  //  0012  LDNIL	R7
-      0x201C0C07,  //  0013  NE	R7	R6	R7
-      0x781E0003,  //  0014  JMPF	R7	#0019
-      0x8C1C0775,  //  0015  GETMET	R7	R3	K117
-      0x5C240C00,  //  0016  MOVE	R9	R6
-      0x7C1C0400,  //  0017  CALL	R7	2
-      0x5C180E00,  //  0018  MOVE	R6	R7
-      0x4C1C0000,  //  0019  LDNIL	R7
-      0x201C0C07,  //  001A  NE	R7	R6	R7
-      0x781E0003,  //  001B  JMPF	R7	#0020
-      0x8C1C0D43,  //  001C  GETMET	R7	R6	K67
-      0x58240076,  //  001D  LDCONST	R9	K118
-      0x7C1C0400,  //  001E  CALL	R7	2
-      0x5C180E00,  //  001F  MOVE	R6	R7
-      0x4C1C0000,  //  0020  LDNIL	R7
-      0x4C200000,  //  0021  LDNIL	R8
-      0x20200C08,  //  0022  NE	R8	R6	R8
-      0x78220012,  //  0023  JMPF	R8	#0037
-      0x8C200B73,  //  0024  GETMET	R8	R5	K115
-      0x58280077,  //  0025  LDCONST	R10	K119
-      0x5C2C0800,  //  0026  MOVE	R11	R4
-      0x7C200600,  //  0027  CALL	R8	3
-      0x5C1C1000,  //  0028  MOVE	R7	R8
-      0x4C200000,  //  0029  LDNIL	R8
-      0x20200E08,  //  002A  NE	R8	R7	R8
-      0x78220003,  //  002B  JMPF	R8	#0030
-      0x8C200775,  //  002C  GETMET	R8	R3	K117
-      0x5C280E00,  //  002D  MOVE	R10	R7
-      0x7C200400,  //  002E  CALL	R8	2
-      0x5C1C1000,  //  002F  MOVE	R7	R8
-      0x4C200000,  //  0030  LDNIL	R8
-      0x20200E08,  //  0031  NE	R8	R7	R8
-      0x78220003,  //  0032  JMPF	R8	#0037
-      0x8C200F43,  //  0033  GETMET	R8	R7	K67
-      0x58280078,  //  0034  LDCONST	R10	K120
-      0x7C200400,  //  0035  CALL	R8	2
-      0x5C1C1000,  //  0036  MOVE	R7	R8
-      0x4C200000,  //  0037  LDNIL	R8
-      0x20200C08,  //  0038  NE	R8	R6	R8
-      0x78220098,  //  0039  JMPF	R8	#00D3
-      0x4C200000,  //  003A  LDNIL	R8
-      0x20200E08,  //  003B  NE	R8	R7	R8
-      0x78220095,  //  003C  JMPF	R8	#00D3
-      0xB822F200,  //  003D  GETNGBL	R8	K121
-      0x60240018,  //  003E  GETGBL	R9	G24
-      0x5828007A,  //  003F  LDCONST	R10	K122
-      0x5C2C0200,  //  0040  MOVE	R11	R1
-      0x60300008,  //  0041  GETGBL	R12	G8
-      0x5C340C00,  //  0042  MOVE	R13	R6
-      0x7C300200,  //  0043  CALL	R12	1
-      0x60340008,  //  0044  GETGBL	R13	G8
-      0x5C380E00,  //  0045  MOVE	R14	R7
-      0x7C340200,  //  0046  CALL	R13	1
-      0x7C240800,  //  0047  CALL	R9	4
-      0x58280068,  //  0048  LDCONST	R10	K104
-      0x7C200400,  //  0049  CALL	R8	2
-      0x8C20017B,  //  004A  GETMET	R8	R0	K123
-      0x5C280C00,  //  004B  MOVE	R10	R6
-      0x5C2C0E00,  //  004C  MOVE	R11	R7
-      0x7C200600,  //  004D  CALL	R8	3
-      0x8C24015E,  //  004E  GETMET	R9	R0	K94
-      0x882C017C,  //  004F  GETMBR	R11	R0	K124
-      0x7C240400,  //  0050  CALL	R9	2
-      0x8C240511,  //  0051  GETMET	R9	R2	K17
-      0x582C007D,  //  0052  LDCONST	R11	K125
-      0x7C240400,  //  0053  CALL	R9	2
-      0x8C24054A,  //  0054  GETMET	R9	R2	K74
-      0x5C2C0200,  //  0055  MOVE	R11	R1
-      0x7C240400,  //  0056  CALL	R9	2
-      0x8C280511,  //  0057  GETMET	R10	R2	K17
-      0x60300018,  //  0058  GETGBL	R12	G24
-      0x5834007E,  //  0059  LDCONST	R13	K126
-      0x5C381200,  //  005A  MOVE	R14	R9
-      0x5C3C1200,  //  005B  MOVE	R15	R9
-      0x7C300600,  //  005C  CALL	R12	3
-      0x7C280400,  //  005D  CALL	R10	2
-      0x8C280511,  //  005E  GETMET	R10	R2	K17
-      0x5830007F,  //  005F  LDCONST	R12	K127
-      0x7C280400,  //  0060  CALL	R10	2
-      0x8C280511,  //  0061  GETMET	R10	R2	K17
-      0x60300018,  //  0062  GETGBL	R12	G24
-      0x58340080,  //  0063  LDCONST	R13	K128
-      0x8C38054A,  //  0064  GETMET	R14	R2	K74
-      0x5C400200,  //  0065  MOVE	R16	R1
-      0x7C380400,  //  0066  CALL	R14	2
-      0x7C300400,  //  0067  CALL	R12	2
-      0x7C280400,  //  0068  CALL	R10	2
-      0x5828001C,  //  0069  LDCONST	R10	K28
-      0x602C000C,  //  006A  GETGBL	R11	G12
-      0x5C301000,  //  006B  MOVE	R12	R8
-      0x7C2C0200,  //  006C  CALL	R11	1
-      0x142C140B,  //  006D  LT	R11	R10	R11
-      0x782E0040,  //  006E  JMPF	R11	#00B0
-      0x942C100A,  //  006F  GETIDX	R11	R8	R10
-      0x8C301743,  //  0070  GETMET	R12	R11	K67
-      0x58380023,  //  0071  LDCONST	R14	K35
-      0x583C0015,  //  0072  LDCONST	R15	K21
-      0x7C300600,  //  0073  CALL	R12	3
-      0x20341915,  //  0074  NE	R13	R12	K21
-      0x78360000,  //  0075  JMPF	R13	#0077
-      0x0032880C,  //  0076  ADD	R12	K68	R12
-      0x88340116,  //  0077  GETMBR	R13	R0	K22
-      0x88341B45,  //  0078  GETMBR	R13	R13	K69
-      0x8C341B43,  //  0079  GETMET	R13	R13	K67
-      0x5C3C1800,  //  007A  MOVE	R15	R12
-      0x7C340400,  //  007B  CALL	R13	2
-      0x58380015,  //  007C  LDCONST	R14	K21
-      0x583C0015,  //  007D  LDCONST	R15	K21
-      0x4C400000,  //  007E  LDNIL	R16
-      0x20401A10,  //  007F  NE	R16	R13	R16
-      0x78420005,  //  0080  JMPF	R16	#0087
-      0x8C401B46,  //  0081  GETMET	R16	R13	K70
-      0x5C481A00,  //  0082  MOVE	R18	R13
-      0x5C4C1600,  //  0083  MOVE	R19	R11
-      0x7C400600,  //  0084  CALL	R16	3
-      0x5C382000,  //  0085  MOVE	R14	R16
-      0x883C1B47,  //  0086  GETMBR	R15	R13	K71
-      0x8C400511,  //  0087  GETMET	R16	R2	K17
-      0x60480018,  //  0088  GETGBL	R18	G24
-      0x584C0081,  //  0089  LDCONST	R19	K129
-      0x5C501400,  //  008A  MOVE	R20	R10
-      0x7C480400,  //  008B  CALL	R18	2
-      0x7C400400,  //  008C  CALL	R16	2
-      0x8C400511,  //  008D  GETMET	R16	R2	K17
-      0x60480018,  //  008E  GETGBL	R18	G24
-      0x584C0082,  //  008F  LDCONST	R19	K130
-      0x5C501400,  //  0090  MOVE	R20	R10
-      0x5C541400,  //  0091  MOVE	R21	R10
-      0x7C480600,  //  0092  CALL	R18	3
-      0x7C400400,  //  0093  CALL	R16	2
-      0x8C400161,  //  0094  GETMET	R16	R0	K97
-      0x5C481800,  //  0095  MOVE	R18	R12
-      0x884C017C,  //  0096  GETMBR	R19	R0	K124
-      0x7C400600,  //  0097  CALL	R16	3
-      0x8C400511,  //  0098  GETMET	R16	R2	K17
-      0x58480083,  //  0099  LDCONST	R18	K131
-      0x7C400400,  //  009A  CALL	R16	2
-      0x8C400511,  //  009B  GETMET	R16	R2	K17
-      0x60480018,  //  009C  GETGBL	R18	G24
-      0x584C0084,  //  009D  LDCONST	R19	K132
-      0x5C501400,  //  009E  MOVE	R20	R10
-      0x5C541400,  //  009F  MOVE	R21	R10
-      0x8C58054A,  //  00A0  GETMET	R22	R2	K74
-      0x5C601C00,  //  00A1  MOVE	R24	R14
-      0x7C580400,  //  00A2  CALL	R22	2
-      0x8C5C054A,  //  00A3  GETMET	R23	R2	K74
-      0x5C641E00,  //  00A4  MOVE	R25	R15
-      0x7C5C0400,  //  00A5  CALL	R23	2
-      0x8C60054A,  //  00A6  GETMET	R24	R2	K74
-      0x5C681E00,  //  00A7  MOVE	R26	R15
-      0x7C600400,  //  00A8  CALL	R24	2
-      0x7C480C00,  //  00A9  CALL	R18	6
-      0x7C400400,  //  00AA  CALL	R16	2
-      0x8C400511,  //  00AB  GETMET	R16	R2	K17
-      0x58480085,  //  00AC  LDCONST	R18	K133
-      0x7C400400,  //  00AD  CALL	R16	2
-      0x0028151E,  //  00AE  ADD	R10	R10	K30
-      0x7001FFB9,  //  00AF  JMP		#006A
-      0x8C2C0511,  //  00B0  GETMET	R11	R2	K17
-      0x60340018,  //  00B1  GETGBL	R13	G24
-      0x58380081,  //  00B2  LDCONST	R14	K129
-      0x5C3C1400,  //  00B3  MOVE	R15	R10
-      0x7C340400,  //  00B4  CALL	R13	2
-      0x7C2C0400,  //  00B5  CALL	R11	2
-      0x8C2C0511,  //  00B6  GETMET	R11	R2	K17
-      0x60340018,  //  00B7  GETGBL	R13	G24
-      0x58380082,  //  00B8  LDCONST	R14	K130
-      0x5C3C1400,  //  00B9  MOVE	R15	R10
-      0x5C401400,  //  00BA  MOVE	R16	R10
-      0x7C340600,  //  00BB  CALL	R13	3
-      0x7C2C0400,  //  00BC  CALL	R11	2
-      0x8C2C0161,  //  00BD  GETMET	R11	R0	K97
-      0x58340015,  //  00BE  LDCONST	R13	K21
-      0x8838017C,  //  00BF  GETMBR	R14	R0	K124
-      0x7C2C0600,  //  00C0  CALL	R11	3
-      0x8C2C0511,  //  00C1  GETMET	R11	R2	K17
-      0x58340083,  //  00C2  LDCONST	R13	K131
-      0x7C2C0400,  //  00C3  CALL	R11	2
-      0x8C2C0511,  //  00C4  GETMET	R11	R2	K17
-      0x60340018,  //  00C5  GETGBL	R13	G24
-      0x58380086,  //  00C6  LDCONST	R14	K134
-      0x5C3C1400,  //  00C7  MOVE	R15	R10
-      0x5C401400,  //  00C8  MOVE	R16	R10
-      0x58440015,  //  00C9  LDCONST	R17	K21
-      0x7C340800,  //  00CA  CALL	R13	4
-      0x7C2C0400,  //  00CB  CALL	R11	2
-      0x8C2C0511,  //  00CC  GETMET	R11	R2	K17
-      0x58340085,  //  00CD  LDCONST	R13	K133
-      0x7C2C0400,  //  00CE  CALL	R11	2
-      0x8C2C0511,  //  00CF  GETMET	R11	R2	K17
-      0x58340087,  //  00D0  LDCONST	R13	K135
-      0x7C2C0400,  //  00D1  CALL	R11	2
-      0x70020007,  //  00D2  JMP		#00DB
-      0x8C200511,  //  00D3  GETMET	R8	R2	K17
-      0x60280018,  //  00D4  GETGBL	R10	G24
-      0x582C0088,  //  00D5  LDCONST	R11	K136
-      0x8C30054A,  //  00D6  GETMET	R12	R2	K74
-      0x5C380200,  //  00D7  MOVE	R14	R1
-      0x7C300400,  //  00D8  CALL	R12	2
-      0x7C280400,  //  00D9  CALL	R10	2
-      0x7C200400,  //  00DA  CALL	R8	2
-      0x80000000,  //  00DB  RET	0
     })
   )
 );
@@ -1405,27 +466,27 @@ be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
     be_str_weak(show_fabric_info),
     &be_const_str_solidified,
     ( &(const binstruction[97]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080311,  //  0001  GETMET	R2	R1	K17
-      0x58100089,  //  0002  LDCONST	R4	K137
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080307,  //  0001  GETMET	R2	R1	K7
+      0x58100022,  //  0002  LDCONST	R4	K34
       0x7C080400,  //  0003  CALL	R2	2
       0x6008000C,  //  0004  GETGBL	R2	G12
-      0x880C0116,  //  0005  GETMBR	R3	R0	K22
-      0x880C072B,  //  0006  GETMBR	R3	R3	K43
-      0x880C072B,  //  0007  GETMBR	R3	R3	K43
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x880C0723,  //  0006  GETMBR	R3	R3	K35
+      0x880C0723,  //  0007  GETMBR	R3	R3	K35
       0x7C080200,  //  0008  CALL	R2	1
-      0x1C08051C,  //  0009  EQ	R2	R2	K28
+      0x1C080506,  //  0009  EQ	R2	R2	K6
       0x780A0003,  //  000A  JMPF	R2	#000F
-      0x8C080311,  //  000B  GETMET	R2	R1	K17
-      0x5810008A,  //  000C  LDCONST	R4	K138
+      0x8C080307,  //  000B  GETMET	R2	R1	K7
+      0x58100024,  //  000C  LDCONST	R4	K36
       0x7C080400,  //  000D  CALL	R2	2
       0x7002004D,  //  000E  JMP		#005D
       0x50080200,  //  000F  LDBOOL	R2	1	0
       0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100116,  //  0011  GETMBR	R4	R0	K22
-      0x8810092B,  //  0012  GETMBR	R4	R4	K43
-      0x8810098B,  //  0013  GETMBR	R4	R4	K139
-      0x8C10098C,  //  0014  GETMET	R4	R4	K140
+      0x88100101,  //  0011  GETMBR	R4	R0	K1
+      0x88100923,  //  0012  GETMBR	R4	R4	K35
+      0x88100925,  //  0013  GETMBR	R4	R4	K37
+      0x8C100926,  //  0014  GETMET	R4	R4	K38
       0x7C100200,  //  0015  CALL	R4	1
       0x7C0C0200,  //  0016  CALL	R3	1
       0xA8020041,  //  0017  EXBLK	0	#005A
@@ -1433,73 +494,73 @@ be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
       0x7C100000,  //  0019  CALL	R4	0
       0x5C140400,  //  001A  MOVE	R5	R2
       0x74160002,  //  001B  JMPT	R5	#001F
-      0x8C140311,  //  001C  GETMET	R5	R1	K17
-      0x581C008D,  //  001D  LDCONST	R7	K141
+      0x8C140307,  //  001C  GETMET	R5	R1	K7
+      0x581C0027,  //  001D  LDCONST	R7	K39
       0x7C140400,  //  001E  CALL	R5	2
       0x50080000,  //  001F  LDBOOL	R2	0	0
-      0x8814098E,  //  0020  GETMBR	R5	R4	K142
+      0x88140928,  //  0020  GETMBR	R5	R4	K40
       0x5C180A00,  //  0021  MOVE	R6	R5
       0x741A0000,  //  0022  JMPT	R6	#0024
-      0x5814008F,  //  0023  LDCONST	R5	K143
-      0x8C18034A,  //  0024  GETMET	R6	R1	K74
+      0x58140029,  //  0023  LDCONST	R5	K41
+      0x8C18032A,  //  0024  GETMET	R6	R1	K42
       0x5C200A00,  //  0025  MOVE	R8	R5
       0x7C180400,  //  0026  CALL	R6	2
       0x5C140C00,  //  0027  MOVE	R5	R6
-      0x8C180311,  //  0028  GETMET	R6	R1	K17
+      0x8C180307,  //  0028  GETMET	R6	R1	K7
       0x60200018,  //  0029  GETGBL	R8	G24
-      0x58240090,  //  002A  LDCONST	R9	K144
-      0x8C280991,  //  002B  GETMET	R10	R4	K145
+      0x5824002B,  //  002A  LDCONST	R9	K43
+      0x8C28092C,  //  002B  GETMET	R10	R4	K44
       0x7C280200,  //  002C  CALL	R10	1
       0x5C2C0A00,  //  002D  MOVE	R11	R5
-      0x8C300992,  //  002E  GETMET	R12	R4	K146
+      0x8C30092D,  //  002E  GETMET	R12	R4	K45
       0x7C300200,  //  002F  CALL	R12	1
       0x7C200800,  //  0030  CALL	R8	4
       0x7C180400,  //  0031  CALL	R6	2
-      0x8C180993,  //  0032  GETMET	R6	R4	K147
+      0x8C18092E,  //  0032  GETMET	R6	R4	K46
       0x7C180200,  //  0033  CALL	R6	1
-      0x8C180D94,  //  0034  GETMET	R6	R6	K148
+      0x8C180D2F,  //  0034  GETMET	R6	R6	K47
       0x7C180200,  //  0035  CALL	R6	1
-      0x8C180D95,  //  0036  GETMET	R6	R6	K149
+      0x8C180D30,  //  0036  GETMET	R6	R6	K48
       0x7C180200,  //  0037  CALL	R6	1
-      0x8C1C0996,  //  0038  GETMET	R7	R4	K150
+      0x8C1C0931,  //  0038  GETMET	R7	R4	K49
       0x7C1C0200,  //  0039  CALL	R7	1
-      0x8C1C0F94,  //  003A  GETMET	R7	R7	K148
+      0x8C1C0F2F,  //  003A  GETMET	R7	R7	K47
       0x7C1C0200,  //  003B  CALL	R7	1
-      0x8C1C0F95,  //  003C  GETMET	R7	R7	K149
+      0x8C1C0F30,  //  003C  GETMET	R7	R7	K48
       0x7C1C0200,  //  003D  CALL	R7	1
-      0x8C200311,  //  003E  GETMET	R8	R1	K17
+      0x8C200307,  //  003E  GETMET	R8	R1	K7
       0x60280018,  //  003F  GETGBL	R10	G24
-      0x582C0097,  //  0040  LDCONST	R11	K151
-      0x8C300D98,  //  0041  GETMET	R12	R6	K152
+      0x582C0032,  //  0040  LDCONST	R11	K50
+      0x8C300D33,  //  0041  GETMET	R12	R6	K51
       0x7C300200,  //  0042  CALL	R12	1
       0x7C280400,  //  0043  CALL	R10	2
       0x7C200400,  //  0044  CALL	R8	2
-      0x8C200311,  //  0045  GETMET	R8	R1	K17
+      0x8C200307,  //  0045  GETMET	R8	R1	K7
       0x60280018,  //  0046  GETGBL	R10	G24
-      0x582C0099,  //  0047  LDCONST	R11	K153
-      0x8C300F98,  //  0048  GETMET	R12	R7	K152
+      0x582C0034,  //  0047  LDCONST	R11	K52
+      0x8C300F33,  //  0048  GETMET	R12	R7	K51
       0x7C300200,  //  0049  CALL	R12	1
       0x7C280400,  //  004A  CALL	R10	2
       0x7C200400,  //  004B  CALL	R8	2
-      0x8C200311,  //  004C  GETMET	R8	R1	K17
-      0x5828009A,  //  004D  LDCONST	R10	K154
+      0x8C200307,  //  004C  GETMET	R8	R1	K7
+      0x58280035,  //  004D  LDCONST	R10	K53
       0x7C200400,  //  004E  CALL	R8	2
-      0x8C200311,  //  004F  GETMET	R8	R1	K17
+      0x8C200307,  //  004F  GETMET	R8	R1	K7
       0x60280018,  //  0050  GETGBL	R10	G24
-      0x582C009B,  //  0051  LDCONST	R11	K155
-      0x8C300991,  //  0052  GETMET	R12	R4	K145
+      0x582C0036,  //  0051  LDCONST	R11	K54
+      0x8C30092C,  //  0052  GETMET	R12	R4	K44
       0x7C300200,  //  0053  CALL	R12	1
       0x7C280400,  //  0054  CALL	R10	2
       0x7C200400,  //  0055  CALL	R8	2
-      0x8C200311,  //  0056  GETMET	R8	R1	K17
-      0x5828009C,  //  0057  LDCONST	R10	K156
+      0x8C200307,  //  0056  GETMET	R8	R1	K7
+      0x58280037,  //  0057  LDCONST	R10	K55
       0x7C200400,  //  0058  CALL	R8	2
       0x7001FFBD,  //  0059  JMP		#0018
-      0x580C0003,  //  005A  LDCONST	R3	K3
+      0x580C001C,  //  005A  LDCONST	R3	K28
       0xAC0C0200,  //  005B  CATCH	R3	1	0
       0xB0080000,  //  005C  RAISE	2	R0	R0
-      0x8C080311,  //  005D  GETMET	R2	R1	K17
-      0x5810009D,  //  005E  LDCONST	R4	K157
+      0x8C080307,  //  005D  GETMET	R2	R1	K7
+      0x58100038,  //  005E  LDCONST	R4	K56
       0x7C080400,  //  005F  CALL	R2	2
       0x80000000,  //  0060  RET	0
     })
@@ -1509,168 +570,11 @@ be_local_closure(class_Matter_UI_show_fabric_info,   /* name */
 
 
 /********************************************************************
-** Solidified function: web_get_arg
+** Solidified function: show_qrcode
 ********************************************************************/
-be_local_closure(class_Matter_UI_web_get_arg,   /* name */
+be_local_closure(class_Matter_UI_show_qrcode,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(web_get_arg),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C08039E,  //  0001  GETMET	R2	R1	K158
-      0x5810009F,  //  0002  LDCONST	R4	K159
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0004,  //  0004  JMPF	R2	#000A
-      0x88080116,  //  0005  GETMBR	R2	R0	K22
-      0x88080533,  //  0006  GETMBR	R2	R2	K51
-      0x8C0805A0,  //  0007  GETMET	R2	R2	K160
-      0x7C080200,  //  0008  CALL	R2	1
-      0x70020007,  //  0009  JMP		#0012
-      0x8C08039E,  //  000A  GETMET	R2	R1	K158
-      0x581000A1,  //  000B  LDCONST	R4	K161
-      0x7C080400,  //  000C  CALL	R2	2
-      0x780A0003,  //  000D  JMPF	R2	#0012
-      0x88080116,  //  000E  GETMBR	R2	R0	K22
-      0x88080533,  //  000F  GETMBR	R2	R2	K51
-      0x8C0805A2,  //  0010  GETMET	R2	R2	K162
-      0x7C080200,  //  0011  CALL	R2	1
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: plugin_option
-********************************************************************/
-be_local_closure(class_Matter_UI_plugin_option,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    11,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(plugin_option),
-    &be_const_str_solidified,
-    ( &(const binstruction[57]) {  /* code */
-      0xA40E0800,  //  0000  IMPORT	R3	K4
-      0xA4127400,  //  0001  IMPORT	R4	K58
-      0x60140012,  //  0002  GETGBL	R5	G18
-      0x7C140000,  //  0003  CALL	R5	0
-      0x60180010,  //  0004  GETGBL	R6	G16
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C180200,  //  0006  CALL	R6	1
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x5C1C0C00,  //  0008  MOVE	R7	R6
-      0x7C1C0000,  //  0009  CALL	R7	0
-      0x8C2009A3,  //  000A  GETMET	R8	R4	K163
-      0x5C280E00,  //  000B  MOVE	R10	R7
-      0x582C00A4,  //  000C  LDCONST	R11	K164
-      0x7C200600,  //  000D  CALL	R8	3
-      0x00140A08,  //  000E  ADD	R5	R5	R8
-      0x7001FFF7,  //  000F  JMP		#0008
-      0x58180003,  //  0010  LDCONST	R6	K3
-      0xAC180200,  //  0011  CATCH	R6	1	0
-      0xB0080000,  //  0012  RAISE	2	R0	R0
-      0x5818001C,  //  0013  LDCONST	R6	K28
-      0x601C000C,  //  0014  GETGBL	R7	G12
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C1C0200,  //  0016  CALL	R7	1
-      0x141C0C07,  //  0017  LT	R7	R6	R7
-      0x781E001E,  //  0018  JMPF	R7	#0038
-      0x941C0A06,  //  0019  GETIDX	R7	R5	R6
-      0x1C200F15,  //  001A  EQ	R8	R7	K21
-      0x78220003,  //  001B  JMPF	R8	#0020
-      0x8C200711,  //  001C  GETMET	R8	R3	K17
-      0x582800A5,  //  001D  LDCONST	R10	K165
-      0x7C200400,  //  001E  CALL	R8	2
-      0x70020015,  //  001F  JMP		#0036
-      0x1C200FA6,  //  0020  EQ	R8	R7	K166
-      0x78220003,  //  0021  JMPF	R8	#0026
-      0x8C200711,  //  0022  GETMET	R8	R3	K17
-      0x582800A7,  //  0023  LDCONST	R10	K167
-      0x7C200400,  //  0024  CALL	R8	2
-      0x7002000F,  //  0025  JMP		#0036
-      0x88200116,  //  0026  GETMBR	R8	R0	K22
-      0x8C201117,  //  0027  GETMET	R8	R8	K23
-      0x5C280E00,  //  0028  MOVE	R10	R7
-      0x7C200400,  //  0029  CALL	R8	2
-      0x8C240711,  //  002A  GETMET	R9	R3	K17
-      0x602C0018,  //  002B  GETGBL	R11	G24
-      0x583000A8,  //  002C  LDCONST	R12	K168
-      0x5C340E00,  //  002D  MOVE	R13	R7
-      0x1C380E01,  //  002E  EQ	R14	R7	R1
-      0x783A0001,  //  002F  JMPF	R14	#0032
-      0x583800A9,  //  0030  LDCONST	R14	K169
-      0x70020000,  //  0031  JMP		#0033
-      0x58380015,  //  0032  LDCONST	R14	K21
-      0x5C3C1000,  //  0033  MOVE	R15	R8
-      0x7C2C0800,  //  0034  CALL	R11	4
-      0x7C240400,  //  0035  CALL	R9	2
-      0x00180D1E,  //  0036  ADD	R6	R6	K30
-      0x7001FFDB,  //  0037  JMP		#0014
-      0x80000000,  //  0038  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_add_config_button
-********************************************************************/
-be_local_closure(class_Matter_UI_web_add_config_button,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(web_add_config_button),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080311,  //  0001  GETMET	R2	R1	K17
-      0x581000AA,  //  0002  LDCONST	R4	K170
-      0x7C080400,  //  0003  CALL	R2	2
-      0x8C080311,  //  0004  GETMET	R2	R1	K17
-      0xB8123400,  //  0005  GETNGBL	R4	K26
-      0x881009AB,  //  0006  GETMBR	R4	R4	K171
-      0x7C080400,  //  0007  CALL	R2	2
-      0x8C080311,  //  0008  GETMET	R2	R1	K17
-      0x581000AC,  //  0009  LDCONST	R4	K172
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Matter_UI_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
+    18,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1679,15 +583,129 @@ be_local_closure(class_Matter_UI_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(init),
+    be_str_weak(show_qrcode),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x90022C01,  //  0000  SETMBR	R0	K22	R1
-      0xB80A3000,  //  0001  GETNGBL	R2	K24
-      0x8C0805AD,  //  0002  GETMET	R2	R2	K173
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80000000,  //  0005  RET	0
+    ( &(const binstruction[120]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x580C0039,  //  0001  LDCONST	R3	K57
+      0x5810003A,  //  0002  LDCONST	R4	K58
+      0x5814003B,  //  0003  LDCONST	R5	K59
+      0x5818003C,  //  0004  LDCONST	R6	K60
+      0xB81E7A00,  //  0005  GETNGBL	R7	K61
+      0x881C0F3E,  //  0006  GETMBR	R7	R7	K62
+      0x8C1C0F3F,  //  0007  GETMET	R7	R7	K63
+      0x5C240200,  //  0008  MOVE	R9	R1
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x94200F40,  //  000A  GETIDX	R8	R7	K64
+      0x94240F41,  //  000B  GETIDX	R9	R7	K65
+      0x8C280507,  //  000C  GETMET	R10	R2	K7
+      0x58300042,  //  000D  LDCONST	R12	K66
+      0x7C280400,  //  000E  CALL	R10	2
+      0x8C280507,  //  000F  GETMET	R10	R2	K7
+      0x58300043,  //  0010  LDCONST	R12	K67
+      0x7C280400,  //  0011  CALL	R10	2
+      0x58280044,  //  0012  LDCONST	R10	K68
+      0x8C2C0507,  //  0013  GETMET	R11	R2	K7
+      0x5C341400,  //  0014  MOVE	R13	R10
+      0x7C2C0400,  //  0015  CALL	R11	2
+      0x58280045,  //  0016  LDCONST	R10	K69
+      0x602C0010,  //  0017  GETGBL	R11	G16
+      0x00301314,  //  0018  ADD	R12	R9	K20
+      0x40320C0C,  //  0019  CONNECT	R12	K6	R12
+      0x7C2C0200,  //  001A  CALL	R11	1
+      0xA8020003,  //  001B  EXBLK	0	#0020
+      0x5C301600,  //  001C  MOVE	R12	R11
+      0x7C300000,  //  001D  CALL	R12	0
+      0x00281404,  //  001E  ADD	R10	R10	R4
+      0x7001FFFB,  //  001F  JMP		#001C
+      0x582C001C,  //  0020  LDCONST	R11	K28
+      0xAC2C0200,  //  0021  CATCH	R11	1	0
+      0xB0080000,  //  0022  RAISE	2	R0	R0
+      0x00281546,  //  0023  ADD	R10	R10	K70
+      0x8C2C0507,  //  0024  GETMET	R11	R2	K7
+      0x5C341400,  //  0025  MOVE	R13	R10
+      0x7C2C0400,  //  0026  CALL	R11	2
+      0x602C0010,  //  0027  GETGBL	R11	G16
+      0x00301314,  //  0028  ADD	R12	R9	K20
+      0x0C301947,  //  0029  DIV	R12	R12	K71
+      0x04301914,  //  002A  SUB	R12	R12	K20
+      0x40320C0C,  //  002B  CONNECT	R12	K6	R12
+      0x7C2C0200,  //  002C  CALL	R11	1
+      0xA802002E,  //  002D  EXBLK	0	#005D
+      0x5C301600,  //  002E  MOVE	R12	R11
+      0x7C300000,  //  002F  CALL	R12	0
+      0x00369006,  //  0030  ADD	R13	K72	R6
+      0x5C281A00,  //  0031  MOVE	R10	R13
+      0x60340010,  //  0032  GETGBL	R13	G16
+      0x04381314,  //  0033  SUB	R14	R9	K20
+      0x403A0C0E,  //  0034  CONNECT	R14	K6	R14
+      0x7C340200,  //  0035  CALL	R13	1
+      0xA802001C,  //  0036  EXBLK	0	#0054
+      0x5C381A00,  //  0037  MOVE	R14	R13
+      0x7C380000,  //  0038  CALL	R14	0
+      0x083C1947,  //  0039  MUL	R15	R12	K71
+      0x943C100F,  //  003A  GETIDX	R15	R8	R15
+      0x943C1E0E,  //  003B  GETIDX	R15	R15	R14
+      0x1C3C1F39,  //  003C  EQ	R15	R15	K57
+      0x08401947,  //  003D  MUL	R16	R12	K71
+      0x00402114,  //  003E  ADD	R16	R16	K20
+      0x14402009,  //  003F  LT	R16	R16	R9
+      0x78420005,  //  0040  JMPF	R16	#0047
+      0x08401947,  //  0041  MUL	R16	R12	K71
+      0x00402114,  //  0042  ADD	R16	R16	K20
+      0x94401010,  //  0043  GETIDX	R16	R8	R16
+      0x9440200E,  //  0044  GETIDX	R16	R16	R14
+      0x1C402139,  //  0045  EQ	R16	R16	K57
+      0x70020000,  //  0046  JMP		#0048
+      0x50400200,  //  0047  LDBOOL	R16	1	0
+      0x783E0004,  //  0048  JMPF	R15	#004E
+      0x78420001,  //  0049  JMPF	R16	#004C
+      0x5C440C00,  //  004A  MOVE	R17	R6
+      0x70020000,  //  004B  JMP		#004D
+      0x5C440A00,  //  004C  MOVE	R17	R5
+      0x70020003,  //  004D  JMP		#0052
+      0x78420001,  //  004E  JMPF	R16	#0051
+      0x5C440800,  //  004F  MOVE	R17	R4
+      0x70020000,  //  0050  JMP		#0052
+      0x5C440600,  //  0051  MOVE	R17	R3
+      0x00281411,  //  0052  ADD	R10	R10	R17
+      0x7001FFE2,  //  0053  JMP		#0037
+      0x5834001C,  //  0054  LDCONST	R13	K28
+      0xAC340200,  //  0055  CATCH	R13	1	0
+      0xB0080000,  //  0056  RAISE	2	R0	R0
+      0x00281406,  //  0057  ADD	R10	R10	R6
+      0x00281546,  //  0058  ADD	R10	R10	K70
+      0x8C340507,  //  0059  GETMET	R13	R2	K7
+      0x5C3C1400,  //  005A  MOVE	R15	R10
+      0x7C340400,  //  005B  CALL	R13	2
+      0x7001FFD0,  //  005C  JMP		#002E
+      0x582C001C,  //  005D  LDCONST	R11	K28
+      0xAC2C0200,  //  005E  CATCH	R11	1	0
+      0xB0080000,  //  005F  RAISE	2	R0	R0
+      0x102C1347,  //  0060  MOD	R11	R9	K71
+      0x1C2C1706,  //  0061  EQ	R11	R11	K6
+      0x782E0010,  //  0062  JMPF	R11	#0074
+      0x58280048,  //  0063  LDCONST	R10	K72
+      0x602C0010,  //  0064  GETGBL	R11	G16
+      0x00301314,  //  0065  ADD	R12	R9	K20
+      0x40320C0C,  //  0066  CONNECT	R12	K6	R12
+      0x7C2C0200,  //  0067  CALL	R11	1
+      0xA8020003,  //  0068  EXBLK	0	#006D
+      0x5C301600,  //  0069  MOVE	R12	R11
+      0x7C300000,  //  006A  CALL	R12	0
+      0x00281405,  //  006B  ADD	R10	R10	R5
+      0x7001FFFB,  //  006C  JMP		#0069
+      0x582C001C,  //  006D  LDCONST	R11	K28
+      0xAC2C0200,  //  006E  CATCH	R11	1	0
+      0xB0080000,  //  006F  RAISE	2	R0	R0
+      0x00281549,  //  0070  ADD	R10	R10	K73
+      0x8C2C0507,  //  0071  GETMET	R11	R2	K7
+      0x5C341400,  //  0072  MOVE	R13	R10
+      0x7C2C0400,  //  0073  CALL	R11	2
+      0x8C2C0507,  //  0074  GETMET	R11	R2	K7
+      0x58340046,  //  0075  LDCONST	R13	K70
+      0x7C2C0400,  //  0076  CALL	R11	2
+      0x80000000,  //  0077  RET	0
     })
   )
 );
@@ -1695,11 +713,11 @@ be_local_closure(class_Matter_UI_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: show_bridge_status
+** Solidified function: web_sensor
 ********************************************************************/
-be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
+be_local_closure(class_Matter_UI_web_sensor,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1708,326 +726,59 @@ be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_bridge_status),
+    be_str_weak(web_sensor),
     &be_const_str_solidified,
-    ( &(const binstruction[118]) {  /* code */
-      0x88040116,  //  0000  GETMBR	R1	R0	K22
-      0x880403AE,  //  0001  GETMBR	R1	R1	K174
-      0x4C080000,  //  0002  LDNIL	R2
-      0x1C040202,  //  0003  EQ	R1	R1	R2
-      0x78060000,  //  0004  JMPF	R1	#0006
-      0x80000200,  //  0005  RET	0
-      0xA4060800,  //  0006  IMPORT	R1	K4
-      0x4C080000,  //  0007  LDNIL	R2
-      0x580C001C,  //  0008  LDCONST	R3	K28
-      0x6010000C,  //  0009  GETGBL	R4	G12
-      0x88140116,  //  000A  GETMBR	R5	R0	K22
-      0x88140BAE,  //  000B  GETMBR	R5	R5	K174
-      0x7C100200,  //  000C  CALL	R4	1
-      0x14100604,  //  000D  LT	R4	R3	R4
-      0x78120019,  //  000E  JMPF	R4	#0029
-      0x88100116,  //  000F  GETMBR	R4	R0	K22
-      0x881009AE,  //  0010  GETMBR	R4	R4	K174
-      0x94100803,  //  0011  GETIDX	R4	R4	R3
-      0x881409AF,  //  0012  GETMBR	R5	R4	K175
-      0x78160012,  //  0013  JMPF	R5	#0027
-      0x4C140000,  //  0014  LDNIL	R5
-      0x1C140405,  //  0015  EQ	R5	R2	R5
-      0x78160002,  //  0016  JMPF	R5	#001A
-      0x60140013,  //  0017  GETGBL	R5	G19
-      0x7C140000,  //  0018  CALL	R5	0
-      0x5C080A00,  //  0019  MOVE	R2	R5
-      0x881409B0,  //  001A  GETMBR	R5	R4	K176
-      0x88140BB1,  //  001B  GETMBR	R5	R5	K177
-      0x8C180502,  //  001C  GETMET	R6	R2	K2
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x741A0002,  //  001F  JMPT	R6	#0023
-      0x60180012,  //  0020  GETGBL	R6	G18
-      0x7C180000,  //  0021  CALL	R6	0
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x94180405,  //  0023  GETIDX	R6	R2	R5
-      0x8C180D22,  //  0024  GETMET	R6	R6	K34
-      0x5C200800,  //  0025  MOVE	R8	R4
+    ( &(const binstruction[50]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C08014A,  //  0001  GETMET	R2	R0	K74
+      0x7C080200,  //  0002  CALL	R2	1
+      0x780A002C,  //  0003  JMPF	R2	#0031
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x88080523,  //  0005  GETMBR	R2	R2	K35
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x20080403,  //  0007  NE	R2	R2	R3
+      0x780A0004,  //  0008  JMPF	R2	#000E
+      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x88080523,  //  000A  GETMBR	R2	R2	K35
+      0x8C08054B,  //  000B  GETMET	R2	R2	K75
+      0x7C080200,  //  000C  CALL	R2	1
+      0x70020000,  //  000D  JMP		#000F
+      0x58080006,  //  000E  LDCONST	R2	K6
+      0x1C0C0506,  //  000F  EQ	R3	R2	K6
+      0x780E0006,  //  0010  JMPF	R3	#0018
+      0x8C0C0307,  //  0011  GETMET	R3	R1	K7
+      0x60140018,  //  0012  GETGBL	R5	G24
+      0x5818004C,  //  0013  LDCONST	R6	K76
+      0x581C004D,  //  0014  LDCONST	R7	K77
+      0x7C140400,  //  0015  CALL	R5	2
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x7002000F,  //  0017  JMP		#0028
+      0x240C0514,  //  0018  GT	R3	R2	K20
+      0x8C100307,  //  0019  GETMET	R4	R1	K7
+      0x60180018,  //  001A  GETGBL	R6	G24
+      0x581C004C,  //  001B  LDCONST	R7	K76
+      0x60200008,  //  001C  GETGBL	R8	G8
+      0x5C240400,  //  001D  MOVE	R9	R2
+      0x7C200200,  //  001E  CALL	R8	1
+      0x00229C08,  //  001F  ADD	R8	K78	R8
+      0x0020114F,  //  0020  ADD	R8	R8	K79
+      0x780E0001,  //  0021  JMPF	R3	#0024
+      0x58240050,  //  0022  LDCONST	R9	K80
+      0x70020000,  //  0023  JMP		#0025
+      0x58240045,  //  0024  LDCONST	R9	K69
+      0x00201009,  //  0025  ADD	R8	R8	R9
       0x7C180400,  //  0026  CALL	R6	2
-      0x000C071E,  //  0027  ADD	R3	R3	K30
-      0x7001FFDF,  //  0028  JMP		#0009
-      0x4C100000,  //  0029  LDNIL	R4
-      0x1C100404,  //  002A  EQ	R4	R2	R4
-      0x78120000,  //  002B  JMPF	R4	#002D
-      0x80000800,  //  002C  RET	0
-      0x8C100311,  //  002D  GETMET	R4	R1	K17
-      0x5818008D,  //  002E  LDCONST	R6	K141
-      0x7C100400,  //  002F  CALL	R4	2
-      0x8C100311,  //  0030  GETMET	R4	R1	K17
-      0x581800B2,  //  0031  LDCONST	R6	K178
-      0x7C100400,  //  0032  CALL	R4	2
-      0x8C100311,  //  0033  GETMET	R4	R1	K17
-      0xB81A3400,  //  0034  GETNGBL	R6	K26
-      0x88180DB3,  //  0035  GETMBR	R6	R6	K179
-      0x7C100400,  //  0036  CALL	R4	2
-      0x60100010,  //  0037  GETGBL	R4	G16
-      0x88140116,  //  0038  GETMBR	R5	R0	K22
-      0x8C140BB4,  //  0039  GETMET	R5	R5	K180
-      0x5C1C0400,  //  003A  MOVE	R7	R2
-      0x7C140400,  //  003B  CALL	R5	2
-      0x7C100200,  //  003C  CALL	R4	1
-      0xA8020030,  //  003D  EXBLK	0	#006F
-      0x5C140800,  //  003E  MOVE	R5	R4
-      0x7C140000,  //  003F  CALL	R5	0
-      0x8C18034A,  //  0040  GETMET	R6	R1	K74
-      0x5C200A00,  //  0041  MOVE	R8	R5
-      0x7C180400,  //  0042  CALL	R6	2
-      0x8C1C034A,  //  0043  GETMET	R7	R1	K74
-      0x88240116,  //  0044  GETMBR	R9	R0	K22
-      0x8C241354,  //  0045  GETMET	R9	R9	K84
-      0x5C2C0A00,  //  0046  MOVE	R11	R5
-      0x7C240400,  //  0047  CALL	R9	2
-      0x8C241343,  //  0048  GETMET	R9	R9	K67
-      0x582C004B,  //  0049  LDCONST	R11	K75
-      0x5C300A00,  //  004A  MOVE	R12	R5
-      0x7C240600,  //  004B  CALL	R9	3
-      0x7C1C0400,  //  004C  CALL	R7	2
-      0x8C200311,  //  004D  GETMET	R8	R1	K17
-      0x60280018,  //  004E  GETGBL	R10	G24
-      0x582C00B5,  //  004F  LDCONST	R11	K181
-      0x5C300C00,  //  0050  MOVE	R12	R6
-      0x5C340C00,  //  0051  MOVE	R13	R6
-      0x5C380E00,  //  0052  MOVE	R14	R7
-      0x7C280800,  //  0053  CALL	R10	4
-      0x7C200400,  //  0054  CALL	R8	2
-      0x94200405,  //  0055  GETIDX	R8	R2	R5
-      0x9420111C,  //  0056  GETIDX	R8	R8	K28
-      0x882011B0,  //  0057  GETMBR	R8	R8	K176
-      0x8C240311,  //  0058  GETMET	R9	R1	K17
-      0x8C2C11B6,  //  0059  GETMET	R11	R8	K182
-      0x7C2C0200,  //  005A  CALL	R11	1
-      0x7C240400,  //  005B  CALL	R9	2
-      0x60240010,  //  005C  GETGBL	R9	G16
-      0x94280405,  //  005D  GETIDX	R10	R2	R5
-      0x7C240200,  //  005E  CALL	R9	1
-      0xA802000A,  //  005F  EXBLK	0	#006B
-      0x5C281200,  //  0060  MOVE	R10	R9
-      0x7C280000,  //  0061  CALL	R10	0
-      0x8C2C0311,  //  0062  GETMET	R11	R1	K17
-      0x583400B7,  //  0063  LDCONST	R13	K183
-      0x7C2C0400,  //  0064  CALL	R11	2
-      0x8C2C15B8,  //  0065  GETMET	R11	R10	K184
-      0x7C2C0200,  //  0066  CALL	R11	1
-      0x8C2C0311,  //  0067  GETMET	R11	R1	K17
-      0x58340085,  //  0068  LDCONST	R13	K133
-      0x7C2C0400,  //  0069  CALL	R11	2
-      0x7001FFF4,  //  006A  JMP		#0060
-      0x58240003,  //  006B  LDCONST	R9	K3
-      0xAC240200,  //  006C  CATCH	R9	1	0
-      0xB0080000,  //  006D  RAISE	2	R0	R0
-      0x7001FFCE,  //  006E  JMP		#003E
-      0x58100003,  //  006F  LDCONST	R4	K3
-      0xAC100200,  //  0070  CATCH	R4	1	0
-      0xB0080000,  //  0071  RAISE	2	R0	R0
-      0x8C100311,  //  0072  GETMET	R4	R1	K17
-      0x581800B9,  //  0073  LDCONST	R6	K185
-      0x7C100400,  //  0074  CALL	R4	2
-      0x80000000,  //  0075  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_add_handler
-********************************************************************/
-be_local_closure(class_Matter_UI_web_add_handler,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 4]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_mgr),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_ctl),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_mgr_adv),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_mgr_add),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(web_add_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C0803BA,  //  0001  GETMET	R2	R1	K186
-      0x581000BB,  //  0002  LDCONST	R4	K187
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x881803BC,  //  0004  GETMBR	R6	R1	K188
-      0x7C080800,  //  0005  CALL	R2	4
-      0x8C0803BA,  //  0006  GETMET	R2	R1	K186
-      0x581000BB,  //  0007  LDCONST	R4	K187
-      0x84140001,  //  0008  CLOSURE	R5	P1
-      0x881803BD,  //  0009  GETMBR	R6	R1	K189
-      0x7C080800,  //  000A  CALL	R2	4
-      0x8C0803BA,  //  000B  GETMET	R2	R1	K186
-      0x581000BE,  //  000C  LDCONST	R4	K190
-      0x84140002,  //  000D  CLOSURE	R5	P2
-      0x881803BC,  //  000E  GETMBR	R6	R1	K188
-      0x7C080800,  //  000F  CALL	R2	4
-      0x8C0803BA,  //  0010  GETMET	R2	R1	K186
-      0x581000BF,  //  0011  LDCONST	R4	K191
-      0x84140003,  //  0012  CLOSURE	R5	P3
-      0x881803BC,  //  0013  GETMBR	R6	R1	K188
-      0x7C080800,  //  0014  CALL	R2	4
-      0xA0000000,  //  0015  CLOSE	R0
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_passcode_form
-********************************************************************/
-be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_passcode_form),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x8C080311,  //  0001  GETMET	R2	R1	K17
-      0x581000C0,  //  0002  LDCONST	R4	K192
-      0x7C080400,  //  0003  CALL	R2	2
-      0x8C080311,  //  0004  GETMET	R2	R1	K17
-      0x60100018,  //  0005  GETGBL	R4	G24
-      0x581400C1,  //  0006  LDCONST	R5	K193
-      0x88180116,  //  0007  GETMBR	R6	R0	K22
-      0x88180DC2,  //  0008  GETMBR	R6	R6	K194
-      0x7C100400,  //  0009  CALL	R4	2
-      0x7C080400,  //  000A  CALL	R2	2
-      0x8C080311,  //  000B  GETMET	R2	R1	K17
-      0x581000C3,  //  000C  LDCONST	R4	K195
-      0x7C080400,  //  000D  CALL	R2	2
-      0x8C080311,  //  000E  GETMET	R2	R1	K17
-      0x60100018,  //  000F  GETGBL	R4	G24
-      0x581400C4,  //  0010  LDCONST	R5	K196
-      0x88180116,  //  0011  GETMBR	R6	R0	K22
-      0x88180DC5,  //  0012  GETMBR	R6	R6	K197
-      0x7C100400,  //  0013  CALL	R4	2
-      0x7C080400,  //  0014  CALL	R2	2
-      0x88080116,  //  0015  GETMBR	R2	R0	K22
-      0x880805C6,  //  0016  GETMBR	R2	R2	K198
-      0x780A0001,  //  0017  JMPF	R2	#001A
-      0x580800C7,  //  0018  LDCONST	R2	K199
-      0x70020000,  //  0019  JMP		#001B
-      0x58080015,  //  001A  LDCONST	R2	K21
-      0x8C0C0311,  //  001B  GETMET	R3	R1	K17
-      0x60140018,  //  001C  GETGBL	R5	G24
-      0x581800C8,  //  001D  LDCONST	R6	K200
-      0x5C1C0400,  //  001E  MOVE	R7	R2
-      0x7C140400,  //  001F  CALL	R5	2
-      0x7C0C0400,  //  0020  CALL	R3	2
-      0x8C0C0311,  //  0021  GETMET	R3	R1	K17
-      0x581400C9,  //  0022  LDCONST	R5	K201
-      0x7C0C0400,  //  0023  CALL	R3	2
-      0x80000000,  //  0024  RET	0
+      0x7C100400,  //  0027  CALL	R4	2
+      0x8C0C0151,  //  0028  GETMET	R3	R0	K81
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0x880C0101,  //  002A  GETMBR	R3	R0	K1
+      0x880C0702,  //  002B  GETMBR	R3	R3	K2
+      0x8C0C0752,  //  002C  GETMET	R3	R3	K82
+      0x7C0C0200,  //  002D  CALL	R3	1
+      0x780E0001,  //  002E  JMPF	R3	#0031
+      0x8C0C0153,  //  002F  GETMET	R3	R0	K83
+      0x7C0C0200,  //  0030  CALL	R3	1
+      0x80000000,  //  0031  RET	0
     })
   )
 );
@@ -2821,154 +1572,11 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
 
 
 /********************************************************************
-** Solidified function: show_qrcode
+** Solidified function: page_part_mgr
 ********************************************************************/
-be_local_closure(class_Matter_UI_show_qrcode,   /* name */
+be_local_closure(class_Matter_UI_page_part_mgr,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_qrcode),
-    &be_const_str_solidified,
-    ( &(const binstruction[120]) {  /* code */
-      0xA40A0800,  //  0000  IMPORT	R2	K4
-      0x580C00CA,  //  0001  LDCONST	R3	K202
-      0x581000CB,  //  0002  LDCONST	R4	K203
-      0x581400CC,  //  0003  LDCONST	R5	K204
-      0x581800CD,  //  0004  LDCONST	R6	K205
-      0xB81E3400,  //  0005  GETNGBL	R7	K26
-      0x881C0FCE,  //  0006  GETMBR	R7	R7	K206
-      0x8C1C0FCF,  //  0007  GETMET	R7	R7	K207
-      0x5C240200,  //  0008  MOVE	R9	R1
-      0x7C1C0400,  //  0009  CALL	R7	2
-      0x94200FD0,  //  000A  GETIDX	R8	R7	K208
-      0x94240FD1,  //  000B  GETIDX	R9	R7	K209
-      0x8C280511,  //  000C  GETMET	R10	R2	K17
-      0x583000D2,  //  000D  LDCONST	R12	K210
-      0x7C280400,  //  000E  CALL	R10	2
-      0x8C280511,  //  000F  GETMET	R10	R2	K17
-      0x583000D3,  //  0010  LDCONST	R12	K211
-      0x7C280400,  //  0011  CALL	R10	2
-      0x582800D4,  //  0012  LDCONST	R10	K212
-      0x8C2C0511,  //  0013  GETMET	R11	R2	K17
-      0x5C341400,  //  0014  MOVE	R13	R10
-      0x7C2C0400,  //  0015  CALL	R11	2
-      0x58280015,  //  0016  LDCONST	R10	K21
-      0x602C0010,  //  0017  GETGBL	R11	G16
-      0x0030131E,  //  0018  ADD	R12	R9	K30
-      0x4032380C,  //  0019  CONNECT	R12	K28	R12
-      0x7C2C0200,  //  001A  CALL	R11	1
-      0xA8020003,  //  001B  EXBLK	0	#0020
-      0x5C301600,  //  001C  MOVE	R12	R11
-      0x7C300000,  //  001D  CALL	R12	0
-      0x00281404,  //  001E  ADD	R10	R10	R4
-      0x7001FFFB,  //  001F  JMP		#001C
-      0x582C0003,  //  0020  LDCONST	R11	K3
-      0xAC2C0200,  //  0021  CATCH	R11	1	0
-      0xB0080000,  //  0022  RAISE	2	R0	R0
-      0x002815D5,  //  0023  ADD	R10	R10	K213
-      0x8C2C0511,  //  0024  GETMET	R11	R2	K17
-      0x5C341400,  //  0025  MOVE	R13	R10
-      0x7C2C0400,  //  0026  CALL	R11	2
-      0x602C0010,  //  0027  GETGBL	R11	G16
-      0x0030131E,  //  0028  ADD	R12	R9	K30
-      0x0C3019D6,  //  0029  DIV	R12	R12	K214
-      0x0430191E,  //  002A  SUB	R12	R12	K30
-      0x4032380C,  //  002B  CONNECT	R12	K28	R12
-      0x7C2C0200,  //  002C  CALL	R11	1
-      0xA802002E,  //  002D  EXBLK	0	#005D
-      0x5C301600,  //  002E  MOVE	R12	R11
-      0x7C300000,  //  002F  CALL	R12	0
-      0x0037AE06,  //  0030  ADD	R13	K215	R6
-      0x5C281A00,  //  0031  MOVE	R10	R13
-      0x60340010,  //  0032  GETGBL	R13	G16
-      0x0438131E,  //  0033  SUB	R14	R9	K30
-      0x403A380E,  //  0034  CONNECT	R14	K28	R14
-      0x7C340200,  //  0035  CALL	R13	1
-      0xA802001C,  //  0036  EXBLK	0	#0054
-      0x5C381A00,  //  0037  MOVE	R14	R13
-      0x7C380000,  //  0038  CALL	R14	0
-      0x083C19D6,  //  0039  MUL	R15	R12	K214
-      0x943C100F,  //  003A  GETIDX	R15	R8	R15
-      0x943C1E0E,  //  003B  GETIDX	R15	R15	R14
-      0x1C3C1FCA,  //  003C  EQ	R15	R15	K202
-      0x084019D6,  //  003D  MUL	R16	R12	K214
-      0x0040211E,  //  003E  ADD	R16	R16	K30
-      0x14402009,  //  003F  LT	R16	R16	R9
-      0x78420005,  //  0040  JMPF	R16	#0047
-      0x084019D6,  //  0041  MUL	R16	R12	K214
-      0x0040211E,  //  0042  ADD	R16	R16	K30
-      0x94401010,  //  0043  GETIDX	R16	R8	R16
-      0x9440200E,  //  0044  GETIDX	R16	R16	R14
-      0x1C4021CA,  //  0045  EQ	R16	R16	K202
-      0x70020000,  //  0046  JMP		#0048
-      0x50400200,  //  0047  LDBOOL	R16	1	0
-      0x783E0004,  //  0048  JMPF	R15	#004E
-      0x78420001,  //  0049  JMPF	R16	#004C
-      0x5C440C00,  //  004A  MOVE	R17	R6
-      0x70020000,  //  004B  JMP		#004D
-      0x5C440A00,  //  004C  MOVE	R17	R5
-      0x70020003,  //  004D  JMP		#0052
-      0x78420001,  //  004E  JMPF	R16	#0051
-      0x5C440800,  //  004F  MOVE	R17	R4
-      0x70020000,  //  0050  JMP		#0052
-      0x5C440600,  //  0051  MOVE	R17	R3
-      0x00281411,  //  0052  ADD	R10	R10	R17
-      0x7001FFE2,  //  0053  JMP		#0037
-      0x58340003,  //  0054  LDCONST	R13	K3
-      0xAC340200,  //  0055  CATCH	R13	1	0
-      0xB0080000,  //  0056  RAISE	2	R0	R0
-      0x00281406,  //  0057  ADD	R10	R10	R6
-      0x002815D5,  //  0058  ADD	R10	R10	K213
-      0x8C340511,  //  0059  GETMET	R13	R2	K17
-      0x5C3C1400,  //  005A  MOVE	R15	R10
-      0x7C340400,  //  005B  CALL	R13	2
-      0x7001FFD0,  //  005C  JMP		#002E
-      0x582C0003,  //  005D  LDCONST	R11	K3
-      0xAC2C0200,  //  005E  CATCH	R11	1	0
-      0xB0080000,  //  005F  RAISE	2	R0	R0
-      0x102C13D6,  //  0060  MOD	R11	R9	K214
-      0x1C2C171C,  //  0061  EQ	R11	R11	K28
-      0x782E0010,  //  0062  JMPF	R11	#0074
-      0x582800D7,  //  0063  LDCONST	R10	K215
-      0x602C0010,  //  0064  GETGBL	R11	G16
-      0x0030131E,  //  0065  ADD	R12	R9	K30
-      0x4032380C,  //  0066  CONNECT	R12	K28	R12
-      0x7C2C0200,  //  0067  CALL	R11	1
-      0xA8020003,  //  0068  EXBLK	0	#006D
-      0x5C301600,  //  0069  MOVE	R12	R11
-      0x7C300000,  //  006A  CALL	R12	0
-      0x00281405,  //  006B  ADD	R10	R10	R5
-      0x7001FFFB,  //  006C  JMP		#0069
-      0x582C0003,  //  006D  LDCONST	R11	K3
-      0xAC2C0200,  //  006E  CATCH	R11	1	0
-      0xB0080000,  //  006F  RAISE	2	R0	R0
-      0x002815D8,  //  0070  ADD	R10	R10	K216
-      0x8C2C0511,  //  0071  GETMET	R11	R2	K17
-      0x5C341400,  //  0072  MOVE	R13	R10
-      0x7C2C0400,  //  0073  CALL	R11	2
-      0x8C2C0511,  //  0074  GETMET	R11	R2	K17
-      0x583400D5,  //  0075  LDCONST	R13	K213
-      0x7C2C0400,  //  0076  CALL	R11	2
-      0x80000000,  //  0077  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_enable
-********************************************************************/
-be_local_closure(class_Matter_UI_show_enable,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -2977,66 +1585,96 @@ be_local_closure(class_Matter_UI_show_enable,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UI,     /* shared constants */
-    be_str_weak(show_enable),
+    be_str_weak(page_part_mgr),
     &be_const_str_solidified,
-    ( &(const binstruction[57]) {  /* code */
-      0xA4060800,  //  0000  IMPORT	R1	K4
-      0x88080109,  //  0001  GETMBR	R2	R0	K9
-      0x8C0C0311,  //  0002  GETMET	R3	R1	K17
-      0x581400D9,  //  0003  LDCONST	R5	K217
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x8C0C0109,  //  0005  GETMET	R3	R0	K9
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x580C00DA,  //  0008  LDCONST	R3	K218
-      0x70020000,  //  0009  JMP		#000B
-      0x580C0015,  //  000A  LDCONST	R3	K21
-      0x8C100311,  //  000B  GETMET	R4	R1	K17
-      0x60180018,  //  000C  GETGBL	R6	G24
-      0x581C00DB,  //  000D  LDCONST	R7	K219
-      0x5C200600,  //  000E  MOVE	R8	R3
-      0x7C180400,  //  000F  CALL	R6	2
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C100311,  //  0011  GETMET	R4	R1	K17
-      0x581800DC,  //  0012  LDCONST	R6	K220
+    ( &(const binstruction[27]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080354,  //  0001  GETMET	R2	R1	K84
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080355,  //  0006  GETMET	R2	R1	K85
+      0x58100056,  //  0007  LDCONST	R4	K86
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080357,  //  0009  GETMET	R2	R1	K87
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C080158,  //  000B  GETMET	R2	R0	K88
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C08014A,  //  000D  GETMET	R2	R0	K74
+      0x7C080200,  //  000E  CALL	R2	1
+      0x780A0001,  //  000F  JMPF	R2	#0012
+      0x8C080159,  //  0010  GETMET	R2	R0	K89
+      0x7C080200,  //  0011  CALL	R2	1
+      0x8C080307,  //  0012  GETMET	R2	R1	K7
+      0x5810005A,  //  0013  LDCONST	R4	K90
+      0x7C080400,  //  0014  CALL	R2	2
+      0x8C08035B,  //  0015  GETMET	R2	R1	K91
+      0x8810035C,  //  0016  GETMBR	R4	R1	K92
+      0x7C080400,  //  0017  CALL	R2	2
+      0x8C08035D,  //  0018  GETMET	R2	R1	K93
+      0x7C080200,  //  0019  CALL	R2	1
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_passcode_form
+********************************************************************/
+be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(show_passcode_form),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080307,  //  0001  GETMET	R2	R1	K7
+      0x5810005E,  //  0002  LDCONST	R4	K94
+      0x7C080400,  //  0003  CALL	R2	2
+      0x8C080307,  //  0004  GETMET	R2	R1	K7
+      0x60100018,  //  0005  GETGBL	R4	G24
+      0x5814005F,  //  0006  LDCONST	R5	K95
+      0x88180101,  //  0007  GETMBR	R6	R0	K1
+      0x88180D60,  //  0008  GETMBR	R6	R6	K96
+      0x7C100400,  //  0009  CALL	R4	2
+      0x7C080400,  //  000A  CALL	R2	2
+      0x8C080307,  //  000B  GETMET	R2	R1	K7
+      0x58100061,  //  000C  LDCONST	R4	K97
+      0x7C080400,  //  000D  CALL	R2	2
+      0x8C080307,  //  000E  GETMET	R2	R1	K7
+      0x60100018,  //  000F  GETGBL	R4	G24
+      0x58140062,  //  0010  LDCONST	R5	K98
+      0x88180101,  //  0011  GETMBR	R6	R0	K1
+      0x88180D63,  //  0012  GETMBR	R6	R6	K99
       0x7C100400,  //  0013  CALL	R4	2
-      0x8C100109,  //  0014  GETMET	R4	R0	K9
-      0x7C100200,  //  0015  CALL	R4	1
-      0x7812001D,  //  0016  JMPF	R4	#0035
-      0x88100116,  //  0017  GETMBR	R4	R0	K22
-      0x88100933,  //  0018  GETMBR	R4	R4	K51
-      0x88100963,  //  0019  GETMBR	R4	R4	K99
-      0x4C140000,  //  001A  LDNIL	R5
-      0x20100805,  //  001B  NE	R4	R4	R5
-      0x78120001,  //  001C  JMPF	R4	#001F
-      0x581000DA,  //  001D  LDCONST	R4	K218
-      0x70020000,  //  001E  JMP		#0020
-      0x58100015,  //  001F  LDCONST	R4	K21
-      0x8C140311,  //  0020  GETMET	R5	R1	K17
-      0x601C0018,  //  0021  GETGBL	R7	G24
-      0x582000DD,  //  0022  LDCONST	R8	K221
-      0x5C240800,  //  0023  MOVE	R9	R4
-      0x7C1C0400,  //  0024  CALL	R7	2
-      0x7C140400,  //  0025  CALL	R5	2
-      0x8C140311,  //  0026  GETMET	R5	R1	K17
-      0x581C00DE,  //  0027  LDCONST	R7	K222
-      0x7C140400,  //  0028  CALL	R5	2
-      0x88140116,  //  0029  GETMBR	R5	R0	K22
-      0x88140BDF,  //  002A  GETMBR	R5	R5	K223
-      0x78160001,  //  002B  JMPF	R5	#002E
-      0x581400C7,  //  002C  LDCONST	R5	K199
-      0x70020000,  //  002D  JMP		#002F
-      0x58140015,  //  002E  LDCONST	R5	K21
-      0x8C180311,  //  002F  GETMET	R6	R1	K17
-      0x60200018,  //  0030  GETGBL	R8	G24
-      0x582400E0,  //  0031  LDCONST	R9	K224
-      0x5C280A00,  //  0032  MOVE	R10	R5
-      0x7C200400,  //  0033  CALL	R8	2
-      0x7C180400,  //  0034  CALL	R6	2
-      0x8C100311,  //  0035  GETMET	R4	R1	K17
-      0x581800E1,  //  0036  LDCONST	R6	K225
-      0x7C100400,  //  0037  CALL	R4	2
-      0x80000000,  //  0038  RET	0
+      0x7C080400,  //  0014  CALL	R2	2
+      0x88080101,  //  0015  GETMBR	R2	R0	K1
+      0x88080564,  //  0016  GETMBR	R2	R2	K100
+      0x780A0001,  //  0017  JMPF	R2	#001A
+      0x58080065,  //  0018  LDCONST	R2	K101
+      0x70020000,  //  0019  JMP		#001B
+      0x58080045,  //  001A  LDCONST	R2	K69
+      0x8C0C0307,  //  001B  GETMET	R3	R1	K7
+      0x60140018,  //  001C  GETGBL	R5	G24
+      0x58180066,  //  001D  LDCONST	R6	K102
+      0x5C1C0400,  //  001E  MOVE	R7	R2
+      0x7C140400,  //  001F  CALL	R5	2
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0x8C0C0307,  //  0021  GETMET	R3	R1	K7
+      0x58140067,  //  0022  LDCONST	R5	K103
+      0x7C0C0400,  //  0023  CALL	R3	2
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -3060,9 +1698,9 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
     be_str_weak(show_plugins_hints_js),
     &be_const_str_solidified,
     ( &(const binstruction[79]) {  /* code */
-      0xA40A0800,  //  0000  IMPORT	R2	K4
-      0xA40EDE00,  //  0001  IMPORT	R3	K111
-      0xA4127400,  //  0002  IMPORT	R4	K58
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40ED000,  //  0001  IMPORT	R3	K104
+      0xA412D200,  //  0002  IMPORT	R4	K105
       0x60140012,  //  0003  GETGBL	R5	G18
       0x7C140000,  //  0004  CALL	R5	0
       0x60180010,  //  0005  GETGBL	R6	G16
@@ -3071,13 +1709,13 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
       0xA8020007,  //  0008  EXBLK	0	#0011
       0x5C1C0C00,  //  0009  MOVE	R7	R6
       0x7C1C0000,  //  000A  CALL	R7	0
-      0x8C2009A3,  //  000B  GETMET	R8	R4	K163
+      0x8C20096A,  //  000B  GETMET	R8	R4	K106
       0x5C280E00,  //  000C  MOVE	R10	R7
-      0x582C00A4,  //  000D  LDCONST	R11	K164
+      0x582C006B,  //  000D  LDCONST	R11	K107
       0x7C200600,  //  000E  CALL	R8	3
       0x00140A08,  //  000F  ADD	R5	R5	R8
       0x7001FFF7,  //  0010  JMP		#0009
-      0x58180003,  //  0011  LDCONST	R6	K3
+      0x5818001C,  //  0011  LDCONST	R6	K28
       0xAC180200,  //  0012  CATCH	R6	1	0
       0xB0080000,  //  0013  RAISE	2	R0	R0
       0x60180013,  //  0014  GETGBL	R6	G19
@@ -3090,22 +1728,22 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
       0xA802001F,  //  001B  EXBLK	0	#003C
       0x5C241000,  //  001C  MOVE	R9	R8
       0x7C240000,  //  001D  CALL	R9	0
-      0x1C281315,  //  001E  EQ	R10	R9	K21
+      0x1C281345,  //  001E  EQ	R10	R9	K69
       0x782A0000,  //  001F  JMPF	R10	#0021
       0x7001FFFA,  //  0020  JMP		#001C
-      0x88280116,  //  0021  GETMBR	R10	R0	K22
-      0x88281545,  //  0022  GETMBR	R10	R10	K69
-      0x8C281543,  //  0023  GETMET	R10	R10	K67
+      0x88280101,  //  0021  GETMBR	R10	R0	K1
+      0x8828156C,  //  0022  GETMBR	R10	R10	K108
+      0x8C28156D,  //  0023  GETMET	R10	R10	K109
       0x5C301200,  //  0024  MOVE	R12	R9
       0x7C280400,  //  0025  CALL	R10	2
       0x4C2C0000,  //  0026  LDNIL	R11
       0x202C140B,  //  0027  NE	R11	R10	R11
       0x782E0011,  //  0028  JMPF	R11	#003B
-      0x882C1547,  //  0029  GETMBR	R11	R10	K71
+      0x882C156E,  //  0029  GETMBR	R11	R10	K110
       0x4C300000,  //  002A  LDNIL	R12
       0x2030160C,  //  002B  NE	R12	R11	R12
       0x7832000D,  //  002C  JMPF	R12	#003B
-      0x8C300F43,  //  002D  GETMET	R12	R7	K67
+      0x8C300F6D,  //  002D  GETMET	R12	R7	K109
       0x5C381600,  //  002E  MOVE	R14	R11
       0x7C300400,  //  002F  CALL	R12	2
       0x4C340000,  //  0030  LDNIL	R13
@@ -3115,30 +1753,1428 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
       0x5C380E00,  //  0034  MOVE	R14	R7
       0x7C340200,  //  0035  CALL	R13	1
       0x5C301A00,  //  0036  MOVE	R12	R13
-      0x8C340F22,  //  0037  GETMET	R13	R7	K34
+      0x8C340F18,  //  0037  GETMET	R13	R7	K24
       0x5C3C1600,  //  0038  MOVE	R15	R11
       0x7C340400,  //  0039  CALL	R13	2
       0x9818120C,  //  003A  SETIDX	R6	R9	R12
       0x7001FFDF,  //  003B  JMP		#001C
-      0x58200003,  //  003C  LDCONST	R8	K3
+      0x5820001C,  //  003C  LDCONST	R8	K28
       0xAC200200,  //  003D  CATCH	R8	1	0
       0xB0080000,  //  003E  RAISE	2	R0	R0
-      0x8C200511,  //  003F  GETMET	R8	R2	K17
+      0x8C200507,  //  003F  GETMET	R8	R2	K7
       0x60280018,  //  0040  GETGBL	R10	G24
-      0x582C00E2,  //  0041  LDCONST	R11	K226
-      0x8C3007E3,  //  0042  GETMET	R12	R3	K227
+      0x582C006F,  //  0041  LDCONST	R11	K111
+      0x8C300770,  //  0042  GETMET	R12	R3	K112
       0x5C380C00,  //  0043  MOVE	R14	R6
       0x7C300400,  //  0044  CALL	R12	2
-      0x8C3407E3,  //  0045  GETMET	R13	R3	K227
+      0x8C340770,  //  0045  GETMET	R13	R3	K112
       0x5C3C0E00,  //  0046  MOVE	R15	R7
       0x7C340400,  //  0047  CALL	R13	2
       0x7C280600,  //  0048  CALL	R10	3
       0x7C200400,  //  0049  CALL	R8	2
-      0x8C200511,  //  004A  GETMET	R8	R2	K17
-      0xB82A3400,  //  004B  GETNGBL	R10	K26
-      0x882815E4,  //  004C  GETMBR	R10	R10	K228
+      0x8C200507,  //  004A  GETMET	R8	R2	K7
+      0xB82A7A00,  //  004B  GETNGBL	R10	K61
+      0x88281571,  //  004C  GETMBR	R10	R10	K113
       0x7C200400,  //  004D  CALL	R8	2
       0x80000000,  //  004E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: matter_enabled
+********************************************************************/
+be_local_closure(class_Matter_UI_matter_enabled,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(matter_enabled),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60040017,  //  0000  GETGBL	R1	G23
+      0xB80A0800,  //  0001  GETNGBL	R2	K4
+      0x8C080572,  //  0002  GETMET	R2	R2	K114
+      0xB8127A00,  //  0003  GETNGBL	R4	K61
+      0x88100973,  //  0004  GETMBR	R4	R4	K115
+      0x7C080400,  //  0005  CALL	R2	2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_enable
+********************************************************************/
+be_local_closure(class_Matter_UI_show_enable,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(show_enable),
+    &be_const_str_solidified,
+    ( &(const binstruction[57]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8808014A,  //  0001  GETMBR	R2	R0	K74
+      0x8C0C0307,  //  0002  GETMET	R3	R1	K7
+      0x58140074,  //  0003  LDCONST	R5	K116
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x8C0C014A,  //  0005  GETMET	R3	R0	K74
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x580C0075,  //  0008  LDCONST	R3	K117
+      0x70020000,  //  0009  JMP		#000B
+      0x580C0045,  //  000A  LDCONST	R3	K69
+      0x8C100307,  //  000B  GETMET	R4	R1	K7
+      0x60180018,  //  000C  GETGBL	R6	G24
+      0x581C0076,  //  000D  LDCONST	R7	K118
+      0x5C200600,  //  000E  MOVE	R8	R3
+      0x7C180400,  //  000F  CALL	R6	2
+      0x7C100400,  //  0010  CALL	R4	2
+      0x8C100307,  //  0011  GETMET	R4	R1	K7
+      0x58180077,  //  0012  LDCONST	R6	K119
+      0x7C100400,  //  0013  CALL	R4	2
+      0x8C10014A,  //  0014  GETMET	R4	R0	K74
+      0x7C100200,  //  0015  CALL	R4	1
+      0x7812001D,  //  0016  JMPF	R4	#0035
+      0x88100101,  //  0017  GETMBR	R4	R0	K1
+      0x88100902,  //  0018  GETMBR	R4	R4	K2
+      0x88100903,  //  0019  GETMBR	R4	R4	K3
+      0x4C140000,  //  001A  LDNIL	R5
+      0x20100805,  //  001B  NE	R4	R4	R5
+      0x78120001,  //  001C  JMPF	R4	#001F
+      0x58100075,  //  001D  LDCONST	R4	K117
+      0x70020000,  //  001E  JMP		#0020
+      0x58100045,  //  001F  LDCONST	R4	K69
+      0x8C140307,  //  0020  GETMET	R5	R1	K7
+      0x601C0018,  //  0021  GETGBL	R7	G24
+      0x58200078,  //  0022  LDCONST	R8	K120
+      0x5C240800,  //  0023  MOVE	R9	R4
+      0x7C1C0400,  //  0024  CALL	R7	2
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C140307,  //  0026  GETMET	R5	R1	K7
+      0x581C0079,  //  0027  LDCONST	R7	K121
+      0x7C140400,  //  0028  CALL	R5	2
+      0x88140101,  //  0029  GETMBR	R5	R0	K1
+      0x88140B7A,  //  002A  GETMBR	R5	R5	K122
+      0x78160001,  //  002B  JMPF	R5	#002E
+      0x58140065,  //  002C  LDCONST	R5	K101
+      0x70020000,  //  002D  JMP		#002F
+      0x58140045,  //  002E  LDCONST	R5	K69
+      0x8C180307,  //  002F  GETMET	R6	R1	K7
+      0x60200018,  //  0030  GETGBL	R8	G24
+      0x5824007B,  //  0031  LDCONST	R9	K123
+      0x5C280A00,  //  0032  MOVE	R10	R5
+      0x7C200400,  //  0033  CALL	R8	2
+      0x7C180400,  //  0034  CALL	R6	2
+      0x8C100307,  //  0035  GETMET	R4	R1	K7
+      0x5818007C,  //  0036  LDCONST	R6	K124
+      0x7C100400,  //  0037  CALL	R4	2
+      0x80000000,  //  0038  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: equal_map
+********************************************************************/
+be_local_closure(class_Matter_UI_equal_map,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(equal_map),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x5808007D,  //  0000  LDCONST	R2	K125
+      0x600C0010,  //  0001  GETGBL	R3	G16
+      0x8C10017E,  //  0002  GETMET	R4	R0	K126
+      0x7C100200,  //  0003  CALL	R4	1
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020010,  //  0005  EXBLK	0	#0017
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140312,  //  0008  GETMET	R5	R1	K18
+      0x5C1C0800,  //  0009  MOVE	R7	R4
+      0x7C140400,  //  000A  CALL	R5	2
+      0x74160002,  //  000B  JMPT	R5	#000F
+      0x50140000,  //  000C  LDBOOL	R5	0	0
+      0xA8040001,  //  000D  EXBLK	1	1
+      0x80040A00,  //  000E  RET	1	R5
+      0x94140204,  //  000F  GETIDX	R5	R1	R4
+      0x94180004,  //  0010  GETIDX	R6	R0	R4
+      0x20140A06,  //  0011  NE	R5	R5	R6
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x50140000,  //  0013  LDBOOL	R5	0	0
+      0xA8040001,  //  0014  EXBLK	1	1
+      0x80040A00,  //  0015  RET	1	R5
+      0x7001FFEE,  //  0016  JMP		#0006
+      0x580C001C,  //  0017  LDCONST	R3	K28
+      0xAC0C0200,  //  0018  CATCH	R3	1	0
+      0xB0080000,  //  0019  RAISE	2	R0	R0
+      0x600C0010,  //  001A  GETGBL	R3	G16
+      0x8C10037E,  //  001B  GETMET	R4	R1	K126
+      0x7C100200,  //  001C  CALL	R4	1
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x8C140112,  //  0021  GETMET	R5	R0	K18
+      0x5C1C0800,  //  0022  MOVE	R7	R4
+      0x7C140400,  //  0023  CALL	R5	2
+      0x74160002,  //  0024  JMPT	R5	#0028
+      0x50140000,  //  0025  LDBOOL	R5	0	0
+      0xA8040001,  //  0026  EXBLK	1	1
+      0x80040A00,  //  0027  RET	1	R5
+      0x94140204,  //  0028  GETIDX	R5	R1	R4
+      0x94180004,  //  0029  GETIDX	R6	R0	R4
+      0x20140A06,  //  002A  NE	R5	R5	R6
+      0x78160002,  //  002B  JMPF	R5	#002F
+      0x50140000,  //  002C  LDBOOL	R5	0	0
+      0xA8040001,  //  002D  EXBLK	1	1
+      0x80040A00,  //  002E  RET	1	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C001C,  //  0030  LDCONST	R3	K28
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x500C0200,  //  0033  LDBOOL	R3	1	0
+      0x80040600,  //  0034  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_get_arg
+********************************************************************/
+be_local_closure(class_Matter_UI_web_get_arg,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(web_get_arg),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C08037F,  //  0001  GETMET	R2	R1	K127
+      0x58100080,  //  0002  LDCONST	R4	K128
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0004,  //  0004  JMPF	R2	#000A
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x88080502,  //  0006  GETMBR	R2	R2	K2
+      0x8C080581,  //  0007  GETMET	R2	R2	K129
+      0x7C080200,  //  0008  CALL	R2	1
+      0x70020007,  //  0009  JMP		#0012
+      0x8C08037F,  //  000A  GETMET	R2	R1	K127
+      0x58100082,  //  000B  LDCONST	R4	K130
+      0x7C080400,  //  000C  CALL	R2	2
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x88080101,  //  000E  GETMBR	R2	R0	K1
+      0x88080502,  //  000F  GETMBR	R2	R2	K2
+      0x8C080583,  //  0010  GETMET	R2	R2	K131
+      0x7C080200,  //  0011  CALL	R2	1
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_plugins_configuration
+********************************************************************/
+be_local_closure(class_Matter_UI_show_plugins_configuration,   /* name */
+  be_nested_proto(
+    29,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(show_plugins_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[347]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40AD200,  //  0001  IMPORT	R2	K105
+      0xA40F0800,  //  0002  IMPORT	R3	K132
+      0x8C100307,  //  0003  GETMET	R4	R1	K7
+      0x58180085,  //  0004  LDCONST	R6	K133
+      0x7C100400,  //  0005  CALL	R4	2
+      0x8C100307,  //  0006  GETMET	R4	R1	K7
+      0x58180086,  //  0007  LDCONST	R6	K134
+      0x7C100400,  //  0008  CALL	R4	2
+      0x8C100307,  //  0009  GETMET	R4	R1	K7
+      0x58180087,  //  000A  LDCONST	R6	K135
+      0x7C100400,  //  000B  CALL	R4	2
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x88100988,  //  000D  GETMBR	R4	R4	K136
+      0x8C100989,  //  000E  GETMET	R4	R4	K137
+      0x5818008A,  //  000F  LDCONST	R6	K138
+      0x7C100400,  //  0010  CALL	R4	2
+      0x88100101,  //  0011  GETMBR	R4	R0	K1
+      0x8C10098B,  //  0012  GETMET	R4	R4	K139
+      0x88180101,  //  0013  GETMBR	R6	R0	K1
+      0x88180D88,  //  0014  GETMBR	R6	R6	K136
+      0x7C100400,  //  0015  CALL	R4	2
+      0x58140006,  //  0016  LDCONST	R5	K6
+      0x50180000,  //  0017  LDBOOL	R6	0	0
+      0x601C000C,  //  0018  GETGBL	R7	G12
+      0x5C200800,  //  0019  MOVE	R8	R4
+      0x7C1C0200,  //  001A  CALL	R7	1
+      0x141C0A07,  //  001B  LT	R7	R5	R7
+      0x781E005D,  //  001C  JMPF	R7	#007B
+      0x941C0805,  //  001D  GETIDX	R7	R4	R5
+      0x88200101,  //  001E  GETMBR	R8	R0	K1
+      0x88201188,  //  001F  GETMBR	R8	R8	K136
+      0x8C20116D,  //  0020  GETMET	R8	R8	K109
+      0x60280008,  //  0021  GETGBL	R10	G8
+      0x5C2C0E00,  //  0022  MOVE	R11	R7
+      0x7C280200,  //  0023  CALL	R10	1
+      0x7C200400,  //  0024  CALL	R8	2
+      0x8C24116D,  //  0025  GETMET	R9	R8	K109
+      0x582C0019,  //  0026  LDCONST	R11	K25
+      0x7C240400,  //  0027  CALL	R9	2
+      0x5C281200,  //  0028  MOVE	R10	R9
+      0x742A0001,  //  0029  JMPT	R10	#002C
+      0x00140B14,  //  002A  ADD	R5	R5	K20
+      0x7001FFEB,  //  002B  JMP		#0018
+      0x8C28056D,  //  002C  GETMET	R10	R2	K109
+      0x5C301200,  //  002D  MOVE	R12	R9
+      0x5834008C,  //  002E  LDCONST	R13	K140
+      0x7C280600,  //  002F  CALL	R10	3
+      0x1C281506,  //  0030  EQ	R10	R10	K6
+      0x782A0001,  //  0031  JMPF	R10	#0034
+      0x00140B14,  //  0032  ADD	R5	R5	K20
+      0x7001FFE3,  //  0033  JMP		#0018
+      0x88280101,  //  0034  GETMBR	R10	R0	K1
+      0x8828156C,  //  0035  GETMBR	R10	R10	K108
+      0x8C28156D,  //  0036  GETMET	R10	R10	K109
+      0x5C301200,  //  0037  MOVE	R12	R9
+      0x7C280400,  //  0038  CALL	R10	2
+      0x582C0045,  //  0039  LDCONST	R11	K69
+      0x58300045,  //  003A  LDCONST	R12	K69
+      0x4C340000,  //  003B  LDNIL	R13
+      0x2034140D,  //  003C  NE	R13	R10	R13
+      0x78360005,  //  003D  JMPF	R13	#0044
+      0x8C34158D,  //  003E  GETMET	R13	R10	K141
+      0x5C3C1400,  //  003F  MOVE	R15	R10
+      0x5C401000,  //  0040  MOVE	R16	R8
+      0x7C340600,  //  0041  CALL	R13	3
+      0x5C2C1A00,  //  0042  MOVE	R11	R13
+      0x8830156E,  //  0043  GETMBR	R12	R10	K110
+      0x50180200,  //  0044  LDBOOL	R6	1	0
+      0x8C340307,  //  0045  GETMET	R13	R1	K7
+      0x603C0018,  //  0046  GETGBL	R15	G24
+      0x5840008E,  //  0047  LDCONST	R16	K142
+      0x5C440E00,  //  0048  MOVE	R17	R7
+      0x7C3C0400,  //  0049  CALL	R15	2
+      0x7C340400,  //  004A  CALL	R13	2
+      0x8C340307,  //  004B  GETMET	R13	R1	K7
+      0x603C0018,  //  004C  GETGBL	R15	G24
+      0x5840008F,  //  004D  LDCONST	R16	K143
+      0x5C440E00,  //  004E  MOVE	R17	R7
+      0x8C48032A,  //  004F  GETMET	R18	R1	K42
+      0x8C50116D,  //  0050  GETMET	R20	R8	K109
+      0x58580090,  //  0051  LDCONST	R22	K144
+      0x585C0045,  //  0052  LDCONST	R23	K69
+      0x7C500600,  //  0053  CALL	R20	3
+      0x7C480400,  //  0054  CALL	R18	2
+      0x7C3C0600,  //  0055  CALL	R15	3
+      0x7C340400,  //  0056  CALL	R13	2
+      0x8C340307,  //  0057  GETMET	R13	R1	K7
+      0x603C0018,  //  0058  GETGBL	R15	G24
+      0x58400091,  //  0059  LDCONST	R16	K145
+      0x8C440192,  //  005A  GETMET	R17	R0	K146
+      0x8C4C116D,  //  005B  GETMET	R19	R8	K109
+      0x58540019,  //  005C  LDCONST	R21	K25
+      0x58580045,  //  005D  LDCONST	R22	K69
+      0x7C4C0600,  //  005E  CALL	R19	3
+      0x7C440400,  //  005F  CALL	R17	2
+      0x7C3C0400,  //  0060  CALL	R15	2
+      0x7C340400,  //  0061  CALL	R13	2
+      0x8C340307,  //  0062  GETMET	R13	R1	K7
+      0x603C0018,  //  0063  GETGBL	R15	G24
+      0x58400093,  //  0064  LDCONST	R16	K147
+      0x5C440E00,  //  0065  MOVE	R17	R7
+      0x8C48032A,  //  0066  GETMET	R18	R1	K42
+      0x5C501600,  //  0067  MOVE	R20	R11
+      0x7C480400,  //  0068  CALL	R18	2
+      0x8C4C032A,  //  0069  GETMET	R19	R1	K42
+      0x5C541800,  //  006A  MOVE	R21	R12
+      0x7C4C0400,  //  006B  CALL	R19	2
+      0x8C50032A,  //  006C  GETMET	R20	R1	K42
+      0x5C581800,  //  006D  MOVE	R22	R12
+      0x7C500400,  //  006E  CALL	R20	2
+      0x7C3C0A00,  //  006F  CALL	R15	5
+      0x7C340400,  //  0070  CALL	R13	2
+      0x8C340307,  //  0071  GETMET	R13	R1	K7
+      0x603C0018,  //  0072  GETGBL	R15	G24
+      0x58400094,  //  0073  LDCONST	R16	K148
+      0x5C440E00,  //  0074  MOVE	R17	R7
+      0x5C480E00,  //  0075  MOVE	R18	R7
+      0x5C4C0E00,  //  0076  MOVE	R19	R7
+      0x7C3C0800,  //  0077  CALL	R15	4
+      0x7C340400,  //  0078  CALL	R13	2
+      0x00140B14,  //  0079  ADD	R5	R5	K20
+      0x7001FF9C,  //  007A  JMP		#0018
+      0x8C1C0307,  //  007B  GETMET	R7	R1	K7
+      0x58240095,  //  007C  LDCONST	R9	K149
+      0x7C1C0400,  //  007D  CALL	R7	2
+      0x5C1C0C00,  //  007E  MOVE	R7	R6
+      0x741E0002,  //  007F  JMPT	R7	#0083
+      0x8C1C0307,  //  0080  GETMET	R7	R1	K7
+      0x58240096,  //  0081  LDCONST	R9	K150
+      0x7C1C0400,  //  0082  CALL	R7	2
+      0x8C1C0307,  //  0083  GETMET	R7	R1	K7
+      0x58240097,  //  0084  LDCONST	R9	K151
+      0x7C1C0400,  //  0085  CALL	R7	2
+      0x601C0012,  //  0086  GETGBL	R7	G18
+      0x7C1C0000,  //  0087  CALL	R7	0
+      0x60200010,  //  0088  GETGBL	R8	G16
+      0x88240101,  //  0089  GETMBR	R9	R0	K1
+      0x88241388,  //  008A  GETMBR	R9	R9	K136
+      0x7C200200,  //  008B  CALL	R8	1
+      0xA802000B,  //  008C  EXBLK	0	#0099
+      0x5C241000,  //  008D  MOVE	R9	R8
+      0x7C240000,  //  008E  CALL	R9	0
+      0x8C28136D,  //  008F  GETMET	R10	R9	K109
+      0x58300098,  //  0090  LDCONST	R12	K152
+      0x7C280400,  //  0091  CALL	R10	2
+      0x4C2C0000,  //  0092  LDNIL	R11
+      0x202C140B,  //  0093  NE	R11	R10	R11
+      0x782E0002,  //  0094  JMPF	R11	#0098
+      0x8C2C0F18,  //  0095  GETMET	R11	R7	K24
+      0x5C341400,  //  0096  MOVE	R13	R10
+      0x7C2C0400,  //  0097  CALL	R11	2
+      0x7001FFF3,  //  0098  JMP		#008D
+      0x5820001C,  //  0099  LDCONST	R8	K28
+      0xAC200200,  //  009A  CATCH	R8	1	0
+      0xB0080000,  //  009B  RAISE	2	R0	R0
+      0x88200101,  //  009C  GETMBR	R8	R0	K1
+      0x8C201199,  //  009D  GETMET	R8	R8	K153
+      0x5C280E00,  //  009E  MOVE	R10	R7
+      0x7C200400,  //  009F  CALL	R8	2
+      0x60200010,  //  00A0  GETGBL	R8	G16
+      0x5C240E00,  //  00A1  MOVE	R9	R7
+      0x7C200200,  //  00A2  CALL	R8	1
+      0xA8020084,  //  00A3  EXBLK	0	#0129
+      0x5C241000,  //  00A4  MOVE	R9	R8
+      0x7C240000,  //  00A5  CALL	R9	0
+      0x8C28032A,  //  00A6  GETMET	R10	R1	K42
+      0x5C301200,  //  00A7  MOVE	R12	R9
+      0x7C280400,  //  00A8  CALL	R10	2
+      0x8C2C032A,  //  00A9  GETMET	R11	R1	K42
+      0x88340101,  //  00AA  GETMBR	R13	R0	K1
+      0x8C341B9A,  //  00AB  GETMET	R13	R13	K154
+      0x5C3C1200,  //  00AC  MOVE	R15	R9
+      0x7C340400,  //  00AD  CALL	R13	2
+      0x8C341B6D,  //  00AE  GETMET	R13	R13	K109
+      0x583C0090,  //  00AF  LDCONST	R15	K144
+      0x5C401200,  //  00B0  MOVE	R16	R9
+      0x7C340600,  //  00B1  CALL	R13	3
+      0x7C2C0400,  //  00B2  CALL	R11	2
+      0x8C300307,  //  00B3  GETMET	R12	R1	K7
+      0x60380018,  //  00B4  GETGBL	R14	G24
+      0x583C009B,  //  00B5  LDCONST	R15	K155
+      0x5C401400,  //  00B6  MOVE	R16	R10
+      0x5C441400,  //  00B7  MOVE	R17	R10
+      0x5C481600,  //  00B8  MOVE	R18	R11
+      0x7C380800,  //  00B9  CALL	R14	4
+      0x7C300400,  //  00BA  CALL	R12	2
+      0x8C300307,  //  00BB  GETMET	R12	R1	K7
+      0x5838009C,  //  00BC  LDCONST	R14	K156
+      0x7C300400,  //  00BD  CALL	R12	2
+      0x50180000,  //  00BE  LDBOOL	R6	0	0
+      0x58140006,  //  00BF  LDCONST	R5	K6
+      0x6030000C,  //  00C0  GETGBL	R12	G12
+      0x5C340800,  //  00C1  MOVE	R13	R4
+      0x7C300200,  //  00C2  CALL	R12	1
+      0x14300A0C,  //  00C3  LT	R12	R5	R12
+      0x7832005F,  //  00C4  JMPF	R12	#0125
+      0x94300805,  //  00C5  GETIDX	R12	R4	R5
+      0x88340101,  //  00C6  GETMBR	R13	R0	K1
+      0x88341B88,  //  00C7  GETMBR	R13	R13	K136
+      0x8C341B6D,  //  00C8  GETMET	R13	R13	K109
+      0x603C0008,  //  00C9  GETGBL	R15	G8
+      0x5C401800,  //  00CA  MOVE	R16	R12
+      0x7C3C0200,  //  00CB  CALL	R15	1
+      0x7C340400,  //  00CC  CALL	R13	2
+      0x8C381B6D,  //  00CD  GETMET	R14	R13	K109
+      0x58400019,  //  00CE  LDCONST	R16	K25
+      0x7C380400,  //  00CF  CALL	R14	2
+      0x5C3C1C00,  //  00D0  MOVE	R15	R14
+      0x743E0001,  //  00D1  JMPT	R15	#00D4
+      0x00140B14,  //  00D2  ADD	R5	R5	K20
+      0x7001FFEB,  //  00D3  JMP		#00C0
+      0x8C3C056D,  //  00D4  GETMET	R15	R2	K109
+      0x5C441C00,  //  00D5  MOVE	R17	R14
+      0x5848008C,  //  00D6  LDCONST	R18	K140
+      0x7C3C0600,  //  00D7  CALL	R15	3
+      0x203C1F06,  //  00D8  NE	R15	R15	K6
+      0x783E0001,  //  00D9  JMPF	R15	#00DC
+      0x00140B14,  //  00DA  ADD	R5	R5	K20
+      0x7001FFE3,  //  00DB  JMP		#00C0
+      0x8C3C1B6D,  //  00DC  GETMET	R15	R13	K109
+      0x58440098,  //  00DD  LDCONST	R17	K152
+      0x7C3C0400,  //  00DE  CALL	R15	2
+      0x203C1E09,  //  00DF  NE	R15	R15	R9
+      0x783E0001,  //  00E0  JMPF	R15	#00E3
+      0x00140B14,  //  00E1  ADD	R5	R5	K20
+      0x7001FFDC,  //  00E2  JMP		#00C0
+      0x883C0101,  //  00E3  GETMBR	R15	R0	K1
+      0x883C1F6C,  //  00E4  GETMBR	R15	R15	K108
+      0x8C3C1F6D,  //  00E5  GETMET	R15	R15	K109
+      0x5C441C00,  //  00E6  MOVE	R17	R14
+      0x7C3C0400,  //  00E7  CALL	R15	2
+      0x58400045,  //  00E8  LDCONST	R16	K69
+      0x58440045,  //  00E9  LDCONST	R17	K69
+      0x4C480000,  //  00EA  LDNIL	R18
+      0x20481E12,  //  00EB  NE	R18	R15	R18
+      0x784A0005,  //  00EC  JMPF	R18	#00F3
+      0x8C481F8D,  //  00ED  GETMET	R18	R15	K141
+      0x5C501E00,  //  00EE  MOVE	R20	R15
+      0x5C541A00,  //  00EF  MOVE	R21	R13
+      0x7C480600,  //  00F0  CALL	R18	3
+      0x5C402400,  //  00F1  MOVE	R16	R18
+      0x88441F6E,  //  00F2  GETMBR	R17	R15	K110
+      0x50180200,  //  00F3  LDBOOL	R6	1	0
+      0x8C480307,  //  00F4  GETMET	R18	R1	K7
+      0x60500018,  //  00F5  GETGBL	R20	G24
+      0x5854009D,  //  00F6  LDCONST	R21	K157
+      0x5C581800,  //  00F7  MOVE	R22	R12
+      0x7C500400,  //  00F8  CALL	R20	2
+      0x7C480400,  //  00F9  CALL	R18	2
+      0x8C480307,  //  00FA  GETMET	R18	R1	K7
+      0x60500018,  //  00FB  GETGBL	R20	G24
+      0x5854009E,  //  00FC  LDCONST	R21	K158
+      0x5C581800,  //  00FD  MOVE	R22	R12
+      0x8C5C032A,  //  00FE  GETMET	R23	R1	K42
+      0x8C641B6D,  //  00FF  GETMET	R25	R13	K109
+      0x586C0090,  //  0100  LDCONST	R27	K144
+      0x58700045,  //  0101  LDCONST	R28	K69
+      0x7C640600,  //  0102  CALL	R25	3
+      0x7C5C0400,  //  0103  CALL	R23	2
+      0x7C500600,  //  0104  CALL	R20	3
+      0x7C480400,  //  0105  CALL	R18	2
+      0x8C480307,  //  0106  GETMET	R18	R1	K7
+      0x60500018,  //  0107  GETGBL	R20	G24
+      0x5854009F,  //  0108  LDCONST	R21	K159
+      0x8C580192,  //  0109  GETMET	R22	R0	K146
+      0x8C601B6D,  //  010A  GETMET	R24	R13	K109
+      0x58680019,  //  010B  LDCONST	R26	K25
+      0x586C0045,  //  010C  LDCONST	R27	K69
+      0x7C600600,  //  010D  CALL	R24	3
+      0x7C580400,  //  010E  CALL	R22	2
+      0x7C500400,  //  010F  CALL	R20	2
+      0x7C480400,  //  0110  CALL	R18	2
+      0x8C480307,  //  0111  GETMET	R18	R1	K7
+      0x60500018,  //  0112  GETGBL	R20	G24
+      0x585400A0,  //  0113  LDCONST	R21	K160
+      0x5C581800,  //  0114  MOVE	R22	R12
+      0x8C5C032A,  //  0115  GETMET	R23	R1	K42
+      0x5C642000,  //  0116  MOVE	R25	R16
+      0x7C5C0400,  //  0117  CALL	R23	2
+      0x8C60032A,  //  0118  GETMET	R24	R1	K42
+      0x5C682200,  //  0119  MOVE	R26	R17
+      0x7C600400,  //  011A  CALL	R24	2
+      0x7C500800,  //  011B  CALL	R20	4
+      0x7C480400,  //  011C  CALL	R18	2
+      0x8C480307,  //  011D  GETMET	R18	R1	K7
+      0x60500018,  //  011E  GETGBL	R20	G24
+      0x585400A1,  //  011F  LDCONST	R21	K161
+      0x5C581800,  //  0120  MOVE	R22	R12
+      0x7C500400,  //  0121  CALL	R20	2
+      0x7C480400,  //  0122  CALL	R18	2
+      0x00140B14,  //  0123  ADD	R5	R5	K20
+      0x7001FF9A,  //  0124  JMP		#00C0
+      0x8C300307,  //  0125  GETMET	R12	R1	K7
+      0x583800A2,  //  0126  LDCONST	R14	K162
+      0x7C300400,  //  0127  CALL	R12	2
+      0x7001FF7A,  //  0128  JMP		#00A4
+      0x5820001C,  //  0129  LDCONST	R8	K28
+      0xAC200200,  //  012A  CATCH	R8	1	0
+      0xB0080000,  //  012B  RAISE	2	R0	R0
+      0x5C200C00,  //  012C  MOVE	R8	R6
+      0x74220002,  //  012D  JMPT	R8	#0131
+      0x8C200307,  //  012E  GETMET	R8	R1	K7
+      0x58280096,  //  012F  LDCONST	R10	K150
+      0x7C200400,  //  0130  CALL	R8	2
+      0x8C200307,  //  0131  GETMET	R8	R1	K7
+      0x582800A3,  //  0132  LDCONST	R10	K163
+      0x7C200400,  //  0133  CALL	R8	2
+      0x88200101,  //  0134  GETMBR	R8	R0	K1
+      0x882011A4,  //  0135  GETMBR	R8	R8	K164
+      0x78220007,  //  0136  JMPF	R8	#013F
+      0x8C2001A5,  //  0137  GETMET	R8	R0	K165
+      0x882801A6,  //  0138  GETMBR	R10	R0	K166
+      0x882C0101,  //  0139  GETMBR	R11	R0	K1
+      0x882C17A4,  //  013A  GETMBR	R11	R11	K164
+      0x882C17A7,  //  013B  GETMBR	R11	R11	K167
+      0x883001A8,  //  013C  GETMBR	R12	R0	K168
+      0x7C200800,  //  013D  CALL	R8	4
+      0x70020003,  //  013E  JMP		#0143
+      0x8C2001A5,  //  013F  GETMET	R8	R0	K165
+      0x882801A6,  //  0140  GETMBR	R10	R0	K166
+      0x882C01A8,  //  0141  GETMBR	R11	R0	K168
+      0x7C200600,  //  0142  CALL	R8	3
+      0x8C200307,  //  0143  GETMET	R8	R1	K7
+      0x582800A9,  //  0144  LDCONST	R10	K169
+      0x7C200400,  //  0145  CALL	R8	2
+      0x88200101,  //  0146  GETMBR	R8	R0	K1
+      0x882011A4,  //  0147  GETMBR	R8	R8	K164
+      0x78220008,  //  0148  JMPF	R8	#0152
+      0x8C2001AA,  //  0149  GETMET	R8	R0	K170
+      0x58280045,  //  014A  LDCONST	R10	K69
+      0x882C01A6,  //  014B  GETMBR	R11	R0	K166
+      0x88300101,  //  014C  GETMBR	R12	R0	K1
+      0x883019A4,  //  014D  GETMBR	R12	R12	K164
+      0x883019A7,  //  014E  GETMBR	R12	R12	K167
+      0x883401A8,  //  014F  GETMBR	R13	R0	K168
+      0x7C200A00,  //  0150  CALL	R8	5
+      0x70020004,  //  0151  JMP		#0157
+      0x8C2001AA,  //  0152  GETMET	R8	R0	K170
+      0x58280045,  //  0153  LDCONST	R10	K69
+      0x882C01A6,  //  0154  GETMBR	R11	R0	K166
+      0x883001A8,  //  0155  GETMBR	R12	R0	K168
+      0x7C200800,  //  0156  CALL	R8	4
+      0x8C200307,  //  0157  GETMET	R8	R1	K7
+      0x582800AB,  //  0158  LDCONST	R10	K171
+      0x7C200400,  //  0159  CALL	R8	2
+      0x80000000,  //  015A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_bridge_status
+********************************************************************/
+be_local_closure(class_Matter_UI_show_bridge_status,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(show_bridge_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[118]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x880403AC,  //  0001  GETMBR	R1	R1	K172
+      0x4C080000,  //  0002  LDNIL	R2
+      0x1C040202,  //  0003  EQ	R1	R1	R2
+      0x78060000,  //  0004  JMPF	R1	#0006
+      0x80000200,  //  0005  RET	0
+      0xA4060000,  //  0006  IMPORT	R1	K0
+      0x4C080000,  //  0007  LDNIL	R2
+      0x580C0006,  //  0008  LDCONST	R3	K6
+      0x6010000C,  //  0009  GETGBL	R4	G12
+      0x88140101,  //  000A  GETMBR	R5	R0	K1
+      0x88140BAC,  //  000B  GETMBR	R5	R5	K172
+      0x7C100200,  //  000C  CALL	R4	1
+      0x14100604,  //  000D  LT	R4	R3	R4
+      0x78120019,  //  000E  JMPF	R4	#0029
+      0x88100101,  //  000F  GETMBR	R4	R0	K1
+      0x881009AC,  //  0010  GETMBR	R4	R4	K172
+      0x94100803,  //  0011  GETIDX	R4	R4	R3
+      0x881409AD,  //  0012  GETMBR	R5	R4	K173
+      0x78160012,  //  0013  JMPF	R5	#0027
+      0x4C140000,  //  0014  LDNIL	R5
+      0x1C140405,  //  0015  EQ	R5	R2	R5
+      0x78160002,  //  0016  JMPF	R5	#001A
+      0x60140013,  //  0017  GETGBL	R5	G19
+      0x7C140000,  //  0018  CALL	R5	0
+      0x5C080A00,  //  0019  MOVE	R2	R5
+      0x881409AE,  //  001A  GETMBR	R5	R4	K174
+      0x88140BAF,  //  001B  GETMBR	R5	R5	K175
+      0x8C180512,  //  001C  GETMET	R6	R2	K18
+      0x5C200A00,  //  001D  MOVE	R8	R5
+      0x7C180400,  //  001E  CALL	R6	2
+      0x741A0002,  //  001F  JMPT	R6	#0023
+      0x60180012,  //  0020  GETGBL	R6	G18
+      0x7C180000,  //  0021  CALL	R6	0
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x94180405,  //  0023  GETIDX	R6	R2	R5
+      0x8C180D18,  //  0024  GETMET	R6	R6	K24
+      0x5C200800,  //  0025  MOVE	R8	R4
+      0x7C180400,  //  0026  CALL	R6	2
+      0x000C0714,  //  0027  ADD	R3	R3	K20
+      0x7001FFDF,  //  0028  JMP		#0009
+      0x4C100000,  //  0029  LDNIL	R4
+      0x1C100404,  //  002A  EQ	R4	R2	R4
+      0x78120000,  //  002B  JMPF	R4	#002D
+      0x80000800,  //  002C  RET	0
+      0x8C100307,  //  002D  GETMET	R4	R1	K7
+      0x58180027,  //  002E  LDCONST	R6	K39
+      0x7C100400,  //  002F  CALL	R4	2
+      0x8C100307,  //  0030  GETMET	R4	R1	K7
+      0x581800B0,  //  0031  LDCONST	R6	K176
+      0x7C100400,  //  0032  CALL	R4	2
+      0x8C100307,  //  0033  GETMET	R4	R1	K7
+      0xB81A7A00,  //  0034  GETNGBL	R6	K61
+      0x88180DB1,  //  0035  GETMBR	R6	R6	K177
+      0x7C100400,  //  0036  CALL	R4	2
+      0x60100010,  //  0037  GETGBL	R4	G16
+      0x88140101,  //  0038  GETMBR	R5	R0	K1
+      0x8C140BB2,  //  0039  GETMET	R5	R5	K178
+      0x5C1C0400,  //  003A  MOVE	R7	R2
+      0x7C140400,  //  003B  CALL	R5	2
+      0x7C100200,  //  003C  CALL	R4	1
+      0xA8020030,  //  003D  EXBLK	0	#006F
+      0x5C140800,  //  003E  MOVE	R5	R4
+      0x7C140000,  //  003F  CALL	R5	0
+      0x8C18032A,  //  0040  GETMET	R6	R1	K42
+      0x5C200A00,  //  0041  MOVE	R8	R5
+      0x7C180400,  //  0042  CALL	R6	2
+      0x8C1C032A,  //  0043  GETMET	R7	R1	K42
+      0x88240101,  //  0044  GETMBR	R9	R0	K1
+      0x8C24139A,  //  0045  GETMET	R9	R9	K154
+      0x5C2C0A00,  //  0046  MOVE	R11	R5
+      0x7C240400,  //  0047  CALL	R9	2
+      0x8C24136D,  //  0048  GETMET	R9	R9	K109
+      0x582C0090,  //  0049  LDCONST	R11	K144
+      0x5C300A00,  //  004A  MOVE	R12	R5
+      0x7C240600,  //  004B  CALL	R9	3
+      0x7C1C0400,  //  004C  CALL	R7	2
+      0x8C200307,  //  004D  GETMET	R8	R1	K7
+      0x60280018,  //  004E  GETGBL	R10	G24
+      0x582C00B3,  //  004F  LDCONST	R11	K179
+      0x5C300C00,  //  0050  MOVE	R12	R6
+      0x5C340C00,  //  0051  MOVE	R13	R6
+      0x5C380E00,  //  0052  MOVE	R14	R7
+      0x7C280800,  //  0053  CALL	R10	4
+      0x7C200400,  //  0054  CALL	R8	2
+      0x94200405,  //  0055  GETIDX	R8	R2	R5
+      0x94201106,  //  0056  GETIDX	R8	R8	K6
+      0x882011AE,  //  0057  GETMBR	R8	R8	K174
+      0x8C240307,  //  0058  GETMET	R9	R1	K7
+      0x8C2C11B4,  //  0059  GETMET	R11	R8	K180
+      0x7C2C0200,  //  005A  CALL	R11	1
+      0x7C240400,  //  005B  CALL	R9	2
+      0x60240010,  //  005C  GETGBL	R9	G16
+      0x94280405,  //  005D  GETIDX	R10	R2	R5
+      0x7C240200,  //  005E  CALL	R9	1
+      0xA802000A,  //  005F  EXBLK	0	#006B
+      0x5C281200,  //  0060  MOVE	R10	R9
+      0x7C280000,  //  0061  CALL	R10	0
+      0x8C2C0307,  //  0062  GETMET	R11	R1	K7
+      0x583400B5,  //  0063  LDCONST	R13	K181
+      0x7C2C0400,  //  0064  CALL	R11	2
+      0x8C2C15B6,  //  0065  GETMET	R11	R10	K182
+      0x7C2C0200,  //  0066  CALL	R11	1
+      0x8C2C0307,  //  0067  GETMET	R11	R1	K7
+      0x583400B7,  //  0068  LDCONST	R13	K183
+      0x7C2C0400,  //  0069  CALL	R11	2
+      0x7001FFF4,  //  006A  JMP		#0060
+      0x5824001C,  //  006B  LDCONST	R9	K28
+      0xAC240200,  //  006C  CATCH	R9	1	0
+      0xB0080000,  //  006D  RAISE	2	R0	R0
+      0x7001FFCE,  //  006E  JMP		#003E
+      0x5810001C,  //  006F  LDCONST	R4	K28
+      0xAC100200,  //  0070  CATCH	R4	1	0
+      0xB0080000,  //  0071  RAISE	2	R0	R0
+      0x8C100307,  //  0072  GETMET	R4	R1	K7
+      0x581800B8,  //  0073  LDCONST	R6	K184
+      0x7C100400,  //  0074  CALL	R4	2
+      0x80000000,  //  0075  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_add_config_button
+********************************************************************/
+be_local_closure(class_Matter_UI_web_add_config_button,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(web_add_config_button),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080307,  //  0001  GETMET	R2	R1	K7
+      0x581000B9,  //  0002  LDCONST	R4	K185
+      0x7C080400,  //  0003  CALL	R2	2
+      0x8C080307,  //  0004  GETMET	R2	R1	K7
+      0xB8127A00,  //  0005  GETNGBL	R4	K61
+      0x881009BA,  //  0006  GETMBR	R4	R4	K186
+      0x7C080400,  //  0007  CALL	R2	2
+      0x8C080307,  //  0008  GETMET	R2	R1	K7
+      0x581000BB,  //  0009  LDCONST	R4	K187
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: plugin_name
+********************************************************************/
+be_local_closure(class_Matter_UI_plugin_name,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    11,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(plugin_name),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x1C0C0345,  //  0000  EQ	R3	R1	K69
+      0x780E0000,  //  0001  JMPF	R3	#0003
+      0x80068A00,  //  0002  RET	1	K69
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x8C0C07BC,  //  0004  GETMET	R3	R3	K188
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x80040600,  //  0007  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_part_mgr_adv
+********************************************************************/
+be_local_closure(class_Matter_UI_page_part_mgr_adv,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(page_part_mgr_adv),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080354,  //  0001  GETMET	R2	R1	K84
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080355,  //  0006  GETMET	R2	R1	K85
+      0x581000BD,  //  0007  LDCONST	R4	K189
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080357,  //  0009  GETMET	R2	R1	K87
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C08014A,  //  000B  GETMET	R2	R0	K74
+      0x7C080200,  //  000C  CALL	R2	1
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C0801BE,  //  000E  GETMET	R2	R0	K190
+      0x7C080200,  //  000F  CALL	R2	1
+      0x8C0801BF,  //  0010  GETMET	R2	R0	K191
+      0x7C080200,  //  0011  CALL	R2	1
+      0x8C0801C0,  //  0012  GETMET	R2	R0	K192
+      0x7C080200,  //  0013  CALL	R2	1
+      0x8C08035D,  //  0014  GETMET	R2	R1	K93
+      0x7C080200,  //  0015  CALL	R2	1
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_part_mgr_add
+********************************************************************/
+be_local_closure(class_Matter_UI_page_part_mgr_add,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(page_part_mgr_add),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080354,  //  0001  GETMET	R2	R1	K84
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080355,  //  0006  GETMET	R2	R1	K85
+      0x581000C1,  //  0007  LDCONST	R4	K193
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080357,  //  0009  GETMET	R2	R1	K87
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C0803C2,  //  000B  GETMET	R2	R1	K194
+      0x58100098,  //  000C  LDCONST	R4	K152
+      0x7C080400,  //  000D  CALL	R2	2
+      0x8C0C014A,  //  000E  GETMET	R3	R0	K74
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x780E0002,  //  0010  JMPF	R3	#0014
+      0x8C0C01C3,  //  0011  GETMET	R3	R0	K195
+      0x5C140400,  //  0012  MOVE	R5	R2
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x8C0C035B,  //  0014  GETMET	R3	R1	K91
+      0x8814035C,  //  0015  GETMBR	R5	R1	K92
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x8C0C035D,  //  0017  GETMET	R3	R1	K93
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: web_add_handler
+********************************************************************/
+be_local_closure(class_Matter_UI_web_add_handler,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 4]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_mgr),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_ctl),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_mgr_adv),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_mgr_add),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(web_add_handler),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C0803C4,  //  0001  GETMET	R2	R1	K196
+      0x581000C5,  //  0002  LDCONST	R4	K197
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x881803C6,  //  0004  GETMBR	R6	R1	K198
+      0x7C080800,  //  0005  CALL	R2	4
+      0x8C0803C4,  //  0006  GETMET	R2	R1	K196
+      0x581000C5,  //  0007  LDCONST	R4	K197
+      0x84140001,  //  0008  CLOSURE	R5	P1
+      0x881803C7,  //  0009  GETMBR	R6	R1	K199
+      0x7C080800,  //  000A  CALL	R2	4
+      0x8C0803C4,  //  000B  GETMET	R2	R1	K196
+      0x581000C8,  //  000C  LDCONST	R4	K200
+      0x84140002,  //  000D  CLOSURE	R5	P2
+      0x881803C6,  //  000E  GETMBR	R6	R1	K198
+      0x7C080800,  //  000F  CALL	R2	4
+      0x8C0803C4,  //  0010  GETMET	R2	R1	K196
+      0x581000C9,  //  0011  LDCONST	R4	K201
+      0x84140003,  //  0012  CLOSURE	R5	P3
+      0x881803C6,  //  0013  GETMBR	R6	R1	K198
+      0x7C080800,  //  0014  CALL	R2	4
+      0xA0000000,  //  0015  CLOSE	R0
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_UI_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x90020201,  //  0000  SETMBR	R0	K1	R1
+      0xB80A0800,  //  0001  GETNGBL	R2	K4
+      0x8C0805CA,  //  0002  GETMET	R2	R2	K202
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: plugin_option
+********************************************************************/
+be_local_closure(class_Matter_UI_plugin_option,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    11,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(plugin_option),
+    &be_const_str_solidified,
+    ( &(const binstruction[63]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA412D200,  //  0001  IMPORT	R4	K105
+      0x60140012,  //  0002  GETGBL	R5	G18
+      0x7C140000,  //  0003  CALL	R5	0
+      0x60180010,  //  0004  GETGBL	R6	G16
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x7C180200,  //  0006  CALL	R6	1
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x5C1C0C00,  //  0008  MOVE	R7	R6
+      0x7C1C0000,  //  0009  CALL	R7	0
+      0x8C20096A,  //  000A  GETMET	R8	R4	K106
+      0x5C280E00,  //  000B  MOVE	R10	R7
+      0x582C006B,  //  000C  LDCONST	R11	K107
+      0x7C200600,  //  000D  CALL	R8	3
+      0x00140A08,  //  000E  ADD	R5	R5	R8
+      0x7001FFF7,  //  000F  JMP		#0008
+      0x5818001C,  //  0010  LDCONST	R6	K28
+      0xAC180200,  //  0011  CATCH	R6	1	0
+      0xB0080000,  //  0012  RAISE	2	R0	R0
+      0x58180006,  //  0013  LDCONST	R6	K6
+      0x601C000C,  //  0014  GETGBL	R7	G12
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C1C0200,  //  0016  CALL	R7	1
+      0x141C0C07,  //  0017  LT	R7	R6	R7
+      0x781E0024,  //  0018  JMPF	R7	#003E
+      0x941C0A06,  //  0019  GETIDX	R7	R5	R6
+      0x1C200F45,  //  001A  EQ	R8	R7	K69
+      0x78220003,  //  001B  JMPF	R8	#0020
+      0x8C200707,  //  001C  GETMET	R8	R3	K7
+      0x582800CB,  //  001D  LDCONST	R10	K203
+      0x7C200400,  //  001E  CALL	R8	2
+      0x7002001B,  //  001F  JMP		#003C
+      0x1C200FCC,  //  0020  EQ	R8	R7	K204
+      0x78220003,  //  0021  JMPF	R8	#0026
+      0x8C200707,  //  0022  GETMET	R8	R3	K7
+      0x582800CD,  //  0023  LDCONST	R10	K205
+      0x7C200400,  //  0024  CALL	R8	2
+      0x70020015,  //  0025  JMP		#003C
+      0x1C200FCE,  //  0026  EQ	R8	R7	K206
+      0x78220003,  //  0027  JMPF	R8	#002C
+      0x8C200707,  //  0028  GETMET	R8	R3	K7
+      0x582800CF,  //  0029  LDCONST	R10	K207
+      0x7C200400,  //  002A  CALL	R8	2
+      0x7002000F,  //  002B  JMP		#003C
+      0x88200101,  //  002C  GETMBR	R8	R0	K1
+      0x8C2011BC,  //  002D  GETMET	R8	R8	K188
+      0x5C280E00,  //  002E  MOVE	R10	R7
+      0x7C200400,  //  002F  CALL	R8	2
+      0x8C240707,  //  0030  GETMET	R9	R3	K7
+      0x602C0018,  //  0031  GETGBL	R11	G24
+      0x583000D0,  //  0032  LDCONST	R12	K208
+      0x5C340E00,  //  0033  MOVE	R13	R7
+      0x1C380E01,  //  0034  EQ	R14	R7	R1
+      0x783A0001,  //  0035  JMPF	R14	#0038
+      0x583800D1,  //  0036  LDCONST	R14	K209
+      0x70020000,  //  0037  JMP		#0039
+      0x58380045,  //  0038  LDCONST	R14	K69
+      0x5C3C1000,  //  0039  MOVE	R15	R8
+      0x7C2C0800,  //  003A  CALL	R11	4
+      0x7C240400,  //  003B  CALL	R9	2
+      0x00180D14,  //  003C  ADD	R6	R6	K20
+      0x7001FFD5,  //  003D  JMP		#0014
+      0x80000000,  //  003E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_remote_autoconf
+********************************************************************/
+be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
+  be_nested_proto(
+    27,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UI,     /* shared constants */
+    be_str_weak(show_remote_autoconf),
+    &be_const_str_solidified,
+    ( &(const binstruction[220]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40ED000,  //  0001  IMPORT	R3	K104
+      0x1C100345,  //  0002  EQ	R4	R1	K69
+      0x78120000,  //  0003  JMPF	R4	#0005
+      0x80000800,  //  0004  RET	0
+      0xB8127A00,  //  0005  GETNGBL	R4	K61
+      0x881009D2,  //  0006  GETMBR	R4	R4	K210
+      0x881009D3,  //  0007  GETMBR	R4	R4	K211
+      0xB8167A00,  //  0008  GETNGBL	R5	K61
+      0x8C140BD4,  //  0009  GETMET	R5	R5	K212
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x5C240800,  //  000C  MOVE	R9	R4
+      0x7C140800,  //  000D  CALL	R5	4
+      0x8C180BD5,  //  000E  GETMET	R6	R5	K213
+      0x582000D6,  //  000F  LDCONST	R8	K214
+      0x5C240800,  //  0010  MOVE	R9	R4
+      0x7C180600,  //  0011  CALL	R6	3
+      0x4C1C0000,  //  0012  LDNIL	R7
+      0x201C0C07,  //  0013  NE	R7	R6	R7
+      0x781E0003,  //  0014  JMPF	R7	#0019
+      0x8C1C07D7,  //  0015  GETMET	R7	R3	K215
+      0x5C240C00,  //  0016  MOVE	R9	R6
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x5C180E00,  //  0018  MOVE	R6	R7
+      0x4C1C0000,  //  0019  LDNIL	R7
+      0x201C0C07,  //  001A  NE	R7	R6	R7
+      0x781E0003,  //  001B  JMPF	R7	#0020
+      0x8C1C0D6D,  //  001C  GETMET	R7	R6	K109
+      0x582400D8,  //  001D  LDCONST	R9	K216
+      0x7C1C0400,  //  001E  CALL	R7	2
+      0x5C180E00,  //  001F  MOVE	R6	R7
+      0x4C1C0000,  //  0020  LDNIL	R7
+      0x4C200000,  //  0021  LDNIL	R8
+      0x20200C08,  //  0022  NE	R8	R6	R8
+      0x78220012,  //  0023  JMPF	R8	#0037
+      0x8C200BD5,  //  0024  GETMET	R8	R5	K213
+      0x582800D9,  //  0025  LDCONST	R10	K217
+      0x5C2C0800,  //  0026  MOVE	R11	R4
+      0x7C200600,  //  0027  CALL	R8	3
+      0x5C1C1000,  //  0028  MOVE	R7	R8
+      0x4C200000,  //  0029  LDNIL	R8
+      0x20200E08,  //  002A  NE	R8	R7	R8
+      0x78220003,  //  002B  JMPF	R8	#0030
+      0x8C2007D7,  //  002C  GETMET	R8	R3	K215
+      0x5C280E00,  //  002D  MOVE	R10	R7
+      0x7C200400,  //  002E  CALL	R8	2
+      0x5C1C1000,  //  002F  MOVE	R7	R8
+      0x4C200000,  //  0030  LDNIL	R8
+      0x20200E08,  //  0031  NE	R8	R7	R8
+      0x78220003,  //  0032  JMPF	R8	#0037
+      0x8C200F6D,  //  0033  GETMET	R8	R7	K109
+      0x582800DA,  //  0034  LDCONST	R10	K218
+      0x7C200400,  //  0035  CALL	R8	2
+      0x5C1C1000,  //  0036  MOVE	R7	R8
+      0x4C200000,  //  0037  LDNIL	R8
+      0x20200C08,  //  0038  NE	R8	R6	R8
+      0x78220098,  //  0039  JMPF	R8	#00D3
+      0x4C200000,  //  003A  LDNIL	R8
+      0x20200E08,  //  003B  NE	R8	R7	R8
+      0x78220095,  //  003C  JMPF	R8	#00D3
+      0xB823B600,  //  003D  GETNGBL	R8	K219
+      0x60240018,  //  003E  GETGBL	R9	G24
+      0x582800DC,  //  003F  LDCONST	R10	K220
+      0x5C2C0200,  //  0040  MOVE	R11	R1
+      0x60300008,  //  0041  GETGBL	R12	G8
+      0x5C340C00,  //  0042  MOVE	R13	R6
+      0x7C300200,  //  0043  CALL	R12	1
+      0x60340008,  //  0044  GETGBL	R13	G8
+      0x5C380E00,  //  0045  MOVE	R14	R7
+      0x7C340200,  //  0046  CALL	R13	1
+      0x7C240800,  //  0047  CALL	R9	4
+      0x5828000B,  //  0048  LDCONST	R10	K11
+      0x7C200400,  //  0049  CALL	R8	2
+      0x8C2001DD,  //  004A  GETMET	R8	R0	K221
+      0x5C280C00,  //  004B  MOVE	R10	R6
+      0x5C2C0E00,  //  004C  MOVE	R11	R7
+      0x7C200600,  //  004D  CALL	R8	3
+      0x8C2401A5,  //  004E  GETMET	R9	R0	K165
+      0x882C01DE,  //  004F  GETMBR	R11	R0	K222
+      0x7C240400,  //  0050  CALL	R9	2
+      0x8C240507,  //  0051  GETMET	R9	R2	K7
+      0x582C00DF,  //  0052  LDCONST	R11	K223
+      0x7C240400,  //  0053  CALL	R9	2
+      0x8C24052A,  //  0054  GETMET	R9	R2	K42
+      0x5C2C0200,  //  0055  MOVE	R11	R1
+      0x7C240400,  //  0056  CALL	R9	2
+      0x8C280507,  //  0057  GETMET	R10	R2	K7
+      0x60300018,  //  0058  GETGBL	R12	G24
+      0x583400E0,  //  0059  LDCONST	R13	K224
+      0x5C381200,  //  005A  MOVE	R14	R9
+      0x5C3C1200,  //  005B  MOVE	R15	R9
+      0x7C300600,  //  005C  CALL	R12	3
+      0x7C280400,  //  005D  CALL	R10	2
+      0x8C280507,  //  005E  GETMET	R10	R2	K7
+      0x583000E1,  //  005F  LDCONST	R12	K225
+      0x7C280400,  //  0060  CALL	R10	2
+      0x8C280507,  //  0061  GETMET	R10	R2	K7
+      0x60300018,  //  0062  GETGBL	R12	G24
+      0x583400E2,  //  0063  LDCONST	R13	K226
+      0x8C38052A,  //  0064  GETMET	R14	R2	K42
+      0x5C400200,  //  0065  MOVE	R16	R1
+      0x7C380400,  //  0066  CALL	R14	2
+      0x7C300400,  //  0067  CALL	R12	2
+      0x7C280400,  //  0068  CALL	R10	2
+      0x58280006,  //  0069  LDCONST	R10	K6
+      0x602C000C,  //  006A  GETGBL	R11	G12
+      0x5C301000,  //  006B  MOVE	R12	R8
+      0x7C2C0200,  //  006C  CALL	R11	1
+      0x142C140B,  //  006D  LT	R11	R10	R11
+      0x782E0040,  //  006E  JMPF	R11	#00B0
+      0x942C100A,  //  006F  GETIDX	R11	R8	R10
+      0x8C30176D,  //  0070  GETMET	R12	R11	K109
+      0x58380019,  //  0071  LDCONST	R14	K25
+      0x583C0045,  //  0072  LDCONST	R15	K69
+      0x7C300600,  //  0073  CALL	R12	3
+      0x20341945,  //  0074  NE	R13	R12	K69
+      0x78360000,  //  0075  JMPF	R13	#0077
+      0x0033180C,  //  0076  ADD	R12	K140	R12
+      0x88340101,  //  0077  GETMBR	R13	R0	K1
+      0x88341B6C,  //  0078  GETMBR	R13	R13	K108
+      0x8C341B6D,  //  0079  GETMET	R13	R13	K109
+      0x5C3C1800,  //  007A  MOVE	R15	R12
+      0x7C340400,  //  007B  CALL	R13	2
+      0x58380045,  //  007C  LDCONST	R14	K69
+      0x583C0045,  //  007D  LDCONST	R15	K69
+      0x4C400000,  //  007E  LDNIL	R16
+      0x20401A10,  //  007F  NE	R16	R13	R16
+      0x78420005,  //  0080  JMPF	R16	#0087
+      0x8C401B8D,  //  0081  GETMET	R16	R13	K141
+      0x5C481A00,  //  0082  MOVE	R18	R13
+      0x5C4C1600,  //  0083  MOVE	R19	R11
+      0x7C400600,  //  0084  CALL	R16	3
+      0x5C382000,  //  0085  MOVE	R14	R16
+      0x883C1B6E,  //  0086  GETMBR	R15	R13	K110
+      0x8C400507,  //  0087  GETMET	R16	R2	K7
+      0x60480018,  //  0088  GETGBL	R18	G24
+      0x584C00E3,  //  0089  LDCONST	R19	K227
+      0x5C501400,  //  008A  MOVE	R20	R10
+      0x7C480400,  //  008B  CALL	R18	2
+      0x7C400400,  //  008C  CALL	R16	2
+      0x8C400507,  //  008D  GETMET	R16	R2	K7
+      0x60480018,  //  008E  GETGBL	R18	G24
+      0x584C00E4,  //  008F  LDCONST	R19	K228
+      0x5C501400,  //  0090  MOVE	R20	R10
+      0x5C541400,  //  0091  MOVE	R21	R10
+      0x7C480600,  //  0092  CALL	R18	3
+      0x7C400400,  //  0093  CALL	R16	2
+      0x8C4001AA,  //  0094  GETMET	R16	R0	K170
+      0x5C481800,  //  0095  MOVE	R18	R12
+      0x884C01DE,  //  0096  GETMBR	R19	R0	K222
+      0x7C400600,  //  0097  CALL	R16	3
+      0x8C400507,  //  0098  GETMET	R16	R2	K7
+      0x584800E5,  //  0099  LDCONST	R18	K229
+      0x7C400400,  //  009A  CALL	R16	2
+      0x8C400507,  //  009B  GETMET	R16	R2	K7
+      0x60480018,  //  009C  GETGBL	R18	G24
+      0x584C00E6,  //  009D  LDCONST	R19	K230
+      0x5C501400,  //  009E  MOVE	R20	R10
+      0x5C541400,  //  009F  MOVE	R21	R10
+      0x8C58052A,  //  00A0  GETMET	R22	R2	K42
+      0x5C601C00,  //  00A1  MOVE	R24	R14
+      0x7C580400,  //  00A2  CALL	R22	2
+      0x8C5C052A,  //  00A3  GETMET	R23	R2	K42
+      0x5C641E00,  //  00A4  MOVE	R25	R15
+      0x7C5C0400,  //  00A5  CALL	R23	2
+      0x8C60052A,  //  00A6  GETMET	R24	R2	K42
+      0x5C681E00,  //  00A7  MOVE	R26	R15
+      0x7C600400,  //  00A8  CALL	R24	2
+      0x7C480C00,  //  00A9  CALL	R18	6
+      0x7C400400,  //  00AA  CALL	R16	2
+      0x8C400507,  //  00AB  GETMET	R16	R2	K7
+      0x584800B7,  //  00AC  LDCONST	R18	K183
+      0x7C400400,  //  00AD  CALL	R16	2
+      0x00281514,  //  00AE  ADD	R10	R10	K20
+      0x7001FFB9,  //  00AF  JMP		#006A
+      0x8C2C0507,  //  00B0  GETMET	R11	R2	K7
+      0x60340018,  //  00B1  GETGBL	R13	G24
+      0x583800E3,  //  00B2  LDCONST	R14	K227
+      0x5C3C1400,  //  00B3  MOVE	R15	R10
+      0x7C340400,  //  00B4  CALL	R13	2
+      0x7C2C0400,  //  00B5  CALL	R11	2
+      0x8C2C0507,  //  00B6  GETMET	R11	R2	K7
+      0x60340018,  //  00B7  GETGBL	R13	G24
+      0x583800E4,  //  00B8  LDCONST	R14	K228
+      0x5C3C1400,  //  00B9  MOVE	R15	R10
+      0x5C401400,  //  00BA  MOVE	R16	R10
+      0x7C340600,  //  00BB  CALL	R13	3
+      0x7C2C0400,  //  00BC  CALL	R11	2
+      0x8C2C01AA,  //  00BD  GETMET	R11	R0	K170
+      0x58340045,  //  00BE  LDCONST	R13	K69
+      0x883801DE,  //  00BF  GETMBR	R14	R0	K222
+      0x7C2C0600,  //  00C0  CALL	R11	3
+      0x8C2C0507,  //  00C1  GETMET	R11	R2	K7
+      0x583400E5,  //  00C2  LDCONST	R13	K229
+      0x7C2C0400,  //  00C3  CALL	R11	2
+      0x8C2C0507,  //  00C4  GETMET	R11	R2	K7
+      0x60340018,  //  00C5  GETGBL	R13	G24
+      0x583800E7,  //  00C6  LDCONST	R14	K231
+      0x5C3C1400,  //  00C7  MOVE	R15	R10
+      0x5C401400,  //  00C8  MOVE	R16	R10
+      0x58440045,  //  00C9  LDCONST	R17	K69
+      0x7C340800,  //  00CA  CALL	R13	4
+      0x7C2C0400,  //  00CB  CALL	R11	2
+      0x8C2C0507,  //  00CC  GETMET	R11	R2	K7
+      0x583400B7,  //  00CD  LDCONST	R13	K183
+      0x7C2C0400,  //  00CE  CALL	R11	2
+      0x8C2C0507,  //  00CF  GETMET	R11	R2	K7
+      0x583400E8,  //  00D0  LDCONST	R13	K232
+      0x7C2C0400,  //  00D1  CALL	R11	2
+      0x70020007,  //  00D2  JMP		#00DB
+      0x8C200507,  //  00D3  GETMET	R8	R2	K7
+      0x60280018,  //  00D4  GETGBL	R10	G24
+      0x582C00E9,  //  00D5  LDCONST	R11	K233
+      0x8C30052A,  //  00D6  GETMET	R12	R2	K42
+      0x5C380200,  //  00D7  MOVE	R14	R1
+      0x7C300400,  //  00D8  CALL	R12	2
+      0x7C280400,  //  00D9  CALL	R10	2
+      0x7C200400,  //  00DA  CALL	R8	2
+      0x80000000,  //  00DB  RET	0
     })
   )
 );
@@ -3151,34 +3187,35 @@ be_local_closure(class_Matter_UI_show_plugins_hints_js,   /* name */
 be_local_class(Matter_UI,
     1,
     NULL,
-    be_nested_map(26,
+    be_nested_map(27,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(equal_map, -1), be_const_static_closure(class_Matter_UI_equal_map_closure) },
-        { be_const_key_weak(page_part_mgr_adv, -1), be_const_closure(class_Matter_UI_page_part_mgr_adv_closure) },
+        { be_const_key_weak(show_remote_autoconf, 9), be_const_closure(class_Matter_UI_show_remote_autoconf_closure) },
         { be_const_key_weak(_CLASSES_TYPES2, -1), be_nested_str_weak(_X7Chttp_relay_X7Chttp_light0_X7Chttp_light1_X7Chttp_light2_X7Chttp_light3_X7Chttp_temperature_X7Chttp_pressure_X7Chttp_illuminance_X7Chttp_humidity_X7Chttp_occupancy_X7Chttp_contact_X7Chttp_flow_X7Chttp_rain_X7Chttp_waterleak_X7Chttp_airquality) },
-        { be_const_key_weak(page_part_mgr, 25), be_const_closure(class_Matter_UI_page_part_mgr_closure) },
-        { be_const_key_weak(show_plugins_hints_js, -1), be_const_closure(class_Matter_UI_show_plugins_hints_js_closure) },
-        { be_const_key_weak(show_enable, -1), be_const_closure(class_Matter_UI_show_enable_closure) },
-        { be_const_key_weak(matter_enabled, 24), be_const_closure(class_Matter_UI_matter_enabled_closure) },
-        { be_const_key_weak(generate_config_from_status, -1), be_const_closure(class_Matter_UI_generate_config_from_status_closure) },
-        { be_const_key_weak(show_qrcode, 21), be_const_closure(class_Matter_UI_show_qrcode_closure) },
-        { be_const_key_weak(page_part_mgr_add, -1), be_const_closure(class_Matter_UI_page_part_mgr_add_closure) },
-        { be_const_key_weak(show_plugins_configuration, -1), be_const_closure(class_Matter_UI_show_plugins_configuration_closure) },
-        { be_const_key_weak(show_commissioning_info, -1), be_const_closure(class_Matter_UI_show_commissioning_info_closure) },
-        { be_const_key_weak(page_part_ctl, 18), be_const_closure(class_Matter_UI_page_part_ctl_closure) },
-        { be_const_key_weak(show_fabric_info, -1), be_const_closure(class_Matter_UI_show_fabric_info_closure) },
-        { be_const_key_weak(_CLASSES_TYPES, 4), be_nested_str_long(_X7Crelay_X7Clight0_X7Clight1_X7Clight2_X7Clight3_X7Cshutter_X7Cshutter_X2Btilt_X7Cgensw_btn_X7Ctemperature_X7Cpressure_X7Cilluminance_X7Chumidity_X7Coccupancy_X7Conoff_X7Ccontact_X7Cflow_X7Crain_X7Cwaterleak_X7Cairquality_X7C_X2Dvirtual_X7Cv_relay_X7Cv_light0_X7Cv_light1_X7Cv_light2_X7Cv_light3_X7Cv_fan_X7Cv_temp_X7Cv_pressure_X7Cv_illuminance_X7Cv_humidity_X7Cv_occupancy_X7Cv_contact_X7Cv_flow_X7Cv_rain_X7Cv_waterleak_X7Cv_airquality) },
-        { be_const_key_weak(web_get_arg, -1), be_const_closure(class_Matter_UI_web_get_arg_closure) },
-        { be_const_key_weak(plugin_option, 5), be_const_closure(class_Matter_UI_plugin_option_closure) },
-        { be_const_key_weak(web_add_config_button, -1), be_const_closure(class_Matter_UI_web_add_config_button_closure) },
         { be_const_key_weak(show_passcode_form, -1), be_const_closure(class_Matter_UI_show_passcode_form_closure) },
-        { be_const_key_weak(show_remote_autoconf, 8), be_const_closure(class_Matter_UI_show_remote_autoconf_closure) },
-        { be_const_key_weak(web_add_handler, -1), be_const_closure(class_Matter_UI_web_add_handler_closure) },
-        { be_const_key_weak(show_bridge_status, 23), be_const_closure(class_Matter_UI_show_bridge_status_closure) },
-        { be_const_key_weak(plugin_name, 12), be_const_closure(class_Matter_UI_plugin_name_closure) },
         { be_const_key_weak(init, -1), be_const_closure(class_Matter_UI_init_closure) },
-        { be_const_key_weak(web_sensor, -1), be_const_closure(class_Matter_UI_web_sensor_closure) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(show_fabric_info, 11), be_const_closure(class_Matter_UI_show_fabric_info_closure) },
+        { be_const_key_weak(show_qrcode, 19), be_const_closure(class_Matter_UI_show_qrcode_closure) },
+        { be_const_key_weak(show_plugins_hints_js, -1), be_const_closure(class_Matter_UI_show_plugins_hints_js_closure) },
+        { be_const_key_weak(page_part_ctl, 2), be_const_closure(class_Matter_UI_page_part_ctl_closure) },
+        { be_const_key_weak(page_part_mgr, 20), be_const_closure(class_Matter_UI_page_part_mgr_closure) },
+        { be_const_key_weak(matter_enabled, -1), be_const_closure(class_Matter_UI_matter_enabled_closure) },
+        { be_const_key_weak(show_commissioning_info, 6), be_const_closure(class_Matter_UI_show_commissioning_info_closure) },
+        { be_const_key_weak(page_part_mgr_adv, -1), be_const_closure(class_Matter_UI_page_part_mgr_adv_closure) },
+        { be_const_key_weak(show_enable, -1), be_const_closure(class_Matter_UI_show_enable_closure) },
+        { be_const_key_weak(equal_map, -1), be_const_static_closure(class_Matter_UI_equal_map_closure) },
+        { be_const_key_weak(web_get_arg, -1), be_const_closure(class_Matter_UI_web_get_arg_closure) },
+        { be_const_key_weak(show_plugins_configuration, -1), be_const_closure(class_Matter_UI_show_plugins_configuration_closure) },
+        { be_const_key_weak(generate_config_from_status, 21), be_const_closure(class_Matter_UI_generate_config_from_status_closure) },
+        { be_const_key_weak(show_bridge_status, -1), be_const_closure(class_Matter_UI_show_bridge_status_closure) },
+        { be_const_key_weak(web_add_config_button, -1), be_const_closure(class_Matter_UI_web_add_config_button_closure) },
+        { be_const_key_weak(_CLASSES_TYPES_STD, -1), be_nested_str_weak(_X7Crelay_X7Clight0_X7Clight1_X7Clight2_X7Clight3_X7Cshutter_X7Cshutter_X2Btilt_X7Cgensw_btn_X7Ctemperature_X7Cpressure_X7Cilluminance_X7Chumidity_X7Coccupancy_X7Conoff_X7Ccontact_X7Cflow_X7Crain_X7Cwaterleak_X7Cairquality) },
+        { be_const_key_weak(plugin_name, -1), be_const_closure(class_Matter_UI_plugin_name_closure) },
+        { be_const_key_weak(_CLASSES_TYPES_VIRTUAL, -1), be_nested_str_weak(_X2Dvirtual_X7Cv_relay_X7Cv_light0_X7Cv_light1_X7Cv_light2_X7Cv_light3_X7Cv_fan_X7Cv_temp_X7Cv_pressure_X7Cv_illuminance_X7Cv_humidity_X7Cv_occupancy_X7Cv_contact_X7Cv_flow_X7Cv_rain_X7Cv_waterleak_X7Cv_airquality) },
+        { be_const_key_weak(page_part_mgr_add, -1), be_const_closure(class_Matter_UI_page_part_mgr_add_closure) },
+        { be_const_key_weak(web_add_handler, -1), be_const_closure(class_Matter_UI_web_add_handler_closure) },
+        { be_const_key_weak(device, 3), be_const_var(0) },
+        { be_const_key_weak(plugin_option, -1), be_const_closure(class_Matter_UI_plugin_option_closure) },
+        { be_const_key_weak(web_sensor, 0), be_const_closure(class_Matter_UI_web_sensor_closure) },
     })),
     be_str_weak(Matter_UI)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Zigbee.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Zigbee.h
@@ -1,0 +1,456 @@
+/* Solidification of Matter_z_Zigbee.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+// compact class 'Matter_Zigbee_Mapper' ktab size: 21, total: 32 (saved 88 bytes)
+static const bvalue be_ktab_class_Matter_Zigbee_Mapper[21] = {
+  /* K0   */  be_nested_str_weak(zigbee),
+  /* K1   */  be_nested_str_weak(device_arg),
+  /* K2   */  be_nested_str_weak(shortaddr),
+  /* K3   */  be_nested_str_weak(zigbee_device),
+  /* K4   */  be_nested_str_weak(find),
+  /* K5   */  be_nested_str_weak(log),
+  /* K6   */  be_nested_str_weak(MTR_X3A_X20cannot_X20find_X20zigbee_X20device_X20_X27_X25s_X27),
+  /* K7   */  be_const_int(3),
+  /* K8   */  be_nested_str_weak(string),
+  /* K9   */  be_nested_str_weak(pi),
+  /* K10  */  be_nested_str_weak(ARG),
+  /* K11  */  be_nested_str_weak(startswith),
+  /* K12  */  be_nested_str_weak(0x),
+  /* K13  */  be_nested_str_weak(0X),
+  /* K14  */  be_nested_str_weak(tasmota),
+  /* K15  */  be_nested_str_weak(set_timer),
+  /* K16  */  be_nested_str_weak(resolve_zb_device),
+  /* K17  */  be_nested_str_weak(info),
+  /* K18  */  be_nested_str_weak(read_zb_info),
+  /* K19  */  be_nested_str_weak(MTR_X3A_X20Read_X20information_X20for_X20zigbee_X20device_X200x_X2504X),
+  /* K20  */  be_nested_str_weak(zigbee_received),
+};
+
+
+extern const bclass be_class_Matter_Zigbee_Mapper;
+
+/********************************************************************
+** Solidified function: resolve_zb_device
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_Mapper_resolve_zb_device,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee_Mapper,     /* shared constants */
+    be_str_weak(resolve_zb_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C080403,  //  0003  EQ	R2	R2	R3
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x50080000,  //  0005  LDBOOL	R2	0	0
+      0x80040400,  //  0006  RET	1	R2
+      0x88080102,  //  0007  GETMBR	R2	R0	K2
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x20080403,  //  0009  NE	R2	R2	R3
+      0x780A0001,  //  000A  JMPF	R2	#000D
+      0x50080200,  //  000B  LDBOOL	R2	1	0
+      0x80040400,  //  000C  RET	1	R2
+      0x8C080304,  //  000D  GETMET	R2	R1	K4
+      0x88100101,  //  000E  GETMBR	R4	R0	K1
+      0x7C080400,  //  000F  CALL	R2	2
+      0x90020602,  //  0010  SETMBR	R0	K3	R2
+      0x88080103,  //  0011  GETMBR	R2	R0	K3
+      0x780A0005,  //  0012  JMPF	R2	#0019
+      0x88080103,  //  0013  GETMBR	R2	R0	K3
+      0x88080502,  //  0014  GETMBR	R2	R2	K2
+      0x90020402,  //  0015  SETMBR	R0	K2	R2
+      0x50080200,  //  0016  LDBOOL	R2	1	0
+      0x80040400,  //  0017  RET	1	R2
+      0x70020008,  //  0018  JMP		#0022
+      0xB80A0A00,  //  0019  GETNGBL	R2	K5
+      0x600C0018,  //  001A  GETGBL	R3	G24
+      0x58100006,  //  001B  LDCONST	R4	K6
+      0x88140101,  //  001C  GETMBR	R5	R0	K1
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x58100007,  //  001E  LDCONST	R4	K7
+      0x7C080400,  //  001F  CALL	R2	2
+      0x50080000,  //  0020  LDBOOL	R2	0	0
+      0x80040400,  //  0021  RET	1	R2
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_configuration
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_Mapper_parse_configuration,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(probe_zb_values),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee_Mapper,     /* shared constants */
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E1000,  //  0001  IMPORT	R3	K8
+      0x8C100304,  //  0002  GETMET	R4	R1	K4
+      0x88180109,  //  0003  GETMBR	R6	R0	K9
+      0x88180D0A,  //  0004  GETMBR	R6	R6	K10
+      0x4C1C0000,  //  0005  LDNIL	R7
+      0x7C100600,  //  0006  CALL	R4	3
+      0x90020204,  //  0007  SETMBR	R0	K1	R4
+      0x60100004,  //  0008  GETGBL	R4	G4
+      0x88140101,  //  0009  GETMBR	R5	R0	K1
+      0x7C100200,  //  000A  CALL	R4	1
+      0x1C100908,  //  000B  EQ	R4	R4	K8
+      0x7812000D,  //  000C  JMPF	R4	#001B
+      0x8C10070B,  //  000D  GETMET	R4	R3	K11
+      0x88180101,  //  000E  GETMBR	R6	R0	K1
+      0x581C000C,  //  000F  LDCONST	R7	K12
+      0x7C100600,  //  0010  CALL	R4	3
+      0x74120004,  //  0011  JMPT	R4	#0017
+      0x8C10070B,  //  0012  GETMET	R4	R3	K11
+      0x88180101,  //  0013  GETMBR	R6	R0	K1
+      0x581C000D,  //  0014  LDCONST	R7	K13
+      0x7C100600,  //  0015  CALL	R4	3
+      0x78120003,  //  0016  JMPF	R4	#001B
+      0x60100009,  //  0017  GETGBL	R4	G9
+      0x88140101,  //  0018  GETMBR	R5	R0	K1
+      0x7C100200,  //  0019  CALL	R4	1
+      0x90020204,  //  001A  SETMBR	R0	K1	R4
+      0x88100101,  //  001B  GETMBR	R4	R0	K1
+      0x4C140000,  //  001C  LDNIL	R5
+      0x20100805,  //  001D  NE	R4	R4	R5
+      0x78120004,  //  001E  JMPF	R4	#0024
+      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x8C10090F,  //  0020  GETMET	R4	R4	K15
+      0x541A0063,  //  0021  LDINT	R6	100
+      0x841C0000,  //  0022  CLOSURE	R7	P0
+      0x7C100600,  //  0023  CALL	R4	3
+      0xA0000000,  //  0024  CLOSE	R0
+      0x80000000,  //  0025  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_zb_info
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_Mapper_read_zb_info,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee_Mapper,     /* shared constants */
+    be_str_weak(read_zb_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C040110,  //  0000  GETMET	R1	R0	K16
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060009,  //  0002  JMPF	R1	#000D
+      0xA4060000,  //  0003  IMPORT	R1	K0
+      0x8C080304,  //  0004  GETMET	R2	R1	K4
+      0x88100102,  //  0005  GETMBR	R4	R0	K2
+      0x7C080400,  //  0006  CALL	R2	2
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x200C0403,  //  0008  NE	R3	R2	R3
+      0x780E0002,  //  0009  JMPF	R3	#000D
+      0x8C0C0511,  //  000A  GETMET	R3	R2	K17
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x80040600,  //  000C  RET	1	R3
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_Mapper_init,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee_Mapper,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90021201,  //  0000  SETMBR	R0	K9	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: probe_zb_values
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_Mapper_probe_zb_values,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee_Mapper,     /* shared constants */
+    be_str_weak(probe_zb_values),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x8C040112,  //  0000  GETMET	R1	R0	K18
+      0x7C040200,  //  0001  CALL	R1	1
+      0x4C080000,  //  0002  LDNIL	R2
+      0x20080202,  //  0003  NE	R2	R1	R2
+      0x780A000B,  //  0004  JMPF	R2	#0011
+      0xB80A0A00,  //  0005  GETNGBL	R2	K5
+      0x600C0018,  //  0006  GETGBL	R3	G24
+      0x58100013,  //  0007  LDCONST	R4	K19
+      0x88140102,  //  0008  GETMBR	R5	R0	K2
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x58100007,  //  000A  LDCONST	R4	K7
+      0x7C080400,  //  000B  CALL	R2	2
+      0x88080109,  //  000C  GETMBR	R2	R0	K9
+      0x8C080514,  //  000D  GETMET	R2	R2	K20
+      0x4C100000,  //  000E  LDNIL	R4
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C080600,  //  0010  CALL	R2	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Zigbee_Mapper
+********************************************************************/
+be_local_class(Matter_Zigbee_Mapper,
+    4,
+    NULL,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(shortaddr, -1), be_const_var(3) },
+        { be_const_key_weak(resolve_zb_device, -1), be_const_closure(class_Matter_Zigbee_Mapper_resolve_zb_device_closure) },
+        { be_const_key_weak(device_arg, -1), be_const_var(1) },
+        { be_const_key_weak(read_zb_info, -1), be_const_closure(class_Matter_Zigbee_Mapper_read_zb_info_closure) },
+        { be_const_key_weak(zigbee_device, -1), be_const_var(2) },
+        { be_const_key_weak(probe_zb_values, 3), be_const_closure(class_Matter_Zigbee_Mapper_probe_zb_values_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Zigbee_Mapper_init_closure) },
+        { be_const_key_weak(parse_configuration, 5), be_const_closure(class_Matter_Zigbee_Mapper_parse_configuration_closure) },
+        { be_const_key_weak(pi, -1), be_const_var(0) },
+    })),
+    be_str_weak(Matter_Zigbee_Mapper)
+);
+
+/********************************************************************
+** Solidified function: matter_zigbee_init
+********************************************************************/
+be_local_closure(matter_zigbee_init,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(Matter_Zigbee),
+    }),
+    be_str_weak(matter_zigbee_init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'Matter_Zigbee' ktab size: 11, total: 12 (saved 8 bytes)
+static const bvalue be_ktab_class_Matter_Zigbee[11] = {
+  /* K0   */  be_nested_str_weak(zigbee),
+  /* K1   */  be_nested_str_weak(device),
+  /* K2   */  be_nested_str_weak(add_handler),
+  /* K3   */  be_nested_str_weak(plugins),
+  /* K4   */  be_const_int(0),
+  /* K5   */  be_nested_str_weak(ZIGBEE),
+  /* K6   */  be_nested_str_weak(zigbee_mapper),
+  /* K7   */  be_nested_str_weak(resolve_zb_device),
+  /* K8   */  be_nested_str_weak(shortaddr),
+  /* K9   */  be_nested_str_weak(zigbee_received),
+  /* K10  */  be_const_int(1),
+};
+
+
+extern const bclass be_class_Matter_Zigbee;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x5C140000,  //  0003  MOVE	R5	R0
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attributes_final
+********************************************************************/
+be_local_closure(class_Matter_Zigbee_attributes_final,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Zigbee,     /* shared constants */
+    be_str_weak(attributes_final),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x88140101,  //  0000  GETMBR	R5	R0	K1
+      0x88140B03,  //  0001  GETMBR	R5	R5	K3
+      0x58180004,  //  0002  LDCONST	R6	K4
+      0x601C000C,  //  0003  GETGBL	R7	G12
+      0x5C200A00,  //  0004  MOVE	R8	R5
+      0x7C1C0200,  //  0005  CALL	R7	1
+      0x141C0C07,  //  0006  LT	R7	R6	R7
+      0x781E0012,  //  0007  JMPF	R7	#001B
+      0x941C0A06,  //  0008  GETIDX	R7	R5	R6
+      0x88200F05,  //  0009  GETMBR	R8	R7	K5
+      0x7822000D,  //  000A  JMPF	R8	#0019
+      0x88200F06,  //  000B  GETMBR	R8	R7	K6
+      0x7822000B,  //  000C  JMPF	R8	#0019
+      0x88200F06,  //  000D  GETMBR	R8	R7	K6
+      0x8C201107,  //  000E  GETMET	R8	R8	K7
+      0x7C200200,  //  000F  CALL	R8	1
+      0x78220007,  //  0010  JMPF	R8	#0019
+      0x88200F06,  //  0011  GETMBR	R8	R7	K6
+      0x88201108,  //  0012  GETMBR	R8	R8	K8
+      0x1C201004,  //  0013  EQ	R8	R8	R4
+      0x78220003,  //  0014  JMPF	R8	#0019
+      0x8C200F09,  //  0015  GETMET	R8	R7	K9
+      0x5C280400,  //  0016  MOVE	R10	R2
+      0x5C2C0600,  //  0017  MOVE	R11	R3
+      0x7C200600,  //  0018  CALL	R8	3
+      0x00180D0A,  //  0019  ADD	R6	R6	K10
+      0x7001FFE7,  //  001A  JMP		#0003
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Zigbee
+********************************************************************/
+be_local_class(Matter_Zigbee,
+    1,
+    NULL,
+    be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(init, 3), be_const_closure(class_Matter_Zigbee_init_closure) },
+        { be_const_key_weak(Matter_Zigbee_Mapper, 4), be_const_class(be_class_Matter_Zigbee_Mapper) },
+        { be_const_key_weak(attributes_final, -1), be_const_closure(class_Matter_Zigbee_attributes_final_closure) },
+        { be_const_key_weak(_CLASSES_TYPES, -1), be_nested_str_weak(_X2Dzigbee_X7Cz_temp_X7Cz_pressure_X7Cz_humidity) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+    })),
+    be_str_weak(Matter_Zigbee)
+);
+
+/********************************************************************
+** Solidified module: matter_zigbee
+********************************************************************/
+be_local_module(matter_zigbee,
+    "matter_zigbee",
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(Matter_Zigbee, -1), be_const_class(be_class_Matter_Zigbee) },
+        { be_const_key_weak(init, 0), be_const_closure(matter_zigbee_init_closure) },
+    }))
+);
+BE_EXPORT_VARIABLE be_define_const_native_module(matter_zigbee);
+/********************************************************************/
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -4,229 +4,263 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_Device;
-// compact class 'Matter_Device' ktab size: 210, total: 454 (saved 1952 bytes)
-static const bvalue be_ktab_class_Matter_Device[210] = {
-  /* K0   */  be_nested_str_weak(crypto),
-  /* K1   */  be_nested_str_weak(tasmota),
-  /* K2   */  be_nested_str_weak(get_option),
-  /* K3   */  be_nested_str_weak(matter),
-  /* K4   */  be_nested_str_weak(MATTER_OPTION),
-  /* K5   */  be_nested_str_weak(UI),
-  /* K6   */  be_nested_str_weak(profiler),
-  /* K7   */  be_nested_str_weak(Profiler),
-  /* K8   */  be_nested_str_weak(started),
-  /* K9   */  be_nested_str_weak(tick),
-  /* K10  */  be_const_int(0),
+// compact class 'Matter_Device' ktab size: 216, total: 463 (saved 1976 bytes)
+static const bvalue be_ktab_class_Matter_Device[216] = {
+  /* K0   */  be_nested_str_weak(udp_server),
+  /* K1   */  be_nested_str_weak(send_UDP),
+  /* K2   */  be_nested_str_weak(is_zigbee_present),
+  /* K3   */  be_nested_str_weak(matter_zigbee),
+  /* K4   */  be_const_class(be_class_Matter_Device),
+  /* K5   */  be_nested_str_weak(keys),
+  /* K6   */  be_nested_str_weak(push),
+  /* K7   */  be_nested_str_weak(stop_iteration),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_nested_str_weak(),
   /* K11  */  be_nested_str_weak(plugins),
-  /* K12  */  be_nested_str_weak(plugins_persist),
-  /* K13  */  be_nested_str_weak(plugins_config_remotes),
-  /* K14  */  be_nested_str_weak(next_ep),
-  /* K15  */  be_nested_str_weak(EP),
-  /* K16  */  be_nested_str_weak(ipv4only),
-  /* K17  */  be_nested_str_weak(disable_bridge_mode),
-  /* K18  */  be_nested_str_weak(commissioning),
-  /* K19  */  be_nested_str_weak(Commissioning),
-  /* K20  */  be_nested_str_weak(load_param),
-  /* K21  */  be_nested_str_weak(sessions),
-  /* K22  */  be_nested_str_weak(Session_Store),
-  /* K23  */  be_nested_str_weak(load_fabrics),
+  /* K12  */  be_nested_str_weak(MtrInfo_one),
+  /* K13  */  be_nested_str_weak(endpoint),
+  /* K14  */  be_nested_str_weak(int),
+  /* K15  */  be_nested_str_weak(find_plugin_by_friendly_name),
+  /* K16  */  be_nested_str_weak(tasmota),
+  /* K17  */  be_nested_str_weak(resp_cmnd_done),
+  /* K18  */  be_nested_str_weak(read_sensors_scheduler),
+  /* K19  */  be_nested_str_weak(every_250ms),
+  /* K20  */  be_nested_str_weak(matter),
+  /* K21  */  be_nested_str_weak(Path),
+  /* K22  */  be_nested_str_weak(cluster),
+  /* K23  */  be_nested_str_weak(attribute),
   /* K24  */  be_nested_str_weak(message_handler),
-  /* K25  */  be_nested_str_weak(MessageHandler),
-  /* K26  */  be_nested_str_weak(events),
-  /* K27  */  be_nested_str_weak(EventHandler),
-  /* K28  */  be_nested_str_weak(ui),
-  /* K29  */  be_nested_str_weak(init_basic_commissioning),
-  /* K30  */  be_nested_str_weak(add_driver),
-  /* K31  */  be_nested_str_weak(register_commands),
-  /* K32  */  be_nested_str_weak(button_handler),
-  /* K33  */  be_const_int(1),
-  /* K34  */  be_const_int(2),
-  /* K35  */  be_nested_str_weak(get_endpoint),
-  /* K36  */  be_nested_str_weak(get_name),
-  /* K37  */  be_nested_str_weak(log),
-  /* K38  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-  /* K39  */  be_nested_str_weak(get_fabric_id),
-  /* K40  */  be_nested_str_weak(copy),
-  /* K41  */  be_nested_str_weak(reverse),
-  /* K42  */  be_nested_str_weak(tohex),
-  /* K43  */  be_nested_str_weak(im),
-  /* K44  */  be_nested_str_weak(subs_shop),
-  /* K45  */  be_nested_str_weak(remove_by_fabric),
-  /* K46  */  be_nested_str_weak(mdns_remove_op_discovery),
-  /* K47  */  be_nested_str_weak(remove_fabric),
-  /* K48  */  be_nested_str_weak(save_fabrics),
-  /* K49  */  be_nested_str_weak(msg_received),
-  /* K50  */  be_nested_str_weak(find),
-  /* K51  */  be_nested_str_weak(add_cmd),
-  /* K52  */  be_nested_str_weak(MtrJoin),
-  /* K53  */  be_nested_str_weak(MtrUpdate),
-  /* K54  */  be_nested_str_weak(MtrInfo),
-  /* K55  */  be_const_class(be_class_Matter_Device),
-  /* K56  */  be_nested_str_weak(keys),
-  /* K57  */  be_nested_str_weak(push),
-  /* K58  */  be_nested_str_weak(stop_iteration),
-  /* K59  */  be_nested_str_weak(start_root_basic_commissioning),
-  /* K60  */  be_nested_str_weak(stop_basic_commissioning),
-  /* K61  */  be_nested_str_weak(resp_cmnd_done),
-  /* K62  */  be_nested_str_weak(Path),
-  /* K63  */  be_nested_str_weak(endpoint),
-  /* K64  */  be_nested_str_weak(cluster),
-  /* K65  */  be_nested_str_weak(attribute),
-  /* K66  */  be_nested_str_weak(attribute_updated_ctx),
-  /* K67  */  be_nested_str_weak(json),
-  /* K68  */  be_nested_str_weak(update_remotes_info),
-  /* K69  */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-  /* K70  */  be_nested_str_weak(root_discriminator),
-  /* K71  */  be_nested_str_weak(root_passcode),
-  /* K72  */  be_nested_str_weak(true),
-  /* K73  */  be_nested_str_weak(false),
-  /* K74  */  be_nested_str_weak(debug),
-  /* K75  */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
-  /* K76  */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
-  /* K77  */  be_nested_str_weak(dump),
-  /* K78  */  be_nested_str_weak(plugins_config),
-  /* K79  */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
-  /* K80  */  be_nested_str_weak(_X7D),
-  /* K81  */  be_nested_str_weak(FILENAME),
-  /* K82  */  be_nested_str_weak(w),
-  /* K83  */  be_nested_str_weak(write),
-  /* K84  */  be_nested_str_weak(close),
-  /* K85  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-  /* K86  */  be_nested_str_weak(_X20and_X20configuration),
-  /* K87  */  be_nested_str_weak(),
-  /* K88  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-  /* K89  */  be_nested_str_weak(_X7C),
-  /* K90  */  be_nested_str_weak(read),
-  /* K91  */  be_nested_str_weak(load),
-  /* K92  */  be_nested_str_weak(distinguish),
-  /* K93  */  be_nested_str_weak(passcode),
-  /* K94  */  be_nested_str_weak(nextep),
-  /* K95  */  be_nested_str_weak(config),
-  /* K96  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
-  /* K97  */  be_const_int(3),
-  /* K98  */  be_nested_str_weak(adjust_next_ep),
-  /* K99  */  be_nested_str_weak(check_config_ep),
-  /* K100 */  be_nested_str_weak(remotes),
-  /* K101 */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-  /* K102 */  be_nested_str_weak(io_error),
-  /* K103 */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
-  /* K104 */  be_nested_str_weak(random),
-  /* K105 */  be_nested_str_weak(get),
-  /* K106 */  be_nested_str_weak(generate_random_passcode),
-  /* K107 */  be_nested_str_weak(save_param),
-  /* K108 */  be_nested_str_weak(http_remotes),
-  /* K109 */  be_nested_str_weak(contains),
-  /* K110 */  be_nested_str_weak(get_timeout),
-  /* K111 */  be_nested_str_weak(set_timeout),
-  /* K112 */  be_nested_str_weak(HTTP_remote),
-  /* K113 */  be_nested_str_weak(set_info),
-  /* K114 */  be_nested_str_weak(remove),
-  /* K115 */  be_nested_str_weak(udp_server),
-  /* K116 */  be_nested_str_weak(received_ack),
-  /* K117 */  be_nested_str_weak(every_second),
-  /* K118 */  be_nested_str_weak(find_plugin_by_endpoint),
-  /* K119 */  be_nested_str_weak(status),
-  /* K120 */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-  /* K121 */  be_nested_str_weak(contains_cluster),
-  /* K122 */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-  /* K123 */  be_nested_str_weak(contains_attribute),
-  /* K124 */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-  /* K125 */  be_nested_str_weak(introspect),
-  /* K126 */  be_nested_str_weak(http_remote),
-  /* K127 */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-  /* K128 */  be_nested_str_weak(addr),
-  /* K129 */  be_nested_str_weak(autoconf_device),
-  /* K130 */  be_nested_str_weak(_start_udp),
-  /* K131 */  be_nested_str_weak(UDP_PORT),
-  /* K132 */  be_nested_str_weak(start_mdns_announce_hostnames),
-  /* K133 */  be_nested_str_weak(send_UDP),
-  /* K134 */  be_nested_str_weak(probe_sensor_time),
-  /* K135 */  be_nested_str_weak(probe_sensor_timestamp),
-  /* K136 */  be_nested_str_weak(jitter),
-  /* K137 */  be_nested_str_weak(remove_driver),
-  /* K138 */  be_nested_str_weak(stop),
-  /* K139 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-  /* K140 */  be_nested_str_weak(UDPServer),
-  /* K141 */  be_nested_str_weak(start),
-  /* K142 */  be_nested_str_weak(MtrInfo_one),
-  /* K143 */  be_nested_str_weak(int),
-  /* K144 */  be_nested_str_weak(find_plugin_by_friendly_name),
-  /* K145 */  be_nested_str_weak(state_json),
-  /* K146 */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
-  /* K147 */  be_nested_str_weak(publish_result),
-  /* K148 */  be_nested_str_weak(wifi),
-  /* K149 */  be_nested_str_weak(up),
-  /* K150 */  be_nested_str_weak(eth),
-  /* K151 */  be_nested_str_weak(read_sensors),
-  /* K152 */  be_nested_str_weak(loglevel),
-  /* K153 */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
-  /* K154 */  be_nested_str_weak(parse_sensors),
-  /* K155 */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-  /* K156 */  be_nested_str_weak(plugins_classes),
-  /* K157 */  be_nested_str_weak(ARG),
-  /* K158 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-  /* K159 */  be_nested_str_weak(_X27_X20skipping),
-  /* K160 */  be_nested_str_weak(type),
-  /* K161 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-  /* K162 */  be_nested_str_weak(conf_to_log),
-  /* K163 */  be_nested_str_weak(signal_endpoints_changed),
-  /* K164 */  be_nested_str_weak(attribute_updated),
-  /* K165 */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-  /* K166 */  be_nested_str_weak(check_network),
-  /* K167 */  be_nested_str_weak(every_50ms),
-  /* K168 */  be_nested_str_weak(k2l),
-  /* K169 */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-  /* K170 */  be_nested_str_weak(resp_cmnd_str),
-  /* K171 */  be_nested_str_weak(Invalid_X20JSON),
-  /* K172 */  be_nested_str_weak(find_key_i),
-  /* K173 */  be_nested_str_weak(Ep),
-  /* K174 */  be_nested_str_weak(Name),
-  /* K175 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
-  /* K176 */  be_nested_str_weak(Invalid_X20Device),
-  /* K177 */  be_nested_str_weak(VIRTUAL),
-  /* K178 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
-  /* K179 */  be_nested_str_weak(consolidate_update_commands),
-  /* K180 */  be_nested_str_weak(find_list_i),
-  /* K181 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
-  /* K182 */  be_nested_str_weak(update_virtual),
-  /* K183 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
-  /* K184 */  be_nested_str_weak(resp_cmnd),
-  /* K185 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
-  /* K186 */  be_nested_str_weak(count_active_fabrics),
-  /* K187 */  be_nested_str_weak(PathGenerator),
-  /* K188 */  be_nested_str_weak(is_direct),
-  /* K189 */  be_nested_str_weak(next_attribute),
-  /* K190 */  be_nested_str_weak(get_pi),
-  /* K191 */  be_nested_str_weak(invoke_request),
-  /* K192 */  be_nested_str_weak(get_info),
-  /* K193 */  be_nested_str_weak(DISPLAY_NAME),
-  /* K194 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-  /* K195 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-  /* K196 */  be_nested_str_weak(clean_remotes),
+  /* K25  */  be_nested_str_weak(im),
+  /* K26  */  be_nested_str_weak(subs_shop),
+  /* K27  */  be_nested_str_weak(attribute_updated_ctx),
+  /* K28  */  be_nested_str_weak(get_endpoint),
+  /* K29  */  be_nested_str_weak(find),
+  /* K30  */  be_nested_str_weak(plugins_config_remotes),
+  /* K31  */  be_nested_str_weak(json),
+  /* K32  */  be_nested_str_weak(update_remotes_info),
+  /* K33  */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+  /* K34  */  be_nested_str_weak(root_discriminator),
+  /* K35  */  be_nested_str_weak(root_passcode),
+  /* K36  */  be_nested_str_weak(ipv4only),
+  /* K37  */  be_nested_str_weak(true),
+  /* K38  */  be_nested_str_weak(false),
+  /* K39  */  be_nested_str_weak(disable_bridge_mode),
+  /* K40  */  be_nested_str_weak(next_ep),
+  /* K41  */  be_nested_str_weak(debug),
+  /* K42  */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
+  /* K43  */  be_nested_str_weak(plugins_persist),
+  /* K44  */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
+  /* K45  */  be_nested_str_weak(dump),
+  /* K46  */  be_nested_str_weak(plugins_config),
+  /* K47  */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
+  /* K48  */  be_nested_str_weak(_X7D),
+  /* K49  */  be_nested_str_weak(FILENAME),
+  /* K50  */  be_nested_str_weak(w),
+  /* K51  */  be_nested_str_weak(write),
+  /* K52  */  be_nested_str_weak(close),
+  /* K53  */  be_nested_str_weak(log),
+  /* K54  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+  /* K55  */  be_nested_str_weak(_X20and_X20configuration),
+  /* K56  */  be_const_int(2),
+  /* K57  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+  /* K58  */  be_nested_str_weak(_X7C),
+  /* K59  */  be_nested_str_weak(remove_driver),
+  /* K60  */  be_nested_str_weak(stop),
+  /* K61  */  be_nested_str_weak(remove),
+  /* K62  */  be_nested_str_weak(sessions),
+  /* K63  */  be_nested_str_weak(count_active_fabrics),
+  /* K64  */  be_nested_str_weak(save_param),
+  /* K65  */  be_nested_str_weak(autoconf),
+  /* K66  */  be_nested_str_weak(Autoconf),
+  /* K67  */  be_nested_str_weak(autoconf_device_map),
+  /* K68  */  be_nested_str_weak(adjust_next_ep),
+  /* K69  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+  /* K70  */  be_const_int(3),
+  /* K71  */  be_nested_str_weak(instantiate_plugins_from_config),
+  /* K72  */  be_nested_str_weak(msg_received),
+  /* K73  */  be_nested_str_weak(find_plugin_by_endpoint),
+  /* K74  */  be_nested_str_weak(status),
+  /* K75  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+  /* K76  */  be_nested_str_weak(contains_cluster),
+  /* K77  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+  /* K78  */  be_nested_str_weak(contains_attribute),
+  /* K79  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+  /* K80  */  be_nested_str_weak(introspect),
+  /* K81  */  be_nested_str_weak(http_remotes),
+  /* K82  */  be_nested_str_weak(get),
+  /* K83  */  be_nested_str_weak(http_remote),
+  /* K84  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+  /* K85  */  be_nested_str_weak(addr),
+  /* K86  */  be_nested_str_weak(invoke_request),
+  /* K87  */  be_nested_str_weak(crypto),
+  /* K88  */  be_nested_str_weak(get_option),
+  /* K89  */  be_nested_str_weak(MATTER_OPTION),
+  /* K90  */  be_nested_str_weak(UI),
+  /* K91  */  be_nested_str_weak(profiler),
+  /* K92  */  be_nested_str_weak(Profiler),
+  /* K93  */  be_nested_str_weak(started),
+  /* K94  */  be_nested_str_weak(tick),
+  /* K95  */  be_nested_str_weak(EP),
+  /* K96  */  be_nested_str_weak(commissioning),
+  /* K97  */  be_nested_str_weak(Commissioning),
+  /* K98  */  be_nested_str_weak(load_param),
+  /* K99  */  be_nested_str_weak(Session_Store),
+  /* K100 */  be_nested_str_weak(load_fabrics),
+  /* K101 */  be_nested_str_weak(MessageHandler),
+  /* K102 */  be_nested_str_weak(events),
+  /* K103 */  be_nested_str_weak(EventHandler),
+  /* K104 */  be_nested_str_weak(zigbee),
+  /* K105 */  be_nested_str_weak(init_zigbee),
+  /* K106 */  be_nested_str_weak(ui),
+  /* K107 */  be_nested_str_weak(init_basic_commissioning),
+  /* K108 */  be_nested_str_weak(add_driver),
+  /* K109 */  be_nested_str_weak(register_commands),
+  /* K110 */  be_nested_str_weak(button_handler),
+  /* K111 */  be_nested_str_weak(get_name),
+  /* K112 */  be_nested_str_weak(wifi),
+  /* K113 */  be_nested_str_weak(up),
+  /* K114 */  be_nested_str_weak(eth),
+  /* K115 */  be_nested_str_weak(start),
+  /* K116 */  be_nested_str_weak(resp_cmnd_str),
+  /* K117 */  be_nested_str_weak(Invalid_X20JSON),
+  /* K118 */  be_nested_str_weak(find_key_i),
+  /* K119 */  be_nested_str_weak(Ep),
+  /* K120 */  be_nested_str_weak(Name),
+  /* K121 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
+  /* K122 */  be_nested_str_weak(Invalid_X20Device),
+  /* K123 */  be_nested_str_weak(VIRTUAL),
+  /* K124 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
+  /* K125 */  be_nested_str_weak(consolidate_update_commands),
+  /* K126 */  be_nested_str_weak(find_list_i),
+  /* K127 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
+  /* K128 */  be_nested_str_weak(update_virtual),
+  /* K129 */  be_nested_str_weak(state_json),
+  /* K130 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
+  /* K131 */  be_nested_str_weak(resp_cmnd),
+  /* K132 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
+  /* K133 */  be_nested_str_weak(check_network),
+  /* K134 */  be_nested_str_weak(every_50ms),
+  /* K135 */  be_nested_str_weak(every_second),
+  /* K136 */  be_nested_str_weak(probe_sensor_time),
+  /* K137 */  be_nested_str_weak(probe_sensor_timestamp),
+  /* K138 */  be_nested_str_weak(jitter),
+  /* K139 */  be_nested_str_weak(plugins_classes),
+  /* K140 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+  /* K141 */  be_nested_str_weak(_X27_X20skipping),
+  /* K142 */  be_nested_str_weak(type),
+  /* K143 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+  /* K144 */  be_nested_str_weak(conf_to_log),
+  /* K145 */  be_nested_str_weak(signal_endpoints_changed),
+  /* K146 */  be_nested_str_weak(contains),
+  /* K147 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+  /* K148 */  be_nested_str_weak(UDPServer),
+  /* K149 */  be_nested_str_weak(attribute_updated),
+  /* K150 */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K151 */  be_nested_str_weak(module),
+  /* K152 */  be_nested_str_weak(ARG),
+  /* K153 */  be_nested_str_weak(get_info),
+  /* K154 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+  /* K155 */  be_nested_str_weak(get_fabric_id),
+  /* K156 */  be_nested_str_weak(copy),
+  /* K157 */  be_nested_str_weak(reverse),
+  /* K158 */  be_nested_str_weak(tohex),
+  /* K159 */  be_nested_str_weak(remove_by_fabric),
+  /* K160 */  be_nested_str_weak(mdns_remove_op_discovery),
+  /* K161 */  be_nested_str_weak(remove_fabric),
+  /* K162 */  be_nested_str_weak(save_fabrics),
+  /* K163 */  be_nested_str_weak(k2l),
+  /* K164 */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+  /* K165 */  be_nested_str_weak(DISPLAY_NAME),
+  /* K166 */  be_nested_str_weak(time_reached),
+  /* K167 */  be_nested_str_weak(_trigger_read_sensors),
+  /* K168 */  be_nested_str_weak(millis),
+  /* K169 */  be_nested_str_weak(get_timeout),
+  /* K170 */  be_nested_str_weak(set_timeout),
+  /* K171 */  be_nested_str_weak(HTTP_remote),
+  /* K172 */  be_nested_str_weak(set_info),
+  /* K173 */  be_nested_str_weak(PathGenerator),
+  /* K174 */  be_nested_str_weak(is_direct),
+  /* K175 */  be_nested_str_weak(next_attribute),
+  /* K176 */  be_nested_str_weak(get_pi),
+  /* K177 */  be_nested_str_weak(read),
+  /* K178 */  be_nested_str_weak(load),
+  /* K179 */  be_nested_str_weak(distinguish),
+  /* K180 */  be_nested_str_weak(passcode),
+  /* K181 */  be_nested_str_weak(nextep),
+  /* K182 */  be_nested_str_weak(config),
+  /* K183 */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
+  /* K184 */  be_nested_str_weak(check_config_ep),
+  /* K185 */  be_nested_str_weak(remotes),
+  /* K186 */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+  /* K187 */  be_nested_str_weak(io_error),
+  /* K188 */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
+  /* K189 */  be_nested_str_weak(random),
+  /* K190 */  be_nested_str_weak(generate_random_passcode),
+  /* K191 */  be_nested_str_weak(read_sensors),
+  /* K192 */  be_nested_str_weak(loglevel),
+  /* K193 */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
+  /* K194 */  be_nested_str_weak(parse_sensors),
+  /* K195 */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+  /* K196 */  be_nested_str_weak(received_ack),
   /* K197 */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
   /* K198 */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
-  /* K199 */  be_nested_str_weak(time_reached),
-  /* K200 */  be_nested_str_weak(_trigger_read_sensors),
-  /* K201 */  be_nested_str_weak(millis),
-  /* K202 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-  /* K203 */  be_nested_str_weak(read_sensors_scheduler),
-  /* K204 */  be_nested_str_weak(every_250ms),
-  /* K205 */  be_nested_str_weak(autoconf),
-  /* K206 */  be_nested_str_weak(Autoconf),
-  /* K207 */  be_nested_str_weak(autoconf_device_map),
-  /* K208 */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-  /* K209 */  be_nested_str_weak(instantiate_plugins_from_config),
+  /* K199 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+  /* K200 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+  /* K201 */  be_nested_str_weak(clean_remotes),
+  /* K202 */  be_nested_str_weak(add_cmd),
+  /* K203 */  be_nested_str_weak(MtrJoin),
+  /* K204 */  be_nested_str_weak(MtrUpdate),
+  /* K205 */  be_nested_str_weak(MtrInfo),
+  /* K206 */  be_nested_str_weak(stop_basic_commissioning),
+  /* K207 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+  /* K208 */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K209 */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
+  /* K210 */  be_nested_str_weak(publish_result),
+  /* K211 */  be_nested_str_weak(Matter_Zigbee_Mapper),
+  /* K212 */  be_nested_str_weak(autoconf_device),
+  /* K213 */  be_nested_str_weak(_start_udp),
+  /* K214 */  be_nested_str_weak(UDP_PORT),
+  /* K215 */  be_nested_str_weak(start_mdns_announce_hostnames),
 };
 
 
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: msg_send
 ********************************************************************/
-be_local_closure(class_Matter_Device_init,   /* name */
+be_local_closure(class_Matter_Device_msg_send,   /* name */
   be_nested_proto(
     5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(msg_send),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init_zigbee
+********************************************************************/
+be_local_closure(class_Matter_Device_init_zigbee,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -235,83 +269,18 @@ be_local_closure(class_Matter_Device_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(init),
+    be_str_weak(init_zigbee),
     &be_const_str_solidified,
-    ( &(const binstruction[74]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x88100904,  //  0004  GETMBR	R4	R4	K4
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0004,  //  0006  JMPT	R2	#000C
-      0xB80A0600,  //  0007  GETNGBL	R2	K3
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x5C100000,  //  0009  MOVE	R4	R0
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000400,  //  000B  RET	0
-      0xB80A0600,  //  000C  GETNGBL	R2	K3
-      0xB80E0600,  //  000D  GETNGBL	R3	K3
-      0x8C0C0707,  //  000E  GETMET	R3	R3	K7
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x900A0C03,  //  0010  SETMBR	R2	K6	R3
-      0x50080000,  //  0011  LDBOOL	R2	0	0
-      0x90021002,  //  0012  SETMBR	R0	K8	R2
-      0x9002130A,  //  0013  SETMBR	R0	K9	K10
-      0x60080012,  //  0014  GETGBL	R2	G18
-      0x7C080000,  //  0015  CALL	R2	0
-      0x90021602,  //  0016  SETMBR	R0	K11	R2
-      0x50080000,  //  0017  LDBOOL	R2	0	0
-      0x90021802,  //  0018  SETMBR	R0	K12	R2
-      0x60080013,  //  0019  GETGBL	R2	G19
-      0x7C080000,  //  001A  CALL	R2	0
-      0x90021A02,  //  001B  SETMBR	R0	K13	R2
-      0x8808010F,  //  001C  GETMBR	R2	R0	K15
-      0x90021C02,  //  001D  SETMBR	R0	K14	R2
-      0x50080000,  //  001E  LDBOOL	R2	0	0
-      0x90022002,  //  001F  SETMBR	R0	K16	R2
-      0x50080000,  //  0020  LDBOOL	R2	0	0
-      0x90022202,  //  0021  SETMBR	R0	K17	R2
-      0xB80A0600,  //  0022  GETNGBL	R2	K3
-      0x8C080513,  //  0023  GETMET	R2	R2	K19
-      0x5C100000,  //  0024  MOVE	R4	R0
-      0x7C080400,  //  0025  CALL	R2	2
-      0x90022402,  //  0026  SETMBR	R0	K18	R2
-      0x8C080114,  //  0027  GETMET	R2	R0	K20
-      0x7C080200,  //  0028  CALL	R2	1
-      0xB80A0600,  //  0029  GETNGBL	R2	K3
-      0x8C080516,  //  002A  GETMET	R2	R2	K22
-      0x5C100000,  //  002B  MOVE	R4	R0
-      0x7C080400,  //  002C  CALL	R2	2
-      0x90022A02,  //  002D  SETMBR	R0	K21	R2
-      0x88080115,  //  002E  GETMBR	R2	R0	K21
-      0x8C080517,  //  002F  GETMET	R2	R2	K23
-      0x7C080200,  //  0030  CALL	R2	1
-      0xB80A0600,  //  0031  GETNGBL	R2	K3
-      0x8C080519,  //  0032  GETMET	R2	R2	K25
-      0x5C100000,  //  0033  MOVE	R4	R0
-      0x7C080400,  //  0034  CALL	R2	2
-      0x90023002,  //  0035  SETMBR	R0	K24	R2
-      0xB80A0600,  //  0036  GETNGBL	R2	K3
-      0x8C08051B,  //  0037  GETMET	R2	R2	K27
-      0x5C100000,  //  0038  MOVE	R4	R0
-      0x7C080400,  //  0039  CALL	R2	2
-      0x90023402,  //  003A  SETMBR	R0	K26	R2
-      0xB80A0600,  //  003B  GETNGBL	R2	K3
-      0x8C080505,  //  003C  GETMET	R2	R2	K5
-      0x5C100000,  //  003D  MOVE	R4	R0
-      0x7C080400,  //  003E  CALL	R2	2
-      0x90023802,  //  003F  SETMBR	R0	K28	R2
-      0x88080112,  //  0040  GETMBR	R2	R0	K18
-      0x8C08051D,  //  0041  GETMET	R2	R2	K29
-      0x7C080200,  //  0042  CALL	R2	1
-      0xB80A0200,  //  0043  GETNGBL	R2	K1
-      0x8C08051E,  //  0044  GETMET	R2	R2	K30
-      0x5C100000,  //  0045  MOVE	R4	R0
-      0x7C080400,  //  0046  CALL	R2	2
-      0x8C08011F,  //  0047  GETMET	R2	R0	K31
-      0x7C080200,  //  0048  CALL	R2	1
-      0x80000000,  //  0049  RET	0
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C040102,  //  0000  GETMET	R1	R0	K2
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060004,  //  0002  JMPF	R1	#0008
+      0xA4060600,  //  0003  IMPORT	R1	K3
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80040400,  //  0007  RET	1	R2
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -319,12 +288,87 @@ be_local_closure(class_Matter_Device_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: button_multi_pressed
+** Solidified function: k2l_num
 ********************************************************************/
-be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
+be_local_closure(class_Matter_Device_k2l_num,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
+    9,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(k2l_num),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020007,  //  000B  EXBLK	0	#0014
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140506,  //  000E  GETMET	R5	R2	K6
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0007,  //  0014  LDCONST	R3	K7
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x04100908,  //  001B  SUB	R4	R4	K8
+      0x40121004,  //  001C  CONNECT	R4	K8	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D09,  //  0023  GT	R7	R6	K9
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D08,  //  0025  SUB	R7	R6	K8
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D08,  //  0029  SUB	R7	R6	K8
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D08,  //  002C  SUB	R6	R6	K8
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0007,  //  0030  LDCONST	R3	K7
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrInfo
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrInfo,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -332,22 +376,49 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(button_multi_pressed),
+    be_str_weak(MtrInfo),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x540E0007,  //  0000  LDINT	R3	8
-      0x3C0C0403,  //  0001  SHR	R3	R2	R3
-      0x541200FE,  //  0002  LDINT	R4	255
-      0x2C0C0604,  //  0003  AND	R3	R3	R4
-      0x541200FE,  //  0004  LDINT	R4	255
-      0x2C100404,  //  0005  AND	R4	R2	R4
-      0x8C140120,  //  0006  GETMET	R5	R0	K32
-      0x001C0921,  //  0007  ADD	R7	R4	K33
-      0x58200022,  //  0008  LDCONST	R8	K34
-      0x5824000A,  //  0009  LDCONST	R9	K10
-      0x5C280600,  //  000A  MOVE	R10	R3
-      0x7C140A00,  //  000B  CALL	R5	5
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[40]) {  /* code */
+      0x1C14070A,  //  0000  EQ	R5	R3	K10
+      0x7815FFFF,  //  0001  JMPF	R5	#0002
+      0x1C14070A,  //  0002  EQ	R5	R3	K10
+      0x7816000D,  //  0003  JMPF	R5	#0012
+      0x60140010,  //  0004  GETGBL	R5	G16
+      0x8818010B,  //  0005  GETMBR	R6	R0	K11
+      0x7C140200,  //  0006  CALL	R5	1
+      0xA8020005,  //  0007  EXBLK	0	#000E
+      0x5C180A00,  //  0008  MOVE	R6	R5
+      0x7C180000,  //  0009  CALL	R6	0
+      0x8C1C010C,  //  000A  GETMET	R7	R0	K12
+      0x88240D0D,  //  000B  GETMBR	R9	R6	K13
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x58140007,  //  000E  LDCONST	R5	K7
+      0xAC140200,  //  000F  CATCH	R5	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x70020011,  //  0011  JMP		#0024
+      0x60140004,  //  0012  GETGBL	R5	G4
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x1C140B0E,  //  0015  EQ	R5	R5	K14
+      0x78160003,  //  0016  JMPF	R5	#001B
+      0x8C14010C,  //  0017  GETMET	R5	R0	K12
+      0x5C1C0800,  //  0018  MOVE	R7	R4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x70020008,  //  001A  JMP		#0024
+      0x8C14010F,  //  001B  GETMET	R5	R0	K15
+      0x5C1C0600,  //  001C  MOVE	R7	R3
+      0x7C140400,  //  001D  CALL	R5	2
+      0x4C180000,  //  001E  LDNIL	R6
+      0x20180A06,  //  001F  NE	R6	R5	R6
+      0x781A0002,  //  0020  JMPF	R6	#0024
+      0x8C18010C,  //  0021  GETMET	R6	R0	K12
+      0x88200B0D,  //  0022  GETMBR	R8	R5	K13
+      0x7C180400,  //  0023  CALL	R6	2
+      0xB8162000,  //  0024  GETNGBL	R5	K16
+      0x8C140B11,  //  0025  GETMET	R5	R5	K17
+      0x7C140200,  //  0026  CALL	R5	1
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -355,9 +426,139 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_plugin_by_endpoint
+** Solidified function: every_250ms
 ********************************************************************/
-be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
+be_local_closure(class_Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8C040112,  //  0000  GETMET	R1	R0	K18
+      0x7C040200,  //  0001  CALL	R1	1
+      0x58040009,  //  0002  LDCONST	R1	K9
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C010B,  //  0004  GETMBR	R3	R0	K11
+      0x7C080200,  //  0005  CALL	R2	1
+      0x14080202,  //  0006  LT	R2	R1	R2
+      0x780A0005,  //  0007  JMPF	R2	#000E
+      0x8808010B,  //  0008  GETMBR	R2	R0	K11
+      0x94080401,  //  0009  GETIDX	R2	R2	R1
+      0x8C080513,  //  000A  GETMET	R2	R2	K19
+      0x7C080200,  //  000B  CALL	R2	1
+      0x00040308,  //  000C  ADD	R1	R1	K8
+      0x7001FFF4,  //  000D  JMP		#0003
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(class_Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8162800,  //  0004  GETNGBL	R5	K20
+      0x8C140B15,  //  0005  GETMET	R5	R5	K21
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90161A01,  //  0007  SETMBR	R5	K13	R1
+      0x90162C02,  //  0008  SETMBR	R5	K22	R2
+      0x90162E03,  //  0009  SETMBR	R5	K23	R3
+      0x88180118,  //  000A  GETMBR	R6	R0	K24
+      0x88180D19,  //  000B  GETMBR	R6	R6	K25
+      0x88180D1A,  //  000C  GETMBR	R6	R6	K26
+      0x8C180D1B,  //  000D  GETMET	R6	R6	K27
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8810010B,  //  0003  GETMBR	R4	R0	K11
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C14091C,  //  0008  GETMET	R5	R4	K28
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B09,  //  000B  EQ	R6	R5	K9
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C18051D,  //  000E  GETMET	R6	R2	K29
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180506,  //  0014  GETMET	R6	R2	K6
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0007,  //  0018  LDCONST	R3	K7
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_remote_info
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
@@ -368,26 +569,16 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(find_plugin_by_endpoint),
+    be_str_weak(get_plugin_remote_info),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x5808000A,  //  0000  LDCONST	R2	K10
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x8810010B,  //  0002  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C010B,  //  0006  GETMBR	R3	R0	K11
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100723,  //  0008  GETMET	R4	R3	K35
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x00080521,  //  000D  ADD	R2	R2	K33
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8808011E,  //  0000  GETMBR	R2	R0	K30
+      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
     })
   )
 );
@@ -395,57 +586,214 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_plugin_by_friendly_name
+** Solidified function: save_param
 ********************************************************************/
-be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
+be_local_closure(class_Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4063E00,  //  0000  IMPORT	R1	K31
+      0x8C080120,  //  0001  GETMET	R2	R0	K32
+      0x7C080200,  //  0002  CALL	R2	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C0021,  //  0004  LDCONST	R3	K33
+      0x88100122,  //  0005  GETMBR	R4	R0	K34
+      0x88140123,  //  0006  GETMBR	R5	R0	K35
+      0x88180124,  //  0007  GETMBR	R6	R0	K36
+      0x781A0001,  //  0008  JMPF	R6	#000B
+      0x58180025,  //  0009  LDCONST	R6	K37
+      0x70020000,  //  000A  JMP		#000C
+      0x58180026,  //  000B  LDCONST	R6	K38
+      0x881C0127,  //  000C  GETMBR	R7	R0	K39
+      0x781E0001,  //  000D  JMPF	R7	#0010
+      0x581C0025,  //  000E  LDCONST	R7	K37
+      0x70020000,  //  000F  JMP		#0011
+      0x581C0026,  //  0010  LDCONST	R7	K38
+      0x88200128,  //  0011  GETMBR	R8	R0	K40
+      0x7C080C00,  //  0012  CALL	R2	6
+      0x880C0129,  //  0013  GETMBR	R3	R0	K41
+      0x780E0000,  //  0014  JMPF	R3	#0016
+      0x0008052A,  //  0015  ADD	R2	R2	K42
+      0x880C012B,  //  0016  GETMBR	R3	R0	K43
+      0x780E000E,  //  0017  JMPF	R3	#0027
+      0x0008052C,  //  0018  ADD	R2	R2	K44
+      0x8C0C032D,  //  0019  GETMET	R3	R1	K45
+      0x8814012E,  //  001A  GETMBR	R5	R0	K46
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x00080403,  //  001C  ADD	R2	R2	R3
+      0x600C000C,  //  001D  GETGBL	R3	G12
+      0x8810011E,  //  001E  GETMBR	R4	R0	K30
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x240C0709,  //  0020  GT	R3	R3	K9
+      0x780E0004,  //  0021  JMPF	R3	#0027
+      0x0008052F,  //  0022  ADD	R2	R2	K47
+      0x8C0C032D,  //  0023  GETMET	R3	R1	K45
+      0x8814011E,  //  0024  GETMBR	R5	R0	K30
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x00080403,  //  0026  ADD	R2	R2	R3
+      0x00080530,  //  0027  ADD	R2	R2	K48
+      0xA8020017,  //  0028  EXBLK	0	#0041
+      0x600C0011,  //  0029  GETGBL	R3	G17
+      0x88100131,  //  002A  GETMBR	R4	R0	K49
+      0x58140032,  //  002B  LDCONST	R5	K50
+      0x7C0C0400,  //  002C  CALL	R3	2
+      0x8C100733,  //  002D  GETMET	R4	R3	K51
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x8C100734,  //  0030  GETMET	R4	R3	K52
+      0x7C100200,  //  0031  CALL	R4	1
+      0xB8126A00,  //  0032  GETNGBL	R4	K53
+      0x60140018,  //  0033  GETGBL	R5	G24
+      0x58180036,  //  0034  LDCONST	R6	K54
+      0x881C012B,  //  0035  GETMBR	R7	R0	K43
+      0x781E0001,  //  0036  JMPF	R7	#0039
+      0x581C0037,  //  0037  LDCONST	R7	K55
+      0x70020000,  //  0038  JMP		#003A
+      0x581C000A,  //  0039  LDCONST	R7	K10
+      0x7C140400,  //  003A  CALL	R5	2
+      0x58180038,  //  003B  LDCONST	R6	K56
+      0x7C100400,  //  003C  CALL	R4	2
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x80040400,  //  003E  RET	1	R2
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8166A00,  //  0043  GETNGBL	R5	K53
+      0x60180008,  //  0044  GETGBL	R6	G8
+      0x5C1C0600,  //  0045  MOVE	R7	R3
+      0x7C180200,  //  0046  CALL	R6	1
+      0x001A7206,  //  0047  ADD	R6	K57	R6
+      0x00180D3A,  //  0048  ADD	R6	R6	K58
+      0x601C0008,  //  0049  GETGBL	R7	G8
+      0x5C200800,  //  004A  MOVE	R8	R4
+      0x7C1C0200,  //  004B  CALL	R7	1
+      0x00180C07,  //  004C  ADD	R6	R6	R7
+      0x581C0038,  //  004D  LDCONST	R7	K56
+      0x7C140400,  //  004E  CALL	R5	2
+      0x80040400,  //  004F  RET	1	R2
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8062000,  //  0000  GETNGBL	R1	K16
+      0x8C04033B,  //  0001  GETMET	R1	R1	K59
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x8C04033C,  //  0007  GETMET	R1	R1	K60
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(class_Matter_Device_sort_distinct,   /* name */
   be_nested_proto(
     7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
+    1,                          /* argc */
+    12,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(find_plugin_by_friendly_name),
+    be_str_weak(sort_distinct),
     &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x740A0004,  //  0002  JMPT	R2	#0008
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x5C0C0200,  //  0004  MOVE	R3	R1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x1C08050A,  //  0006  EQ	R2	R2	K10
-      0x780A0001,  //  0007  JMPF	R2	#000A
-      0x4C080000,  //  0008  LDNIL	R2
-      0x80040400,  //  0009  RET	1	R2
-      0x5808000A,  //  000A  LDCONST	R2	K10
-      0x600C000C,  //  000B  GETGBL	R3	G12
-      0x8810010B,  //  000C  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x140C0403,  //  000E  LT	R3	R2	R3
-      0x780E0010,  //  000F  JMPF	R3	#0021
-      0x880C010B,  //  0010  GETMBR	R3	R0	K11
-      0x940C0602,  //  0011  GETIDX	R3	R3	R2
-      0x8C100724,  //  0012  GETMET	R4	R3	K36
-      0x7C100200,  //  0013  CALL	R4	1
-      0x4C140000,  //  0014  LDNIL	R5
-      0x20140805,  //  0015  NE	R5	R4	R5
-      0x78160007,  //  0016  JMPF	R5	#001F
-      0x6014000C,  //  0017  GETGBL	R5	G12
-      0x5C180800,  //  0018  MOVE	R6	R4
-      0x7C140200,  //  0019  CALL	R5	1
-      0x24140B0A,  //  001A  GT	R5	R5	K10
-      0x78160002,  //  001B  JMPF	R5	#001F
-      0x1C140801,  //  001C  EQ	R5	R4	R1
-      0x78160000,  //  001D  JMPF	R5	#001F
-      0x80040600,  //  001E  RET	1	R3
-      0x00080521,  //  001F  ADD	R2	R2	K33
-      0x7001FFE9,  //  0020  JMP		#000B
-      0x4C0C0000,  //  0021  LDNIL	R3
-      0x80040600,  //  0022  RET	1	R3
+    ( &(const binstruction[53]) {  /* code */
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0708,  //  0005  SUB	R3	R3	K8
+      0x400E1003,  //  0006  CONNECT	R3	K8	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B09,  //  000D  GT	R6	R5	K9
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B08,  //  000F  SUB	R6	R5	K8
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B08,  //  0013  SUB	R6	R5	K8
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B08,  //  0016  SUB	R5	R5	K8
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080007,  //  001A  LDCONST	R2	K7
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080008,  //  001D  LDCONST	R2	K8
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0708,  //  0021  LE	R3	R3	K8
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0109,  //  0024  GETIDX	R3	R0	K9
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C10013D,  //  002D  GETMET	R4	R0	K61
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080508,  //  0032  ADD	R2	R2	K8
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
     })
   )
 );
@@ -453,12 +801,12 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_fabric
+** Solidified function: event_fabrics_saved
 ********************************************************************/
-be_local_closure(class_Matter_Device_remove_fabric,   /* name */
+be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    3,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -466,42 +814,94 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(remove_fabric),
+    be_str_weak(event_fabrics_saved),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0019,  //  0002  JMPF	R2	#001D
-      0xB80A4A00,  //  0003  GETNGBL	R2	K37
-      0x8C0C0327,  //  0004  GETMET	R3	R1	K39
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0728,  //  0006  GETMET	R3	R3	K40
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C0729,  //  0008  GETMET	R3	R3	K41
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C0C072A,  //  000A  GETMET	R3	R3	K42
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x000E4C03,  //  000C  ADD	R3	K38	R3
-      0x58100022,  //  000D  LDCONST	R4	K34
+    ( &(const binstruction[12]) {  /* code */
+      0x8804013E,  //  0000  GETMBR	R1	R0	K62
+      0x8C04033F,  //  0001  GETMET	R1	R1	K63
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040309,  //  0003  GT	R1	R1	K9
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x8804012B,  //  0005  GETMBR	R1	R0	K43
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90025601,  //  0008  SETMBR	R0	K43	R1
+      0x8C040140,  //  0009  GETMET	R1	R0	K64
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(class_Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0xA4063E00,  //  0000  IMPORT	R1	K31
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C010B,  //  0002  GETMBR	R3	R0	K11
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080509,  //  0004  GT	R2	R2	K9
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x88080141,  //  0007  GETMBR	R2	R0	K65
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x1C080403,  //  0009  EQ	R2	R2	R3
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0xB80A2800,  //  000B  GETNGBL	R2	K20
+      0x8C080542,  //  000C  GETMET	R2	R2	K66
+      0x5C100000,  //  000D  MOVE	R4	R0
       0x7C080400,  //  000E  CALL	R2	2
-      0x88080118,  //  000F  GETMBR	R2	R0	K24
-      0x8808052B,  //  0010  GETMBR	R2	R2	K43
-      0x8808052C,  //  0011  GETMBR	R2	R2	K44
-      0x8C08052D,  //  0012  GETMET	R2	R2	K45
-      0x5C100200,  //  0013  MOVE	R4	R1
-      0x7C080400,  //  0014  CALL	R2	2
-      0x88080112,  //  0015  GETMBR	R2	R0	K18
-      0x8C08052E,  //  0016  GETMET	R2	R2	K46
-      0x5C100200,  //  0017  MOVE	R4	R1
-      0x7C080400,  //  0018  CALL	R2	2
-      0x88080115,  //  0019  GETMBR	R2	R0	K21
-      0x8C08052F,  //  001A  GETMET	R2	R2	K47
-      0x5C100200,  //  001B  MOVE	R4	R1
-      0x7C080400,  //  001C  CALL	R2	2
-      0x88080115,  //  001D  GETMBR	R2	R0	K21
-      0x8C080530,  //  001E  GETMET	R2	R2	K48
-      0x7C080200,  //  001F  CALL	R2	1
-      0x80000000,  //  0020  RET	0
+      0x90028202,  //  000F  SETMBR	R0	K65	R2
+      0x8808012B,  //  0010  GETMBR	R2	R0	K43
+      0x740A000F,  //  0011  JMPT	R2	#0022
+      0x88080141,  //  0012  GETMBR	R2	R0	K65
+      0x8C080543,  //  0013  GETMET	R2	R2	K67
+      0x7C080200,  //  0014  CALL	R2	1
+      0x90025C02,  //  0015  SETMBR	R0	K46	R2
+      0x60080013,  //  0016  GETGBL	R2	G19
+      0x7C080000,  //  0017  CALL	R2	0
+      0x90023C02,  //  0018  SETMBR	R0	K30	R2
+      0x8C080144,  //  0019  GETMET	R2	R0	K68
+      0x7C080200,  //  001A  CALL	R2	1
+      0xB80A6A00,  //  001B  GETNGBL	R2	K53
+      0x600C0008,  //  001C  GETGBL	R3	G8
+      0x8810012E,  //  001D  GETMBR	R4	R0	K46
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x000E8A03,  //  001F  ADD	R3	K69	R3
+      0x58100046,  //  0020  LDCONST	R4	K70
+      0x7C080400,  //  0021  CALL	R2	2
+      0x88080141,  //  0022  GETMBR	R2	R0	K65
+      0x8C080547,  //  0023  GETMET	R2	R2	K71
+      0x8810012E,  //  0024  GETMBR	R4	R0	K46
+      0x7C080400,  //  0025  CALL	R2	2
+      0x8808012B,  //  0026  GETMBR	R2	R0	K43
+      0x740A0008,  //  0027  JMPT	R2	#0031
+      0x8808013E,  //  0028  GETMBR	R2	R0	K62
+      0x8C08053F,  //  0029  GETMET	R2	R2	K63
+      0x7C080200,  //  002A  CALL	R2	1
+      0x24080509,  //  002B  GT	R2	R2	K9
+      0x780A0003,  //  002C  JMPF	R2	#0031
+      0x50080200,  //  002D  LDBOOL	R2	1	0
+      0x90025602,  //  002E  SETMBR	R0	K43	R2
+      0x8C080140,  //  002F  GETMET	R2	R0	K64
+      0x7C080200,  //  0030  CALL	R2	1
+      0x80000000,  //  0031  RET	0
     })
   )
 );
@@ -526,7 +926,7 @@ be_local_closure(class_Matter_Device_msg_received,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x88100118,  //  0000  GETMBR	R4	R0	K24
-      0x8C100931,  //  0001  GETMET	R4	R4	K49
+      0x8C100948,  //  0001  GETMET	R4	R4	K72
       0x5C180200,  //  0002  MOVE	R6	R1
       0x5C1C0400,  //  0003  MOVE	R7	R2
       0x5C200600,  //  0004  MOVE	R8	R3
@@ -539,11 +939,11 @@ be_local_closure(class_Matter_Device_msg_received,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_plugin_remote_info
+** Solidified function: resolve_attribute_read_solo
 ********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
+be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -552,16 +952,306 @@ be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_remote_info),
+    be_str_weak(resolve_attribute_read_solo),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8808010D,  //  0000  GETMBR	R2	R0	K13
-      0x8C080532,  //  0001  GETMET	R2	R2	K50
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C140000,  //  0004  CALL	R5	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80040400,  //  0006  RET	1	R2
+    ( &(const binstruction[47]) {  /* code */
+      0x8808030D,  //  0000  GETMBR	R2	R1	K13
+      0x880C0316,  //  0001  GETMBR	R3	R1	K22
+      0x88100317,  //  0002  GETMBR	R4	R1	K23
+      0x4C140000,  //  0003  LDNIL	R5
+      0x1C140405,  //  0004  EQ	R5	R2	R5
+      0x74160005,  //  0005  JMPT	R5	#000C
+      0x4C140000,  //  0006  LDNIL	R5
+      0x1C140605,  //  0007  EQ	R5	R3	R5
+      0x74160002,  //  0008  JMPT	R5	#000C
+      0x4C140000,  //  0009  LDNIL	R5
+      0x1C140805,  //  000A  EQ	R5	R4	R5
+      0x78160001,  //  000B  JMPF	R5	#000E
+      0x4C140000,  //  000C  LDNIL	R5
+      0x80040A00,  //  000D  RET	1	R5
+      0x8C140149,  //  000E  GETMET	R5	R0	K73
+      0x5C1C0400,  //  000F  MOVE	R7	R2
+      0x7C140400,  //  0010  CALL	R5	2
+      0x4C180000,  //  0011  LDNIL	R6
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0xB81A2800,  //  0014  GETNGBL	R6	K20
+      0x88180D4B,  //  0015  GETMBR	R6	R6	K75
+      0x90069406,  //  0016  SETMBR	R1	K74	R6
+      0x4C180000,  //  0017  LDNIL	R6
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020013,  //  0019  JMP		#002E
+      0x8C180B4C,  //  001A  GETMET	R6	R5	K76
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x741A0005,  //  001D  JMPT	R6	#0024
+      0xB81A2800,  //  001E  GETNGBL	R6	K20
+      0x88180D4D,  //  001F  GETMBR	R6	R6	K77
+      0x90069406,  //  0020  SETMBR	R1	K74	R6
+      0x4C180000,  //  0021  LDNIL	R6
+      0x80040C00,  //  0022  RET	1	R6
+      0x70020009,  //  0023  JMP		#002E
+      0x8C180B4E,  //  0024  GETMET	R6	R5	K78
+      0x5C200600,  //  0025  MOVE	R8	R3
+      0x5C240800,  //  0026  MOVE	R9	R4
+      0x7C180600,  //  0027  CALL	R6	3
+      0x741A0004,  //  0028  JMPT	R6	#002E
+      0xB81A2800,  //  0029  GETNGBL	R6	K20
+      0x88180D4F,  //  002A  GETMBR	R6	R6	K79
+      0x90069406,  //  002B  SETMBR	R1	K74	R6
+      0x4C180000,  //  002C  LDNIL	R6
+      0x80040C00,  //  002D  RET	1	R6
+      0x80040A00,  //  002E  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(class_Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA406A000,  //  0000  IMPORT	R1	K80
+      0x88080151,  //  0001  GETMBR	R2	R0	K81
+      0x780A004B,  //  0002  JMPF	R2	#004F
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100151,  //  0006  GETMBR	R4	R0	K81
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080909,  //  000B  SETIDX	R2	R4	K9
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0007,  //  000D  LDCONST	R3	K7
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x8810010B,  //  0011  GETMBR	R4	R0	K11
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C140352,  //  0016  GETMET	R5	R1	K82
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200053,  //  0018  LDCONST	R8	K83
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C18051D,  //  001D  GETMET	R6	R2	K29
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240009,  //  001F  LDCONST	R9	K9
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0007,  //  0024  LDCONST	R3	K7
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0012,  //  0027  GETGBL	R3	G18
+      0x7C0C0000,  //  0028  CALL	R3	0
+      0x60100010,  //  0029  GETGBL	R4	G16
+      0x8C140505,  //  002A  GETMET	R5	R2	K5
+      0x7C140200,  //  002B  CALL	R5	1
+      0x7C100200,  //  002C  CALL	R4	1
+      0xA8020008,  //  002D  EXBLK	0	#0037
+      0x5C140800,  //  002E  MOVE	R5	R4
+      0x7C140000,  //  002F  CALL	R5	0
+      0x94180405,  //  0030  GETIDX	R6	R2	R5
+      0x1C180D09,  //  0031  EQ	R6	R6	K9
+      0x781A0002,  //  0032  JMPF	R6	#0036
+      0x8C180706,  //  0033  GETMET	R6	R3	K6
+      0x5C200A00,  //  0034  MOVE	R8	R5
+      0x7C180400,  //  0035  CALL	R6	2
+      0x7001FFF6,  //  0036  JMP		#002E
+      0x58100007,  //  0037  LDCONST	R4	K7
+      0xAC100200,  //  0038  CATCH	R4	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x60100010,  //  003A  GETGBL	R4	G16
+      0x5C140600,  //  003B  MOVE	R5	R3
+      0x7C100200,  //  003C  CALL	R4	1
+      0xA802000D,  //  003D  EXBLK	0	#004C
+      0x5C140800,  //  003E  MOVE	R5	R4
+      0x7C140000,  //  003F  CALL	R5	0
+      0xB81A6A00,  //  0040  GETNGBL	R6	K53
+      0x881C0B55,  //  0041  GETMBR	R7	R5	K85
+      0x001EA807,  //  0042  ADD	R7	K84	R7
+      0x58200046,  //  0043  LDCONST	R8	K70
+      0x7C180400,  //  0044  CALL	R6	2
+      0x8C180B34,  //  0045  GETMET	R6	R5	K52
+      0x7C180200,  //  0046  CALL	R6	1
+      0x88180151,  //  0047  GETMBR	R6	R0	K81
+      0x8C180D3D,  //  0048  GETMET	R6	R6	K61
+      0x88200B55,  //  0049  GETMBR	R8	R5	K85
+      0x7C180400,  //  004A  CALL	R6	2
+      0x7001FFF1,  //  004B  JMP		#003E
+      0x58100007,  //  004C  LDCONST	R4	K7
+      0xAC100200,  //  004D  CATCH	R4	1	0
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(class_Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100009,  //  0000  LDCONST	R4	K9
+      0x8814070D,  //  0001  GETMBR	R5	R3	K13
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C010B,  //  0003  GETMBR	R7	R0	K11
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x8818010B,  //  0007  GETMBR	R6	R0	K11
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D0D,  //  0009  GETMBR	R7	R6	K13
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D56,  //  000C  GETMET	R7	R6	K86
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100908,  //  0012  ADD	R4	R4	K8
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A2800,  //  0014  GETNGBL	R6	K20
+      0x88180D4B,  //  0015  GETMBR	R6	R6	K75
+      0x900E9406,  //  0016  SETMBR	R3	K74	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Device_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0xA406AE00,  //  0000  IMPORT	R1	K87
+      0xB80A2000,  //  0001  GETNGBL	R2	K16
+      0x8C080558,  //  0002  GETMET	R2	R2	K88
+      0xB8122800,  //  0003  GETNGBL	R4	K20
+      0x88100959,  //  0004  GETMBR	R4	R4	K89
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0004,  //  0006  JMPT	R2	#000C
+      0xB80A2800,  //  0007  GETNGBL	R2	K20
+      0x8C08055A,  //  0008  GETMET	R2	R2	K90
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000400,  //  000B  RET	0
+      0xB80A2800,  //  000C  GETNGBL	R2	K20
+      0xB80E2800,  //  000D  GETNGBL	R3	K20
+      0x8C0C075C,  //  000E  GETMET	R3	R3	K92
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x900AB603,  //  0010  SETMBR	R2	K91	R3
+      0x50080000,  //  0011  LDBOOL	R2	0	0
+      0x9002BA02,  //  0012  SETMBR	R0	K93	R2
+      0x9002BD09,  //  0013  SETMBR	R0	K94	K9
+      0x60080012,  //  0014  GETGBL	R2	G18
+      0x7C080000,  //  0015  CALL	R2	0
+      0x90021602,  //  0016  SETMBR	R0	K11	R2
+      0x50080000,  //  0017  LDBOOL	R2	0	0
+      0x90025602,  //  0018  SETMBR	R0	K43	R2
+      0x60080013,  //  0019  GETGBL	R2	G19
+      0x7C080000,  //  001A  CALL	R2	0
+      0x90023C02,  //  001B  SETMBR	R0	K30	R2
+      0x8808015F,  //  001C  GETMBR	R2	R0	K95
+      0x90025002,  //  001D  SETMBR	R0	K40	R2
+      0x50080000,  //  001E  LDBOOL	R2	0	0
+      0x90024802,  //  001F  SETMBR	R0	K36	R2
+      0x50080000,  //  0020  LDBOOL	R2	0	0
+      0x90024E02,  //  0021  SETMBR	R0	K39	R2
+      0xB80A2800,  //  0022  GETNGBL	R2	K20
+      0x8C080561,  //  0023  GETMET	R2	R2	K97
+      0x5C100000,  //  0024  MOVE	R4	R0
+      0x7C080400,  //  0025  CALL	R2	2
+      0x9002C002,  //  0026  SETMBR	R0	K96	R2
+      0x8C080162,  //  0027  GETMET	R2	R0	K98
+      0x7C080200,  //  0028  CALL	R2	1
+      0xB80A2800,  //  0029  GETNGBL	R2	K20
+      0x8C080563,  //  002A  GETMET	R2	R2	K99
+      0x5C100000,  //  002B  MOVE	R4	R0
+      0x7C080400,  //  002C  CALL	R2	2
+      0x90027C02,  //  002D  SETMBR	R0	K62	R2
+      0x8808013E,  //  002E  GETMBR	R2	R0	K62
+      0x8C080564,  //  002F  GETMET	R2	R2	K100
+      0x7C080200,  //  0030  CALL	R2	1
+      0xB80A2800,  //  0031  GETNGBL	R2	K20
+      0x8C080565,  //  0032  GETMET	R2	R2	K101
+      0x5C100000,  //  0033  MOVE	R4	R0
+      0x7C080400,  //  0034  CALL	R2	2
+      0x90023002,  //  0035  SETMBR	R0	K24	R2
+      0xB80A2800,  //  0036  GETNGBL	R2	K20
+      0x8C080567,  //  0037  GETMET	R2	R2	K103
+      0x5C100000,  //  0038  MOVE	R4	R0
+      0x7C080400,  //  0039  CALL	R2	2
+      0x9002CC02,  //  003A  SETMBR	R0	K102	R2
+      0x8C080169,  //  003B  GETMET	R2	R0	K105
+      0x7C080200,  //  003C  CALL	R2	1
+      0x9002D002,  //  003D  SETMBR	R0	K104	R2
+      0xB80A2800,  //  003E  GETNGBL	R2	K20
+      0x8C08055A,  //  003F  GETMET	R2	R2	K90
+      0x5C100000,  //  0040  MOVE	R4	R0
+      0x7C080400,  //  0041  CALL	R2	2
+      0x9002D402,  //  0042  SETMBR	R0	K106	R2
+      0x88080160,  //  0043  GETMBR	R2	R0	K96
+      0x8C08056B,  //  0044  GETMET	R2	R2	K107
+      0x7C080200,  //  0045  CALL	R2	1
+      0xB80A2000,  //  0046  GETNGBL	R2	K16
+      0x8C08056C,  //  0047  GETMET	R2	R2	K108
+      0x5C100000,  //  0048  MOVE	R4	R0
+      0x7C080400,  //  0049  CALL	R2	2
+      0x8C08016D,  //  004A  GETMET	R2	R0	K109
+      0x7C080200,  //  004B  CALL	R2	1
+      0x80000000,  //  004C  RET	0
     })
   )
 );
@@ -599,20 +1289,1624 @@ be_local_closure(class_Matter_Device_button_pressed,   /* name */
       0x3C180406,  //  000B  SHR	R6	R2	R6
       0x541E00FE,  //  000C  LDINT	R7	255
       0x2C180C07,  //  000D  AND	R6	R6	R7
-      0x8C1C0120,  //  000E  GETMET	R7	R0	K32
-      0x00240B21,  //  000F  ADD	R9	R5	K33
+      0x8C1C016E,  //  000E  GETMET	R7	R0	K110
+      0x00240B08,  //  000F  ADD	R9	R5	K8
       0x20280604,  //  0010  NE	R10	R3	R4
       0x782A0001,  //  0011  JMPF	R10	#0014
-      0x58280021,  //  0012  LDCONST	R10	K33
+      0x58280008,  //  0012  LDCONST	R10	K8
       0x70020000,  //  0013  JMP		#0015
-      0x5828000A,  //  0014  LDCONST	R10	K10
+      0x58280009,  //  0014  LDCONST	R10	K9
       0x780E0001,  //  0015  JMPF	R3	#0018
-      0x582C000A,  //  0016  LDCONST	R11	K10
+      0x582C0009,  //  0016  LDCONST	R11	K9
       0x70020000,  //  0017  JMP		#0019
-      0x582C0021,  //  0018  LDCONST	R11	K33
+      0x582C0008,  //  0018  LDCONST	R11	K8
       0x5C300C00,  //  0019  MOVE	R12	R6
       0x7C1C0A00,  //  001A  CALL	R7	5
       0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_friendly_name
+********************************************************************/
+be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(find_plugin_by_friendly_name),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x740A0004,  //  0002  JMPT	R2	#0008
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x5C0C0200,  //  0004  MOVE	R3	R1
+      0x7C080200,  //  0005  CALL	R2	1
+      0x1C080509,  //  0006  EQ	R2	R2	K9
+      0x780A0001,  //  0007  JMPF	R2	#000A
+      0x4C080000,  //  0008  LDNIL	R2
+      0x80040400,  //  0009  RET	1	R2
+      0x58080009,  //  000A  LDCONST	R2	K9
+      0x600C000C,  //  000B  GETGBL	R3	G12
+      0x8810010B,  //  000C  GETMBR	R4	R0	K11
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x140C0403,  //  000E  LT	R3	R2	R3
+      0x780E0010,  //  000F  JMPF	R3	#0021
+      0x880C010B,  //  0010  GETMBR	R3	R0	K11
+      0x940C0602,  //  0011  GETIDX	R3	R3	R2
+      0x8C10076F,  //  0012  GETMET	R4	R3	K111
+      0x7C100200,  //  0013  CALL	R4	1
+      0x4C140000,  //  0014  LDNIL	R5
+      0x20140805,  //  0015  NE	R5	R4	R5
+      0x78160007,  //  0016  JMPF	R5	#001F
+      0x6014000C,  //  0017  GETGBL	R5	G12
+      0x5C180800,  //  0018  MOVE	R6	R4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x24140B09,  //  001A  GT	R5	R5	K9
+      0x78160002,  //  001B  JMPF	R5	#001F
+      0x1C140801,  //  001C  EQ	R5	R4	R1
+      0x78160000,  //  001D  JMPF	R5	#001F
+      0x80040600,  //  001E  RET	1	R3
+      0x00080508,  //  001F  ADD	R2	R2	K8
+      0x7001FFE9,  //  0020  JMP		#000B
+      0x4C0C0000,  //  0021  LDNIL	R3
+      0x80040600,  //  0022  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_network
+********************************************************************/
+be_local_closure(class_Matter_Device_check_network,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(check_network),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x8804015D,  //  0000  GETMBR	R1	R0	K93
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0xB8062000,  //  0003  GETNGBL	R1	K16
+      0x8C040370,  //  0004  GETMET	R1	R1	K112
+      0x7C040200,  //  0005  CALL	R1	1
+      0x94040371,  //  0006  GETIDX	R1	R1	K113
+      0x74060004,  //  0007  JMPT	R1	#000D
+      0xB8062000,  //  0008  GETNGBL	R1	K16
+      0x8C040372,  //  0009  GETMET	R1	R1	K114
+      0x7C040200,  //  000A  CALL	R1	1
+      0x94040371,  //  000B  GETIDX	R1	R1	K113
+      0x78060001,  //  000C  JMPF	R1	#000F
+      0x8C040173,  //  000D  GETMET	R1	R0	K115
+      0x7C040200,  //  000E  CALL	R1	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrUpdate
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrUpdate),
+    &be_const_str_solidified,
+    ( &(const binstruction[126]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160004,  //  0002  JMPF	R5	#0008
+      0xB8162000,  //  0003  GETNGBL	R5	K16
+      0x8C140B74,  //  0004  GETMET	R5	R5	K116
+      0x581C0075,  //  0005  LDCONST	R7	K117
+      0x7C140400,  //  0006  CALL	R5	2
+      0x80040A00,  //  0007  RET	1	R5
+      0xB8162000,  //  0008  GETNGBL	R5	K16
+      0x8C140B76,  //  0009  GETMET	R5	R5	K118
+      0x5C1C0800,  //  000A  MOVE	R7	R4
+      0x58200077,  //  000B  LDCONST	R8	K119
+      0x7C140600,  //  000C  CALL	R5	3
+      0xB81A2000,  //  000D  GETNGBL	R6	K16
+      0x8C180D76,  //  000E  GETMET	R6	R6	K118
+      0x5C200800,  //  000F  MOVE	R8	R4
+      0x58240078,  //  0010  LDCONST	R9	K120
+      0x7C180600,  //  0011  CALL	R6	3
+      0x74160000,  //  0012  JMPT	R5	#0014
+      0x781A0064,  //  0013  JMPF	R6	#0079
+      0x4C1C0000,  //  0014  LDNIL	R7
+      0x78160010,  //  0015  JMPF	R5	#0027
+      0x60200009,  //  0016  GETGBL	R8	G9
+      0x94240805,  //  0017  GETIDX	R9	R4	R5
+      0x7C200200,  //  0018  CALL	R8	1
+      0x18241109,  //  0019  LE	R9	R8	K9
+      0x78260004,  //  001A  JMPF	R9	#0020
+      0xB8262000,  //  001B  GETNGBL	R9	K16
+      0x8C241374,  //  001C  GETMET	R9	R9	K116
+      0x582C0079,  //  001D  LDCONST	R11	K121
+      0x7C240400,  //  001E  CALL	R9	2
+      0x80041200,  //  001F  RET	1	R9
+      0x8C240149,  //  0020  GETMET	R9	R0	K73
+      0x5C2C1000,  //  0021  MOVE	R11	R8
+      0x7C240400,  //  0022  CALL	R9	2
+      0x5C1C1200,  //  0023  MOVE	R7	R9
+      0x8C24093D,  //  0024  GETMET	R9	R4	K61
+      0x5C2C0A00,  //  0025  MOVE	R11	R5
+      0x7C240400,  //  0026  CALL	R9	2
+      0x781A0009,  //  0027  JMPF	R6	#0032
+      0x4C200000,  //  0028  LDNIL	R8
+      0x1C200E08,  //  0029  EQ	R8	R7	R8
+      0x78220003,  //  002A  JMPF	R8	#002F
+      0x8C20010F,  //  002B  GETMET	R8	R0	K15
+      0x94280806,  //  002C  GETIDX	R10	R4	R6
+      0x7C200400,  //  002D  CALL	R8	2
+      0x5C1C1000,  //  002E  MOVE	R7	R8
+      0x8C20093D,  //  002F  GETMET	R8	R4	K61
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C200400,  //  0031  CALL	R8	2
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220004,  //  0034  JMPF	R8	#003A
+      0xB8222000,  //  0035  GETNGBL	R8	K16
+      0x8C201174,  //  0036  GETMET	R8	R8	K116
+      0x5828007A,  //  0037  LDCONST	R10	K122
+      0x7C200400,  //  0038  CALL	R8	2
+      0x80041000,  //  0039  RET	1	R8
+      0x88200F7B,  //  003A  GETMBR	R8	R7	K123
+      0x74220004,  //  003B  JMPT	R8	#0041
+      0xB8222000,  //  003C  GETNGBL	R8	K16
+      0x8C201174,  //  003D  GETMET	R8	R8	K116
+      0x5828007C,  //  003E  LDCONST	R10	K124
+      0x7C200400,  //  003F  CALL	R8	2
+      0x80041000,  //  0040  RET	1	R8
+      0x8C200F7D,  //  0041  GETMET	R8	R7	K125
+      0x7C200200,  //  0042  CALL	R8	1
+      0x60240013,  //  0043  GETGBL	R9	G19
+      0x7C240000,  //  0044  CALL	R9	0
+      0x60280010,  //  0045  GETGBL	R10	G16
+      0x8C2C0905,  //  0046  GETMET	R11	R4	K5
+      0x7C2C0200,  //  0047  CALL	R11	1
+      0x7C280200,  //  0048  CALL	R10	1
+      0xA8020016,  //  0049  EXBLK	0	#0061
+      0x5C2C1400,  //  004A  MOVE	R11	R10
+      0x7C2C0000,  //  004B  CALL	R11	0
+      0xB8322000,  //  004C  GETNGBL	R12	K16
+      0x8C30197E,  //  004D  GETMET	R12	R12	K126
+      0x5C381000,  //  004E  MOVE	R14	R8
+      0x5C3C1600,  //  004F  MOVE	R15	R11
+      0x7C300600,  //  0050  CALL	R12	3
+      0x4C340000,  //  0051  LDNIL	R13
+      0x1C34180D,  //  0052  EQ	R13	R12	R13
+      0x78360008,  //  0053  JMPF	R13	#005D
+      0xB8362000,  //  0054  GETNGBL	R13	K16
+      0x8C341B74,  //  0055  GETMET	R13	R13	K116
+      0x603C0018,  //  0056  GETGBL	R15	G24
+      0x5840007F,  //  0057  LDCONST	R16	K127
+      0x5C441600,  //  0058  MOVE	R17	R11
+      0x7C3C0400,  //  0059  CALL	R15	2
+      0x7C340400,  //  005A  CALL	R13	2
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x80001A00,  //  005C  RET	0
+      0x9434100C,  //  005D  GETIDX	R13	R8	R12
+      0x9438080B,  //  005E  GETIDX	R14	R4	R11
+      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
+      0x7001FFE8,  //  0060  JMP		#004A
+      0x58280007,  //  0061  LDCONST	R10	K7
+      0xAC280200,  //  0062  CATCH	R10	1	0
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x8C280F80,  //  0064  GETMET	R10	R7	K128
+      0x5C301200,  //  0065  MOVE	R12	R9
+      0x7C280400,  //  0066  CALL	R10	2
+      0x8C280F81,  //  0067  GETMET	R10	R7	K129
+      0x7C280200,  //  0068  CALL	R10	1
+      0x782A000A,  //  0069  JMPF	R10	#0075
+      0x602C0018,  //  006A  GETGBL	R11	G24
+      0x58300082,  //  006B  LDCONST	R12	K130
+      0x5C340200,  //  006C  MOVE	R13	R1
+      0x5C381400,  //  006D  MOVE	R14	R10
+      0x7C2C0600,  //  006E  CALL	R11	3
+      0xB8322000,  //  006F  GETNGBL	R12	K16
+      0x8C301983,  //  0070  GETMET	R12	R12	K131
+      0x5C381600,  //  0071  MOVE	R14	R11
+      0x7C300400,  //  0072  CALL	R12	2
+      0x80041800,  //  0073  RET	1	R12
+      0x70020003,  //  0074  JMP		#0079
+      0xB82E2000,  //  0075  GETNGBL	R11	K16
+      0x8C2C1711,  //  0076  GETMET	R11	R11	K17
+      0x7C2C0200,  //  0077  CALL	R11	1
+      0x80041600,  //  0078  RET	1	R11
+      0xB81E2000,  //  0079  GETNGBL	R7	K16
+      0x8C1C0F74,  //  007A  GETMET	R7	R7	K116
+      0x58240084,  //  007B  LDCONST	R9	K132
+      0x7C1C0400,  //  007C  CALL	R7	2
+      0x80000000,  //  007D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(class_Matter_Device_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C040185,  //  0000  GETMET	R1	R0	K133
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8804015E,  //  0002  GETMBR	R1	R0	K94
+      0x00040308,  //  0003  ADD	R1	R1	K8
+      0x9002BC01,  //  0004  SETMBR	R0	K94	R1
+      0x88040118,  //  0005  GETMBR	R1	R0	K24
+      0x8C040386,  //  0006  GETMET	R1	R1	K134
+      0x7C040200,  //  0007  CALL	R1	1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(class_Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8804013E,  //  0000  GETMBR	R1	R0	K62
+      0x8C040387,  //  0001  GETMET	R1	R1	K135
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040118,  //  0003  GETMBR	R1	R0	K24
+      0x8C040387,  //  0004  GETMET	R1	R1	K135
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040166,  //  0006  GETMBR	R1	R0	K102
+      0x8C040387,  //  0007  GETMET	R1	R1	K135
+      0x7C040200,  //  0008  CALL	R1	1
+      0x88040160,  //  0009  GETMBR	R1	R0	K96
+      0x8C040387,  //  000A  GETMET	R1	R1	K135
+      0x7C040200,  //  000B  CALL	R1	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_read_sensors_schedule
+********************************************************************/
+be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(add_read_sensors_schedule),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88080188,  //  0000  GETMBR	R2	R0	K136
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x740A0002,  //  0003  JMPT	R2	#0007
+      0x88080188,  //  0004  GETMBR	R2	R0	K136
+      0x24080401,  //  0005  GT	R2	R2	R1
+      0x780A0005,  //  0006  JMPF	R2	#000D
+      0x90031001,  //  0007  SETMBR	R0	K136	R1
+      0xB80A2800,  //  0008  GETNGBL	R2	K20
+      0x8C08058A,  //  0009  GETMET	R2	R2	K138
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x90031202,  //  000C  SETMBR	R0	K137	R2
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_add_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(bridge_add_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[68]) {  /* code */
+      0x880C018B,  //  0000  GETMBR	R3	R0	K139
+      0x8C0C071D,  //  0001  GETMET	R3	R3	K29
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0xB8126A00,  //  0007  GETNGBL	R4	K53
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00171805,  //  000B  ADD	R5	K140	R5
+      0x00140B8D,  //  000C  ADD	R5	R5	K141
+      0x58180046,  //  000D  LDCONST	R6	K70
+      0x7C100400,  //  000E  CALL	R4	2
+      0x80000800,  //  000F  RET	0
+      0x88100128,  //  0010  GETMBR	R4	R0	K40
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x5C180800,  //  0012  MOVE	R6	R4
+      0x7C140200,  //  0013  CALL	R5	1
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x5C1C0000,  //  0015  MOVE	R7	R0
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x5C240400,  //  0017  MOVE	R9	R2
+      0x7C180600,  //  0018  CALL	R6	3
+      0x881C010B,  //  0019  GETMBR	R7	R0	K11
+      0x8C1C0F06,  //  001A  GETMET	R7	R7	K6
+      0x5C240C00,  //  001B  MOVE	R9	R6
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x601C0013,  //  001D  GETGBL	R7	G19
+      0x7C1C0000,  //  001E  CALL	R7	0
+      0x981F1C01,  //  001F  SETIDX	R7	K142	R1
+      0x60200010,  //  0020  GETGBL	R8	G16
+      0x8C240505,  //  0021  GETMET	R9	R2	K5
+      0x7C240200,  //  0022  CALL	R9	1
+      0x7C200200,  //  0023  CALL	R8	1
+      0xA8020004,  //  0024  EXBLK	0	#002A
+      0x5C241000,  //  0025  MOVE	R9	R8
+      0x7C240000,  //  0026  CALL	R9	0
+      0x94280409,  //  0027  GETIDX	R10	R2	R9
+      0x981C120A,  //  0028  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  0029  JMP		#0025
+      0x58200007,  //  002A  LDCONST	R8	K7
+      0xAC200200,  //  002B  CATCH	R8	1	0
+      0xB0080000,  //  002C  RAISE	2	R0	R0
+      0xB8226A00,  //  002D  GETNGBL	R8	K53
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x5828008F,  //  002F  LDCONST	R10	K143
+      0x5C2C0800,  //  0030  MOVE	R11	R4
+      0x5C300200,  //  0031  MOVE	R12	R1
+      0x8C340190,  //  0032  GETMET	R13	R0	K144
+      0x5C3C0400,  //  0033  MOVE	R15	R2
+      0x7C340400,  //  0034  CALL	R13	2
+      0x7C240800,  //  0035  CALL	R9	4
+      0x58280038,  //  0036  LDCONST	R10	K56
+      0x7C200400,  //  0037  CALL	R8	2
+      0x8820012E,  //  0038  GETMBR	R8	R0	K46
+      0x98200A07,  //  0039  SETIDX	R8	R5	R7
+      0x50200200,  //  003A  LDBOOL	R8	1	0
+      0x90025608,  //  003B  SETMBR	R0	K43	R8
+      0x88200128,  //  003C  GETMBR	R8	R0	K40
+      0x00201108,  //  003D  ADD	R8	R8	K8
+      0x90025008,  //  003E  SETMBR	R0	K40	R8
+      0x8C200140,  //  003F  GETMET	R8	R0	K64
+      0x7C200200,  //  0040  CALL	R8	1
+      0x8C200191,  //  0041  GETMET	R8	R0	K145
+      0x7C200200,  //  0042  CALL	R8	1
+      0x80040800,  //  0043  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: button_handler
+********************************************************************/
+be_local_closure(class_Matter_Device_button_handler,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(button_handler),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x58140009,  //  0000  LDCONST	R5	K9
+      0xA41AA000,  //  0001  IMPORT	R6	K80
+      0x601C000C,  //  0002  GETGBL	R7	G12
+      0x8820010B,  //  0003  GETMBR	R8	R0	K11
+      0x7C1C0200,  //  0004  CALL	R7	1
+      0x141C0A07,  //  0005  LT	R7	R5	R7
+      0x781E0010,  //  0006  JMPF	R7	#0018
+      0x881C010B,  //  0007  GETMBR	R7	R0	K11
+      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
+      0x8C200D92,  //  0009  GETMET	R8	R6	K146
+      0x5C280E00,  //  000A  MOVE	R10	R7
+      0x582C006E,  //  000B  LDCONST	R11	K110
+      0x7C200600,  //  000C  CALL	R8	3
+      0x78220007,  //  000D  JMPF	R8	#0016
+      0x8820010B,  //  000E  GETMBR	R8	R0	K11
+      0x94201005,  //  000F  GETIDX	R8	R8	R5
+      0x8C20116E,  //  0010  GETMET	R8	R8	K110
+      0x5C280200,  //  0011  MOVE	R10	R1
+      0x5C2C0400,  //  0012  MOVE	R11	R2
+      0x5C300600,  //  0013  MOVE	R12	R3
+      0x5C340800,  //  0014  MOVE	R13	R4
+      0x7C200A00,  //  0015  CALL	R8	5
+      0x00140B08,  //  0016  ADD	R5	R5	K8
+      0x7001FFE9,  //  0017  JMP		#0002
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(class_Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A6A00,  //  0007  GETNGBL	R2	K53
+      0x600C0008,  //  0008  GETGBL	R3	G8
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x000F2603,  //  000B  ADD	R3	K147	R3
+      0x58100038,  //  000C  LDCONST	R4	K56
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80A2800,  //  000E  GETNGBL	R2	K20
+      0x8C080594,  //  000F  GETMET	R2	R2	K148
+      0x5C100000,  //  0010  MOVE	R4	R0
+      0x5814000A,  //  0011  LDCONST	R5	K10
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x7C080800,  //  0013  CALL	R2	4
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080573,  //  0016  GETMET	R2	R2	K115
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: signal_endpoints_changed
+********************************************************************/
+be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(signal_endpoints_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C040195,  //  0000  GETMET	R1	R0	K149
+      0x580C0009,  //  0001  LDCONST	R3	K9
+      0x5412001C,  //  0002  LDINT	R4	29
+      0x58140046,  //  0003  LDCONST	R5	K70
+      0x50180000,  //  0004  LDBOOL	R6	0	0
+      0x7C040A00,  //  0005  CALL	R1	5
+      0x8C040195,  //  0006  GETMET	R1	R0	K149
+      0xB80E2800,  //  0007  GETNGBL	R3	K20
+      0x880C0796,  //  0008  GETMBR	R3	R3	K150
+      0x5412001C,  //  0009  LDINT	R4	29
+      0x58140046,  //  000A  LDCONST	R5	K70
+      0x50180000,  //  000B  LDBOOL	R6	0	0
+      0x7C040A00,  //  000C  CALL	R1	5
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_zigbee_present
+********************************************************************/
+be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(is_zigbee_present),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA406A000,  //  0000  IMPORT	R1	K80
+      0x8C080397,  //  0001  GETMET	R2	R1	K151
+      0x58100003,  //  0002  LDCONST	R4	K3
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x20080403,  //  0005  NE	R2	R2	R3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_arg
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_plugin_class_arg),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8808018B,  //  0000  GETMBR	R2	R0	K139
+      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0598,  //  0005  GETMBR	R3	R2	K152
+      0x70020000,  //  0006  JMP		#0008
+      0x580C000A,  //  0007  LDCONST	R3	K10
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080151,  //  0002  GETMBR	R2	R0	K81
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C0151,  //  0007  GETMBR	R3	R0	K81
+      0x8C0C0705,  //  0008  GETMET	R3	R3	K5
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x88100151,  //  000E  GETMBR	R4	R0	K81
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C100999,  //  0010  GETMET	R4	R4	K153
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B09,  //  0018  GT	R5	R5	K9
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080007,  //  001C  LDCONST	R2	K7
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90023C01,  //  001F  SETMBR	R0	K30	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(class_Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x20080202,  //  0001  NE	R2	R1	R2
+      0x780A0019,  //  0002  JMPF	R2	#001D
+      0xB80A6A00,  //  0003  GETNGBL	R2	K53
+      0x8C0C039B,  //  0004  GETMET	R3	R1	K155
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C079C,  //  0006  GETMET	R3	R3	K156
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C079D,  //  0008  GETMET	R3	R3	K157
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C0C079E,  //  000A  GETMET	R3	R3	K158
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x000F3403,  //  000C  ADD	R3	K154	R3
+      0x58100038,  //  000D  LDCONST	R4	K56
+      0x7C080400,  //  000E  CALL	R2	2
+      0x88080118,  //  000F  GETMBR	R2	R0	K24
+      0x88080519,  //  0010  GETMBR	R2	R2	K25
+      0x8808051A,  //  0011  GETMBR	R2	R2	K26
+      0x8C08059F,  //  0012  GETMET	R2	R2	K159
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x88080160,  //  0015  GETMBR	R2	R0	K96
+      0x8C0805A0,  //  0016  GETMET	R2	R2	K160
+      0x5C100200,  //  0017  MOVE	R4	R1
+      0x7C080400,  //  0018  CALL	R2	2
+      0x8808013E,  //  0019  GETMBR	R2	R0	K62
+      0x8C0805A1,  //  001A  GETMET	R2	R2	K161
+      0x5C100200,  //  001B  MOVE	R4	R1
+      0x7C080400,  //  001C  CALL	R2	2
+      0x8808013E,  //  001D  GETMBR	R2	R0	K62
+      0x8C0805A2,  //  001E  GETMET	R2	R2	K162
+      0x7C080200,  //  001F  CALL	R2	1
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: conf_to_log
+********************************************************************/
+be_local_closure(class_Matter_Device_conf_to_log,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(conf_to_log),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x5808000A,  //  0001  LDCONST	R2	K10
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C1003A3,  //  0003  GETMET	R4	R1	K163
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C14098E,  //  000A  EQ	R5	R4	K142
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x581800A4,  //  000E  LDCONST	R6	K164
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0007,  //  0014  LDCONST	R3	K7
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x8808012E,  //  0001  GETMBR	R2	R0	K46
+      0x8C080505,  //  0002  GETMET	R2	R2	K5
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x88100128,  //  000B  GETMBR	R4	R0	K40
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x00100708,  //  000E  ADD	R4	R3	K8
+      0x90025004,  //  000F  SETMBR	R0	K40	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040007,  //  0011  LDCONST	R1	K7
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset_param
+********************************************************************/
+be_local_closure(class_Matter_Device_reset_param,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(reset_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x90025601,  //  0001  SETMBR	R0	K43	R1
+      0x8804015F,  //  0002  GETMBR	R1	R0	K95
+      0x90025001,  //  0003  SETMBR	R0	K40	R1
+      0x8C040140,  //  0004  GETMET	R1	R0	K64
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_displayname
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_plugin_class_displayname),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8808018B,  //  0000  GETMBR	R2	R0	K139
+      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C05A5,  //  0005  GETMBR	R3	R2	K165
+      0x70020000,  //  0006  JMP		#0008
+      0x580C000A,  //  0007  LDCONST	R3	K10
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_sensors_scheduler
+********************************************************************/
+be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(read_sensors_scheduler),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040188,  //  0000  GETMBR	R1	R0	K136
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0x88040189,  //  0005  GETMBR	R1	R0	K137
+      0x1C040309,  //  0006  EQ	R1	R1	K9
+      0x74060004,  //  0007  JMPT	R1	#000D
+      0xB8062000,  //  0008  GETNGBL	R1	K16
+      0x8C0403A6,  //  0009  GETMET	R1	R1	K166
+      0x880C0189,  //  000A  GETMBR	R3	R0	K137
+      0x7C040400,  //  000B  CALL	R1	2
+      0x78060006,  //  000C  JMPF	R1	#0014
+      0x8C0401A7,  //  000D  GETMET	R1	R0	K167
+      0x7C040200,  //  000E  CALL	R1	1
+      0xB8062000,  //  000F  GETNGBL	R1	K16
+      0x8C0403A8,  //  0010  GETMET	R1	R1	K168
+      0x880C0188,  //  0011  GETMBR	R3	R0	K136
+      0x7C040400,  //  0012  CALL	R1	2
+      0x90031201,  //  0013  SETMBR	R0	K137	R1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_http_remote
+********************************************************************/
+be_local_closure(class_Matter_Device_register_http_remote,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(register_http_remote),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x880C0151,  //  0000  GETMBR	R3	R0	K81
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x9002A203,  //  0006  SETMBR	R0	K81	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x88100151,  //  0008  GETMBR	R4	R0	K81
+      0x8C100992,  //  0009  GETMET	R4	R4	K146
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100151,  //  000D  GETMBR	R4	R0	K81
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C1407A9,  //  000F  GETMET	R5	R3	K169
+      0x7C140200,  //  0010  CALL	R5	1
+      0x14140405,  //  0011  LT	R5	R2	R5
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x8C1407AA,  //  0013  GETMET	R5	R3	K170
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C140400,  //  0015  CALL	R5	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8122800,  //  0017  GETNGBL	R4	K20
+      0x8C1009AB,  //  0018  GETMET	R4	R4	K171
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x8810011E,  //  001E  GETMBR	R4	R0	K30
+      0x8C100992,  //  001F  GETMET	R4	R4	K146
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C1007AC,  //  0023  GETMET	R4	R3	K172
+      0x8818011E,  //  0024  GETMBR	R6	R0	K30
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x88100151,  //  0027  GETMBR	R4	R0	K81
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_attribute_expansion
+********************************************************************/
+be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(process_attribute_expansion),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x880C030D,  //  0000  GETMBR	R3	R1	K13
+      0x88100316,  //  0001  GETMBR	R4	R1	K22
+      0x88140317,  //  0002  GETMBR	R5	R1	K23
+      0xB81A2800,  //  0003  GETNGBL	R6	K20
+      0x8C180DAD,  //  0004  GETMET	R6	R6	K173
+      0x5C200000,  //  0005  MOVE	R8	R0
+      0x7C180400,  //  0006  CALL	R6	2
+      0x8C1C0D73,  //  0007  GETMET	R7	R6	K115
+      0x5C240600,  //  0008  MOVE	R9	R3
+      0x5C280800,  //  0009  MOVE	R10	R4
+      0x5C2C0A00,  //  000A  MOVE	R11	R5
+      0x7C1C0800,  //  000B  CALL	R7	4
+      0x8C1C0DAE,  //  000C  GETMET	R7	R6	K174
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0x4C200000,  //  000E  LDNIL	R8
+      0x8C240DAF,  //  000F  GETMET	R9	R6	K175
+      0x7C240200,  //  0010  CALL	R9	1
+      0x5C201200,  //  0011  MOVE	R8	R9
+      0x4C280000,  //  0012  LDNIL	R10
+      0x2024120A,  //  0013  NE	R9	R9	R10
+      0x78260005,  //  0014  JMPF	R9	#001B
+      0x5C240400,  //  0015  MOVE	R9	R2
+      0x8C280DB0,  //  0016  GETMET	R10	R6	K176
+      0x7C280200,  //  0017  CALL	R10	1
+      0x5C2C1000,  //  0018  MOVE	R11	R8
+      0x7C240400,  //  0019  CALL	R9	2
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(class_Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[136]) {  /* code */
+      0xA406AE00,  //  0000  IMPORT	R1	K87
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0xA8020056,  //  0002  EXBLK	0	#005A
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x88100131,  //  0004  GETMBR	R4	R0	K49
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C1007B1,  //  0006  GETMET	R4	R3	K177
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C140734,  //  0008  GETMET	R5	R3	K52
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4163E00,  //  000A  IMPORT	R5	K31
+      0x8C180BB2,  //  000B  GETMET	R6	R5	K178
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D1D,  //  000E  GETMET	R7	R6	K29
+      0x582400B3,  //  000F  LDCONST	R9	K179
+      0x88280122,  //  0010  GETMBR	R10	R0	K34
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90024407,  //  0012  SETMBR	R0	K34	R7
+      0x8C1C0D1D,  //  0013  GETMET	R7	R6	K29
+      0x582400B4,  //  0014  LDCONST	R9	K180
+      0x88280123,  //  0015  GETMBR	R10	R0	K35
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90024607,  //  0017  SETMBR	R0	K35	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D1D,  //  0019  GETMET	R8	R6	K29
+      0x58280024,  //  001A  LDCONST	R10	K36
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90024807,  //  001E  SETMBR	R0	K36	R7
+      0x601C0017,  //  001F  GETGBL	R7	G23
+      0x8C200D1D,  //  0020  GETMET	R8	R6	K29
+      0x58280027,  //  0021  LDCONST	R10	K39
+      0x502C0000,  //  0022  LDBOOL	R11	0	0
+      0x7C200600,  //  0023  CALL	R8	3
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x90024E07,  //  0025  SETMBR	R0	K39	R7
+      0x8C1C0D1D,  //  0026  GETMET	R7	R6	K29
+      0x582400B5,  //  0027  LDCONST	R9	K181
+      0x88280128,  //  0028  GETMBR	R10	R0	K40
+      0x7C1C0600,  //  0029  CALL	R7	3
+      0x90025007,  //  002A  SETMBR	R0	K40	R7
+      0x8C1C0D1D,  //  002B  GETMET	R7	R6	K29
+      0x582400B6,  //  002C  LDCONST	R9	K182
+      0x60280013,  //  002D  GETGBL	R10	G19
+      0x7C280000,  //  002E  CALL	R10	0
+      0x7C1C0600,  //  002F  CALL	R7	3
+      0x90025C07,  //  0030  SETMBR	R0	K46	R7
+      0x601C0017,  //  0031  GETGBL	R7	G23
+      0x8C200D1D,  //  0032  GETMET	R8	R6	K29
+      0x58280029,  //  0033  LDCONST	R10	K41
+      0x7C200400,  //  0034  CALL	R8	2
+      0x7C1C0200,  //  0035  CALL	R7	1
+      0x90025207,  //  0036  SETMBR	R0	K41	R7
+      0x881C012E,  //  0037  GETMBR	R7	R0	K46
+      0x4C200000,  //  0038  LDNIL	R8
+      0x201C0E08,  //  0039  NE	R7	R7	R8
+      0x781E000D,  //  003A  JMPF	R7	#0049
+      0xB81E6A00,  //  003B  GETNGBL	R7	K53
+      0x60200018,  //  003C  GETGBL	R8	G24
+      0x582400B7,  //  003D  LDCONST	R9	K183
+      0x8828012E,  //  003E  GETMBR	R10	R0	K46
+      0x7C200400,  //  003F  CALL	R8	2
+      0x58240046,  //  0040  LDCONST	R9	K70
+      0x7C1C0400,  //  0041  CALL	R7	2
+      0x8C1C0144,  //  0042  GETMET	R7	R0	K68
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x8C1C01B8,  //  0044  GETMET	R7	R0	K184
+      0x7C1C0200,  //  0045  CALL	R7	1
+      0x5C080E00,  //  0046  MOVE	R2	R7
+      0x501C0200,  //  0047  LDBOOL	R7	1	0
+      0x90025607,  //  0048  SETMBR	R0	K43	R7
+      0x8C1C0D1D,  //  0049  GETMET	R7	R6	K29
+      0x582400B9,  //  004A  LDCONST	R9	K185
+      0x60280013,  //  004B  GETGBL	R10	G19
+      0x7C280000,  //  004C  CALL	R10	0
+      0x7C1C0600,  //  004D  CALL	R7	3
+      0x90023C07,  //  004E  SETMBR	R0	K30	R7
+      0x881C011E,  //  004F  GETMBR	R7	R0	K30
+      0x781E0006,  //  0050  JMPF	R7	#0058
+      0xB81E6A00,  //  0051  GETNGBL	R7	K53
+      0x60200008,  //  0052  GETGBL	R8	G8
+      0x8824011E,  //  0053  GETMBR	R9	R0	K30
+      0x7C200200,  //  0054  CALL	R8	1
+      0x00237408,  //  0055  ADD	R8	K186	R8
+      0x58240046,  //  0056  LDCONST	R9	K70
+      0x7C1C0400,  //  0057  CALL	R7	2
+      0xA8040001,  //  0058  EXBLK	1	1
+      0x70020011,  //  0059  JMP		#006C
+      0xAC0C0002,  //  005A  CATCH	R3	0	2
+      0x7002000E,  //  005B  JMP		#006B
+      0x201407BB,  //  005C  NE	R5	R3	K187
+      0x7816000B,  //  005D  JMPF	R5	#006A
+      0xB8166A00,  //  005E  GETNGBL	R5	K53
+      0x60180008,  //  005F  GETGBL	R6	G8
+      0x5C1C0600,  //  0060  MOVE	R7	R3
+      0x7C180200,  //  0061  CALL	R6	1
+      0x001B7806,  //  0062  ADD	R6	K188	R6
+      0x00180D3A,  //  0063  ADD	R6	R6	K58
+      0x601C0008,  //  0064  GETGBL	R7	G8
+      0x5C200800,  //  0065  MOVE	R8	R4
+      0x7C1C0200,  //  0066  CALL	R7	1
+      0x00180C07,  //  0067  ADD	R6	R6	R7
+      0x581C0038,  //  0068  LDCONST	R7	K56
+      0x7C140400,  //  0069  CALL	R5	2
+      0x70020000,  //  006A  JMP		#006C
+      0xB0080000,  //  006B  RAISE	2	R0	R0
+      0x880C0122,  //  006C  GETMBR	R3	R0	K34
+      0x4C100000,  //  006D  LDNIL	R4
+      0x1C0C0604,  //  006E  EQ	R3	R3	R4
+      0x780E000A,  //  006F  JMPF	R3	#007B
+      0x8C0C03BD,  //  0070  GETMET	R3	R1	K189
+      0x58140038,  //  0071  LDCONST	R5	K56
+      0x7C0C0400,  //  0072  CALL	R3	2
+      0x8C0C0752,  //  0073  GETMET	R3	R3	K82
+      0x58140009,  //  0074  LDCONST	R5	K9
+      0x58180038,  //  0075  LDCONST	R6	K56
+      0x7C0C0600,  //  0076  CALL	R3	3
+      0x54120FFE,  //  0077  LDINT	R4	4095
+      0x2C0C0604,  //  0078  AND	R3	R3	R4
+      0x90024403,  //  0079  SETMBR	R0	K34	R3
+      0x50080200,  //  007A  LDBOOL	R2	1	0
+      0x880C0123,  //  007B  GETMBR	R3	R0	K35
+      0x4C100000,  //  007C  LDNIL	R4
+      0x1C0C0604,  //  007D  EQ	R3	R3	R4
+      0x780E0004,  //  007E  JMPF	R3	#0084
+      0x880C0160,  //  007F  GETMBR	R3	R0	K96
+      0x8C0C07BE,  //  0080  GETMET	R3	R3	K190
+      0x7C0C0200,  //  0081  CALL	R3	1
+      0x90024603,  //  0082  SETMBR	R0	K35	R3
+      0x50080200,  //  0083  LDBOOL	R2	1	0
+      0x780A0001,  //  0084  JMPF	R2	#0087
+      0x8C0C0140,  //  0085  GETMET	R3	R0	K64
+      0x7C0C0200,  //  0086  CALL	R3	1
+      0x80000000,  //  0087  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0xA4063E00,  //  0000  IMPORT	R1	K31
+      0xB80A2000,  //  0001  GETNGBL	R2	K16
+      0x8C0805BF,  //  0002  GETMET	R2	R2	K191
+      0x7C080200,  //  0003  CALL	R2	1
+      0xB80E2000,  //  0004  GETNGBL	R3	K16
+      0x8C0C07C0,  //  0005  GETMET	R3	R3	K192
+      0x58140046,  //  0006  LDCONST	R5	K70
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0006,  //  0008  JMPF	R3	#0010
+      0xB80E6A00,  //  0009  GETNGBL	R3	K53
+      0x60100008,  //  000A  GETGBL	R4	G8
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00138204,  //  000D  ADD	R4	K193	R4
+      0x58140046,  //  000E  LDCONST	R5	K70
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x4C0C0000,  //  0010  LDNIL	R3
+      0x1C0C0403,  //  0011  EQ	R3	R2	R3
+      0x780E0000,  //  0012  JMPF	R3	#0014
+      0x80000600,  //  0013  RET	0
+      0x8C0C03B2,  //  0014  GETMET	R3	R1	K178
+      0x5C140400,  //  0015  MOVE	R5	R2
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x4C100000,  //  0017  LDNIL	R4
+      0x20100604,  //  0018  NE	R4	R3	R4
+      0x7812000D,  //  0019  JMPF	R4	#0028
+      0x58100009,  //  001A  LDCONST	R4	K9
+      0x6014000C,  //  001B  GETGBL	R5	G12
+      0x8818010B,  //  001C  GETMBR	R6	R0	K11
+      0x7C140200,  //  001D  CALL	R5	1
+      0x14140805,  //  001E  LT	R5	R4	R5
+      0x78160006,  //  001F  JMPF	R5	#0027
+      0x8814010B,  //  0020  GETMBR	R5	R0	K11
+      0x94140A04,  //  0021  GETIDX	R5	R5	R4
+      0x8C140BC2,  //  0022  GETMET	R5	R5	K194
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C140400,  //  0024  CALL	R5	2
+      0x00100908,  //  0025  ADD	R4	R4	K8
+      0x7001FFF3,  //  0026  JMP		#001B
+      0x70020006,  //  0027  JMP		#002F
+      0xB8126A00,  //  0028  GETNGBL	R4	K53
+      0x60140008,  //  0029  GETGBL	R5	G8
+      0x5C180400,  //  002A  MOVE	R6	R2
+      0x7C140200,  //  002B  CALL	R5	1
+      0x00178605,  //  002C  ADD	R5	K195	R5
+      0x58180046,  //  002D  LDCONST	R6	K70
+      0x7C100400,  //  002E  CALL	R4	2
+      0x80000000,  //  002F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(class_Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C0805C4,  //  0001  GETMET	R2	R2	K196
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_config_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_check_config_ep,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(check_config_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x600C0010,  //  0003  GETGBL	R3	G16
+      0x8810012E,  //  0004  GETMBR	R4	R0	K46
+      0x8C100905,  //  0005  GETMET	R4	R4	K5
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020007,  //  0008  EXBLK	0	#0011
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x8C140506,  //  000B  GETMET	R5	R2	K6
+      0x601C0009,  //  000C  GETGBL	R7	G9
+      0x5C200800,  //  000D  MOVE	R8	R4
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x7001FFF7,  //  0010  JMP		#0009
+      0x580C0007,  //  0011  LDCONST	R3	K7
+      0xAC0C0200,  //  0012  CATCH	R3	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x600C0010,  //  0014  GETGBL	R3	G16
+      0x5C100400,  //  0015  MOVE	R4	R2
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0xA8020030,  //  0017  EXBLK	0	#0049
+      0x5C100600,  //  0018  MOVE	R4	R3
+      0x7C100000,  //  0019  CALL	R4	0
+      0x1C140909,  //  001A  EQ	R5	R4	K9
+      0x7816000B,  //  001B  JMPF	R5	#0028
+      0xB8166A00,  //  001C  GETNGBL	R5	K53
+      0x581800C5,  //  001D  LDCONST	R6	K197
+      0x581C0038,  //  001E  LDCONST	R7	K56
+      0x7C140400,  //  001F  CALL	R5	2
+      0x8814012E,  //  0020  GETMBR	R5	R0	K46
+      0x8C140B3D,  //  0021  GETMET	R5	R5	K61
+      0x601C0008,  //  0022  GETGBL	R7	G8
+      0x5C200800,  //  0023  MOVE	R8	R4
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x7C140400,  //  0025  CALL	R5	2
+      0x50040200,  //  0026  LDBOOL	R1	1	0
+      0x7002001F,  //  0027  JMP		#0048
+      0xB8162800,  //  0028  GETNGBL	R5	K20
+      0x88140B96,  //  0029  GETMBR	R5	R5	K150
+      0x1C140805,  //  002A  EQ	R5	R4	R5
+      0x7816001B,  //  002B  JMPF	R5	#0048
+      0x50040200,  //  002C  LDBOOL	R1	1	0
+      0xB8166A00,  //  002D  GETNGBL	R5	K53
+      0x60180018,  //  002E  GETGBL	R6	G24
+      0x581C00C6,  //  002F  LDCONST	R7	K198
+      0x5C200800,  //  0030  MOVE	R8	R4
+      0x88240128,  //  0031  GETMBR	R9	R0	K40
+      0x7C180600,  //  0032  CALL	R6	3
+      0x581C0038,  //  0033  LDCONST	R7	K56
+      0x7C140400,  //  0034  CALL	R5	2
+      0x60140008,  //  0035  GETGBL	R5	G8
+      0x88180128,  //  0036  GETMBR	R6	R0	K40
+      0x7C140200,  //  0037  CALL	R5	1
+      0x8818012E,  //  0038  GETMBR	R6	R0	K46
+      0x601C0008,  //  0039  GETGBL	R7	G8
+      0x5C200800,  //  003A  MOVE	R8	R4
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x8820012E,  //  003C  GETMBR	R8	R0	K46
+      0x941C1007,  //  003D  GETIDX	R7	R8	R7
+      0x98180A07,  //  003E  SETIDX	R6	R5	R7
+      0x8814012E,  //  003F  GETMBR	R5	R0	K46
+      0x8C140B3D,  //  0040  GETMET	R5	R5	K61
+      0x601C0008,  //  0041  GETGBL	R7	G8
+      0x5C200800,  //  0042  MOVE	R8	R4
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x7C140400,  //  0044  CALL	R5	2
+      0x88140128,  //  0045  GETMBR	R5	R0	K40
+      0x00140B08,  //  0046  ADD	R5	R5	K8
+      0x90025005,  //  0047  SETMBR	R0	K40	R5
+      0x7001FFCE,  //  0048  JMP		#0018
+      0x580C0007,  //  0049  LDCONST	R3	K7
+      0xAC0C0200,  //  004A  CATCH	R3	1	0
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80040200,  //  004C  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: button_multi_pressed
+********************************************************************/
+be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(button_multi_pressed),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x540E0007,  //  0000  LDINT	R3	8
+      0x3C0C0403,  //  0001  SHR	R3	R2	R3
+      0x541200FE,  //  0002  LDINT	R4	255
+      0x2C0C0604,  //  0003  AND	R3	R3	R4
+      0x541200FE,  //  0004  LDINT	R4	255
+      0x2C100404,  //  0005  AND	R4	R2	R4
+      0x8C14016E,  //  0006  GETMET	R5	R0	K110
+      0x001C0908,  //  0007  ADD	R7	R4	K8
+      0x58200038,  //  0008  LDCONST	R8	K56
+      0x58240009,  //  0009  LDCONST	R9	K9
+      0x5C280600,  //  000A  MOVE	R10	R3
+      0x7C140A00,  //  000B  CALL	R5	5
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_remove_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(bridge_remove_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0xA40A3E00,  //  0000  IMPORT	R2	K31
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x4C140000,  //  0005  LDNIL	R5
+      0x8818012E,  //  0006  GETMBR	R6	R0	K46
+      0x8C180D92,  //  0007  GETMET	R6	R6	K146
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0004,  //  000A  JMPT	R6	#0010
+      0xB81A6A00,  //  000B  GETNGBL	R6	K53
+      0x001F8E03,  //  000C  ADD	R7	K199	R3
+      0x58200046,  //  000D  LDCONST	R8	K70
+      0x7C180400,  //  000E  CALL	R6	2
+      0x80000C00,  //  000F  RET	0
+      0xB81A6A00,  //  0010  GETNGBL	R6	K53
+      0x601C0018,  //  0011  GETGBL	R7	G24
+      0x582000C8,  //  0012  LDCONST	R8	K200
+      0x5C240200,  //  0013  MOVE	R9	R1
+      0x7C1C0400,  //  0014  CALL	R7	2
+      0x58200038,  //  0015  LDCONST	R8	K56
+      0x7C180400,  //  0016  CALL	R6	2
+      0x8818012E,  //  0017  GETMBR	R6	R0	K46
+      0x8C180D3D,  //  0018  GETMET	R6	R6	K61
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x7C180400,  //  001A  CALL	R6	2
+      0x50180200,  //  001B  LDBOOL	R6	1	0
+      0x90025606,  //  001C  SETMBR	R0	K43	R6
+      0x58180009,  //  001D  LDCONST	R6	K9
+      0x601C000C,  //  001E  GETGBL	R7	G12
+      0x8820010B,  //  001F  GETMBR	R8	R0	K11
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x141C0C07,  //  0021  LT	R7	R6	R7
+      0x781E000D,  //  0022  JMPF	R7	#0031
+      0x881C010B,  //  0023  GETMBR	R7	R0	K11
+      0x941C0E06,  //  0024  GETIDX	R7	R7	R6
+      0x8C1C0F1C,  //  0025  GETMET	R7	R7	K28
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x1C1C0207,  //  0027  EQ	R7	R1	R7
+      0x781E0005,  //  0028  JMPF	R7	#002F
+      0x881C010B,  //  0029  GETMBR	R7	R0	K11
+      0x8C1C0F3D,  //  002A  GETMET	R7	R7	K61
+      0x5C240C00,  //  002B  MOVE	R9	R6
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x70020002,  //  002D  JMP		#0031
+      0x70020000,  //  002E  JMP		#0030
+      0x00180D08,  //  002F  ADD	R6	R6	K8
+      0x7001FFEC,  //  0030  JMP		#001E
+      0x8C1C01C9,  //  0031  GETMET	R7	R0	K201
+      0x7C1C0200,  //  0032  CALL	R7	1
+      0x8C1C0140,  //  0033  GETMET	R7	R0	K64
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x8C1C0191,  //  0035  GETMET	R7	R0	K145
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(find_plugin_by_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080009,  //  0000  LDCONST	R2	K9
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x8810010B,  //  0002  GETMBR	R4	R0	K11
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C010B,  //  0006  GETMBR	R3	R0	K11
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C10071C,  //  0008  GETMET	R4	R3	K28
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x00080508,  //  000D  ADD	R2	R2	K8
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
     })
   )
 );
@@ -718,19 +3012,19 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
     be_str_weak(register_commands),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040333,  //  0001  GETMET	R1	R1	K51
-      0x580C0034,  //  0002  LDCONST	R3	K52
+      0xB8062000,  //  0000  GETNGBL	R1	K16
+      0x8C0403CA,  //  0001  GETMET	R1	R1	K202
+      0x580C00CB,  //  0002  LDCONST	R3	K203
       0x84100000,  //  0003  CLOSURE	R4	P0
       0x7C040600,  //  0004  CALL	R1	3
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040333,  //  0006  GETMET	R1	R1	K51
-      0x580C0035,  //  0007  LDCONST	R3	K53
+      0xB8062000,  //  0005  GETNGBL	R1	K16
+      0x8C0403CA,  //  0006  GETMET	R1	R1	K202
+      0x580C00CC,  //  0007  LDCONST	R3	K204
       0x84100001,  //  0008  CLOSURE	R4	P1
       0x7C040600,  //  0009  CALL	R1	3
-      0xB8060200,  //  000A  GETNGBL	R1	K1
-      0x8C040333,  //  000B  GETMET	R1	R1	K51
-      0x580C0036,  //  000C  LDCONST	R3	K54
+      0xB8062000,  //  000A  GETNGBL	R1	K16
+      0x8C0403CA,  //  000B  GETMET	R1	R1	K202
+      0x580C00CD,  //  000C  LDCONST	R3	K205
       0x84100002,  //  000D  CLOSURE	R4	P2
       0x7C040600,  //  000E  CALL	R1	3
       0xA0000000,  //  000F  CLOSE	R0
@@ -742,72 +3036,29 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
 
 
 /********************************************************************
-** Solidified function: k2l
+** Solidified function: save_before_restart
 ********************************************************************/
-be_local_closure(class_Matter_Device_k2l,   /* name */
+be_local_closure(class_Matter_Device_save_before_restart,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
-    12,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(k2l),
+    be_str_weak(save_before_restart),
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58040037,  //  0000  LDCONST	R1	K55
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100138,  //  0008  GETMET	R4	R0	K56
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140539,  //  000E  GETMET	R5	R2	K57
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C003A,  //  0012  LDCONST	R3	K58
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100921,  //  0019  SUB	R4	R4	K33
-      0x40124204,  //  001A  CONNECT	R4	K33	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D0A,  //  0021  GT	R7	R6	K10
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D21,  //  0023  SUB	R7	R6	K33
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D21,  //  0027  SUB	R7	R6	K33
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D21,  //  002A  SUB	R6	R6	K33
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C003A,  //  002E  LDCONST	R3	K58
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040160,  //  0000  GETMBR	R1	R0	K96
+      0x8C0403CE,  //  0001  GETMET	R1	R1	K206
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040160,  //  0003  GETMBR	R1	R0	K96
+      0x8C0403CF,  //  0004  GETMET	R1	R1	K207
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -835,15 +3086,15 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
       0x5C180600,  //  0001  MOVE	R6	R3
       0x7C140200,  //  0002  CALL	R5	1
       0x78160003,  //  0003  JMPF	R5	#0008
-      0x88180112,  //  0004  GETMBR	R6	R0	K18
-      0x8C180D3B,  //  0005  GETMET	R6	R6	K59
+      0x88180160,  //  0004  GETMBR	R6	R0	K96
+      0x8C180DD0,  //  0005  GETMET	R6	R6	K208
       0x7C180200,  //  0006  CALL	R6	1
       0x70020002,  //  0007  JMP		#000B
-      0x88180112,  //  0008  GETMBR	R6	R0	K18
-      0x8C180D3C,  //  0009  GETMET	R6	R6	K60
+      0x88180160,  //  0008  GETMBR	R6	R0	K96
+      0x8C180DCE,  //  0009  GETMET	R6	R6	K206
       0x7C180200,  //  000A  CALL	R6	1
-      0xB81A0200,  //  000B  GETNGBL	R6	K1
-      0x8C180D3D,  //  000C  GETMET	R6	R6	K61
+      0xB81A2000,  //  000B  GETNGBL	R6	K16
+      0x8C180D11,  //  000C  GETMET	R6	R6	K17
       0x7C180200,  //  000D  CALL	R6	1
       0x80000000,  //  000E  RET	0
     })
@@ -853,382 +3104,11 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
 
 
 /********************************************************************
-** Solidified function: attribute_updated
+** Solidified function: k2l
 ********************************************************************/
-be_local_closure(class_Matter_Device_attribute_updated,   /* name */
+be_local_closure(class_Matter_Device_k2l,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160600,  //  0004  GETNGBL	R5	K3
-      0x8C140B3E,  //  0005  GETMET	R5	R5	K62
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90167E01,  //  0007  SETMBR	R5	K63	R1
-      0x90168002,  //  0008  SETMBR	R5	K64	R2
-      0x90168203,  //  0009  SETMBR	R5	K65	R3
-      0x88180118,  //  000A  GETMBR	R6	R0	K24
-      0x88180D2B,  //  000B  GETMBR	R6	R6	K43
-      0x88180D2C,  //  000C  GETMBR	R6	R6	K44
-      0x8C180D42,  //  000D  GETMET	R6	R6	K66
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(class_Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4068600,  //  0000  IMPORT	R1	K67
-      0x8C080144,  //  0001  GETMET	R2	R0	K68
-      0x7C080200,  //  0002  CALL	R2	1
-      0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0045,  //  0004  LDCONST	R3	K69
-      0x88100146,  //  0005  GETMBR	R4	R0	K70
-      0x88140147,  //  0006  GETMBR	R5	R0	K71
-      0x88180110,  //  0007  GETMBR	R6	R0	K16
-      0x781A0001,  //  0008  JMPF	R6	#000B
-      0x58180048,  //  0009  LDCONST	R6	K72
-      0x70020000,  //  000A  JMP		#000C
-      0x58180049,  //  000B  LDCONST	R6	K73
-      0x881C0111,  //  000C  GETMBR	R7	R0	K17
-      0x781E0001,  //  000D  JMPF	R7	#0010
-      0x581C0048,  //  000E  LDCONST	R7	K72
-      0x70020000,  //  000F  JMP		#0011
-      0x581C0049,  //  0010  LDCONST	R7	K73
-      0x8820010E,  //  0011  GETMBR	R8	R0	K14
-      0x7C080C00,  //  0012  CALL	R2	6
-      0x880C014A,  //  0013  GETMBR	R3	R0	K74
-      0x780E0000,  //  0014  JMPF	R3	#0016
-      0x0008054B,  //  0015  ADD	R2	R2	K75
-      0x880C010C,  //  0016  GETMBR	R3	R0	K12
-      0x780E000E,  //  0017  JMPF	R3	#0027
-      0x0008054C,  //  0018  ADD	R2	R2	K76
-      0x8C0C034D,  //  0019  GETMET	R3	R1	K77
-      0x8814014E,  //  001A  GETMBR	R5	R0	K78
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x00080403,  //  001C  ADD	R2	R2	R3
-      0x600C000C,  //  001D  GETGBL	R3	G12
-      0x8810010D,  //  001E  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x240C070A,  //  0020  GT	R3	R3	K10
-      0x780E0004,  //  0021  JMPF	R3	#0027
-      0x0008054F,  //  0022  ADD	R2	R2	K79
-      0x8C0C034D,  //  0023  GETMET	R3	R1	K77
-      0x8814010D,  //  0024  GETMBR	R5	R0	K13
-      0x7C0C0400,  //  0025  CALL	R3	2
-      0x00080403,  //  0026  ADD	R2	R2	R3
-      0x00080550,  //  0027  ADD	R2	R2	K80
-      0xA8020017,  //  0028  EXBLK	0	#0041
-      0x600C0011,  //  0029  GETGBL	R3	G17
-      0x88100151,  //  002A  GETMBR	R4	R0	K81
-      0x58140052,  //  002B  LDCONST	R5	K82
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0x8C100753,  //  002D  GETMET	R4	R3	K83
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x8C100754,  //  0030  GETMET	R4	R3	K84
-      0x7C100200,  //  0031  CALL	R4	1
-      0xB8124A00,  //  0032  GETNGBL	R4	K37
-      0x60140018,  //  0033  GETGBL	R5	G24
-      0x58180055,  //  0034  LDCONST	R6	K85
-      0x881C010C,  //  0035  GETMBR	R7	R0	K12
-      0x781E0001,  //  0036  JMPF	R7	#0039
-      0x581C0056,  //  0037  LDCONST	R7	K86
-      0x70020000,  //  0038  JMP		#003A
-      0x581C0057,  //  0039  LDCONST	R7	K87
-      0x7C140400,  //  003A  CALL	R5	2
-      0x58180022,  //  003B  LDCONST	R6	K34
-      0x7C100400,  //  003C  CALL	R4	2
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x80040400,  //  003E  RET	1	R2
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8164A00,  //  0043  GETNGBL	R5	K37
-      0x60180008,  //  0044  GETGBL	R6	G8
-      0x5C1C0600,  //  0045  MOVE	R7	R3
-      0x7C180200,  //  0046  CALL	R6	1
-      0x001AB006,  //  0047  ADD	R6	K88	R6
-      0x00180D59,  //  0048  ADD	R6	R6	K89
-      0x601C0008,  //  0049  GETGBL	R7	G8
-      0x5C200800,  //  004A  MOVE	R8	R4
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0022,  //  004D  LDCONST	R7	K34
-      0x7C140400,  //  004E  CALL	R5	2
-      0x80040400,  //  004F  RET	1	R2
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(class_Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[136]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080000,  //  0001  LDBOOL	R2	0	0
-      0xA8020056,  //  0002  EXBLK	0	#005A
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100151,  //  0004  GETMBR	R4	R0	K81
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C10075A,  //  0006  GETMET	R4	R3	K90
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140754,  //  0008  GETMET	R5	R3	K84
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4168600,  //  000A  IMPORT	R5	K67
-      0x8C180B5B,  //  000B  GETMET	R6	R5	K91
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D32,  //  000E  GETMET	R7	R6	K50
-      0x5824005C,  //  000F  LDCONST	R9	K92
-      0x88280146,  //  0010  GETMBR	R10	R0	K70
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x90028C07,  //  0012  SETMBR	R0	K70	R7
-      0x8C1C0D32,  //  0013  GETMET	R7	R6	K50
-      0x5824005D,  //  0014  LDCONST	R9	K93
-      0x88280147,  //  0015  GETMBR	R10	R0	K71
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x90028E07,  //  0017  SETMBR	R0	K71	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D32,  //  0019  GETMET	R8	R6	K50
-      0x58280010,  //  001A  LDCONST	R10	K16
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90022007,  //  001E  SETMBR	R0	K16	R7
-      0x601C0017,  //  001F  GETGBL	R7	G23
-      0x8C200D32,  //  0020  GETMET	R8	R6	K50
-      0x58280011,  //  0021  LDCONST	R10	K17
-      0x502C0000,  //  0022  LDBOOL	R11	0	0
-      0x7C200600,  //  0023  CALL	R8	3
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x90022207,  //  0025  SETMBR	R0	K17	R7
-      0x8C1C0D32,  //  0026  GETMET	R7	R6	K50
-      0x5824005E,  //  0027  LDCONST	R9	K94
-      0x8828010E,  //  0028  GETMBR	R10	R0	K14
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x90021C07,  //  002A  SETMBR	R0	K14	R7
-      0x8C1C0D32,  //  002B  GETMET	R7	R6	K50
-      0x5824005F,  //  002C  LDCONST	R9	K95
-      0x60280013,  //  002D  GETGBL	R10	G19
-      0x7C280000,  //  002E  CALL	R10	0
-      0x7C1C0600,  //  002F  CALL	R7	3
-      0x90029C07,  //  0030  SETMBR	R0	K78	R7
-      0x601C0017,  //  0031  GETGBL	R7	G23
-      0x8C200D32,  //  0032  GETMET	R8	R6	K50
-      0x5828004A,  //  0033  LDCONST	R10	K74
-      0x7C200400,  //  0034  CALL	R8	2
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0x90029407,  //  0036  SETMBR	R0	K74	R7
-      0x881C014E,  //  0037  GETMBR	R7	R0	K78
-      0x4C200000,  //  0038  LDNIL	R8
-      0x201C0E08,  //  0039  NE	R7	R7	R8
-      0x781E000D,  //  003A  JMPF	R7	#0049
-      0xB81E4A00,  //  003B  GETNGBL	R7	K37
-      0x60200018,  //  003C  GETGBL	R8	G24
-      0x58240060,  //  003D  LDCONST	R9	K96
-      0x8828014E,  //  003E  GETMBR	R10	R0	K78
-      0x7C200400,  //  003F  CALL	R8	2
-      0x58240061,  //  0040  LDCONST	R9	K97
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x8C1C0162,  //  0042  GETMET	R7	R0	K98
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x8C1C0163,  //  0044  GETMET	R7	R0	K99
-      0x7C1C0200,  //  0045  CALL	R7	1
-      0x5C080E00,  //  0046  MOVE	R2	R7
-      0x501C0200,  //  0047  LDBOOL	R7	1	0
-      0x90021807,  //  0048  SETMBR	R0	K12	R7
-      0x8C1C0D32,  //  0049  GETMET	R7	R6	K50
-      0x58240064,  //  004A  LDCONST	R9	K100
-      0x60280013,  //  004B  GETGBL	R10	G19
-      0x7C280000,  //  004C  CALL	R10	0
-      0x7C1C0600,  //  004D  CALL	R7	3
-      0x90021A07,  //  004E  SETMBR	R0	K13	R7
-      0x881C010D,  //  004F  GETMBR	R7	R0	K13
-      0x781E0006,  //  0050  JMPF	R7	#0058
-      0xB81E4A00,  //  0051  GETNGBL	R7	K37
-      0x60200008,  //  0052  GETGBL	R8	G8
-      0x8824010D,  //  0053  GETMBR	R9	R0	K13
-      0x7C200200,  //  0054  CALL	R8	1
-      0x0022CA08,  //  0055  ADD	R8	K101	R8
-      0x58240061,  //  0056  LDCONST	R9	K97
-      0x7C1C0400,  //  0057  CALL	R7	2
-      0xA8040001,  //  0058  EXBLK	1	1
-      0x70020011,  //  0059  JMP		#006C
-      0xAC0C0002,  //  005A  CATCH	R3	0	2
-      0x7002000E,  //  005B  JMP		#006B
-      0x20140766,  //  005C  NE	R5	R3	K102
-      0x7816000B,  //  005D  JMPF	R5	#006A
-      0xB8164A00,  //  005E  GETNGBL	R5	K37
-      0x60180008,  //  005F  GETGBL	R6	G8
-      0x5C1C0600,  //  0060  MOVE	R7	R3
-      0x7C180200,  //  0061  CALL	R6	1
-      0x001ACE06,  //  0062  ADD	R6	K103	R6
-      0x00180D59,  //  0063  ADD	R6	R6	K89
-      0x601C0008,  //  0064  GETGBL	R7	G8
-      0x5C200800,  //  0065  MOVE	R8	R4
-      0x7C1C0200,  //  0066  CALL	R7	1
-      0x00180C07,  //  0067  ADD	R6	R6	R7
-      0x581C0022,  //  0068  LDCONST	R7	K34
-      0x7C140400,  //  0069  CALL	R5	2
-      0x70020000,  //  006A  JMP		#006C
-      0xB0080000,  //  006B  RAISE	2	R0	R0
-      0x880C0146,  //  006C  GETMBR	R3	R0	K70
-      0x4C100000,  //  006D  LDNIL	R4
-      0x1C0C0604,  //  006E  EQ	R3	R3	R4
-      0x780E000A,  //  006F  JMPF	R3	#007B
-      0x8C0C0368,  //  0070  GETMET	R3	R1	K104
-      0x58140022,  //  0071  LDCONST	R5	K34
-      0x7C0C0400,  //  0072  CALL	R3	2
-      0x8C0C0769,  //  0073  GETMET	R3	R3	K105
-      0x5814000A,  //  0074  LDCONST	R5	K10
-      0x58180022,  //  0075  LDCONST	R6	K34
-      0x7C0C0600,  //  0076  CALL	R3	3
-      0x54120FFE,  //  0077  LDINT	R4	4095
-      0x2C0C0604,  //  0078  AND	R3	R3	R4
-      0x90028C03,  //  0079  SETMBR	R0	K70	R3
-      0x50080200,  //  007A  LDBOOL	R2	1	0
-      0x880C0147,  //  007B  GETMBR	R3	R0	K71
-      0x4C100000,  //  007C  LDNIL	R4
-      0x1C0C0604,  //  007D  EQ	R3	R3	R4
-      0x780E0004,  //  007E  JMPF	R3	#0084
-      0x880C0112,  //  007F  GETMBR	R3	R0	K18
-      0x8C0C076A,  //  0080  GETMET	R3	R3	K106
-      0x7C0C0200,  //  0081  CALL	R3	1
-      0x90028E03,  //  0082  SETMBR	R0	K71	R3
-      0x50080200,  //  0083  LDBOOL	R2	1	0
-      0x780A0001,  //  0084  JMPF	R2	#0087
-      0x8C0C016B,  //  0085  GETMET	R3	R0	K107
-      0x7C0C0200,  //  0086  CALL	R3	1
-      0x80000000,  //  0087  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(class_Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x880C016C,  //  0000  GETMBR	R3	R0	K108
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x9002D803,  //  0006  SETMBR	R0	K108	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x8810016C,  //  0008  GETMBR	R4	R0	K108
-      0x8C10096D,  //  0009  GETMET	R4	R4	K109
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x8810016C,  //  000D  GETMBR	R4	R0	K108
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C14076E,  //  000F  GETMET	R5	R3	K110
-      0x7C140200,  //  0010  CALL	R5	1
-      0x14140405,  //  0011  LT	R5	R2	R5
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x8C14076F,  //  0013  GETMET	R5	R3	K111
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C140400,  //  0015  CALL	R5	2
-      0x70020011,  //  0016  JMP		#0029
-      0xB8120600,  //  0017  GETNGBL	R4	K3
-      0x8C100970,  //  0018  GETMET	R4	R4	K112
-      0x5C180000,  //  0019  MOVE	R6	R0
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x5C200400,  //  001B  MOVE	R8	R2
-      0x7C100800,  //  001C  CALL	R4	4
-      0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x8810010D,  //  001E  GETMBR	R4	R0	K13
-      0x8C10096D,  //  001F  GETMET	R4	R4	K109
-      0x5C180200,  //  0020  MOVE	R6	R1
-      0x7C100400,  //  0021  CALL	R4	2
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C100771,  //  0023  GETMET	R4	R3	K113
-      0x8818010D,  //  0024  GETMBR	R6	R0	K13
-      0x94180C01,  //  0025  GETIDX	R6	R6	R1
-      0x7C100400,  //  0026  CALL	R4	2
-      0x8810016C,  //  0027  GETMBR	R4	R0	K108
-      0x98100203,  //  0028  SETIDX	R4	R1	R3
-      0x80040600,  //  0029  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort_distinct
-********************************************************************/
-be_local_closure(class_Matter_Device_sort_distinct,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     12,                          /* varg */
     0,                          /* has upvals */
@@ -1237,673 +3117,59 @@ be_local_closure(class_Matter_Device_sort_distinct,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(sort_distinct),
+    be_str_weak(k2l),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58040037,  //  0000  LDCONST	R1	K55
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0721,  //  0005  SUB	R3	R3	K33
-      0x400E4203,  //  0006  CONNECT	R3	K33	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B0A,  //  000D  GT	R6	R5	K10
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B21,  //  000F  SUB	R6	R5	K33
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B21,  //  0013  SUB	R6	R5	K33
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B21,  //  0016  SUB	R5	R5	K33
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x5808003A,  //  001A  LDCONST	R2	K58
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080021,  //  001D  LDCONST	R2	K33
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0721,  //  0021  LE	R3	R3	K33
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C010A,  //  0024  GETIDX	R3	R0	K10
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100172,  //  002D  GETMET	R4	R0	K114
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080521,  //  0032  ADD	R2	R2	K33
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(class_Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080173,  //  0000  GETMBR	R2	R0	K115
-      0x8C080574,  //  0001  GETMET	R2	R2	K116
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(class_Matter_Device_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
-      0x8C040375,  //  0001  GETMET	R1	R1	K117
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040118,  //  0003  GETMBR	R1	R0	K24
-      0x8C040375,  //  0004  GETMET	R1	R1	K117
-      0x7C040200,  //  0005  CALL	R1	1
-      0x8804011A,  //  0006  GETMBR	R1	R0	K26
-      0x8C040375,  //  0007  GETMET	R1	R1	K117
-      0x7C040200,  //  0008  CALL	R1	1
-      0x88040112,  //  0009  GETMBR	R1	R0	K18
-      0x8C040375,  //  000A  GETMET	R1	R1	K117
-      0x7C040200,  //  000B  CALL	R1	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8810010B,  //  0003  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140923,  //  0008  GETMET	R5	R4	K35
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B0A,  //  000B  EQ	R6	R5	K10
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180532,  //  000E  GETMET	R6	R2	K50
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180539,  //  0014  GETMET	R6	R2	K57
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C003A,  //  0018  LDCONST	R3	K58
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resolve_attribute_read_solo
-********************************************************************/
-be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(resolve_attribute_read_solo),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x8808033F,  //  0000  GETMBR	R2	R1	K63
-      0x880C0340,  //  0001  GETMBR	R3	R1	K64
-      0x88100341,  //  0002  GETMBR	R4	R1	K65
-      0x4C140000,  //  0003  LDNIL	R5
-      0x1C140405,  //  0004  EQ	R5	R2	R5
-      0x74160005,  //  0005  JMPT	R5	#000C
-      0x4C140000,  //  0006  LDNIL	R5
-      0x1C140605,  //  0007  EQ	R5	R3	R5
-      0x74160002,  //  0008  JMPT	R5	#000C
-      0x4C140000,  //  0009  LDNIL	R5
-      0x1C140805,  //  000A  EQ	R5	R4	R5
-      0x78160001,  //  000B  JMPF	R5	#000E
-      0x4C140000,  //  000C  LDNIL	R5
-      0x80040A00,  //  000D  RET	1	R5
-      0x8C140176,  //  000E  GETMET	R5	R0	K118
-      0x5C1C0400,  //  000F  MOVE	R7	R2
-      0x7C140400,  //  0010  CALL	R5	2
-      0x4C180000,  //  0011  LDNIL	R6
-      0x1C180A06,  //  0012  EQ	R6	R5	R6
-      0x781A0005,  //  0013  JMPF	R6	#001A
-      0xB81A0600,  //  0014  GETNGBL	R6	K3
-      0x88180D78,  //  0015  GETMBR	R6	R6	K120
-      0x9006EE06,  //  0016  SETMBR	R1	K119	R6
-      0x4C180000,  //  0017  LDNIL	R6
-      0x80040C00,  //  0018  RET	1	R6
-      0x70020013,  //  0019  JMP		#002E
-      0x8C180B79,  //  001A  GETMET	R6	R5	K121
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x741A0005,  //  001D  JMPT	R6	#0024
-      0xB81A0600,  //  001E  GETNGBL	R6	K3
-      0x88180D7A,  //  001F  GETMBR	R6	R6	K122
-      0x9006EE06,  //  0020  SETMBR	R1	K119	R6
-      0x4C180000,  //  0021  LDNIL	R6
-      0x80040C00,  //  0022  RET	1	R6
-      0x70020009,  //  0023  JMP		#002E
-      0x8C180B7B,  //  0024  GETMET	R6	R5	K123
-      0x5C200600,  //  0025  MOVE	R8	R3
-      0x5C240800,  //  0026  MOVE	R9	R4
-      0x7C180600,  //  0027  CALL	R6	3
-      0x741A0004,  //  0028  JMPT	R6	#002E
-      0xB81A0600,  //  0029  GETNGBL	R6	K3
-      0x88180D7C,  //  002A  GETMBR	R6	R6	K124
-      0x9006EE06,  //  002B  SETMBR	R1	K119	R6
-      0x4C180000,  //  002C  LDNIL	R6
-      0x80040C00,  //  002D  RET	1	R6
-      0x80040A00,  //  002E  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clean_remotes
-********************************************************************/
-be_local_closure(class_Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA406FA00,  //  0000  IMPORT	R1	K125
-      0x8808016C,  //  0001  GETMBR	R2	R0	K108
-      0x780A004B,  //  0002  JMPF	R2	#004F
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x8810016C,  //  0006  GETMBR	R4	R0	K108
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x9808090A,  //  000B  SETIDX	R2	R4	K10
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C003A,  //  000D  LDCONST	R3	K58
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x8810010B,  //  0011  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140369,  //  0016  GETMET	R5	R1	K105
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x5820007E,  //  0018  LDCONST	R8	K126
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C180532,  //  001D  GETMET	R6	R2	K50
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x5824000A,  //  001F  LDCONST	R9	K10
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D21,  //  0021  ADD	R6	R6	K33
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C003A,  //  0024  LDCONST	R3	K58
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0012,  //  0027  GETGBL	R3	G18
-      0x7C0C0000,  //  0028  CALL	R3	0
-      0x60100010,  //  0029  GETGBL	R4	G16
-      0x8C140538,  //  002A  GETMET	R5	R2	K56
-      0x7C140200,  //  002B  CALL	R5	1
-      0x7C100200,  //  002C  CALL	R4	1
-      0xA8020008,  //  002D  EXBLK	0	#0037
-      0x5C140800,  //  002E  MOVE	R5	R4
-      0x7C140000,  //  002F  CALL	R5	0
-      0x94180405,  //  0030  GETIDX	R6	R2	R5
-      0x1C180D0A,  //  0031  EQ	R6	R6	K10
-      0x781A0002,  //  0032  JMPF	R6	#0036
-      0x8C180739,  //  0033  GETMET	R6	R3	K57
-      0x5C200A00,  //  0034  MOVE	R8	R5
-      0x7C180400,  //  0035  CALL	R6	2
-      0x7001FFF6,  //  0036  JMP		#002E
-      0x5810003A,  //  0037  LDCONST	R4	K58
-      0xAC100200,  //  0038  CATCH	R4	1	0
-      0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x60100010,  //  003A  GETGBL	R4	G16
-      0x5C140600,  //  003B  MOVE	R5	R3
-      0x7C100200,  //  003C  CALL	R4	1
-      0xA802000D,  //  003D  EXBLK	0	#004C
-      0x5C140800,  //  003E  MOVE	R5	R4
-      0x7C140000,  //  003F  CALL	R5	0
-      0xB81A4A00,  //  0040  GETNGBL	R6	K37
-      0x881C0B80,  //  0041  GETMBR	R7	R5	K128
-      0x001EFE07,  //  0042  ADD	R7	K127	R7
-      0x58200061,  //  0043  LDCONST	R8	K97
-      0x7C180400,  //  0044  CALL	R6	2
-      0x8C180B54,  //  0045  GETMET	R6	R5	K84
-      0x7C180200,  //  0046  CALL	R6	1
-      0x8818016C,  //  0047  GETMBR	R6	R0	K108
-      0x8C180D72,  //  0048  GETMET	R6	R6	K114
-      0x88200B80,  //  0049  GETMBR	R8	R5	K128
-      0x7C180400,  //  004A  CALL	R6	2
-      0x7001FFF1,  //  004B  JMP		#003E
-      0x5810003A,  //  004C  LDCONST	R4	K58
-      0xAC100200,  //  004D  CATCH	R4	1	0
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_Matter_Device_start,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88040108,  //  0000  GETMBR	R1	R0	K8
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x8C040181,  //  0003  GETMET	R1	R0	K129
-      0x7C040200,  //  0004  CALL	R1	1
-      0x8C040182,  //  0005  GETMET	R1	R0	K130
-      0x880C0183,  //  0006  GETMBR	R3	R0	K131
-      0x7C040400,  //  0007  CALL	R1	2
-      0x88040112,  //  0008  GETMBR	R1	R0	K18
-      0x8C040384,  //  0009  GETMET	R1	R1	K132
-      0x7C040200,  //  000A  CALL	R1	1
-      0x50040200,  //  000B  LDBOOL	R1	1	0
-      0x90021001,  //  000C  SETMBR	R0	K8	R1
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(class_Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080173,  //  0000  GETMBR	R2	R0	K115
-      0x8C080585,  //  0001  GETMET	R2	R2	K133
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: button_handler
-********************************************************************/
-be_local_closure(class_Matter_Device_button_handler,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(button_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x5814000A,  //  0000  LDCONST	R5	K10
-      0xA41AFA00,  //  0001  IMPORT	R6	K125
-      0x601C000C,  //  0002  GETGBL	R7	G12
-      0x8820010B,  //  0003  GETMBR	R8	R0	K11
-      0x7C1C0200,  //  0004  CALL	R7	1
-      0x141C0A07,  //  0005  LT	R7	R5	R7
-      0x781E0010,  //  0006  JMPF	R7	#0018
-      0x881C010B,  //  0007  GETMBR	R7	R0	K11
-      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
-      0x8C200D6D,  //  0009  GETMET	R8	R6	K109
-      0x5C280E00,  //  000A  MOVE	R10	R7
-      0x582C0020,  //  000B  LDCONST	R11	K32
-      0x7C200600,  //  000C  CALL	R8	3
-      0x78220007,  //  000D  JMPF	R8	#0016
-      0x8820010B,  //  000E  GETMBR	R8	R0	K11
-      0x94201005,  //  000F  GETIDX	R8	R8	R5
-      0x8C201120,  //  0010  GETMET	R8	R8	K32
-      0x5C280200,  //  0011  MOVE	R10	R1
-      0x5C2C0400,  //  0012  MOVE	R11	R2
-      0x5C300600,  //  0013  MOVE	R12	R3
-      0x5C340800,  //  0014  MOVE	R13	R4
-      0x7C200A00,  //  0015  CALL	R8	5
-      0x00140B21,  //  0016  ADD	R5	R5	K33
-      0x7001FFE9,  //  0017  JMP		#0002
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_read_sensors_schedule
-********************************************************************/
-be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(add_read_sensors_schedule),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080186,  //  0000  GETMBR	R2	R0	K134
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C080403,  //  0002  EQ	R2	R2	R3
-      0x740A0002,  //  0003  JMPT	R2	#0007
-      0x88080186,  //  0004  GETMBR	R2	R0	K134
-      0x24080401,  //  0005  GT	R2	R2	R1
-      0x780A0005,  //  0006  JMPF	R2	#000D
-      0x90030C01,  //  0007  SETMBR	R0	K134	R1
-      0xB80A0600,  //  0008  GETNGBL	R2	K3
-      0x8C080588,  //  0009  GETMET	R2	R2	K136
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x90030E02,  //  000C  SETMBR	R0	K135	R2
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040389,  //  0001  GETMET	R1	R1	K137
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040173,  //  0004  GETMBR	R1	R0	K115
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040173,  //  0006  GETMBR	R1	R0	K115
-      0x8C04038A,  //  0007  GETMET	R1	R1	K138
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(class_Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080173,  //  0000  GETMBR	R2	R0	K115
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A4A00,  //  0007  GETNGBL	R2	K37
-      0x600C0008,  //  0008  GETGBL	R3	G8
-      0x5C100200,  //  0009  MOVE	R4	R1
+    ( &(const binstruction[50]) {  /* code */
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x7C100200,  //  0009  CALL	R4	1
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x000F1603,  //  000B  ADD	R3	K139	R3
-      0x58100022,  //  000C  LDCONST	R4	K34
-      0x7C080400,  //  000D  CALL	R2	2
-      0xB80A0600,  //  000E  GETNGBL	R2	K3
-      0x8C08058C,  //  000F  GETMET	R2	R2	K140
-      0x5C100000,  //  0010  MOVE	R4	R0
-      0x58140057,  //  0011  LDCONST	R5	K87
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x7C080800,  //  0013  CALL	R2	4
-      0x9002E602,  //  0014  SETMBR	R0	K115	R2
-      0x88080173,  //  0015  GETMBR	R2	R0	K115
-      0x8C08058D,  //  0016  GETMET	R2	R2	K141
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrInfo
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrInfo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrInfo),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x1C140757,  //  0000  EQ	R5	R3	K87
-      0x7815FFFF,  //  0001  JMPF	R5	#0002
-      0x1C140757,  //  0002  EQ	R5	R3	K87
-      0x7816000D,  //  0003  JMPF	R5	#0012
-      0x60140010,  //  0004  GETGBL	R5	G16
-      0x8818010B,  //  0005  GETMBR	R6	R0	K11
-      0x7C140200,  //  0006  CALL	R5	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C180A00,  //  0008  MOVE	R6	R5
-      0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C018E,  //  000A  GETMET	R7	R0	K142
-      0x88240D3F,  //  000B  GETMBR	R9	R6	K63
-      0x7C1C0400,  //  000C  CALL	R7	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x5814003A,  //  000E  LDCONST	R5	K58
-      0xAC140200,  //  000F  CATCH	R5	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x70020011,  //  0011  JMP		#0024
-      0x60140004,  //  0012  GETGBL	R5	G4
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x1C140B8F,  //  0015  EQ	R5	R5	K143
-      0x78160003,  //  0016  JMPF	R5	#001B
-      0x8C14018E,  //  0017  GETMET	R5	R0	K142
-      0x5C1C0800,  //  0018  MOVE	R7	R4
-      0x7C140400,  //  0019  CALL	R5	2
-      0x70020008,  //  001A  JMP		#0024
-      0x8C140190,  //  001B  GETMET	R5	R0	K144
-      0x5C1C0600,  //  001C  MOVE	R7	R3
-      0x7C140400,  //  001D  CALL	R5	2
-      0x4C180000,  //  001E  LDNIL	R6
-      0x20180A06,  //  001F  NE	R6	R5	R6
-      0x781A0002,  //  0020  JMPF	R6	#0024
-      0x8C18018E,  //  0021  GETMET	R6	R0	K142
-      0x88200B3F,  //  0022  GETMBR	R8	R5	K63
-      0x7C180400,  //  0023  CALL	R6	2
-      0xB8160200,  //  0024  GETNGBL	R5	K1
-      0x8C140B3D,  //  0025  GETMET	R5	R5	K61
-      0x7C140200,  //  0026  CALL	R5	1
-      0x80000000,  //  0027  RET	0
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140506,  //  000E  GETMET	R5	R2	K6
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0007,  //  0012  LDCONST	R3	K7
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x04100908,  //  0019  SUB	R4	R4	K8
+      0x40121004,  //  001A  CONNECT	R4	K8	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D09,  //  0021  GT	R7	R6	K9
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D08,  //  0023  SUB	R7	R6	K8
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D08,  //  0027  SUB	R7	R6	K8
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D08,  //  002A  SUB	R6	R6	K8
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0007,  //  002E  LDCONST	R3	K7
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
     })
   )
 );
@@ -1927,24 +3193,24 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
     be_str_weak(MtrInfo_one),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x8C080176,  //  0000  GETMET	R2	R0	K118
+      0x8C080149,  //  0000  GETMET	R2	R0	K73
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C0C0403,  //  0004  EQ	R3	R2	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x80000600,  //  0006  RET	0
-      0x8C0C0591,  //  0007  GETMET	R3	R2	K145
+      0x8C0C0581,  //  0007  GETMET	R3	R2	K129
       0x7C0C0200,  //  0008  CALL	R3	1
       0x780E0008,  //  0009  JMPF	R3	#0013
       0x60100018,  //  000A  GETGBL	R4	G24
-      0x58140092,  //  000B  LDCONST	R5	K146
+      0x581400D1,  //  000B  LDCONST	R5	K209
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
-      0xB8160200,  //  000E  GETNGBL	R5	K1
-      0x8C140B93,  //  000F  GETMET	R5	R5	K147
+      0xB8162000,  //  000E  GETNGBL	R5	K16
+      0x8C140BD2,  //  000F  GETMET	R5	R5	K210
       0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x58200057,  //  0011  LDCONST	R8	K87
+      0x5820000A,  //  0011  LDCONST	R8	K10
       0x7C140600,  //  0012  CALL	R5	3
       0x80000000,  //  0013  RET	0
     })
@@ -1954,119 +3220,9 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
 
 
 /********************************************************************
-** Solidified function: check_network
+** Solidified function: create_zb_mapper
 ********************************************************************/
-be_local_closure(class_Matter_Device_check_network,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(check_network),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x88040108,  //  0000  GETMBR	R1	R0	K8
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0xB8060200,  //  0003  GETNGBL	R1	K1
-      0x8C040394,  //  0004  GETMET	R1	R1	K148
-      0x7C040200,  //  0005  CALL	R1	1
-      0x94040395,  //  0006  GETIDX	R1	R1	K149
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8060200,  //  0008  GETNGBL	R1	K1
-      0x8C040396,  //  0009  GETMET	R1	R1	K150
-      0x7C040200,  //  000A  CALL	R1	1
-      0x94040395,  //  000B  GETIDX	R1	R1	K149
-      0x78060001,  //  000C  JMPF	R1	#000F
-      0x8C04018D,  //  000D  GETMET	R1	R0	K141
-      0x7C040200,  //  000E  CALL	R1	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0xA4068600,  //  0000  IMPORT	R1	K67
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080597,  //  0002  GETMET	R2	R2	K151
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E0200,  //  0004  GETNGBL	R3	K1
-      0x8C0C0798,  //  0005  GETMET	R3	R3	K152
-      0x58140061,  //  0006  LDCONST	R5	K97
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0006,  //  0008  JMPF	R3	#0010
-      0xB80E4A00,  //  0009  GETNGBL	R3	K37
-      0x60100008,  //  000A  GETGBL	R4	G8
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C100200,  //  000C  CALL	R4	1
-      0x00133204,  //  000D  ADD	R4	K153	R4
-      0x58140061,  //  000E  LDCONST	R5	K97
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x4C0C0000,  //  0010  LDNIL	R3
-      0x1C0C0403,  //  0011  EQ	R3	R2	R3
-      0x780E0000,  //  0012  JMPF	R3	#0014
-      0x80000600,  //  0013  RET	0
-      0x8C0C035B,  //  0014  GETMET	R3	R1	K91
-      0x5C140400,  //  0015  MOVE	R5	R2
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x4C100000,  //  0017  LDNIL	R4
-      0x20100604,  //  0018  NE	R4	R3	R4
-      0x7812000D,  //  0019  JMPF	R4	#0028
-      0x5810000A,  //  001A  LDCONST	R4	K10
-      0x6014000C,  //  001B  GETGBL	R5	G12
-      0x8818010B,  //  001C  GETMBR	R6	R0	K11
-      0x7C140200,  //  001D  CALL	R5	1
-      0x14140805,  //  001E  LT	R5	R4	R5
-      0x78160006,  //  001F  JMPF	R5	#0027
-      0x8814010B,  //  0020  GETMBR	R5	R0	K11
-      0x94140A04,  //  0021  GETIDX	R5	R5	R4
-      0x8C140B9A,  //  0022  GETMET	R5	R5	K154
-      0x5C1C0600,  //  0023  MOVE	R7	R3
-      0x7C140400,  //  0024  CALL	R5	2
-      0x00100921,  //  0025  ADD	R4	R4	K33
-      0x7001FFF3,  //  0026  JMP		#001B
-      0x70020006,  //  0027  JMP		#002F
-      0xB8124A00,  //  0028  GETNGBL	R4	K37
-      0x60140008,  //  0029  GETGBL	R5	G8
-      0x5C180400,  //  002A  MOVE	R6	R2
-      0x7C140200,  //  002B  CALL	R5	1
-      0x00173605,  //  002C  ADD	R5	K155	R5
-      0x58180061,  //  002D  LDCONST	R6	K97
-      0x7C100400,  //  002E  CALL	R4	2
-      0x80000000,  //  002F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_arg
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
+be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -2077,18 +3233,17 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_class_arg),
+    be_str_weak(create_zb_mapper),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8808019C,  //  0000  GETMBR	R2	R0	K156
-      0x8C080532,  //  0001  GETMET	R2	R2	K50
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C059D,  //  0005  GETMBR	R3	R2	K157
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0057,  //  0007  LDCONST	R3	K87
-      0x80040600,  //  0008  RET	1	R3
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88080168,  //  0000  GETMBR	R2	R0	K104
+      0x780A0004,  //  0001  JMPF	R2	#0007
+      0x88080168,  //  0002  GETMBR	R2	R0	K104
+      0x8C0805D3,  //  0003  GETMET	R2	R2	K211
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80040400,  //  0006  RET	1	R2
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -2096,102 +3251,11 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
 
 
 /********************************************************************
-** Solidified function: bridge_add_endpoint
+** Solidified function: start
 ********************************************************************/
-be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
+be_local_closure(class_Matter_Device_start,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(bridge_add_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0x880C019C,  //  0000  GETMBR	R3	R0	K156
-      0x8C0C0732,  //  0001  GETMET	R3	R3	K50
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0xB8124A00,  //  0007  GETNGBL	R4	K37
-      0x60140008,  //  0008  GETGBL	R5	G8
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C140200,  //  000A  CALL	R5	1
-      0x00173C05,  //  000B  ADD	R5	K158	R5
-      0x00140B9F,  //  000C  ADD	R5	R5	K159
-      0x58180061,  //  000D  LDCONST	R6	K97
-      0x7C100400,  //  000E  CALL	R4	2
-      0x80000800,  //  000F  RET	0
-      0x8810010E,  //  0010  GETMBR	R4	R0	K14
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x5C180800,  //  0012  MOVE	R6	R4
-      0x7C140200,  //  0013  CALL	R5	1
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x5C1C0000,  //  0015  MOVE	R7	R0
-      0x5C200800,  //  0016  MOVE	R8	R4
-      0x5C240400,  //  0017  MOVE	R9	R2
-      0x7C180600,  //  0018  CALL	R6	3
-      0x881C010B,  //  0019  GETMBR	R7	R0	K11
-      0x8C1C0F39,  //  001A  GETMET	R7	R7	K57
-      0x5C240C00,  //  001B  MOVE	R9	R6
-      0x7C1C0400,  //  001C  CALL	R7	2
-      0x601C0013,  //  001D  GETGBL	R7	G19
-      0x7C1C0000,  //  001E  CALL	R7	0
-      0x981F4001,  //  001F  SETIDX	R7	K160	R1
-      0x60200010,  //  0020  GETGBL	R8	G16
-      0x8C240538,  //  0021  GETMET	R9	R2	K56
-      0x7C240200,  //  0022  CALL	R9	1
-      0x7C200200,  //  0023  CALL	R8	1
-      0xA8020004,  //  0024  EXBLK	0	#002A
-      0x5C241000,  //  0025  MOVE	R9	R8
-      0x7C240000,  //  0026  CALL	R9	0
-      0x94280409,  //  0027  GETIDX	R10	R2	R9
-      0x981C120A,  //  0028  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  0029  JMP		#0025
-      0x5820003A,  //  002A  LDCONST	R8	K58
-      0xAC200200,  //  002B  CATCH	R8	1	0
-      0xB0080000,  //  002C  RAISE	2	R0	R0
-      0xB8224A00,  //  002D  GETNGBL	R8	K37
-      0x60240018,  //  002E  GETGBL	R9	G24
-      0x582800A1,  //  002F  LDCONST	R10	K161
-      0x5C2C0800,  //  0030  MOVE	R11	R4
-      0x5C300200,  //  0031  MOVE	R12	R1
-      0x8C3401A2,  //  0032  GETMET	R13	R0	K162
-      0x5C3C0400,  //  0033  MOVE	R15	R2
-      0x7C340400,  //  0034  CALL	R13	2
-      0x7C240800,  //  0035  CALL	R9	4
-      0x58280022,  //  0036  LDCONST	R10	K34
-      0x7C200400,  //  0037  CALL	R8	2
-      0x8820014E,  //  0038  GETMBR	R8	R0	K78
-      0x98200A07,  //  0039  SETIDX	R8	R5	R7
-      0x50200200,  //  003A  LDBOOL	R8	1	0
-      0x90021808,  //  003B  SETMBR	R0	K12	R8
-      0x8820010E,  //  003C  GETMBR	R8	R0	K14
-      0x00201121,  //  003D  ADD	R8	R8	K33
-      0x90021C08,  //  003E  SETMBR	R0	K14	R8
-      0x8C20016B,  //  003F  GETMET	R8	R0	K107
-      0x7C200200,  //  0040  CALL	R8	1
-      0x8C2001A3,  //  0041  GETMET	R8	R0	K163
-      0x7C200200,  //  0042  CALL	R8	1
-      0x80040800,  //  0043  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: signal_endpoints_changed
-********************************************************************/
-be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -2200,985 +3264,23 @@ be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(signal_endpoints_changed),
+    be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8C0401A4,  //  0000  GETMET	R1	R0	K164
-      0x580C000A,  //  0001  LDCONST	R3	K10
-      0x5412001C,  //  0002  LDINT	R4	29
-      0x58140061,  //  0003  LDCONST	R5	K97
-      0x50180000,  //  0004  LDBOOL	R6	0	0
-      0x7C040A00,  //  0005  CALL	R1	5
-      0x8C0401A4,  //  0006  GETMET	R1	R0	K164
-      0xB80E0600,  //  0007  GETNGBL	R3	K3
-      0x880C07A5,  //  0008  GETMBR	R3	R3	K165
-      0x5412001C,  //  0009  LDINT	R4	29
-      0x58140061,  //  000A  LDCONST	R5	K97
-      0x50180000,  //  000B  LDBOOL	R6	0	0
-      0x7C040A00,  //  000C  CALL	R1	5
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_50ms
-********************************************************************/
-be_local_closure(class_Matter_Device_every_50ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_50ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C0401A6,  //  0000  GETMET	R1	R0	K166
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040109,  //  0002  GETMBR	R1	R0	K9
-      0x00040321,  //  0003  ADD	R1	R1	K33
-      0x90021201,  //  0004  SETMBR	R0	K9	R1
-      0x88040118,  //  0005  GETMBR	R1	R0	K24
-      0x8C0403A7,  //  0006  GETMET	R1	R1	K167
-      0x7C040200,  //  0007  CALL	R1	1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reset_param
-********************************************************************/
-be_local_closure(class_Matter_Device_reset_param,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(reset_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90021801,  //  0001  SETMBR	R0	K12	R1
-      0x8804010F,  //  0002  GETMBR	R1	R0	K15
-      0x90021C01,  //  0003  SETMBR	R0	K14	R1
-      0x8C04016B,  //  0004  GETMET	R1	R0	K107
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: conf_to_log
-********************************************************************/
-be_local_closure(class_Matter_Device_conf_to_log,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(conf_to_log),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040037,  //  0000  LDCONST	R1	K55
-      0x58080057,  //  0001  LDCONST	R2	K87
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C1003A8,  //  0003  GETMET	R4	R1	K168
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA802000B,  //  0007  EXBLK	0	#0014
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x1C1409A0,  //  000A  EQ	R5	R4	K160
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x7001FFFA,  //  000C  JMP		#0008
-      0x60140018,  //  000D  GETGBL	R5	G24
-      0x581800A9,  //  000E  LDCONST	R6	K169
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x94200004,  //  0010  GETIDX	R8	R0	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x00080405,  //  0012  ADD	R2	R2	R5
-      0x7001FFF3,  //  0013  JMP		#0008
-      0x580C003A,  //  0014  LDCONST	R3	K58
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l_num
-********************************************************************/
-be_local_closure(class_Matter_Device_k2l_num,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(k2l_num),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x58040037,  //  0000  LDCONST	R1	K55
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100138,  //  0008  GETMET	R4	R0	K56
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020007,  //  000B  EXBLK	0	#0014
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140539,  //  000E  GETMET	R5	R2	K57
-      0x601C0009,  //  000F  GETGBL	R7	G9
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C140400,  //  0012  CALL	R5	2
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x580C003A,  //  0014  LDCONST	R3	K58
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x600C0010,  //  0017  GETGBL	R3	G16
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x7C100200,  //  001A  CALL	R4	1
-      0x04100921,  //  001B  SUB	R4	R4	K33
-      0x40124204,  //  001C  CONNECT	R4	K33	R4
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x94140404,  //  0021  GETIDX	R5	R2	R4
-      0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D0A,  //  0023  GT	R7	R6	K10
-      0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D21,  //  0025  SUB	R7	R6	K33
-      0x941C0407,  //  0026  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0027  GT	R7	R7	R5
-      0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D21,  //  0029  SUB	R7	R6	K33
-      0x941C0407,  //  002A  GETIDX	R7	R2	R7
-      0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D21,  //  002C  SUB	R6	R6	K33
-      0x7001FFF4,  //  002D  JMP		#0023
-      0x98080C05,  //  002E  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C003A,  //  0030  LDCONST	R3	K58
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80040400,  //  0033  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrUpdate
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrUpdate),
-    &be_const_str_solidified,
-    ( &(const binstruction[126]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160004,  //  0002  JMPF	R5	#0008
-      0xB8160200,  //  0003  GETNGBL	R5	K1
-      0x8C140BAA,  //  0004  GETMET	R5	R5	K170
-      0x581C00AB,  //  0005  LDCONST	R7	K171
-      0x7C140400,  //  0006  CALL	R5	2
-      0x80040A00,  //  0007  RET	1	R5
-      0xB8160200,  //  0008  GETNGBL	R5	K1
-      0x8C140BAC,  //  0009  GETMET	R5	R5	K172
-      0x5C1C0800,  //  000A  MOVE	R7	R4
-      0x582000AD,  //  000B  LDCONST	R8	K173
-      0x7C140600,  //  000C  CALL	R5	3
-      0xB81A0200,  //  000D  GETNGBL	R6	K1
-      0x8C180DAC,  //  000E  GETMET	R6	R6	K172
-      0x5C200800,  //  000F  MOVE	R8	R4
-      0x582400AE,  //  0010  LDCONST	R9	K174
-      0x7C180600,  //  0011  CALL	R6	3
-      0x74160000,  //  0012  JMPT	R5	#0014
-      0x781A0064,  //  0013  JMPF	R6	#0079
-      0x4C1C0000,  //  0014  LDNIL	R7
-      0x78160010,  //  0015  JMPF	R5	#0027
-      0x60200009,  //  0016  GETGBL	R8	G9
-      0x94240805,  //  0017  GETIDX	R9	R4	R5
-      0x7C200200,  //  0018  CALL	R8	1
-      0x1824110A,  //  0019  LE	R9	R8	K10
-      0x78260004,  //  001A  JMPF	R9	#0020
-      0xB8260200,  //  001B  GETNGBL	R9	K1
-      0x8C2413AA,  //  001C  GETMET	R9	R9	K170
-      0x582C00AF,  //  001D  LDCONST	R11	K175
-      0x7C240400,  //  001E  CALL	R9	2
-      0x80041200,  //  001F  RET	1	R9
-      0x8C240176,  //  0020  GETMET	R9	R0	K118
-      0x5C2C1000,  //  0021  MOVE	R11	R8
-      0x7C240400,  //  0022  CALL	R9	2
-      0x5C1C1200,  //  0023  MOVE	R7	R9
-      0x8C240972,  //  0024  GETMET	R9	R4	K114
-      0x5C2C0A00,  //  0025  MOVE	R11	R5
-      0x7C240400,  //  0026  CALL	R9	2
-      0x781A0009,  //  0027  JMPF	R6	#0032
-      0x4C200000,  //  0028  LDNIL	R8
-      0x1C200E08,  //  0029  EQ	R8	R7	R8
-      0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C200190,  //  002B  GETMET	R8	R0	K144
-      0x94280806,  //  002C  GETIDX	R10	R4	R6
-      0x7C200400,  //  002D  CALL	R8	2
-      0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x8C200972,  //  002F  GETMET	R8	R4	K114
-      0x5C280C00,  //  0030  MOVE	R10	R6
-      0x7C200400,  //  0031  CALL	R8	2
-      0x4C200000,  //  0032  LDNIL	R8
-      0x1C200E08,  //  0033  EQ	R8	R7	R8
-      0x78220004,  //  0034  JMPF	R8	#003A
-      0xB8220200,  //  0035  GETNGBL	R8	K1
-      0x8C2011AA,  //  0036  GETMET	R8	R8	K170
-      0x582800B0,  //  0037  LDCONST	R10	K176
-      0x7C200400,  //  0038  CALL	R8	2
-      0x80041000,  //  0039  RET	1	R8
-      0x88200FB1,  //  003A  GETMBR	R8	R7	K177
-      0x74220004,  //  003B  JMPT	R8	#0041
-      0xB8220200,  //  003C  GETNGBL	R8	K1
-      0x8C2011AA,  //  003D  GETMET	R8	R8	K170
-      0x582800B2,  //  003E  LDCONST	R10	K178
-      0x7C200400,  //  003F  CALL	R8	2
-      0x80041000,  //  0040  RET	1	R8
-      0x8C200FB3,  //  0041  GETMET	R8	R7	K179
-      0x7C200200,  //  0042  CALL	R8	1
-      0x60240013,  //  0043  GETGBL	R9	G19
-      0x7C240000,  //  0044  CALL	R9	0
-      0x60280010,  //  0045  GETGBL	R10	G16
-      0x8C2C0938,  //  0046  GETMET	R11	R4	K56
-      0x7C2C0200,  //  0047  CALL	R11	1
-      0x7C280200,  //  0048  CALL	R10	1
-      0xA8020016,  //  0049  EXBLK	0	#0061
-      0x5C2C1400,  //  004A  MOVE	R11	R10
-      0x7C2C0000,  //  004B  CALL	R11	0
-      0xB8320200,  //  004C  GETNGBL	R12	K1
-      0x8C3019B4,  //  004D  GETMET	R12	R12	K180
-      0x5C381000,  //  004E  MOVE	R14	R8
-      0x5C3C1600,  //  004F  MOVE	R15	R11
-      0x7C300600,  //  0050  CALL	R12	3
-      0x4C340000,  //  0051  LDNIL	R13
-      0x1C34180D,  //  0052  EQ	R13	R12	R13
-      0x78360008,  //  0053  JMPF	R13	#005D
-      0xB8360200,  //  0054  GETNGBL	R13	K1
-      0x8C341BAA,  //  0055  GETMET	R13	R13	K170
-      0x603C0018,  //  0056  GETGBL	R15	G24
-      0x584000B5,  //  0057  LDCONST	R16	K181
-      0x5C441600,  //  0058  MOVE	R17	R11
-      0x7C3C0400,  //  0059  CALL	R15	2
-      0x7C340400,  //  005A  CALL	R13	2
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x80001A00,  //  005C  RET	0
-      0x9434100C,  //  005D  GETIDX	R13	R8	R12
-      0x9438080B,  //  005E  GETIDX	R14	R4	R11
-      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
-      0x7001FFE8,  //  0060  JMP		#004A
-      0x5828003A,  //  0061  LDCONST	R10	K58
-      0xAC280200,  //  0062  CATCH	R10	1	0
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x8C280FB6,  //  0064  GETMET	R10	R7	K182
-      0x5C301200,  //  0065  MOVE	R12	R9
-      0x7C280400,  //  0066  CALL	R10	2
-      0x8C280F91,  //  0067  GETMET	R10	R7	K145
-      0x7C280200,  //  0068  CALL	R10	1
-      0x782A000A,  //  0069  JMPF	R10	#0075
-      0x602C0018,  //  006A  GETGBL	R11	G24
-      0x583000B7,  //  006B  LDCONST	R12	K183
-      0x5C340200,  //  006C  MOVE	R13	R1
-      0x5C381400,  //  006D  MOVE	R14	R10
-      0x7C2C0600,  //  006E  CALL	R11	3
-      0xB8320200,  //  006F  GETNGBL	R12	K1
-      0x8C3019B8,  //  0070  GETMET	R12	R12	K184
-      0x5C381600,  //  0071  MOVE	R14	R11
-      0x7C300400,  //  0072  CALL	R12	2
-      0x80041800,  //  0073  RET	1	R12
-      0x70020003,  //  0074  JMP		#0079
-      0xB82E0200,  //  0075  GETNGBL	R11	K1
-      0x8C2C173D,  //  0076  GETMET	R11	R11	K61
-      0x7C2C0200,  //  0077  CALL	R11	1
-      0x80041600,  //  0078  RET	1	R11
-      0xB81E0200,  //  0079  GETNGBL	R7	K1
-      0x8C1C0FAA,  //  007A  GETMET	R7	R7	K170
-      0x582400B9,  //  007B  LDCONST	R9	K185
-      0x7C1C0400,  //  007C  CALL	R7	2
-      0x80000000,  //  007D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_fabrics_saved
-********************************************************************/
-be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
-      0x8C0403BA,  //  0001  GETMET	R1	R1	K186
-      0x7C040200,  //  0002  CALL	R1	1
-      0x2404030A,  //  0003  GT	R1	R1	K10
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x8804010C,  //  0005  GETMBR	R1	R0	K12
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90021801,  //  0008  SETMBR	R0	K12	R1
-      0x8C04016B,  //  0009  GETMET	R1	R0	K107
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_attribute_expansion
-********************************************************************/
-be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(process_attribute_expansion),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x880C033F,  //  0000  GETMBR	R3	R1	K63
-      0x88100340,  //  0001  GETMBR	R4	R1	K64
-      0x88140341,  //  0002  GETMBR	R5	R1	K65
-      0xB81A0600,  //  0003  GETNGBL	R6	K3
-      0x8C180DBB,  //  0004  GETMET	R6	R6	K187
-      0x5C200000,  //  0005  MOVE	R8	R0
-      0x7C180400,  //  0006  CALL	R6	2
-      0x8C1C0D8D,  //  0007  GETMET	R7	R6	K141
-      0x5C240600,  //  0008  MOVE	R9	R3
-      0x5C280800,  //  0009  MOVE	R10	R4
-      0x5C2C0A00,  //  000A  MOVE	R11	R5
-      0x7C1C0800,  //  000B  CALL	R7	4
-      0x8C1C0DBC,  //  000C  GETMET	R7	R6	K188
-      0x7C1C0200,  //  000D  CALL	R7	1
-      0x4C200000,  //  000E  LDNIL	R8
-      0x8C240DBD,  //  000F  GETMET	R9	R6	K189
-      0x7C240200,  //  0010  CALL	R9	1
-      0x5C201200,  //  0011  MOVE	R8	R9
-      0x4C280000,  //  0012  LDNIL	R10
-      0x2024120A,  //  0013  NE	R9	R9	R10
-      0x78260005,  //  0014  JMPF	R9	#001B
-      0x5C240400,  //  0015  MOVE	R9	R2
-      0x8C280DBE,  //  0016  GETMET	R10	R6	K190
-      0x7C280200,  //  0017  CALL	R10	1
-      0x5C2C1000,  //  0018  MOVE	R11	R8
-      0x7C240400,  //  0019  CALL	R9	2
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(class_Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x5810000A,  //  0000  LDCONST	R4	K10
-      0x8814073F,  //  0001  GETMBR	R5	R3	K63
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C010B,  //  0003  GETMBR	R7	R0	K11
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x8818010B,  //  0007  GETMBR	R6	R0	K11
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D3F,  //  0009  GETMBR	R7	R6	K63
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0DBF,  //  000C  GETMET	R7	R6	K191
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100921,  //  0012  ADD	R4	R4	K33
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0600,  //  0014  GETNGBL	R6	K3
-      0x88180D78,  //  0015  GETMBR	R6	R6	K120
-      0x900EEE06,  //  0016  SETMBR	R3	K119	R6
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_remotes_info
-********************************************************************/
-be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(update_remotes_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x8808016C,  //  0002  GETMBR	R2	R0	K108
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0018,  //  0005  JMPF	R2	#001F
-      0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C016C,  //  0007  GETMBR	R3	R0	K108
-      0x8C0C0738,  //  0008  GETMET	R3	R3	K56
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7C080200,  //  000A  CALL	R2	1
-      0xA802000F,  //  000B  EXBLK	0	#001C
-      0x5C0C0400,  //  000C  MOVE	R3	R2
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x8810016C,  //  000E  GETMBR	R4	R0	K108
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C1009C0,  //  0010  GETMET	R4	R4	K192
-      0x7C100200,  //  0011  CALL	R4	1
-      0x4C140000,  //  0012  LDNIL	R5
-      0x20140805,  //  0013  NE	R5	R4	R5
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180800,  //  0016  MOVE	R6	R4
-      0x7C140200,  //  0017  CALL	R5	1
-      0x24140B0A,  //  0018  GT	R5	R5	K10
-      0x78160000,  //  0019  JMPF	R5	#001B
-      0x98040604,  //  001A  SETIDX	R1	R3	R4
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x5808003A,  //  001C  LDCONST	R2	K58
-      0xAC080200,  //  001D  CATCH	R2	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90021A01,  //  001F  SETMBR	R0	K13	R1
-      0x80040200,  //  0020  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8808019C,  //  0000  GETMBR	R2	R0	K156
-      0x8C080532,  //  0001  GETMET	R2	R2	K50
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C05C1,  //  0005  GETMBR	R3	R2	K193
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0057,  //  0007  LDCONST	R3	K87
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_remove_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(bridge_remove_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0xA40A8600,  //  0000  IMPORT	R2	K67
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x4C140000,  //  0005  LDNIL	R5
-      0x8818014E,  //  0006  GETMBR	R6	R0	K78
-      0x8C180D6D,  //  0007  GETMET	R6	R6	K109
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x741A0004,  //  000A  JMPT	R6	#0010
-      0xB81A4A00,  //  000B  GETNGBL	R6	K37
-      0x001F8403,  //  000C  ADD	R7	K194	R3
-      0x58200061,  //  000D  LDCONST	R8	K97
-      0x7C180400,  //  000E  CALL	R6	2
-      0x80000C00,  //  000F  RET	0
-      0xB81A4A00,  //  0010  GETNGBL	R6	K37
-      0x601C0018,  //  0011  GETGBL	R7	G24
-      0x582000C3,  //  0012  LDCONST	R8	K195
-      0x5C240200,  //  0013  MOVE	R9	R1
-      0x7C1C0400,  //  0014  CALL	R7	2
-      0x58200022,  //  0015  LDCONST	R8	K34
-      0x7C180400,  //  0016  CALL	R6	2
-      0x8818014E,  //  0017  GETMBR	R6	R0	K78
-      0x8C180D72,  //  0018  GETMET	R6	R6	K114
-      0x5C200600,  //  0019  MOVE	R8	R3
-      0x7C180400,  //  001A  CALL	R6	2
-      0x50180200,  //  001B  LDBOOL	R6	1	0
-      0x90021806,  //  001C  SETMBR	R0	K12	R6
-      0x5818000A,  //  001D  LDCONST	R6	K10
-      0x601C000C,  //  001E  GETGBL	R7	G12
-      0x8820010B,  //  001F  GETMBR	R8	R0	K11
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x141C0C07,  //  0021  LT	R7	R6	R7
-      0x781E000D,  //  0022  JMPF	R7	#0031
-      0x881C010B,  //  0023  GETMBR	R7	R0	K11
-      0x941C0E06,  //  0024  GETIDX	R7	R7	R6
-      0x8C1C0F23,  //  0025  GETMET	R7	R7	K35
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x1C1C0207,  //  0027  EQ	R7	R1	R7
-      0x781E0005,  //  0028  JMPF	R7	#002F
-      0x881C010B,  //  0029  GETMBR	R7	R0	K11
-      0x8C1C0F72,  //  002A  GETMET	R7	R7	K114
-      0x5C240C00,  //  002B  MOVE	R9	R6
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x70020002,  //  002D  JMP		#0031
-      0x70020000,  //  002E  JMP		#0030
-      0x00180D21,  //  002F  ADD	R6	R6	K33
-      0x7001FFEC,  //  0030  JMP		#001E
-      0x8C1C01C4,  //  0031  GETMET	R7	R0	K196
-      0x7C1C0200,  //  0032  CALL	R7	1
-      0x8C1C016B,  //  0033  GETMET	R7	R0	K107
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C01A3,  //  0035  GETMET	R7	R0	K163
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0x80000000,  //  0037  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_config_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_check_config_ep,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(check_config_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x600C0010,  //  0003  GETGBL	R3	G16
-      0x8810014E,  //  0004  GETMBR	R4	R0	K78
-      0x8C100938,  //  0005  GETMET	R4	R4	K56
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020007,  //  0008  EXBLK	0	#0011
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x8C140539,  //  000B  GETMET	R5	R2	K57
-      0x601C0009,  //  000C  GETGBL	R7	G9
-      0x5C200800,  //  000D  MOVE	R8	R4
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x7001FFF7,  //  0010  JMP		#0009
-      0x580C003A,  //  0011  LDCONST	R3	K58
-      0xAC0C0200,  //  0012  CATCH	R3	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x600C0010,  //  0014  GETGBL	R3	G16
-      0x5C100400,  //  0015  MOVE	R4	R2
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0xA8020030,  //  0017  EXBLK	0	#0049
-      0x5C100600,  //  0018  MOVE	R4	R3
-      0x7C100000,  //  0019  CALL	R4	0
-      0x1C14090A,  //  001A  EQ	R5	R4	K10
-      0x7816000B,  //  001B  JMPF	R5	#0028
-      0xB8164A00,  //  001C  GETNGBL	R5	K37
-      0x581800C5,  //  001D  LDCONST	R6	K197
-      0x581C0022,  //  001E  LDCONST	R7	K34
-      0x7C140400,  //  001F  CALL	R5	2
-      0x8814014E,  //  0020  GETMBR	R5	R0	K78
-      0x8C140B72,  //  0021  GETMET	R5	R5	K114
-      0x601C0008,  //  0022  GETGBL	R7	G8
-      0x5C200800,  //  0023  MOVE	R8	R4
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x7C140400,  //  0025  CALL	R5	2
-      0x50040200,  //  0026  LDBOOL	R1	1	0
-      0x7002001F,  //  0027  JMP		#0048
-      0xB8160600,  //  0028  GETNGBL	R5	K3
-      0x88140BA5,  //  0029  GETMBR	R5	R5	K165
-      0x1C140805,  //  002A  EQ	R5	R4	R5
-      0x7816001B,  //  002B  JMPF	R5	#0048
-      0x50040200,  //  002C  LDBOOL	R1	1	0
-      0xB8164A00,  //  002D  GETNGBL	R5	K37
-      0x60180018,  //  002E  GETGBL	R6	G24
-      0x581C00C6,  //  002F  LDCONST	R7	K198
-      0x5C200800,  //  0030  MOVE	R8	R4
-      0x8824010E,  //  0031  GETMBR	R9	R0	K14
-      0x7C180600,  //  0032  CALL	R6	3
-      0x581C0022,  //  0033  LDCONST	R7	K34
-      0x7C140400,  //  0034  CALL	R5	2
-      0x60140008,  //  0035  GETGBL	R5	G8
-      0x8818010E,  //  0036  GETMBR	R6	R0	K14
-      0x7C140200,  //  0037  CALL	R5	1
-      0x8818014E,  //  0038  GETMBR	R6	R0	K78
-      0x601C0008,  //  0039  GETGBL	R7	G8
-      0x5C200800,  //  003A  MOVE	R8	R4
-      0x7C1C0200,  //  003B  CALL	R7	1
-      0x8820014E,  //  003C  GETMBR	R8	R0	K78
-      0x941C1007,  //  003D  GETIDX	R7	R8	R7
-      0x98180A07,  //  003E  SETIDX	R6	R5	R7
-      0x8814014E,  //  003F  GETMBR	R5	R0	K78
-      0x8C140B72,  //  0040  GETMET	R5	R5	K114
-      0x601C0008,  //  0041  GETGBL	R7	G8
-      0x5C200800,  //  0042  MOVE	R8	R4
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x7C140400,  //  0044  CALL	R5	2
-      0x8814010E,  //  0045  GETMBR	R5	R0	K14
-      0x00140B21,  //  0046  ADD	R5	R5	K33
-      0x90021C05,  //  0047  SETMBR	R0	K14	R5
-      0x7001FFCE,  //  0048  JMP		#0018
-      0x580C003A,  //  0049  LDCONST	R3	K58
-      0xAC0C0200,  //  004A  CATCH	R3	1	0
-      0xB0080000,  //  004B  RAISE	2	R0	R0
-      0x80040200,  //  004C  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_sensors_scheduler
-********************************************************************/
-be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(read_sensors_scheduler),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040186,  //  0000  GETMBR	R1	R0	K134
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0x88040187,  //  0005  GETMBR	R1	R0	K135
-      0x1C04030A,  //  0006  EQ	R1	R1	K10
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8060200,  //  0008  GETNGBL	R1	K1
-      0x8C0403C7,  //  0009  GETMET	R1	R1	K199
-      0x880C0187,  //  000A  GETMBR	R3	R0	K135
-      0x7C040400,  //  000B  CALL	R1	2
-      0x78060006,  //  000C  JMPF	R1	#0014
-      0x8C0401C8,  //  000D  GETMET	R1	R0	K200
-      0x7C040200,  //  000E  CALL	R1	1
-      0xB8060200,  //  000F  GETNGBL	R1	K1
-      0x8C0403C9,  //  0010  GETMET	R1	R1	K201
-      0x880C0186,  //  0011  GETMBR	R3	R0	K134
-      0x7C040400,  //  0012  CALL	R1	2
-      0x90030E01,  //  0013  SETMBR	R0	K135	R1
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(class_Matter_Device_save_before_restart,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040112,  //  0000  GETMBR	R1	R0	K18
-      0x8C04033C,  //  0001  GETMET	R1	R1	K60
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040112,  //  0003  GETMBR	R1	R0	K18
-      0x8C0403CA,  //  0004  GETMET	R1	R1	K202
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x8808014E,  //  0001  GETMBR	R2	R0	K78
-      0x8C080538,  //  0002  GETMET	R2	R2	K56
-      0x7C080200,  //  0003  CALL	R2	1
+      0x8804015D,  //  0000  GETMBR	R1	R0	K93
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x8C0401D4,  //  0003  GETMET	R1	R0	K212
       0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x8810010E,  //  000B  GETMBR	R4	R0	K14
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x00100721,  //  000E  ADD	R4	R3	K33
-      0x90021C04,  //  000F  SETMBR	R0	K14	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x5804003A,  //  0011  LDCONST	R1	K58
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(class_Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x8C0401CB,  //  0000  GETMET	R1	R0	K203
-      0x7C040200,  //  0001  CALL	R1	1
-      0x5804000A,  //  0002  LDCONST	R1	K10
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C010B,  //  0004  GETMBR	R3	R0	K11
-      0x7C080200,  //  0005  CALL	R2	1
-      0x14080202,  //  0006  LT	R2	R1	R2
-      0x780A0005,  //  0007  JMPF	R2	#000E
-      0x8808010B,  //  0008  GETMBR	R2	R0	K11
-      0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C0805CC,  //  000A  GETMET	R2	R2	K204
-      0x7C080200,  //  000B  CALL	R2	1
-      0x00040321,  //  000C  ADD	R1	R1	K33
-      0x7001FFF4,  //  000D  JMP		#0003
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_device
-********************************************************************/
-be_local_closure(class_Matter_Device_autoconf_device,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(autoconf_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0xA4068600,  //  0000  IMPORT	R1	K67
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C010B,  //  0002  GETMBR	R3	R0	K11
-      0x7C080200,  //  0003  CALL	R2	1
-      0x2408050A,  //  0004  GT	R2	R2	K10
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x880801CD,  //  0007  GETMBR	R2	R0	K205
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x1C080403,  //  0009  EQ	R2	R2	R3
-      0x780A0004,  //  000A  JMPF	R2	#0010
-      0xB80A0600,  //  000B  GETNGBL	R2	K3
-      0x8C0805CE,  //  000C  GETMET	R2	R2	K206
-      0x5C100000,  //  000D  MOVE	R4	R0
-      0x7C080400,  //  000E  CALL	R2	2
-      0x90039A02,  //  000F  SETMBR	R0	K205	R2
-      0x8808010C,  //  0010  GETMBR	R2	R0	K12
-      0x740A000F,  //  0011  JMPT	R2	#0022
-      0x880801CD,  //  0012  GETMBR	R2	R0	K205
-      0x8C0805CF,  //  0013  GETMET	R2	R2	K207
-      0x7C080200,  //  0014  CALL	R2	1
-      0x90029C02,  //  0015  SETMBR	R0	K78	R2
-      0x60080013,  //  0016  GETGBL	R2	G19
-      0x7C080000,  //  0017  CALL	R2	0
-      0x90021A02,  //  0018  SETMBR	R0	K13	R2
-      0x8C080162,  //  0019  GETMET	R2	R0	K98
-      0x7C080200,  //  001A  CALL	R2	1
-      0xB80A4A00,  //  001B  GETNGBL	R2	K37
-      0x600C0008,  //  001C  GETGBL	R3	G8
-      0x8810014E,  //  001D  GETMBR	R4	R0	K78
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x000FA003,  //  001F  ADD	R3	K208	R3
-      0x58100061,  //  0020  LDCONST	R4	K97
-      0x7C080400,  //  0021  CALL	R2	2
-      0x880801CD,  //  0022  GETMBR	R2	R0	K205
-      0x8C0805D1,  //  0023  GETMET	R2	R2	K209
-      0x8810014E,  //  0024  GETMBR	R4	R0	K78
-      0x7C080400,  //  0025  CALL	R2	2
-      0x8808010C,  //  0026  GETMBR	R2	R0	K12
-      0x740A0008,  //  0027  JMPT	R2	#0031
-      0x88080115,  //  0028  GETMBR	R2	R0	K21
-      0x8C0805BA,  //  0029  GETMET	R2	R2	K186
-      0x7C080200,  //  002A  CALL	R2	1
-      0x2408050A,  //  002B  GT	R2	R2	K10
-      0x780A0003,  //  002C  JMPF	R2	#0031
-      0x50080200,  //  002D  LDBOOL	R2	1	0
-      0x90021802,  //  002E  SETMBR	R0	K12	R2
-      0x8C08016B,  //  002F  GETMET	R2	R0	K107
-      0x7C080200,  //  0030  CALL	R2	1
-      0x80000000,  //  0031  RET	0
+      0x8C0401D5,  //  0005  GETMET	R1	R0	K213
+      0x880C01D6,  //  0006  GETMBR	R3	R0	K214
+      0x7C040400,  //  0007  CALL	R1	2
+      0x88040160,  //  0008  GETMBR	R1	R0	K96
+      0x8C0403D7,  //  0009  GETMET	R1	R1	K215
+      0x7C040200,  //  000A  CALL	R1	1
+      0x50040200,  //  000B  LDBOOL	R1	1	0
+      0x9002BA01,  //  000C  SETMBR	R0	K93	R1
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -3189,146 +3291,153 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    23,
+    24,
     NULL,
-    be_nested_map(80,
+    be_nested_map(84,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(probe_sensor_time, 5), be_const_var(21) },
-        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
-        { be_const_key_weak(button_multi_pressed, -1), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(16) },
-        { be_const_key_weak(find_plugin_by_endpoint, 75), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(every_250ms, 9), be_const_closure(class_Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(remove_fabric, 47), be_const_closure(class_Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(msg_received, 64), be_const_closure(class_Matter_Device_msg_received_closure) },
-        { be_const_key_weak(plugins_classes, 61), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(53,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(occupancy, -1), be_const_class(be_class_Matter_Plugin_Sensor_Occupancy) },
-        { be_const_key_weak(pressure, -1), be_const_class(be_class_Matter_Plugin_Sensor_Pressure) },
-        { be_const_key_weak(http_light2, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light2) },
-        { be_const_key_weak(v_contact, 36), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Contact) },
-        { be_const_key_weak(v_occupancy, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Occupancy) },
-        { be_const_key_weak(flow, 8), be_const_class(be_class_Matter_Plugin_Sensor_Flow) },
-        { be_const_key_weak(http_contact, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Contact) },
-        { be_const_key_weak(shutter, -1), be_const_class(be_class_Matter_Plugin_Shutter) },
-        { be_const_key_weak(v_pressure, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Pressure) },
-        { be_const_key_weak(http_rain, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Rain) },
-        { be_const_key_weak(http_pressure, 12), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Pressure) },
-        { be_const_key_weak(v_light2, -1), be_const_class(be_class_Matter_Plugin_Virt_Light2) },
-        { be_const_key_weak(v_flow, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Flow) },
-        { be_const_key_weak(relay, -1), be_const_class(be_class_Matter_Plugin_OnOff) },
-        { be_const_key_weak(v_illuminance, 29), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Illuminance) },
-        { be_const_key_weak(v_airquality, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Air_Quality) },
-        { be_const_key_weak(temperature, 20), be_const_class(be_class_Matter_Plugin_Sensor_Temp) },
-        { be_const_key_weak(waterleak, -1), be_const_class(be_class_Matter_Plugin_Sensor_Waterleak) },
-        { be_const_key_weak(v_fan, -1), be_const_class(be_class_Matter_Plugin_Virt_Fan) },
-        { be_const_key_weak(http_occupancy, 6), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Occupancy) },
-        { be_const_key_weak(http_relay, -1), be_const_class(be_class_Matter_Plugin_Bridge_OnOff) },
-        { be_const_key_weak(fan, -1), be_const_class(be_class_Matter_Plugin_Fan) },
-        { be_const_key_weak(light1, -1), be_const_class(be_class_Matter_Plugin_Light1) },
-        { be_const_key_weak(root, -1), be_const_class(be_class_Matter_Plugin_Root) },
-        { be_const_key_weak(illuminance, -1), be_const_class(be_class_Matter_Plugin_Sensor_Illuminance) },
-        { be_const_key_weak(v_temp, 15), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Temp) },
-        { be_const_key_weak(v_light1, -1), be_const_class(be_class_Matter_Plugin_Virt_Light1) },
-        { be_const_key_weak(v_waterleak, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Waterleak) },
-        { be_const_key_weak(v_relay, -1), be_const_class(be_class_Matter_Plugin_Virt_OnOff) },
-        { be_const_key_weak(contact, 52), be_const_class(be_class_Matter_Plugin_Sensor_Contact) },
-        { be_const_key_weak(light2, 27), be_const_class(be_class_Matter_Plugin_Light2) },
-        { be_const_key_weak(http_light1, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light1) },
-        { be_const_key_weak(gensw_btn, -1), be_const_class(be_class_Matter_Plugin_Sensor_GenericSwitch_Btn) },
-        { be_const_key_weak(onoff, -1), be_const_class(be_class_Matter_Plugin_Sensor_OnOff) },
-        { be_const_key_weak(v_light0, -1), be_const_class(be_class_Matter_Plugin_Virt_Light0) },
-        { be_const_key_weak(light3, -1), be_const_class(be_class_Matter_Plugin_Light3) },
-        { be_const_key_weak(http_humidity, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Humidity) },
-        { be_const_key_weak(http_illuminance, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Illuminance) },
-        { be_const_key_weak(v_rain, 43), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Rain) },
-        { be_const_key_weak(http_light0, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light0) },
-        { be_const_key_weak(http_waterleak, 45), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Waterleak) },
-        { be_const_key_weak(shutter_X2Btilt, -1), be_const_class(be_class_Matter_Plugin_ShutterTilt) },
-        { be_const_key_weak(v_light3, -1), be_const_class(be_class_Matter_Plugin_Virt_Light3) },
-        { be_const_key_weak(airquality, 35), be_const_class(be_class_Matter_Plugin_Sensor_Air_Quality) },
-        { be_const_key_weak(http_flow, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Flow) },
-        { be_const_key_weak(humidity, -1), be_const_class(be_class_Matter_Plugin_Sensor_Humidity) },
-        { be_const_key_weak(http_temperature, 41), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Temp) },
-        { be_const_key_weak(http_light3, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light3) },
-        { be_const_key_weak(v_humidity, 1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Humidity) },
-        { be_const_key_weak(http_airquality, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Air_Quality) },
-        { be_const_key_weak(aggregator, 11), be_const_class(be_class_Matter_Plugin_Aggregator) },
-        { be_const_key_weak(rain, -1), be_const_class(be_class_Matter_Plugin_Sensor_Rain) },
-        { be_const_key_weak(light0, -1), be_const_class(be_class_Matter_Plugin_Light0) },
-    }))    ) } )) },
-        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
-        { be_const_key_weak(register_commands, 59), be_const_closure(class_Matter_Device_register_commands_closure) },
+        { be_const_key_weak(commissioning, -1), be_const_var(8) },
+        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
+        { be_const_key_weak(plugins_config, -1), be_const_var(3) },
+        { be_const_key_weak(k2l_num, 73), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(plugins_persist, 7), be_const_var(2) },
+        { be_const_key_weak(EP, -1), be_const_int(2) },
+        { be_const_key_weak(MtrInfo, -1), be_const_closure(class_Matter_Device_MtrInfo_closure) },
+        { be_const_key_weak(msg_received, -1), be_const_closure(class_Matter_Device_msg_received_closure) },
+        { be_const_key_weak(every_250ms, 77), be_const_closure(class_Matter_Device_every_250ms_closure) },
         { be_const_key_weak(k2l, -1), be_const_static_closure(class_Matter_Device_k2l_closure) },
-        { be_const_key_weak(http_remotes, -1), be_const_var(14) },
-        { be_const_key_weak(MtrJoin, -1), be_const_closure(class_Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(class_Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(find_plugin_by_friendly_name, 32), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
-        { be_const_key_weak(save_before_restart, 57), be_const_closure(class_Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(save_param, 6), be_const_closure(class_Matter_Device_save_param_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(class_Matter_Device_load_param_closure) },
-        { be_const_key_weak(register_http_remote, -1), be_const_closure(class_Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(sort_distinct, 77), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(read_sensors_scheduler, -1), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_Device_received_ack_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(get_plugin_remote_info, 54), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(init_zigbee, 12), be_const_closure(class_Matter_Device_init_zigbee_closure) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(MtrJoin, 56), be_const_closure(class_Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(4) },
+        { be_const_key_weak(save_param, 37), be_const_closure(class_Matter_Device_save_param_closure) },
+        { be_const_key_weak(register_commands, -1), be_const_closure(class_Matter_Device_register_commands_closure) },
+        { be_const_key_weak(debug, 48), be_const_var(21) },
+        { be_const_key_weak(stop, 68), be_const_closure(class_Matter_Device_stop_closure) },
+        { be_const_key_weak(udp_server, 33), be_const_var(5) },
+        { be_const_key_weak(find_plugin_by_endpoint, 66), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
+        { be_const_key_weak(events, -1), be_const_var(14) },
+        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(check_network, -1), be_const_closure(class_Matter_Device_check_network_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(root_passcode, -1), be_const_var(17) },
+        { be_const_key_weak(zigbee, -1), be_const_var(11) },
         { be_const_key_weak(sessions, -1), be_const_var(10) },
         { be_const_key_weak(resolve_attribute_read_solo, -1), be_const_closure(class_Matter_Device_resolve_attribute_read_solo_closure) },
-        { be_const_key_weak(clean_remotes, -1), be_const_closure(class_Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_Matter_Device_start_closure) },
-        { be_const_key_weak(next_ep, 1), be_const_var(19) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
+        { be_const_key_weak(clean_remotes, 24), be_const_closure(class_Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(get_plugin_remote_info, 79), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(check_config_ep, 13), be_const_closure(class_Matter_Device_check_config_ep_closure) },
+        { be_const_key_weak(root_discriminator, -1), be_const_var(16) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(probe_sensor_time, -1), be_const_var(22) },
         { be_const_key_weak(button_handler, -1), be_const_closure(class_Matter_Device_button_handler_closure) },
-        { be_const_key_weak(init, 10), be_const_closure(class_Matter_Device_init_closure) },
-        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
-        { be_const_key_weak(stop, -1), be_const_closure(class_Matter_Device_stop_closure) },
         { be_const_key_weak(_start_udp, -1), be_const_closure(class_Matter_Device__start_udp_closure) },
-        { be_const_key_weak(probe_sensor_timestamp, 73), be_const_var(22) },
-        { be_const_key_weak(ipv4only, 60), be_const_var(17) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(MtrInfo, -1), be_const_closure(class_Matter_Device_MtrInfo_closure) },
-        { be_const_key_weak(events, -1), be_const_var(13) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
-        { be_const_key_weak(started, 69), be_const_var(0) },
-        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(EP, -1), be_const_int(2) },
-        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(18) },
-        { be_const_key_weak(ui, 76), be_const_var(11) },
-        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(class_Matter_Device_get_plugin_class_arg_closure) },
-        { be_const_key_weak(profiler, -1), be_const_var(6) },
-        { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
-        { be_const_key_weak(invoke_request, 50), be_const_closure(class_Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
-        { be_const_key_weak(reset_param, -1), be_const_closure(class_Matter_Device_reset_param_closure) },
-        { be_const_key_weak(plugins_config, 56), be_const_var(3) },
-        { be_const_key_weak(plugins_config_remotes, 17), be_const_var(4) },
-        { be_const_key_weak(MtrUpdate, 26), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
-        { be_const_key_weak(commissioning, -1), be_const_var(8) },
-        { be_const_key_weak(conf_to_log, 53), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(find_plugin_by_friendly_name, -1), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
+        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(19) },
+        { be_const_key_weak(load_param, -1), be_const_closure(class_Matter_Device_load_param_closure) },
+        { be_const_key_weak(MtrUpdate, 15), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
         { be_const_key_weak(every_50ms, -1), be_const_closure(class_Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(update_remotes_info, -1), be_const_closure(class_Matter_Device_update_remotes_info_closure) },
-        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
-        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
-        { be_const_key_weak(autoconf, 43), be_const_var(9) },
-        { be_const_key_weak(check_network, -1), be_const_closure(class_Matter_Device_check_network_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(5) },
-        { be_const_key_weak(k2l_num, 23), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(debug, 21), be_const_var(20) },
-        { be_const_key_weak(message_handler, -1), be_const_var(7) },
+        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
+        { be_const_key_weak(profiler, 49), be_const_var(6) },
+        { be_const_key_weak(register_http_remote, 5), be_const_closure(class_Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(sort_distinct, 38), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(signal_endpoints_changed, 57), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(is_zigbee_present, 65), be_const_closure(class_Matter_Device_is_zigbee_present_closure) },
+        { be_const_key_weak(plugins_classes, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(56,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(v_temp, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Temp) },
+        { be_const_key_weak(z_pressure, -1), be_const_class(be_class_Matter_Plugin_Zigbee_Pressure) },
+        { be_const_key_weak(http_flow, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Flow) },
+        { be_const_key_weak(v_airquality, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Air_Quality) },
+        { be_const_key_weak(z_temp, 28), be_const_class(be_class_Matter_Plugin_Zigbee_Temperature) },
+        { be_const_key_weak(root, 11), be_const_class(be_class_Matter_Plugin_Root) },
+        { be_const_key_weak(http_contact, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Contact) },
+        { be_const_key_weak(http_airquality, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Air_Quality) },
+        { be_const_key_weak(http_light2, 48), be_const_class(be_class_Matter_Plugin_Bridge_Light2) },
+        { be_const_key_weak(http_light1, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light1) },
+        { be_const_key_weak(v_pressure, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Pressure) },
+        { be_const_key_weak(onoff, -1), be_const_class(be_class_Matter_Plugin_Sensor_OnOff) },
+        { be_const_key_weak(light3, -1), be_const_class(be_class_Matter_Plugin_Light3) },
+        { be_const_key_weak(light0, 10), be_const_class(be_class_Matter_Plugin_Light0) },
+        { be_const_key_weak(v_fan, -1), be_const_class(be_class_Matter_Plugin_Virt_Fan) },
+        { be_const_key_weak(v_light3, 32), be_const_class(be_class_Matter_Plugin_Virt_Light3) },
+        { be_const_key_weak(light1, -1), be_const_class(be_class_Matter_Plugin_Light1) },
+        { be_const_key_weak(shutter_X2Btilt, -1), be_const_class(be_class_Matter_Plugin_ShutterTilt) },
+        { be_const_key_weak(v_light0, -1), be_const_class(be_class_Matter_Plugin_Virt_Light0) },
+        { be_const_key_weak(http_humidity, 39), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Humidity) },
+        { be_const_key_weak(aggregator, -1), be_const_class(be_class_Matter_Plugin_Aggregator) },
+        { be_const_key_weak(flow, -1), be_const_class(be_class_Matter_Plugin_Sensor_Flow) },
+        { be_const_key_weak(v_waterleak, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Waterleak) },
+        { be_const_key_weak(v_occupancy, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Occupancy) },
+        { be_const_key_weak(gensw_btn, -1), be_const_class(be_class_Matter_Plugin_Sensor_GenericSwitch_Btn) },
+        { be_const_key_weak(v_light1, -1), be_const_class(be_class_Matter_Plugin_Virt_Light1) },
+        { be_const_key_weak(fan, -1), be_const_class(be_class_Matter_Plugin_Fan) },
+        { be_const_key_weak(v_illuminance, 37), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Illuminance) },
+        { be_const_key_weak(http_rain, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Rain) },
+        { be_const_key_weak(pressure, 45), be_const_class(be_class_Matter_Plugin_Sensor_Pressure) },
+        { be_const_key_weak(http_light3, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light3) },
+        { be_const_key_weak(light2, 33), be_const_class(be_class_Matter_Plugin_Light2) },
+        { be_const_key_weak(http_relay, -1), be_const_class(be_class_Matter_Plugin_Bridge_OnOff) },
+        { be_const_key_weak(v_humidity, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Humidity) },
+        { be_const_key_weak(http_waterleak, 29), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Waterleak) },
+        { be_const_key_weak(v_relay, -1), be_const_class(be_class_Matter_Plugin_Virt_OnOff) },
+        { be_const_key_weak(http_temperature, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Temp) },
+        { be_const_key_weak(z_humidity, 30), be_const_class(be_class_Matter_Plugin_Zigbee_Humidity) },
+        { be_const_key_weak(occupancy, -1), be_const_class(be_class_Matter_Plugin_Sensor_Occupancy) },
+        { be_const_key_weak(rain, -1), be_const_class(be_class_Matter_Plugin_Sensor_Rain) },
+        { be_const_key_weak(v_rain, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Rain) },
+        { be_const_key_weak(http_pressure, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Pressure) },
+        { be_const_key_weak(relay, -1), be_const_class(be_class_Matter_Plugin_OnOff) },
+        { be_const_key_weak(contact, -1), be_const_class(be_class_Matter_Plugin_Sensor_Contact) },
+        { be_const_key_weak(airquality, 17), be_const_class(be_class_Matter_Plugin_Sensor_Air_Quality) },
+        { be_const_key_weak(v_contact, 18), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Contact) },
+        { be_const_key_weak(http_light0, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light0) },
+        { be_const_key_weak(waterleak, 7), be_const_class(be_class_Matter_Plugin_Sensor_Waterleak) },
+        { be_const_key_weak(humidity, -1), be_const_class(be_class_Matter_Plugin_Sensor_Humidity) },
+        { be_const_key_weak(v_flow, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Flow) },
+        { be_const_key_weak(shutter, 16), be_const_class(be_class_Matter_Plugin_Shutter) },
+        { be_const_key_weak(http_occupancy, 14), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Occupancy) },
+        { be_const_key_weak(v_light2, -1), be_const_class(be_class_Matter_Plugin_Virt_Light2) },
+        { be_const_key_weak(temperature, 25), be_const_class(be_class_Matter_Plugin_Sensor_Temp) },
+        { be_const_key_weak(illuminance, 49), be_const_class(be_class_Matter_Plugin_Sensor_Illuminance) },
+        { be_const_key_weak(http_illuminance, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Illuminance) },
+    }))    ) } )) },
         { be_const_key_weak(adjust_next_ep, -1), be_const_closure(class_Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(tick, -1), be_const_var(12) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(15) },
-        { be_const_key_weak(check_config_ep, 3), be_const_closure(class_Matter_Device_check_config_ep_closure) },
-        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(class_Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(get_plugin_class_displayname, 2), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(class_Matter_Device_get_plugin_class_arg_closure) },
+        { be_const_key_weak(started, 54), be_const_var(0) },
+        { be_const_key_weak(ui, 62), be_const_var(12) },
+        { be_const_key_weak(bridge_add_endpoint, 61), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
+        { be_const_key_weak(message_handler, -1), be_const_var(7) },
+        { be_const_key_weak(read_sensors_scheduler, 42), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
+        { be_const_key_weak(next_ep, 53), be_const_var(20) },
+        { be_const_key_weak(autoconf, -1), be_const_var(9) },
+        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(attribute_updated, 46), be_const_closure(class_Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(update_remotes_info, -1), be_const_closure(class_Matter_Device_update_remotes_info_closure) },
+        { be_const_key_weak(http_remotes, 41), be_const_var(15) },
+        { be_const_key_weak(reset_param, 39), be_const_closure(class_Matter_Device_reset_param_closure) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_Device_received_ack_closure) },
+        { be_const_key_weak(plugins, -1), be_const_var(1) },
+        { be_const_key_weak(button_multi_pressed, -1), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
+        { be_const_key_weak(init, 21), be_const_closure(class_Matter_Device_init_closure) },
+        { be_const_key_weak(ipv4only, 19), be_const_var(18) },
+        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(class_Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(probe_sensor_timestamp, -1), be_const_var(23) },
+        { be_const_key_weak(tick, 9), be_const_var(13) },
+        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
+        { be_const_key_weak(create_zb_mapper, -1), be_const_closure(class_Matter_Device_create_zb_mapper_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(class_Matter_Device_start_closure) },
     })),
     be_str_weak(Matter_Device)
 );


### PR DESCRIPTION
## Description:

First phase of Matter-Zigbee bridging.

Support for simple sensors:
- Temperature
- Pressure
- Humidity

You simply need to choose the Zigbee Matter type and select the Zigbee device: either by shortaddr (ex: `0xABCD`) or by friendlyname (preferred).

<img width="185" alt="image" src="https://github.com/user-attachments/assets/fb5311fa-a066-4968-87d4-708db0d6adec">

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
