### PR TITLE
Update antiburn.be

### DIFF
--- a/tasmota/berry/modules/antiburn/antiburn.be
+++ b/tasmota/berry/modules/antiburn/antiburn.be
@@ -21,7 +21,7 @@ antiburn.init = def (m)
                 lv.start()
 
                 if self.antiburn == nil
-                    var antiburn = lv.obj(lv.layer_top())
+                    var antiburn = lv.obj(lv.layer_sys())
                     antiburn.set_style_radius(0, 0)
                     antiburn.set_style_border_width(0, 0)
                     antiburn.set_style_bg_opa(255, 0)


### PR DESCRIPTION
Currently antiburn doesn't cover other objects if they are on lv.layer_top, moving it to lv.layer_sys fixes this issue.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
