### PR TITLE
fix compile error with core 3.0.0 for Range Extender driver xdrv_58_range_extender.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
@@ -83,15 +83,7 @@ Backlog RgxSSID rangeextender ; RgxPassword securepassword ; RgxAddress 192.168.
 #else
 #error CONFIG_LWIP_IPV4_NAPT not set, arduino-esp32 v2 or later required with CONFIG_LWIP_IPV4_NAPT support
 #endif // CONFIG_LWIP_IPV4_NAPT
-#ifdef IP_NAPT_PORTMAP
-// All good
-#else
-#warning IP_NAPT_PORTMAP not set, arduino-esp32 v2 or later required with IP_NAPT_PORTMAP support
-#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
-#undef USE_WIFI_RANGE_EXTENDER_PORTADD
-#endif // USE_WIFI_RANGE_EXTENDER_PORTADD
-#endif // IP_NAPT_PORTMAP
-#endif // CONFIG_LWIP_IPV4_NAPT
+#endif // CONFIG_LWIP_IP_FORWARD
 #endif // ESP32
 
 const char kDrvRgxCommands[] PROGMEM = "Rgx|" // Prefix
@@ -101,10 +93,8 @@ const char kDrvRgxCommands[] PROGMEM = "Rgx|" // Prefix
 #ifdef USE_WIFI_RANGE_EXTENDER_NAPT
                                        "|"
                                        "NAPT"
-#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
                                        "|"
                                        "Port"
-#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
                                        "|"
                                        "Clients"
@@ -119,9 +109,7 @@ void (*const DrvRgxCommand[])(void) PROGMEM = {
     &CmndRgxPassword,
 #ifdef USE_WIFI_RANGE_EXTENDER_NAPT
     &CmndRgxNAPT,
-#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
     &CmndRgxPort,
-#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
     &CmndRgxClients,
     &CmndRgxAddresses,
@@ -301,7 +289,6 @@ void CmndRgxNAPT(void)
   ResponseCmndStateText(Settings->sbflag1.range_extender_napt);
 }
 
-#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
 // CmndRgxPort helper: Do port map and set response if successful
 void CmndRgxPortMap(uint8_t proto, uint16_t gw_port, uint32_t dst_ip, uint16_t dst_port)
 {
@@ -385,7 +372,6 @@ void CmndRgxPort(void)
   wifi_softap_free_station_info();
 #endif // ESP8266
 }
-#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
 
 void ResponseRgxConfig(void)

--- a/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
@@ -41,7 +41,6 @@ List AP clients (MAC, IP and RSSI) with command RgxClients on ESP32
 An example full static configuration:
 #define USE_WIFI_RANGE_EXTENDER
 #define USE_WIFI_RANGE_EXTENDER_NAPT
-#define USE_WIFI_RANGE_EXTENDER_CLIENTS
 #define WIFI_RGX_STATE 1
 #define WIFI_RGX_NAPT 1
 #define WIFI_RGX_SSID "rangeextender"
@@ -83,7 +82,15 @@ Backlog RgxSSID rangeextender ; RgxPassword securepassword ; RgxAddress 192.168.
 // All good
 #else
 #error CONFIG_LWIP_IPV4_NAPT not set, arduino-esp32 v2 or later required with CONFIG_LWIP_IPV4_NAPT support
-#endif // IP_NAPT
+#endif // CONFIG_LWIP_IPV4_NAPT
+#ifdef IP_NAPT_PORTMAP
+// All good
+#else
+#warning IP_NAPT_PORTMAP not set, arduino-esp32 v2 or later required with IP_NAPT_PORTMAP support
+#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
+#undef USE_WIFI_RANGE_EXTENDER_PORTADD
+#endif // USE_WIFI_RANGE_EXTENDER_PORTADD
+#endif // IP_NAPT_PORTMAP
 #endif // CONFIG_LWIP_IPV4_NAPT
 #endif // ESP32
 
@@ -94,8 +101,10 @@ const char kDrvRgxCommands[] PROGMEM = "Rgx|" // Prefix
 #ifdef USE_WIFI_RANGE_EXTENDER_NAPT
                                        "|"
                                        "NAPT"
+#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
                                        "|"
                                        "Port"
+#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
                                        "|"
                                        "Clients"
@@ -110,7 +119,9 @@ void (*const DrvRgxCommand[])(void) PROGMEM = {
     &CmndRgxPassword,
 #ifdef USE_WIFI_RANGE_EXTENDER_NAPT
     &CmndRgxNAPT,
+#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
     &CmndRgxPort,
+#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
     &CmndRgxClients,
     &CmndRgxAddresses,
@@ -131,6 +142,7 @@ void (*const DrvRgxCommand[])(void) PROGMEM = {
 #include "lwip/lwip_napt.h"
 #include <dhcpserver/dhcpserver.h>
 #include "esp_wifi.h"
+#include "esp_wifi_ap_get_sta_list.h"
 #endif // ESP32
 
 #define RGX_NOT_CONFIGURED 0
@@ -182,16 +194,16 @@ void CmndRgxClients(void)
 
 #if defined(ESP32)
   wifi_sta_list_t wifi_sta_list = {0};
-  tcpip_adapter_sta_list_t adapter_sta_list = {0};
+  wifi_sta_mac_ip_list_t wifi_sta_mac_ip_list = {0};
 
   esp_wifi_ap_get_sta_list(&wifi_sta_list);
-  tcpip_adapter_get_sta_list(&wifi_sta_list, &adapter_sta_list);
+  esp_wifi_ap_get_sta_list_with_ip(&wifi_sta_list, &wifi_sta_mac_ip_list);
 
-  for (int i=0; i<adapter_sta_list.num; i++)
+  for (int i=0; i<wifi_sta_mac_ip_list.num; i++)
   {
-    const uint8_t *m = adapter_sta_list.sta[i].mac;
+    const uint8_t *m = wifi_sta_mac_ip_list.sta[i].mac;
     ResponseAppend_P(PSTR("%s\"%02X%02X%02X%02X%02X%02X\":{\"" D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_RSSI "\":%d}"),
-      sep, m[0], m[1], m[2], m[3], m[4], m[5], adapter_sta_list.sta[i].ip, wifi_sta_list.sta[i].rssi);
+      sep, m[0], m[1], m[2], m[3], m[4], m[5], wifi_sta_mac_ip_list.sta[i].ip, wifi_sta_list.sta[i].rssi);
     sep = ",";
   }
 #elif defined(ESP8266)
@@ -289,6 +301,7 @@ void CmndRgxNAPT(void)
   ResponseCmndStateText(Settings->sbflag1.range_extender_napt);
 }
 
+#ifdef USE_WIFI_RANGE_EXTENDER_PORTADD
 // CmndRgxPort helper: Do port map and set response if successful
 void CmndRgxPortMap(uint8_t proto, uint16_t gw_port, uint32_t dst_ip, uint16_t dst_port)
 {
@@ -347,14 +360,14 @@ void CmndRgxPort(void)
   // Forward address is a mac, find the associated ip...
 #if defined(ESP32)
   wifi_sta_list_t wifi_sta_list = {0};
-  tcpip_adapter_sta_list_t adapter_sta_list = {0};
+  wifi_sta_mac_ip_list_t wifi_sta_mac_ip_list = {0};
 
   esp_wifi_ap_get_sta_list(&wifi_sta_list);
-  tcpip_adapter_get_sta_list(&wifi_sta_list, &adapter_sta_list);
+  esp_wifi_ap_get_sta_list_with_ip(&wifi_sta_list, &wifi_sta_mac_ip_list);
 
-  for (int i=0; i<adapter_sta_list.num; i++)
+  for (int i=0; i<wifi_sta_mac_ip_list.num; i++)
   {
-    if (CmndRgxPortMapCheck(adapter_sta_list.sta[i].mac, parm_addr, proto, gw, adapter_sta_list.sta[i].ip.addr, dst))
+    if (CmndRgxPortMapCheck(wifi_sta_mac_ip_list.sta[i].mac, parm_addr, proto, gw, wifi_sta_mac_ip_list.sta[i].ip.addr, dst))
     {
       break;
     }
@@ -372,6 +385,7 @@ void CmndRgxPort(void)
   wifi_softap_free_station_info();
 #endif // ESP8266
 }
+#endif
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
 
 void ResponseRgxConfig(void)
@@ -400,14 +414,16 @@ void rngxSetup()
 #endif // ESP8266
 #ifdef ESP32
   esp_err_t err;
-  tcpip_adapter_dns_info_t ip_dns;
+  esp_netif_t* esp_netif_STA = get_esp_interface_netif(ESP_IF_WIFI_STA);
+  esp_netif_t* esp_netif_AP = get_esp_interface_netif(ESP_IF_WIFI_AP);
+  esp_netif_dns_info_t ip_dns;
 
-  err = tcpip_adapter_dhcps_stop(TCPIP_ADAPTER_IF_AP);
-  err = tcpip_adapter_get_dns_info(TCPIP_ADAPTER_IF_STA, ESP_NETIF_DNS_MAIN, &ip_dns);
-  err = tcpip_adapter_set_dns_info(TCPIP_ADAPTER_IF_AP, ESP_NETIF_DNS_MAIN, &ip_dns);
+  err = esp_netif_dhcps_stop(esp_netif_AP);
+  err = esp_netif_get_dns_info(esp_netif_STA, ESP_NETIF_DNS_MAIN, &ip_dns);
+  err = esp_netif_set_dns_info(esp_netif_AP, ESP_NETIF_DNS_MAIN, &ip_dns);
   dhcps_offer_t opt_val = OFFER_DNS; // supply a dns server via dhcps
-  tcpip_adapter_dhcps_option(ESP_NETIF_OP_SET, ESP_NETIF_DOMAIN_NAME_SERVER, &opt_val, 1);
-  err = tcpip_adapter_dhcps_start(TCPIP_ADAPTER_IF_AP);
+  err = esp_netif_dhcps_option(esp_netif_AP, ESP_NETIF_OP_SET, ESP_NETIF_DOMAIN_NAME_SERVER, &opt_val, 1);
+  err = esp_netif_dhcps_start(esp_netif_AP);
 #endif // ESP32
   // WiFi.softAPConfig(EXTENDER_LOCAL_IP, EXTENDER_GATEWAY_IP, EXTENDER_SUBNET);
   WiFi.softAPConfig(Settings->ipv4_rgx_address, Settings->ipv4_rgx_address, Settings->ipv4_rgx_subnetmask);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
