### PR TITLE
MI32 legacy: widget support for Berry/dashboard

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -1,6 +1,6 @@
 /********************************************************************
  * Tasmota lib
- * 
+ *
  * To use: `import MI32`
  *******************************************************************/
 #include "be_constobj.h"
@@ -25,6 +25,9 @@ BE_FUNC_CTYPE_DECLARE(be_MI32_set_hum, "", "ii");
 extern void be_MI32_set_temp(int slot, int temp_val);
 BE_FUNC_CTYPE_DECLARE(be_MI32_set_temp, "", "ii");
 
+extern bbool be_MI32_widget(const char *sbuf, void* function);
+BE_FUNC_CTYPE_DECLARE(be_MI32_widget, "b", "s[c]");
+
 #include "be_fixed_MI32.h"
 
 /* @const_object_info_begin
@@ -35,12 +38,13 @@ module MI32 (scope: global) {
   set_bat,    ctype_func(be_MI32_set_bat)
   set_hum,    ctype_func(be_MI32_set_hum)
   set_temp,   ctype_func(be_MI32_set_temp)
+  widget,     ctype_func(be_MI32_widget)
 }
 @const_object_info_end */
 
 /********************************************************************
  * Tasmota lib
- * 
+ *
  * To use: `import BLE`
  *******************************************************************/
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -28,14 +28,14 @@
 
 /*********************************************************************************************\
  * Native functions mapped to Berry functions
- * 
- * 
+ *
+ *
 \*********************************************************************************************/
 extern "C" {
 
 /********************************************************************
 **  MI32 - sensor specific functions
-********************************************************************/ 
+********************************************************************/
 
   extern uint32_t MI32numberOfDevices();
   extern char * MI32getDeviceName(uint32_t slot);
@@ -44,15 +44,21 @@ extern "C" {
   extern void MI32setTemperatureForSlot(uint32_t slot, float value);
   extern uint8_t * MI32getDeviceMAC(uint32_t slot);
 
+  struct {
+    const char * data = nullptr;
+    size_t size = 0;
+    void* callback = nullptr;
+  } be_MI32Widget;
+
   int be_MI32_devices(void) {
     return MI32numberOfDevices();
   }
 
-  void be_MI32_set_bat(int slot, int bat_val){    
+  void be_MI32_set_bat(int slot, int bat_val){
     MI32setBatteryForSlot(slot,bat_val);
   }
 
-  const char* be_MI32_get_name(int slot){    
+  const char* be_MI32_get_name(int slot){
     return  MI32getDeviceName(slot);
   }
 
@@ -65,12 +71,24 @@ extern "C" {
     return buffer;
   }
 
-  void be_MI32_set_hum(int slot, int hum_val){    
+  void be_MI32_set_hum(int slot, int hum_val){
     MI32setHumidityForSlot(slot,hum_val);
   }
 
-  void be_MI32_set_temp(int slot, int temp_val){    
+  void be_MI32_set_temp(int slot, int temp_val){
     MI32setTemperatureForSlot(slot,temp_val);
+  }
+
+  bool be_MI32_widget(const char* sbuf, void* function){
+    if (function){
+      be_MI32Widget.callback = function;
+    }
+    if(be_MI32Widget.size == 0){
+      be_MI32Widget.data = sbuf;
+      be_MI32Widget.size = strlen(sbuf);
+      return true;
+    }
+    return false;
   }
 
 
@@ -103,12 +121,12 @@ extern "C" {
   }
 
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
-  void be_BLE_reg_conn_cb(void* function, uint8_t *buffer){    
+  void be_BLE_reg_conn_cb(void* function, uint8_t *buffer){
     MI32setBerryConnCB(function,buffer);
   }
 
   void be_BLE_reg_server_cb(void* function, uint8_t *buffer);
-  void be_BLE_reg_server_cb(void* function, uint8_t *buffer){    
+  void be_BLE_reg_server_cb(void* function, uint8_t *buffer){
     MI32setBerryServerCB(function,buffer);
   }
 
@@ -145,7 +163,7 @@ extern "C" {
   }
 
   void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes);
-  void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes){    
+  void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes){
     bool _discoverAttributes = false;
     if(discoverAttributes){
       _discoverAttributes = discoverAttributes ;
@@ -157,7 +175,7 @@ extern "C" {
 
   void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
   void be_BLE_set_characteristic(struct bvm *vm, const char *Chr){
-      
+
     if (MI32setBerryCtxChr(Chr)) return;
 
     be_raisef(vm, "ble_error", "BLE: could not set characteristic");
@@ -166,7 +184,7 @@ extern "C" {
   void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1);
   void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1){
     int32_t argc = be_top(vm); // Get the number of arguments
-    bool _response = false;    
+    bool _response = false;
     if(response){
       _response = response;
     }
@@ -181,7 +199,7 @@ extern "C" {
   }
 
   void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
-  void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){    
+  void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){
     if(!be_BLE_MAC_size(vm, size)){
       return;
     }
@@ -190,12 +208,12 @@ extern "C" {
       _type = type;
     }
     if(MI32addMACtoBlockList(buf, _type)) return;
-  
+
   be_raisef(vm, "ble_error", "BLE: could not block MAC");
   }
 
   void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
-  void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){    
+  void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){
     if(!be_BLE_MAC_size(vm, size)){
       return;
     }
@@ -331,7 +349,7 @@ __commands
 201 add/set advertisement
 202 add/set scan response
 
-211 add/set characteristic 
+211 add/set characteristic
 
 __response
 221 onRead
@@ -358,5 +376,6 @@ MI32.get_MAC(slot)
 MI32.set_bat(slot,int)
 MI32.set_hum(slot,float)
 MI32.set_temp(slot,float)
+MI32.widget(string[,cb])
 
 */


### PR DESCRIPTION
## Description:

Adds some small hooks to the MI32 driver dashboard for easier integration of Berry code typically used with but not limited to Bluetooth.
Adds method `widget()` to the `MI32` module, that takes HTML code as a string and an optional callback function.
The dashboard expects a <div> element with class `box` and needs an `id` tag in order to be able to update it.

```
import MI32
var widget = '<div class="box"  id="mywidget">This could be any HTML<div>'
if MI32.widget(widget) == true
  log("Could send widget")
else
  log("could not send widget because an old widget is still not deployed. We need some logic in the code to send again.")
end
```

The optional callback function will be called by the web handle of the MI32 driver. This allows the usage of Berry's `webserver` module to catch the moment of the page load or handle AJAX calls, thus allowing pretty complex Berry apps for special use cases, that keep the core driver small.

Example:
https://github.com/Staars/berry-examples/blob/main/ble/blescan_widget.be
<img width="1388" alt="widget" src="https://github.com/user-attachments/assets/4ed88223-3d4a-49ed-af0e-bab666c077c0">

(Some code cleanups to remove messy whitespace trash)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241023
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
