### PR TITLE
Fixing build error xdrv_13_display.ino with JPEG_PICTS

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -2442,6 +2442,28 @@ void Draw_RGB_Bitmap(char *file, uint16_t xp, uint16_t yp, uint8_t scale, bool i
 #ifdef ESP32
 #ifdef JPEG_PICTS
 #define JPG_DEFSIZE 150000
+void Draw_jpeg(uint8_t *mem, uint16_t jpgsize, uint16_t xp, uint16_t yp, uint8_t scale) {
+  if (mem[0] == 0xff && mem[1] == 0xd8) {
+    uint16_t xsize;
+    uint16_t ysize;
+    get_jpeg_size(mem, jpgsize, &xsize, &ysize);
+    //AddLog(LOG_LEVEL_INFO, PSTR("Pict size %d - %d - %d"), xsize, ysize, jpgsize);
+    scale &= 3;
+    uint8_t fac = 1 << scale;
+    xsize /= fac;
+    ysize /= fac;
+    renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
+    uint8_t *rgbmem = (uint8_t *)special_malloc(xsize * ysize * 2);
+    if (rgbmem) {
+      //jpg2rgb565(mem, jpgsize, rgbmem, JPG_SCALE_NONE);
+      jpg2rgb565(mem, jpgsize, rgbmem, (jpg_scale_t)scale);
+      renderer->pushColors((uint16_t*)rgbmem, xsize * ysize, true);
+      free(rgbmem);
+    }
+    renderer->setAddrWindow(0, 0, 0, 0);
+  }
+}
+
 void Draw_JPG_from_URL(char *url, uint16_t xp, uint16_t yp, uint8_t scale) {
   uint8_t *mem = 0;
   WiFiClient http_client;
@@ -2483,28 +2505,6 @@ void Draw_JPG_from_URL(char *url, uint16_t xp, uint16_t yp, uint8_t scale) {
     Draw_jpeg(mem, jpgsize, xp, yp, scale);
   }
   if (mem) free(mem);
-}
-
-void Draw_jpeg(uint8_t *mem, uint16_t jpgsize, uint16_t xp, uint16_t yp, uint8_t scale) {
-  if (mem[0] == 0xff && mem[1] == 0xd8) {
-    uint16_t xsize;
-    uint16_t ysize;
-    get_jpeg_size(mem, jpgsize, &xsize, &ysize);
-    //AddLog(LOG_LEVEL_INFO, PSTR("Pict size %d - %d - %d"), xsize, ysize, jpgsize);
-    scale &= 3;
-    uint8_t fac = 1 << scale;
-    xsize /= fac;
-    ysize /= fac;
-    renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
-    uint8_t *rgbmem = (uint8_t *)special_malloc(xsize * ysize * 2);
-    if (rgbmem) {
-      //jpg2rgb565(mem, jpgsize, rgbmem, JPG_SCALE_NONE);
-      jpg2rgb565(mem, jpgsize, rgbmem, (jpg_scale_t)scale);
-      renderer->pushColors((uint16_t*)rgbmem, xsize * ysize, true);
-      free(rgbmem);
-    }
-    renderer->setAddrWindow(0, 0, 0, 0);
-  }
 }
 #endif // JPEG_PICTS
 #endif // ESP32


### PR DESCRIPTION
On ESP32, with `#define JPEG_PICTS` without the scripter, build fails due to the function `Draw_jpeg` being defined after use. Order swapped to satisfy the compiler.

Change tested to compile without errors, but not being 100% sure of when/how it is supposed to work, no verification of this.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
