### PR TITLE
ESP32S3 UART output mode for Tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- ESP32S3 UART output mode for Tx
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_41_tcp_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_41_tcp_bridge.ino
@@ -149,6 +149,12 @@ void TCPInit(void) {
     if (!Settings->tcp_baudrate) { 
       Settings->tcp_baudrate = 115200 / 300;
     }
+    // patch for ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S3
+    pinMode(Pin(GPIO_TCP_TX), OUTPUT);
+    digitalWrite(Pin(GPIO_TCP_TX), HIGH);
+    sleep(1);
+#endif // CONFIG_IDF_TARGET_ESP32S3
     TCPSerial = new TasmotaSerial(Pin(GPIO_TCP_RX), Pin(GPIO_TCP_TX), TasmotaGlobal.seriallog_level ? 1 : 2, 0, TCP_BRIDGE_BUF_SIZE);   // set a receive buffer of 256 bytes
     tcp_serial = TCPSerial->begin(Settings->tcp_baudrate * 300, ConvertSerialConfig(0x7F & Settings->tcp_config));
     if (PinUsed(GPIO_TCP_TX_EN)) {


### PR DESCRIPTION
## Description:

When configuring UART, the Tx GPIO is not automatically configured as OUTPUT. I'm not sure if the problem is only on ESP32S3, so I'm limiting to this chip for now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
