### PR TITLE
MI32: Prevent active BLE read with unencrypted MI-format beacons

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -792,7 +792,7 @@ int genericSensorReadFn(int slot, int force){
       break;*/
     case MI_LYWSD03MMC:
       // don't read if key present and we've decoded at least one advert
-      if (MIBLEsensors[slot].needkey == KEY_REQUIRED_AND_FOUND && !force) return -2;
+      if ((MIBLEsensors[slot].needkey == KEY_NOT_REQUIRED || MIBLEsensors[slot].needkey == KEY_REQUIRED_AND_FOUND) && !force) return -2;
       res = MI32Operation(slot, OP_READ_HT_LY, LYWSD03_Svc, nullptr, LYWSD03_BattNotifyChar);
       break;
     case MI_LYWSD02MMC:
@@ -800,7 +800,7 @@ int genericSensorReadFn(int slot, int force){
       break;
     case MI_MHOC401:
       // don't read if key present and we've decoded at least one advert
-      if (MIBLEsensors[slot].needkey == KEY_REQUIRED_AND_FOUND && !force) return -2;
+      if ((MIBLEsensors[slot].needkey == KEY_NOT_REQUIRED || MIBLEsensors[slot].needkey == KEY_REQUIRED_AND_FOUND) && !force) return -2;
       res = MI32Operation(slot, OP_READ_HT_LY, MHOC401_Svc, nullptr, MHOC401_BattNotifyChar);
       break;
 


### PR DESCRIPTION
## Description:

I have various LYWSD03 sensors running ATC firmware that are sending unencrypted MI-format beacons. This is causing Tasmota to constantly try and make active read connections to them. These connections are not necessary as the beacons are unencrypted.

Currently, Tasmota skips the active connection for encrypted beacons if the key is known, this PR make it also skip if the beacons are unencrypted.

I can see the same code is present for the MHOC401 sensor and have applied the same fix, although I haven't tested on this device.

Note: I noticed this issue due to regular reboots caused by `BLE disconnect taking > 60s`. These no longer happen running this branch.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
