### PR TITLE
use sdkconfig define `CONFIG_ETH_ENABLED` to check Ethernet availability

### DIFF
--- a/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
+++ b/lib/libesp32/ESP-Mail-Client/src/extras/Networks_Provider.h
@@ -75,7 +75,7 @@
 
 #if !defined(ESP_MAIL_DISABLE_NATIVE_ETHERNET)
 
-#if defined(ESP32) && __has_include(<esp_eth_driver.h>)
+#if defined(ESP32) && defined(CONFIG_ETH_ENABLED)
 #include <ETH.h>
 #define ESP_MAIL_ETH_IS_AVAILABLE
 #elif defined(ESP8266) && defined(ESP8266_CORE_SDK_V3_X_X)


### PR DESCRIPTION
## Description:

follow up of #22473 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
