### PR TITLE
fix trx pin error

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -3246,14 +3246,15 @@ dddef_exit:
           mmp->params = strtol(lp1, &lp1, 10);
           if (*lp1 != ',') goto next_line;
           lp1++;
-          mmp->prefix[SML_PREFIX_SIZE - 1] = 0;
           for (uint32_t cnt = 0; cnt < SML_PREFIX_SIZE; cnt++) {
-            if (*lp1 == SCRIPT_EOL || *lp1 == ',') {
+            if (!*lp1 || *lp1 == SCRIPT_EOL || *lp1 == ',') {
               mmp->prefix[cnt] = 0;
               break;
             }
-           mmp->prefix[cnt] = *lp1++;
+            mmp->prefix[cnt] = *lp1++;
           }
+          mmp->prefix[SML_PREFIX_SIZE - 1] = 0;
+
           if (*lp1 == ',') {
             lp1++;
             // get TRX pin


### PR DESCRIPTION
## Description:

fix an issue where header line ends with ID name and no TRX pin is defined, TRX pin is accidentally set to PIN 0 instead to not used.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
