### PR TITLE
Berry I2C to prepare M5Stack I2C STM32 based devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee flashing CC2562P with latest firmware (#22117)
 - SML trx pin error (#22119)
 - Shutter remaining issues on shutterinvert (#22120)
+- Berry I2C to prepare M5Stack I2C STM32 based devices
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/Wire.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/Wire.be
@@ -6,15 +6,16 @@
 class Wire
   var bus
 
-  def read_bytes(addr,reg,sz)
+  def read_bytes(addr, reg, sz)
     self._begin_transmission(addr)
     self._write(reg)
-    self._end_transmission(false)
-    self._request_from(addr,sz)
-    var ret=bytes(sz)
+    self._end_transmission(true)
+    self._request_from(addr, sz)
+    var ret = bytes(sz)
     while (self._available())
-      ret..self._read()
+      ret.append(self._read())
     end
+    self._end_transmission(true)
     return ret
   end
   

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_Wire.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_Wire.h
@@ -9,7 +9,7 @@
 ********************************************************************/
 be_local_closure(class_Wire_read_bytes,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    9,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -17,17 +17,18 @@ be_local_closure(class_Wire_read_bytes,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str(_begin_transmission),
     /* K1   */  be_nested_str(_write),
     /* K2   */  be_nested_str(_end_transmission),
     /* K3   */  be_nested_str(_request_from),
     /* K4   */  be_nested_str(_available),
-    /* K5   */  be_nested_str(_read),
+    /* K5   */  be_nested_str(append),
+    /* K6   */  be_nested_str(_read),
     }),
     &be_const_str_read_bytes,
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
+    ( &(const binstruction[28]) {  /* code */
       0x8C100100,  //  0000  GETMET	R4	R0	K0
       0x5C180200,  //  0001  MOVE	R6	R1
       0x7C100400,  //  0002  CALL	R4	2
@@ -35,7 +36,7 @@ be_local_closure(class_Wire_read_bytes,   /* name */
       0x5C180400,  //  0004  MOVE	R6	R2
       0x7C100400,  //  0005  CALL	R4	2
       0x8C100102,  //  0006  GETMET	R4	R0	K2
-      0x50180000,  //  0007  LDBOOL	R6	0	0
+      0x50180200,  //  0007  LDBOOL	R6	1	0
       0x7C100400,  //  0008  CALL	R4	2
       0x8C100103,  //  0009  GETMET	R4	R0	K3
       0x5C180200,  //  000A  MOVE	R6	R1
@@ -46,12 +47,16 @@ be_local_closure(class_Wire_read_bytes,   /* name */
       0x7C100200,  //  000F  CALL	R4	1
       0x8C140104,  //  0010  GETMET	R5	R0	K4
       0x7C140200,  //  0011  CALL	R5	1
-      0x78160003,  //  0012  JMPF	R5	#0017
-      0x8C140105,  //  0013  GETMET	R5	R0	K5
-      0x7C140200,  //  0014  CALL	R5	1
-      0x40140805,  //  0015  CONNECT	R5	R4	R5
-      0x7001FFF8,  //  0016  JMP		#0010
-      0x80040800,  //  0017  RET	1	R4
+      0x78160004,  //  0012  JMPF	R5	#0018
+      0x8C140905,  //  0013  GETMET	R5	R4	K5
+      0x8C1C0106,  //  0014  GETMET	R7	R0	K6
+      0x7C1C0200,  //  0015  CALL	R7	1
+      0x7C140400,  //  0016  CALL	R5	2
+      0x7001FFF7,  //  0017  JMP		#0010
+      0x8C140102,  //  0018  GETMET	R5	R0	K2
+      0x501C0200,  //  0019  LDBOOL	R7	1	0
+      0x7C140400,  //  001A  CALL	R5	2
+      0x80040800,  //  001B  RET	1	R4
     })
   )
 );

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -24,6 +24,7 @@
 
 #include <berry.h>
 #include <Wire.h>
+#include <byteswap.h>
 
 // read the `bus` attribute and return `Wire` or `Wire1`
 // Can return nullptr reference if the bus is not initialized
@@ -217,8 +218,8 @@ extern "C" {
     if (top == 5 && be_isint(vm, 2) && be_isint(vm, 3) && be_isint(vm, 4) && be_isint(vm, 5)) {
       uint8_t addr = be_toint(vm, 2);
       uint8_t reg = be_toint(vm, 3);
-      uint8_t val = be_toint(vm, 4);
-      uint8_t size = be_toint(vm, 5);
+      int32_t val = be_toint(vm, 4);
+      int32_t size = be_toint(vm, 5);
       bool ok = I2cWrite(addr, reg, val, size, bus);
       be_pushbool(vm, ok);
       be_return(vm); // Return
@@ -234,10 +235,24 @@ extern "C" {
     if (top == 4 && be_isint(vm, 2) && be_isint(vm, 3) && be_isint(vm, 4)) {
       uint8_t addr = be_toint(vm, 2);
       uint8_t reg = be_toint(vm, 3);
-      uint8_t size = be_toint(vm, 4);
-      bool ok = I2cValidRead(addr, reg, size, bus);  // TODO
+      int32_t size = be_toint(vm, 4);
+      bool little_endian = false;
+      if (size < 0) {
+        little_endian = true;
+        size = -size;
+      }
+      bool ok = I2cValidRead(addr, reg, size, bus, true);  // force sendStop
       if (ok) {
-        be_pushint(vm, i2c_buffer);
+        int32_t val = i2c_buffer;
+        if (little_endian) {
+          if (size == 2) {
+            val = __bswap_16(val);
+          }
+          else if (size == 4) {
+            val = __bswap_32(val);
+          }
+        }
+        be_pushint(vm, val);
       } else {
         be_pushnil(vm);
       }


### PR DESCRIPTION
## Description:

Berry I2C fixes:
- fix `wire.write()` which would not handle correctly value large than 1 byte
- add ability to `wire.read()` to invert Endianness when reading 16/32 bits values. It appears that some M5Stack devices are not compliant with the standard Big Endian of I2C
- force I2C Bus Stop to avoid M5Stack I2C devices to crash and block the I2C bus

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
