### PR TITLE
HASPmota fix current page parsing

### DIFF
--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -10932,344 +10932,136 @@ be_local_class(lvh_page,
     be_str_weak(lvh_page)
 );
 extern const bclass be_class_HASPmota;
-// compact class 'HASPmota' ktab size: 122, total: 190 (saved 544 bytes)
-static const bvalue be_ktab_class_HASPmota[122] = {
-  /* K0   */  be_const_class(be_class_HASPmota),
-  /* K1   */  be_nested_str_weak(introspect),
-  /* K2   */  be_nested_str_weak(get),
-  /* K3   */  be_nested_str_weak(lv),
-  /* K4   */  be_nested_str_weak(version),
-  /* K5   */  be_nested_str_weak(int),
-  /* K6   */  be_nested_str_weak(json),
-  /* K7   */  be_nested_str_weak(load),
-  /* K8   */  be_nested_str_weak(instance),
-  /* K9   */  be_nested_str_weak(parse_page),
-  /* K10  */  be_nested_str_weak(parse_obj),
-  /* K11  */  be_nested_str_weak(lvh_pages),
-  /* K12  */  be_nested_str_weak(lvh_page_cur_idx),
-  /* K13  */  be_nested_str_weak(value_error),
-  /* K14  */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
-  /* K15  */  be_const_int(0),
-  /* K16  */  be_nested_str_weak(keys),
-  /* K17  */  be_nested_str_weak(push),
-  /* K18  */  be_nested_str_weak(stop_iteration),
-  /* K19  */  be_nested_str_weak(sort),
-  /* K20  */  be_nested_str_weak(find),
-  /* K21  */  be_const_int(1),
-  /* K22  */  be_nested_str_weak(fix_lv_version),
-  /* K23  */  be_nested_str_weak(re),
-  /* K24  */  be_nested_str_weak(re_page_target),
-  /* K25  */  be_nested_str_weak(compile),
-  /* K26  */  be_nested_str_weak(p_X5Cd_X2B),
-  /* K27  */  be_nested_str_weak(has),
-  /* K28  */  be_nested_str_weak(page),
-  /* K29  */  be_nested_str_weak(contains),
-  /* K30  */  be_nested_str_weak(lvh_page),
-  /* K31  */  be_nested_str_weak(id),
-  /* K32  */  be_nested_str_weak(get_page_cur),
-  /* K33  */  be_nested_str_weak(prev),
-  /* K34  */  be_nested_str_weak(next),
-  /* K35  */  be_nested_str_weak(back),
-  /* K36  */  be_nested_str_weak(EVENT_CLICKED),
-  /* K37  */  be_nested_str_weak(page_show),
-  /* K38  */  be_nested_str_weak(_action),
-  /* K39  */  be_nested_str_weak(cb),
-  /* K40  */  be_nested_str_weak(event_cb),
-  /* K41  */  be_nested_str_weak(gen_cb),
-  /* K42  */  be_nested_str_weak(_lv_obj),
-  /* K43  */  be_nested_str_weak(add_event_cb),
-  /* K44  */  be_nested_str_weak(toptr),
-  /* K45  */  be_nested_str_weak(string),
-  /* K46  */  be_nested_str_weak(r),
-  /* K47  */  be_nested_str_weak(read),
-  /* K48  */  be_nested_str_weak(close),
-  /* K49  */  be_nested_str_weak(split),
-  /* K50  */  be_nested_str_weak(_X0A),
-  /* K51  */  be_nested_str_weak(tasmota),
-  /* K52  */  be_nested_str_weak(loglevel),
-  /* K53  */  be_nested_str_weak(log),
-  /* K54  */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
-  /* K55  */  be_nested_str_weak(no_X20page_X20_X27id_X27_X20defined),
-  /* K56  */  be_nested_str_weak(tr),
-  /* K57  */  be_nested_str_weak(_X20_X09),
-  /* K58  */  be_nested_str_weak(),
-  /* K59  */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
-  /* K60  */  be_const_int(2),
-  /* K61  */  be_nested_str_weak(remove),
-  /* K62  */  be_nested_str_weak(pages_list_sorted),
-  /* K63  */  be_nested_str_weak(no_X20page_X20object_X20defined),
-  /* K64  */  be_nested_str_weak(show),
-  /* K65  */  be_nested_str_weak(delete),
-  /* K66  */  be_nested_str_weak(match),
-  /* K67  */  be_nested_str_weak(path),
-  /* K68  */  be_nested_str_weak(def_templ_name),
-  /* K69  */  be_nested_str_weak(exists),
-  /* K70  */  be_nested_str_weak(file_X20_X27),
-  /* K71  */  be_nested_str_weak(_X27_X20not_X20found),
-  /* K72  */  be_nested_str_weak(io_erorr),
-  /* K73  */  be_nested_str_weak(start),
-  /* K74  */  be_nested_str_weak(dark),
-  /* K75  */  be_nested_str_weak(hres),
-  /* K76  */  be_nested_str_weak(get_hor_res),
-  /* K77  */  be_nested_str_weak(vres),
-  /* K78  */  be_nested_str_weak(get_ver_res),
-  /* K79  */  be_nested_str_weak(scr),
-  /* K80  */  be_nested_str_weak(scr_act),
-  /* K81  */  be_nested_str_weak(r16),
-  /* K82  */  be_nested_str_weak(font_embedded),
-  /* K83  */  be_nested_str_weak(robotocondensed),
-  /* K84  */  be_nested_str_weak(montserrat),
-  /* K85  */  be_nested_str_weak(theme_haspmota_init),
-  /* K86  */  be_nested_str_weak(color),
-  /* K87  */  be_const_int(16711935),
-  /* K88  */  be_const_int(3158064),
-  /* K89  */  be_nested_str_weak(get_disp),
-  /* K90  */  be_nested_str_weak(set_theme),
-  /* K91  */  be_nested_str_weak(set_style_bg_color),
-  /* K92  */  be_const_int(16777215),
-  /* K93  */  be_nested_str_weak(theme_apply),
-  /* K94  */  be_nested_str_weak(layer_top),
-  /* K95  */  be_nested_str_weak(set_style_bg_opa),
-  /* K96  */  be_nested_str_weak(_load),
-  /* K97  */  be_nested_str_weak(global),
-  /* K98  */  be_nested_str_weak(p_X25s),
-  /* K99  */  be_nested_str_weak(obj),
-  /* K100 */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20_X25s_X20for_X20_X27obj_X27_X3A_X20_X25s),
-  /* K101 */  be_nested_str_weak(get_obj),
-  /* K102 */  be_nested_str_weak(parentid),
-  /* K103 */  be_nested_str_weak(get_scr),
-  /* K104 */  be_nested_str_weak(lvh_),
-  /* K105 */  be_nested_str_weak(class),
-  /* K106 */  be_nested_str_weak(lvh_obj),
-  /* K107 */  be_nested_str_weak(module),
-  /* K108 */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20_X25s),
-  /* K109 */  be_nested_str_weak(add_obj),
-  /* K110 */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X3A_X27_X25s_X27_X20for_X20_X27id_X27_X3A0),
-  /* K111 */  be_nested_str_weak(post_config),
-  /* K112 */  be_nested_str_weak(berry_run),
-  /* K113 */  be_nested_str_weak(nil),
-  /* K114 */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-  /* K115 */  be_nested_str_weak(function),
-  /* K116 */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-  /* K117 */  be_nested_str_weak(event),
-  /* K118 */  be_nested_str_weak(_p),
-  /* K119 */  be_nested_str_weak(lv_event),
-  /* K120 */  be_nested_str_weak(get_user_data),
-  /* K121 */  be_nested_str_weak(fromptr),
+// compact class 'HASPmota' ktab size: 124, total: 196 (saved 576 bytes)
+static const bvalue be_ktab_class_HASPmota[124] = {
+  /* K0   */  be_nested_str_weak(has),
+  /* K1   */  be_nested_str_weak(page),
+  /* K2   */  be_nested_str_weak(int),
+  /* K3   */  be_nested_str_weak(lvh_page_cur_idx_parsing),
+  /* K4   */  be_nested_str_weak(lvh_page_cur_idx),
+  /* K5   */  be_nested_str_weak(lvh_pages),
+  /* K6   */  be_nested_str_weak(contains),
+  /* K7   */  be_nested_str_weak(lvh_page),
+  /* K8   */  be_nested_str_weak(find),
+  /* K9   */  be_nested_str_weak(id),
+  /* K10  */  be_const_int(0),
+  /* K11  */  be_nested_str_weak(get_page_cur_parsing),
+  /* K12  */  be_nested_str_weak(prev),
+  /* K13  */  be_nested_str_weak(next),
+  /* K14  */  be_nested_str_weak(back),
+  /* K15  */  be_nested_str_weak(get_page_cur),
+  /* K16  */  be_nested_str_weak(pages_list_sorted),
+  /* K17  */  be_const_int(1),
+  /* K18  */  be_nested_str_weak(delete),
+  /* K19  */  be_nested_str_weak(re_page_target),
+  /* K20  */  be_nested_str_weak(match),
+  /* K21  */  be_nested_str_weak(show),
+  /* K22  */  be_nested_str_weak(global),
+  /* K23  */  be_nested_str_weak(introspect),
+  /* K24  */  be_nested_str_weak(obj),
+  /* K25  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20_X25s_X20for_X20_X27obj_X27_X3A_X20_X25s),
+  /* K26  */  be_nested_str_weak(get_obj),
+  /* K27  */  be_nested_str_weak(parentid),
+  /* K28  */  be_nested_str_weak(_lv_obj),
+  /* K29  */  be_nested_str_weak(get_scr),
+  /* K30  */  be_nested_str_weak(get),
+  /* K31  */  be_nested_str_weak(lvh_),
+  /* K32  */  be_nested_str_weak(class),
+  /* K33  */  be_nested_str_weak(lvh_obj),
+  /* K34  */  be_nested_str_weak(module),
+  /* K35  */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20_X25s),
+  /* K36  */  be_nested_str_weak(add_obj),
+  /* K37  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X3A_X27_X25s_X27_X20for_X20_X27id_X27_X3A0),
+  /* K38  */  be_nested_str_weak(keys),
+  /* K39  */  be_nested_str_weak(stop_iteration),
+  /* K40  */  be_nested_str_weak(post_config),
+  /* K41  */  be_nested_str_weak(berry_run),
+  /* K42  */  be_nested_str_weak(nil),
+  /* K43  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K44  */  be_nested_str_weak(function),
+  /* K45  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K46  */  be_nested_str_weak(page_show),
+  /* K47  */  be_nested_str_weak(remove),
+  /* K48  */  be_nested_str_weak(p_X25s),
+  /* K49  */  be_nested_str_weak(push),
+  /* K50  */  be_nested_str_weak(sort),
+  /* K51  */  be_nested_str_weak(toptr),
+  /* K52  */  be_nested_str_weak(event),
+  /* K53  */  be_nested_str_weak(_p),
+  /* K54  */  be_nested_str_weak(lv),
+  /* K55  */  be_nested_str_weak(lv_event),
+  /* K56  */  be_nested_str_weak(get_user_data),
+  /* K57  */  be_nested_str_weak(fromptr),
+  /* K58  */  be_nested_str_weak(instance),
+  /* K59  */  be_nested_str_weak(event_cb),
+  /* K60  */  be_const_class(be_class_HASPmota),
+  /* K61  */  be_nested_str_weak(version),
+  /* K62  */  be_nested_str_weak(cb),
+  /* K63  */  be_nested_str_weak(gen_cb),
+  /* K64  */  be_nested_str_weak(add_event_cb),
+  /* K65  */  be_nested_str_weak(json),
+  /* K66  */  be_nested_str_weak(load),
+  /* K67  */  be_nested_str_weak(parse_page),
+  /* K68  */  be_nested_str_weak(parse_obj),
+  /* K69  */  be_nested_str_weak(value_error),
+  /* K70  */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
+  /* K71  */  be_nested_str_weak(fix_lv_version),
+  /* K72  */  be_nested_str_weak(re),
+  /* K73  */  be_nested_str_weak(compile),
+  /* K74  */  be_nested_str_weak(p_X5Cd_X2B),
+  /* K75  */  be_nested_str_weak(path),
+  /* K76  */  be_nested_str_weak(def_templ_name),
+  /* K77  */  be_nested_str_weak(exists),
+  /* K78  */  be_nested_str_weak(file_X20_X27),
+  /* K79  */  be_nested_str_weak(_X27_X20not_X20found),
+  /* K80  */  be_nested_str_weak(io_erorr),
+  /* K81  */  be_nested_str_weak(start),
+  /* K82  */  be_nested_str_weak(dark),
+  /* K83  */  be_nested_str_weak(hres),
+  /* K84  */  be_nested_str_weak(get_hor_res),
+  /* K85  */  be_nested_str_weak(vres),
+  /* K86  */  be_nested_str_weak(get_ver_res),
+  /* K87  */  be_nested_str_weak(scr),
+  /* K88  */  be_nested_str_weak(scr_act),
+  /* K89  */  be_nested_str_weak(r16),
+  /* K90  */  be_nested_str_weak(font_embedded),
+  /* K91  */  be_nested_str_weak(robotocondensed),
+  /* K92  */  be_nested_str_weak(montserrat),
+  /* K93  */  be_nested_str_weak(theme_haspmota_init),
+  /* K94  */  be_nested_str_weak(color),
+  /* K95  */  be_const_int(16711935),
+  /* K96  */  be_const_int(3158064),
+  /* K97  */  be_nested_str_weak(get_disp),
+  /* K98  */  be_nested_str_weak(set_theme),
+  /* K99  */  be_nested_str_weak(set_style_bg_color),
+  /* K100 */  be_const_int(16777215),
+  /* K101 */  be_nested_str_weak(theme_apply),
+  /* K102 */  be_nested_str_weak(layer_top),
+  /* K103 */  be_nested_str_weak(set_style_bg_opa),
+  /* K104 */  be_nested_str_weak(_load),
+  /* K105 */  be_const_int(2),
+  /* K106 */  be_nested_str_weak(EVENT_CLICKED),
+  /* K107 */  be_nested_str_weak(_action),
+  /* K108 */  be_nested_str_weak(string),
+  /* K109 */  be_nested_str_weak(r),
+  /* K110 */  be_nested_str_weak(read),
+  /* K111 */  be_nested_str_weak(close),
+  /* K112 */  be_nested_str_weak(split),
+  /* K113 */  be_nested_str_weak(_X0A),
+  /* K114 */  be_nested_str_weak(tasmota),
+  /* K115 */  be_nested_str_weak(loglevel),
+  /* K116 */  be_nested_str_weak(log),
+  /* K117 */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
+  /* K118 */  be_nested_str_weak(no_X20page_X20_X27id_X27_X20defined),
+  /* K119 */  be_nested_str_weak(tr),
+  /* K120 */  be_nested_str_weak(_X20_X09),
+  /* K121 */  be_nested_str_weak(),
+  /* K122 */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
+  /* K123 */  be_nested_str_weak(no_X20page_X20object_X20defined),
 };
 
 
 extern const bclass be_class_HASPmota;
-
-/********************************************************************
-** Solidified function: fix_lv_version
-********************************************************************/
-be_local_closure(class_HASPmota_fix_lv_version,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    0,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(fix_lv_version),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x58000000,  //  0000  LDCONST	R0	K0
-      0xA4060200,  //  0001  IMPORT	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
-      0x7C080600,  //  0005  CALL	R2	3
-      0x600C0004,  //  0006  GETGBL	R3	G4
-      0x5C100400,  //  0007  MOVE	R4	R2
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x200C0705,  //  0009  NE	R3	R3	K5
-      0x780E0002,  //  000A  JMPF	R3	#000E
-      0xB80E0600,  //  000B  GETNGBL	R3	K3
-      0x54120007,  //  000C  LDINT	R4	8
-      0x900E0804,  //  000D  SETMBR	R3	K4	R4
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse
-********************************************************************/
-be_local_closure(class_HASPmota_parse,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(parse),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA40A0C00,  //  0000  IMPORT	R2	K6
-      0x8C0C0507,  //  0001  GETMET	R3	R2	K7
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x60100004,  //  0004  GETGBL	R4	G4
-      0x5C140600,  //  0005  MOVE	R5	R3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x1C100908,  //  0007  EQ	R4	R4	K8
-      0x78120009,  //  0008  JMPF	R4	#0013
-      0x8C100109,  //  0009  GETMET	R4	R0	K9
-      0x5C180600,  //  000A  MOVE	R6	R3
-      0x7C100400,  //  000B  CALL	R4	2
-      0x8C10010A,  //  000C  GETMET	R4	R0	K10
-      0x5C180600,  //  000D  MOVE	R6	R3
-      0x881C010B,  //  000E  GETMBR	R7	R0	K11
-      0x8820010C,  //  000F  GETMBR	R8	R0	K12
-      0x941C0E08,  //  0010  GETIDX	R7	R7	R8
-      0x7C100600,  //  0011  CALL	R4	3
-      0x70020000,  //  0012  JMP		#0014
-      0xB0061B0E,  //  0013  RAISE	1	K13	K14
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pages_list_sorted
-********************************************************************/
-be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(pages_list_sorted),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x1C0C030F,  //  0002  EQ	R3	R1	K15
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x8804010C,  //  0004  GETMBR	R1	R0	K12
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x8810010B,  //  0006  GETMBR	R4	R0	K11
-      0x8C100910,  //  0007  GETMET	R4	R4	K16
-      0x7C100200,  //  0008  CALL	R4	1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0xA8020007,  //  000A  EXBLK	0	#0013
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x2014090F,  //  000D  NE	R5	R4	K15
-      0x78160002,  //  000E  JMPF	R5	#0012
-      0x8C140511,  //  000F  GETMET	R5	R2	K17
-      0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x7C140400,  //  0011  CALL	R5	2
-      0x7001FFF7,  //  0012  JMP		#000B
-      0x580C0012,  //  0013  LDCONST	R3	K18
-      0xAC0C0200,  //  0014  CATCH	R3	1	0
-      0xB0080000,  //  0015  RAISE	2	R0	R0
-      0x8C0C0113,  //  0016  GETMET	R3	R0	K19
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x5C080600,  //  0019  MOVE	R2	R3
-      0x4C0C0000,  //  001A  LDNIL	R3
-      0x1C0C0203,  //  001B  EQ	R3	R1	R3
-      0x780E0000,  //  001C  JMPF	R3	#001E
-      0x80040400,  //  001D  RET	1	R2
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100400,  //  001F  MOVE	R4	R2
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x00080402,  //  0021  ADD	R2	R2	R2
-      0x8C100514,  //  0022  GETMET	R4	R2	K20
-      0x5C180200,  //  0023  MOVE	R6	R1
-      0x7C100400,  //  0024  CALL	R4	2
-      0x4C140000,  //  0025  LDNIL	R5
-      0x1C140805,  //  0026  EQ	R5	R4	R5
-      0x78160001,  //  0027  JMPF	R5	#002A
-      0x4C140000,  //  0028  LDNIL	R5
-      0x80040A00,  //  0029  RET	1	R5
-      0x00140803,  //  002A  ADD	R5	R4	R3
-      0x04140B15,  //  002B  SUB	R5	R5	K21
-      0x40140805,  //  002C  CONNECT	R5	R4	R5
-      0x94080405,  //  002D  GETIDX	R2	R2	R5
-      0x80040400,  //  002E  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_HASPmota_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8C040116,  //  0000  GETMET	R1	R0	K22
-      0x7C040200,  //  0001  CALL	R1	1
-      0xA4062E00,  //  0002  IMPORT	R1	K23
-      0x8C080319,  //  0003  GETMET	R2	R1	K25
-      0x5810001A,  //  0004  LDCONST	R4	K26
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90023002,  //  0006  SETMBR	R0	K24	R2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_page_cur
-********************************************************************/
-be_local_closure(class_HASPmota_get_page_cur,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(get_page_cur),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8804010B,  //  0000  GETMBR	R1	R0	K11
-      0x8808010C,  //  0001  GETMBR	R2	R0	K12
-      0x94040202,  //  0002  GETIDX	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified function: parse_page
@@ -11287,338 +11079,66 @@ be_local_closure(class_HASPmota_parse_page,   /* name */
     &be_ktab_class_HASPmota,     /* shared constants */
     be_str_weak(parse_page),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x8C08031B,  //  0000  GETMET	R2	R1	K27
-      0x5810001C,  //  0001  LDCONST	R4	K28
+    ( &(const binstruction[59]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
       0x7C080400,  //  0002  CALL	R2	2
-      0x780A0030,  //  0003  JMPF	R2	#0035
+      0x780A0035,  //  0003  JMPF	R2	#003A
       0x60080004,  //  0004  GETGBL	R2	G4
-      0x940C031C,  //  0005  GETIDX	R3	R1	K28
+      0x940C0301,  //  0005  GETIDX	R3	R1	K1
       0x7C080200,  //  0006  CALL	R2	1
-      0x1C080505,  //  0007  EQ	R2	R2	K5
-      0x780A002B,  //  0008  JMPF	R2	#0035
+      0x1C080502,  //  0007  EQ	R2	R2	K2
+      0x780A0030,  //  0008  JMPF	R2	#003A
       0x60080009,  //  0009  GETGBL	R2	G9
-      0x940C031C,  //  000A  GETIDX	R3	R1	K28
+      0x940C0301,  //  000A  GETIDX	R3	R1	K1
       0x7C080200,  //  000B  CALL	R2	1
-      0x90021802,  //  000C  SETMBR	R0	K12	R2
-      0x880C010B,  //  000D  GETMBR	R3	R0	K11
-      0x8C0C071D,  //  000E  GETMET	R3	R3	K29
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x740E0006,  //  0011  JMPT	R3	#0019
-      0x880C011E,  //  0012  GETMBR	R3	R0	K30
-      0x8810010B,  //  0013  GETMBR	R4	R0	K11
-      0x5C140600,  //  0014  MOVE	R5	R3
-      0x5C180400,  //  0015  MOVE	R6	R2
-      0x5C1C0000,  //  0016  MOVE	R7	R0
-      0x7C140400,  //  0017  CALL	R5	2
-      0x98100405,  //  0018  SETIDX	R4	R2	R5
-      0x8C0C0314,  //  0019  GETMET	R3	R1	K20
-      0x5814001F,  //  001A  LDCONST	R5	K31
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x1C0C070F,  //  001C  EQ	R3	R3	K15
-      0x780E0016,  //  001D  JMPF	R3	#0035
-      0x8C0C0120,  //  001E  GETMET	R3	R0	K32
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x60100009,  //  0020  GETGBL	R4	G9
-      0x8C140314,  //  0021  GETMET	R5	R1	K20
-      0x581C0021,  //  0022  LDCONST	R7	K33
-      0x4C200000,  //  0023  LDNIL	R8
-      0x7C140600,  //  0024  CALL	R5	3
-      0x7C100200,  //  0025  CALL	R4	1
-      0x900E4204,  //  0026  SETMBR	R3	K33	R4
-      0x60100009,  //  0027  GETGBL	R4	G9
-      0x8C140314,  //  0028  GETMET	R5	R1	K20
-      0x581C0022,  //  0029  LDCONST	R7	K34
-      0x4C200000,  //  002A  LDNIL	R8
-      0x7C140600,  //  002B  CALL	R5	3
-      0x7C100200,  //  002C  CALL	R4	1
-      0x900E4404,  //  002D  SETMBR	R3	K34	R4
-      0x60100009,  //  002E  GETGBL	R4	G9
-      0x8C140314,  //  002F  GETMET	R5	R1	K20
-      0x581C0023,  //  0030  LDCONST	R7	K35
-      0x4C200000,  //  0031  LDNIL	R8
-      0x7C140600,  //  0032  CALL	R5	3
-      0x7C100200,  //  0033  CALL	R4	1
-      0x900E4604,  //  0034  SETMBR	R3	K35	R4
-      0x80000000,  //  0035  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: do_action
-********************************************************************/
-be_local_closure(class_HASPmota_do_action,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(do_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB80E0600,  //  0000  GETNGBL	R3	K3
-      0x880C0724,  //  0001  GETMBR	R3	R3	K36
-      0x200C0403,  //  0002  NE	R3	R2	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x80000600,  //  0004  RET	0
-      0x8C0C0125,  //  0005  GETMET	R3	R0	K37
-      0x88140326,  //  0006  GETMBR	R5	R1	K38
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_event
-********************************************************************/
-be_local_closure(class_HASPmota_register_event,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(event_dispatch),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68040000,  //  0000  GETUPV	R1	U0
-          0x8C040300,  //  0001  GETMET	R1	R1	K0
-          0x5C0C0000,  //  0002  MOVE	R3	R0
-          0x7C040400,  //  0003  CALL	R1	2
-          0x80040200,  //  0004  RET	1	R1
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(register_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xA40E4E00,  //  0000  IMPORT	R3	K39
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x88140128,  //  0002  GETMBR	R5	R0	K40
-      0x4C180000,  //  0003  LDNIL	R6
-      0x1C140A06,  //  0004  EQ	R5	R5	R6
-      0x78160003,  //  0005  JMPF	R5	#000A
-      0x8C140729,  //  0006  GETMET	R5	R3	K41
-      0x841C0000,  //  0007  CLOSURE	R7	P0
-      0x7C140400,  //  0008  CALL	R5	2
-      0x90025005,  //  0009  SETMBR	R0	K40	R5
-      0x8814032A,  //  000A  GETMBR	R5	R1	K42
-      0x8C180B2B,  //  000B  GETMET	R6	R5	K43
-      0x88200128,  //  000C  GETMBR	R8	R0	K40
-      0x5C240400,  //  000D  MOVE	R9	R2
-      0x8C28092C,  //  000E  GETMET	R10	R4	K44
-      0x5C300200,  //  000F  MOVE	R12	R1
-      0x7C280400,  //  0010  CALL	R10	2
-      0x7C180800,  //  0011  CALL	R6	4
-      0xA0000000,  //  0012  CLOSE	R0
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _load
-********************************************************************/
-be_local_closure(class_HASPmota__load,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(_load),
-    &be_const_str_solidified,
-    ( &(const binstruction[99]) {  /* code */
-      0xA40A5A00,  //  0000  IMPORT	R2	K45
-      0xA40E0C00,  //  0001  IMPORT	R3	K6
-      0x60100011,  //  0002  GETGBL	R4	G17
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x5818002E,  //  0004  LDCONST	R6	K46
-      0x7C100400,  //  0005  CALL	R4	2
-      0x8C14092F,  //  0006  GETMET	R5	R4	K47
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C180930,  //  0008  GETMET	R6	R4	K48
-      0x7C180200,  //  0009  CALL	R6	1
-      0x8C180531,  //  000A  GETMET	R6	R2	K49
-      0x5C200A00,  //  000B  MOVE	R8	R5
-      0x58240032,  //  000C  LDCONST	R9	K50
-      0x7C180600,  //  000D  CALL	R6	3
+      0x90020602,  //  000C  SETMBR	R0	K3	R2
+      0x880C0104,  //  000D  GETMBR	R3	R0	K4
       0x4C100000,  //  000E  LDNIL	R4
-      0x4C140000,  //  000F  LDNIL	R5
-      0x601C000C,  //  0010  GETGBL	R7	G12
-      0x5C200C00,  //  0011  MOVE	R8	R6
-      0x7C1C0200,  //  0012  CALL	R7	1
-      0x241C0F0F,  //  0013  GT	R7	R7	K15
-      0x781E0039,  //  0014  JMPF	R7	#004F
-      0x8C1C0707,  //  0015  GETMET	R7	R3	K7
-      0x94240D0F,  //  0016  GETIDX	R9	R6	K15
-      0x7C1C0400,  //  0017  CALL	R7	2
-      0x60200004,  //  0018  GETGBL	R8	G4
-      0x5C240E00,  //  0019  MOVE	R9	R7
-      0x7C200200,  //  001A  CALL	R8	1
-      0x1C201108,  //  001B  EQ	R8	R8	K8
-      0x7822001B,  //  001C  JMPF	R8	#0039
-      0xB8226600,  //  001D  GETNGBL	R8	K51
-      0x8C201134,  //  001E  GETMET	R8	R8	K52
-      0x542A0003,  //  001F  LDINT	R10	4
-      0x7C200400,  //  0020  CALL	R8	2
-      0x78220007,  //  0021  JMPF	R8	#002A
-      0xB8226600,  //  0022  GETNGBL	R8	K51
-      0x8C201135,  //  0023  GETMET	R8	R8	K53
-      0x60280018,  //  0024  GETGBL	R10	G24
-      0x582C0036,  //  0025  LDCONST	R11	K54
-      0x94300D0F,  //  0026  GETIDX	R12	R6	K15
-      0x7C280400,  //  0027  CALL	R10	2
-      0x542E0003,  //  0028  LDINT	R11	4
-      0x7C200600,  //  0029  CALL	R8	3
-      0x8C200109,  //  002A  GETMET	R8	R0	K9
-      0x5C280E00,  //  002B  MOVE	R10	R7
-      0x7C200400,  //  002C  CALL	R8	2
-      0x8820010B,  //  002D  GETMBR	R8	R0	K11
-      0x4C240000,  //  002E  LDNIL	R9
-      0x1C201009,  //  002F  EQ	R8	R8	R9
-      0x78220000,  //  0030  JMPF	R8	#0032
-      0xB0061B37,  //  0031  RAISE	1	K13	K55
-      0x8C20010A,  //  0032  GETMET	R8	R0	K10
-      0x5C280E00,  //  0033  MOVE	R10	R7
-      0x882C010B,  //  0034  GETMBR	R11	R0	K11
-      0x8830010C,  //  0035  GETMBR	R12	R0	K12
-      0x942C160C,  //  0036  GETIDX	R11	R11	R12
-      0x7C200600,  //  0037  CALL	R8	3
-      0x70020010,  //  0038  JMP		#004A
-      0x6020000C,  //  0039  GETGBL	R8	G12
-      0x8C240538,  //  003A  GETMET	R9	R2	K56
-      0x942C0D0F,  //  003B  GETIDX	R11	R6	K15
-      0x58300039,  //  003C  LDCONST	R12	K57
-      0x5834003A,  //  003D  LDCONST	R13	K58
-      0x7C240800,  //  003E  CALL	R9	4
-      0x7C200200,  //  003F  CALL	R8	1
-      0x2420110F,  //  0040  GT	R8	R8	K15
-      0x78220007,  //  0041  JMPF	R8	#004A
-      0xB8226600,  //  0042  GETNGBL	R8	K51
-      0x8C201135,  //  0043  GETMET	R8	R8	K53
-      0x60280018,  //  0044  GETGBL	R10	G24
-      0x582C003B,  //  0045  LDCONST	R11	K59
-      0x94300D0F,  //  0046  GETIDX	R12	R6	K15
-      0x7C280400,  //  0047  CALL	R10	2
-      0x582C003C,  //  0048  LDCONST	R11	K60
-      0x7C200600,  //  0049  CALL	R8	3
-      0x4C1C0000,  //  004A  LDNIL	R7
-      0x8C200D3D,  //  004B  GETMET	R8	R6	K61
-      0x5828000F,  //  004C  LDCONST	R10	K15
-      0x7C200400,  //  004D  CALL	R8	2
-      0x7001FFC0,  //  004E  JMP		#0010
-      0x4C180000,  //  004F  LDNIL	R6
-      0x8C1C013E,  //  0050  GETMET	R7	R0	K62
-      0x4C240000,  //  0051  LDNIL	R9
-      0x7C1C0400,  //  0052  CALL	R7	2
-      0x6020000C,  //  0053  GETGBL	R8	G12
-      0x5C240E00,  //  0054  MOVE	R9	R7
-      0x7C200200,  //  0055  CALL	R8	1
-      0x1C20110F,  //  0056  EQ	R8	R8	K15
-      0x78220000,  //  0057  JMPF	R8	#0059
-      0xB0061B3F,  //  0058  RAISE	1	K13	K63
-      0x94200F0F,  //  0059  GETIDX	R8	R7	K15
-      0x90021808,  //  005A  SETMBR	R0	K12	R8
-      0x8820010B,  //  005B  GETMBR	R8	R0	K11
-      0x8824010C,  //  005C  GETMBR	R9	R0	K12
-      0x94201009,  //  005D  GETIDX	R8	R8	R9
-      0x8C201140,  //  005E  GETMET	R8	R8	K64
-      0x5828000F,  //  005F  LDCONST	R10	K15
-      0x582C000F,  //  0060  LDCONST	R11	K15
-      0x7C200600,  //  0061  CALL	R8	3
-      0x80000000,  //  0062  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: page_dir_to
-********************************************************************/
-be_local_closure(class_HASPmota_page_dir_to,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(page_dir_to),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x8C08013E,  //  0000  GETMET	R2	R0	K62
-      0x5810000F,  //  0001  LDCONST	R4	K15
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80061E00,  //  0006  RET	1	K15
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x5C100400,  //  0008  MOVE	R4	R2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x18100715,  //  000A  LE	R4	R3	K21
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80061E00,  //  000C  RET	1	K15
-      0x1C10073C,  //  000D  EQ	R4	R3	K60
-      0x78120000,  //  000E  JMPF	R4	#0010
-      0x80062A00,  //  000F  RET	1	K21
-      0x8C100514,  //  0010  GETMET	R4	R2	K20
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x7C100400,  //  0012  CALL	R4	2
-      0x4C140000,  //  0013  LDNIL	R5
-      0x1C140805,  //  0014  EQ	R5	R4	R5
-      0x78160000,  //  0015  JMPF	R5	#0017
-      0x80061E00,  //  0016  RET	1	K15
-      0x00140715,  //  0017  ADD	R5	R3	K21
-      0x0C140B3C,  //  0018  DIV	R5	R5	K60
-      0x18140805,  //  0019  LE	R5	R4	R5
-      0x78160001,  //  001A  JMPF	R5	#001D
-      0x80062A00,  //  001B  RET	1	K21
-      0x70020001,  //  001C  JMP		#001F
-      0x5415FFFE,  //  001D  LDINT	R5	-1
-      0x80040A00,  //  001E  RET	1	R5
-      0x80000000,  //  001F  RET	0
+      0x1C0C0604,  //  000F  EQ	R3	R3	R4
+      0x780E0000,  //  0010  JMPF	R3	#0012
+      0x90020802,  //  0011  SETMBR	R0	K4	R2
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0013  GETMET	R3	R3	K6
+      0x5C140400,  //  0014  MOVE	R5	R2
+      0x7C0C0400,  //  0015  CALL	R3	2
+      0x740E0006,  //  0016  JMPT	R3	#001E
+      0x880C0107,  //  0017  GETMBR	R3	R0	K7
+      0x88100105,  //  0018  GETMBR	R4	R0	K5
+      0x5C140600,  //  0019  MOVE	R5	R3
+      0x5C180400,  //  001A  MOVE	R6	R2
+      0x5C1C0000,  //  001B  MOVE	R7	R0
+      0x7C140400,  //  001C  CALL	R5	2
+      0x98100405,  //  001D  SETIDX	R4	R2	R5
+      0x8C0C0308,  //  001E  GETMET	R3	R1	K8
+      0x58140009,  //  001F  LDCONST	R5	K9
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0x1C0C070A,  //  0021  EQ	R3	R3	K10
+      0x780E0016,  //  0022  JMPF	R3	#003A
+      0x8C0C010B,  //  0023  GETMET	R3	R0	K11
+      0x7C0C0200,  //  0024  CALL	R3	1
+      0x60100009,  //  0025  GETGBL	R4	G9
+      0x8C140308,  //  0026  GETMET	R5	R1	K8
+      0x581C000C,  //  0027  LDCONST	R7	K12
+      0x4C200000,  //  0028  LDNIL	R8
+      0x7C140600,  //  0029  CALL	R5	3
+      0x7C100200,  //  002A  CALL	R4	1
+      0x900E1804,  //  002B  SETMBR	R3	K12	R4
+      0x60100009,  //  002C  GETGBL	R4	G9
+      0x8C140308,  //  002D  GETMET	R5	R1	K8
+      0x581C000D,  //  002E  LDCONST	R7	K13
+      0x4C200000,  //  002F  LDNIL	R8
+      0x7C140600,  //  0030  CALL	R5	3
+      0x7C100200,  //  0031  CALL	R4	1
+      0x900E1A04,  //  0032  SETMBR	R3	K13	R4
+      0x60100009,  //  0033  GETGBL	R4	G9
+      0x8C140308,  //  0034  GETMET	R5	R1	K8
+      0x581C000E,  //  0035  LDCONST	R7	K14
+      0x4C200000,  //  0036  LDNIL	R8
+      0x7C140600,  //  0037  CALL	R5	3
+      0x7C100200,  //  0038  CALL	R4	1
+      0x900E1C04,  //  0039  SETMBR	R3	K14	R4
+      0x80000000,  //  003A  RET	0
     })
   )
 );
@@ -11675,23 +11195,23 @@ be_local_closure(class_HASPmota_page_show,   /* name */
     ( &(const binstruction[108]) {  /* code */
       0x84100000,  //  0000  CLOSURE	R4	P0
       0x4C140000,  //  0001  LDNIL	R5
-      0x8C180120,  //  0002  GETMET	R6	R0	K32
+      0x8C18010F,  //  0002  GETMET	R6	R0	K15
       0x7C180200,  //  0003  CALL	R6	1
-      0x8C1C013E,  //  0004  GETMET	R7	R0	K62
-      0x8824010C,  //  0005  GETMBR	R9	R0	K12
+      0x8C1C0110,  //  0004  GETMET	R7	R0	K16
+      0x88240104,  //  0005  GETMBR	R9	R0	K4
       0x7C1C0400,  //  0006  CALL	R7	2
       0x6020000C,  //  0007  GETGBL	R8	G12
       0x5C240E00,  //  0008  MOVE	R9	R7
       0x7C200200,  //  0009  CALL	R8	1
-      0x18201115,  //  000A  LE	R8	R8	K21
+      0x18201111,  //  000A  LE	R8	R8	K17
       0x78220001,  //  000B  JMPF	R8	#000E
       0x4C200000,  //  000C  LDNIL	R8
       0x80041000,  //  000D  RET	1	R8
-      0x1C200321,  //  000E  EQ	R8	R1	K33
+      0x1C20030C,  //  000E  EQ	R8	R1	K12
       0x78220009,  //  000F  JMPF	R8	#001A
       0x5C200800,  //  0010  MOVE	R8	R4
       0x60240009,  //  0011  GETGBL	R9	G9
-      0x88280D21,  //  0012  GETMBR	R10	R6	K33
+      0x88280D0C,  //  0012  GETMBR	R10	R6	K12
       0x7C240200,  //  0013  CALL	R9	1
       0x5429FFFE,  //  0014  LDINT	R10	-1
       0x94280E0A,  //  0015  GETIDX	R10	R7	R10
@@ -11699,66 +11219,66 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x7C200600,  //  0017  CALL	R8	3
       0x5C141000,  //  0018  MOVE	R5	R8
       0x70020041,  //  0019  JMP		#005C
-      0x1C200322,  //  001A  EQ	R8	R1	K34
+      0x1C20030D,  //  001A  EQ	R8	R1	K13
       0x78220008,  //  001B  JMPF	R8	#0025
       0x5C200800,  //  001C  MOVE	R8	R4
       0x60240009,  //  001D  GETGBL	R9	G9
-      0x88280D22,  //  001E  GETMBR	R10	R6	K34
+      0x88280D0D,  //  001E  GETMBR	R10	R6	K13
       0x7C240200,  //  001F  CALL	R9	1
-      0x94280F15,  //  0020  GETIDX	R10	R7	K21
+      0x94280F11,  //  0020  GETIDX	R10	R7	K17
       0x5C2C0E00,  //  0021  MOVE	R11	R7
       0x7C200600,  //  0022  CALL	R8	3
       0x5C141000,  //  0023  MOVE	R5	R8
       0x70020036,  //  0024  JMP		#005C
-      0x1C200323,  //  0025  EQ	R8	R1	K35
+      0x1C20030E,  //  0025  EQ	R8	R1	K14
       0x7822000B,  //  0026  JMPF	R8	#0033
       0x5C200800,  //  0027  MOVE	R8	R4
       0x60240009,  //  0028  GETGBL	R9	G9
-      0x88280D23,  //  0029  GETMBR	R10	R6	K35
+      0x88280D0E,  //  0029  GETMBR	R10	R6	K14
       0x7C240200,  //  002A  CALL	R9	1
-      0x8C28013E,  //  002B  GETMET	R10	R0	K62
+      0x8C280110,  //  002B  GETMET	R10	R0	K16
       0x4C300000,  //  002C  LDNIL	R12
       0x7C280400,  //  002D  CALL	R10	2
-      0x9428150F,  //  002E  GETIDX	R10	R10	K15
+      0x9428150A,  //  002E  GETIDX	R10	R10	K10
       0x5C2C0E00,  //  002F  MOVE	R11	R7
       0x7C200600,  //  0030  CALL	R8	3
       0x5C141000,  //  0031  MOVE	R5	R8
       0x70020028,  //  0032  JMP		#005C
-      0x1C200341,  //  0033  EQ	R8	R1	K65
+      0x1C200312,  //  0033  EQ	R8	R1	K18
       0x78220017,  //  0034  JMPF	R8	#004D
       0x5C200800,  //  0035  MOVE	R8	R4
       0x60240009,  //  0036  GETGBL	R9	G9
-      0x88280D23,  //  0037  GETMBR	R10	R6	K35
+      0x88280D0E,  //  0037  GETMBR	R10	R6	K14
       0x7C240200,  //  0038  CALL	R9	1
-      0x8C28013E,  //  0039  GETMET	R10	R0	K62
+      0x8C280110,  //  0039  GETMET	R10	R0	K16
       0x4C300000,  //  003A  LDNIL	R12
       0x7C280400,  //  003B  CALL	R10	2
-      0x9428150F,  //  003C  GETIDX	R10	R10	K15
+      0x9428150A,  //  003C  GETIDX	R10	R10	K10
       0x5C2C0E00,  //  003D  MOVE	R11	R7
       0x7C200600,  //  003E  CALL	R8	3
       0x5C141000,  //  003F  MOVE	R5	R8
-      0x8C200D1F,  //  0040  GETMET	R8	R6	K31
+      0x8C200D09,  //  0040  GETMET	R8	R6	K9
       0x7C200200,  //  0041  CALL	R8	1
       0x1C200A08,  //  0042  EQ	R8	R5	R8
       0x78220007,  //  0043  JMPF	R8	#004C
       0x5C200800,  //  0044  MOVE	R8	R4
       0x60240009,  //  0045  GETGBL	R9	G9
-      0x88280D22,  //  0046  GETMBR	R10	R6	K34
+      0x88280D0D,  //  0046  GETMBR	R10	R6	K13
       0x7C240200,  //  0047  CALL	R9	1
-      0x94280F15,  //  0048  GETIDX	R10	R7	K21
+      0x94280F11,  //  0048  GETIDX	R10	R7	K17
       0x5C2C0E00,  //  0049  MOVE	R11	R7
       0x7C200600,  //  004A  CALL	R8	3
       0x5C141000,  //  004B  MOVE	R5	R8
       0x7002000E,  //  004C  JMP		#005C
-      0x88200118,  //  004D  GETMBR	R8	R0	K24
-      0x8C201142,  //  004E  GETMET	R8	R8	K66
+      0x88200113,  //  004D  GETMBR	R8	R0	K19
+      0x8C201114,  //  004E  GETMET	R8	R8	K20
       0x5C280200,  //  004F  MOVE	R10	R1
       0x7C200400,  //  0050  CALL	R8	2
       0x78220009,  //  0051  JMPF	R8	#005C
       0x5C200800,  //  0052  MOVE	R8	R4
       0x60240009,  //  0053  GETGBL	R9	G9
       0x5429FFFE,  //  0054  LDINT	R10	-1
-      0x402A2A0A,  //  0055  CONNECT	R10	K21	R10
+      0x402A220A,  //  0055  CONNECT	R10	K17	R10
       0x9428020A,  //  0056  GETIDX	R10	R1	R10
       0x7C240200,  //  0057  CALL	R9	1
       0x4C280000,  //  0058  LDNIL	R10
@@ -11768,255 +11288,19 @@ be_local_closure(class_HASPmota_page_show,   /* name */
       0x4C200000,  //  005C  LDNIL	R8
       0x20200A08,  //  005D  NE	R8	R5	R8
       0x7822000B,  //  005E  JMPF	R8	#006B
-      0x24200B0F,  //  005F  GT	R8	R5	K15
+      0x24200B0A,  //  005F  GT	R8	R5	K10
       0x78220009,  //  0060  JMPF	R8	#006B
-      0x8820010B,  //  0061  GETMBR	R8	R0	K11
+      0x88200105,  //  0061  GETMBR	R8	R0	K5
       0x94201005,  //  0062  GETIDX	R8	R8	R5
       0x4C240000,  //  0063  LDNIL	R9
       0x20241009,  //  0064  NE	R9	R8	R9
       0x78260003,  //  0065  JMPF	R9	#006A
-      0x8C241140,  //  0066  GETMET	R9	R8	K64
+      0x8C241115,  //  0066  GETMET	R9	R8	K21
       0x5C2C0400,  //  0067  MOVE	R11	R2
       0x5C300600,  //  0068  MOVE	R12	R3
       0x7C240600,  //  0069  CALL	R9	3
       0x80041000,  //  006A  RET	1	R8
       0x80000000,  //  006B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_HASPmota_start,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
-      0xA40E8600,  //  0000  IMPORT	R3	K67
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C100404,  //  0002  EQ	R4	R2	R4
-      0x78120000,  //  0003  JMPF	R4	#0005
-      0x88080144,  //  0004  GETMBR	R2	R0	K68
-      0x8C100745,  //  0005  GETMET	R4	R3	K69
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x7C100400,  //  0007  CALL	R4	2
-      0x74120002,  //  0008  JMPT	R4	#000C
-      0x00128C02,  //  0009  ADD	R4	K70	R2
-      0x00100947,  //  000A  ADD	R4	R4	K71
-      0xB0069004,  //  000B  RAISE	1	K72	R4
-      0xB8120600,  //  000C  GETNGBL	R4	K3
-      0x8C100949,  //  000D  GETMET	R4	R4	K73
-      0x7C100200,  //  000E  CALL	R4	1
-      0x60100017,  //  000F  GETGBL	R4	G23
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C100200,  //  0011  CALL	R4	1
-      0x90029404,  //  0012  SETMBR	R0	K74	R4
-      0xB8120600,  //  0013  GETNGBL	R4	K3
-      0x8C10094C,  //  0014  GETMET	R4	R4	K76
-      0x7C100200,  //  0015  CALL	R4	1
-      0x90029604,  //  0016  SETMBR	R0	K75	R4
-      0xB8120600,  //  0017  GETNGBL	R4	K3
-      0x8C10094E,  //  0018  GETMET	R4	R4	K78
-      0x7C100200,  //  0019  CALL	R4	1
-      0x90029A04,  //  001A  SETMBR	R0	K77	R4
-      0xB8120600,  //  001B  GETNGBL	R4	K3
-      0x8C100950,  //  001C  GETMET	R4	R4	K80
-      0x7C100200,  //  001D  CALL	R4	1
-      0x90029E04,  //  001E  SETMBR	R0	K79	R4
-      0xA8020007,  //  001F  EXBLK	0	#0028
-      0xB8120600,  //  0020  GETNGBL	R4	K3
-      0x8C100952,  //  0021  GETMET	R4	R4	K82
-      0x58180053,  //  0022  LDCONST	R6	K83
-      0x541E000F,  //  0023  LDINT	R7	16
-      0x7C100600,  //  0024  CALL	R4	3
-      0x9002A204,  //  0025  SETMBR	R0	K81	R4
-      0xA8040001,  //  0026  EXBLK	1	1
-      0x70020009,  //  0027  JMP		#0032
-      0xAC100000,  //  0028  CATCH	R4	0	0
-      0x70020006,  //  0029  JMP		#0031
-      0xB8120600,  //  002A  GETNGBL	R4	K3
-      0x8C100952,  //  002B  GETMET	R4	R4	K82
-      0x58180054,  //  002C  LDCONST	R6	K84
-      0x541E000D,  //  002D  LDINT	R7	14
-      0x7C100600,  //  002E  CALL	R4	3
-      0x9002A204,  //  002F  SETMBR	R0	K81	R4
-      0x70020000,  //  0030  JMP		#0032
-      0xB0080000,  //  0031  RAISE	2	R0	R0
-      0xB8120600,  //  0032  GETNGBL	R4	K3
-      0x8C100955,  //  0033  GETMET	R4	R4	K85
-      0x5818000F,  //  0034  LDCONST	R6	K15
-      0xB81E0600,  //  0035  GETNGBL	R7	K3
-      0x8C1C0F56,  //  0036  GETMET	R7	R7	K86
-      0x58240057,  //  0037  LDCONST	R9	K87
-      0x7C1C0400,  //  0038  CALL	R7	2
-      0xB8220600,  //  0039  GETNGBL	R8	K3
-      0x8C201156,  //  003A  GETMET	R8	R8	K86
-      0x58280058,  //  003B  LDCONST	R10	K88
-      0x7C200400,  //  003C  CALL	R8	2
-      0x8824014A,  //  003D  GETMBR	R9	R0	K74
-      0x88280151,  //  003E  GETMBR	R10	R0	K81
-      0x7C100C00,  //  003F  CALL	R4	6
-      0x8814014F,  //  0040  GETMBR	R5	R0	K79
-      0x8C140B59,  //  0041  GETMET	R5	R5	K89
-      0x7C140200,  //  0042  CALL	R5	1
-      0x8C140B5A,  //  0043  GETMET	R5	R5	K90
-      0x5C1C0800,  //  0044  MOVE	R7	R4
-      0x7C140400,  //  0045  CALL	R5	2
-      0x8814014F,  //  0046  GETMBR	R5	R0	K79
-      0x8C140B5B,  //  0047  GETMET	R5	R5	K91
-      0x881C014A,  //  0048  GETMBR	R7	R0	K74
-      0x781E0004,  //  0049  JMPF	R7	#004F
-      0xB81E0600,  //  004A  GETNGBL	R7	K3
-      0x8C1C0F56,  //  004B  GETMET	R7	R7	K86
-      0x5824000F,  //  004C  LDCONST	R9	K15
-      0x7C1C0400,  //  004D  CALL	R7	2
-      0x70020003,  //  004E  JMP		#0053
-      0xB81E0600,  //  004F  GETNGBL	R7	K3
-      0x8C1C0F56,  //  0050  GETMET	R7	R7	K86
-      0x5824005C,  //  0051  LDCONST	R9	K92
-      0x7C1C0400,  //  0052  CALL	R7	2
-      0x5820000F,  //  0053  LDCONST	R8	K15
-      0x7C140600,  //  0054  CALL	R5	3
-      0xB8160600,  //  0055  GETNGBL	R5	K3
-      0x8C140B5D,  //  0056  GETMET	R5	R5	K93
-      0xB81E0600,  //  0057  GETNGBL	R7	K3
-      0x8C1C0F5E,  //  0058  GETMET	R7	R7	K94
-      0x7C1C0200,  //  0059  CALL	R7	1
-      0x7C140400,  //  005A  CALL	R5	2
-      0xB8160600,  //  005B  GETNGBL	R5	K3
-      0x8C140B5E,  //  005C  GETMET	R5	R5	K94
-      0x7C140200,  //  005D  CALL	R5	1
-      0x8C140B5F,  //  005E  GETMET	R5	R5	K95
-      0x581C000F,  //  005F  LDCONST	R7	K15
-      0x5820000F,  //  0060  LDCONST	R8	K15
-      0x7C140600,  //  0061  CALL	R5	3
-      0x60140013,  //  0062  GETGBL	R5	G19
-      0x7C140000,  //  0063  CALL	R5	0
-      0x90021605,  //  0064  SETMBR	R0	K11	R5
-      0x8C140160,  //  0065  GETMET	R5	R0	K96
-      0x5C1C0400,  //  0066  MOVE	R7	R2
-      0x7C140400,  //  0067  CALL	R5	2
-      0x80000000,  //  0068  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _remove_page
-********************************************************************/
-be_local_closure(class_HASPmota__remove_page,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(_remove_page),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x8C080120,  //  0000  GETMET	R2	R0	K32
-      0x7C080200,  //  0001  CALL	R2	1
-      0x8C08051F,  //  0002  GETMET	R2	R2	K31
-      0x7C080200,  //  0003  CALL	R2	1
-      0x1C0C0202,  //  0004  EQ	R3	R1	R2
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x8C0C0125,  //  0006  GETMET	R3	R0	K37
-      0x58140041,  //  0007  LDCONST	R5	K65
-      0x5818000F,  //  0008  LDCONST	R6	K15
-      0x581C000F,  //  0009  LDCONST	R7	K15
-      0x7C0C0800,  //  000A  CALL	R3	4
-      0x4C100000,  //  000B  LDNIL	R4
-      0x1C100604,  //  000C  EQ	R4	R3	R4
-      0x78120000,  //  000D  JMPF	R4	#000F
-      0x80000800,  //  000E  RET	0
-      0x880C010B,  //  000F  GETMBR	R3	R0	K11
-      0x8C0C071D,  //  0010  GETMET	R3	R3	K29
-      0x5C140200,  //  0011  MOVE	R5	R1
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x780E0003,  //  0013  JMPF	R3	#0018
-      0x880C010B,  //  0014  GETMBR	R3	R0	K11
-      0x8C0C073D,  //  0015  GETMET	R3	R3	K61
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x7C0C0400,  //  0017  CALL	R3	2
-      0x600C0018,  //  0018  GETGBL	R3	G24
-      0x58100062,  //  0019  LDCONST	R4	K98
-      0x5C140200,  //  001A  MOVE	R5	R1
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0xB812C200,  //  001C  GETNGBL	R4	K97
-      0x4C140000,  //  001D  LDNIL	R5
-      0x90100605,  //  001E  SETMBR	R4	R3	R5
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort
-********************************************************************/
-be_local_closure(class_HASPmota_sort,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_HASPmota,     /* shared constants */
-    be_str_weak(sort),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0715,  //  0005  SUB	R3	R3	K21
-      0x400E2A03,  //  0006  CONNECT	R3	K21	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B0F,  //  000D  GT	R6	R5	K15
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B15,  //  000F  SUB	R6	R5	K21
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B15,  //  0013  SUB	R6	R5	K21
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B15,  //  0016  SUB	R5	R5	K21
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080012,  //  001A  LDCONST	R2	K18
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x80040000,  //  001D  RET	1	R0
     })
   )
 );
@@ -12040,15 +11324,15 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
     be_str_weak(parse_obj),
     &be_const_str_solidified,
     ( &(const binstruction[239]) {  /* code */
-      0xA40EC200,  //  0000  IMPORT	R3	K97
-      0xA4120200,  //  0001  IMPORT	R4	K1
+      0xA40E2C00,  //  0000  IMPORT	R3	K22
+      0xA4122E00,  //  0001  IMPORT	R4	K23
       0x60140009,  //  0002  GETGBL	R5	G9
-      0x8C180314,  //  0003  GETMET	R6	R1	K20
-      0x5820001F,  //  0004  LDCONST	R8	K31
+      0x8C180308,  //  0003  GETMET	R6	R1	K8
+      0x58200009,  //  0004  LDCONST	R8	K9
       0x7C180400,  //  0005  CALL	R6	2
       0x7C140200,  //  0006  CALL	R5	1
-      0x8C180314,  //  0007  GETMET	R6	R1	K20
-      0x58200063,  //  0008  LDCONST	R8	K99
+      0x8C180308,  //  0007  GETMET	R6	R1	K8
+      0x58200018,  //  0008  LDCONST	R8	K24
       0x7C180400,  //  0009  CALL	R6	2
       0x4C1C0000,  //  000A  LDNIL	R7
       0x201C0C07,  //  000B  NE	R7	R6	R7
@@ -12059,30 +11343,30 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020000,  //  0010  JMP		#0012
       0x4C1C0000,  //  0011  LDNIL	R7
       0x5C180E00,  //  0012  MOVE	R6	R7
-      0x8C1C0120,  //  0013  GETMET	R7	R0	K32
+      0x8C1C010B,  //  0013  GETMET	R7	R0	K11
       0x7C1C0200,  //  0014  CALL	R7	1
       0x4C200000,  //  0015  LDNIL	R8
       0x20200A08,  //  0016  NE	R8	R5	R8
       0x78220011,  //  0017  JMPF	R8	#002A
-      0x14200B0F,  //  0018  LT	R8	R5	K15
+      0x14200B0A,  //  0018  LT	R8	R5	K10
       0x74220002,  //  0019  JMPT	R8	#001D
       0x542200FD,  //  001A  LDINT	R8	254
       0x24200A08,  //  001B  GT	R8	R5	R8
       0x7822000C,  //  001C  JMPF	R8	#002A
-      0x20200B0F,  //  001D  NE	R8	R5	K15
+      0x20200B0A,  //  001D  NE	R8	R5	K10
       0x74220002,  //  001E  JMPT	R8	#0022
       0x4C200000,  //  001F  LDNIL	R8
       0x1C200C08,  //  0020  EQ	R8	R6	R8
       0x78220007,  //  0021  JMPF	R8	#002A
       0x60200001,  //  0022  GETGBL	R8	G1
       0x60240018,  //  0023  GETGBL	R9	G24
-      0x58280064,  //  0024  LDCONST	R10	K100
+      0x58280019,  //  0024  LDCONST	R10	K25
       0x5C2C0A00,  //  0025  MOVE	R11	R5
       0x5C300C00,  //  0026  MOVE	R12	R6
       0x7C240600,  //  0027  CALL	R9	3
       0x7C200200,  //  0028  CALL	R8	1
       0x80001000,  //  0029  RET	0
-      0x8C200F65,  //  002A  GETMET	R8	R7	K101
+      0x8C200F1A,  //  002A  GETMET	R8	R7	K26
       0x5C280A00,  //  002B  MOVE	R10	R5
       0x7C200400,  //  002C  CALL	R8	2
       0x4C240000,  //  002D  LDNIL	R9
@@ -12095,8 +11379,8 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x1C241009,  //  0034  EQ	R9	R8	R9
       0x78260059,  //  0035  JMPF	R9	#0090
       0x60240009,  //  0036  GETGBL	R9	G9
-      0x8C280314,  //  0037  GETMET	R10	R1	K20
-      0x58300066,  //  0038  LDCONST	R12	K102
+      0x8C280308,  //  0037  GETMET	R10	R1	K8
+      0x5830001B,  //  0038  LDCONST	R12	K27
       0x7C280400,  //  0039  CALL	R10	2
       0x7C240200,  //  003A  CALL	R9	1
       0x4C280000,  //  003B  LDNIL	R10
@@ -12104,29 +11388,29 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x4C300000,  //  003D  LDNIL	R12
       0x2030120C,  //  003E  NE	R12	R9	R12
       0x78320007,  //  003F  JMPF	R12	#0048
-      0x8C300F65,  //  0040  GETMET	R12	R7	K101
+      0x8C300F1A,  //  0040  GETMET	R12	R7	K26
       0x5C381200,  //  0041  MOVE	R14	R9
       0x7C300400,  //  0042  CALL	R12	2
       0x5C281800,  //  0043  MOVE	R10	R12
       0x4C300000,  //  0044  LDNIL	R12
       0x2030140C,  //  0045  NE	R12	R10	R12
       0x78320000,  //  0046  JMPF	R12	#0048
-      0x882C152A,  //  0047  GETMBR	R11	R10	K42
+      0x882C151C,  //  0047  GETMBR	R11	R10	K28
       0x4C300000,  //  0048  LDNIL	R12
       0x1C30160C,  //  0049  EQ	R12	R11	R12
       0x78320002,  //  004A  JMPF	R12	#004E
-      0x8C300F67,  //  004B  GETMET	R12	R7	K103
+      0x8C300F1D,  //  004B  GETMET	R12	R7	K29
       0x7C300200,  //  004C  CALL	R12	1
       0x5C2C1800,  //  004D  MOVE	R11	R12
-      0x8C300902,  //  004E  GETMET	R12	R4	K2
+      0x8C30091E,  //  004E  GETMET	R12	R4	K30
       0x5C380000,  //  004F  MOVE	R14	R0
-      0x003ED006,  //  0050  ADD	R15	K104	R6
+      0x003E3E06,  //  0050  ADD	R15	K31	R6
       0x7C300600,  //  0051  CALL	R12	3
       0x4C340000,  //  0052  LDNIL	R13
       0x4C380000,  //  0053  LDNIL	R14
       0x1C38180E,  //  0054  EQ	R14	R12	R14
       0x783A0010,  //  0055  JMPF	R14	#0067
-      0x8C380902,  //  0056  GETMET	R14	R4	K2
+      0x8C38091E,  //  0056  GETMET	R14	R4	K30
       0x5C400600,  //  0057  MOVE	R16	R3
       0x5C440C00,  //  0058  MOVE	R17	R6
       0x7C380600,  //  0059  CALL	R14	3
@@ -12136,17 +11420,17 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x603C0004,  //  005D  GETGBL	R15	G4
       0x5C401C00,  //  005E  MOVE	R16	R14
       0x7C3C0200,  //  005F  CALL	R15	1
-      0x1C3C1F69,  //  0060  EQ	R15	R15	K105
+      0x1C3C1F20,  //  0060  EQ	R15	R15	K32
       0x783E0004,  //  0061  JMPF	R15	#0067
       0x5C3C1C00,  //  0062  MOVE	R15	R14
       0x5C401600,  //  0063  MOVE	R16	R11
       0x7C3C0200,  //  0064  CALL	R15	1
       0x5C341E00,  //  0065  MOVE	R13	R15
-      0x8830016A,  //  0066  GETMBR	R12	R0	K106
+      0x88300121,  //  0066  GETMBR	R12	R0	K33
       0x4C380000,  //  0067  LDNIL	R14
       0x1C38180E,  //  0068  EQ	R14	R12	R14
       0x783A000F,  //  0069  JMPF	R14	#007A
-      0x8C38096B,  //  006A  GETMET	R14	R4	K107
+      0x8C380922,  //  006A  GETMET	R14	R4	K34
       0x5C400C00,  //  006B  MOVE	R16	R6
       0x7C380400,  //  006C  CALL	R14	2
       0x4C3C0000,  //  006D  LDNIL	R15
@@ -12155,19 +11439,19 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x603C0004,  //  0070  GETGBL	R15	G4
       0x5C401C00,  //  0071  MOVE	R16	R14
       0x7C3C0200,  //  0072  CALL	R15	1
-      0x1C3C1F69,  //  0073  EQ	R15	R15	K105
+      0x1C3C1F20,  //  0073  EQ	R15	R15	K32
       0x783E0004,  //  0074  JMPF	R15	#007A
       0x5C3C1C00,  //  0075  MOVE	R15	R14
       0x5C401600,  //  0076  MOVE	R16	R11
       0x7C3C0200,  //  0077  CALL	R15	1
       0x5C341E00,  //  0078  MOVE	R13	R15
-      0x8830016A,  //  0079  GETMBR	R12	R0	K106
+      0x88300121,  //  0079  GETMBR	R12	R0	K33
       0x4C380000,  //  007A  LDNIL	R14
       0x1C38180E,  //  007B  EQ	R14	R12	R14
       0x783A0006,  //  007C  JMPF	R14	#0084
       0x60380001,  //  007D  GETGBL	R14	G1
       0x603C0018,  //  007E  GETGBL	R15	G24
-      0x5840006C,  //  007F  LDCONST	R16	K108
+      0x58400023,  //  007F  LDCONST	R16	K35
       0x5C440C00,  //  0080  MOVE	R17	R6
       0x7C3C0400,  //  0081  CALL	R15	2
       0x7C380200,  //  0082  CALL	R14	1
@@ -12180,33 +11464,33 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x5C4C1400,  //  0089  MOVE	R19	R10
       0x7C380A00,  //  008A  CALL	R14	5
       0x5C201C00,  //  008B  MOVE	R8	R14
-      0x8C380F6D,  //  008C  GETMET	R14	R7	K109
+      0x8C380F24,  //  008C  GETMET	R14	R7	K36
       0x5C400A00,  //  008D  MOVE	R16	R5
       0x5C441000,  //  008E  MOVE	R17	R8
       0x7C380600,  //  008F  CALL	R14	3
-      0x1C240B0F,  //  0090  EQ	R9	R5	K15
+      0x1C240B0A,  //  0090  EQ	R9	R5	K10
       0x7826000F,  //  0091  JMPF	R9	#00A2
       0x4C240000,  //  0092  LDNIL	R9
       0x20240C09,  //  0093  NE	R9	R6	R9
       0x78260006,  //  0094  JMPF	R9	#009C
       0x60240001,  //  0095  GETGBL	R9	G1
       0x60280018,  //  0096  GETGBL	R10	G24
-      0x582C006E,  //  0097  LDCONST	R11	K110
+      0x582C0025,  //  0097  LDCONST	R11	K37
       0x5C300C00,  //  0098  MOVE	R12	R6
       0x7C280400,  //  0099  CALL	R10	2
       0x7C240200,  //  009A  CALL	R9	1
       0x80001200,  //  009B  RET	0
-      0x8C240120,  //  009C  GETMET	R9	R0	K32
+      0x8C24010B,  //  009C  GETMET	R9	R0	K11
       0x7C240200,  //  009D  CALL	R9	1
-      0x8C241365,  //  009E  GETMET	R9	R9	K101
-      0x582C000F,  //  009F  LDCONST	R11	K15
+      0x8C24131A,  //  009E  GETMET	R9	R9	K26
+      0x582C000A,  //  009F  LDCONST	R11	K10
       0x7C240400,  //  00A0  CALL	R9	2
       0x5C201200,  //  00A1  MOVE	R8	R9
       0x4C240000,  //  00A2  LDNIL	R9
       0x20241009,  //  00A3  NE	R9	R8	R9
       0x7826000C,  //  00A4  JMPF	R9	#00B2
       0x60240010,  //  00A5  GETGBL	R9	G16
-      0x8C280310,  //  00A6  GETMET	R10	R1	K16
+      0x8C280326,  //  00A6  GETMET	R10	R1	K38
       0x7C280200,  //  00A7  CALL	R10	1
       0x7C240200,  //  00A8  CALL	R9	1
       0xA8020004,  //  00A9  EXBLK	0	#00AF
@@ -12215,21 +11499,21 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x942C020A,  //  00AC  GETIDX	R11	R1	R10
       0x9020140B,  //  00AD  SETMBR	R8	R10	R11
       0x7001FFFA,  //  00AE  JMP		#00AA
-      0x58240012,  //  00AF  LDCONST	R9	K18
+      0x58240027,  //  00AF  LDCONST	R9	K39
       0xAC240200,  //  00B0  CATCH	R9	1	0
       0xB0080000,  //  00B1  RAISE	2	R0	R0
       0x4C240000,  //  00B2  LDNIL	R9
       0x20241009,  //  00B3  NE	R9	R8	R9
       0x78260001,  //  00B4  JMPF	R9	#00B7
-      0x8C24116F,  //  00B5  GETMET	R9	R8	K111
+      0x8C241128,  //  00B5  GETMET	R9	R8	K40
       0x7C240200,  //  00B6  CALL	R9	1
       0x4C240000,  //  00B7  LDNIL	R9
       0x60280008,  //  00B8  GETGBL	R10	G8
-      0x8C2C0314,  //  00B9  GETMET	R11	R1	K20
-      0x58340070,  //  00BA  LDCONST	R13	K112
+      0x8C2C0308,  //  00B9  GETMET	R11	R1	K8
+      0x58340029,  //  00BA  LDCONST	R13	K41
       0x7C2C0400,  //  00BB  CALL	R11	2
       0x7C280200,  //  00BC  CALL	R10	1
-      0x202C1571,  //  00BD  NE	R11	R10	K113
+      0x202C152A,  //  00BD  NE	R11	R10	K42
       0x782E0012,  //  00BE  JMPF	R11	#00D2
       0xA8020005,  //  00BF  EXBLK	0	#00C6
       0x602C000D,  //  00C0  GETGBL	R11	G13
@@ -12242,7 +11526,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020008,  //  00C7  JMP		#00D1
       0x60340001,  //  00C8  GETGBL	R13	G1
       0x60380018,  //  00C9  GETGBL	R14	G24
-      0x583C0072,  //  00CA  LDCONST	R15	K114
+      0x583C002B,  //  00CA  LDCONST	R15	K43
       0x5C401400,  //  00CB  MOVE	R16	R10
       0x5C441600,  //  00CC  MOVE	R17	R11
       0x5C481800,  //  00CD  MOVE	R18	R12
@@ -12259,7 +11543,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x60300004,  //  00D8  GETGBL	R12	G4
       0x5C341600,  //  00D9  MOVE	R13	R11
       0x7C300200,  //  00DA  CALL	R12	1
-      0x1C301973,  //  00DB  EQ	R12	R12	K115
+      0x1C30192C,  //  00DB  EQ	R12	R12	K44
       0x78320002,  //  00DC  JMPF	R12	#00E0
       0x5C301600,  //  00DD  MOVE	R12	R11
       0x5C341000,  //  00DE  MOVE	R13	R8
@@ -12270,7 +11554,7 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020008,  //  00E3  JMP		#00ED
       0x60340001,  //  00E4  GETGBL	R13	G1
       0x60380018,  //  00E5  GETGBL	R14	G24
-      0x583C0074,  //  00E6  LDCONST	R15	K116
+      0x583C002D,  //  00E6  LDCONST	R15	K45
       0x5C401400,  //  00E7  MOVE	R16	R10
       0x5C441600,  //  00E8  MOVE	R17	R11
       0x5C481800,  //  00E9  MOVE	R18	R12
@@ -12279,6 +11563,163 @@ be_local_closure(class_HASPmota_parse_obj,   /* name */
       0x70020000,  //  00EC  JMP		#00EE
       0xB0080000,  //  00ED  RAISE	2	R0	R0
       0x80000000,  //  00EE  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _remove_page
+********************************************************************/
+be_local_closure(class_HASPmota__remove_page,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(_remove_page),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0x8C08010F,  //  0000  GETMET	R2	R0	K15
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C080509,  //  0002  GETMET	R2	R2	K9
+      0x7C080200,  //  0003  CALL	R2	1
+      0x1C0C0202,  //  0004  EQ	R3	R1	R2
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x8C0C012E,  //  0006  GETMET	R3	R0	K46
+      0x58140012,  //  0007  LDCONST	R5	K18
+      0x5818000A,  //  0008  LDCONST	R6	K10
+      0x581C000A,  //  0009  LDCONST	R7	K10
+      0x7C0C0800,  //  000A  CALL	R3	4
+      0x4C100000,  //  000B  LDNIL	R4
+      0x1C100604,  //  000C  EQ	R4	R3	R4
+      0x78120000,  //  000D  JMPF	R4	#000F
+      0x80000800,  //  000E  RET	0
+      0x880C0103,  //  000F  GETMBR	R3	R0	K3
+      0x1C0C0601,  //  0010  EQ	R3	R3	R1
+      0x780E0001,  //  0011  JMPF	R3	#0014
+      0x880C0104,  //  0012  GETMBR	R3	R0	K4
+      0x90020603,  //  0013  SETMBR	R0	K3	R3
+      0x880C0105,  //  0014  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
+      0x5C140200,  //  0016  MOVE	R5	R1
+      0x7C0C0400,  //  0017  CALL	R3	2
+      0x780E0003,  //  0018  JMPF	R3	#001D
+      0x880C0105,  //  0019  GETMBR	R3	R0	K5
+      0x8C0C072F,  //  001A  GETMET	R3	R3	K47
+      0x5C140200,  //  001B  MOVE	R5	R1
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0x600C0018,  //  001D  GETGBL	R3	G24
+      0x58100030,  //  001E  LDCONST	R4	K48
+      0x5C140200,  //  001F  MOVE	R5	R1
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0xB8122C00,  //  0021  GETNGBL	R4	K22
+      0x4C140000,  //  0022  LDNIL	R5
+      0x90100605,  //  0023  SETMBR	R4	R3	R5
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_page_cur_parsing
+********************************************************************/
+be_local_closure(class_HASPmota_get_page_cur_parsing,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(get_page_cur_parsing),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x88080103,  //  0001  GETMBR	R2	R0	K3
+      0x94040202,  //  0002  GETIDX	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pages_list_sorted
+********************************************************************/
+be_local_closure(class_HASPmota_pages_list_sorted,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(pages_list_sorted),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x1C0C030A,  //  0002  EQ	R3	R1	K10
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x88040104,  //  0004  GETMBR	R1	R0	K4
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100105,  //  0006  GETMBR	R4	R0	K5
+      0x8C100926,  //  0007  GETMET	R4	R4	K38
+      0x7C100200,  //  0008  CALL	R4	1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0xA8020007,  //  000A  EXBLK	0	#0013
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x2014090A,  //  000D  NE	R5	R4	K10
+      0x78160002,  //  000E  JMPF	R5	#0012
+      0x8C140531,  //  000F  GETMET	R5	R2	K49
+      0x5C1C0800,  //  0010  MOVE	R7	R4
+      0x7C140400,  //  0011  CALL	R5	2
+      0x7001FFF7,  //  0012  JMP		#000B
+      0x580C0027,  //  0013  LDCONST	R3	K39
+      0xAC0C0200,  //  0014  CATCH	R3	1	0
+      0xB0080000,  //  0015  RAISE	2	R0	R0
+      0x8C0C0132,  //  0016  GETMET	R3	R0	K50
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x5C080600,  //  0019  MOVE	R2	R3
+      0x4C0C0000,  //  001A  LDNIL	R3
+      0x1C0C0203,  //  001B  EQ	R3	R1	R3
+      0x780E0000,  //  001C  JMPF	R3	#001E
+      0x80040400,  //  001D  RET	1	R2
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100400,  //  001F  MOVE	R4	R2
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x00080402,  //  0021  ADD	R2	R2	R2
+      0x8C100508,  //  0022  GETMET	R4	R2	K8
+      0x5C180200,  //  0023  MOVE	R6	R1
+      0x7C100400,  //  0024  CALL	R4	2
+      0x4C140000,  //  0025  LDNIL	R5
+      0x1C140805,  //  0026  EQ	R5	R4	R5
+      0x78160001,  //  0027  JMPF	R5	#002A
+      0x4C140000,  //  0028  LDNIL	R5
+      0x80040A00,  //  0029  RET	1	R5
+      0x00140803,  //  002A  ADD	R5	R4	R3
+      0x04140B11,  //  002B  SUB	R5	R5	K17
+      0x40140805,  //  002C  CONNECT	R5	R4	R5
+      0x94080405,  //  002D  GETIDX	R2	R2	R5
+      0x80040400,  //  002E  RET	1	R2
     })
   )
 );
@@ -12302,40 +11743,638 @@ be_local_closure(class_HASPmota_event_dispatch,   /* name */
     be_str_weak(event_dispatch),
     &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA40A0200,  //  0000  IMPORT	R2	K1
-      0x8C0C052C,  //  0001  GETMET	R3	R2	K44
+      0xA40A2E00,  //  0000  IMPORT	R2	K23
+      0x8C0C0533,  //  0001  GETMET	R3	R2	K51
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
-      0x88100175,  //  0004  GETMBR	R4	R0	K117
+      0x88100134,  //  0004  GETMBR	R4	R0	K52
       0x78120002,  //  0005  JMPF	R4	#0009
-      0x88100175,  //  0006  GETMBR	R4	R0	K117
-      0x9012EC03,  //  0007  SETMBR	R4	K118	R3
+      0x88100134,  //  0006  GETMBR	R4	R0	K52
+      0x90126A03,  //  0007  SETMBR	R4	K53	R3
       0x70020004,  //  0008  JMP		#000E
-      0xB8120600,  //  0009  GETNGBL	R4	K3
-      0x8C100977,  //  000A  GETMET	R4	R4	K119
+      0xB8126C00,  //  0009  GETNGBL	R4	K54
+      0x8C100937,  //  000A  GETMET	R4	R4	K55
       0x5C180600,  //  000B  MOVE	R6	R3
       0x7C100400,  //  000C  CALL	R4	2
-      0x9002EA04,  //  000D  SETMBR	R0	K117	R4
-      0x88100175,  //  000E  GETMBR	R4	R0	K117
-      0x8C100978,  //  000F  GETMET	R4	R4	K120
+      0x90026804,  //  000D  SETMBR	R0	K52	R4
+      0x88100134,  //  000E  GETMBR	R4	R0	K52
+      0x8C100938,  //  000F  GETMET	R4	R4	K56
       0x7C100200,  //  0010  CALL	R4	1
       0x60140009,  //  0011  GETGBL	R5	G9
       0x5C180800,  //  0012  MOVE	R6	R4
       0x7C140200,  //  0013  CALL	R5	1
-      0x20140B0F,  //  0014  NE	R5	R5	K15
+      0x20140B0A,  //  0014  NE	R5	R5	K10
       0x7816000A,  //  0015  JMPF	R5	#0021
-      0x8C140579,  //  0016  GETMET	R5	R2	K121
+      0x8C140539,  //  0016  GETMET	R5	R2	K57
       0x5C1C0800,  //  0017  MOVE	R7	R4
       0x7C140400,  //  0018  CALL	R5	2
       0x60180004,  //  0019  GETGBL	R6	G4
       0x5C1C0A00,  //  001A  MOVE	R7	R5
       0x7C180200,  //  001B  CALL	R6	1
-      0x1C180D08,  //  001C  EQ	R6	R6	K8
+      0x1C180D3A,  //  001C  EQ	R6	R6	K58
       0x781A0002,  //  001D  JMPF	R6	#0021
-      0x8C180B28,  //  001E  GETMET	R6	R5	K40
-      0x88200175,  //  001F  GETMBR	R8	R0	K117
+      0x8C180B3B,  //  001E  GETMET	R6	R5	K59
+      0x88200134,  //  001F  GETMBR	R8	R0	K52
       0x7C180400,  //  0020  CALL	R6	2
       0x80000000,  //  0021  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_page_cur
+********************************************************************/
+be_local_closure(class_HASPmota_get_page_cur,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(get_page_cur),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x88080104,  //  0001  GETMBR	R2	R0	K4
+      0x94040202,  //  0002  GETIDX	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fix_lv_version
+********************************************************************/
+be_local_closure(class_HASPmota_fix_lv_version,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    0,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(fix_lv_version),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x5800003C,  //  0000  LDCONST	R0	K60
+      0xA4062E00,  //  0001  IMPORT	R1	K23
+      0x8C08031E,  //  0002  GETMET	R2	R1	K30
+      0xB8126C00,  //  0003  GETNGBL	R4	K54
+      0x5814003D,  //  0004  LDCONST	R5	K61
+      0x7C080600,  //  0005  CALL	R2	3
+      0x600C0004,  //  0006  GETGBL	R3	G4
+      0x5C100400,  //  0007  MOVE	R4	R2
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x200C0702,  //  0009  NE	R3	R3	K2
+      0x780E0002,  //  000A  JMPF	R3	#000E
+      0xB80E6C00,  //  000B  GETNGBL	R3	K54
+      0x54120007,  //  000C  LDINT	R4	8
+      0x900E7A04,  //  000D  SETMBR	R3	K61	R4
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_event
+********************************************************************/
+be_local_closure(class_HASPmota_register_event,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(event_dispatch),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68040000,  //  0000  GETUPV	R1	U0
+          0x8C040300,  //  0001  GETMET	R1	R1	K0
+          0x5C0C0000,  //  0002  MOVE	R3	R0
+          0x7C040400,  //  0003  CALL	R1	2
+          0x80040200,  //  0004  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(register_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0xA40E7C00,  //  0000  IMPORT	R3	K62
+      0xA4122E00,  //  0001  IMPORT	R4	K23
+      0x8814013B,  //  0002  GETMBR	R5	R0	K59
+      0x4C180000,  //  0003  LDNIL	R6
+      0x1C140A06,  //  0004  EQ	R5	R5	R6
+      0x78160003,  //  0005  JMPF	R5	#000A
+      0x8C14073F,  //  0006  GETMET	R5	R3	K63
+      0x841C0000,  //  0007  CLOSURE	R7	P0
+      0x7C140400,  //  0008  CALL	R5	2
+      0x90027605,  //  0009  SETMBR	R0	K59	R5
+      0x8814031C,  //  000A  GETMBR	R5	R1	K28
+      0x8C180B40,  //  000B  GETMET	R6	R5	K64
+      0x8820013B,  //  000C  GETMBR	R8	R0	K59
+      0x5C240400,  //  000D  MOVE	R9	R2
+      0x8C280933,  //  000E  GETMET	R10	R4	K51
+      0x5C300200,  //  000F  MOVE	R12	R1
+      0x7C280400,  //  0010  CALL	R10	2
+      0x7C180800,  //  0011  CALL	R6	4
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse
+********************************************************************/
+be_local_closure(class_HASPmota_parse,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(parse),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0xA40A8200,  //  0000  IMPORT	R2	K65
+      0x8C0C0542,  //  0001  GETMET	R3	R2	K66
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x60100004,  //  0004  GETGBL	R4	G4
+      0x5C140600,  //  0005  MOVE	R5	R3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x1C10093A,  //  0007  EQ	R4	R4	K58
+      0x78120009,  //  0008  JMPF	R4	#0013
+      0x8C100143,  //  0009  GETMET	R4	R0	K67
+      0x5C180600,  //  000A  MOVE	R6	R3
+      0x7C100400,  //  000B  CALL	R4	2
+      0x8C100144,  //  000C  GETMET	R4	R0	K68
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x881C0105,  //  000E  GETMBR	R7	R0	K5
+      0x88200104,  //  000F  GETMBR	R8	R0	K4
+      0x941C0E08,  //  0010  GETIDX	R7	R7	R8
+      0x7C100600,  //  0011  CALL	R4	3
+      0x70020000,  //  0012  JMP		#0014
+      0xB0068B46,  //  0013  RAISE	1	K69	K70
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_HASPmota_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8C040147,  //  0000  GETMET	R1	R0	K71
+      0x7C040200,  //  0001  CALL	R1	1
+      0xA4069000,  //  0002  IMPORT	R1	K72
+      0x8C080349,  //  0003  GETMET	R2	R1	K73
+      0x5810004A,  //  0004  LDCONST	R4	K74
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90022602,  //  0006  SETMBR	R0	K19	R2
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_HASPmota_start,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[105]) {  /* code */
+      0xA40E9600,  //  0000  IMPORT	R3	K75
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C100404,  //  0002  EQ	R4	R2	R4
+      0x78120000,  //  0003  JMPF	R4	#0005
+      0x8808014C,  //  0004  GETMBR	R2	R0	K76
+      0x8C10074D,  //  0005  GETMET	R4	R3	K77
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x7C100400,  //  0007  CALL	R4	2
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x00129C02,  //  0009  ADD	R4	K78	R2
+      0x0010094F,  //  000A  ADD	R4	R4	K79
+      0xB006A004,  //  000B  RAISE	1	K80	R4
+      0xB8126C00,  //  000C  GETNGBL	R4	K54
+      0x8C100951,  //  000D  GETMET	R4	R4	K81
+      0x7C100200,  //  000E  CALL	R4	1
+      0x60100017,  //  000F  GETGBL	R4	G23
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C100200,  //  0011  CALL	R4	1
+      0x9002A404,  //  0012  SETMBR	R0	K82	R4
+      0xB8126C00,  //  0013  GETNGBL	R4	K54
+      0x8C100954,  //  0014  GETMET	R4	R4	K84
+      0x7C100200,  //  0015  CALL	R4	1
+      0x9002A604,  //  0016  SETMBR	R0	K83	R4
+      0xB8126C00,  //  0017  GETNGBL	R4	K54
+      0x8C100956,  //  0018  GETMET	R4	R4	K86
+      0x7C100200,  //  0019  CALL	R4	1
+      0x9002AA04,  //  001A  SETMBR	R0	K85	R4
+      0xB8126C00,  //  001B  GETNGBL	R4	K54
+      0x8C100958,  //  001C  GETMET	R4	R4	K88
+      0x7C100200,  //  001D  CALL	R4	1
+      0x9002AE04,  //  001E  SETMBR	R0	K87	R4
+      0xA8020007,  //  001F  EXBLK	0	#0028
+      0xB8126C00,  //  0020  GETNGBL	R4	K54
+      0x8C10095A,  //  0021  GETMET	R4	R4	K90
+      0x5818005B,  //  0022  LDCONST	R6	K91
+      0x541E000F,  //  0023  LDINT	R7	16
+      0x7C100600,  //  0024  CALL	R4	3
+      0x9002B204,  //  0025  SETMBR	R0	K89	R4
+      0xA8040001,  //  0026  EXBLK	1	1
+      0x70020009,  //  0027  JMP		#0032
+      0xAC100000,  //  0028  CATCH	R4	0	0
+      0x70020006,  //  0029  JMP		#0031
+      0xB8126C00,  //  002A  GETNGBL	R4	K54
+      0x8C10095A,  //  002B  GETMET	R4	R4	K90
+      0x5818005C,  //  002C  LDCONST	R6	K92
+      0x541E000D,  //  002D  LDINT	R7	14
+      0x7C100600,  //  002E  CALL	R4	3
+      0x9002B204,  //  002F  SETMBR	R0	K89	R4
+      0x70020000,  //  0030  JMP		#0032
+      0xB0080000,  //  0031  RAISE	2	R0	R0
+      0xB8126C00,  //  0032  GETNGBL	R4	K54
+      0x8C10095D,  //  0033  GETMET	R4	R4	K93
+      0x5818000A,  //  0034  LDCONST	R6	K10
+      0xB81E6C00,  //  0035  GETNGBL	R7	K54
+      0x8C1C0F5E,  //  0036  GETMET	R7	R7	K94
+      0x5824005F,  //  0037  LDCONST	R9	K95
+      0x7C1C0400,  //  0038  CALL	R7	2
+      0xB8226C00,  //  0039  GETNGBL	R8	K54
+      0x8C20115E,  //  003A  GETMET	R8	R8	K94
+      0x58280060,  //  003B  LDCONST	R10	K96
+      0x7C200400,  //  003C  CALL	R8	2
+      0x88240152,  //  003D  GETMBR	R9	R0	K82
+      0x88280159,  //  003E  GETMBR	R10	R0	K89
+      0x7C100C00,  //  003F  CALL	R4	6
+      0x88140157,  //  0040  GETMBR	R5	R0	K87
+      0x8C140B61,  //  0041  GETMET	R5	R5	K97
+      0x7C140200,  //  0042  CALL	R5	1
+      0x8C140B62,  //  0043  GETMET	R5	R5	K98
+      0x5C1C0800,  //  0044  MOVE	R7	R4
+      0x7C140400,  //  0045  CALL	R5	2
+      0x88140157,  //  0046  GETMBR	R5	R0	K87
+      0x8C140B63,  //  0047  GETMET	R5	R5	K99
+      0x881C0152,  //  0048  GETMBR	R7	R0	K82
+      0x781E0004,  //  0049  JMPF	R7	#004F
+      0xB81E6C00,  //  004A  GETNGBL	R7	K54
+      0x8C1C0F5E,  //  004B  GETMET	R7	R7	K94
+      0x5824000A,  //  004C  LDCONST	R9	K10
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x70020003,  //  004E  JMP		#0053
+      0xB81E6C00,  //  004F  GETNGBL	R7	K54
+      0x8C1C0F5E,  //  0050  GETMET	R7	R7	K94
+      0x58240064,  //  0051  LDCONST	R9	K100
+      0x7C1C0400,  //  0052  CALL	R7	2
+      0x5820000A,  //  0053  LDCONST	R8	K10
+      0x7C140600,  //  0054  CALL	R5	3
+      0xB8166C00,  //  0055  GETNGBL	R5	K54
+      0x8C140B65,  //  0056  GETMET	R5	R5	K101
+      0xB81E6C00,  //  0057  GETNGBL	R7	K54
+      0x8C1C0F66,  //  0058  GETMET	R7	R7	K102
+      0x7C1C0200,  //  0059  CALL	R7	1
+      0x7C140400,  //  005A  CALL	R5	2
+      0xB8166C00,  //  005B  GETNGBL	R5	K54
+      0x8C140B66,  //  005C  GETMET	R5	R5	K102
+      0x7C140200,  //  005D  CALL	R5	1
+      0x8C140B67,  //  005E  GETMET	R5	R5	K103
+      0x581C000A,  //  005F  LDCONST	R7	K10
+      0x5820000A,  //  0060  LDCONST	R8	K10
+      0x7C140600,  //  0061  CALL	R5	3
+      0x60140013,  //  0062  GETGBL	R5	G19
+      0x7C140000,  //  0063  CALL	R5	0
+      0x90020A05,  //  0064  SETMBR	R0	K5	R5
+      0x8C140168,  //  0065  GETMET	R5	R0	K104
+      0x5C1C0400,  //  0066  MOVE	R7	R2
+      0x7C140400,  //  0067  CALL	R5	2
+      0x80000000,  //  0068  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_dir_to
+********************************************************************/
+be_local_closure(class_HASPmota_page_dir_to,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(page_dir_to),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x8C080110,  //  0000  GETMET	R2	R0	K16
+      0x5810000A,  //  0001  LDCONST	R4	K10
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80061400,  //  0006  RET	1	K10
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x5C100400,  //  0008  MOVE	R4	R2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x18100711,  //  000A  LE	R4	R3	K17
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80061400,  //  000C  RET	1	K10
+      0x1C100769,  //  000D  EQ	R4	R3	K105
+      0x78120000,  //  000E  JMPF	R4	#0010
+      0x80062200,  //  000F  RET	1	K17
+      0x8C100508,  //  0010  GETMET	R4	R2	K8
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x7C100400,  //  0012  CALL	R4	2
+      0x4C140000,  //  0013  LDNIL	R5
+      0x1C140805,  //  0014  EQ	R5	R4	R5
+      0x78160000,  //  0015  JMPF	R5	#0017
+      0x80061400,  //  0016  RET	1	K10
+      0x00140711,  //  0017  ADD	R5	R3	K17
+      0x0C140B69,  //  0018  DIV	R5	R5	K105
+      0x18140805,  //  0019  LE	R5	R4	R5
+      0x78160001,  //  001A  JMPF	R5	#001D
+      0x80062200,  //  001B  RET	1	K17
+      0x70020001,  //  001C  JMP		#001F
+      0x5415FFFE,  //  001D  LDINT	R5	-1
+      0x80040A00,  //  001E  RET	1	R5
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: do_action
+********************************************************************/
+be_local_closure(class_HASPmota_do_action,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(do_action),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB80E6C00,  //  0000  GETNGBL	R3	K54
+      0x880C076A,  //  0001  GETMBR	R3	R3	K106
+      0x200C0403,  //  0002  NE	R3	R2	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80000600,  //  0004  RET	0
+      0x8C0C012E,  //  0005  GETMET	R3	R0	K46
+      0x8814036B,  //  0006  GETMBR	R5	R1	K107
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _load
+********************************************************************/
+be_local_closure(class_HASPmota__load,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(_load),
+    &be_const_str_solidified,
+    ( &(const binstruction[99]) {  /* code */
+      0xA40AD800,  //  0000  IMPORT	R2	K108
+      0xA40E8200,  //  0001  IMPORT	R3	K65
+      0x60100011,  //  0002  GETGBL	R4	G17
+      0x5C140200,  //  0003  MOVE	R5	R1
+      0x5818006D,  //  0004  LDCONST	R6	K109
+      0x7C100400,  //  0005  CALL	R4	2
+      0x8C14096E,  //  0006  GETMET	R5	R4	K110
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C18096F,  //  0008  GETMET	R6	R4	K111
+      0x7C180200,  //  0009  CALL	R6	1
+      0x8C180570,  //  000A  GETMET	R6	R2	K112
+      0x5C200A00,  //  000B  MOVE	R8	R5
+      0x58240071,  //  000C  LDCONST	R9	K113
+      0x7C180600,  //  000D  CALL	R6	3
+      0x4C100000,  //  000E  LDNIL	R4
+      0x4C140000,  //  000F  LDNIL	R5
+      0x601C000C,  //  0010  GETGBL	R7	G12
+      0x5C200C00,  //  0011  MOVE	R8	R6
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0x241C0F0A,  //  0013  GT	R7	R7	K10
+      0x781E0039,  //  0014  JMPF	R7	#004F
+      0x8C1C0742,  //  0015  GETMET	R7	R3	K66
+      0x94240D0A,  //  0016  GETIDX	R9	R6	K10
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x60200004,  //  0018  GETGBL	R8	G4
+      0x5C240E00,  //  0019  MOVE	R9	R7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x1C20113A,  //  001B  EQ	R8	R8	K58
+      0x7822001B,  //  001C  JMPF	R8	#0039
+      0xB822E400,  //  001D  GETNGBL	R8	K114
+      0x8C201173,  //  001E  GETMET	R8	R8	K115
+      0x542A0003,  //  001F  LDINT	R10	4
+      0x7C200400,  //  0020  CALL	R8	2
+      0x78220007,  //  0021  JMPF	R8	#002A
+      0xB822E400,  //  0022  GETNGBL	R8	K114
+      0x8C201174,  //  0023  GETMET	R8	R8	K116
+      0x60280018,  //  0024  GETGBL	R10	G24
+      0x582C0075,  //  0025  LDCONST	R11	K117
+      0x94300D0A,  //  0026  GETIDX	R12	R6	K10
+      0x7C280400,  //  0027  CALL	R10	2
+      0x542E0003,  //  0028  LDINT	R11	4
+      0x7C200600,  //  0029  CALL	R8	3
+      0x8C200143,  //  002A  GETMET	R8	R0	K67
+      0x5C280E00,  //  002B  MOVE	R10	R7
+      0x7C200400,  //  002C  CALL	R8	2
+      0x88200105,  //  002D  GETMBR	R8	R0	K5
+      0x4C240000,  //  002E  LDNIL	R9
+      0x1C201009,  //  002F  EQ	R8	R8	R9
+      0x78220000,  //  0030  JMPF	R8	#0032
+      0xB0068B76,  //  0031  RAISE	1	K69	K118
+      0x8C200144,  //  0032  GETMET	R8	R0	K68
+      0x5C280E00,  //  0033  MOVE	R10	R7
+      0x882C0105,  //  0034  GETMBR	R11	R0	K5
+      0x88300103,  //  0035  GETMBR	R12	R0	K3
+      0x942C160C,  //  0036  GETIDX	R11	R11	R12
+      0x7C200600,  //  0037  CALL	R8	3
+      0x70020010,  //  0038  JMP		#004A
+      0x6020000C,  //  0039  GETGBL	R8	G12
+      0x8C240577,  //  003A  GETMET	R9	R2	K119
+      0x942C0D0A,  //  003B  GETIDX	R11	R6	K10
+      0x58300078,  //  003C  LDCONST	R12	K120
+      0x58340079,  //  003D  LDCONST	R13	K121
+      0x7C240800,  //  003E  CALL	R9	4
+      0x7C200200,  //  003F  CALL	R8	1
+      0x2420110A,  //  0040  GT	R8	R8	K10
+      0x78220007,  //  0041  JMPF	R8	#004A
+      0xB822E400,  //  0042  GETNGBL	R8	K114
+      0x8C201174,  //  0043  GETMET	R8	R8	K116
+      0x60280018,  //  0044  GETGBL	R10	G24
+      0x582C007A,  //  0045  LDCONST	R11	K122
+      0x94300D0A,  //  0046  GETIDX	R12	R6	K10
+      0x7C280400,  //  0047  CALL	R10	2
+      0x582C0069,  //  0048  LDCONST	R11	K105
+      0x7C200600,  //  0049  CALL	R8	3
+      0x4C1C0000,  //  004A  LDNIL	R7
+      0x8C200D2F,  //  004B  GETMET	R8	R6	K47
+      0x5828000A,  //  004C  LDCONST	R10	K10
+      0x7C200400,  //  004D  CALL	R8	2
+      0x7001FFC0,  //  004E  JMP		#0010
+      0x4C180000,  //  004F  LDNIL	R6
+      0x8C1C0110,  //  0050  GETMET	R7	R0	K16
+      0x4C240000,  //  0051  LDNIL	R9
+      0x7C1C0400,  //  0052  CALL	R7	2
+      0x6020000C,  //  0053  GETGBL	R8	G12
+      0x5C240E00,  //  0054  MOVE	R9	R7
+      0x7C200200,  //  0055  CALL	R8	1
+      0x1C20110A,  //  0056  EQ	R8	R8	K10
+      0x78220000,  //  0057  JMPF	R8	#0059
+      0xB0068B7B,  //  0058  RAISE	1	K69	K123
+      0x94200F0A,  //  0059  GETIDX	R8	R7	K10
+      0x90020808,  //  005A  SETMBR	R0	K4	R8
+      0x88200105,  //  005B  GETMBR	R8	R0	K5
+      0x88240104,  //  005C  GETMBR	R9	R0	K4
+      0x94201009,  //  005D  GETIDX	R8	R8	R9
+      0x8C201115,  //  005E  GETMET	R8	R8	K21
+      0x5828000A,  //  005F  LDCONST	R10	K10
+      0x582C000A,  //  0060  LDCONST	R11	K10
+      0x7C200600,  //  0061  CALL	R8	3
+      0x80000000,  //  0062  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort
+********************************************************************/
+be_local_closure(class_HASPmota_sort,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_HASPmota,     /* shared constants */
+    be_str_weak(sort),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x5804003C,  //  0000  LDCONST	R1	K60
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0711,  //  0005  SUB	R3	R3	K17
+      0x400E2203,  //  0006  CONNECT	R3	K17	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B0A,  //  000D  GT	R6	R5	K10
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B11,  //  000F  SUB	R6	R5	K17
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B11,  //  0013  SUB	R6	R5	K17
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B11,  //  0016  SUB	R5	R5	K17
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080027,  //  001A  LDCONST	R2	K39
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x80040000,  //  001D  RET	1	R0
     })
   )
 );
@@ -12346,67 +12385,69 @@ be_local_closure(class_HASPmota_event_dispatch,   /* name */
 ** Solidified class: HASPmota
 ********************************************************************/
 be_local_class(HASPmota,
-    10,
+    11,
     NULL,
-    be_nested_map(57,
+    be_nested_map(59,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(re_page_target, 4), be_const_var(7) },
-        { be_const_key_weak(lvh_line, -1), be_const_class(be_class_lvh_line) },
-        { be_const_key_weak(lvh_pages, -1), be_const_var(5) },
-        { be_const_key_weak(lvh_dropdown_list, -1), be_const_class(be_class_lvh_dropdown_list) },
-        { be_const_key_weak(lvh_dropdown, -1), be_const_class(be_class_lvh_dropdown) },
-        { be_const_key_weak(lvh_label, 53), be_const_class(be_class_lvh_label) },
-        { be_const_key_weak(lvh_spinner, -1), be_const_class(be_class_lvh_spinner) },
-        { be_const_key_weak(lvh_scale, -1), be_const_class(be_class_lvh_scale) },
-        { be_const_key_weak(lvh_obj, -1), be_const_class(be_class_lvh_obj) },
-        { be_const_key_weak(event_dispatch, -1), be_const_closure(class_HASPmota_event_dispatch_closure) },
-        { be_const_key_weak(parse, 2), be_const_closure(class_HASPmota_parse_closure) },
-        { be_const_key_weak(scr, -1), be_const_var(3) },
-        { be_const_key_weak(lvh_msgbox, 25), be_const_class(be_class_lvh_msgbox) },
-        { be_const_key_weak(lvh_fixed, -1), be_const_class(be_class_lvh_fixed) },
-        { be_const_key_weak(lvh_checkbox, -1), be_const_class(be_class_lvh_checkbox) },
-        { be_const_key_weak(hres, 49), be_const_var(1) },
-        { be_const_key_weak(lvh_page, 46), be_const_class(be_class_lvh_page) },
-        { be_const_key_weak(sort, -1), be_const_static_closure(class_HASPmota_sort_closure) },
-        { be_const_key_weak(dark, 32), be_const_var(0) },
-        { be_const_key_weak(lvh_scale_line, -1), be_const_class(be_class_lvh_scale_line) },
-        { be_const_key_weak(get_page_cur, -1), be_const_closure(class_HASPmota_get_page_cur_closure) },
-        { be_const_key_weak(event, -1), be_const_var(8) },
-        { be_const_key_weak(lvh_led, -1), be_const_class(be_class_lvh_led) },
-        { be_const_key_weak(parse_page, -1), be_const_closure(class_HASPmota_parse_page_closure) },
+        { be_const_key_weak(lvh_dropdown_list, 50), be_const_class(be_class_lvh_dropdown_list) },
+        { be_const_key_weak(lvh_line, 19), be_const_class(be_class_lvh_line) },
         { be_const_key_weak(r16, -1), be_const_var(4) },
-        { be_const_key_weak(event_cb, 13), be_const_var(9) },
-        { be_const_key_weak(lvh_btn, -1), be_const_class(be_class_lvh_btn) },
-        { be_const_key_weak(lvh_bar, -1), be_const_class(be_class_lvh_bar) },
-        { be_const_key_weak(lvh_scale_section, 38), be_const_class(be_class_lvh_scale_section) },
-        { be_const_key_weak(do_action, -1), be_const_closure(class_HASPmota_do_action_closure) },
-        { be_const_key_weak(lvh_root, -1), be_const_class(be_class_lvh_root) },
-        { be_const_key_weak(_remove_page, 43), be_const_closure(class_HASPmota__remove_page_closure) },
-        { be_const_key_weak(lvh_roller, -1), be_const_class(be_class_lvh_roller) },
-        { be_const_key_weak(lvh_img, 16), be_const_class(be_class_lvh_img) },
-        { be_const_key_weak(lvh_qrcode, 35), be_const_class(be_class_lvh_qrcode) },
-        { be_const_key_weak(lvh_span, -1), be_const_class(be_class_lvh_span) },
-        { be_const_key_weak(page_dir_to, -1), be_const_closure(class_HASPmota_page_dir_to_closure) },
-        { be_const_key_weak(def_templ_name, -1), be_nested_str_weak(pages_X2Ejsonl) },
-        { be_const_key_weak(lvh_switch, -1), be_const_class(be_class_lvh_switch) },
-        { be_const_key_weak(lvh_slider, -1), be_const_class(be_class_lvh_slider) },
         { be_const_key_weak(page_show, -1), be_const_closure(class_HASPmota_page_show_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_HASPmota_start_closure) },
-        { be_const_key_weak(pages_list_sorted, 34), be_const_closure(class_HASPmota_pages_list_sorted_closure) },
-        { be_const_key_weak(_load, -1), be_const_closure(class_HASPmota__load_closure) },
-        { be_const_key_weak(lvh_scr, -1), be_const_class(be_class_lvh_scr) },
-        { be_const_key_weak(lvh_chart, 31), be_const_class(be_class_lvh_chart) },
-        { be_const_key_weak(register_event, -1), be_const_closure(class_HASPmota_register_event_closure) },
-        { be_const_key_weak(lvh_btnmatrix, 18), be_const_class(be_class_lvh_btnmatrix) },
-        { be_const_key_weak(lvh_cpicker, 17), be_const_class(be_class_lvh_cpicker) },
-        { be_const_key_weak(lvh_flex, -1), be_const_class(be_class_lvh_flex) },
-        { be_const_key_weak(parse_obj, 8), be_const_closure(class_HASPmota_parse_obj_closure) },
-        { be_const_key_weak(init, 12), be_const_closure(class_HASPmota_init_closure) },
-        { be_const_key_weak(vres, 9), be_const_var(2) },
+        { be_const_key_weak(parse_page, -1), be_const_closure(class_HASPmota_parse_page_closure) },
+        { be_const_key_weak(sort, 12), be_const_static_closure(class_HASPmota_sort_closure) },
+        { be_const_key_weak(event_dispatch, -1), be_const_closure(class_HASPmota_event_dispatch_closure) },
+        { be_const_key_weak(lvh_roller, 10), be_const_class(be_class_lvh_roller) },
+        { be_const_key_weak(lvh_page_cur_idx_parsing, -1), be_const_var(7) },
+        { be_const_key_weak(hres, -1), be_const_var(1) },
         { be_const_key_weak(lvh_page_cur_idx, -1), be_const_var(6) },
-        { be_const_key_weak(fix_lv_version, 7), be_const_static_closure(class_HASPmota_fix_lv_version_closure) },
+        { be_const_key_weak(_remove_page, 13), be_const_closure(class_HASPmota__remove_page_closure) },
+        { be_const_key_weak(lvh_chart, -1), be_const_class(be_class_lvh_chart) },
+        { be_const_key_weak(_load, 16), be_const_closure(class_HASPmota__load_closure) },
+        { be_const_key_weak(dark, 5), be_const_var(0) },
+        { be_const_key_weak(parse_obj, 6), be_const_closure(class_HASPmota_parse_obj_closure) },
+        { be_const_key_weak(lvh_msgbox, -1), be_const_class(be_class_lvh_msgbox) },
+        { be_const_key_weak(get_page_cur, 29), be_const_closure(class_HASPmota_get_page_cur_closure) },
+        { be_const_key_weak(event, -1), be_const_var(9) },
+        { be_const_key_weak(scr, 51), be_const_var(3) },
+        { be_const_key_weak(vres, -1), be_const_var(2) },
+        { be_const_key_weak(lvh_scale, -1), be_const_class(be_class_lvh_scale) },
+        { be_const_key_weak(register_event, 24), be_const_closure(class_HASPmota_register_event_closure) },
         { be_const_key_weak(lvh_arc, -1), be_const_class(be_class_lvh_arc) },
+        { be_const_key_weak(do_action, 23), be_const_closure(class_HASPmota_do_action_closure) },
+        { be_const_key_weak(lvh_dropdown, -1), be_const_class(be_class_lvh_dropdown) },
+        { be_const_key_weak(lvh_fixed, -1), be_const_class(be_class_lvh_fixed) },
+        { be_const_key_weak(re_page_target, 43), be_const_var(8) },
+        { be_const_key_weak(lvh_slider, -1), be_const_class(be_class_lvh_slider) },
+        { be_const_key_weak(fix_lv_version, -1), be_const_static_closure(class_HASPmota_fix_lv_version_closure) },
+        { be_const_key_weak(lvh_checkbox, -1), be_const_class(be_class_lvh_checkbox) },
+        { be_const_key_weak(parse, 47), be_const_closure(class_HASPmota_parse_closure) },
+        { be_const_key_weak(lvh_pages, -1), be_const_var(5) },
+        { be_const_key_weak(lvh_btn, -1), be_const_class(be_class_lvh_btn) },
+        { be_const_key_weak(start, -1), be_const_closure(class_HASPmota_start_closure) },
+        { be_const_key_weak(lvh_root, -1), be_const_class(be_class_lvh_root) },
+        { be_const_key_weak(lvh_page, -1), be_const_class(be_class_lvh_page) },
+        { be_const_key_weak(pages_list_sorted, 26), be_const_closure(class_HASPmota_pages_list_sorted_closure) },
+        { be_const_key_weak(lvh_qrcode, 45), be_const_class(be_class_lvh_qrcode) },
+        { be_const_key_weak(lvh_label, -1), be_const_class(be_class_lvh_label) },
+        { be_const_key_weak(lvh_scr, 28), be_const_class(be_class_lvh_scr) },
+        { be_const_key_weak(lvh_img, 27), be_const_class(be_class_lvh_img) },
+        { be_const_key_weak(get_page_cur_parsing, 30), be_const_closure(class_HASPmota_get_page_cur_parsing_closure) },
+        { be_const_key_weak(page_dir_to, 49), be_const_closure(class_HASPmota_page_dir_to_closure) },
+        { be_const_key_weak(lvh_obj, -1), be_const_class(be_class_lvh_obj) },
+        { be_const_key_weak(lvh_switch, -1), be_const_class(be_class_lvh_switch) },
+        { be_const_key_weak(lvh_bar, -1), be_const_class(be_class_lvh_bar) },
+        { be_const_key_weak(init, -1), be_const_closure(class_HASPmota_init_closure) },
+        { be_const_key_weak(lvh_btnmatrix, -1), be_const_class(be_class_lvh_btnmatrix) },
+        { be_const_key_weak(lvh_spinner, 52), be_const_class(be_class_lvh_spinner) },
+        { be_const_key_weak(lvh_led, 3), be_const_class(be_class_lvh_led) },
+        { be_const_key_weak(lvh_flex, 57), be_const_class(be_class_lvh_flex) },
         { be_const_key_weak(lvh_spangroup, -1), be_const_class(be_class_lvh_spangroup) },
+        { be_const_key_weak(lvh_span, -1), be_const_class(be_class_lvh_span) },
+        { be_const_key_weak(def_templ_name, 9), be_nested_str_weak(pages_X2Ejsonl) },
+        { be_const_key_weak(lvh_scale_section, 7), be_const_class(be_class_lvh_scale_section) },
+        { be_const_key_weak(event_cb, -1), be_const_var(10) },
+        { be_const_key_weak(lvh_scale_line, -1), be_const_class(be_class_lvh_scale_line) },
+        { be_const_key_weak(lvh_cpicker, -1), be_const_class(be_class_lvh_cpicker) },
     })),
     be_str_weak(HASPmota)
 );


### PR DESCRIPTION
## Description:

HASPmota separate current page on screen `haspmota.lvh_page_cur_idx` and current page being parsed as JSONL `haspmota.lvh_page_cur_idx_parsing`. See on Discord.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
