### PR TITLE
Optimized behavior to publish shutter data with sensor request

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -195,6 +195,7 @@ struct SHUTTERGLOBAL {
   bool     callibration_run = false;         // if true a callibration is running and additional measures are captured
   uint8_t  stopp_armed = 0;                  // Count each step power usage is below limit of 1 Watt
   uint16_t cycle_time = 0;                   // used for shuttersetup to get accurate timing
+  bool     sensor_data_reported = false;     // ensure that shutter sensor data reported every sedond is only reported if shutter is moving and there is a change.
 } ShutterGlobal;
 
 #define SHT_DIV_ROUND(__A, __B) (((__A) + (__B)/2) / (__B))
@@ -946,7 +947,7 @@ void ShutterRelayChanged(void)
 
 void ShutterReportPosition(bool always, uint32_t index)
 {
-  Response_P(PSTR("{"));
+  
   uint32_t i = 0;
   uint32_t n = TasmotaGlobal.shutters_present;
   uint8_t shutter_running = 0;
@@ -958,7 +959,7 @@ void ShutterReportPosition(bool always, uint32_t index)
 
   // Allow function exit if nothing to report (99.9% use case)
   if (!always && !shutter_running) return;
-
+  Response_P(PSTR("{"));
   if( index != MAX_SHUTTERS_ESP32) {
     i = index;
     n = index+1;
@@ -976,7 +977,7 @@ void ShutterReportPosition(bool always, uint32_t index)
     uint32_t position = ShutterRealToPercentPosition(Shutter[i].real_position, i);
     uint32_t target   = ShutterRealToPercentPosition(Shutter[i].target_position, i);
     ResponseAppend_P(JSON_SHUTTER_POS, i + 1, (ShutterSettings.shutter_options[i] & 1) ? 100 - position : position, Shutter[i].direction,(ShutterSettings.shutter_options[i] & 1) ? 100 - target : target, Shutter[i].tilt_real_pos );
-   }
+  }
   ResponseJsonEnd();
   if (always || shutter_running) {
     MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_PRFX_SHUTTER));  // RulesProcess() now re-entry protected
@@ -1196,6 +1197,7 @@ void ShutterStartInit(uint32_t i, int32_t direction, int32_t target_pos)
     Shutter[i].target_position              = target_pos;
     Shutter[i].start_position               = Shutter[i].real_position;
     TasmotaGlobal.rules_flag.shutter_moving = 1;
+    ShutterGlobal.sensor_data_reported      = false;
     ShutterAllowPreStartProcedure(i);
     Shutter[i].time                         = Shutter[i].last_reported_time = 0;
 
@@ -2330,18 +2332,24 @@ bool Xdrv27(uint32_t function)
         }
         break;
       case FUNC_JSON_APPEND:
-        for (uint8_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
-          ResponseAppend_P(",");
-          uint8_t position = ShutterRealToPercentPosition(Shutter[i].real_position, i);
-          position = (ShutterSettings.shutter_options[i] & 1) ? 100 - position : position;
-          uint8_t target   = ShutterRealToPercentPosition(Shutter[i].target_position, i);
-          target = (ShutterSettings.shutter_options[i] & 1) ? 100 - target : target;
-          ResponseAppend_P(JSON_SHUTTER_POS, i + 1,  position, Shutter[i].direction, target, Shutter[i].tilt_real_pos );
-#ifdef USE_DOMOTICZ
-          if ((0 == TasmotaGlobal.tele_period) && (0 == i)) {
-             DomoticzSensor(DZ_SHUTTER, position);
+        if (!ShutterGlobal.sensor_data_reported) {
+          ShutterGlobal.sensor_data_reported = true;
+          for (uint8_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
+            ResponseAppend_P(",");
+            uint8_t position = ShutterRealToPercentPosition(Shutter[i].real_position, i);
+            position = (ShutterSettings.shutter_options[i] & 1) ? 100 - position : position;
+            uint8_t target   = ShutterRealToPercentPosition(Shutter[i].target_position, i);
+            target = (ShutterSettings.shutter_options[i] & 1) ? 100 - target : target;
+            ResponseAppend_P(JSON_SHUTTER_POS, i + 1,  position, Shutter[i].direction, target, Shutter[i].tilt_real_pos );
+            if (Shutter[i].direction != 0) {
+              ShutterGlobal.sensor_data_reported = false;
+            }
+  #ifdef USE_DOMOTICZ
+            if ((0 == TasmotaGlobal.tele_period) && (0 == i)) {
+              DomoticzSensor(DZ_SHUTTER, position);
+            }
+  #endif  // USE_DOMOTICZ
           }
-#endif  // USE_DOMOTICZ
         }
         break;
       case FUNC_SET_POWER:


### PR DESCRIPTION
## Description:
Before the shutterposition and other data where published every second as sensor data. Building rules on this data was difficult. With the change the data to shutter data is now only published every second, if the shutter is moving

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#22282

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241023
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
