### PR TITLE
Berry improve `persist` dirty data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - ESP32 platform update from 2024.09.10 to 2024.09.30 and Framework (Arduino Core) from v3.0.5 to v3.1.0.240926 (#22203)
+- Berry improve `persist` dirty data handling
 
 ### Fixed
 - ESP32 Range Extender compile error with core 3.0.0 (#22205)

--- a/lib/libesp32/berry_tasmota/src/embedded/persist.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/persist.be
@@ -38,6 +38,11 @@ class Persist
     self._dirty = true
   end
   
+  #- force dirty -#
+  def dirty()
+    self._dirty = true
+  end
+
   def remove(k)
       self._p.remove(k)
       self._dirty = true
@@ -83,8 +88,8 @@ class Persist
     # print("Loading")
   end
 
-  def save()
-    if self._dirty    # do not save if not dirty
+  def save(force_save)
+    if self._dirty || force_save   # do not save if not dirty
       var f       # file object
       try
         f = open(self._filename, "w")

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_persist.h
@@ -31,55 +31,55 @@ be_local_closure(_anonymous_,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'Persist' ktab size: 35, total: 65 (saved 240 bytes)
+// compact class 'Persist' ktab size: 35, total: 66 (saved 248 bytes)
 static const bvalue be_ktab_class_Persist[35] = {
-  /* K0   */  be_nested_str(json),
-  /* K1   */  be_nested_str(write),
-  /* K2   */  be_nested_str(_X7B),
-  /* K3   */  be_nested_str(keys),
-  /* K4   */  be_nested_str(dump),
-  /* K5   */  be_nested_str(_X3A),
-  /* K6   */  be_nested_str(json_fdump_any),
-  /* K7   */  be_nested_str(_X2C),
-  /* K8   */  be_nested_str(stop_iteration),
-  /* K9   */  be_nested_str(_X7D),
-  /* K10  */  be_nested_str(json_fdump_map),
-  /* K11  */  be_nested_str(json_fdump_list),
-  /* K12  */  be_nested_str(_p),
-  /* K13  */  be_nested_str(_dirty),
-  /* K14  */  be_nested_str(load),
-  /* K15  */  be_nested_str(_filename),
-  /* K16  */  be_nested_str(w),
-  /* K17  */  be_nested_str(json_fdump),
-  /* K18  */  be_nested_str(close),
-  /* K19  */  be_nested_str(_X7B_X7D),
-  /* K20  */  be_nested_str(find),
-  /* K21  */  be_nested_str(contains),
-  /* K22  */  be_nested_str(_X5B),
-  /* K23  */  be_const_int(0),
-  /* K24  */  be_const_int(1),
-  /* K25  */  be_nested_str(_X5D),
-  /* K26  */  be_nested_str(internal_error),
-  /* K27  */  be_nested_str(persist_X2E_p_X20is_X20not_X20a_X20map),
+  /* K0   */  be_nested_str(_dirty),
+  /* K1   */  be_nested_str(_filename),
+  /* K2   */  be_nested_str(w),
+  /* K3   */  be_nested_str(json_fdump),
+  /* K4   */  be_nested_str(close),
+  /* K5   */  be_nested_str(write),
+  /* K6   */  be_nested_str(_X7B_X7D),
+  /* K7   */  be_nested_str(_p),
+  /* K8   */  be_nested_str(load),
+  /* K9   */  be_nested_str(remove),
+  /* K10  */  be_nested_str(contains),
+  /* K11  */  be_nested_str(json),
+  /* K12  */  be_nested_str(json_fdump_map),
+  /* K13  */  be_nested_str(internal_error),
+  /* K14  */  be_nested_str(persist_X2E_p_X20is_X20not_X20a_X20map),
+  /* K15  */  be_nested_str(_X7B),
+  /* K16  */  be_nested_str(keys),
+  /* K17  */  be_nested_str(dump),
+  /* K18  */  be_nested_str(_X3A),
+  /* K19  */  be_nested_str(json_fdump_any),
+  /* K20  */  be_nested_str(_X2C),
+  /* K21  */  be_nested_str(stop_iteration),
+  /* K22  */  be_nested_str(_X7D),
+  /* K23  */  be_nested_str(find),
+  /* K24  */  be_nested_str(_X5B),
+  /* K25  */  be_const_int(0),
+  /* K26  */  be_const_int(1),
+  /* K27  */  be_nested_str(_X5D),
   /* K28  */  be_nested_str(path),
   /* K29  */  be_nested_str(exists),
   /* K30  */  be_nested_str(r),
   /* K31  */  be_nested_str(read),
   /* K32  */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson),
   /* K33  */  be_nested_str(save),
-  /* K34  */  be_nested_str(remove),
+  /* K34  */  be_nested_str(json_fdump_list),
 };
 
 
 extern const bclass be_class_Persist;
 
 /********************************************************************
-** Solidified function: json_fdump_map
+** Solidified function: save
 ********************************************************************/
-be_local_closure(class_Persist_json_fdump_map,   /* name */
+be_local_closure(class_Persist_save,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -87,50 +87,60 @@ be_local_closure(class_Persist_json_fdump_map,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_json_fdump_map,
+    &be_const_str_save,
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100301,  //  0001  GETMET	R4	R1	K1
-      0x58180002,  //  0002  LDCONST	R6	K2
-      0x7C100400,  //  0003  CALL	R4	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x60140010,  //  0005  GETGBL	R5	G16
-      0x8C180503,  //  0006  GETMET	R6	R2	K3
-      0x7C180200,  //  0007  CALL	R6	1
-      0x7C140200,  //  0008  CALL	R5	1
-      0xA8020017,  //  0009  EXBLK	0	#0022
-      0x5C180A00,  //  000A  MOVE	R6	R5
-      0x7C180000,  //  000B  CALL	R6	0
-      0x4C1C0000,  //  000C  LDNIL	R7
-      0x201C0807,  //  000D  NE	R7	R4	R7
-      0x781E0002,  //  000E  JMPF	R7	#0012
-      0x8C1C0301,  //  000F  GETMET	R7	R1	K1
-      0x5C240800,  //  0010  MOVE	R9	R4
-      0x7C1C0400,  //  0011  CALL	R7	2
-      0x8C1C0301,  //  0012  GETMET	R7	R1	K1
-      0x8C240704,  //  0013  GETMET	R9	R3	K4
-      0x602C0008,  //  0014  GETGBL	R11	G8
-      0x5C300C00,  //  0015  MOVE	R12	R6
-      0x7C2C0200,  //  0016  CALL	R11	1
-      0x7C240400,  //  0017  CALL	R9	2
-      0x7C1C0400,  //  0018  CALL	R7	2
-      0x8C1C0301,  //  0019  GETMET	R7	R1	K1
-      0x58240005,  //  001A  LDCONST	R9	K5
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x8C1C0106,  //  001C  GETMET	R7	R0	K6
-      0x5C240200,  //  001D  MOVE	R9	R1
-      0x94280406,  //  001E  GETIDX	R10	R2	R6
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x58100007,  //  0020  LDCONST	R4	K7
-      0x7001FFE7,  //  0021  JMP		#000A
-      0x58140008,  //  0022  LDCONST	R5	K8
-      0xAC140200,  //  0023  CATCH	R5	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x8C140301,  //  0025  GETMET	R5	R1	K1
-      0x581C0009,  //  0026  LDCONST	R7	K9
-      0x7C140400,  //  0027  CALL	R5	2
-      0x80000000,  //  0028  RET	0
+    ( &(const binstruction[51]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0000,  //  0001  JMPT	R2	#0003
+      0x7806002E,  //  0002  JMPF	R1	#0032
+      0x4C080000,  //  0003  LDNIL	R2
+      0xA802000B,  //  0004  EXBLK	0	#0011
+      0x600C0011,  //  0005  GETGBL	R3	G17
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x58140002,  //  0007  LDCONST	R5	K2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x8C0C0103,  //  000A  GETMET	R3	R0	K3
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x8C0C0504,  //  000D  GETMET	R3	R2	K4
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0xA8040001,  //  000F  EXBLK	1	1
+      0x7002001E,  //  0010  JMP		#0030
+      0xAC0C0002,  //  0011  CATCH	R3	0	2
+      0x7002001B,  //  0012  JMP		#002F
+      0x4C140000,  //  0013  LDNIL	R5
+      0x20140405,  //  0014  NE	R5	R2	R5
+      0x78160001,  //  0015  JMPF	R5	#0018
+      0x8C140504,  //  0016  GETMET	R5	R2	K4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x4C080000,  //  0018  LDNIL	R2
+      0xA8020009,  //  0019  EXBLK	0	#0024
+      0x60140011,  //  001A  GETGBL	R5	G17
+      0x88180101,  //  001B  GETMBR	R6	R0	K1
+      0x581C0002,  //  001C  LDCONST	R7	K2
+      0x7C140400,  //  001D  CALL	R5	2
+      0x5C080A00,  //  001E  MOVE	R2	R5
+      0x8C140505,  //  001F  GETMET	R5	R2	K5
+      0x581C0006,  //  0020  LDCONST	R7	K6
+      0x7C140400,  //  0021  CALL	R5	2
+      0xA8040001,  //  0022  EXBLK	1	1
+      0x70020003,  //  0023  JMP		#0028
+      0xAC140000,  //  0024  CATCH	R5	0	0
+      0x70020000,  //  0025  JMP		#0027
+      0x70020000,  //  0026  JMP		#0028
+      0xB0080000,  //  0027  RAISE	2	R0	R0
+      0x4C140000,  //  0028  LDNIL	R5
+      0x20140405,  //  0029  NE	R5	R2	R5
+      0x78160001,  //  002A  JMPF	R5	#002D
+      0x8C140504,  //  002B  GETMET	R5	R2	K4
+      0x7C140200,  //  002C  CALL	R5	1
+      0xB0040604,  //  002D  RAISE	1	R3	R4
+      0x70020000,  //  002E  JMP		#0030
+      0xB0080000,  //  002F  RAISE	2	R0	R0
+      0x500C0000,  //  0030  LDBOOL	R3	0	0
+      0x90020003,  //  0031  SETMBR	R0	K0	R3
+      0x80000000,  //  0032  RET	0
     })
   )
 );
@@ -138,11 +148,11 @@ be_local_closure(class_Persist_json_fdump_map,   /* name */
 
 
 /********************************************************************
-** Solidified function: json_fdump_any
+** Solidified function: setmember
 ********************************************************************/
-be_local_closure(class_Persist_json_fdump_any,   /* name */
+be_local_closure(class_Persist_setmember,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    4,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -151,36 +161,14 @@ be_local_closure(class_Persist_json_fdump_any,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_json_fdump_any,
+    &be_const_str_setmember,
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x6010000F,  //  0001  GETGBL	R4	G15
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x60180013,  //  0003  GETGBL	R6	G19
-      0x7C100400,  //  0004  CALL	R4	2
-      0x78120004,  //  0005  JMPF	R4	#000B
-      0x8C10010A,  //  0006  GETMET	R4	R0	K10
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x5C1C0400,  //  0008  MOVE	R7	R2
-      0x7C100600,  //  0009  CALL	R4	3
-      0x7002000E,  //  000A  JMP		#001A
-      0x6010000F,  //  000B  GETGBL	R4	G15
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x60180012,  //  000D  GETGBL	R6	G18
-      0x7C100400,  //  000E  CALL	R4	2
-      0x78120004,  //  000F  JMPF	R4	#0015
-      0x8C10010B,  //  0010  GETMET	R4	R0	K11
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x5C1C0400,  //  0012  MOVE	R7	R2
-      0x7C100600,  //  0013  CALL	R4	3
-      0x70020004,  //  0014  JMP		#001A
-      0x8C100301,  //  0015  GETMET	R4	R1	K1
-      0x8C180704,  //  0016  GETMET	R6	R3	K4
-      0x5C200400,  //  0017  MOVE	R8	R2
-      0x7C180400,  //  0018  CALL	R6	2
-      0x7C100400,  //  0019  CALL	R4	2
-      0x80000000,  //  001A  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x880C0107,  //  0000  GETMBR	R3	R0	K7
+      0x980C0202,  //  0001  SETIDX	R3	R1	R2
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x90020003,  //  0003  SETMBR	R0	K0	R3
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -206,10 +194,10 @@ be_local_closure(class_Persist_init,   /* name */
     ( &(const binstruction[ 8]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x90021801,  //  0002  SETMBR	R0	K12	R1
+      0x90020E01,  //  0002  SETMBR	R0	K7	R1
       0x50040000,  //  0003  LDBOOL	R1	0	0
-      0x90021A01,  //  0004  SETMBR	R0	K13	R1
-      0x8C04010E,  //  0005  GETMET	R1	R0	K14
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
+      0x8C040108,  //  0005  GETMET	R1	R0	K8
       0x7C040200,  //  0006  CALL	R1	1
       0x80000000,  //  0007  RET	0
     })
@@ -219,11 +207,69 @@ be_local_closure(class_Persist_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: save
+** Solidified function: remove
 ********************************************************************/
-be_local_closure(class_Persist_save,   /* name */
+be_local_closure(class_Persist_remove,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_remove,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C080509,  //  0001  GETMET	R2	R2	K9
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x50080200,  //  0004  LDBOOL	R2	1	0
+      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: contains
+********************************************************************/
+be_local_closure(class_Persist_contains,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_contains,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Persist_dirty,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -232,59 +278,168 @@ be_local_closure(class_Persist_save,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_save,
+    &be_const_str_dirty,
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x8804010D,  //  0000  GETMBR	R1	R0	K13
-      0x7806002E,  //  0001  JMPF	R1	#0031
-      0x4C040000,  //  0002  LDNIL	R1
-      0xA802000B,  //  0003  EXBLK	0	#0010
-      0x60080011,  //  0004  GETGBL	R2	G17
-      0x880C010F,  //  0005  GETMBR	R3	R0	K15
-      0x58100010,  //  0006  LDCONST	R4	K16
-      0x7C080400,  //  0007  CALL	R2	2
-      0x5C040400,  //  0008  MOVE	R1	R2
-      0x8C080111,  //  0009  GETMET	R2	R0	K17
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x8C080312,  //  000C  GETMET	R2	R1	K18
-      0x7C080200,  //  000D  CALL	R2	1
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x7002001E,  //  000F  JMP		#002F
-      0xAC080002,  //  0010  CATCH	R2	0	2
-      0x7002001B,  //  0011  JMP		#002E
-      0x4C100000,  //  0012  LDNIL	R4
-      0x20100204,  //  0013  NE	R4	R1	R4
-      0x78120001,  //  0014  JMPF	R4	#0017
-      0x8C100312,  //  0015  GETMET	R4	R1	K18
-      0x7C100200,  //  0016  CALL	R4	1
-      0x4C040000,  //  0017  LDNIL	R1
-      0xA8020009,  //  0018  EXBLK	0	#0023
-      0x60100011,  //  0019  GETGBL	R4	G17
-      0x8814010F,  //  001A  GETMBR	R5	R0	K15
-      0x58180010,  //  001B  LDCONST	R6	K16
-      0x7C100400,  //  001C  CALL	R4	2
-      0x5C040800,  //  001D  MOVE	R1	R4
-      0x8C100301,  //  001E  GETMET	R4	R1	K1
-      0x58180013,  //  001F  LDCONST	R6	K19
-      0x7C100400,  //  0020  CALL	R4	2
-      0xA8040001,  //  0021  EXBLK	1	1
-      0x70020003,  //  0022  JMP		#0027
-      0xAC100000,  //  0023  CATCH	R4	0	0
-      0x70020000,  //  0024  JMP		#0026
-      0x70020000,  //  0025  JMP		#0027
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x4C100000,  //  0027  LDNIL	R4
-      0x20100204,  //  0028  NE	R4	R1	R4
-      0x78120001,  //  0029  JMPF	R4	#002C
-      0x8C100312,  //  002A  GETMET	R4	R1	K18
-      0x7C100200,  //  002B  CALL	R4	1
-      0xB0040403,  //  002C  RAISE	1	R2	R3
-      0x70020000,  //  002D  JMP		#002F
-      0xB0080000,  //  002E  RAISE	2	R0	R0
-      0x50080000,  //  002F  LDBOOL	R2	0	0
-      0x90021A02,  //  0030  SETMBR	R0	K13	R2
-      0x80000000,  //  0031  RET	0
+    ( &(const binstruction[ 3]) {  /* code */
+      0x50040200,  //  0000  LDBOOL	R1	1	0
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: json_fdump
+********************************************************************/
+be_local_closure(class_Persist_json_fdump,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_json_fdump,
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0xA40A1600,  //  0000  IMPORT	R2	K11
+      0x600C000F,  //  0001  GETGBL	R3	G15
+      0x88100107,  //  0002  GETMBR	R4	R0	K7
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x780E0004,  //  0005  JMPF	R3	#000B
+      0x8C0C010C,  //  0006  GETMET	R3	R0	K12
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x88180107,  //  0008  GETMBR	R6	R0	K7
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0x70020000,  //  000A  JMP		#000C
+      0xB0061B0E,  //  000B  RAISE	1	K13	K14
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: has
+********************************************************************/
+be_local_closure(class_Persist_has,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_has,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C08050A,  //  0001  GETMET	R2	R2	K10
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: json_fdump_map
+********************************************************************/
+be_local_closure(class_Persist_json_fdump_map,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_json_fdump_map,
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0xA40E1600,  //  0000  IMPORT	R3	K11
+      0x8C100305,  //  0001  GETMET	R4	R1	K5
+      0x5818000F,  //  0002  LDCONST	R6	K15
+      0x7C100400,  //  0003  CALL	R4	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x60140010,  //  0005  GETGBL	R5	G16
+      0x8C180510,  //  0006  GETMET	R6	R2	K16
+      0x7C180200,  //  0007  CALL	R6	1
+      0x7C140200,  //  0008  CALL	R5	1
+      0xA8020017,  //  0009  EXBLK	0	#0022
+      0x5C180A00,  //  000A  MOVE	R6	R5
+      0x7C180000,  //  000B  CALL	R6	0
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x201C0807,  //  000D  NE	R7	R4	R7
+      0x781E0002,  //  000E  JMPF	R7	#0012
+      0x8C1C0305,  //  000F  GETMET	R7	R1	K5
+      0x5C240800,  //  0010  MOVE	R9	R4
+      0x7C1C0400,  //  0011  CALL	R7	2
+      0x8C1C0305,  //  0012  GETMET	R7	R1	K5
+      0x8C240711,  //  0013  GETMET	R9	R3	K17
+      0x602C0008,  //  0014  GETGBL	R11	G8
+      0x5C300C00,  //  0015  MOVE	R12	R6
+      0x7C2C0200,  //  0016  CALL	R11	1
+      0x7C240400,  //  0017  CALL	R9	2
+      0x7C1C0400,  //  0018  CALL	R7	2
+      0x8C1C0305,  //  0019  GETMET	R7	R1	K5
+      0x58240012,  //  001A  LDCONST	R9	K18
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x8C1C0113,  //  001C  GETMET	R7	R0	K19
+      0x5C240200,  //  001D  MOVE	R9	R1
+      0x94280406,  //  001E  GETIDX	R10	R2	R6
+      0x7C1C0600,  //  001F  CALL	R7	3
+      0x58100014,  //  0020  LDCONST	R4	K20
+      0x7001FFE7,  //  0021  JMP		#000A
+      0x58140015,  //  0022  LDCONST	R5	K21
+      0xAC140200,  //  0023  CATCH	R5	1	0
+      0xB0080000,  //  0024  RAISE	2	R0	R0
+      0x8C140305,  //  0025  GETMET	R5	R1	K5
+      0x581C0016,  //  0026  LDCONST	R7	K22
+      0x7C140400,  //  0027  CALL	R5	2
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: member
+********************************************************************/
+be_local_closure(class_Persist_member,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_member,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x8C080517,  //  0001  GETMET	R2	R2	K23
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -310,67 +465,10 @@ be_local_closure(class_Persist_zero,   /* name */
     ( &(const binstruction[ 6]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x90021801,  //  0002  SETMBR	R0	K12	R1
+      0x90020E01,  //  0002  SETMBR	R0	K7	R1
       0x50040200,  //  0003  LDBOOL	R1	1	0
-      0x90021A01,  //  0004  SETMBR	R0	K13	R1
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find
-********************************************************************/
-be_local_closure(class_Persist_find,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_find,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x880C010C,  //  0000  GETMBR	R3	R0	K12
-      0x8C0C0714,  //  0001  GETMET	R3	R3	K20
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x5C180400,  //  0003  MOVE	R6	R2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x80040600,  //  0005  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: has
-********************************************************************/
-be_local_closure(class_Persist_has,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_has,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808010C,  //  0000  GETMBR	R2	R0	K12
-      0x8C080515,  //  0001  GETMET	R2	R2	K21
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -394,151 +492,31 @@ be_local_closure(class_Persist_json_fdump_list,   /* name */
     &be_const_str_json_fdump_list,
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100301,  //  0001  GETMET	R4	R1	K1
-      0x58180016,  //  0002  LDCONST	R6	K22
+      0xA40E1600,  //  0000  IMPORT	R3	K11
+      0x8C100305,  //  0001  GETMET	R4	R1	K5
+      0x58180018,  //  0002  LDCONST	R6	K24
       0x7C100400,  //  0003  CALL	R4	2
-      0x58100017,  //  0004  LDCONST	R4	K23
+      0x58100019,  //  0004  LDCONST	R4	K25
       0x6014000C,  //  0005  GETGBL	R5	G12
       0x5C180400,  //  0006  MOVE	R6	R2
       0x7C140200,  //  0007  CALL	R5	1
       0x14140805,  //  0008  LT	R5	R4	R5
       0x7816000A,  //  0009  JMPF	R5	#0015
-      0x24140917,  //  000A  GT	R5	R4	K23
+      0x24140919,  //  000A  GT	R5	R4	K25
       0x78160002,  //  000B  JMPF	R5	#000F
-      0x8C140301,  //  000C  GETMET	R5	R1	K1
-      0x581C0007,  //  000D  LDCONST	R7	K7
+      0x8C140305,  //  000C  GETMET	R5	R1	K5
+      0x581C0014,  //  000D  LDCONST	R7	K20
       0x7C140400,  //  000E  CALL	R5	2
-      0x8C140106,  //  000F  GETMET	R5	R0	K6
+      0x8C140113,  //  000F  GETMET	R5	R0	K19
       0x5C1C0200,  //  0010  MOVE	R7	R1
       0x94200404,  //  0011  GETIDX	R8	R2	R4
       0x7C140600,  //  0012  CALL	R5	3
-      0x00100918,  //  0013  ADD	R4	R4	K24
+      0x0010091A,  //  0013  ADD	R4	R4	K26
       0x7001FFEF,  //  0014  JMP		#0005
-      0x8C140301,  //  0015  GETMET	R5	R1	K1
-      0x581C0019,  //  0016  LDCONST	R7	K25
+      0x8C140305,  //  0015  GETMET	R5	R1	K5
+      0x581C001B,  //  0016  LDCONST	R7	K27
       0x7C140400,  //  0017  CALL	R5	2
       0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: member
-********************************************************************/
-be_local_closure(class_Persist_member,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_member,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808010C,  //  0000  GETMBR	R2	R0	K12
-      0x8C080514,  //  0001  GETMET	R2	R2	K20
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: setmember
-********************************************************************/
-be_local_closure(class_Persist_setmember,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_setmember,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x880C010C,  //  0000  GETMBR	R3	R0	K12
-      0x980C0202,  //  0001  SETIDX	R3	R1	R2
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x90021A03,  //  0003  SETMBR	R0	K13	R3
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: contains
-********************************************************************/
-be_local_closure(class_Persist_contains,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_contains,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808010C,  //  0000  GETMBR	R2	R0	K12
-      0x8C080515,  //  0001  GETMET	R2	R2	K21
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: json_fdump
-********************************************************************/
-be_local_closure(class_Persist_json_fdump,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_json_fdump,
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C000F,  //  0001  GETGBL	R3	G15
-      0x8810010C,  //  0002  GETMBR	R4	R0	K12
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x780E0004,  //  0005  JMPF	R3	#000B
-      0x8C0C010A,  //  0006  GETMET	R3	R0	K10
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x8818010C,  //  0008  GETMBR	R6	R0	K12
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x70020000,  //  000A  JMP		#000C
-      0xB006351B,  //  000B  RAISE	1	K26	K27
-      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -562,26 +540,26 @@ be_local_closure(class_Persist_load,   /* name */
     &be_const_str_load,
     &be_const_str_solidified,
     ( &(const binstruction[49]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA4061600,  //  0000  IMPORT	R1	K11
       0xA40A3800,  //  0001  IMPORT	R2	K28
       0x4C0C0000,  //  0002  LDNIL	R3
       0x4C100000,  //  0003  LDNIL	R4
       0x8C14051D,  //  0004  GETMET	R5	R2	K29
-      0x881C010F,  //  0005  GETMBR	R7	R0	K15
+      0x881C0101,  //  0005  GETMBR	R7	R0	K1
       0x7C140400,  //  0006  CALL	R5	2
       0x78160025,  //  0007  JMPF	R5	#002E
       0xA802000D,  //  0008  EXBLK	0	#0017
       0x60140011,  //  0009  GETGBL	R5	G17
-      0x8818010F,  //  000A  GETMBR	R6	R0	K15
+      0x88180101,  //  000A  GETMBR	R6	R0	K1
       0x581C001E,  //  000B  LDCONST	R7	K30
       0x7C140400,  //  000C  CALL	R5	2
       0x5C0C0A00,  //  000D  MOVE	R3	R5
-      0x8C14030E,  //  000E  GETMET	R5	R1	K14
+      0x8C140308,  //  000E  GETMET	R5	R1	K8
       0x8C1C071F,  //  000F  GETMET	R7	R3	K31
       0x7C1C0200,  //  0010  CALL	R7	1
       0x7C140400,  //  0011  CALL	R5	2
       0x5C100A00,  //  0012  MOVE	R4	R5
-      0x8C140712,  //  0013  GETMET	R5	R3	K18
+      0x8C140704,  //  0013  GETMET	R5	R3	K4
       0x7C140200,  //  0014  CALL	R5	1
       0xA8040001,  //  0015  EXBLK	1	1
       0x70020009,  //  0016  JMP		#0021
@@ -590,7 +568,7 @@ be_local_closure(class_Persist_load,   /* name */
       0x4C1C0000,  //  0019  LDNIL	R7
       0x201C0607,  //  001A  NE	R7	R3	R7
       0x781E0001,  //  001B  JMPF	R7	#001E
-      0x8C1C0712,  //  001C  GETMET	R7	R3	K18
+      0x8C1C0704,  //  001C  GETMET	R7	R3	K4
       0x7C1C0200,  //  001D  CALL	R7	1
       0xB0040A06,  //  001E  RAISE	1	R5	R6
       0x70020000,  //  001F  JMP		#0021
@@ -600,13 +578,13 @@ be_local_closure(class_Persist_load,   /* name */
       0x601C0013,  //  0023  GETGBL	R7	G19
       0x7C140400,  //  0024  CALL	R5	2
       0x78160001,  //  0025  JMPF	R5	#0028
-      0x90021804,  //  0026  SETMBR	R0	K12	R4
+      0x90020E04,  //  0026  SETMBR	R0	K7	R4
       0x70020002,  //  0027  JMP		#002B
       0x60140001,  //  0028  GETGBL	R5	G1
       0x58180020,  //  0029  LDCONST	R6	K32
       0x7C140200,  //  002A  CALL	R5	1
       0x50140000,  //  002B  LDBOOL	R5	0	0
-      0x90021A05,  //  002C  SETMBR	R0	K13	R5
+      0x90020005,  //  002C  SETMBR	R0	K0	R5
       0x70020001,  //  002D  JMP		#0030
       0x8C140121,  //  002E  GETMET	R5	R0	K33
       0x7C140200,  //  002F  CALL	R5	1
@@ -618,12 +596,12 @@ be_local_closure(class_Persist_load,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove
+** Solidified function: json_fdump_any
 ********************************************************************/
-be_local_closure(class_Persist_remove,   /* name */
+be_local_closure(class_Persist_json_fdump_any,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    9,                          /* nstack */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -631,16 +609,65 @@ be_local_closure(class_Persist_remove,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Persist,     /* shared constants */
-    &be_const_str_remove,
+    &be_const_str_json_fdump_any,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8808010C,  //  0000  GETMBR	R2	R0	K12
-      0x8C080522,  //  0001  GETMET	R2	R2	K34
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x50080200,  //  0004  LDBOOL	R2	1	0
-      0x90021A02,  //  0005  SETMBR	R0	K13	R2
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[27]) {  /* code */
+      0xA40E1600,  //  0000  IMPORT	R3	K11
+      0x6010000F,  //  0001  GETGBL	R4	G15
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x60180013,  //  0003  GETGBL	R6	G19
+      0x7C100400,  //  0004  CALL	R4	2
+      0x78120004,  //  0005  JMPF	R4	#000B
+      0x8C10010C,  //  0006  GETMET	R4	R0	K12
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x7C100600,  //  0009  CALL	R4	3
+      0x7002000E,  //  000A  JMP		#001A
+      0x6010000F,  //  000B  GETGBL	R4	G15
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x60180012,  //  000D  GETGBL	R6	G18
+      0x7C100400,  //  000E  CALL	R4	2
+      0x78120004,  //  000F  JMPF	R4	#0015
+      0x8C100122,  //  0010  GETMET	R4	R0	K34
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x5C1C0400,  //  0012  MOVE	R7	R2
+      0x7C100600,  //  0013  CALL	R4	3
+      0x70020004,  //  0014  JMP		#001A
+      0x8C100305,  //  0015  GETMET	R4	R1	K5
+      0x8C180711,  //  0016  GETMET	R6	R3	K17
+      0x5C200400,  //  0017  MOVE	R8	R2
+      0x7C180400,  //  0018  CALL	R6	2
+      0x7C100400,  //  0019  CALL	R4	2
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find
+********************************************************************/
+be_local_closure(class_Persist_find,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Persist,     /* shared constants */
+    &be_const_str_find,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x880C0107,  //  0000  GETMBR	R3	R0	K7
+      0x8C0C0717,  //  0001  GETMET	R3	R3	K23
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x80040600,  //  0005  RET	1	R3
     })
   )
 );
@@ -653,25 +680,26 @@ be_local_closure(class_Persist_remove,   /* name */
 be_local_class(Persist,
     2,
     NULL,
-    be_nested_map(17,
+    be_nested_map(18,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(save, -1), be_const_closure(class_Persist_save_closure) },
+        { be_const_key(setmember, 12), be_const_closure(class_Persist_setmember_closure) },
+        { be_const_key(dirty, -1), be_const_closure(class_Persist_dirty_closure) },
         { be_const_key(remove, -1), be_const_closure(class_Persist_remove_closure) },
-        { be_const_key(_filename, -1), be_nested_str(_persist_X2Ejson) },
-        { be_const_key(json_fdump_any, 4), be_const_closure(class_Persist_json_fdump_any_closure) },
-        { be_const_key(load, 16), be_const_closure(class_Persist_load_closure) },
-        { be_const_key(zero, -1), be_const_closure(class_Persist_zero_closure) },
-        { be_const_key(json_fdump_list, -1), be_const_closure(class_Persist_json_fdump_list_closure) },
-        { be_const_key(find, 5), be_const_closure(class_Persist_find_closure) },
-        { be_const_key(has, -1), be_const_closure(class_Persist_has_closure) },
-        { be_const_key(member, -1), be_const_closure(class_Persist_member_closure) },
-        { be_const_key(setmember, 8), be_const_closure(class_Persist_setmember_closure) },
-        { be_const_key(_dirty, 0), be_const_var(1) },
-        { be_const_key(save, 9), be_const_closure(class_Persist_save_closure) },
         { be_const_key(contains, -1), be_const_closure(class_Persist_contains_closure) },
-        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(json_fdump_map, 2), be_const_closure(class_Persist_json_fdump_map_closure) },
         { be_const_key(json_fdump, -1), be_const_closure(class_Persist_json_fdump_closure) },
-        { be_const_key(json_fdump_map, 3), be_const_closure(class_Persist_json_fdump_map_closure) },
-        { be_const_key(init, -1), be_const_closure(class_Persist_init_closure) },
+        { be_const_key(has, -1), be_const_closure(class_Persist_has_closure) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(json_fdump_any, -1), be_const_closure(class_Persist_json_fdump_any_closure) },
+        { be_const_key(zero, -1), be_const_closure(class_Persist_zero_closure) },
+        { be_const_key(load, 10), be_const_closure(class_Persist_load_closure) },
+        { be_const_key(json_fdump_list, 5), be_const_closure(class_Persist_json_fdump_list_closure) },
+        { be_const_key(member, 11), be_const_closure(class_Persist_member_closure) },
+        { be_const_key(_dirty, -1), be_const_var(1) },
+        { be_const_key(init, 9), be_const_closure(class_Persist_init_closure) },
+        { be_const_key(find, -1), be_const_closure(class_Persist_find_closure) },
+        { be_const_key(_filename, -1), be_nested_str(_persist_X2Ejson) },
     })),
     (bstring*) &be_const_str_Persist
 );


### PR DESCRIPTION
## Description:

Berry improve `persist` dirty data handling:
- `persist` module is unable to detect changes in sub-objects like lists or maps
- added `persist.dirty()` to indicate that data changed
- added `persist.save(true)` to force saving even if data is not marked as dirty

**Related issue (if applicable):** fixes #22187

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
