### PR TITLE
Temporarily disable SPI DMA for uDisplay (broken since esp-idf 5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Dali compile error with core 3.x (#22214)
 - Dali received data decoding
 - ESP32 Ethernet using EthClockMode 3 (#22248)
+- Temporarily disable SPI DMA for uDisplay (broken since esp-idf 5.3)
 
 ### Removed
 

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -599,6 +599,10 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
           case 'B':
             lvgl_param.flushlines = next_val(&lp1);
             lvgl_param.data = next_val(&lp1);
+            // temporary fix to disable DMA due to a problem in esp-idf 5.3
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+            lvgl_param.use_dma = false;
+#endif
             break;
           case 'M':
             rotmap_xmin = next_val(&lp1);


### PR DESCRIPTION
## Description:

@gemu2015 It seems that the call to `spi_bus_initialize()` breaks SPI. So I temporarily disable DMA support from templates until we find a fix.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
