### PR TITLE
I2C over Serial, preliminary stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.3.0.3]
 ### Added
+- I2C over Serial, preliminary stub
 
 ### Breaking Changed
 

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -226,6 +226,7 @@ enum UserSelectablePins {
   GPIO_BL0906_RX,                       // BL0906 Serial interface
   GPIO_DALI_RX_INV, GPIO_DALI_TX_INV,   // DALI
   GPIO_LD2410S_TX, GPIO_LD2410S_RX,     // HLK-LD2410S
+  GPIO_I2C_SER_TX, GPIO_I2C_SER_RX,     // I2C via Serial using SC18IM704 protocol (xdrv74)
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -499,6 +500,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_BL0906_RX "|"
   D_SENSOR_DALI_RX "_i|" D_SENSOR_DALI_TX "_i|"
   D_SENSOR_LD2410S_TX "|" D_SENSOR_LD2410S_RX "|"
+  D_SENSOR_I2C_SER_TX "|" D_SENSOR_I2C_SER_RX "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -602,6 +604,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_PCF8574
   AGPIO(GPIO_PCF8574_INT),              // PCF8574 Interrupt
 #endif  // USE_PCF8574
+#ifdef USE_I2C_SERIAL
+  AGPIO(GPIO_I2C_SER_TX) + MAX_I2C,     // I2C via Serial TX
+  AGPIO(GPIO_I2C_SER_RX) + MAX_I2C,     // I2C via Serial RX
+#endif // USE_I2C_SERIAL
 #endif
 
 #if defined(USE_I2S_AUDIO) || defined (USE_I2S)

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCl"
 #define D_SENSOR_I2C_SDA       "I2C SDa"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MClk"
 #define D_SENSOR_I2S_BCLK      "I2S BClk"
 #define D_SENSOR_I2S_WS_IN     "I2S BClk In"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20                "DS18x20"
 #define D_SENSOR_I2C_SCL                "I2C - SCL"
 #define D_SENSOR_I2C_SDA                "I2C - SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK               "I2S - MCLK"
 #define D_SENSOR_I2S_BCLK               "I2S - BCLK"
 #define D_SENSOR_I2S_WS_IN              "I2S - BCLK IN"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -699,6 +699,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -698,6 +698,8 @@
 #define D_SENSOR_DS18X20       "DS18x20"
 #define D_SENSOR_I2C_SCL       "I2C SCL"
 #define D_SENSOR_I2C_SDA       "I2C SDA"
+#define D_SENSOR_I2C_SER_TX    "I2C Ser TX"
+#define D_SENSOR_I2C_SER_RX    "I2C Ser RX"
 #define D_SENSOR_I2S_MCLK      "I2S MCLK"
 #define D_SENSOR_I2S_BCLK      "I2S BCLK"
 #define D_SENSOR_I2S_WS_IN     "I2S BCLK IN"

--- a/tasmota/tasmota_support/support_a_i2c.ino
+++ b/tasmota/tasmota_support/support_a_i2c.ino
@@ -78,19 +78,29 @@ bool I2cBegin(int sda, int scl, uint32_t bus, uint32_t frequency) {
   return result;
 }
 
+TwoWire * I2CSerialGetWire(TwoWire * orig_wire, uint8_t bus);
+
 TwoWire& I2cGetWire(uint8_t bus = 0) {
   if ((0 == bus) && TasmotaGlobal.i2c_enabled[0]) {
 #ifdef USE_I2C_BUS2_ESP8266
     I2cSetBus(bus);
 #endif
+#ifdef USE_I2C_SERIAL
+    return I2CSerialGetWire(Wire, bus);
+#else
     return Wire;
+#endif // USE_I2C_SERIAL
   }
 #ifdef USE_I2C_BUS2
   else if ((1 == bus) && TasmotaGlobal.i2c_enabled[1]) {
 #ifdef USE_I2C_BUS2_ESP8266
     I2cSetBus(bus);
 #endif
+#ifdef USE_I2C_SERIAL
+    return I2CSerialGetWire(Wire1, bus);
+#else
     return Wire1;
+#endif // USE_I2C_SERIAL
   }
 #endif  // USE_I2C_BUS2
   else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
@@ -25,20 +25,20 @@ class TwoWireSerial;
 
 struct {
   bool active = false;
-  uint8_t bus;
-  uint8_t tx;
-  uint8_t rx;
+  uint8_t bus = 0;
+  uint8_t tx = 0;
+  uint8_t rx = 0;
   TwoWireSerial *WireSerial = nullptr;      // replacement object for TwoWire
-} i2c_serial = {0};
+} i2c_serial;
 
 class TwoWireSerial : public TwoWire {
 protected:
   uint8_t tx;
   uint8_t rx;
-  TasmotaSerial *serial = nullptr;       // serial instance to communicate with SC18IM704
+  TasmotaSerial *serial;                    // serial instance to communicate with SC18IM704
 private:
 public:
-  TwoWireSerial(uint8_t bus_num) : tx(-1), rx(-1), TwoWire(bus_num) {
+  TwoWireSerial(uint8_t bus_num) : tx(-1), rx(-1), serial(nullptr), TwoWire(bus_num) {
     AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: TwoWireSerial(%i)", bus_num);
   };
   // ~TwoWireSerial() {};

--- a/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
@@ -1,0 +1,163 @@
+/*
+  xdrv_76_serial_i2c.ino - UART to I2C using SC18IM704 compatible protocol
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C_SERIAL
+
+#define XDRV_76           76
+
+class TwoWireSerial;
+
+struct {
+  bool active = false;
+  uint8_t bus;
+  uint8_t tx;
+  uint8_t rx;
+  TwoWireSerial *WireSerial = nullptr;      // replacement object for TwoWire
+} i2c_serial = {0};
+
+class TwoWireSerial : public TwoWire {
+protected:
+  uint8_t tx;
+  uint8_t rx;
+  TasmotaSerial *serial = nullptr;       // serial instance to communicate with SC18IM704
+private:
+public:
+  TwoWireSerial(uint8_t bus_num) : tx(-1), rx(-1), TwoWire(bus_num) {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: TwoWireSerial(%i)", bus_num);
+  };
+  // ~TwoWireSerial() {};
+
+  bool setPins(int _tx, int _rx) {
+    if (_tx >= 0 && _rx >= 0) {
+      tx = _tx;
+      rx = _rx;
+      return true;
+    }
+    return false;
+  }
+
+
+  // virtual bool begin() 
+  // virtual bool begin(uint8_t address) override{ Serial.printf(">>>>>>> begin\n"); return true; };
+  // virtual bool end() = 0;
+  bool beginSerial() {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: beginSerial");
+    if (tx >= 0 && rx >= 0) {
+      serial = new TasmotaSerial(tx, rx);
+      if (serial) {
+        serial->begin(115200);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  virtual bool setClock(uint32_t freq) override {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: setClock(%i) -- ignored", freq);
+    return true;
+  }
+
+  virtual void beginTransmission(uint8_t address) override {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: beginTransmission(0x%02X)", address);
+  };
+  virtual uint8_t endTransmission(bool stopBit) override {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: endTransmission(%i)", stopBit);
+    return 2;
+  }
+  virtual uint8_t endTransmission(void) override {
+    AddLog(LOG_LEVEL_DEBUG_MORE, "ISR: endTransmission()");
+    return 2;
+  }
+
+  // not used, but redefine to avoid any accidental call
+  virtual size_t requestFrom(uint8_t address, size_t len, bool stopBit) override { return 0; };
+  virtual size_t requestFrom(uint8_t address, size_t len) override { return 0; };
+};
+
+// return the original Wire object or the I2C Serial object
+TwoWire & I2CSerialGetWire(TwoWire & orig_wire, uint8_t bus) {
+  if (i2c_serial.active && i2c_serial.bus == bus) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR("I2C: Bus%d %p"), bus +1, i2c_serial.WireSerial);
+    return *i2c_serial.WireSerial;
+  } else {
+    return orig_wire;
+  }
+}
+
+// Initialize I2C Serial
+// - check if I2C serial is configured on some GPIOs
+// - configure serial bus
+// - register serial bus with Tasmota
+void I2CSerialInit(void) {
+  i2c_serial.active = false;
+  // check if I2C serial is configured on some GPIOs
+  for (uint32_t bus = 0; bus < MAX_I2C; bus++) {
+    if (PinUsed(GPIO_I2C_SER_TX, bus) && PinUsed(GPIO_I2C_SER_RX, bus)) {
+      if (i2c_serial.active) {
+        // Error: I2C Serial was already configured on bus 0, we don't accept a second one
+        AddLog(LOG_LEVEL_ERROR, "I2C: I2C serial can be configured only on 1 bus");
+        continue;
+      }
+      if (TasmotaGlobal.i2c_enabled[bus]) {
+        // Error: I2C was already configured with SDA/SCL on this bus
+        AddLog(LOG_LEVEL_ERROR, "I2C: I2C serial failed on bus %i because SDA/SCL already configured", bus + 1);
+      } else {
+        // all good
+        i2c_serial.bus = bus;
+        i2c_serial.tx = Pin(GPIO_I2C_SER_TX, bus);
+        i2c_serial.rx = Pin(GPIO_I2C_SER_RX, bus);
+        i2c_serial.active = true;
+      }
+    }
+  }
+  // configure serial bus
+  if (i2c_serial.active) {
+    i2c_serial.WireSerial = new TwoWireSerial(1);   // TODO is it ok to use UART 1 ?
+    i2c_serial.WireSerial->setPins(i2c_serial.tx, i2c_serial.rx);
+    if (i2c_serial.WireSerial->beginSerial()) {
+      TasmotaGlobal.i2c_enabled[i2c_serial.bus] = true;          // enable at Tasmota level
+      AddLog(LOG_LEVEL_INFO, "I2C: I2C serial configured on GPIO TX %i / RX %i for bus %i", i2c_serial.tx, i2c_serial.rx, i2c_serial.bus + 1);
+    } else {
+      delete i2c_serial.WireSerial;
+      i2c_serial.active = false;
+    }
+  }
+  AddLog(LOG_LEVEL_DEBUG_MORE, "I2C: I2C serial active %i, bus %i, tx %i / rx %i, wire %p", i2c_serial.active, i2c_serial.bus + 1, i2c_serial.tx, i2c_serial.rx, i2c_serial.WireSerial);
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv76(uint32_t function) {
+  bool result = false;
+
+  if (FUNC_PRE_INIT == function) {
+    I2CSerialInit();
+  } else if (i2c_serial.active) {
+    switch (function) {
+      case FUNC_ACTIVE:
+        result = true;
+        break;
+    }
+  }
+  return result;
+}
+
+#endif  // USE_I2C_SERIAL


### PR DESCRIPTION
## Description:

This feature is still incomplete, the PR's goal is to reserve GPIO numbers and driver number.

The goal is to have I2C bus over Serial, mainly to be able to use I2C on Seed Studio SenseCap for which the I2C bus in connected to RP2040. 

The serial protocol chosen if NXP SC18IM704. Datasheet: https://www.nxp.com/docs/en/data-sheet/SC18IM704.pdf

This feature requires `#define USE_I2C_SERIAL`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
