### PR TITLE
dedicated special framework "ITEAD" not needed anymore

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -262,7 +262,6 @@ board_build.partitions  = partitions/esp32_partition_app1856k_fs1344k.csv
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-zbbrdgpro.bin"'
                           -DFIRMWARE_ZBBRDGPRO
-                          -DFRAMEWORK_ARDUINO_ITEAD
 custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
                           tools/fw_SonoffZigbeeBridgePro_cc2652/Sonoff_ZBPro.autoconf
                           tasmota/berry/zigbee/cc2652_flasher.be
@@ -270,13 +269,16 @@ custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
                           tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
                           tools/fw_SonoffZigbeeBridgePro_cc2652/SonoffZBPro_coord_20220219.hex
 lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
+custom_sdkconfig        = CONFIG_D0WD_PSRAM_CLK_IO=5
+                          CONFIG_D0WD_PSRAM_CS_IO=18
 
 [env:tasmota32-nspanel]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_NSPANEL
-                          -DFRAMEWORK_ARDUINO_ITEAD
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-nspanel.bin"'
+custom_sdkconfig        = CONFIG_D0WD_PSRAM_CLK_IO=5
+                          CONFIG_D0WD_PSRAM_CS_IO=18
 
 [env:tasmota32-AD]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

the needed changed GPIO settings for PSRAM are now applied and set via Hybrid compile.
-> Preparing end of providing special Tasmota Arduino framework ITEAD

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
