### PR TITLE
Added new BLEScan mode: BLEScan2 nn - start a manual scan for nn seco…

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -84,7 +84,8 @@
         performs a manual scan or set passive/active
         *BLEScan0 0 - set passive scan
         BLEScan0 1 - set active scan (you may get names)
-        BLEScan1 nn - start a manula scan for nn seconds
+        BLEScan1 nn - start a manual scan for nn seconds
+        BLEScan2 nn - start a manual scan for nn seconds and publish on tele when at least one device is found
       BLEAlias
         <mac>=<name> <mac>=<name> - set one or more aliases for addresses
       BLEName
@@ -603,6 +604,7 @@ uint8_t BLEMode = BLEModeRegularScan;
 uint8_t BLETriggerScan = 0;
 uint8_t BLEAdvertMode = BLE_ADV_TELE;
 uint8_t BLEdeviceLimitReached = 0;
+uint8_t BLEpostWhenFound = 0;
 
 uint8_t BLEStop = 0;
 uint64_t BLEStopAt = 0;
@@ -2347,6 +2349,12 @@ static void BLEEverySecond(bool restart){
     BLE_ESP32::BLEPostMQTT(false); // show all operations, not just completed
   }
 
+  if ((BLEpostWhenFound == 1) && (seenDevices.size() > 0))
+  {
+    BLEPublishDevices = 2; // mqtt publish as 'STAT'
+    BLEpostWhenFound = 0;
+  }
+
   if (BLEPublishDevices){
     BLEPostMQTTSeenDevices(BLEPublishDevices);
     BLEShowStats();
@@ -2725,6 +2733,8 @@ void CmndBLEScan(void){
       }
     } break;
 
+    case 2: // post on tele when at leat one device is found
+      BLEpostWhenFound = 1;
     case 1: // do a manual scan now
       switch (BLEMode){
         case BLEModeScanByCommand: {


### PR DESCRIPTION

## Description:

Implemented a new BLEScan mode:
**BLEScan2 nn** - Initiates a manual scan for nn seconds and publishes results on tele when at least one device is detected.
This feature is useful for receiving immediate notifications from the Tasmota device when a device is found, without waiting for periodic telemetry messages.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
