### PR TITLE
HASPmota make `delete()` backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ All notable changes to this project will be documented in this file.
 - Support for DALI 1 on ESP8266
 
 ### Breaking Changed
-- HASPmota `delete` instead of `delete()` (#22245)
 
 ### Changed
 - ESP32 platform update from 2024.09.10 to 2024.09.30 and Framework (Arduino Core) from v3.0.5 to v3.1.0.240926 (#22203)
 - Berry improve `persist` dirty data handling (#22246)
+- HASPmota `delete` instead of `delete()` (#22245)
 
 ### Fixed
 - ESP32 Range Extender compile error with core 3.0.0 (#22205)

--- a/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
+++ b/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
@@ -133,6 +133,7 @@ class lvh_root
   end
   def get_delete()
     self._delete()
+    return def () end
   end
   def _delete()
     # to be overriden

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -345,16 +345,34 @@ be_local_closure(class_lvh_root_get_delete,   /* name */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        0,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        0,                          /* has constants */
+        NULL,                       /* no const */
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 1]) {  /* code */
+          0x80000000,  //  0000  RET	0
+        })
+      ),
+    }),
     1,                          /* has constants */
     &be_ktab_class_lvh_root,     /* shared constants */
     be_str_weak(get_delete),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x8C040119,  //  0000  GETMET	R1	R0	K25
       0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+      0x84040000,  //  0002  CLOSURE	R1	P0
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );


### PR DESCRIPTION
## Description:

Change #22245 to make it backwards compatible (not a breaking change anymore)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
