### PR TITLE
arduino idf compile prepare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.gcda
 
 ## Project files ######
+managed_components
 .platformio
 .pio
 .clang_complete

--- a/boards/esp32-fix.json
+++ b/boards/esp32-fix.json
@@ -19,7 +19,8 @@
     "openocd_target": "esp32.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32 >= 4M Flash, PSRAM with fix, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32.json
+++ b/boards/esp32.json
@@ -19,7 +19,8 @@
       "openocd_target": "esp32.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32 >= 4M Flash PSRAM, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32_solo1.json
+++ b/boards/esp32_solo1.json
@@ -19,7 +19,8 @@
     "openocd_target": "esp32-solo-1.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-solo1 >= 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c2.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C2 = 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c2.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C2 = 2M Flash, Tasmota 1245kB Code/OTA, 64k FS",
     "upload": {

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c3.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C3 >= 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32c3ser.json
+++ b/boards/esp32c3ser.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c3.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C3 >= 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32c6.json
+++ b/boards/esp32c6.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c6.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C6 >= 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32c6ser.json
+++ b/boards/esp32c6ser.json
@@ -17,7 +17,8 @@
       "openocd_target": "esp32c6.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-C6 >= 4M Flash, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -16,7 +16,8 @@
     "openocd_target": "esp32s2.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S2 >= 4M Flash PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -16,7 +16,8 @@
     "openocd_target": "esp32s2.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S2 >= 4M Flash PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3-opi_opi.json
+++ b/boards/esp32s3-opi_opi.json
@@ -21,7 +21,8 @@
       "openocd_target": "esp32s3.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32s3-opi_opi_120.json
+++ b/boards/esp32s3-opi_opi_120.json
@@ -23,7 +23,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3-qio_opi.json
+++ b/boards/esp32s3-qio_opi.json
@@ -21,7 +21,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M Flash OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3-qio_opi_120.json
+++ b/boards/esp32s3-qio_opi_120.json
@@ -23,7 +23,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3-qio_qspi.json
+++ b/boards/esp32s3-qio_qspi.json
@@ -21,7 +21,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M Flash QSPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3-qio_qspi_120.json
+++ b/boards/esp32s3-qio_qspi_120.json
@@ -23,7 +23,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + QSPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3ser-opi_opi.json
+++ b/boards/esp32s3ser-opi_opi.json
@@ -21,7 +21,8 @@
       "openocd_target": "esp32s3.cfg"
     },
     "frameworks": [
-      "arduino"
+      "arduino",
+      "espidf"
     ],
     "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
     "upload": {

--- a/boards/esp32s3ser-opi_opi_120.json
+++ b/boards/esp32s3ser-opi_opi_120.json
@@ -23,7 +23,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3ser-qio_opi.json
+++ b/boards/esp32s3ser-qio_opi.json
@@ -21,7 +21,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M Flash OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3ser-qio_opi_120.json
+++ b/boards/esp32s3ser-qio_opi_120.json
@@ -23,7 +23,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/boards/esp32s3ser-qio_qspi.json
+++ b/boards/esp32s3ser-qio_qspi.json
@@ -21,7 +21,8 @@
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "espidf"
   ],
   "name": "Espressif Generic ESP32-S3 >= 4M Flash QSPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {

--- a/tasmota/CMakeLists.txt
+++ b/tasmota/CMakeLists.txt
@@ -1,0 +1,2 @@
+FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/tasmota/*.*)
+idf_component_register(SRCS ${app_sources})


### PR DESCRIPTION
## Description:

add framework espidf esp32x to boards.json. Prep for compile Tasmota as Arduino/IDF project

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
