### PR TITLE
Better check for existing Ethernet support in Arduino libs

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -189,10 +189,12 @@
 #undef USE_ESP32_WDT                                  // disable watchdog on SAFEBOOT until more testing is done
 
 #if CONFIG_FREERTOS_UNICORE || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_ETH_ENABLED                               // Check for Ethernet support in Arduino libs
 //  #undef USE_MQTT_TLS
 //  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+4.5k code)
   #define USE_SPI                                    // Make SPI Ethernet adapters useable (+124 bytes)
   #define USE_ETHERNET
+#endif  // CONFIG_ETH_ENABLED
 #endif  // CONFIG_FREERTOS_UNICORE || CONFIG_IDF_TARGET_ESP32S3
 
 #endif  // FIRMWARE_SAFEBOOT
@@ -830,15 +832,15 @@
 #endif // USE_MATTER_DEVICE
 
 /*********************************************************************************************\
- * Post-process compile options for esp32-c2
+ * Post-process for switched off Ethernet support in Arduino static libs
 \*********************************************************************************************/
 
-#ifdef CONFIG_IDF_TARGET_ESP32C2
+#ifndef CONFIG_ETH_ENABLED
   #undef USE_ETHERNET
   #ifdef FIRMWARE_MINIMAL
     #undef USE_SPI
   #endif  // FIRMWARE_MINIMAL
-#endif  // CONFIG_IDF_TARGET_ESP32C2
+#endif  // CONFIG_ETH_ENABLED
 
 #endif  // ESP32
 #endif  // _TASMOTA_CONFIGURATIONS_ESP32_H_

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -18,7 +18,8 @@
 */
 
 #ifdef ESP32
-#ifndef CONFIG_IDF_TARGET_ESP32C2
+#include "sdkconfig.h"
+#ifdef CONFIG_ETH_ENABLED
 #ifdef USE_ETHERNET
 /*********************************************************************************************\
  * Ethernet support for ESP32


### PR DESCRIPTION
## Description:

with Hybrid compile it is the possible to enable / disable Ethernet for every MCU
The PR makes sure Ethernet will not possible to enable when not supported from Arduino libs

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
