### PR TITLE
Replace NeoPixelBus with TasmotaLED on ESP32x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Hybrid compile take custom boards settings in account (#22542)
 
 ### Breaking Changed
+- ArtNet on ESP32 switches from GRB to RGB encoding
 
 ### Changed
 - ESP32 max number of supported switches/buttons/relays from 28 to 32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 max number of interlocks from 14 to 16
 - ESP32 Platform from 2024.11.30 to 2024.11.31, Framework (Arduino Core) from v3.1.0.241030 to v3.1.0.241117 and IDF to 5.3.1.241024 (#22504)
 - Prevent active BLE operations with unencrypted MI-format beacons (#22453)
+- Replace NeoPixelBus with TasmotaLED on ESP32x
 
 ### Fixed
 - ESP32 upgrade by file upload response based on file size (#22500)

--- a/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
+++ b/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod_idf5.h
@@ -69,7 +69,7 @@ typedef struct {
     rmt_symbol_word_t reset_code;
 } rmt_led_strip_encoder_t;
 
-static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+static IRAM_ATTR size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
 {
     rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
     rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;

--- a/lib/lib_basic/TasmotaLED/library.json
+++ b/lib/lib_basic/TasmotaLED/library.json
@@ -1,0 +1,17 @@
+{
+    "name": "TasmotaLED",
+    "version": "0.1",
+    "keywords": [
+      "ws2816", "sk6812", "leds"
+    ],
+    "description": "Lightweight implementation for adressable leds.",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/arendst/Tasmota/lib/lib_basic/TasmotaLED"
+    },
+    "frameworks": "arduino",
+    "platforms": [
+      "espressif32"
+    ]
+}

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLED.cpp
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLED.cpp
@@ -1,0 +1,237 @@
+/*
+  TasmotaLED.cpp - Lightweight implementation for adressable leds.
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#ifdef ESP32
+
+#include "TasmotaLEDPusher.h"
+#include "TasmotaLED.h"
+
+// DRAM_ATTR to force in IRAM because we use this in show loop
+static const DRAM_ATTR uint8_t TASMOTALED_CHANNEL_ORDERS[6][3] = {
+    {1, 0, 2},  // GRB (0)
+    {2, 0, 1},  // GBR (1)
+    {0, 1, 2},  // RGB (2)
+    {0, 2, 1},  // RBG (3)
+    {2, 1, 0},  // BRG (4)
+    {1, 2, 0}   // BGR (5)
+};
+
+static const TasmotaLED_Timing TasmotaLED_Timings[] = {
+  // WS2812
+  // RmtBit0 0x00228010 RmtBit1 0x00128020 RmtReset 0x800207D0
+  {
+    .T0H = 400,
+    .T0L = 850,
+    .T1H = 800,
+    .T1L = 450,
+    .Reset = 80000      // it is 50000 for WS2812, but for compatibility with SK6812, we raise to 80000
+  },
+  // SK6812
+  // RmtBit0 0x0024800C RmtBit1 0x00188018 RmtReset 0x80020C80
+  {
+    .T0H = 300,
+    .T0L = 900,
+    .T1H = 600,
+    .T1L = 600,
+    .Reset = 80000
+  },
+};
+
+// enable AddLog
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+
+
+TasmotaLED::TasmotaLED(uint16_t type, uint16_t num_leds) :
+  _type(type),
+  _pixel_order((type >> 4) & 0x07),
+  _w_before(type & 0x08),
+  _timing((type >> 8) & 0xFF),
+  _started(false),
+  _dirty(true),
+  _raw_format(false),
+  _pixel_count(num_leds),
+  _buf_work(nullptr),
+  _buf_show(nullptr),
+  _pixel_matrix(&TASMOTALED_CHANNEL_ORDERS[0]),
+  _pusher(nullptr)
+{
+  if (_timing > (TasmotaLed_TimingEnd >> 8)) {
+    _timing = 0;
+  }
+  switch (_type & 0x0F) {
+    // case TasmotaLed_1_W:
+    //   _pixel_size = 1;
+    //   break;
+    case TasmotaLed_4_WRGB:
+      _pixel_size = 4;
+      break;
+    case TasmotaLed_3_RGB:
+    default:  // fallback
+      _pixel_size = 3;
+      break;
+  }
+
+  _pixel_matrix = &TASMOTALED_CHANNEL_ORDERS[_pixel_order];
+
+  _buf_work = new uint8_t[_pixel_count * _pixel_size];
+  memset(_buf_work, 0, _pixel_count * _pixel_size);
+  _buf_show = new uint8_t[_pixel_count * _pixel_size];
+  memset(_buf_show, 0, _pixel_count * _pixel_size);
+  // AddLog(LOG_LEVEL_DEBUG, "LED: type=0x%04X pixel_order=0x%02X _timing=%i ", _type, _pixel_order, _timing);
+}
+
+TasmotaLED::~TasmotaLED() {
+  if (_pusher) {
+    delete _pusher;
+    _pusher = nullptr;
+  }
+  delete _buf_work;
+  _buf_work = nullptr;
+  delete _buf_show;
+  _buf_show = nullptr;
+}
+
+// Color is passed as 0xWWRRGGBB and copied as WWRRGGBB in _buf_work
+void TasmotaLED::ClearTo(uint32_t wrgb, int32_t first, int32_t last) {
+  // adjust first and last to be in range of 0 to _pixel_count-1
+  if (first <0) { first += _pixel_count; }
+  if (last <0) { last += _pixel_count; }
+  if (first < 0) { first = 0; }
+  if (last >= _pixel_count) { last = _pixel_count - 1; }
+  if (first > last) { return; }
+  // adjust to pixel format
+  uint8_t b0 = (wrgb >> 24) & 0xFF;
+  uint8_t b1 = (wrgb >> 16) & 0xFF;
+  uint8_t b2 = (wrgb >>  8) & 0xFF;
+  uint8_t b3 = (wrgb      ) & 0xFF;
+
+  if ((b0 | b1 | b2 | b3) == 0) {
+    // special version for clearing to black
+    memset(_buf_work + first * _pixel_size, 0, (last - first + 1) * _pixel_size);
+  } else {
+    // fill sub-buffer with RRGGBB or WWRRGGBB (or raw)
+    uint8_t *buf = _buf_work + first * _pixel_size;
+    for (uint32_t i = first; i <= last; i++) {
+      if (_pixel_size == 4) { *buf++ = b0;}
+      *buf++ = b1;
+      *buf++ = b2;
+      *buf++ = b3;
+    }
+  }
+}
+
+void TasmotaLED::Show(void) {
+  if (_pusher) {
+    _dirty = false;                                               // we don't use the _dirty attribute and always show
+
+    // copy the input buffer to the work buffer in format to be understood by LED strip
+    if (_raw_format) {
+      memmove(_buf_show, _buf_work, _pixel_count * _pixel_size);    // copy buffer in next buffer so we start with the current content
+    } else {
+      uint8_t *buf_from = _buf_work;
+      uint8_t *buf_to = _buf_show;
+      if (_pixel_size == 3) {
+        // copying with swapping 512 pixels (1536 bytes) takes 124 microseconds to copy, so it's negligeable
+        for (uint32_t i = 0; i < _pixel_count; i++) {
+          buf_to[(*_pixel_matrix)[0]] = buf_from[0];   // R
+          buf_to[(*_pixel_matrix)[1]] = buf_from[1];   // G
+          buf_to[(*_pixel_matrix)[2]] = buf_from[2];   // B
+          buf_to += 3;
+          buf_from += 3;
+        }
+      } else if (_pixel_size == 4) {
+        for (uint32_t i = 0; i < _pixel_count; i++) {
+          if (_w_before) { *buf_to++ = buf_from[3]; }
+          buf_to[(*_pixel_matrix)[0]] = buf_from[0];   // R
+          buf_to[(*_pixel_matrix)[1]] = buf_from[1];   // G
+          buf_to[(*_pixel_matrix)[2]] = buf_from[2];   // B
+          if (!_w_before) { *buf_to++ = buf_from[3]; }
+          buf_to += 3;    // one increment already happened
+          buf_from += 4;
+        }
+      }
+    }
+    _pusher->Push(_buf_show);          // push to leds
+  }
+}
+
+void TasmotaLED::SetPixelColor(int32_t index, uint32_t wrgb) {
+  if (index < 0) { index += _pixel_count; }
+  if ((index >= 0) && (index < _pixel_count)) {
+    uint8_t *buf = _buf_work + index * _pixel_size;
+    uint8_t b0 = (wrgb >> 24) & 0xFF;
+    uint8_t b1 = (wrgb >> 16) & 0xFF;
+    uint8_t b2 = (wrgb >>  8) & 0xFF;
+    uint8_t b3 = (wrgb      ) & 0xFF;
+
+    if (_pixel_size == 4) { *buf++ = b0;}
+    *buf++ = b1;
+    *buf++ = b2;
+    *buf++ = b3;
+    _dirty = true;
+  }
+}
+
+uint32_t TasmotaLED::GetPixelColor(int32_t index) {
+  if (index < 0) { index += _pixel_count; }
+  if ((index >= 0) && (index < _pixel_count)) {
+    uint8_t *buf = _buf_work + index * _pixel_size;
+    uint32_t wrgb = 0;
+    if (_pixel_size == 4) { wrgb = (*buf++) << 24; }
+    wrgb |= (*buf++) << 16;
+    wrgb |= (*buf++) <<  8;
+    wrgb |= (*buf++);
+    return wrgb;
+  } else {
+    return 0;
+  }
+}
+
+void TasmotaLED::SetPusher(TasmotaLEDPusher *pusher) {
+  if (_pusher) {
+    delete _pusher;
+  }
+  _pusher = pusher;
+  _started = false;
+}
+
+bool TasmotaLED::Begin(void) {
+  if (_pusher) {
+    if (_started) {
+      return true;
+    } else {
+      const TasmotaLED_Timing * timing = &TasmotaLED_Timings[_timing];
+      // AddLog(LOG_LEVEL_DEBUG, "LED: T0H=%i T0L=%i T1H=%i T1L=%i Reset=%i", timing.T0H, timing.T0L, timing.T1H, timing.T1L, timing.Reset);
+      return _pusher->Begin(_pixel_count, _pixel_size, timing);
+    }
+  } else {
+    return false;
+  }
+}
+
+bool TasmotaLED::CanShow(void) const {
+  if (_pusher) {
+    return _pusher->CanShow();
+  }
+  return false;
+}
+
+#endif // ESP32

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
@@ -1,0 +1,129 @@
+/*
+  TasmotaLED.h - Lightweight implementation for adressable leds.
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __TASMOTALED_H__
+#define __TASMOTALED_H__
+
+enum TasmotaLEDTypesEncoding : uint16_t {
+  // bits 0..3 encode for number of bytes per pixel
+  TasmotaLed_1_W    = 0x0,    // 1 byte per pixel (not used yet)
+  TasmotaLed_3_RGB  = 0x1,    // 3 bytes per pixel
+  TasmotaLed_4_WRGB = 0x2,    // 4 bytes per pixel
+  // bits 4..6 encode for pixel order
+  TasmotaLed_GRB = 0b000 << 4,
+  TasmotaLed_GBR = 0b001 << 4,
+  TasmotaLed_RGB = 0b010 << 4,
+  TasmotaLed_RBG = 0b011 << 4,
+  TasmotaLed_BRG = 0b100 << 4,
+  TasmotaLed_BGR = 0b101 << 4,
+  // bit 7 sets the position for W channel
+  TasmotaLed_xxxW = 0b0 << 7,   // W channel after color
+  TasmotaLed_Wxxx = 0b1 << 7,   // W channel before color
+  // bits 8..15 encode for timing specifics
+  TasmotaLed_WS2812 = 0 << 8,
+  TasmotaLed_SK6812 = 1 << 8,
+  TasmotaLed_TimingEnd = 2 << 8,
+};
+
+enum TasmotaLEDHardware : uint32_t {
+  // low-order bits are reserved for channels numbers and hardware flags - currenlty not useds
+  // bits 16..23
+  TasmotaLed_HW_Default = 0x0 << 16,
+  TasmotaLed_RMT  = 1 << 16,
+  TasmotaLed_SPI  = 2 << 16,
+  TasmotaLed_I2S  = 3 << 16,
+  TasmotaLed_HW_None = 0xFF << 16,    // indicates that the specified HW is not supported
+};
+
+// Below is the encoding for full strips
+// We need to keep backwards compatibility so:
+// 0 = WS2812 (GRB)
+// 1 = SK6812 with White (GRBW)
+enum TasmotaLEDTypes : uint16_t {
+  ws2812_grb  = TasmotaLed_3_RGB  | TasmotaLed_GRB | TasmotaLed_WS2812,                     // 1 for backwards compatibility
+  sk6812_grbw = TasmotaLed_4_WRGB | TasmotaLed_GRB | TasmotaLed_xxxW | TasmotaLed_SK6812,   // 2 for backwards compatibility
+  sk6812_grb  = TasmotaLed_3_RGB  | TasmotaLed_GRB | TasmotaLed_SK6812,
+};
+
+#ifdef __cplusplus
+
+/*******************************************************************************************\
+ * class TasmotaLED
+ * 
+ * This class is a lightweight replacement for NeoPixelBus library with a smaller
+ * implementation focusing only on pushing a buffer to the leds.
+ * 
+ * It supports:
+ *   - RMT and I2S hardware support
+ *     Possible enhancements could be considered with SPI and Serial
+ *   - Led size of 3 bytes (GRB) and 4 bytes (GRBW)
+ *     APIs take 0xRRGGBB or 0xRRGGBBWW as input
+ *     but Internal buffers use GGRRBB and GGRRBBWW
+ *   - Led type of WS2812 and SK6812
+ *   - There is no buffer swapping, the working buffer is copied to an internal
+ *     buffer just before display, so you can keep a reference to the buffer
+ *     and modify it without having to worry about the display
+ *   - buffer is cleared at start
+ *   - "Dirty" is kept for API compatibility with NeoPixelBus but is glbally ignored
+ *     so any call to `Show()` pushes the pixels even if they haven't changed.
+ *     Control for dirty pixels should be done by the caller if required.
+ *   - We tried to keep as close as possible to NeoPixelBus method names to ease transition
+\*******************************************************************************************/
+class TasmotaLEDPusher;   // forward definition
+class TasmotaLED {
+public:
+  TasmotaLED(uint16_t type, uint16_t num_leds);
+  ~TasmotaLED();
+
+  bool Begin(void);
+  void SetPusher(TasmotaLEDPusher *pusher);   // needs to be called before `Begin()`, sets the hardware implementation
+  void Show(void);                            // pushes the pixels to the LED strip
+  inline void SetRawFormat(bool raw_format) { _raw_format = raw_format; }
+
+  void ClearTo(uint32_t rgbw, int32_t first = 0, int32_t last = -1);
+  void SetPixelColor(int32_t index, uint32_t wrgb);
+  uint32_t GetPixelColor(int32_t index);
+
+  uint8_t GetType(void) const { return _type; }
+  uint16_t PixelCount(void) const { return _pixel_count; }
+  uint8_t PixelSize(void) const { return _pixel_size; }
+  inline uint8_t * Pixels(void) const { return _buf_work; }
+  inline bool IsDirty(void) const { return _dirty; }
+  inline void Dirty(void) { _dirty = true; }
+  
+  bool CanShow(void) const;
+
+protected:
+  uint16_t _type;                     // the composite type
+  uint8_t _pixel_order;               // permutation between RGB and position of W
+  bool _w_before;                     // true if W channel comes first (4 channels only)
+  uint8_t _timing;                    // timing code for strip, 0=WS2812, 1=SK6812...
+  bool _started;                      // true if the hardware implementation is configured
+  bool _dirty;                        // for NeoPixelBus compatibility, but ignored by `Push()`
+  bool _raw_format;                   // if true, copy raw to leds, if false, convert from RGB to GRB or LED format
+  uint16_t _pixel_count;              // how many pixels in the strip
+  uint8_t _pixel_size;                // how many bytes per pixels, only 3 and 4 are supported
+  uint8_t *_buf_work;                 // buffer used to draw into, can be modified directly by the caller
+  uint8_t *_buf_show;                 // copy of the buffer used to push to leds, private to this class
+  const uint8_t (*_pixel_matrix)[3];  // pointer to the pixer_order_matrix
+  TasmotaLEDPusher *_pusher;          // pixels pusher implementation based on hardware (RMT, I2S...)
+};
+
+#endif  // __cplusplus
+#endif  // __TASMOTALED_H__

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.cpp
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.cpp
@@ -1,0 +1,97 @@
+/*
+  TasmotaLEDPusher.cpp - Implementation to push Leds via hardware acceleration
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef ESP32
+
+#include "TasmotaLEDPusher.h"
+#include "TasmotaLED.h"
+
+//**************************************************************************************************************
+// enable AddLog support within a C++ library
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+//**************************************************************************************************************
+
+
+// convert to the appropriate hardware acceleration based on capacities of the SOC
+uint32_t TasmotaLEDPusher::ResolveHardware(uint32_t hw) {
+uint32_t hw_orig = hw;
+  // Step 1. discard any unsupported hardware, and replace with TasmotaLed_HW_Default
+  uint32_t hw_type = hw & 0xFF0000;     // discard bits 0..15
+#if !TASMOTALED_HARDWARE_RMT
+  if (hw_type == TasmotaLed_RMT) {
+    hw = TasmotaLed_HW_None;
+  }
+#endif // TASMOTALED_HARDWARE_RMT
+#if !TASMOTALED_HARDWARE_SPI
+  if (hw_type == TasmotaLed_SPI) {
+    hw = TasmotaLed_HW_None;
+  }
+#endif // TASMOTALED_HARDWARE_SPI
+#if !TASMOTALED_HARDWARE_I2S
+  if (hw_type == TasmotaLed_I2S) {
+    hw = TasmotaLed_HW_None;
+  }
+#endif // TASMOTALED_HARDWARE_I2S
+
+  // Step 2. If TasmotaLed_HW_Default, find a suitable scheme, RMT preferred
+#if TASMOTALED_HARDWARE_RMT
+  if ((hw & 0xFF0000) == TasmotaLed_HW_Default) {
+    hw = TasmotaLed_RMT;
+  }
+#endif // TASMOTALED_HARDWARE_RMT
+#if TASMOTALED_HARDWARE_I2S
+  if ((hw & 0xFF0000) == TasmotaLed_HW_Default) {
+    hw = TasmotaLed_I2S;
+  }
+#endif // TASMOTALED_HARDWARE_I2S
+#if TASMOTALED_HARDWARE_SPI
+  if ((hw & 0xFF0000) == TasmotaLed_HW_Default) {
+    hw = TasmotaLed_SPI;
+  }
+#endif // TASMOTALED_HARDWARE_SPI
+  return hw;
+}
+
+
+TasmotaLEDPusher * TasmotaLEDPusher::Create(uint32_t hw, int8_t gpio) {
+  TasmotaLEDPusher * pusher = nullptr;
+
+  hw = TasmotaLEDPusher::ResolveHardware(hw);
+
+  switch (hw & 0XFF0000) {
+#if TASMOTALED_HARDWARE_RMT
+    case TasmotaLed_RMT:
+      pusher = new TasmotaLEDPusherRMT(gpio);
+      AddLog(LOG_LEVEL_DEBUG, "LED: RMT gpio %i", gpio);
+      break;
+#endif // TASMOTALED_HARDWARE_RMT
+#if TASMOTALED_HARDWARE_SPI
+    case TasmotaLed_SPI:
+      pusher = new TasmotaLEDPusherSPI(gpio);
+      AddLog(LOG_LEVEL_DEBUG, "LED: SPI gpio %i", gpio);
+      break;
+#endif // TASMOTALED_HARDWARE_SPI
+    default:
+      break;
+  }
+  return pusher;
+}
+
+#endif // ESP32

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
@@ -1,0 +1,161 @@
+/*
+  TasmotaLEDPusher.h - Abstract class for Leds pusher (RMT, SPI, I2S...)
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __TASMOTALEDPUSHER_H__
+#define __TASMOTALEDPUSHER_H__
+
+#include <Arduino.h>
+
+// Below are flags to enable of disable each hardware support: RMT, I2S, SPI
+// By default, only enable RMT support, and SPI is used as fallback if no protocol works
+//
+// Use de defines below:
+//    #define TASMOTALED_HARDWARE_RMT 0/1
+//    #define TASMOTALED_HARDWARE_I2S 0/1
+//    #define TASMOTALED_HARDWARE_SPI 0/1
+//
+#ifndef TASMOTALED_HARDWARE_RMT
+  #define TASMOTALED_HARDWARE_RMT 1
+#endif
+
+#ifndef TASMOTALED_HARDWARE_I2S
+  #define TASMOTALED_HARDWARE_I2S 0
+#endif
+
+#ifndef TASMOTALED_HARDWARE_SPI
+  #define TASMOTALED_HARDWARE_SPI 0
+#endif
+
+// Disable any hardware if not supported by the SOC
+#if TASMOTALED_HARDWARE_RMT && !defined(SOC_RMT_SUPPORTED)
+  #undef TASMOTALED_HARDWARE_RMT
+  #define TASMOTALED_HARDWARE_RMT 0
+#endif
+
+#if TASMOTALED_HARDWARE_I2S && !defined(SOC_I2S_SUPPORTED)
+  #undef TASMOTALED_HARDWARE_I2S
+  #define TASMOTALED_HARDWARE_I2S 0
+#endif
+
+#if TASMOTALED_HARDWARE_SPI && !defined(SOC_GPSPI_SUPPORTED)
+  #undef TASMOTALED_HARDWARE_SPI
+  #define TASMOTALED_HARDWARE_SPI 0
+#endif
+
+// if no protocol is defined, use SPI as fallback
+#if !TASMOTALED_HARDWARE_RMT && !TASMOTALED_HARDWARE_I2S && !TASMOTALED_HARDWARE_SPI
+  #undef TASMOTALED_HARDWARE_SPI
+  #define TASMOTALED_HARDWARE_SPI 1
+#endif
+
+// Timing structure for LEDS - in nanoseconds
+// It is passed by TasmotaLed to the pushers
+typedef struct TasmotaLED_Timing {
+  uint16_t    T0H, T0L, T1H, T1L;
+  uint32_t    Reset;
+} TasmotaLED_Timing;
+
+/*******************************************************************************************\
+ * class TasmotaLEDPusher
+ * 
+ * This is an virtual abstract class for Leds pusher (RMT, SPI, I2S...)
+ *
+ * Below are interfaces for current implementations
+\*******************************************************************************************/
+class TasmotaLEDPusher {
+public:
+  TasmotaLEDPusher() : _pixel_count(0), _pixel_size(0), _led_timing(nullptr) {};
+  virtual ~TasmotaLEDPusher() {};
+
+  virtual bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) {
+    _pixel_count = pixel_count;
+    _pixel_size = pixel_size;
+    _led_timing = led_timing;
+    return true;
+  }
+  virtual bool Push(uint8_t *buf) = 0;
+  virtual bool CanShow(void) = 0;
+
+  static uint32_t ResolveHardware(uint32_t hw);    // convert to the appropriate hardware acceleration based on capacities of the SOC
+  static TasmotaLEDPusher * Create(uint32_t hw, int8_t gpio);   // create instance for the provided type, or nullptr if failed
+  
+protected:
+  uint16_t _pixel_count;
+  uint16_t _pixel_size;
+  const TasmotaLED_Timing * _led_timing;
+};
+
+/*******************************************************************************************\
+ * class TasmotaLEDPusherRMT
+ * 
+ * Implementation based on RMT driver
+\*******************************************************************************************/
+#if TASMOTALED_HARDWARE_RMT
+#include "driver/rmt_tx.h"
+class TasmotaLEDPusherRMT : public TasmotaLEDPusher {
+public:
+  TasmotaLEDPusherRMT(int8_t pin) : _pin(pin) {};
+  ~TasmotaLEDPusherRMT();
+
+  bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) override;
+
+  bool Push(uint8_t *buf) override;
+  bool CanShow(void) override;
+protected:
+  int8_t _pin;
+  rmt_transmit_config_t _tx_config = {};
+  rmt_channel_handle_t _channel = nullptr;;
+  rmt_encoder_handle_t _led_encoder = nullptr;
+};
+#endif  // TASMOTALED_HARDWARE_RMT
+
+/*******************************************************************************************\
+ * class TasmotaLEDPusherSPI
+ * 
+ * Implementation based on SPI driver, mandatory for C2
+\*******************************************************************************************/
+#if TASMOTALED_HARDWARE_SPI
+#include <driver/spi_master.h>
+
+typedef struct led_strip_spi_obj_t {
+    uint8_t * pixel_buf;
+    uint16_t strip_len;
+    uint8_t bytes_per_pixel;
+    spi_host_device_t spi_host;
+    spi_device_handle_t spi_device;
+    spi_transaction_t tx_conf;              // transaction in process if any
+} led_strip_spi_obj;
+
+class TasmotaLEDPusherSPI : public TasmotaLEDPusher {
+public:
+  TasmotaLEDPusherSPI(int8_t pin) : _pin(pin), _spi_strip({}) {};
+  ~TasmotaLEDPusherSPI();
+
+  bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) override;
+
+  bool Push(uint8_t *buf) override;
+  bool CanShow(void) override;
+  
+protected:
+  int8_t _pin;
+  struct led_strip_spi_obj_t _spi_strip;
+};
+#endif  // TASMOTALED_HARDWARE_SPI
+
+#endif  // __TASMOTALEDPUSHER_H__

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusherRMT.cpp
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusherRMT.cpp
@@ -1,0 +1,240 @@
+/*
+  TasmotaLEDPusherRMT.cpp - Implementation to push Leds via RMT channel
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef ESP32
+
+#include "TasmotaLEDPusher.h"
+#include "TasmotaLED.h"
+
+#if TASMOTALED_HARDWARE_RMT
+#include <rom/gpio.h>
+#include <esp_check.h>
+
+//**************************************************************************************************************
+// enable AddLog support within a C++ library
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+//**************************************************************************************************************
+
+/*******************************************************************************************\
+ * Implementation for TasmotaLEDPusherRMT
+ * 
+ * Code mostly copied from Tasmota patch to NeoPixelBus applied to support esp-idf 5.x
+ * itself inspired from esp-idf example for RMT encoder from
+ * https://github.com/espressif/esp-idf/tree/v5.3.1/examples/peripherals/rmt/ir_nec_transceiver
+\*******************************************************************************************/
+#define RMT_LED_STRIP_RESOLUTION_HZ 40000000 // 40MHz resolution, steps of 25 nanoseconds
+
+// structure used to pass arguments to `rmt_new_led_strip_encoder`
+// currently only the encoder resolution in Hz
+typedef struct {
+    uint32_t resolution; /*!< Encoder resolution, in Hz */
+} led_strip_encoder_config_t;
+
+// structure used to store all the necessary information for the RMT encoder
+typedef struct {
+    rmt_encoder_t base;
+    rmt_encoder_t *bytes_encoder;
+    rmt_encoder_t *copy_encoder;
+    int32_t state;
+    rmt_symbol_word_t reset_code;
+} rmt_led_strip_encoder_t;
+
+static IRAM_ATTR size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+{
+  rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
+  rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
+  rmt_encode_state_t session_state = RMT_ENCODING_RESET;
+  rmt_encode_state_t state = RMT_ENCODING_RESET;
+  size_t encoded_symbols = 0;
+  switch (led_encoder->state) {
+  case 0: // send RGB data
+    encoded_symbols += bytes_encoder->encode(bytes_encoder, channel, primary_data, data_size, &session_state);
+    if (session_state & RMT_ENCODING_COMPLETE) {
+        led_encoder->state = 1; // switch to next state when current encoding session finished
+    }
+    if (session_state & RMT_ENCODING_MEM_FULL) {
+        state = static_cast<rmt_encode_state_t>(static_cast<uint8_t>(state) | static_cast<uint8_t>(RMT_ENCODING_MEM_FULL));
+        goto out; // yield if there's no free space for encoding artifacts
+    }
+  // fall-through
+  case 1: // send reset code
+    encoded_symbols += copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code, sizeof(led_encoder->reset_code), &session_state);
+    if (session_state & RMT_ENCODING_COMPLETE) {
+        led_encoder->state = RMT_ENCODING_RESET; // back to the initial encoding session
+        state = static_cast<rmt_encode_state_t>(static_cast<uint8_t>(state) | static_cast<uint8_t>(RMT_ENCODING_COMPLETE));
+    }
+    if (session_state & RMT_ENCODING_MEM_FULL) {
+        state = static_cast<rmt_encode_state_t>(static_cast<uint8_t>(state) | static_cast<uint8_t>(RMT_ENCODING_MEM_FULL));
+        goto out; // yield if there's no free space for encoding artifacts
+    }
+  }
+out:
+  *ret_state = state;
+  return encoded_symbols;
+}
+
+static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder) {
+  rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_del_encoder(led_encoder->bytes_encoder);
+  rmt_del_encoder(led_encoder->copy_encoder);
+  delete led_encoder;
+  return ESP_OK;
+}
+
+static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder) {
+  rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_encoder_reset(led_encoder->bytes_encoder);
+  rmt_encoder_reset(led_encoder->copy_encoder);
+  led_encoder->state = RMT_ENCODING_RESET;
+  return ESP_OK;
+}
+
+static esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder, rmt_symbol_word_t bit0,  rmt_symbol_word_t bit1, rmt_symbol_word_t reset_code) {
+  static const char* TAG = "TASMOTA_RMT";
+  esp_err_t ret = ESP_OK;
+  rmt_led_strip_encoder_t *led_encoder = NULL;
+  rmt_bytes_encoder_config_t bytes_encoder_config;
+  rmt_copy_encoder_config_t copy_encoder_config = {};
+
+  ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+  led_encoder = new rmt_led_strip_encoder_t();
+  ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG, "no mem for led strip encoder");
+  led_encoder->base.encode = rmt_encode_led_strip;
+  led_encoder->base.del = rmt_del_led_strip_encoder;
+  led_encoder->base.reset = rmt_led_strip_encoder_reset;
+  led_encoder->reset_code = reset_code;
+
+  bytes_encoder_config.bit0 = bit0;
+  bytes_encoder_config.bit1 = bit1;
+  bytes_encoder_config.flags.msb_first = 1; // WS2812 transfer bit order: G7...G0R7...R0B7...B0 - TODO: more checks
+
+  ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
+  ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
+
+  *ret_encoder = &led_encoder->base;
+  return ret;
+err:
+  AddLog(LOG_LEVEL_INFO, "RMT: could not init led encoder");
+  if (led_encoder) {
+    if (led_encoder->bytes_encoder) { rmt_del_encoder(led_encoder->bytes_encoder); }
+    if (led_encoder->copy_encoder) { rmt_del_encoder(led_encoder->copy_encoder); }
+    delete led_encoder;
+  }
+  return ret;
+}
+
+TasmotaLEDPusherRMT::~TasmotaLEDPusherRMT() {
+  if (_channel) {
+    rmt_tx_wait_all_done(_channel, 10000 / portTICK_PERIOD_MS);
+    rmt_del_channel(_channel);
+    _channel = nullptr;
+  }
+
+  if (_pin >= 0) {
+    gpio_matrix_out(_pin, 0x100, false, false);
+    pinMode(_pin, INPUT);
+    _pin = -1;
+  }
+}
+
+bool TasmotaLEDPusherRMT::Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) {
+  TasmotaLEDPusher::Begin(pixel_count, pixel_size, led_timing);
+
+  esp_err_t ret = ESP_OK;
+  rmt_tx_channel_config_t config = {};
+  config.clk_src = RMT_CLK_SRC_DEFAULT;
+  config.gpio_num = static_cast<gpio_num_t>(_pin);
+  config.mem_block_symbols = 192;         // memory block size, 64 * 4 = 256 Bytes
+  config.resolution_hz = RMT_LED_STRIP_RESOLUTION_HZ; // 40 MHz tick resolution, i.e., 1 tick = 0.025 µs or 25 ns
+  config.trans_queue_depth = 4;           // set the number of transactions that can pend in the background
+  config.flags.invert_out = false;        // do not invert output signal
+  config.flags.with_dma = false;          // do not need DMA backend
+
+  ret = rmt_new_tx_channel(&config, &_channel);
+  if (ret != ESP_OK) {
+    AddLog(LOG_LEVEL_INFO, "RMT: cannot initialize Gpio %i err=%i", _pin, ret);
+    return false;
+  }
+  led_strip_encoder_config_t encoder_config = {
+    .resolution = RMT_LED_STRIP_RESOLUTION_HZ,
+  };
+
+  _tx_config.loop_count = 0;  // no loop
+
+  rmt_symbol_word_t RmtBit0 = {
+    .duration0 = (uint16_t) (led_timing->T0H * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000),
+    .level0 = 1,
+    .duration1 = (uint16_t) (led_timing->T0L * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000),
+    .level1 = 0,
+  };
+  rmt_symbol_word_t RmtBit1 = {
+    .duration0 = (uint16_t) (led_timing->T1H * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000),
+    .level0 = 1,
+    .duration1 = (uint16_t) (led_timing->T1L * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000),
+    .level1 = 0,
+  };
+  rmt_symbol_word_t RmtReset = {
+    .duration0 = (uint16_t) (led_timing->Reset * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000),
+    .level0 = 0,
+    .duration1 = 50 * (RMT_LED_STRIP_RESOLUTION_HZ / 1000000) / 1000,
+    .level1 = 1,
+  };
+  // AddLog(LOG_LEVEL_INFO, "RMT: RmtBit0 0x%08X RmtBit1 0x%08X RmtReset 0x%08X", RmtBit0.val, RmtBit1.val, RmtReset.val);
+  ret = rmt_new_led_strip_encoder(&encoder_config, &_led_encoder, RmtBit0, RmtBit1, RmtReset);
+  if (ret != ESP_OK) {
+    // AddLog(LOG_LEVEL_INFO, "RMT: cannot initialize led strip encoder err=%i", ret);
+    return false;
+  }
+  ret = rmt_enable(_channel);
+  if (ret != ESP_OK) {
+    // AddLog(LOG_LEVEL_INFO, "RMT: cannot enable channel err=%i", ret);
+    return false;
+  }
+  return true;
+}
+
+bool TasmotaLEDPusherRMT::CanShow(void) {
+  if (_channel) {
+    return (ESP_OK == rmt_tx_wait_all_done(_channel, 0));
+  } else {
+    return false;
+  }
+}
+
+bool TasmotaLEDPusherRMT::Push(uint8_t *buf) {
+
+  // wait for not actively sending data
+  // this will time out at 1 second, an arbitrarily long period of time
+  // and do nothing if this happens
+  esp_err_t ret = rmt_tx_wait_all_done(_channel, 1000 / portTICK_PERIOD_MS);
+  if (ESP_OK == ret) {
+    // now start the RMT transmit with the editing buffer before we swap
+    ret = rmt_transmit(_channel, _led_encoder, buf, _pixel_count * _pixel_size, &_tx_config);
+    if (ESP_OK != ret) {
+      AddLog(LOG_LEVEL_DEBUG, "RMT: cannot transmit err=%i", ret);
+      return false;
+    }
+  }
+  return true;
+}
+
+#endif // TASMOTALED_HARDWARE_RMT
+#endif // ESP32

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusherSPI.cpp
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusherSPI.cpp
@@ -1,0 +1,191 @@
+/*
+  TasmotaLEDPusherRMT.cpp - Implementation to push Leds via SPI channel
+
+  Copyright (C) 2024  Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef ESP32
+
+#include "TasmotaLEDPusher.h"
+#include "TasmotaLED.h"
+
+#if TASMOTALED_HARDWARE_SPI
+#include <rom/gpio.h>
+
+//**************************************************************************************************************
+// enable AddLog support within a C++ library
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+//**************************************************************************************************************
+
+/*******************************************************************************************\
+ * Implementation for TasmotaLEDPusherSPI
+ * 
+\*******************************************************************************************/
+
+#define LED_STRIP_SPI_DEFAULT_RESOLUTION (25 * 100 * 1000) // 2.5MHz resolution
+#define LED_STRIP_SPI_DEFAULT_TRANS_QUEUE_SIZE 4
+
+#define SPI_BYTES_PER_COLOR_BYTE 3
+#define SPI_BITS_PER_COLOR_BYTE (SPI_BYTES_PER_COLOR_BYTE * 8)
+
+static void __led_strip_spi_bit(uint8_t data, uint8_t *buf)
+{
+  // Each color of 1 bit is represented by 3 bits of SPI, low_level:100 ,high_level:110
+  // So a color byte occupies 3 bytes of SPI.
+  buf[0] = (data & BIT(5) ? BIT(1) | BIT(0) : BIT(1)) | (data & BIT(6) ? BIT(4) | BIT(3) : BIT(4)) | (data & BIT(7) ? BIT(7) | BIT(6) : BIT(7));
+  buf[1] = (BIT(0)) | (data & BIT(3) ? BIT(3) | BIT(2) : BIT(3)) | (data & BIT(4) ? BIT(6) | BIT(5) : BIT(6));
+  buf[2] = (data & BIT(0) ? BIT(2) | BIT(1) : BIT(2)) | (data & BIT(1) ? BIT(5) | BIT(4) : BIT(5)) | (data & BIT(2) ? BIT(7) : 0x00);
+}
+
+esp_err_t led_strip_spi_refresh(led_strip_spi_obj * spi_strip)
+{
+  spi_strip->tx_conf.length = spi_strip->strip_len * spi_strip->bytes_per_pixel * SPI_BITS_PER_COLOR_BYTE;
+  spi_strip->tx_conf.tx_buffer = spi_strip->pixel_buf;
+  spi_strip->tx_conf.rx_buffer = NULL;
+  spi_device_transmit(spi_strip->spi_device, &spi_strip->tx_conf);
+  return ESP_OK;
+}
+
+void led_strip_transmit_buffer(led_strip_spi_obj * spi_strip, uint8_t * buffer_rgbw) {
+  // Timing for 512 pixels (extreme test)
+  // Copying to buffer: 418 us
+  // sending pixels: 16.2 ms
+  uint8_t * buf = buffer_rgbw;
+  uint8_t * pix_buf = spi_strip->pixel_buf;
+  for (int i = 0; i < spi_strip->strip_len; i++) {
+    // LED_PIXEL_FORMAT_GRB takes 72bits(9bytes)
+    __led_strip_spi_bit(*buf++, pix_buf);     pix_buf += SPI_BYTES_PER_COLOR_BYTE;
+    __led_strip_spi_bit(*buf++, pix_buf);     pix_buf += SPI_BYTES_PER_COLOR_BYTE;
+    __led_strip_spi_bit(*buf++, pix_buf);     pix_buf += SPI_BYTES_PER_COLOR_BYTE;
+    if (spi_strip->bytes_per_pixel > 3) {
+      __led_strip_spi_bit(*buf++, pix_buf); pix_buf += SPI_BYTES_PER_COLOR_BYTE;
+    }
+  }
+  /* Refresh the strip to send data */
+  led_strip_spi_refresh(spi_strip);
+}
+
+
+TasmotaLEDPusherSPI::~TasmotaLEDPusherSPI() {
+  if (_spi_strip.spi_device) {
+    spi_bus_remove_device(_spi_strip.spi_device);
+  }
+  if (_spi_strip.spi_host) {
+    spi_bus_free(_spi_strip.spi_host);
+  }
+
+  if (_pin >= 0) {
+    gpio_matrix_out(_pin, 0x100, false, false);
+    pinMode(_pin, INPUT);
+    _pin = -1;
+  }
+}
+
+bool TasmotaLEDPusherSPI::Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) {
+  TasmotaLEDPusher::Begin(pixel_count, pixel_size, led_timing);
+  _spi_strip.bytes_per_pixel = _pixel_size;
+  _spi_strip.strip_len = _pixel_count;
+
+  esp_err_t err = ESP_OK;
+  uint32_t mem_caps = MALLOC_CAP_DEFAULT;
+  // spi_clock_source_t clk_src = SPI_CLK_SRC_DEFAULT;
+  spi_bus_config_t spi_bus_cfg;
+  spi_device_interface_config_t spi_dev_cfg;
+  spi_host_device_t spi_host = SPI2_HOST;
+  bool with_dma = true; /// TODO: pass value or compute based on pixelcount
+  int clock_resolution_khz = 0;
+
+  if (with_dma) {  // TODO
+      // DMA buffer must be placed in internal SRAM
+      mem_caps |= MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA;
+  }
+  _spi_strip.pixel_buf = (uint8_t *)heap_caps_calloc(1, _pixel_count * _pixel_size * SPI_BYTES_PER_COLOR_BYTE, mem_caps);
+  if (_spi_strip.pixel_buf == nullptr) {
+    AddLog(LOG_LEVEL_INFO, PSTR("LED: Error no mem for spi strip"));
+    goto err;
+  }
+
+  spi_bus_cfg = {
+      .mosi_io_num = _pin,
+      //Only use MOSI to generate the signal, set -1 when other pins are not used.
+      .miso_io_num = -1,
+      .sclk_io_num = -1,
+      .quadwp_io_num = -1,
+      .quadhd_io_num = -1,
+      .max_transfer_sz = _pixel_count * _pixel_size * SPI_BYTES_PER_COLOR_BYTE,
+  };
+  err = spi_bus_initialize(spi_host, &spi_bus_cfg, with_dma ? SPI_DMA_CH_AUTO : SPI_DMA_DISABLED);
+  if (err != ESP_OK) {
+    AddLog(LOG_LEVEL_INFO, PSTR("LED: Error create SPI bus failed"));
+    goto err;
+  }
+  _spi_strip.spi_host = spi_host;     // confirmed working, so keep it's value to free it later
+
+  spi_dev_cfg = {
+      .command_bits = 0,
+      .address_bits = 0,
+      .dummy_bits = 0,
+      .mode = 0,
+      //set -1 when CS is not used
+      .clock_source = SPI_CLK_SRC_DEFAULT,    // clk_src,
+      .clock_speed_hz = LED_STRIP_SPI_DEFAULT_RESOLUTION,
+      .spics_io_num = -1,
+      .queue_size = LED_STRIP_SPI_DEFAULT_TRANS_QUEUE_SIZE,
+  };
+  err = spi_bus_add_device(_spi_strip.spi_host, &spi_dev_cfg, &_spi_strip.spi_device);
+  if (err != ESP_OK) {
+    // AddLog(LOG_LEVEL_INFO, "LED: Error failed to add spi device");
+    goto err;
+  }
+
+  spi_device_get_actual_freq(_spi_strip.spi_device, &clock_resolution_khz);
+  if (err != ESP_OK) {
+    // AddLog(LOG_LEVEL_INFO, "LED: Error failed to get spi frequency");
+    goto err;
+  }
+  // TODO: ideally we should decide the SPI_BYTES_PER_COLOR_BYTE by the real clock resolution
+  // But now, let's fixed the resolution, the downside is, we don't support a clock source whose frequency is not multiple of LED_STRIP_SPI_DEFAULT_RESOLUTION
+  if (clock_resolution_khz != LED_STRIP_SPI_DEFAULT_RESOLUTION / 1000) {
+    // AddLog(LOG_LEVEL_INFO, "LED: Error unsupported clock resolution: %dKHz", clock_resolution_khz);
+    goto err;
+  }
+
+  return true;
+err:
+  if (_spi_strip.spi_device) {
+    spi_bus_remove_device(_spi_strip.spi_device);
+  }
+  if (_spi_strip.spi_host) {
+    spi_bus_free(_spi_strip.spi_host);
+  }
+  return false;
+}
+
+bool TasmotaLEDPusherSPI::CanShow(void) {
+  return true; // TODO
+}
+
+bool TasmotaLEDPusherSPI::Push(uint8_t *buf) {
+
+  if (CanShow()) {
+    led_strip_transmit_buffer(&_spi_strip, buf);
+  }
+  return true;
+}
+
+#endif // TASMOTALED_HARDWARE_SPI
+#endif // ESP32

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -152,7 +152,7 @@ BERRY_LOCAL const bntvmodule_t* const be_module_table[] = {
     &be_native_module(unishox),
 #endif // USE_UNISHOX_COMPRESSION
 
-#ifdef USE_WS2812
+#if defined(USE_WS2812) && !defined(USE_WS2812_FORCE_NEOPIXELBUS)
     &be_native_module(animate),
 #endif // USE_WS2812
 
@@ -293,7 +293,7 @@ BERRY_LOCAL bclass_array be_class_table = {
 #ifdef USE_BERRY_TCPSERVER
     &be_native_class(tcpserver),
 #endif // USE_BERRY_TCPSERVER
-#ifdef USE_WS2812
+#if defined(USE_WS2812) && !defined(USE_WS2812_FORCE_NEOPIXELBUS)
     &be_native_class(Leds_ntv),
     &be_native_class(Leds),
 #endif // USE_WS2812

--- a/lib/libesp32/berry_animate/src/be_berry_leds_frame.cpp
+++ b/lib/libesp32/berry_animate/src/be_berry_leds_frame.cpp
@@ -45,10 +45,10 @@ extern "C" {
       uint32_t g2 = (color_b >>  8) & 0xFF;
       uint32_t b2 = (color_b      ) & 0xFF;
       uint32_t a2 = (color_b >> 24) & 0xFF;
-      uint32_t r3 = changeUIntScale(alpha, 0, 255, r2, r);
-      uint32_t g3 = changeUIntScale(alpha, 0, 255, g2, g);
-      uint32_t b3 = changeUIntScale(alpha, 0, 255, b2, b);
-      uint32_t a3 = changeUIntScale(alpha, 0, 255, a2, a);
+      uint8_t r3 = changeUIntScale(alpha, 0, 255, r2, r);
+      uint8_t g3 = changeUIntScale(alpha, 0, 255, g2, g);
+      uint8_t b3 = changeUIntScale(alpha, 0, 255, b2, b);
+      uint8_t a3 = changeUIntScale(alpha, 0, 255, a2, a);
       uint32_t rgb = (a3 << 24) | (r3 << 16) | (g3 << 8) | b3;
       be_pushint(vm, rgb);
       be_return(vm);
@@ -97,9 +97,9 @@ extern "C" {
             uint32_t fore_g = (fore_argb >>  8) & 0xFF;
             uint32_t back_b = (back_argb      ) & 0xFF;
             uint32_t fore_b = (fore_argb      ) & 0xFF;
-            uint32_t dest_r_new = changeUIntScale(fore_alpha, 0, 255, fore_r, back_r);
-            uint32_t dest_g_new = changeUIntScale(fore_alpha, 0, 255, fore_g, back_g);
-            uint32_t dest_b_new = changeUIntScale(fore_alpha, 0, 255, fore_b, back_b);
+            uint8_t dest_r_new = changeUIntScale(fore_alpha, 0, 255, fore_r, back_r);
+            uint8_t dest_g_new = changeUIntScale(fore_alpha, 0, 255, fore_g, back_g);
+            uint8_t dest_b_new = changeUIntScale(fore_alpha, 0, 255, fore_b, back_b);
             dest_rgb_new = (dest_r_new << 16) | (dest_g_new << 8) | dest_b_new;
           }
           dest[i] = dest_rgb_new;
@@ -135,7 +135,7 @@ extern "C" {
 
   // Leds_frame.paste_pixels(neopixel:bytes(), led_buffer:bytes(), bri:int 0..100, gamma:bool)
   //
-  // Copy from ARGB buffer to GRB
+  // Copy from ARGB buffer to RGB
   int32_t be_leds_paste_pixels(bvm *vm);
   int32_t be_leds_paste_pixels(bvm *vm) {
     int32_t top = be_top(vm); // Get the number of arguments
@@ -162,8 +162,8 @@ extern "C" {
           uint32_t src_r = (src_argb >> 16) & 0xFF;
           uint32_t src_g = (src_argb >>  8) & 0xFF;
           uint32_t src_b = (src_argb      ) & 0xFF;
-          dest_buf[i * 3 + 0] = src_g;
-          dest_buf[i * 3 + 1] = src_r;
+          dest_buf[i * 3 + 0] = src_r;
+          dest_buf[i * 3 + 1] = src_g;
           dest_buf[i * 3 + 2] = src_b;
         }
       }

--- a/lib/libesp32/berry_tasmota/src/be_leds_ntv_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_leds_ntv_lib.c
@@ -7,7 +7,9 @@
 
 #ifdef USE_WS2812
 
-extern int be_neopixelbus_call_native(bvm *vm);
+#include "TasmotaLED.h"
+
+extern int be_tasmotaled_call_native(bvm *vm);
 extern int be_leds_blend_color(bvm *vm);
 extern int be_leds_apply_bri_gamma(bvm *vm);
 
@@ -16,10 +18,15 @@ class be_class_Leds_ntv (scope: global, name: Leds_ntv, strings: weak) {
   _p, var
   _t, var
 
-  WS2812_GRB, int(1)
-  SK6812_GRBW, int(2)
+  WS2812_GRB, int(ws2812_grb)
+  SK6812_GRBW, int(sk6812_grbw)
+  SK6812_GRB, int(sk6812_grb)
 
-  call_native, func(be_neopixelbus_call_native)
+  RMT, int(TasmotaLed_RMT)
+  SPI, int(TasmotaLed_SPI)
+  I2S, int(TasmotaLed_I2S)
+
+  call_native, func(be_tasmotaled_call_native)
 
   blend_color, static_func(be_leds_blend_color)
   apply_bri_gamma, static_func(be_leds_apply_bri_gamma)

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -3,471 +3,9 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-extern const bclass be_class_Leds_segment;
 extern const bclass be_class_Leds;
 extern const bclass be_class_Leds_matrix;
-// compact class 'Leds_segment' ktab size: 16, total: 34 (saved 144 bytes)
-static const bvalue be_ktab_class_Leds_segment[16] = {
-  /* K0   */  be_nested_str(offset),
-  /* K1   */  be_nested_str(bri),
-  /* K2   */  be_nested_str(strip),
-  /* K3   */  be_nested_str(call_native),
-  /* K4   */  be_nested_str(to_gamma),
-  /* K5   */  be_nested_str(leds),
-  /* K6   */  be_nested_str(dirty),
-  /* K7   */  be_nested_str(can_show),
-  /* K8   */  be_nested_str(set_pixel_color),
-  /* K9   */  be_nested_str(is_dirty),
-  /* K10  */  be_nested_str(clear_to),
-  /* K11  */  be_const_int(0),
-  /* K12  */  be_nested_str(show),
-  /* K13  */  be_nested_str(get_pixel_color),
-  /* K14  */  be_nested_str(offseta),
-  /* K15  */  be_nested_str(pixel_size),
-};
-
-
 extern const bclass be_class_Leds_segment;
-
-/********************************************************************
-** Solidified function: pixel_offset
-********************************************************************/
-be_local_closure(class_Leds_segment_pixel_offset,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_offset,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_to
-********************************************************************/
-be_local_closure(class_Leds_segment_clear_to,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_clear_to,
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
-      0x880C0102,  //  0004  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
-      0x54160008,  //  0006  LDINT	R5	9
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x8C180D04,  //  0008  GETMET	R6	R6	K4
-      0x5C200200,  //  0009  MOVE	R8	R1
-      0x5C240400,  //  000A  MOVE	R9	R2
-      0x7C180600,  //  000B  CALL	R6	3
-      0x881C0100,  //  000C  GETMBR	R7	R0	K0
-      0x88200105,  //  000D  GETMBR	R8	R0	K5
-      0x7C0C0A00,  //  000E  CALL	R3	5
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_count
-********************************************************************/
-be_local_closure(class_Leds_segment_pixel_count,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_count,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040105,  //  0000  GETMBR	R1	R0	K5
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixels_buffer
-********************************************************************/
-be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixels_buffer,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: dirty
-********************************************************************/
-be_local_closure(class_Leds_segment_dirty,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040306,  //  0001  GETMET	R1	R1	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: can_show
-********************************************************************/
-be_local_closure(class_Leds_segment_can_show,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_can_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040307,  //  0001  GETMET	R1	R1	K7
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_set_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100604,  //  0001  EQ	R4	R3	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x8C100908,  //  0005  GETMET	R4	R4	K8
-      0x88180100,  //  0006  GETMBR	R6	R0	K0
-      0x00180206,  //  0007  ADD	R6	R1	R6
-      0x5C1C0400,  //  0008  MOVE	R7	R2
-      0x5C200600,  //  0009  MOVE	R8	R3
-      0x7C100800,  //  000A  CALL	R4	4
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_dirty
-********************************************************************/
-be_local_closure(class_Leds_segment_is_dirty,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_is_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040309,  //  0001  GETMET	R1	R1	K9
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(class_Leds_segment_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C04010A,  //  0000  GETMET	R1	R0	K10
-      0x580C000B,  //  0001  LDCONST	R3	K11
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C04010C,  //  0003  GETMET	R1	R0	K12
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin
-********************************************************************/
-be_local_closure(class_Leds_segment_begin,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_begin,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88080102,  //  0000  GETMBR	R2	R0	K2
-      0x8C08050D,  //  0001  GETMET	R2	R2	K13
-      0x8810010E,  //  0002  GETMBR	R4	R0	K14
-      0x00100204,  //  0003  ADD	R4	R1	R4
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_size
-********************************************************************/
-be_local_closure(class_Leds_segment_pixel_size,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_size,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C04030F,  //  0001  GETMET	R1	R1	K15
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Leds_segment_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x90020401,  //  0000  SETMBR	R0	K2	R1
-      0x60100009,  //  0001  GETGBL	R4	G9
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x90020004,  //  0004  SETMBR	R0	K0	R4
-      0x60100009,  //  0005  GETGBL	R4	G9
-      0x5C140600,  //  0006  MOVE	R5	R3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x90020A04,  //  0008  SETMBR	R0	K5	R4
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show
-********************************************************************/
-be_local_closure(class_Leds_segment_show,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x740A0007,  //  0003  JMPT	R2	#000C
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x1C08050B,  //  0005  EQ	R2	R2	K11
-      0x780A0007,  //  0006  JMPF	R2	#000F
-      0x88080105,  //  0007  GETMBR	R2	R0	K5
-      0x880C0102,  //  0008  GETMBR	R3	R0	K2
-      0x880C0705,  //  0009  GETMBR	R3	R3	K5
-      0x1C080403,  //  000A  EQ	R2	R2	R3
-      0x780A0002,  //  000B  JMPF	R2	#000F
-      0x88080102,  //  000C  GETMBR	R2	R0	K2
-      0x8C08050C,  //  000D  GETMET	R2	R2	K12
-      0x7C080200,  //  000E  CALL	R2	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: Leds_segment
-********************************************************************/
-be_local_class(Leds_segment,
-    3,
-    NULL,
-    be_nested_map(17,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(pixel_offset, 9), be_const_closure(class_Leds_segment_pixel_offset_closure) },
-        { be_const_key(clear_to, -1), be_const_closure(class_Leds_segment_clear_to_closure) },
-        { be_const_key(show, -1), be_const_closure(class_Leds_segment_show_closure) },
-        { be_const_key(pixels_buffer, 10), be_const_closure(class_Leds_segment_pixels_buffer_closure) },
-        { be_const_key(offset, -1), be_const_var(1) },
-        { be_const_key(dirty, -1), be_const_closure(class_Leds_segment_dirty_closure) },
-        { be_const_key(can_show, -1), be_const_closure(class_Leds_segment_can_show_closure) },
-        { be_const_key(set_pixel_color, 6), be_const_closure(class_Leds_segment_set_pixel_color_closure) },
-        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_segment_get_pixel_color_closure) },
-        { be_const_key(pixel_count, -1), be_const_closure(class_Leds_segment_pixel_count_closure) },
-        { be_const_key(strip, 7), be_const_var(0) },
-        { be_const_key(leds, -1), be_const_var(2) },
-        { be_const_key(begin, -1), be_const_closure(class_Leds_segment_begin_closure) },
-        { be_const_key(is_dirty, 8), be_const_closure(class_Leds_segment_is_dirty_closure) },
-        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_segment_pixel_size_closure) },
-        { be_const_key(init, -1), be_const_closure(class_Leds_segment_init_closure) },
-        { be_const_key(clear, 2), be_const_closure(class_Leds_segment_clear_closure) },
-    })),
-    (bstring*) &be_const_str_Leds_segment
-);
 // compact class 'Leds_matrix' ktab size: 24, total: 62 (saved 304 bytes)
 static const bvalue be_ktab_class_Leds_matrix[24] = {
   /* K0   */  be_nested_str(strip),
@@ -1111,140 +649,35 @@ be_local_class(Leds_matrix,
     })),
     (bstring*) &be_const_str_Leds_matrix
 );
-// compact class 'Leds' ktab size: 43, total: 83 (saved 320 bytes)
-static const bvalue be_ktab_class_Leds[43] = {
-  /* K0   */  be_nested_str(leds),
-  /* K1   */  be_const_int(0),
-  /* K2   */  be_nested_str(value_error),
-  /* K3   */  be_nested_str(out_X20of_X20range),
-  /* K4   */  be_const_class(be_class_Leds_segment),
-  /* K5   */  be_nested_str(bri),
-  /* K6   */  be_nested_str(call_native),
-  /* K7   */  be_const_int(1),
-  /* K8   */  be_nested_str(clear_to),
-  /* K9   */  be_nested_str(show),
-  /* K10  */  be_nested_str(gpio),
-  /* K11  */  be_nested_str(gamma),
-  /* K12  */  be_nested_str(pin),
-  /* K13  */  be_nested_str(WS2812),
-  /* K14  */  be_nested_str(ctor),
-  /* K15  */  be_nested_str(pixel_count),
-  /* K16  */  be_nested_str(light),
-  /* K17  */  be_nested_str(get),
-  /* K18  */  be_nested_str(_p),
-  /* K19  */  be_nested_str(internal_error),
-  /* K20  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
-  /* K21  */  be_nested_str(begin),
-  /* K22  */  be_nested_str(apply_bri_gamma),
-  /* K23  */  be_const_int(2),
-  /* K24  */  be_const_class(be_class_Leds),
-  /* K25  */  be_nested_str(Leds),
-  /* K26  */  be_nested_str(create_matrix),
-  /* K27  */  be_nested_str(to_gamma),
-  /* K28  */  be_const_class(be_class_Leds_matrix),
-  /* K29  */  be_const_int(3),
-  /* K30  */  be_nested_str(invalid_X20GPIO_X20number),
-  /* K31  */  be_nested_str(global),
-  /* K32  */  be_nested_str(contains),
-  /* K33  */  be_nested_str(_rmt),
-  /* K34  */  be_nested_str(MAX_RMT),
-  /* K35  */  be_nested_str(push),
-  /* K36  */  be_nested_str(stop_iteration),
-  /* K37  */  be_nested_str(pin_used),
-  /* K38  */  be_nested_str(no_X20more_X20RMT_X20channel_X20available),
-  /* K39  */  be_nested_str(WS2812_GRB),
-  /* K40  */  be_nested_str(assign_rmt),
-  /* K41  */  be_nested_str(pixel_size),
-  /* K42  */  be_nested_str(_change_buffer),
+// compact class 'Leds_segment' ktab size: 16, total: 34 (saved 144 bytes)
+static const bvalue be_ktab_class_Leds_segment[16] = {
+  /* K0   */  be_nested_str(offset),
+  /* K1   */  be_nested_str(bri),
+  /* K2   */  be_nested_str(strip),
+  /* K3   */  be_nested_str(call_native),
+  /* K4   */  be_nested_str(to_gamma),
+  /* K5   */  be_nested_str(leds),
+  /* K6   */  be_nested_str(dirty),
+  /* K7   */  be_nested_str(can_show),
+  /* K8   */  be_nested_str(set_pixel_color),
+  /* K9   */  be_nested_str(is_dirty),
+  /* K10  */  be_nested_str(clear_to),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str(show),
+  /* K13  */  be_nested_str(get_pixel_color),
+  /* K14  */  be_nested_str(offseta),
+  /* K15  */  be_nested_str(pixel_size),
 };
 
 
-extern const bclass be_class_Leds;
+extern const bclass be_class_Leds_segment;
 
 /********************************************************************
-** Solidified function: create_segment
+** Solidified function: pixel_offset
 ********************************************************************/
-be_local_closure(class_Leds_create_segment,   /* name */
+be_local_closure(class_Leds_segment_pixel_offset,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_create_segment,
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x600C0009,  //  0000  GETGBL	R3	G9
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x60100009,  //  0003  GETGBL	R4	G9
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C100200,  //  0005  CALL	R4	1
-      0x000C0604,  //  0006  ADD	R3	R3	R4
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x240C0604,  //  0008  GT	R3	R3	R4
-      0x740E0003,  //  0009  JMPT	R3	#000E
-      0x140C0301,  //  000A  LT	R3	R1	K1
-      0x740E0001,  //  000B  JMPT	R3	#000E
-      0x140C0501,  //  000C  LT	R3	R2	K1
-      0x780E0000,  //  000D  JMPF	R3	#000F
-      0xB0060503,  //  000E  RAISE	1	K2	K3
-      0x580C0004,  //  000F  LDCONST	R3	K4
-      0xB4000004,  //  0010  CLASS	K4
-      0x5C100600,  //  0011  MOVE	R4	R3
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C100600,  //  0015  CALL	R4	3
-      0x80040800,  //  0016  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bri
-********************************************************************/
-be_local_closure(class_Leds_set_bri,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_set_bri,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x14080301,  //  0000  LT	R2	R1	K1
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0x540A00FE,  //  0003  LDINT	R2	255
-      0x24080202,  //  0004  GT	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540600FE,  //  0006  LDINT	R1	255
-      0x90020A01,  //  0007  SETMBR	R0	K5	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin
-********************************************************************/
-be_local_closure(class_Leds_begin,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1252,14 +685,12 @@ be_local_closure(class_Leds_begin,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_begin,
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_offset,
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x580C0007,  //  0001  LDCONST	R3	K7
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1267,106 +698,11 @@ be_local_closure(class_Leds_begin,   /* name */
 
 
 /********************************************************************
-** Solidified function: clear
+** Solidified function: clear_to
 ********************************************************************/
-be_local_closure(class_Leds_clear,   /* name */
+be_local_closure(class_Leds_segment_clear_to,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040108,  //  0000  GETMET	R1	R0	K8
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C040109,  //  0003  GETMET	R1	R0	K9
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Leds_init,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA4161400,  //  0000  IMPORT	R5	K10
-      0x50180200,  //  0001  LDBOOL	R6	1	0
-      0x90021606,  //  0002  SETMBR	R0	K11	R6
-      0x4C180000,  //  0003  LDNIL	R6
-      0x1C180406,  //  0004  EQ	R6	R2	R6
-      0x741A0005,  //  0005  JMPT	R6	#000C
-      0x8C180B0C,  //  0006  GETMET	R6	R5	K12
-      0x88200B0D,  //  0007  GETMBR	R8	R5	K13
-      0x58240001,  //  0008  LDCONST	R9	K1
-      0x7C180600,  //  0009  CALL	R6	3
-      0x1C180406,  //  000A  EQ	R6	R2	R6
-      0x781A000A,  //  000B  JMPF	R6	#0017
-      0x8C18010E,  //  000C  GETMET	R6	R0	K14
-      0x7C180200,  //  000D  CALL	R6	1
-      0x8C18010F,  //  000E  GETMET	R6	R0	K15
-      0x7C180200,  //  000F  CALL	R6	1
-      0x90020006,  //  0010  SETMBR	R0	K0	R6
-      0xA41A2000,  //  0011  IMPORT	R6	K16
-      0x8C1C0D11,  //  0012  GETMET	R7	R6	K17
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x941C0F05,  //  0014  GETIDX	R7	R7	K5
-      0x90020A07,  //  0015  SETMBR	R0	K5	R7
-      0x7002000B,  //  0016  JMP		#0023
-      0x60180009,  //  0017  GETGBL	R6	G9
-      0x5C1C0200,  //  0018  MOVE	R7	R1
-      0x7C180200,  //  0019  CALL	R6	1
-      0x90020006,  //  001A  SETMBR	R0	K0	R6
-      0x541A007E,  //  001B  LDINT	R6	127
-      0x90020A06,  //  001C  SETMBR	R0	K5	R6
-      0x8C18010E,  //  001D  GETMET	R6	R0	K14
-      0x88200100,  //  001E  GETMBR	R8	R0	K0
-      0x5C240400,  //  001F  MOVE	R9	R2
-      0x5C280600,  //  0020  MOVE	R10	R3
-      0x5C2C0800,  //  0021  MOVE	R11	R4
-      0x7C180A00,  //  0022  CALL	R6	5
-      0x88180112,  //  0023  GETMBR	R6	R0	K18
-      0x4C1C0000,  //  0024  LDNIL	R7
-      0x1C180C07,  //  0025  EQ	R6	R6	R7
-      0x781A0000,  //  0026  JMPF	R6	#0028
-      0xB0062714,  //  0027  RAISE	1	K19	K20
-      0x8C180115,  //  0028  GETMET	R6	R0	K21
-      0x7C180200,  //  0029  CALL	R6	1
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: to_gamma
-********************************************************************/
-be_local_closure(class_Leds_to_gamma,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1374,47 +710,26 @@ be_local_closure(class_Leds_to_gamma,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_to_gamma,
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_clear_to,
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
+    ( &(const binstruction[16]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080105,  //  0003  GETMBR	R2	R0	K5
-      0x8C0C0116,  //  0004  GETMET	R3	R0	K22
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x881C010B,  //  0007  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x80040600,  //  0009  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show
-********************************************************************/
-be_local_closure(class_Leds_show,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x580C0017,  //  0001  LDCONST	R3	K23
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
+      0x54160008,  //  0006  LDINT	R5	9
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x8C180D04,  //  0008  GETMET	R6	R6	K4
+      0x5C200200,  //  0009  MOVE	R8	R1
+      0x5C240400,  //  000A  MOVE	R9	R2
+      0x7C180600,  //  000B  CALL	R6	3
+      0x881C0100,  //  000C  GETMBR	R7	R0	K0
+      0x88200105,  //  000D  GETMBR	R8	R0	K5
+      0x7C0C0A00,  //  000E  CALL	R3	5
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -1424,7 +739,422 @@ be_local_closure(class_Leds_show,   /* name */
 /********************************************************************
 ** Solidified function: pixel_count
 ********************************************************************/
-be_local_closure(class_Leds_pixel_count,   /* name */
+be_local_closure(class_Leds_segment_pixel_count,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_count,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixels_buffer
+********************************************************************/
+be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixels_buffer,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Leds_segment_dirty,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040306,  //  0001  GETMET	R1	R1	K6
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: can_show
+********************************************************************/
+be_local_closure(class_Leds_segment_can_show,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_can_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_set_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120000,  //  0002  JMPF	R4	#0004
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x8C100908,  //  0005  GETMET	R4	R4	K8
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
+      0x00180206,  //  0007  ADD	R6	R1	R6
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x5C200600,  //  0009  MOVE	R8	R3
+      0x7C100800,  //  000A  CALL	R4	4
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_dirty
+********************************************************************/
+be_local_closure(class_Leds_segment_is_dirty,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_is_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_Leds_segment_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
+      0x580C000B,  //  0001  LDCONST	R3	K11
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C04010C,  //  0003  GETMET	R1	R0	K12
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(class_Leds_segment_begin,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_get_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C08050D,  //  0001  GETMET	R2	R2	K13
+      0x8810010E,  //  0002  GETMBR	R4	R0	K14
+      0x00100204,  //  0003  ADD	R4	R1	R4
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_size
+********************************************************************/
+be_local_closure(class_Leds_segment_pixel_size,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_size,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Leds_segment_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020401,  //  0000  SETMBR	R0	K2	R1
+      0x60100009,  //  0001  GETGBL	R4	G9
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x90020004,  //  0004  SETMBR	R0	K0	R4
+      0x60100009,  //  0005  GETGBL	R4	G9
+      0x5C140600,  //  0006  MOVE	R5	R3
+      0x7C100200,  //  0007  CALL	R4	1
+      0x90020A04,  //  0008  SETMBR	R0	K5	R4
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show
+********************************************************************/
+be_local_closure(class_Leds_segment_show,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0007,  //  0003  JMPT	R2	#000C
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x1C08050B,  //  0005  EQ	R2	R2	K11
+      0x780A0007,  //  0006  JMPF	R2	#000F
+      0x88080105,  //  0007  GETMBR	R2	R0	K5
+      0x880C0102,  //  0008  GETMBR	R3	R0	K2
+      0x880C0705,  //  0009  GETMBR	R3	R3	K5
+      0x1C080403,  //  000A  EQ	R2	R2	R3
+      0x780A0002,  //  000B  JMPF	R2	#000F
+      0x88080102,  //  000C  GETMBR	R2	R0	K2
+      0x8C08050C,  //  000D  GETMET	R2	R2	K12
+      0x7C080200,  //  000E  CALL	R2	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Leds_segment
+********************************************************************/
+be_local_class(Leds_segment,
+    3,
+    NULL,
+    be_nested_map(17,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(pixel_offset, 9), be_const_closure(class_Leds_segment_pixel_offset_closure) },
+        { be_const_key(clear_to, -1), be_const_closure(class_Leds_segment_clear_to_closure) },
+        { be_const_key(show, -1), be_const_closure(class_Leds_segment_show_closure) },
+        { be_const_key(pixels_buffer, 10), be_const_closure(class_Leds_segment_pixels_buffer_closure) },
+        { be_const_key(offset, -1), be_const_var(1) },
+        { be_const_key(dirty, -1), be_const_closure(class_Leds_segment_dirty_closure) },
+        { be_const_key(can_show, -1), be_const_closure(class_Leds_segment_can_show_closure) },
+        { be_const_key(set_pixel_color, 6), be_const_closure(class_Leds_segment_set_pixel_color_closure) },
+        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_segment_get_pixel_color_closure) },
+        { be_const_key(pixel_count, -1), be_const_closure(class_Leds_segment_pixel_count_closure) },
+        { be_const_key(strip, 7), be_const_var(0) },
+        { be_const_key(leds, -1), be_const_var(2) },
+        { be_const_key(begin, -1), be_const_closure(class_Leds_segment_begin_closure) },
+        { be_const_key(is_dirty, 8), be_const_closure(class_Leds_segment_is_dirty_closure) },
+        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_segment_pixel_size_closure) },
+        { be_const_key(init, -1), be_const_closure(class_Leds_segment_init_closure) },
+        { be_const_key(clear, 2), be_const_closure(class_Leds_segment_clear_closure) },
+    })),
+    (bstring*) &be_const_str_Leds_segment
+);
+// compact class 'Leds' ktab size: 33, total: 65 (saved 256 bytes)
+static const bvalue be_ktab_class_Leds[33] = {
+  /* K0   */  be_nested_str(call_native),
+  /* K1   */  be_nested_str(bri),
+  /* K2   */  be_const_class(be_class_Leds),
+  /* K3   */  be_nested_str(Leds),
+  /* K4   */  be_nested_str(create_matrix),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_const_int(3),
+  /* K7   */  be_nested_str(gamma),
+  /* K8   */  be_const_int(2),
+  /* K9   */  be_nested_str(WS2812_GRB),
+  /* K10  */  be_nested_str(leds),
+  /* K11  */  be_nested_str(value_error),
+  /* K12  */  be_nested_str(out_X20of_X20range),
+  /* K13  */  be_const_class(be_class_Leds_matrix),
+  /* K14  */  be_nested_str(to_gamma),
+  /* K15  */  be_const_class(be_class_Leds_segment),
+  /* K16  */  be_nested_str(gpio),
+  /* K17  */  be_nested_str(pin),
+  /* K18  */  be_nested_str(WS2812),
+  /* K19  */  be_nested_str(ctor),
+  /* K20  */  be_nested_str(pixel_count),
+  /* K21  */  be_nested_str(light),
+  /* K22  */  be_nested_str(get),
+  /* K23  */  be_nested_str(_p),
+  /* K24  */  be_nested_str(internal_error),
+  /* K25  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
+  /* K26  */  be_nested_str(begin),
+  /* K27  */  be_nested_str(clear_to),
+  /* K28  */  be_nested_str(show),
+  /* K29  */  be_const_int(1),
+  /* K30  */  be_nested_str(apply_bri_gamma),
+  /* K31  */  be_nested_str(pixel_size),
+  /* K32  */  be_nested_str(_change_buffer),
+};
+
+
+extern const bclass be_class_Leds;
+
+/********************************************************************
+** Solidified function: is_dirty
+********************************************************************/
+be_local_closure(class_Leds_is_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1435,11 +1165,11 @@ be_local_closure(class_Leds_pixel_count,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_pixel_count,
+    &be_const_str_is_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E0007,  //  0001  LDINT	R3	8
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0003,  //  0001  LDINT	R3	4
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
     })
@@ -1465,8 +1195,102 @@ be_local_closure(class_Leds_get_bri,   /* name */
     &be_const_str_get_bri,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
       0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: matrix
+********************************************************************/
+be_local_closure(class_Leds_matrix,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_matrix,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x58100002,  //  0000  LDCONST	R4	K2
+      0xB8160600,  //  0001  GETNGBL	R5	K3
+      0x08180001,  //  0002  MUL	R6	R0	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C140600,  //  0005  CALL	R5	3
+      0x8C180B04,  //  0006  GETMET	R6	R5	K4
+      0x5C200000,  //  0007  MOVE	R8	R0
+      0x5C240200,  //  0008  MOVE	R9	R1
+      0x58280005,  //  0009  LDCONST	R10	K5
+      0x7C180800,  //  000A  CALL	R6	4
+      0x80040C00,  //  000B  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: can_show
+********************************************************************/
+be_local_closure(class_Leds_can_show,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_can_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0006,  //  0001  LDCONST	R3	K6
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_bri
+********************************************************************/
+be_local_closure(class_Leds_set_bri,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_bri,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x14080305,  //  0000  LT	R2	R1	K5
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x58040005,  //  0002  LDCONST	R1	K5
+      0x540A00FE,  //  0003  LDINT	R2	255
+      0x24080202,  //  0004  GT	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540600FE,  //  0006  LDINT	R1	255
+      0x90020201,  //  0007  SETMBR	R0	K1	R1
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -1493,7 +1317,7 @@ be_local_closure(class_Leds_set_gamma,   /* name */
       0x60080017,  //  0000  GETGBL	R2	G23
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x90021602,  //  0003  SETMBR	R0	K11	R2
+      0x90020E02,  //  0003  SETMBR	R0	K7	R2
       0x80000000,  //  0004  RET	0
     })
   )
@@ -1502,37 +1326,9 @@ be_local_closure(class_Leds_set_gamma,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_pixel_color
+** Solidified function: show
 ********************************************************************/
-be_local_closure(class_Leds_get_pixel_color,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C080106,  //  0000  GETMET	R2	R0	K6
-      0x5412000A,  //  0001  LDINT	R4	11
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C080600,  //  0003  CALL	R2	3
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: dirty
-********************************************************************/
-be_local_closure(class_Leds_dirty,   /* name */
+be_local_closure(class_Leds_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1543,11 +1339,11 @@ be_local_closure(class_Leds_dirty,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_dirty,
+    &be_const_str_show,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E0004,  //  0001  LDINT	R3	5
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0008,  //  0001  LDCONST	R3	K8
       0x7C040400,  //  0002  CALL	R1	2
       0x80000000,  //  0003  RET	0
     })
@@ -1557,106 +1353,12 @@ be_local_closure(class_Leds_dirty,   /* name */
 
 
 /********************************************************************
-** Solidified function: matrix
+** Solidified function: ctor
 ********************************************************************/
-be_local_closure(class_Leds_matrix,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    4,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_matrix,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x58100018,  //  0000  LDCONST	R4	K24
-      0xB8163200,  //  0001  GETNGBL	R5	K25
-      0x08180001,  //  0002  MUL	R6	R0	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C140600,  //  0005  CALL	R5	3
-      0x8C180B1A,  //  0006  GETMET	R6	R5	K26
-      0x5C200000,  //  0007  MOVE	R8	R0
-      0x5C240200,  //  0008  MOVE	R9	R1
-      0x58280001,  //  0009  LDCONST	R10	K1
-      0x7C180800,  //  000A  CALL	R6	4
-      0x80040C00,  //  000B  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_offset
-********************************************************************/
-be_local_closure(class_Leds_pixel_offset,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_pixel_offset,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80060200,  //  0000  RET	1	K1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_to
-********************************************************************/
-be_local_closure(class_Leds_clear_to,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_clear_to,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080105,  //  0003  GETMBR	R2	R0	K5
-      0x8C0C0106,  //  0004  GETMET	R3	R0	K6
-      0x54160008,  //  0005  LDINT	R5	9
-      0x8C18011B,  //  0006  GETMET	R6	R0	K27
-      0x5C200200,  //  0007  MOVE	R8	R1
-      0x5C240400,  //  0008  MOVE	R9	R2
-      0x7C180600,  //  0009  CALL	R6	3
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_set_pixel_color,   /* name */
+be_local_closure(class_Leds_ctor,   /* name */
   be_nested_proto(
     12,                          /* nstack */
-    4,                          /* argc */
+    5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1664,22 +1366,28 @@ be_local_closure(class_Leds_set_pixel_color,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_set_pixel_color,
+    &be_const_str_ctor,
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100604,  //  0001  EQ	R4	R3	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0105,  //  0003  GETMBR	R3	R0	K5
-      0x8C100106,  //  0004  GETMET	R4	R0	K6
-      0x541A0009,  //  0005  LDINT	R6	10
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x8C20011B,  //  0007  GETMET	R8	R0	K27
-      0x5C280400,  //  0008  MOVE	R10	R2
-      0x5C2C0600,  //  0009  MOVE	R11	R3
-      0x7C200600,  //  000A  CALL	R8	3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[19]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140405,  //  0001  EQ	R5	R2	R5
+      0x78160003,  //  0002  JMPF	R5	#0007
+      0x8C140100,  //  0003  GETMET	R5	R0	K0
+      0x581C0005,  //  0004  LDCONST	R7	K5
+      0x7C140400,  //  0005  CALL	R5	2
+      0x7002000A,  //  0006  JMP		#0012
+      0x4C140000,  //  0007  LDNIL	R5
+      0x1C140605,  //  0008  EQ	R5	R3	R5
+      0x78160000,  //  0009  JMPF	R5	#000B
+      0x880C0109,  //  000A  GETMBR	R3	R0	K9
+      0x8C140100,  //  000B  GETMET	R5	R0	K0
+      0x581C0005,  //  000C  LDCONST	R7	K5
+      0x5C200200,  //  000D  MOVE	R8	R1
+      0x5C240400,  //  000E  MOVE	R9	R2
+      0x5C280600,  //  000F  MOVE	R10	R3
+      0x5C2C0800,  //  0010  MOVE	R11	R4
+      0x7C140C00,  //  0011  CALL	R5	6
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -1703,10 +1411,114 @@ be_local_closure(class_Leds_pixel_size,   /* name */
     &be_const_str_pixel_size,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x540E0006,  //  0001  LDINT	R3	7
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Leds_dirty,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0004,  //  0001  LDINT	R3	5
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_offset
+********************************************************************/
+be_local_closure(class_Leds_pixel_offset,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixel_offset,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80060A00,  //  0000  RET	1	K5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_get_pixel_color,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5412000A,  //  0001  LDINT	R4	11
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C080600,  //  0003  CALL	R2	3
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_gamma
+********************************************************************/
+be_local_closure(class_Leds_get_gamma,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_gamma,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1745,21 +1557,21 @@ be_local_closure(class_Leds_create_matrix,   /* name */
       0x4C100000,  //  000C  LDNIL	R4
       0x1C100604,  //  000D  EQ	R4	R3	R4
       0x78120000,  //  000E  JMPF	R4	#0010
-      0x580C0001,  //  000F  LDCONST	R3	K1
+      0x580C0005,  //  000F  LDCONST	R3	K5
       0x08100202,  //  0010  MUL	R4	R1	R2
       0x00100803,  //  0011  ADD	R4	R4	R3
-      0x88140100,  //  0012  GETMBR	R5	R0	K0
+      0x8814010A,  //  0012  GETMBR	R5	R0	K10
       0x24100805,  //  0013  GT	R4	R4	R5
       0x74120005,  //  0014  JMPT	R4	#001B
-      0x14100501,  //  0015  LT	R4	R2	K1
+      0x14100505,  //  0015  LT	R4	R2	K5
       0x74120003,  //  0016  JMPT	R4	#001B
-      0x14100301,  //  0017  LT	R4	R1	K1
+      0x14100305,  //  0017  LT	R4	R1	K5
       0x74120001,  //  0018  JMPT	R4	#001B
-      0x14100701,  //  0019  LT	R4	R3	K1
+      0x14100705,  //  0019  LT	R4	R3	K5
       0x78120000,  //  001A  JMPF	R4	#001C
-      0xB0060503,  //  001B  RAISE	1	K2	K3
-      0x5810001C,  //  001C  LDCONST	R4	K28
-      0xB400001C,  //  001D  CLASS	K28
+      0xB006170C,  //  001B  RAISE	1	K11	K12
+      0x5810000D,  //  001C  LDCONST	R4	K13
+      0xB400000D,  //  001D  CLASS	K13
       0x5C140800,  //  001E  MOVE	R5	R4
       0x5C180000,  //  001F  MOVE	R6	R0
       0x5C1C0200,  //  0020  MOVE	R7	R1
@@ -1774,183 +1586,9 @@ be_local_closure(class_Leds_create_matrix,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_gamma
+** Solidified function: clear_to
 ********************************************************************/
-be_local_closure(class_Leds_get_gamma,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_get_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x8804010B,  //  0000  GETMBR	R1	R0	K11
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_dirty
-********************************************************************/
-be_local_closure(class_Leds_is_dirty,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_is_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E0003,  //  0001  LDINT	R3	4
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: can_show
-********************************************************************/
-be_local_closure(class_Leds_can_show,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_can_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x580C001D,  //  0001  LDCONST	R3	K29
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: assign_rmt
-********************************************************************/
-be_local_closure(class_Leds_assign_rmt,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_assign_rmt,
-    &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
-      0x58040018,  //  0000  LDCONST	R1	K24
-      0x60080009,  //  0001  GETGBL	R2	G9
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x5C000400,  //  0004  MOVE	R0	R2
-      0x14080101,  //  0005  LT	R2	R0	K1
-      0x780A0000,  //  0006  JMPF	R2	#0008
-      0xB006051E,  //  0007  RAISE	1	K2	K30
-      0xA40A3E00,  //  0008  IMPORT	R2	K31
-      0x4C0C0000,  //  0009  LDNIL	R3
-      0x8C100520,  //  000A  GETMET	R4	R2	K32
-      0x58180021,  //  000B  LDCONST	R6	K33
-      0x7C100400,  //  000C  CALL	R4	2
-      0x74120021,  //  000D  JMPT	R4	#0030
-      0x60100012,  //  000E  GETGBL	R4	G18
-      0x7C100000,  //  000F  CALL	R4	0
-      0x5C0C0800,  //  0010  MOVE	R3	R4
-      0x900A4203,  //  0011  SETMBR	R2	K33	R3
-      0x60100010,  //  0012  GETGBL	R4	G16
-      0xB8161400,  //  0013  GETNGBL	R5	K10
-      0x88140B22,  //  0014  GETMBR	R5	R5	K34
-      0x04140B07,  //  0015  SUB	R5	R5	K7
-      0x40160205,  //  0016  CONNECT	R5	K1	R5
-      0x7C100200,  //  0017  CALL	R4	1
-      0xA8020005,  //  0018  EXBLK	0	#001F
-      0x5C140800,  //  0019  MOVE	R5	R4
-      0x7C140000,  //  001A  CALL	R5	0
-      0x8C180723,  //  001B  GETMET	R6	R3	K35
-      0x5421FFFE,  //  001C  LDINT	R8	-1
-      0x7C180400,  //  001D  CALL	R6	2
-      0x7001FFF9,  //  001E  JMP		#0019
-      0x58100024,  //  001F  LDCONST	R4	K36
-      0xAC100200,  //  0020  CATCH	R4	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0xB8121400,  //  0022  GETNGBL	R4	K10
-      0x8C100925,  //  0023  GETMET	R4	R4	K37
-      0xB81A1400,  //  0024  GETNGBL	R6	K10
-      0x88180D0D,  //  0025  GETMBR	R6	R6	K13
-      0x581C0001,  //  0026  LDCONST	R7	K1
-      0x7C100600,  //  0027  CALL	R4	3
-      0x78120006,  //  0028  JMPF	R4	#0030
-      0xB8121400,  //  0029  GETNGBL	R4	K10
-      0x8C10090C,  //  002A  GETMET	R4	R4	K12
-      0xB81A1400,  //  002B  GETNGBL	R6	K10
-      0x88180D0D,  //  002C  GETMBR	R6	R6	K13
-      0x581C0001,  //  002D  LDCONST	R7	K1
-      0x7C100600,  //  002E  CALL	R4	3
-      0x980E0204,  //  002F  SETIDX	R3	K1	R4
-      0x880C0521,  //  0030  GETMBR	R3	R2	K33
-      0x58100001,  //  0031  LDCONST	R4	K1
-      0x5415FFFE,  //  0032  LDINT	R5	-1
-      0xB81A1400,  //  0033  GETNGBL	R6	K10
-      0x88180D22,  //  0034  GETMBR	R6	R6	K34
-      0x14180806,  //  0035  LT	R6	R4	R6
-      0x781A000A,  //  0036  JMPF	R6	#0042
-      0x94180604,  //  0037  GETIDX	R6	R3	R4
-      0x1C1C0C00,  //  0038  EQ	R7	R6	R0
-      0x781E0000,  //  0039  JMPF	R7	#003B
-      0x80040800,  //  003A  RET	1	R4
-      0x141C0D01,  //  003B  LT	R7	R6	K1
-      0x781E0002,  //  003C  JMPF	R7	#0040
-      0x141C0B01,  //  003D  LT	R7	R5	K1
-      0x781E0000,  //  003E  JMPF	R7	#0040
-      0x5C140800,  //  003F  MOVE	R5	R4
-      0x00100907,  //  0040  ADD	R4	R4	K7
-      0x7001FFF0,  //  0041  JMP		#0033
-      0x28180B01,  //  0042  GE	R6	R5	K1
-      0x781A0001,  //  0043  JMPF	R6	#0046
-      0x980C0A00,  //  0044  SETIDX	R3	R5	R0
-      0x80040A00,  //  0045  RET	1	R5
-      0xB0062726,  //  0046  RAISE	1	K19	K38
-      0x80000000,  //  0047  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: ctor
-********************************************************************/
-be_local_closure(class_Leds_ctor,   /* name */
+be_local_closure(class_Leds_clear_to,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     5,                          /* argc */
@@ -1961,35 +1599,301 @@ be_local_closure(class_Leds_ctor,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_ctor,
+    &be_const_str_clear_to,
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
+    ( &(const binstruction[28]) {  /* code */
       0x4C140000,  //  0000  LDNIL	R5
       0x1C140405,  //  0001  EQ	R5	R2	R5
-      0x78160003,  //  0002  JMPF	R5	#0007
-      0x8C140106,  //  0003  GETMET	R5	R0	K6
-      0x581C0001,  //  0004  LDCONST	R7	K1
-      0x7C140400,  //  0005  CALL	R5	2
-      0x70020011,  //  0006  JMP		#0019
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x4C140000,  //  0004  LDNIL	R5
+      0x20140605,  //  0005  NE	R5	R3	R5
+      0x7816000C,  //  0006  JMPF	R5	#0014
       0x4C140000,  //  0007  LDNIL	R5
-      0x1C140605,  //  0008  EQ	R5	R3	R5
-      0x78160000,  //  0009  JMPF	R5	#000B
-      0x880C0127,  //  000A  GETMBR	R3	R0	K39
-      0x4C140000,  //  000B  LDNIL	R5
-      0x1C140805,  //  000C  EQ	R5	R4	R5
-      0x78160003,  //  000D  JMPF	R5	#0012
-      0x8C140128,  //  000E  GETMET	R5	R0	K40
-      0x5C1C0400,  //  000F  MOVE	R7	R2
-      0x7C140400,  //  0010  CALL	R5	2
-      0x5C100A00,  //  0011  MOVE	R4	R5
-      0x8C140106,  //  0012  GETMET	R5	R0	K6
-      0x581C0001,  //  0013  LDCONST	R7	K1
-      0x5C200200,  //  0014  MOVE	R8	R1
-      0x5C240400,  //  0015  MOVE	R9	R2
-      0x5C280600,  //  0016  MOVE	R10	R3
-      0x5C2C0800,  //  0017  MOVE	R11	R4
-      0x7C140C00,  //  0018  CALL	R5	6
-      0x80000000,  //  0019  RET	0
+      0x20140805,  //  0008  NE	R5	R4	R5
+      0x78160009,  //  0009  JMPF	R5	#0014
+      0x8C140100,  //  000A  GETMET	R5	R0	K0
+      0x541E0008,  //  000B  LDINT	R7	9
+      0x8C20010E,  //  000C  GETMET	R8	R0	K14
+      0x5C280200,  //  000D  MOVE	R10	R1
+      0x5C2C0400,  //  000E  MOVE	R11	R2
+      0x7C200600,  //  000F  CALL	R8	3
+      0x5C240600,  //  0010  MOVE	R9	R3
+      0x5C280800,  //  0011  MOVE	R10	R4
+      0x7C140A00,  //  0012  CALL	R5	5
+      0x70020006,  //  0013  JMP		#001B
+      0x8C140100,  //  0014  GETMET	R5	R0	K0
+      0x541E0008,  //  0015  LDINT	R7	9
+      0x8C20010E,  //  0016  GETMET	R8	R0	K14
+      0x5C280200,  //  0017  MOVE	R10	R1
+      0x5C2C0400,  //  0018  MOVE	R11	R2
+      0x7C200600,  //  0019  CALL	R8	3
+      0x7C140600,  //  001A  CALL	R5	3
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_segment
+********************************************************************/
+be_local_closure(class_Leds_create_segment,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_create_segment,
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x600C0009,  //  0000  GETGBL	R3	G9
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x60100009,  //  0003  GETGBL	R4	G9
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C100200,  //  0005  CALL	R4	1
+      0x000C0604,  //  0006  ADD	R3	R3	R4
+      0x8810010A,  //  0007  GETMBR	R4	R0	K10
+      0x240C0604,  //  0008  GT	R3	R3	R4
+      0x740E0003,  //  0009  JMPT	R3	#000E
+      0x140C0305,  //  000A  LT	R3	R1	K5
+      0x740E0001,  //  000B  JMPT	R3	#000E
+      0x140C0505,  //  000C  LT	R3	R2	K5
+      0x780E0000,  //  000D  JMPF	R3	#000F
+      0xB006170C,  //  000E  RAISE	1	K11	K12
+      0x580C000F,  //  000F  LDCONST	R3	K15
+      0xB400000F,  //  0010  CLASS	K15
+      0x5C100600,  //  0011  MOVE	R4	R3
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C100600,  //  0015  CALL	R4	3
+      0x80040800,  //  0016  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_set_pixel_color,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120000,  //  0002  JMPF	R4	#0004
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x8C100100,  //  0004  GETMET	R4	R0	K0
+      0x541A0009,  //  0005  LDINT	R6	10
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x8C20010E,  //  0007  GETMET	R8	R0	K14
+      0x5C280400,  //  0008  MOVE	R10	R2
+      0x5C2C0600,  //  0009  MOVE	R11	R3
+      0x7C200600,  //  000A  CALL	R8	3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Leds_init,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[43]) {  /* code */
+      0xA4162000,  //  0000  IMPORT	R5	K16
+      0x50180200,  //  0001  LDBOOL	R6	1	0
+      0x90020E06,  //  0002  SETMBR	R0	K7	R6
+      0x4C180000,  //  0003  LDNIL	R6
+      0x1C180406,  //  0004  EQ	R6	R2	R6
+      0x741A0005,  //  0005  JMPT	R6	#000C
+      0x8C180B11,  //  0006  GETMET	R6	R5	K17
+      0x88200B12,  //  0007  GETMBR	R8	R5	K18
+      0x58240005,  //  0008  LDCONST	R9	K5
+      0x7C180600,  //  0009  CALL	R6	3
+      0x1C180406,  //  000A  EQ	R6	R2	R6
+      0x781A000A,  //  000B  JMPF	R6	#0017
+      0x8C180113,  //  000C  GETMET	R6	R0	K19
+      0x7C180200,  //  000D  CALL	R6	1
+      0x8C180114,  //  000E  GETMET	R6	R0	K20
+      0x7C180200,  //  000F  CALL	R6	1
+      0x90021406,  //  0010  SETMBR	R0	K10	R6
+      0xA41A2A00,  //  0011  IMPORT	R6	K21
+      0x8C1C0D16,  //  0012  GETMET	R7	R6	K22
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x941C0F01,  //  0014  GETIDX	R7	R7	K1
+      0x90020207,  //  0015  SETMBR	R0	K1	R7
+      0x7002000B,  //  0016  JMP		#0023
+      0x60180009,  //  0017  GETGBL	R6	G9
+      0x5C1C0200,  //  0018  MOVE	R7	R1
+      0x7C180200,  //  0019  CALL	R6	1
+      0x90021406,  //  001A  SETMBR	R0	K10	R6
+      0x541A007E,  //  001B  LDINT	R6	127
+      0x90020206,  //  001C  SETMBR	R0	K1	R6
+      0x8C180113,  //  001D  GETMET	R6	R0	K19
+      0x8820010A,  //  001E  GETMBR	R8	R0	K10
+      0x5C240400,  //  001F  MOVE	R9	R2
+      0x5C280600,  //  0020  MOVE	R10	R3
+      0x5C2C0800,  //  0021  MOVE	R11	R4
+      0x7C180A00,  //  0022  CALL	R6	5
+      0x88180117,  //  0023  GETMBR	R6	R0	K23
+      0x4C1C0000,  //  0024  LDNIL	R7
+      0x1C180C07,  //  0025  EQ	R6	R6	R7
+      0x781A0000,  //  0026  JMPF	R6	#0028
+      0xB0063119,  //  0027  RAISE	1	K24	K25
+      0x8C18011A,  //  0028  GETMET	R6	R0	K26
+      0x7C180200,  //  0029  CALL	R6	1
+      0x80000000,  //  002A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_Leds_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C04011B,  //  0000  GETMET	R1	R0	K27
+      0x580C0005,  //  0001  LDCONST	R3	K5
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C04011C,  //  0003  GETMET	R1	R0	K28
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(class_Leds_begin,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C001D,  //  0001  LDCONST	R3	K29
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_count
+********************************************************************/
+be_local_closure(class_Leds_pixel_count,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixel_count,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0007,  //  0001  LDINT	R3	8
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_gamma
+********************************************************************/
+be_local_closure(class_Leds_to_gamma,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_to_gamma,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x8C0C011E,  //  0004  GETMET	R3	R0	K30
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x881C0107,  //  0007  GETMBR	R7	R0	K7
+      0x7C0C0800,  //  0008  CALL	R3	4
+      0x80040600,  //  0009  RET	1	R3
     })
   )
 );
@@ -2013,7 +1917,7 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
     &be_const_str_pixels_buffer,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C080106,  //  0000  GETMET	R2	R0	K6
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
       0x54120005,  //  0001  LDINT	R4	6
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -2021,15 +1925,15 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
       0x780E0009,  //  0005  JMPF	R3	#0010
       0x600C0015,  //  0006  GETGBL	R3	G21
       0x5C100400,  //  0007  MOVE	R4	R2
-      0x8C140129,  //  0008  GETMET	R5	R0	K41
+      0x8C14011F,  //  0008  GETMET	R5	R0	K31
       0x7C140200,  //  0009  CALL	R5	1
-      0x8C18010F,  //  000A  GETMET	R6	R0	K15
+      0x8C180114,  //  000A  GETMET	R6	R0	K20
       0x7C180200,  //  000B  CALL	R6	1
       0x08140A06,  //  000C  MUL	R5	R5	R6
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80040600,  //  000E  RET	1	R3
       0x70020003,  //  000F  JMP		#0014
-      0x8C0C032A,  //  0010  GETMET	R3	R1	K42
+      0x8C0C0320,  //  0010  GETMET	R3	R1	K32
       0x5C140400,  //  0011  MOVE	R5	R2
       0x7C0C0400,  //  0012  CALL	R3	2
       0x80040200,  //  0013  RET	1	R1
@@ -2047,35 +1951,34 @@ extern const bclass be_class_Leds_ntv;
 be_local_class(Leds,
     3,
     &be_class_Leds_ntv,
-    be_nested_map(27,
+    be_nested_map(26,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(leds, -1), be_const_var(1) },
-        { be_const_key(create_segment, 25), be_const_closure(class_Leds_create_segment_closure) },
-        { be_const_key(clear, -1), be_const_closure(class_Leds_clear_closure) },
-        { be_const_key(begin, -1), be_const_closure(class_Leds_begin_closure) },
-        { be_const_key(ctor, 7), be_const_closure(class_Leds_ctor_closure) },
-        { be_const_key(assign_rmt, 12), be_const_static_closure(class_Leds_assign_rmt_closure) },
-        { be_const_key(to_gamma, 8), be_const_closure(class_Leds_to_gamma_closure) },
-        { be_const_key(dirty, -1), be_const_closure(class_Leds_dirty_closure) },
-        { be_const_key(matrix, -1), be_const_static_closure(class_Leds_matrix_closure) },
-        { be_const_key(pixel_offset, 2), be_const_closure(class_Leds_pixel_offset_closure) },
-        { be_const_key(set_gamma, 4), be_const_closure(class_Leds_set_gamma_closure) },
-        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_get_pixel_color_closure) },
-        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_pixel_size_closure) },
-        { be_const_key(create_matrix, -1), be_const_closure(class_Leds_create_matrix_closure) },
-        { be_const_key(set_bri, 9), be_const_closure(class_Leds_set_bri_closure) },
-        { be_const_key(clear_to, -1), be_const_closure(class_Leds_clear_to_closure) },
-        { be_const_key(set_pixel_color, -1), be_const_closure(class_Leds_set_pixel_color_closure) },
-        { be_const_key(gamma, -1), be_const_var(0) },
-        { be_const_key(pixel_count, 17), be_const_closure(class_Leds_pixel_count_closure) },
-        { be_const_key(get_bri, 13), be_const_closure(class_Leds_get_bri_closure) },
-        { be_const_key(get_gamma, -1), be_const_closure(class_Leds_get_gamma_closure) },
-        { be_const_key(bri, -1), be_const_var(2) },
         { be_const_key(is_dirty, -1), be_const_closure(class_Leds_is_dirty_closure) },
-        { be_const_key(can_show, -1), be_const_closure(class_Leds_can_show_closure) },
-        { be_const_key(init, 5), be_const_closure(class_Leds_init_closure) },
-        { be_const_key(show, -1), be_const_closure(class_Leds_show_closure) },
         { be_const_key(pixels_buffer, -1), be_const_closure(class_Leds_pixels_buffer_closure) },
+        { be_const_key(to_gamma, -1), be_const_closure(class_Leds_to_gamma_closure) },
+        { be_const_key(can_show, -1), be_const_closure(class_Leds_can_show_closure) },
+        { be_const_key(pixel_offset, -1), be_const_closure(class_Leds_pixel_offset_closure) },
+        { be_const_key(set_bri, 24), be_const_closure(class_Leds_set_bri_closure) },
+        { be_const_key(show, 2), be_const_closure(class_Leds_show_closure) },
+        { be_const_key(ctor, -1), be_const_closure(class_Leds_ctor_closure) },
+        { be_const_key(begin, 22), be_const_closure(class_Leds_begin_closure) },
+        { be_const_key(leds, -1), be_const_var(1) },
+        { be_const_key(set_pixel_color, -1), be_const_closure(class_Leds_set_pixel_color_closure) },
+        { be_const_key(dirty, 4), be_const_closure(class_Leds_dirty_closure) },
+        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_get_pixel_color_closure) },
+        { be_const_key(get_gamma, -1), be_const_closure(class_Leds_get_gamma_closure) },
+        { be_const_key(gamma, -1), be_const_var(0) },
+        { be_const_key(create_matrix, -1), be_const_closure(class_Leds_create_matrix_closure) },
+        { be_const_key(matrix, 8), be_const_static_closure(class_Leds_matrix_closure) },
+        { be_const_key(create_segment, -1), be_const_closure(class_Leds_create_segment_closure) },
+        { be_const_key(bri, 10), be_const_var(2) },
+        { be_const_key(init, -1), be_const_closure(class_Leds_init_closure) },
+        { be_const_key(clear, -1), be_const_closure(class_Leds_clear_closure) },
+        { be_const_key(get_bri, 9), be_const_closure(class_Leds_get_bri_closure) },
+        { be_const_key(clear_to, -1), be_const_closure(class_Leds_clear_to_closure) },
+        { be_const_key(pixel_count, -1), be_const_closure(class_Leds_pixel_count_closure) },
+        { be_const_key(set_gamma, -1), be_const_closure(class_Leds_set_gamma_closure) },
+        { be_const_key(pixel_size, 1), be_const_closure(class_Leds_pixel_size_closure) },
     })),
     (bstring*) &be_const_str_Leds
 );

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -562,14 +562,7 @@
 //  #define MAGICSWITCH_MASKING_WINDOW_LEN  5      // Overridable masking window (in number of 50ms loops)
 
 // -- Optional light modules ----------------------
-#define USE_LIGHT                                // Add support for light control
-#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
-//  #define USE_WS2812_DMA                         // ESP8266 only, DMA supports only GPIO03 (= Serial RXD) (+1k mem). When USE_WS2812_DMA is enabled expect Exceptions on Pow
-  #define USE_WS2812_RMT  0                      // ESP32 only, hardware RMT support (default). Specify the RMT channel 0..7. This should be preferred to software bit bang.
-//  #define USE_WS2812_I2S  0                      // ESP32 only, hardware I2S support. Specify the I2S channel 0..2. This is exclusive from RMT. By default, prefer RMT support
-//  #define USE_WS2812_INVERTED                    // Use inverted data signal
-  #define USE_WS2812_HARDWARE  NEO_HW_WS2812     // Hardware type (NEO_HW_WS2812, NEO_HW_WS2812X, NEO_HW_WS2813, NEO_HW_SK6812, NEO_HW_LC8812, NEO_HW_APA106, NEO_HW_P9813)
-  #define USE_WS2812_CTYPE     NEO_GRB           // Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
+#define USE_LIGHT                                // Add support for light control  
 #define USE_MY92X1                               // Add support for MY92X1 RGBCW led controller as used in Sonoff B1, Ailight and Lohas
 #define USE_SM16716                              // Add support for SM16716 RGB LED controller (+0k7 code)
 #define USE_SM2135                               // Add support for SM2135 RGBCW led control as used in Action LSC (+0k6 code)
@@ -582,6 +575,18 @@
 #define USE_LIGHT_VIRTUAL_CT                     // Add support for Virtual White Color Temperature (+1.1k code)
 #define USE_DGR_LIGHT_SEQUENCE                   // Add support for device group light sequencing (requires USE_DEVICE_GROUPS) (+0k2 code)
 //#define USE_LSC_MCSL                             // Add support for GPE Multi color smart light as sold by Action in the Netherlands (+1k1 code)
+
+// -- Optional adressable leds ----------------------
+#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
+// -------- below is for ESP8266 only
+//  #define USE_WS2812_DMA                         // ESP8266 only, DMA supports only GPIO03 (= Serial RXD) (+1k mem). When USE_WS2812_DMA is enabled expect Exceptions on Pow
+  #define USE_WS2812_RMT  0                      // ESP32 only, hardware RMT support (default). Specify the RMT channel 0..7. This should be preferred to software bit bang.
+//  #define USE_WS2812_I2S  0                      // ESP32 only, hardware I2S support. Specify the I2S channel 0..2. This is exclusive from RMT. By default, prefer RMT support
+//  #define USE_WS2812_INVERTED                    // Use inverted data signal
+  #define USE_WS2812_HARDWARE  NEO_HW_WS2812     // Hardware type (NEO_HW_WS2812, NEO_HW_WS2812X, NEO_HW_WS2813, NEO_HW_SK6812, NEO_HW_LC8812, NEO_HW_APA106, NEO_HW_P9813)
+  #define USE_WS2812_CTYPE     NEO_GRB           // Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
+// -------- below if for ESP32x only -- ESP32 uses a lightweight library instead of NeoPixelBus
+  // #define USE_WS2812_FORCE_NEOPIXELBUS           // this option forces to use NeoPixelBus (like ESP866), which disables Berry support and limits features -- DO NOT USE unless you have a good reason
 
 // #define USE_LIGHT_ARTNET                         // Add support for DMX/ArtNet via UDP on port 6454 (+3.5k code)
   #define USE_LIGHT_ARTNET_MCAST 239,255,25,54   // Multicast address used to listen: 239.255.25.54

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
@@ -386,7 +386,7 @@ bool ArtNetStart(void) {
           Settings->light_rotation = 0;
           Ws2812InitStrip();
         } else {
-          Ws2812Clear();
+          Ws2812Clear(true);
         }
       }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -24,22 +24,8 @@
 
 #ifdef USE_WS2812
 
-#include <NeoPixelBus.h>
-
-enum {
-  ws2812_grb = 1,
-  sk6812_grbw = 2,
-
-  neopixel_type_end
-};
-
-#ifdef CONFIG_IDF_TARGET_ESP32C2
-typedef NeoPixelBus<NeoGrbFeature, NeoEsp32SpiN800KbpsMethod> neopixel_ws2812_grb_t;
-typedef NeoPixelBus<NeoGrbwFeature, NeoEsp32SpiNSk6812Method> neopixel_sk6812_grbw_t;
-#else
-typedef NeoPixelBus<NeoGrbFeature, NeoEsp32RmtN800KbpsMethod> neopixel_ws2812_grb_t;
-typedef NeoPixelBus<NeoGrbwFeature, NeoEsp32RmtNSk6812Method> neopixel_sk6812_grbw_t;
-#endif
+#include "TasmotaLED.h"
+#include "TasmotaLEDPusher.h"
 
 /*********************************************************************************************\
  * Functions from Tasmota WS2812 driver
@@ -86,12 +72,12 @@ extern "C" {
   // # 22 : ShiftLeft    (rot:int [, first:int, last:int]) -> void
   // # 23 : ShiftRight   (rot:int [, first:int, last:int]) -> void
 
-  void * be_get_neopixelbus(bvm *vm) {
+  void * be_get_tasmotaled(bvm *vm) {
     be_getmember(vm, 1, "_p");
     void * strip = (void*) be_tocomptr(vm, -1);
     be_pop(vm, 1);
     if (strip == nullptr) {
-      be_raise(vm, "internal_error", "neopixelbus object not initialized");
+      be_raise(vm, "internal_error", "tasmotaled object not initialized");
     }
     return strip;
   }
@@ -99,70 +85,65 @@ extern "C" {
     be_getmember(vm, 1, "_t");
     int32_t type = be_toint(vm, -1);
     be_pop(vm, 1);
-    if (type < 0 || type >= neopixel_type_end) {
+    if (type < 0) {
       be_raise(vm, "internal_error", "invalid leds type");
     }
     return type;
   }
 
-  int be_neopixelbus_call_native(bvm *vm);
-  int be_neopixelbus_call_native(bvm *vm) {
+  int be_tasmotaled_call_native(bvm *vm);
+  int be_tasmotaled_call_native(bvm *vm) {
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 2 && be_isint(vm, 2)) {
       int32_t cmd = be_toint(vm, 2);
 
       if (0 == cmd) { // 00 : ctor         (leds:int, gpio:int) -> void
-        if ((argc != 2) && !(argc >= 6 && be_isint(vm, 3) && be_isint(vm, 4) && be_isint(vm, 5) && be_isint(vm, 6))) {
-          be_raise(vm, "value_error", "bad arguments for neopixelbus:ctor");
+        if ((argc != 2) && !(argc >= 5 && be_isint(vm, 3) && be_isint(vm, 4) && be_isint(vm, 5))) {
+          be_raise(vm, "value_error", "bad arguments for tasmotaled:ctor");
         }
         int32_t leds = -1;
         int32_t gpio = -1;
-        int32_t neopixel_type = 0;
-        int32_t rmt = 0;
-        void * strip = nullptr;
+        int32_t led_type = 0;
+        int32_t hardware = 0;
+        if (argc >= 6 && be_isint(vm, 6)) {
+          hardware = be_toint(vm, 6) & 0xFF0000;    // remove the low 16 bits to avoid any interference with legacy parameter for RMT channels
+        }
+        TasmotaLED * strip = nullptr;
         if (argc > 2) {
           leds = be_toint(vm, 3);
           gpio = be_toint(vm, 4);
-          neopixel_type = be_toint(vm, 5);
-          rmt = be_toint(vm, 6);
+          led_type = be_toint(vm, 5);
         }
 
         if (-1 == gpio) {
           // if GPIO is '-1'
-          neopixel_type = 0;
-          Ws2812InitStrip();          // ensure the NeoPixelbus object is initialized, because Berry code runs before the driver is initialized
-          strip = Ws2812GetStrip();
+          led_type = 0;
+          Ws2812InitStrip();          // ensure the tasmotaled object is initialized, because Berry code runs before the driver is initialized
+          // strip = Ws2812GetStrip(); TODO
         } else {
-          // allocate a new RMT
-          if (neopixel_type < 1) { neopixel_type = 1; }
-          if (neopixel_type >= neopixel_type_end) { neopixel_type = neopixel_type_end - 1; }
-          if (rmt < 0) { rmt = 0; }
-          if (rmt >= MAX_RMT) { rmt = MAX_RMT - 1; }
-
-          switch (neopixel_type) {
-            case ws2812_grb:    strip = new neopixel_ws2812_grb_t(leds, gpio, (NeoBusChannel) rmt);
-              break;
-            case sk6812_grbw:   strip = new neopixel_sk6812_grbw_t(leds, gpio, (NeoBusChannel) rmt);
-            break;
+          if (led_type < 1) { led_type = 1; }
+          TasmotaLEDPusher * pusher = TasmotaLEDPusher::Create(hardware, gpio);
+          if (pusher == nullptr) {
+            be_raise(vm, "value_error", "LED interface not supported");
           }
+          strip = new TasmotaLED(led_type, leds);
+          strip->SetPusher(pusher);
         }
 
+        // AddLog(LOG_LEVEL_DEBUG, "LED: leds %i gpio %i type %i", leds, gpio, led_type);
         // store type in attribute `_t`
-        be_pushint(vm, neopixel_type);
+        be_pushint(vm, led_type);
         be_setmember(vm, 1, "_t");
         be_pop(vm, 1);
 
-        be_pushcomptr(vm, (void*) strip);
+        be_pushcomptr(vm, (void*) strip);   // if native driver, it is NULL
         be_setmember(vm, 1, "_p");
         be_pop(vm, 1);
         be_pushnil(vm);
       } else {
-        // all other commands need a valid neopixelbus pointer
+        // all other commands need a valid tasmotaled pointer
         int32_t leds_type = be_get_leds_type(vm);
-        const void * s = be_get_neopixelbus(vm);    // raises an exception if pointer is invalid
-        // initialize all possible variants
-        neopixel_ws2812_grb_t * s_ws2812_grb = (leds_type == ws2812_grb) ? (neopixel_ws2812_grb_t*) s : nullptr;
-        neopixel_sk6812_grbw_t * s_sk6812_grbw = (leds_type == sk6812_grbw) ? (neopixel_sk6812_grbw_t*) s : nullptr;
+        TasmotaLED * strip = (TasmotaLED*) be_get_tasmotaled(vm);    // raises an exception if pointer is invalid
         // detect native driver
         bool native = (leds_type == 0);
 
@@ -171,8 +152,7 @@ extern "C" {
         switch (cmd) {
           case 1: // # 01 : begin        void -> void
             if (native)             Ws2812Begin();
-            if (s_ws2812_grb)       s_ws2812_grb->Begin();
-            if (s_sk6812_grbw)      s_sk6812_grbw->Begin();
+            else if (strip)              strip->Begin();
             break;
           case 2: // # 02 : show         void -> void
             {
@@ -195,49 +175,50 @@ extern "C" {
               }
             }
             uint32_t pixels_size;       // number of bytes to push
-            if (native)           { Ws2812Show(); pixels_size = Ws2812PixelsSize(); }
-            if (s_ws2812_grb)     { s_ws2812_grb->Show();   pixels_size = s_ws2812_grb->PixelsSize(); }
-            if (s_sk6812_grbw)    { s_sk6812_grbw->Show();  pixels_size = s_sk6812_grbw->PixelsSize(); }
+            bool update_completed = false;
+            if (native) {
+              Ws2812Show();
+              pixels_size = Ws2812PixelsSize();
+              update_completed =Ws2812CanShow();
+            }
+            else if (strip) {
+              strip->Show();
+              pixels_size = strip->PixelCount() * strip->PixelSize();
+              update_completed = strip->CanShow();
+            }
 
             // Wait for RMT/I2S to complete fixes distortion due to analogRead
             // 1ms is needed for 96 bytes
-            SystemBusyDelay((pixels_size + 95) / 96);
+            if (!update_completed) {
+              SystemBusyDelay((pixels_size + 95) / 96);
+            }
             }
             break;
           case 3: // # 03 : CanShow      void -> bool
             if (native)             be_pushbool(vm, Ws2812CanShow());
-            if (s_ws2812_grb)       be_pushbool(vm, s_ws2812_grb->CanShow());
-            if (s_sk6812_grbw)      be_pushbool(vm, s_sk6812_grbw->CanShow());
+            else if (strip)         be_pushbool(vm, strip->CanShow());
             break;
           case 4: // # 04 : IsDirty      void -> bool
             if (native)             be_pushbool(vm, Ws2812IsDirty());
-            if (s_ws2812_grb)       be_pushbool(vm, s_ws2812_grb->IsDirty());
-            if (s_sk6812_grbw)      be_pushbool(vm, s_sk6812_grbw->IsDirty());
+            else if (strip)         be_pushbool(vm, strip->IsDirty());
             break;
           case 5: // # 05 : Dirty        void -> void
             if (native)             Ws2812Dirty();
-            if (s_ws2812_grb)       s_ws2812_grb->Dirty();
-            if (s_sk6812_grbw)      s_sk6812_grbw->Dirty();
+            else if (strip)         strip->Dirty();
             break;
           case 6: // # 06 : Pixels       void -> bytes() (mapped to the buffer)
             {
-            uint8_t * pixels;
-            if (native)             pixels = Ws2812Pixels();
-            if (s_ws2812_grb)       pixels = s_ws2812_grb->Pixels();
-            if (s_sk6812_grbw)      pixels = s_sk6812_grbw->Pixels();
-
-            be_pushcomptr(vm, pixels);
+            if (native)             be_pushcomptr(vm, Ws2812Pixels());
+            else if (strip)         be_pushcomptr(vm, strip->Pixels());
             }
             break;
           case 7: // # 07 : PixelSize    void -> int
             if (native)             be_pushint(vm, Ws2812PixelSize());
-            if (s_ws2812_grb)       be_pushint(vm, s_ws2812_grb->PixelSize());
-            if (s_sk6812_grbw)      be_pushint(vm, s_sk6812_grbw->PixelSize());
+            else if (strip)         be_pushint(vm, strip->PixelSize());
             break;
           case 8: // # 08 : PixelCount   void -> int
             if (native)             be_pushint(vm, Ws2812PixelCount());
-            if (s_ws2812_grb)       be_pushint(vm, s_ws2812_grb->PixelCount());
-            if (s_sk6812_grbw)      be_pushint(vm, s_sk6812_grbw->PixelCount());
+            else if (strip)         be_pushint(vm, strip->PixelCount());
             break;
           case 9: // # 09 : ClearTo      (color:??) -> void
             {
@@ -253,42 +234,35 @@ extern "C" {
               if (len < 0)           { len = 0; }
 
               if (native)             Ws2812ClearTo(r, g, b, w, from, from + len - 1);
-              if (s_ws2812_grb)       s_ws2812_grb->ClearTo(RgbColor(r, g, b), from, from + len - 1);
-              if (s_sk6812_grbw)      s_sk6812_grbw->ClearTo(RgbwColor(r, g, b, w), from, from + len - 1);
+              else if (strip)         strip->ClearTo(rgbw, from, from + len - 1);
             } else {
               if (native)             Ws2812ClearTo(r, g, b, w, -1, -1);
-              if (s_ws2812_grb)       s_ws2812_grb->ClearTo(RgbColor(r, g, b));
-              if (s_sk6812_grbw)      s_sk6812_grbw->ClearTo(RgbwColor(r, g, b, w));
+              else if (strip)         strip->ClearTo(rgbw);
             }
             }
             break;
-          case 10: // # 10 : SetPixelColor (idx:int, color:??) -> void
+          case 10: // # 10 : SetPixelColor (idx:int, color:int wrgb) -> void
             {
             int32_t idx = be_toint(vm, 3);
-            uint32_t rgbw = be_toint(vm, 4);
-            uint8_t w = (rgbw >> 24) & 0xFF;
-            uint8_t r = (rgbw >> 16) & 0xFF;
-            uint8_t g = (rgbw >>  8) & 0xFF;
-            uint8_t b = (rgbw      ) & 0xFF;
-            if (native)             Ws2812SetPixelColor(idx, r, g, b, w);
-            if (s_ws2812_grb)       s_ws2812_grb->SetPixelColor(idx, RgbColor(r, g, b));
-            if (s_sk6812_grbw)      s_sk6812_grbw->SetPixelColor(idx, RgbwColor(r, g, b, w));
+            uint32_t wrgb = be_toint(vm, 4);
+            if (native) {
+              uint8_t w = (wrgb >> 24) & 0xFF;
+              uint8_t r = (wrgb >> 16) & 0xFF;
+              uint8_t g = (wrgb >>  8) & 0xFF;
+              uint8_t b = (wrgb      ) & 0xFF;
+              Ws2812SetPixelColor(idx, r, g, b, w);
+            } else if (strip) {
+              strip->SetPixelColor(idx, wrgb);
+            }
             }
             break;
-          case 11: // # 11 : GetPixelColor (idx:int) -> color:??
+          case 11: // # 11 : GetPixelColor (idx:int) -> color:int wrgb
             {
             int32_t idx = be_toint(vm, 3);
-
             if (native) {
               be_pushint(vm, Ws2812GetPixelColor(idx));
-            }
-            if (s_ws2812_grb) {
-              RgbColor rgb = s_ws2812_grb->GetPixelColor(idx);
-              be_pushint(vm, (rgb.R << 16) | (rgb.G << 8) | rgb.B);
-            }
-            if (s_sk6812_grbw) {
-              RgbwColor rgbw = s_sk6812_grbw->GetPixelColor(idx);
-              be_pushint(vm, (rgbw.W << 24) | (rgbw.R << 16) | (rgbw.G << 8) | rgbw.B);
+            } else if (strip) {
+              be_pushint(vm, strip->GetPixelColor(idx));
             }
             }
             break;


### PR DESCRIPTION
## Description:

Replace NeoPixelBus with TasmotaLED on ESP32x variants. Tasmota already started to diverge from NeoPixelBus with esp-idf 5.1 support, and we are using only a tiny fraction of the lib.

TasmotaLED focuses only on pushing raw pixels:
- support RMT and SPI. RMT is enabled on all RMT compatible devices, SPI is enabled on C2.
- I2S could be supported, but there is no current need and the code size is significant
- major change: internal buffers are `RRGGBB` to simplify encoding, conversion to `GGRRBB` is done when pushing the buffers
- `dirty` is not needed anymore, pixels are pushed anyways when calling `show()`
- ArtNet on ESP32 now requires RGB encoding and not GRB anymore

You can revert to NeoPixelBus with `#define USE_WS2812_FORCE_NEOPIXELBUS` but this disables Berry support.

No change on ESP8266

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
