### PR TITLE
Platform 2024.10.30 (Arduino core 3.1.0.241015 / IDF 5.3.1+)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.240926
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -82,7 +82,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.09.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.10.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Tasmota release Arduino 3.1.0.241015 and IDF 5.3.1+
Support for the ESP32/ESP32solo1, ESP32C2, ESP32C3, ESP32C6, ESP32S2, ESP32S3, ESP32-H2 and ESP32-P4
```                  
[platformio]
platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.10.30/platform-espressif32.zip
framework = arduino
```
## Hybrid compile: Build customized Arduino IDF libraries
Adding the new option `custom_sdkconfig` in an `[env]` will compile the Arduino libraries using the sdkconfig settings from the framework and adds the changes specified in `custom_sdkconfig`. After the compile run the Arduino project `[env]` is compiled with the customized libraries.

Example: Switching off PPP modem support only for `[env: tasmota32-no-PPP]`
```
[env: tasmota32-no-PPP]
board = esp32
custom_sdkconfig = '# CONFIG_LWIP_PPP_SUPPORT is not set'
```

Above example saves 27kbyte of flash, by disabling PPP modem support.

@Staars thx for the help :-)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
