### PR TITLE
no exception when tasmota-metrics is not found

### DIFF
--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -6,8 +6,11 @@ from os.path import join
 
 def firm_metrics(source, target, env):
     if env["PIOPLATFORM"] == "espressif32":
-        import tasmota_metrics
-        env.Execute("$PYTHONEXE -m tasmota_metrics \"" + str(tasmotapiolib.get_source_map_path(env).resolve()) + "\"")
+        try:
+            import tasmota_metrics
+            env.Execute("$PYTHONEXE -m tasmota_metrics \"" + str(tasmotapiolib.get_source_map_path(env).resolve()) + "\"")
+        except:
+            pass
     elif env["PIOPLATFORM"] == "espressif8266":
         map_file = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
         with open(map_file,'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Description:

currently missing tasmota-metrics in Python env results in an ungracefully compile end.
With the PR compile is finished normally, just the metrics info is not shown. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
