### PR TITLE
MI32 legacy: fix compilation with Bluetooth 5

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -754,6 +754,7 @@ extern "C" {
         success = true;
         break;
       case 232: // set adv params via bytes() descriptor of size 5,
+        #ifndef CONFIG_BT_NIMBLE_EXT_ADV
         if(MI32.conCtx->buffer[0] == 5){
           uint16_t itvl_min = MI32.conCtx->buffer[2] + (MI32.conCtx->buffer[3] << 8);
           uint16_t itvl_max = MI32.conCtx->buffer[4] + (MI32.conCtx->buffer[5] << 8);
@@ -763,6 +764,7 @@ extern "C" {
           AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: adv params: type: %u, min: %u, max: %u"),MI32.conCtx->buffer[1], (uint16_t)(itvl_min * 0.625), (uint16_t)(itvl_max * 0.625)) ;
           success = true;
         }
+        #endif //CONFIG_BT_NIMBLE_EXT_ADV
         break;
       case 233:
         int ret = ble_svc_gap_device_name_set((const char*)MI32.conCtx->buffer + 1);
@@ -1995,7 +1997,7 @@ void MI32parseBTHomePacket(char * _buf, uint32_t length, uint8_t addr[6], int RS
        idx += 3;
        break;
       case 0x0b:
-        // power ??
+        // power in W
         idx += 4;
         break;
       case 0x0c:
@@ -2003,11 +2005,15 @@ void MI32parseBTHomePacket(char * _buf, uint32_t length, uint8_t addr[6], int RS
         idx += 3;
         break;
       case 0x10:
-        // binary power on/off??
+        // power on/off
+        idx += 2;
+        break;
+      case 0x11:
+        // opening closed=0/open=1
         idx += 2;
         break;
       default:
-        AddLog(LOG_LEVEL_INFO,PSTR("M32: unknown BTHome data type: %u, discard rest of data buffer!"),_buf[idx]);
+        AddLog(LOG_LEVEL_INFO,PSTR("M32: unknown BTHome data type: %x, discard rest of data buffer!"),_buf[idx]);
         AddLogBuffer(LOG_LEVEL_DEBUG,(uint8_t*)_buf,length);
         idx = length; // "break"
         break;


### PR DESCRIPTION
## Description:

Fix compilation when building with Bluetooth 5 turned on.

The overall performance of BLE 5 on the ESP32 (ESP32-C3 in my last tests) is very underwhelming in my tests and did not improve in the last few months in the context of scanning. The only sensors with software support for BLE 5 that I know are the ones supported by the custom firmware from PVVX. I can clearly see, that I receive data on the Coded PHY (the longe range packets), but this does not gain a single meter in comparison to the same Xiaomi sensor without enabled long range. Both sensors (placed side by side) become invisible in the same distance.
I do not expect further improvements here and for me BLE 5 in the ESP32 family is only a pseudo feature, but I would be more than happy to be proven wrong.

Small addition to the packet parser to suppress unnecessary log messages.
 
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
