### PR TITLE
Make disabling of IRremote possible

### DIFF
--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -1029,21 +1029,23 @@
   #define SEND_PRONTO false                      // Exclude PRONTO protocol
 #else
   #define _IR_ENABLE_DEFAULT_ false              // disable all protocols by default
-  // below are the default IR protocols
-  #define DECODE_HASH true
-  #ifdef USE_IR_SEND_NEC
-    #define SEND_NEC   true                      // Support IRsend NEC protocol
-    #define DECODE_NEC true                      // Support IRreceive NEC protocol
-  #endif
-  #ifdef USE_IR_SEND_RC5
-    #define SEND_RC5   true                      // Support IRsend Philips RC5 protocol
-    #define DECODE_RC5 true                      // Support IRreceive Philips RC5 protocol
-  #endif
-  #ifdef USE_IR_SEND_RC6
-    #define SEND_RC6   true                      // Support IRsend Philips RC6 protocol
-    #define DECODE_RC6 true                      // Support IRreceive Philips RC6 protocol
-  #endif
-#endif
+  #ifdef USE_IR_REMOTE
+    // below are the default IR protocols
+    #define DECODE_HASH true
+    #ifdef USE_IR_SEND_NEC
+      #define SEND_NEC   true                    // Support IRsend NEC protocol
+      #define DECODE_NEC true                    // Support IRreceive NEC protocol
+    #endif // USE_IR_SEND_NEC
+    #ifdef USE_IR_SEND_RC5
+      #define SEND_RC5   true                    // Support IRsend Philips RC5 protocol
+      #define DECODE_RC5 true                    // Support IRreceive Philips RC5 protocol
+    #endif // USE_IR_SEND_RC5
+    #ifdef USE_IR_SEND_RC6
+      #define SEND_RC6   true                    // Support IRsend Philips RC6 protocol
+      #define DECODE_RC6 true                    // Support IRreceive Philips RC6 protocol
+    #endif // USE_IR_SEND_RC6
+  #endif // USE_IR_REMOTE
+#endif // USE_IR_REMOTE_FULL
 
 /*********************************************************************************************\
  * Mandatory defines satisfying disabled defines


### PR DESCRIPTION
## Description:

currently always some ir protocols are enabled. With the PR it is possible to disable all. No change in behaviour since the used `USE_IR_REMOTE` in the added if check is default set in `my_user_config.h`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241015
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
