### PR TITLE
Platform 2024.11.31 Tasmota Arduino Core 3.1.0.241117 based on IDF 5.3.1.241024

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241030
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/lib/default/WiFiHelper/src/WiFiHelper.h
+++ b/lib/default/WiFiHelper/src/WiFiHelper.h
@@ -59,11 +59,7 @@ typedef enum WiFiPhyMode
 class WiFiHelper {
 public:
 #ifdef ESP32
-#if __has_include("esp_eap_client.h") && __has_include("chip-debug-report.h")  // check for Tasmota framework
   static wl_status_t begin(const char* wpa2_ssid, wpa2_auth_method_t method, const char* wpa2_identity=NULL, const char* wpa2_username=NULL, const char *wpa2_password=NULL, const char* ca_pem=NULL, const char* client_crt=NULL, const char* client_key=NULL, int ttls_phase2_type=-1, int32_t channel=0, const uint8_t* bssid=0, bool connect=true);
-#else
-  static wl_status_t begin(const char* wpa2_ssid, wpa2_auth_method_t method, const char* wpa2_identity=NULL, const char* wpa2_username=NULL, const char *wpa2_password=NULL, const char* ca_pem=NULL, const char* client_crt=NULL, const char* client_key=NULL, int32_t channel=0, const uint8_t* bssid=0, bool connect=true);
-#endif
 #endif
   static wl_status_t begin(const char* ssid, const char *passphrase = NULL, int32_t channel = 0, const uint8_t* bssid = NULL, bool connect = true);
   static wl_status_t begin(char* ssid, char *passphrase = NULL, int32_t channel = 0, const uint8_t* bssid = NULL, bool connect = true);

--- a/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
+++ b/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
@@ -34,21 +34,12 @@ ip_addr_t dns_save6[DNS_MAX_SERVERS] = {};      // IPv6 DNS servers
 #include "tasmota_options.h"
 #include "lwip/dns.h"
 
-#if __has_include("esp_eap_client.h") && __has_include("chip-debug-report.h")  // check for Tasmota framework
 wl_status_t WiFiHelper::begin(const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity, const char *wpa2_username, const char *wpa2_password, const char *ca_pem, const char *client_crt, const char *client_key, int ttls_phase2_type, int32_t channel, const uint8_t *bssid, bool connect) {
   WiFiHelper::scrubDNS();
   wl_status_t ret = WiFi.begin(wpa2_ssid, method, wpa2_identity, wpa2_username, wpa2_password, ca_pem, client_crt, client_key, ttls_phase2_type, channel, bssid, connect);
   WiFiHelper::scrubDNS();
   return ret;
 }
-#else
-wl_status_t WiFiHelper::begin(const char* wpa2_ssid, wpa2_auth_method_t method, const char* wpa2_identity, const char* wpa2_username, const char *wpa2_password, const char* ca_pem, const char* client_crt, const char* client_key, int32_t channel, const uint8_t* bssid, bool connect) {
-  WiFiHelper::scrubDNS();
-  wl_status_t ret = WiFi.begin(wpa2_ssid, method, wpa2_identity, wpa2_username, wpa2_password, ca_pem, client_crt, client_key, channel, bssid, connect);
-  WiFiHelper::scrubDNS();
-  return ret;
-}
-#endif
 
 wl_status_t WiFiHelper::begin(const char* ssid, const char *passphrase, int32_t channel, const uint8_t* bssid, bool connect) {
   WiFiHelper::scrubDNS();

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.11.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.11.31/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- Update to latest Arduino core 3.1.0 from 2024.11.17
Breaking change option ` ttls_phase2_type` added in Arduino `WiFiSTA`. Code is now align with Arduino upstream.
- IDF no changes
- Hybrid compile reworked, bugs removed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
