### PR TITLE
`i2c_enabled` refactored as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - ESP32 Platform from 2024.10.30 to 2024.11.30, Framework (Arduino Core) from v3.1.0.241023 to v3.1.0.241030 and IDF to 5.3.1.241024 (#22384)
 - ESP32 LVGL library from v9.2.0 to v9.2.2
+- `i2c_enabled` refactored as array
 
 ### Fixed
 - ESP32 Arduino Core IPv6 zones used by Matter (#22378)

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -312,8 +312,7 @@ struct TasmotaGlobal_t {
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
   bool pwm_present;                         // Any PWM channel configured with SetOption15 0
-  bool i2c_enabled;                         // I2C configured
-  bool i2c_enabled_2;                       // I2C configured, second controller, Wire1
+  bool i2c_enabled[MAX_I2S];                // I2C configured for all possible buses (1 or 2)
 #ifdef ESP32
   bool ota_factory;                         // Select safeboot binary
 #endif

--- a/tasmota/tasmota_support/support_a_i2c.ino
+++ b/tasmota/tasmota_support/support_a_i2c.ino
@@ -79,14 +79,14 @@ bool I2cBegin(int sda, int scl, uint32_t bus, uint32_t frequency) {
 }
 
 TwoWire& I2cGetWire(uint8_t bus = 0) {
-  if ((0 == bus) && TasmotaGlobal.i2c_enabled) {
+  if ((0 == bus) && TasmotaGlobal.i2c_enabled[0]) {
 #ifdef USE_I2C_BUS2_ESP8266
     I2cSetBus(bus);
 #endif
     return Wire;
   }
 #ifdef USE_I2C_BUS2
-  else if ((1 == bus) && TasmotaGlobal.i2c_enabled_2) {
+  else if ((1 == bus) && TasmotaGlobal.i2c_enabled[1]) {
 #ifdef USE_I2C_BUS2_ESP8266
     I2cSetBus(bus);
 #endif

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -2752,12 +2752,12 @@ void CmndBatteryPercent(void) {
 void CmndI2cScan(void) {
   // I2CScan   - Scan bus1 then bus2
   bool jsflag = false;
-  if (TasmotaGlobal.i2c_enabled) {
+  if (TasmotaGlobal.i2c_enabled[0]) {
     I2cScan();
     jsflag = true;
   }
 #ifdef USE_I2C_BUS2
-  if (TasmotaGlobal.i2c_enabled_2) {
+  if (TasmotaGlobal.i2c_enabled[1]) {
     if (jsflag) {
       MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, XdrvMailbox.command);
     }

--- a/tasmota/tasmota_support/support_eeprom.ino
+++ b/tasmota/tasmota_support/support_eeprom.ino
@@ -39,7 +39,7 @@ void eeprom_readBytes(uint32_t addr, uint32_t len, uint8_t *buff) {
 }
 
 uint32_t eeprom_init(uint32_t size) {
-  if (TasmotaGlobal.i2c_enabled) {
+  if (TasmotaGlobal.i2c_enabled[0]) {
     if (I2cActive(EEPROM_ADDRESS) || I2cSetDevice(EEPROM_ADDRESS)) {
       // eeprom is present
       I2cSetActiveFound(EEPROM_ADDRESS, "24C256");

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -2234,17 +2234,17 @@ void GpioInit(void)
 #ifdef USE_I2C
 /*
   if (PinUsed(GPIO_I2C_SCL) && PinUsed(GPIO_I2C_SDA)) {
-    TasmotaGlobal.i2c_enabled = I2cBegin(Pin(GPIO_I2C_SDA), Pin(GPIO_I2C_SCL));
+    TasmotaGlobal.i2c_enabled[0] = I2cBegin(Pin(GPIO_I2C_SDA), Pin(GPIO_I2C_SCL));
 #ifdef ESP32
-    if (TasmotaGlobal.i2c_enabled) {
+    if (TasmotaGlobal.i2c_enabled[0]) {
       AddLog(LOG_LEVEL_INFO, PSTR("I2C: Bus1 using GPIO%02d(SCL) and GPIO%02d(SDA)"), Pin(GPIO_I2C_SCL), Pin(GPIO_I2C_SDA));
     }
 #endif
   }
 #ifdef ESP32
   if (PinUsed(GPIO_I2C_SCL, 1) && PinUsed(GPIO_I2C_SDA, 1)) {
-    TasmotaGlobal.i2c_enabled_2 = I2cBegin(Pin(GPIO_I2C_SDA, 1), Pin(GPIO_I2C_SCL, 1), 1);
-    if (TasmotaGlobal.i2c_enabled_2) {
+    TasmotaGlobal.i2c_enabled[1] = I2cBegin(Pin(GPIO_I2C_SDA, 1), Pin(GPIO_I2C_SCL, 1), 1);
+    if (TasmotaGlobal.i2c_enabled[1]) {
       AddLog(LOG_LEVEL_INFO, PSTR("I2C: Bus2 using GPIO%02d(SCL) and GPIO%02d(SDA)"), Pin(GPIO_I2C_SCL, 1), Pin(GPIO_I2C_SDA, 1));
     }
   }
@@ -2258,11 +2258,11 @@ void GpioInit(void)
     if (PinUsed(GPIO_I2C_SCL, bus) && PinUsed(GPIO_I2C_SDA, bus)) {
       if (I2cBegin(Pin(GPIO_I2C_SDA, bus), Pin(GPIO_I2C_SCL, bus), bus)) {
         if (0 == bus) { 
-          TasmotaGlobal.i2c_enabled = true;
+          TasmotaGlobal.i2c_enabled[0] = true;
         }
 #ifdef USE_I2C_BUS2
         else { 
-          TasmotaGlobal.i2c_enabled_2 = true;
+          TasmotaGlobal.i2c_enabled[1] = true;
         }
         AddLog(LOG_LEVEL_INFO, PSTR("I2C: Bus%d using GPIO%02d(SCL) and GPIO%02d(SDA)"), bus +1, Pin(GPIO_I2C_SCL, bus), Pin(GPIO_I2C_SDA, bus));
 #endif  // USE_I2C_BUS2

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -13213,7 +13213,7 @@ uint32_t script_i2c(uint8_t sel, uint16_t val, uint32_t val1) {
       Wire1.end();
       Wire1.begin(val & 0x7f, val1);
       glob_script_mem.script_i2c_wire = &Wire1;
-      TasmotaGlobal.i2c_enabled_2 = true;
+      TasmotaGlobal.i2c_enabled[1] = true;
       if (val & 128) {
         XsnsCall(FUNC_INIT);
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_127_debug.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_127_debug.ino
@@ -667,7 +667,7 @@ void CmndFlashDump(void)
 void CmndI2cWrite(void)
 {
   // I2cWrite <address>,<data>..
-  if (TasmotaGlobal.i2c_enabled) {
+  if (TasmotaGlobal.i2c_enabled[0]) {
     char* parms = XdrvMailbox.data;
     uint8_t buffer[100];
     uint32_t index = 0;
@@ -696,7 +696,7 @@ void CmndI2cWrite(void)
 void CmndI2cRead(void)
 {
   // I2cRead <address>,<size>
-  if (TasmotaGlobal.i2c_enabled) {
+  if (TasmotaGlobal.i2c_enabled[0]) {
     char* parms = XdrvMailbox.data;
     uint8_t buffer[100];
     uint32_t index = 0;
@@ -729,7 +729,7 @@ void CmndI2cRead(void)
 void CmndI2cStretch(void)
 {
 #ifdef ESP8266
-  if (TasmotaGlobal.i2c_enabled && (XdrvMailbox.payload > 0)) {
+  if (TasmotaGlobal.i2c_enabled[0] && (XdrvMailbox.payload > 0)) {
     Wire.setClockStretchLimit(XdrvMailbox.payload);
   }
   ResponseCmndDone();
@@ -738,7 +738,7 @@ void CmndI2cStretch(void)
 
 void CmndI2cClock(void)
 {
-  if (TasmotaGlobal.i2c_enabled && (XdrvMailbox.payload > 0)) {
+  if (TasmotaGlobal.i2c_enabled[0] && (XdrvMailbox.payload > 0)) {
     Wire.setClock(XdrvMailbox.payload);
   }
   ResponseCmndDone();

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -117,7 +117,7 @@ void ZigbeeInit(void)
 
 #ifdef USE_ZIGBEE_EZSP
     // Check the I2C EEprom
-    if (TasmotaGlobal.i2c_enabled) {
+    if (TasmotaGlobal.i2c_enabled[0]) {
       Wire.beginTransmission(USE_ZIGBEE_ZBBRIDGE_EEPROM);
       uint8_t error = Wire.endTransmission();
       if (0 == error) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_4_i2s_codecs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_4_i2s_codecs.ino
@@ -124,7 +124,7 @@ uint32_t ES8311_init() {
 }
 
 void S3boxInit(void) {
-  if (TasmotaGlobal.i2c_enabled_2) {
+  if (TasmotaGlobal.i2c_enabled[1]) {
     // box lite
     ES8156_init();
     es7243e_init();
@@ -143,7 +143,7 @@ void S3boxInit(void) {
 #include <wm8960.h>
 
 void W8960_Init1(void) {
-  if (TasmotaGlobal.i2c_enabled_2) {
+  if (TasmotaGlobal.i2c_enabled[1]) {
     if (I2cSetDevice(W8960_ADDR, 1)) {
       I2cSetActiveFound(W8960_ADDR, "W8960-I2C", 1);
       W8960_Init(&Wire1);

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -33,10 +33,10 @@ TwoWire & getWire(bvm *vm) {
   be_getmember(vm, 1, "bus");
   int32_t bus = be_toint(vm, -1); // bus is 1 or 2
   be_pop(vm, 1);
-  if (1 == bus && TasmotaGlobal.i2c_enabled) {
+  if (1 == bus && TasmotaGlobal.i2c_enabled[0]) {
     return Wire;
 #ifdef USE_I2C_BUS2
-  } else if (2 == bus && TasmotaGlobal.i2c_enabled_2) {
+  } else if (2 == bus && TasmotaGlobal.i2c_enabled[1]) {
     return Wire1;
 #endif  // USE_I2C_BUS2
   } else {
@@ -50,9 +50,9 @@ bool I2cEnabled(bvm *vm) {
   be_getmember(vm, 1, "bus");
   int32_t bus = be_toint(vm, -1); // bus is 1 or 2
   be_pop(vm, 1);
-  if (1 == bus && TasmotaGlobal.i2c_enabled) {
+  if (1 == bus && TasmotaGlobal.i2c_enabled[0]) {
     return true;
-  } else if (2 == bus && TasmotaGlobal.i2c_enabled_2) {
+  } else if (2 == bus && TasmotaGlobal.i2c_enabled[1]) {
     return true;
   } else {
     return false;

--- a/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
@@ -236,7 +236,7 @@ void CmndHDMIType(void) {
 // The buffer must be allocated to uint8_t[256] by caller
 // Only checksum is checked
 bool ReadEdid256(uint8_t *buf) {
-  if (!TasmotaGlobal.i2c_enabled) { return true; }    // abort if I2C is not started
+  if (!TasmotaGlobal.i2c_enabled[0]) { return true; }    // abort if I2C is not started
 
   if (I2cReadBuffer(HDMI_EDID_ADDRESS,   0, buf      , 128)) { return true; }
   if (I2cReadBuffer(HDMI_EDID_ADDRESS, 128, buf + 128, 128)) { return true; }

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -213,11 +213,11 @@ bool WcPinUsed(void) {
 //    }
   }
 
-  AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: i2c_enabled_2: %d"), TasmotaGlobal.i2c_enabled_2);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: i2c_enabled_2: %d"), TasmotaGlobal.i2c_enabled[1]);
 
   if (!PinUsed(GPIO_WEBCAM_XCLK) || !PinUsed(GPIO_WEBCAM_PCLK) ||
       !PinUsed(GPIO_WEBCAM_VSYNC) || !PinUsed(GPIO_WEBCAM_HREF) ||
-      ((!PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) && !TasmotaGlobal.i2c_enabled_2)    // preferred option is to reuse and share I2Cbus 2
+      ((!PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) && !TasmotaGlobal.i2c_enabled[1])    // preferred option is to reuse and share I2Cbus 2
       ) {
         pin_used = false;
   }
@@ -383,7 +383,7 @@ uint32_t WcSetup(int32_t fsiz) {
     config.pin_href = Pin(GPIO_WEBCAM_HREF);      // HREF_GPIO_NUM;
     config.pin_sccb_sda = Pin(GPIO_WEBCAM_SIOD);  // SIOD_GPIO_NUM; - unset to use shared I2C bus 2
     config.pin_sccb_scl = Pin(GPIO_WEBCAM_SIOC);  // SIOC_GPIO_NUM;
-    if(TasmotaGlobal.i2c_enabled_2){              // configure SIOD and SIOC as SDA,2 and SCL,2
+    if(TasmotaGlobal.i2c_enabled[1]){              // configure SIOD and SIOC as SDA,2 and SCL,2
       config.sccb_i2c_port = 1;                   // reuse initialized bus 2, can be shared now
       if(config.pin_sccb_sda < 0){                // GPIO_WEBCAM_SIOD must not be set to really make it happen
         AddLog(LOG_LEVEL_INFO, PSTR("CAM: Use I2C bus2"));

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -761,12 +761,12 @@ bool WcPinUsed(void) {
   }
 
 #ifdef WEBCAM_DEV_DEBUG  
-  AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: i2c_enabled_2: %d"), TasmotaGlobal.i2c_enabled_2);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: i2c_enabled_2: %d"), TasmotaGlobal.i2c_enabled[1]);
 #endif
 
   if (!PinUsed(GPIO_WEBCAM_XCLK) || !PinUsed(GPIO_WEBCAM_PCLK) ||
       !PinUsed(GPIO_WEBCAM_VSYNC) || !PinUsed(GPIO_WEBCAM_HREF) ||
-      ((!PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) && !TasmotaGlobal.i2c_enabled_2)    // preferred option is to reuse and share I2Cbus 2
+      ((!PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) && !TasmotaGlobal.i2c_enabled[1])    // preferred option is to reuse and share I2Cbus 2
       ) {
         pin_used = false;
   }
@@ -974,7 +974,7 @@ uint32_t WcSetup(int32_t fsiz) {
     config.pin_href = Pin(GPIO_WEBCAM_HREF);      // HREF_GPIO_NUM;
     config.pin_sccb_sda = Pin(GPIO_WEBCAM_SIOD);  // SIOD_GPIO_NUM; - unset to use shared I2C bus 2
     config.pin_sccb_scl = Pin(GPIO_WEBCAM_SIOC);  // SIOC_GPIO_NUM;
-    if(TasmotaGlobal.i2c_enabled_2){              // configure SIOD and SIOC as SDA,2 and SCL,2
+    if(TasmotaGlobal.i2c_enabled[1]){              // configure SIOD and SIOC as SDA,2 and SCL,2
       config.sccb_i2c_port = 1;                   // reuse initialized bus 2, can be shared now
       if(config.pin_sccb_sda < 0){                // GPIO_WEBCAM_SIOD must not be set to really make it happen
 #ifdef WEBCAM_DEV_DEBUG  

--- a/tasmota/tasmota_xdsp_display/xdsp_01_lcd.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_01_lcd.ino
@@ -56,7 +56,7 @@ void LcdInit(uint8_t mode)
 }
 
 void LcdInitDriver(void) {
-  if (!TasmotaGlobal.i2c_enabled) { return; }
+  if (!TasmotaGlobal.i2c_enabled[0]) { return; }
 
   if (!Settings->display_model) {
     if (I2cSetDevice(LCD_ADDRESS1)) {

--- a/tasmota/tasmota_xdsp_display/xdsp_03_matrix.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_03_matrix.ino
@@ -195,7 +195,7 @@ void MatrixInit(uint8_t mode)
 }
 
 void MatrixInitDriver(void) {
-  if (!TasmotaGlobal.i2c_enabled) { return; }
+  if (!TasmotaGlobal.i2c_enabled[0]) { return; }
 
   mtx_buffer = (char*)(malloc(MTX_MAX_SCREEN_BUFFER));
   if (mtx_buffer != nullptr) {

--- a/tasmota/tasmota_xdsp_display/xdsp_11_sevenseg.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_11_sevenseg.ino
@@ -148,7 +148,7 @@ void SevensegInit(uint8_t mode)
 }
 
 void SevensegInitDriver(void) {
-  if (!TasmotaGlobal.i2c_enabled) { return; }
+  if (!TasmotaGlobal.i2c_enabled[0]) { return; }
 
   if (!Settings->display_model) {
     if (I2cSetDevice(Settings->display_address[0])) {

--- a/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
@@ -176,13 +176,13 @@ Renderer *Init_uDisplay(const char *desc) {
       replacepin(&cp, Pin(GPIO_OLED_RESET));
 
       if (wire_n == 0) {
-        if (!TasmotaGlobal.i2c_enabled) {
+        if (!TasmotaGlobal.i2c_enabled[0]) {
           I2cBegin(sda, scl);
         }
       }
 #ifdef ESP32
       if (wire_n == 1) {
-        if (!TasmotaGlobal.i2c_enabled_2) {
+        if (!TasmotaGlobal.i2c_enabled[1]) {
           I2cBegin(sda, scl, 1);
         }
       }
@@ -370,13 +370,13 @@ Renderer *Init_uDisplay(const char *desc) {
       }
 
       if (wire_n == 0) {
-        if (!TasmotaGlobal.i2c_enabled) {
+        if (!TasmotaGlobal.i2c_enabled[0]) {
           I2cBegin(sda, scl);
         }
       }
 #ifdef ESP32
       if (wire_n == 1) {
-        if (!TasmotaGlobal.i2c_enabled_2) {
+        if (!TasmotaGlobal.i2c_enabled[1]) {
           I2cBegin(sda, scl, 1, 400000);
         }
       }

--- a/tasmota/tasmota_xdsp_display/xdsp_20_tm1650.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_20_tm1650.ino
@@ -253,7 +253,7 @@ void TM1650Init(uint8_t mode)
 \*********************************************************************************************/
 void TM1650InitDriver(void)
 {
-  if (!TasmotaGlobal.i2c_enabled) {
+  if (!TasmotaGlobal.i2c_enabled[0]) {
     return;
   }
 

--- a/tasmota/tasmota_xsns_sensor/xsns_09_bmp.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_09_bmp.ino
@@ -559,7 +559,7 @@ void BmpShow(bool json) {
         // BMP280-77
         snprintf_P(name, sizeof(name), PSTR("%s%c%02X"), name, IndexSeparator(), bmp_sensors[bmp_idx].bmp_address);
 #ifdef USE_I2C_BUS2
-        if (TasmotaGlobal.i2c_enabled_2) {           // Second bus enabled
+        if (TasmotaGlobal.i2c_enabled[1]) {           // Second bus enabled
           uint8_t bus = bmp_sensors[0].bmp_bus;
           for (uint32_t i = 1; i < bmp_count; i++) {
             if (bus != bmp_sensors[i].bmp_bus) {     // Different busses

--- a/tasmota/tasmota_xsns_sensor/xsns_103_sen5x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_103_sen5x.ino
@@ -56,7 +56,7 @@ void sen5x_Init(void) {
 #ifdef ESP32
   if (!I2cSetDevice(SEN5X_ADDRESS, 0)) {
     DEBUG_SENSOR_LOG(PSTR("Sensirion SEN5X not found, i2c bus 0"));
-    if (TasmotaGlobal.i2c_enabled_2 ) {
+    if (TasmotaGlobal.i2c_enabled[1] ) {
       if(!I2cSetDevice(SEN5X_ADDRESS, 1)) {
         DEBUG_SENSOR_LOG(PSTR("Sensirion SEN5X not found, i2c bus 1"));
         return;

--- a/tasmota/tasmota_xsns_sensor/xsns_12_ads1115.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_12_ads1115.ino
@@ -200,7 +200,7 @@ void Ads1115Label(char* label, uint32_t maxsize, uint32_t device) {
     // "ADS1115-48":{"A0":3240,"A1":3235,"A2":3269,"A3":3269},"ADS1115-49":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
     snprintf_P(label, maxsize, PSTR("%s%c%02X"), label, IndexSeparator(), Ads1115[device].address);
 #ifdef USE_I2C_BUS2
-    if (TasmotaGlobal.i2c_enabled_2) {           // Second bus enabled
+    if (TasmotaGlobal.i2c_enabled[1]) {           // Second bus enabled
       uint8_t bus = Ads1115[0].bus;
       for (uint32_t i = 1; i < ads1115_count; i++) {
         if (bus != Ads1115[i].bus) {             // Different busses

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -192,7 +192,7 @@ void Sht3xShow(bool json) {
       if (sht3x_count > 1) {
         snprintf_P(types, sizeof(types), PSTR("%s%c%02X"), types, IndexSeparator(), sht3x_sensors[idx].address);  // "SHT3X-0xXX"  
 #ifdef USE_I2C_BUS2
-        if (TasmotaGlobal.i2c_enabled_2) {
+        if (TasmotaGlobal.i2c_enabled[1]) {
           for (uint32_t i = 1; i < sht3x_count; i++) {
             if (sht3x_sensors[0].bus != sht3x_sensors[i].bus) {
               snprintf_P(types, sizeof(types), PSTR("%s%c%d"), types, IndexSeparator(), sht3x_sensors[idx].bus + 1); // "SHT3X-0xXX-X"  

--- a/tasmota/tasmota_xx2c_global/xx2c_interface.ino
+++ b/tasmota/tasmota_xx2c_global/xx2c_interface.ino
@@ -413,9 +413,9 @@ const uint8_t kI2cList[] = {
 /*********************************************************************************************/
 
 bool I2cEnabled(uint32_t i2c_index) {
-  return ((TasmotaGlobal.i2c_enabled
+  return ((TasmotaGlobal.i2c_enabled[0]
 #ifdef USE_I2C_BUS2
-   || TasmotaGlobal.i2c_enabled_2
+   || TasmotaGlobal.i2c_enabled[1]
 #endif
    ) && bitRead(Settings->i2c_drivers[i2c_index / 32], i2c_index % 32));
 }


### PR DESCRIPTION
## Description:

I2C internal refactoring from:
```C
  bool i2c_enabled;                         // I2C configured
  bool i2c_enabled_2;                       // I2C configured, second controller, Wire1
```

to
```C
  bool i2c_enabled[MAX_I2S];                // I2C configured for all possible buses (1 or 2)
```

which makes it easier to iterate through both buses and avoid code duplication.

This affects only `TasmotaGlobal` internal structure.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
