### PR TITLE
add lp_core to Berry ULP module

### DIFF
--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -178,7 +178,7 @@ BERRY_LOCAL const bntvmodule_t* const be_module_table[] = {
     &be_native_module(partition_core),
     &be_native_module(crc),
     &be_native_module(crypto),
-#if defined(USE_BERRY_ULP) && ((CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
+#if defined(USE_BERRY_ULP) && defined(CONFIG_ULP_COPROC_ENABLED)
     &be_native_module(ULP),
 #endif // USE_BERRY_ULP
 #if defined(USE_BERRY_TF_LITE)

--- a/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
@@ -6,7 +6,7 @@
 #include "be_constobj.h"
 #include "be_mapping.h"
 
-#if defined(USE_BERRY_ULP) &&  (defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
+#if defined(USE_BERRY_ULP) && defined(CONFIG_ULP_COPROC_ENABLED)
 
 extern void be_ULP_run(int32_t entry);
 BE_FUNC_CTYPE_DECLARE(be_ULP_run, "", "[i]");


### PR DESCRIPTION
## Description:

Adding support for the low power coprocessor of the ESP32C6, which is named lp_core instead of ULP in the ESP-IDF, but for Tasmota it will be supported by the existing ULP module.
The internal changed API is abstracted away for the ULP module.
ADC  and some other things are not supported before ESP-IDF 5.4, but can be added in the future.

The recommended way for code generation is to build an ESP-IDF project and then use the web application of Tasmotas docs to convert this to a barebone application in Berry.
https://tasmota.github.io/docs/ULP/#export-from-esp-idf-project

The use of this lp_core will very likely stay a niche use case in the context of Tasmota, but the performance is pretty amazing. When diving down from the usual C code to hand optimized assembly, it is possible to create bursts of  200 nanoseconds. This allows bit banging with a WS2812 LED strip, that I could successfully control with the lp_core alone.
It clearly shows the potential to offload relevant work to this coprocessor in special applications.

Some cleanups of the code and removal of code sections for older ESP-IDF versions.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
