### PR TITLE
Remove logging from safeboot

### DIFF
--- a/tasmota/tasmota_support/support_a_spi.ino
+++ b/tasmota/tasmota_support/support_a_spi.ino
@@ -43,6 +43,7 @@ SPIClass *SpiBegin(uint32 bus) {
 /********************************************************************************************/
 
 void AddLogSpi(uint32_t hardware, int clk, int mosi, int miso) {
+#ifndef FIRMWARE_MINIMAL
   uint32_t enabled = TasmotaGlobal.soft_spi_enabled;
   char hwswbus[8];
   if (hardware) {
@@ -72,4 +73,5 @@ void AddLogSpi(uint32_t hardware, int clk, int mosi, int miso) {
         hwswbus, clk, mosi, miso);
       break;
   }
+#endif // FIRMWARE_MINIMAL
 }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -956,7 +956,9 @@ void CmndStatus(void)
 
   if ((0 == payload) || (5 == payload)) {
 #ifdef USE_IPV6
+#ifndef FIRMWARE_MINIMAL
     if (5 == payload) { WifiDumpAddressesIPv6(); }
+#endif // FIRMWARE_MINIMAL
     Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
                           D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
                           D_JSON_DNSSERVER "1\":\"%s\",\"" D_JSON_DNSSERVER "2\":\"%s\",\""

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -168,10 +168,12 @@ void EthernetEvent(arduino_event_t *event) {
       }
       TasmotaGlobal.rules_flag.eth_connected = 1;
       TasmotaGlobal.global_state.eth_down = 0;
+#ifndef FIRMWARE_MINIMAL
       AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: IPv4 %_I, mask %_I, gateway %_I"),
               event->event_info.got_ip.ip_info.ip.addr,
               event->event_info.got_ip.ip_info.netmask.addr,
               event->event_info.got_ip.ip_info.gw.addr);
+#endif // FIRMWARE_MINIMAL
       WiFiHelper::scrubDNS();    // internal calls to reconnect can zero the DNS servers, save DNS for future use
       break;
 
@@ -181,9 +183,11 @@ void EthernetEvent(arduino_event_t *event) {
       ip_addr_t ip_addr6;
       ip_addr_copy_from_ip6(ip_addr6, event->event_info.got_ip6.ip6_info.ip);
       IPAddress addr(&ip_addr6);
+#ifndef FIRMWARE_MINIMAL
       AddLog(LOG_LEVEL_DEBUG, PSTR("%s: IPv6 %s %s"),
              event->event_id == ARDUINO_EVENT_ETH_GOT_IP6 ? "ETH" : "WIF",
              IPv6isLocal(addr) ? PSTR("Local") : PSTR("Global"), addr.toString().c_str());
+#endif // FIRMWARE_MINIMAL
       if (!IPv6isLocal(addr)) {    // declare network up on IPv6
         TasmotaGlobal.rules_flag.eth_connected = 1;
         TasmotaGlobal.global_state.eth_down = 0;
@@ -235,13 +239,17 @@ void EthernetInit(void) {
   if (eth_uses_spi) {
     // Uses SPI Ethernet and needs at least SPI CS being ETH MDC
     if (!PinUsed(GPIO_ETH_PHY_MDC)) {
+#ifndef FIRMWARE_MINIMAL
       AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ETH "No ETH MDC as SPI CS GPIO defined"));
+#endif // FIRMWARE_MINIMAL
       return;
     }
   } else {
     // Native ESP32
     if (!PinUsed(GPIO_ETH_PHY_MDC) && !PinUsed(GPIO_ETH_PHY_MDIO)) {  // && should be || but keep for backward compatibility
+#ifndef FIRMWARE_MINIMAL
       AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ETH "No ETH MDC and ETH MDIO GPIO defined"));
+#endif // FIRMWARE_MINIMAL
       return;
     }
   }


### PR DESCRIPTION
## Description:

This is the first of a series to reduce safeboot size and enable ethernet support for all variants (problem is on C6).

Removed some logging from safeboot: 1066 bytes saved

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
