### PR TITLE
Add internal I2C argument to send stop while reading

### DIFF
--- a/tasmota/tasmota_support/support_a_i2c.ino
+++ b/tasmota/tasmota_support/support_a_i2c.ino
@@ -62,7 +62,7 @@ TwoWire& I2cGetWire(uint8_t bus = 0) {
  * Return code: 0 = Error, 1 = OK
 \*-------------------------------------------------------------------------------------------*/
 
-bool I2cValidRead(uint8_t addr, uint8_t reg, uint8_t size, uint8_t bus = 0) {
+bool I2cValidRead(uint8_t addr, uint8_t reg, uint8_t size, uint8_t bus = 0, bool sendStop = false) {
   i2c_buffer = 0;
 
   TwoWire& myWire = I2cGetWire(bus);
@@ -73,7 +73,7 @@ bool I2cValidRead(uint8_t addr, uint8_t reg, uint8_t size, uint8_t bus = 0) {
   while (!status && retry) {
     myWire.beginTransmission(addr);                       // start transmission to device
     myWire.write(reg);                                    // sends register address to read from
-    if (0 == myWire.endTransmission(false)) {             // Try to become I2C Master, send data and collect bytes, keep master status for next request...
+    if (0 == myWire.endTransmission(sendStop)) {          // Try to become I2C Master, send data and collect bytes, keep master status for next request...
       myWire.requestFrom((int)addr, (int)size);           // send data n-bytes read
       if (myWire.available() == size) {
         for (uint32_t i = 0; i < size; i++) {


### PR DESCRIPTION
## Description:

M5Stack I2C devices seem to require to send a Stop after sending the register and before reading registers. This PR adds an optional argument to force the stop. It will be used by Berry I2C driver.

No functional change to existing code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
