### PR TITLE
MI32 legacy: add config operations for Berry

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
@@ -444,12 +444,13 @@ int NimBLEDevice::getPower() {
  */
 /* STATIC*/
 NimBLEAddress NimBLEDevice::getAddress() {
-    ble_addr_t addr = {BLE_ADDR_PUBLIC, 0};
+    ble_addr_t addr = {m_own_addr_type, 0};
 
-    if(BLE_HS_ENOADDR == ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, addr.val, NULL)) {
-        NIMBLE_LOGD(LOG_TAG, "Public address not found, checking random");
-        addr.type = BLE_ADDR_RANDOM;
-        ble_hs_id_copy_addr(BLE_ADDR_RANDOM, addr.val, NULL);
+    if(BLE_HS_ENOADDR == ble_hs_id_copy_addr(m_own_addr_type, addr.val, NULL)) {
+        // NIMBLE_LOGD(LOG_TAG, "Public address not found, checking random");
+        // addr.type = BLE_ADDR_RANDOM;
+        // ble_hs_id_copy_addr(BLE_ADDR_RANDOM, addr.val, NULL);
+        return NimBLEAddress(); // return blank to report error
     }
 
     return NimBLEAddress(addr);


### PR DESCRIPTION
## Description:

Add a few BLE operations to configure some options of the BLE stack at runtime when acting as a central device. These are executed immediately.
This can be helpful to emulate other devices like AirTags for educational purposes or explore projects like openhaystack.

Op code | function:
231 - set own address to random:

            var m = bytes(aabbccddeeff).reverse() # directly set value of ble_addr_t, which is reversed
            BLE.set_MAC(m,1) # 1 -> address type random
            BLE.run(231)

232 - set advertising parameters with bytes()-descriptor of length 5 [advType:byte, minInterval:uint16_t, max interval: uint16_t]

       #BLE_GAP_CONN_MODE_NON    (0) - not connectable advertising
       #BLE_GAP_CONN_MODE_DIR    (1) - directed connectable advertising
       #BLE_GAP_CONN_MODE_UND    (2) - undirected connectable advertising

        var minitvl = int(1000 / 0.625) # in 0.625ms units
        var maxitvl = int(2000 / 0.625) # in 0.625ms units
        cbuf.setbytes(0,bytes("050200000000")) # 5 bytes, type 2 
        cbuf.seti(2,minitvl,2)
        cbuf.seti(4,maxitvl,2)
        BLE.run(232)

233 - set GAP name of the device

	var name = "Tasmota BLE“
        cbuf[0] = size(name) + 1
        cbuf.setbytes(1,bytes().fromstring(name))
        BLE.run(233)



A partial backport of esp-nimble-cpp is included, but there are many other breaking changes upstream. Thus we will not update the whole library for now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
