### PR TITLE
uDisplay force cache writes to RGB display on ESP32S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - ESP32 Range Extender compile error with core 3.0.0 (#22205)
 - HASPmota error when page '1' is not defined
+- uDisplay force cache writes to RGB display on ESP32S3
 
 ### Removed
 

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -2282,14 +2282,11 @@ void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean not_swapped) {
           }
         }
         uint16_t * flush_ptr = rgb_fb + (int32_t)seta_yp1 * _width + seta_xp1;
-        esp_cache_msync(flush_ptr, (seta_xp2 - seta_xp1) * 2, 0);
+        Cache_WriteBack_Addr((uint32_t)flush_ptr, (seta_xp2 - seta_xp1) * 2);
         fb_y += _width;
         seta_yp1++;
         if (!lenc) break; 
       }
-      // using esp_cache_msync() to flush the PSRAM cache and ensure that all data is actually written to PSRAM
-      // from https://github.com/espressif/esp-idf/blob/636ff35b52f10e1a804a3760a5bd94e68f4b1b71/components/esp_lcd/rgb/esp_lcd_panel_rgb.c#L159
-
     }
 #endif
     return;


### PR DESCRIPTION
## Description:

Fix visible artifacts on ESP32S3 with RGB displays. The problem is caused by cache lines not being flushed after updating the display (the internal memory is updated but writes to PSRAM which stored the frame buffer are delayed until cache lines are reclaimed).

It seems that the previously used `esp_cache_msync()` does not work anymore, it is replace by `Cache_WriteBack_Addr()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
