### PR TITLE
fix removal of negative values (recreate #16044)

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_75_prometheus.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_75_prometheus.ino
@@ -298,7 +298,7 @@ void HandleMetrics(void) {
             JsonParserObject Object3 = value2.getObject();
             for (auto key3 : Object3) {
               const char *value = key3.getValue().getStr(nullptr);
-              if (value != nullptr && isdigit(value[0])) {
+              if (value != nullptr && (isdigit(value[0]) || (value[0] == '-') || (value[0] == '.'))) {
                 String sensor = FormatMetricName(key2.getStr());
                 String type = FormatMetricName(key3.getStr());
 
@@ -311,7 +311,7 @@ void HandleMetrics(void) {
             }
           } else {
             const char *value = value2.getStr(nullptr);
-            if (value != nullptr && isdigit(value[0])) {
+            if (value != nullptr && (isdigit(value[0]) || (value[0] == '-') || (value[0] == '.'))) {
               String sensor = FormatMetricName(key1.getStr());
               String type = FormatMetricName(key2.getStr());
               if (strcmp(type.c_str(), "totalstarttime") != 0) {  // this metric causes Prometheus of fail
@@ -336,7 +336,7 @@ void HandleMetrics(void) {
         const char *value = value1.getStr(nullptr);
         String sensor = FormatMetricName(key1.getStr());
 
-        if (value != nullptr && isdigit(value[0] && strcmp(sensor.c_str(), "time") != 0)) {  //remove false 'time' metric
+        if (value != nullptr && (isdigit(value[0]) || (value[0] == '-') || (value[0] == '.')) && strcmp(sensor.c_str(), "time") != 0) {  //remove false 'time' metric
           WritePromMetricStr(PSTR("sensors"), kPromMetricGauge, value,
             PSTR("sensor"), sensor.c_str(),
             nullptr);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #22228 by recreating #16044

Fix removal of values starting with a non digit, such as starting with '-' for negative values or '.' for floating with leading 0

Originaly tested in #16044.
Not re-tested, just tested for comiplation of tasmota and tasmota32

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
