### PR TITLE
Prevent crashing when `display.ini` is missing end `#`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Matter provisioning with matter.js controller (#22470)
+- Prevent crashing when `display.ini` is missing end `#`
 
 ### Removed
 

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -680,14 +680,15 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
     if (*lp == '\n' || *lp == ' ') {   // Add space char
       lp++;
     } else {
-      lp = strchr(lp, '\n');
-      if (!lp) {
-        lp = strchr(lp, ' ');
-        if (!lp) {
+      char *lp1;
+      lp1 = strchr(lp, '\n');
+      if (!lp1) {
+        lp1 = strchr(lp, ' ');
+        if (!lp1) {
           break;
         }
       }
-      lp++;
+      lp = lp1 + 1;
     }
   }
 


### PR DESCRIPTION
## Description:

@gemu2015 This fix avoids a crash when `display.ini` is lacking the final `#`

Here, when `strchr` returns `NULL`, we can't call again `strchr` with `NULL` pointer:
```C
lp = strchr(lp, '\n');
      if (!lp) {
        lp = strchr(lp, ' ');
```

Can you please check my fix?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
