### PR TITLE
Compute US AQI and EPA AQI for PMS5003x sensors

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -1008,7 +1008,8 @@ const char HTTP_SNS_F_ENVIRONMENTAL_CONCENTRATION[] PROGMEM = "{s}%s " D_ENVIRON
 const char HTTP_SNS_PARTICALS_BEYOND[] PROGMEM =              "{s}%s " D_PARTICALS_BEYOND            " %s " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER       "{e}";
 const char HTTP_SNS_AVG_RAD_DOSE[]     PROGMEM =              "{s}%s " D_AVG_RAD_DOSE                " %s " D_UNIT_MINUTE     "{m}%d.%02d " D_UNIT_US_H                  "{e}";
 const char HTTP_SNS_US_AQI[] PROGMEM =                        "{s}%s US AQI {m}%d{e}";
-const char HTTP_SNS_US_EPA_AQI[] PROGMEM =                    "{s}%s EPA US AQI {m}%d{e}";
+const char HTTP_SNS_US_EPA_AQI[] PROGMEM =                    "{s}%s US EPA AQI {m}%d{e}";
+const char HTTP_SNS_EUROPEAN_AQI[] PROGMEM =                  "{s}%s European AQI {m}%s{e}";
 
 const char HTTP_SNS_VOLTAGE[]             PROGMEM = "{s}" D_VOLTAGE                 "{m}%s " D_UNIT_VOLT          "{e}";
 const char HTTP_SNS_CURRENT[]             PROGMEM = "{s}" D_CURRENT                 "{m}%s " D_UNIT_AMPERE        "{e}";

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -1007,6 +1007,8 @@ const char HTTP_SNS_ENVIRONMENTAL_CONCENTRATION[] PROGMEM =   "{s}%s " D_ENVIRON
 const char HTTP_SNS_F_ENVIRONMENTAL_CONCENTRATION[] PROGMEM = "{s}%s " D_ENVIRONMENTAL_CONCENTRATION " %s " D_UNIT_MICROMETER "{m}%1_f " D_UNIT_MICROGRAM_PER_CUBIC_METER "{e}";
 const char HTTP_SNS_PARTICALS_BEYOND[] PROGMEM =              "{s}%s " D_PARTICALS_BEYOND            " %s " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER       "{e}";
 const char HTTP_SNS_AVG_RAD_DOSE[]     PROGMEM =              "{s}%s " D_AVG_RAD_DOSE                " %s " D_UNIT_MINUTE     "{m}%d.%02d " D_UNIT_US_H                  "{e}";
+const char HTTP_SNS_US_AQI[] PROGMEM =                        "{s}%s US AQI {m}%d{e}";
+const char HTTP_SNS_US_EPA_AQI[] PROGMEM =                    "{s}%s EPA US AQI {m}%d{e}";
 
 const char HTTP_SNS_VOLTAGE[]             PROGMEM = "{s}" D_VOLTAGE                 "{m}%s " D_UNIT_VOLT          "{e}";
 const char HTTP_SNS_CURRENT[]             PROGMEM = "{s}" D_CURRENT                 "{m}%s " D_UNIT_AMPERE        "{e}";

--- a/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
@@ -373,15 +373,15 @@ int usaEpaStandardPm2d5Adjustment(int pm25_standard, int relative_humidity)
   float x = pm25_standard;
   float RH = relative_humidity;
   if (x<30) {
-    return 0.524 * x - 0.0862 * RH + 5.75;
+    return 0.524f * x - 0.0862f * RH + 5.75f;
   } else if(x<50) {
-    return (0.786 * (x/20.0 - 3.0/2.0) + 0.524 * (1.0 - (x/20.0 - 3.0/2.0))) * x - 0.0862 * RH + 5.75;
+    return (0.786f * (x/20.0f - 3.0f/2.0f) + 0.524f * (1.0f - (x/20.0f - 3.0f/2.0f))) * x - 0.0862f * RH + 5.75f;
   } else if(x<210) {
-    return 0.786 * x - 0.0862 * RH + 5.75;
+    return 0.786f * x - 0.0862f * RH + 5.75f;
   } else if(x<260) {
-    return (0.69 * (x/50.0 - 21.0/5.0) + 0.786 * (1.0 - (x/50.0 - 21.0/5.0))) * x - 0.0862 * RH * (1.0 - (x/50.0 - 21.0/5.0)) + 2.966 * (x/50.0 - 21.0/5.0) + 5.75 * (1.0 - (x/50.0 - 21.0/5.0)) + 8.84 * pow(10.0, -4.0) * pow(x,2.0) * (x/50.0 - 21.0/5.0);
+    return (0.69f * (x/50.0f - 21.0f/5.0f) + 0.786f * (1.0f - (x/50.0f - 21.0f/5.0f))) * x - 0.0862f * RH * (1.0f - (x/50.0f - 21.0f/5.0f)) + 2.966f * (x/50.0f - 21.0f/5.0f) + 5.75f * (1.0f - (x/50.0f - 21.0f/5.0f)) + 8.84f * FastPrecisePowf(10.0f, -4.0f) * FastPrecisePowf(x,2.0f) * (x/50.0f - 21.0f/5.0f);
   } else {
-    return 2.966 + 0.69 * x + 8.84 * pow(10.0, -4.0) * pow(x, 2.0);
+    return 2.966f + 0.69f * x + 8.84f * FastPrecisePowf(10.0f, -4.0f) * FastPrecisePowf(x, 2.0f);
   }
 }
 
@@ -391,16 +391,16 @@ int compute_us_aqi(int pm25_standard)
 {
   if (pm25_standard <= 9) {
     return map_double(pm25_standard, 0, 9, 0, 50);
-  } else if (pm25_standard <= 35.4) {
-    return map_double(pm25_standard, 9.1, 35.4, 51, 100);
-  } else if (pm25_standard <= 55.4) {
-    return map_double(pm25_standard, 35.5, 55.4, 101, 150);
-  } else if (pm25_standard <= 125.4) {
-    return map_double(pm25_standard, 55.5, 125.4, 151, 200);
-  } else if (pm25_standard <= 225.4) {
-    return map_double(pm25_standard, 125.5, 225.4, 201, 300);
-  } else if (pm25_standard <= 325.4) {
-    return map_double(pm25_standard, 225.5, 325.4, 301, 500);
+  } else if (pm25_standard <= 35) {
+    return map_double(pm25_standard, 9.1f, 35.4f, 51, 100);
+  } else if (pm25_standard <= 55) {
+    return map_double(pm25_standard, 35.5f, 55.4f, 101, 150);
+  } else if (pm25_standard <= 125) {
+    return map_double(pm25_standard, 55.5f, 125.4f, 151, 200);
+  } else if (pm25_standard <= 225) {
+    return map_double(pm25_standard, 125.5f, 225.4f, 201, 300);
+  } else if (pm25_standard <= 325) {
+    return map_double(pm25_standard, 225.5f, 325.4f, 301, 500);
   } else {
     return 500;
   }


### PR DESCRIPTION
## Description: 

AQI is a common way to display PM2.5 data and the thresholds are easier to remember than raw pm2.5 data.  This PR adds a calculation for standard US AQI and a second one that uses the US EPA adjustments which gives a more accurate AQI for places that experience wildfire smoke.  

![image](https://github.com/user-attachments/assets/3fc3d7d9-8b44-44b1-9d92-efeafb596674)

```
12:58:21.042 MQT: tele/Home_Garage_AQI/SENSOR = {"Time":"2024-10-14T12:58:21","PMS5003T":{"CF1":2,"CF2.5":2,"CF10":2,"PM1":2,"PM2.5":2,"PM10":2,"AQI":11,"PB0.3":378,"PB0.5":115,"PB1":17,"PB2.5":0,"Temperature":74.5,"Humidity":47.9,"DewPoint":53.4,"EPA_AQI":11},"TempUnit":"F"}

```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
