### PR TITLE
prep Hybrid: add Hybrid compile examples

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -106,34 +106,34 @@ custom_sdkconfig            = '# CONFIG_COMPILER_OPTIMIZATION_SIZE is not set'
 
 [env:tasmota32c2-no-NAPT]
 ; Hybrid compile: No IDF BT support, disabled PPP, Ethernet and NAPT
-extends                 = env:tasmota32_base
-board                   = esp32c2
-build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_TASMOTA32
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
-                          Micro-RTSP
-custom_sdkconfig        = 
-                          '# CONFIG_BT_ENABLED is not set'
-                          '# CONFIG_BT_NIMBLE_ENABLED is not set'
-                          '# CONFIG_BT_CONTROLLER_ENABLED is not set'
-                          CONFIG_BT_CONTROLLER_DISABLED=y
-                          '# CONFIG_LWIP_IP_FORWARD is not set'
-                          '# CONFIG_LWIP_IPV4_NAPT is not set'
-                          '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
-                          '# CONFIG_ETH_ENABLED is not set'
-                          '# CONFIG_ETH_USE_SPI_ETHERNET is not set'
-                          '# CONFIG_ETH_TRANSMIT_MUTEX is not set'
-                          '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
-                          '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
-                          '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
-                          '# CONFIG_LWIP_PPP_SUPPORT is not set'
+extends                     = env:tasmota32_base
+board                       = esp32c2
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_TASMOTA32
+                              -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
+lib_ignore                  = ${env:tasmota32_base.lib_ignore}
+                               Micro-RTSP
+custom_sdkconfig            = 
+                              '# CONFIG_BT_ENABLED is not set'
+                              '# CONFIG_BT_NIMBLE_ENABLED is not set'
+                              '# CONFIG_BT_CONTROLLER_ENABLED is not set'
+                              CONFIG_BT_CONTROLLER_DISABLED=y
+                              '# CONFIG_LWIP_IP_FORWARD is not set'
+                              '# CONFIG_LWIP_IPV4_NAPT is not set'
+                              '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
+                              '# CONFIG_ETH_ENABLED is not set'
+                              '# CONFIG_ETH_USE_SPI_ETHERNET is not set'
+                              '# CONFIG_ETH_TRANSMIT_MUTEX is not set'
+                              '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
+                              '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
+                              '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
+                              '# CONFIG_LWIP_PPP_SUPPORT is not set'
 ; disable not needed IDF managed components for Arduino libs compile
-custom_component_remove = espressif/esp_hosted
-                          espressif/esp_wifi_remote
-                          espressif/esp_modem
+custom_component_remove     = espressif/esp_hosted
+                              espressif/esp_wifi_remote
+                              espressif/esp_modem
 ; add IDF component from espressif registry for Arduino libs compile
-custom_component_add    = espressif/esp-dsp @ ^1.5.2
+custom_component_add        = espressif/esp-dsp @ ^1.5.2
 
 [env:tasmota32s3-opi_opi]
 extends                     = env:tasmota32_base

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -67,6 +67,16 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DUSE_LVGL_OPENHASP
                               -DOTA_URL='""'
 
+[env:tasmota32-WPA3_SAE]
+; Arduino libs with WiFi Enterprise support
+extends                     = env:tasmota32_base
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_TASMOTA32
+                              -DOTA_URL='""'
+lib_ignore                  = Micro-RTSP
+custom_sdkconfig            = CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=y
+                              CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA=y
+
 [env:tasmota32s3-qio_opi_per]
 ; device needs >= 8MB Flash!! Hybrid compile for max. performance when using Displays
 extends                     = env:tasmota32_base

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -75,6 +75,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DOTA_URL='""'
 lib_ignore                  = Micro-RTSP
 custom_sdkconfig            = CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=y
+                              CONFIG_WIFI_AUTH_WPA2_ENTERPRISE=y
+                              CONFIG_WIFI_AUTH_WPA3_ENTERPRISE=y
+                              CONFIG_WIFI_AUTH_WPA2_WPA3_ENTERPRISE=y
                               CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=y
                               CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA=y
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -74,7 +74,8 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_TASMOTA32
                               -DOTA_URL='""'
 lib_ignore                  = Micro-RTSP
-custom_sdkconfig            = CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=y
+custom_sdkconfig            = CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=y
+                              CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=y
                               CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA=y
 
 [env:tasmota32s3-qio_opi_per]

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -67,6 +67,74 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DUSE_LVGL_OPENHASP
                               -DOTA_URL='""'
 
+[env:tasmota32s3-qio_opi_per]
+; device needs >= 8MB Flash!! Hybrid compile for max. performance when using Displays
+extends                     = env:tasmota32_base
+board                       = esp32s3-qio_opi_120
+board_build.partitions      = partitions/esp32_partition_app3904k_fs3392k.csv
+board_upload.flash_size     = 8MB
+board_upload.maximum_size   = 8388608
+build_unflags               = ${env:tasmota32_base.build_unflags}
+                              -Os
+                              -ffunction-sections
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -Ofast
+                              -mtext-section-literals
+                              -DUSE_BERRY_ULP
+                              -DFIRMWARE_LVGL
+                              -DUSE_LVGL_OPENHASP
+                              -DOTA_URL='""'
+custom_sdkconfig            = '# CONFIG_COMPILER_OPTIMIZATION_SIZE is not set'
+                              CONFIG_COMPILER_OPTIMIZATION_PERF=y
+                              '# CONFIG_ESP_DEBUG_INCLUDE_OCD_STUB_BINS is not set'
+                              '# CONFIG_LWIP_PPP_SUPPORT is not set'
+                              '# SPI_FLASH_ENABLE_ENCRYPTED_READ_WRITE is not set'
+                              CONFIG_SPIRAM_MODE_OCT=y
+                              CONFIG_SPIRAM_SPEED_120M=y
+                              CONFIG_SPIRAM_IGNORE_NOTFOUND=y
+                              '# CONFIG_SPIRAM_MEMTEST is not set'
+                              CONFIG_LCD_RGB_ISR_IRAM_SAFE=y
+                              CONFIG_GDMA_CTRL_FUNC_IN_IRAM=y
+                              CONFIG_I2S_ISR_IRAM_SAFE=y
+                              CONFIG_GDMA_ISR_IRAM_SAFE=y
+                              CONFIG_SPIRAM_XIP_FROM_PSRAM=y
+                              CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y
+                              CONFIG_SPIRAM_RODATA=y
+                              CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+                              CONFIG_ESP32S3_DATA_CACHE_64KB=y
+                              CONFIG_ESP32S3_DATA_CACHE_LINE_64B=y
+
+[env:tasmota32c2-no-NAPT]
+; Hybrid compile: No IDF BT support, disabled PPP, Ethernet and NAPT
+extends                 = env:tasmota32_base
+board                   = esp32c2
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
+                          Micro-RTSP
+custom_sdkconfig        = 
+                          '# CONFIG_BT_ENABLED is not set'
+                          '# CONFIG_BT_NIMBLE_ENABLED is not set'
+                          '# CONFIG_BT_CONTROLLER_ENABLED is not set'
+                          CONFIG_BT_CONTROLLER_DISABLED=y
+                          '# CONFIG_LWIP_IP_FORWARD is not set'
+                          '# CONFIG_LWIP_IPV4_NAPT is not set'
+                          '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
+                          '# CONFIG_ETH_ENABLED is not set'
+                          '# CONFIG_ETH_USE_SPI_ETHERNET is not set'
+                          '# CONFIG_ETH_TRANSMIT_MUTEX is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
+                          '# CONFIG_LWIP_PPP_SUPPORT is not set'
+; disable not needed IDF managed components for Arduino libs compile
+custom_component_remove = espressif/esp_hosted
+                          espressif/esp_wifi_remote
+                          espressif/esp_modem
+; add IDF component from espressif registry for Arduino libs compile
+custom_component_add    = espressif/esp-dsp @ ^1.5.2
+
 [env:tasmota32s3-opi_opi]
 extends                     = env:tasmota32_base
 board                       = esp32s3-opi_opi


### PR DESCRIPTION
## Description:

add Hybrid compile example env.
The examples are already fully working with latest Tasmota32 Platform release.
There is not yet support for WPA Enterprise in Tasmota code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
