### PR TITLE
Alexa Hue with multiple devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Ethernet on -DFRAMEWORK_ARDUINO_ITEAD framework regression from v14.3.0 (#22367)
+- Alexa Hue with multiple devices
 
 ### Removed
 - DALI inverted signal configuration using compile time defines


### PR DESCRIPTION
## Description:

**BREAKING CHANGE** if you have Alexa/Hue emulation with more than 1 device, or with Zigbee. In such case, you need to remove the devices in the Alexa app and discover them again. No change if you have only 1 Alexa device per Tasmota.

There is now a problem with Alexa / Hue emulation when multiple devices are on the same Tasmota. Before, mutiple devices would be distinguished by:
> `"uniqueid": "78:e3:6d:09:1d:a4:00:11-01"`
> `"uniqueid": "78:e3:6d:09:1d:a4:00:11-02"`
> `"uniqueid": "78:e3:6d:09:1d:a4:00:11-03"`

It seems now that the Alexa app gets confused if they differ only by the characters after `-`. We are now changing the encoding as follows:

> `"uniqueid": "78:e3:6d:09:1d:a4:XX:YY-01"`

where XX is the high 8 bits of id (unchanged) and YY is the low 8 bits xor 0x10 (so default `1` becomes `0x11`)

If the endpoint is not zero, XOR the second byte (rare case)

**Related issue (if applicable):** fixes #22227

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241023
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
