### PR TITLE
[Solax X1] Increase receive buffer

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_12_solaxX1.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_12_solaxX1.ino
@@ -329,7 +329,7 @@ void solaxX1_SwitchMeterMode(bool MeterMode) {
 /*********************************************************************************************/
 
 void solaxX1_CyclicTask(void) { // Every 100/250 milliseconds
-  uint8_t DataRead[80] = {0};
+  uint8_t DataRead[256] = {0};
   uint8_t TempData[16] = {0};
   char TempDataChar[32];
   float TempFloat;
@@ -571,7 +571,7 @@ return;
 
 void solaxX1_SnsInit(void) {
   AddLog(LOG_LEVEL_INFO, PSTR("SX1: Init - RX-pin: %d, TX-pin: %d, RTS-pin: %d"), Pin(GPIO_SOLAXX1_RX), Pin(GPIO_SOLAXX1_TX), Pin(GPIO_SOLAXX1_RTS));
-  solaxX1Serial = new TasmotaSerial(Pin(GPIO_SOLAXX1_RX), Pin(GPIO_SOLAXX1_TX), 1);
+  solaxX1Serial = new TasmotaSerial(Pin(GPIO_SOLAXX1_RX), Pin(GPIO_SOLAXX1_TX), 1, 0, 256);
   if (solaxX1Serial->begin(SOLAXX1_SPEED)) {
     if (solaxX1Serial->hardwareSerial()) { ClaimSerial(); }
 #ifdef ESP32


### PR DESCRIPTION
## Description:
Increase receive buffer, because it was too small, especially when using Software Serial. The length of a dataset can reach 256 bytes.
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).