### PR TITLE
Fixed Compressor and Operation for MiElHVAC

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
@@ -90,9 +90,16 @@ struct miel_hvac_data_roomtemp {
 };
 
 struct miel_hvac_data_status {
-	uint8_t			_pad1[2];
+	uint8_t			_pad1[3];
 	uint8_t			compressor;
+#define MIEL_HVAC_STATUS_COMPRESSOR_OFF	0x00
+#define MIEL_HVAC_STATUS_COMPRESSOR_ON	0x01
 	uint8_t			operation;
+#define MIEL_HVAC_STATUS_OPERATION_OFF	0x00
+#define MIEL_HVAC_STATUS_OPERATION_1	0x01
+#define MIEL_HVAC_STATUS_OPERATION_2	0x02
+#define MIEL_HVAC_STATUS_OPERATION_3	0x03
+#define MIEL_HVAC_STATUS_OPERATION_4	0x04
 };
 
 struct miel_hvac_data {
@@ -129,6 +136,9 @@ CTASSERT(offsetof(struct miel_hvac_data, data.settings.airdirection) == 14);
 
 CTASSERT(offsetof(struct miel_hvac_data, data.roomtemp.temp) == 3);
 CTASSERT(offsetof(struct miel_hvac_data, data.roomtemp.temp05) == 6);
+
+CTASSERT(offsetof(struct miel_hvac_data, data.status.compressor) == 4);
+CTASSERT(offsetof(struct miel_hvac_data, data.status.operation) == 5);
 
 /* to hvac */
 
@@ -206,7 +216,7 @@ struct miel_hvac_msg_update {
 	uint8_t			_pad1[4];
 	uint8_t			widevane;
 #define MIEL_HVAC_UPDATE_WIDEVANE_MASK	0x0f
-#define MIEL_HVAC_UPDATE_WIDEVANE_ISEE	0x00
+#define MIEL_HVAC_UPDATE_WIDEVANE_AUTO	0x00
 #define MIEL_HVAC_UPDATE_WIDEVANE_LL	0x01
 #define MIEL_HVAC_UPDATE_WIDEVANE_L	0x02
 #define MIEL_HVAC_UPDATE_WIDEVANE_C	0x03
@@ -304,6 +314,11 @@ struct miel_hvac_map {
 	const char		*name;
 };
 
+static const struct miel_hvac_map miel_hvac_power_map[] = {
+	{ MIEL_HVAC_UPDATE_POWER_OFF,	"off"	},
+	{ MIEL_HVAC_UPDATE_POWER_ON,	"on"	},
+};
+
 static const struct miel_hvac_map miel_hvac_mode_map[] = {
 	{ MIEL_HVAC_UPDATE_MODE_HEAT,		"heat"	},
 	{ MIEL_HVAC_UPDATE_MODE_DRY,		"dry"	},
@@ -335,7 +350,7 @@ static const struct miel_hvac_map miel_hvac_vane_map[] = {
 };
 
 static const struct miel_hvac_map miel_hvac_widevane_map[] = {
-	{ MIEL_HVAC_UPDATE_WIDEVANE_ISEE,	"isee"	},
+	{ MIEL_HVAC_UPDATE_WIDEVANE_AUTO,	"auto"	},
 	{ MIEL_HVAC_UPDATE_WIDEVANE_LL,		"left"	},
 	{ MIEL_HVAC_UPDATE_WIDEVANE_L,		"left_middle"	},
 	{ MIEL_HVAC_UPDATE_WIDEVANE_C,		"center"	},
@@ -360,6 +375,19 @@ static const struct miel_hvac_map miel_hvac_airdirection_map[] = {
 	{ MIEL_HVAC_UPDATE_AIRDIRECTION_EVEN,	"even"	},
 	{ MIEL_HVAC_UPDATE_AIRDIRECTION_INDIRECT,	"indirect"	},
 	{ MIEL_HVAC_UPDATE_AIRDIRECTION_DIRECT,	"direct"	},
+};
+
+static const struct miel_hvac_map miel_hvac_compressor_map[] = {
+	{ MIEL_HVAC_STATUS_COMPRESSOR_OFF,	"off"	},
+	{ MIEL_HVAC_STATUS_COMPRESSOR_ON,	"on"	},
+};
+
+static const struct miel_hvac_map miel_hvac_operation_map[] = {
+	{ MIEL_HVAC_STATUS_OPERATION_OFF,	"off"	},
+	{ MIEL_HVAC_STATUS_OPERATION_1,	"1"	},
+	{ MIEL_HVAC_STATUS_OPERATION_2,	"2"	},
+	{ MIEL_HVAC_STATUS_OPERATION_3,	"3"	},
+	{ MIEL_HVAC_STATUS_OPERATION_4,	"4"	},
 };
 
 enum miel_hvac_parser_state {
@@ -997,8 +1025,12 @@ miel_hvac_publish_settings(struct miel_hvac_softc *sc)
 	const char *name;
 	const char *name_swing_h;
 
-	Response_P(PSTR("{\"" D_JSON_IRHVAC_POWER "\":\"%s\""),
-	    set->power ? "ON" : "OFF");
+	name = miel_hvac_map_byval(set->power,
+	    miel_hvac_power_map, nitems(miel_hvac_power_map));
+	if (name != NULL) {
+		Response_P(PSTR("{\"" D_JSON_IRHVAC_POWER "\":\"%s\""),
+		     name);
+	}	
 
 	name = miel_hvac_map_byval( set->mode &
 	    MIEL_HVAC_SETTINGS_MODE_MASK,
@@ -1046,7 +1078,7 @@ miel_hvac_publish_settings(struct miel_hvac_softc *sc)
 	    miel_hvac_airdirection_map, nitems(miel_hvac_airdirection_map));
 	if (name != NULL) {
 		ResponseAppend_P(PSTR(",\"AirDirection\":\"%s\""),
-		    name_swing_h == "isee" ? name : "OFF");
+		    name_swing_h == "auto" ? name : "OFF");
 	}
 
 	name = miel_hvac_map_byval(set->prohibit,
@@ -1236,8 +1268,13 @@ miel_hvac_sensor(struct miel_hvac_softc *sc)
 	const char *name_swing_h;
 
 	ResponseAppend_P(PSTR("," "\"MiElHVAC\":{"));
-	ResponseAppend_P(PSTR("\"Power\":\"%s\""),
-	    set->power ? "ON" : "OFF");
+
+	name = miel_hvac_map_byval(set->power,
+	    miel_hvac_power_map, nitems(miel_hvac_power_map));
+	if (name != NULL) {
+		ResponseAppend_P(PSTR("\"Power\":\"%s\""),
+		     name);
+	}
 
 	name = miel_hvac_map_byval( set->mode &
 	    MIEL_HVAC_SETTINGS_MODE_MASK,
@@ -1283,7 +1320,7 @@ miel_hvac_sensor(struct miel_hvac_softc *sc)
 	    miel_hvac_airdirection_map, nitems(miel_hvac_airdirection_map));
 	if (name != NULL) {
 		ResponseAppend_P(PSTR(",\"AirDirection\":\"%s\""),
-		    name_swing_h == "isee" ? name : "OFF");
+		    name_swing_h == "auto" ? name : "off");
 	}
 
 	name = miel_hvac_map_byval(set->prohibit,
@@ -1317,13 +1354,22 @@ miel_hvac_sensor(struct miel_hvac_softc *sc)
 	}
 
 	if (sc->sc_status.type != 0) {
-		const struct miel_hvac_data_status *s =
+		const struct miel_hvac_data_status *status =
 		    &sc->sc_status.data.status;
 
-		ResponseAppend_P(PSTR(",\"Operation\":\"%s\""),
-		    s->operation ? "ON" : "OFF");
-		ResponseAppend_P(PSTR(",\"Compressor\":\"%s\""),
-		    s->compressor ? "ON" : "OFF");	
+		name = miel_hvac_map_byval(status->compressor,
+	    miel_hvac_compressor_map, nitems(miel_hvac_compressor_map));
+		if (name != NULL) {
+		    ResponseAppend_P(PSTR(",\"Compressor\":\"%s\""),
+		        name);	
+		}
+
+        name = miel_hvac_map_byval(status->operation,
+	    miel_hvac_operation_map, nitems(miel_hvac_operation_map));
+		if (name != NULL) {
+		    ResponseAppend_P(PSTR(",\"Operation\":\"%s\""),
+		        name);
+		}	
 	}
 
 	if (sc->sc_temp.type != 0) {


### PR DESCRIPTION
## Description:
Added map for Compressor and Operation status.
Changed widevane position name from ISEE to AUTO, display sam as in MELCLoud service.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
