### PR TITLE
fix compile when no `core_version.h` exists

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -20,7 +20,9 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <core_version.h>
+#ifndef ESP32_STAGE                         // ESP32 Stage has no core_version.h file. Disable include via PlatformIO Option
+#include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_7_1)
+#endif  // ESP32_STAGE
 
 #ifndef wificlientlightbearssl_h
 #define wificlientlightbearssl_h


### PR DESCRIPTION
## Description:

happens when Tasmota is build with original espressif32 core with pioarduino via Hybrid compile

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
