### PR TITLE
Prepare for virtual I2C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- AHT1X/AHT2X/AHT3X ready for virtual I2C
+- SGP4X ready for virtual I2C
 
 ### Fixed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_109_sgp4x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_109_sgp4x.ino
@@ -81,7 +81,7 @@ void sgp4x_Init(void)
   uint16_t serialNumber[serialNumberSize];
   uint16_t error;
 
-  sgp4x.begin(Wire);
+  sgp4x.begin(I2cGetWire());
   error = sgp4x.getSerialNumber(serialNumber, serialNumberSize);
 
   if (error) {

--- a/tasmota/tasmota_xsns_sensor/xsns_63_aht1x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_63_aht1x.ino
@@ -94,9 +94,10 @@ struct {
 } aht1x_sensors[AHT1X_MAX_SENSORS];
 
 bool AHT1XWrite(uint8_t aht1x_idx) {
-  Wire.beginTransmission(aht1x_sensors[aht1x_idx].address);
-  Wire.write(AHTMeasureCmd, 3);
-  if (Wire.endTransmission() != 0)
+  TwoWire &wire = I2cGetWire();
+  wire.beginTransmission(aht1x_sensors[aht1x_idx].address);
+  wire.write(AHTMeasureCmd, 3);
+  if (wire.endTransmission() != 0)
     return false;
   delay(AHT1X_MEAS_DELAY);
   return true;
@@ -104,10 +105,11 @@ bool AHT1XWrite(uint8_t aht1x_idx) {
 
 bool AHT1XRead(uint8_t aht1x_idx) {
   uint8_t data[6];
-  Wire.requestFrom(aht1x_sensors[aht1x_idx].address, (uint8_t) 6);
+  TwoWire &wire = I2cGetWire();
+  wire.requestFrom(aht1x_sensors[aht1x_idx].address, (uint8_t) 6);
 
-  for(uint8_t i = 0; Wire.available() > 0; i++) {
-     data[i] = Wire.read();
+  for(uint8_t i = 0; wire.available() > 0; i++) {
+     data[i] = wire.read();
   }
   if (data[0] & 0x80)
     return false; //device is busy
@@ -141,23 +143,26 @@ unsigned char AHT1XReadStatus(uint8_t aht1x_address) {
   //Wire.beginTransmission(aht1x_address);
   //Wire.write(0x71);
   //if (Wire.endTransmission() != 0) return false;
-  Wire.requestFrom(aht1x_address, (uint8_t) 1);
-  result = Wire.read();
+  TwoWire &wire = I2cGetWire();
+  wire.requestFrom(aht1x_address, (uint8_t) 1);
+  result = wire.read();
   return result;
 }
 
 void AHT1XReset(uint8_t aht1x_address) {
-  Wire.beginTransmission(aht1x_address);
-  Wire.write(AHTResetCmd);
-  Wire.endTransmission();
+  TwoWire &wire = I2cGetWire();
+  wire.beginTransmission(aht1x_address);
+  wire.write(AHTResetCmd);
+  wire.endTransmission();
   delay(AHT1X_RST_DELAY);
 }
 
 /********************************************************************************************/
 bool AHT1XInit(uint8_t aht1x_address) {
-  Wire.beginTransmission(aht1x_address);
-  Wire.write(AHTSetCalCmd, 3);
-  if (Wire.endTransmission() != 0)
+  TwoWire &wire = I2cGetWire();
+  wire.beginTransmission(aht1x_address);
+  wire.write(AHTSetCalCmd, 3);
+  if (wire.endTransmission() != 0)
     return false;
   delay(AHT1X_CMD_DELAY);
   if(AHT1XReadStatus(aht1x_address) & 0x08) // Sensor calibrated?


### PR DESCRIPTION
## Description:

Prepare some I2C drivers to be compatible with virtual I2C drivers.

Concretely, it means using `I2cGetWire()` to get the reference to `wire` instead of using the global `Wire` object.

No functional change

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
