### PR TITLE
BUGFIX: fix LED, C2 has no i2s

### DIFF
--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -97,7 +97,7 @@ const uint16_t kTasLed_Type = kTasLed_PixelSize | kTasLed_PixelOrder | kTasLed_P
 
 // select hardware acceleration - bitbanging is not supported on ESP32 due to interference of interrupts
 #if CONFIG_IDF_TARGET_ESP32C2
-  const uint32_t kTasLed_Hardware = TasmotaLed_I2S;   // I2S
+  const uint32_t kTasLed_Hardware = TasmotaLed_SPI;   // no I2S for the C2
 #else // all other ESP32 variants
   #if defined(USE_WS2812_DMA)
     const uint32_t kTasLed_Hardware = TasmotaLed_RMT;   // default DMA to RMT


### PR DESCRIPTION
## Description:

SPI is the only way to support WS2812 on the C2.
Successfully tested with our new LED driver.

@Jason2866 Please check too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
