### PR TITLE
Issue#22535 applying masking window to any power change

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
@@ -105,6 +105,11 @@ void MagicSwitchLoop()
   }
 }
 
+void MagicSwitchSetPower(void) {
+  // In case of any power state change, whatever is the source, the masking windows is restarted
+  MagicSwitch->switch_state = MAGICSWITCH_MASKING_WINDOW_LEN;
+}
+
 /********************************************************************************************************
  * Driver initialisation
  */
@@ -172,6 +177,9 @@ bool Xdrv71(uint32_t function) {
       case FUNC_EVERY_50_MSECOND:
       //case FUNC_EVERY_250_MSECOND:
         MagicSwitchLoop();
+        break;
+      case FUNC_SET_POWER:
+        MagixSwitchSetPower();
         break;
       case FUNC_ADD_SWITCH:
         result = MagicSwitchAddSwitch();

--- a/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
@@ -106,8 +106,8 @@ void MagicSwitchLoop()
 }
 
 void MagicSwitchSetPower(void) {
-  // In case of any power state change, whatever is the source, the masking windows is restarted because
-  // it can happen that load switching can create mains disturbances that is understood as a MagicSwitch pulse
+  // It can happen that on relay switch, disturbances on the mains is falsy see as a MagicSwitch pulse
+  // This restart the masking windows on every power change to avoid that effect
   MagicSwitch->switch_state = MAGICSWITCH_MASKING_WINDOW_LEN;
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_71_magic_switch.ino
@@ -106,7 +106,8 @@ void MagicSwitchLoop()
 }
 
 void MagicSwitchSetPower(void) {
-  // In case of any power state change, whatever is the source, the masking windows is restarted
+  // In case of any power state change, whatever is the source, the masking windows is restarted because
+  // it can happen that load switching can create mains disturbances that is understood as a MagicSwitch pulse
   MagicSwitch->switch_state = MAGICSWITCH_MASKING_WINDOW_LEN;
 }
 
@@ -179,7 +180,7 @@ bool Xdrv71(uint32_t function) {
         MagicSwitchLoop();
         break;
       case FUNC_SET_POWER:
-        MagixSwitchSetPower();
+        MagicSwitchSetPower();
         break;
       case FUNC_ADD_SWITCH:
         result = MagicSwitchAddSwitch();


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #22535 

Apply a masking window to the MagicSwitch input in case of a power state change whatever is the source.
Should avoid load switch to create disturbances that is falsy understood as a MagicSwitch pulse

tested by OP #crhass

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [-] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
