### PR TITLE
remove LTO settings in build flags...

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -8,7 +8,6 @@ build_unflags               = ${esp_defaults.build_unflags}
                               -Wincompatible-pointer-types
                               -Wnonnull-compare
                               -fexceptions
-                              -fno-lto
                               -Wpointer-arith
 build_flags                 = ${esp_defaults.build_flags}
                               ; comment next line to disable IPv6 support
@@ -17,7 +16,6 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wno-switch-unreachable
                               -Wno-stringop-overflow
                               -fno-exceptions
-                              -flto=auto
                               -DBUFFER_LENGTH=128
                               -DHTTP_UPLOAD_BUFLEN=2048
                               -DMQTT_MAX_PACKET_SIZE=1200


### PR DESCRIPTION
## Description:

since LTO is now standard in Tasmota Arduino framework. **No changes in resulting firmwares when compiling Tasmota (with Arduino framework, which is default).**
By removing this setting (IDF code is not `LTO ready`) and some small changes in IDF (Tasmota is using an IDF fork) it is possible to build Tasmota as an Arduino component of IDF. This compile option will result in general in bigger Tasmota firmware size (since no `LTO` possible)
It is an way to change all available settings from IDF.

To build Tasmota as an Arduino as a component of IDF project add in `platformio.ini`
 to the entry `framework = arduino` the entry `espidf` resulting in `framework = arduino, espidf`
This change will affect **ALL** [env]. Since there is no espidf for esp8266 [env] for, all will fail to compile. To build Tasmota "normal" again, just remove the `espidf` entry.

To clarify: There are now three ways to compile Tasmota
- with Tasmota Arduino (standard) since the beginning
- Hybrid compile: Build customized Arduino IDF libraries (since PR #22299)
- with this PR Tasmota as an Arduino component of IDF

  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
