### PR TITLE
Expanded option72 for Shelly 3EM and other devices to only count import energy in today, yesterday and total.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
@@ -278,7 +278,13 @@ void EnergyUpdateToday(void) {
       int32_t delta = Energy->kWhtoday_delta[i] / 1000;
       delta_sum_balanced += delta;
       Energy->kWhtoday_delta[i] -= (delta * 1000);
+#ifdef USE_ADE7880
+      if (!Settings->flag3.hardware_energy_total || delta > 0) {     // Import energy
+      	Energy->kWhtoday[i] += delta;
+	  }
+#else
       Energy->kWhtoday[i] += delta;
+#endif
       if (delta < 0) {     // Export energy
         Energy->kWhtoday_export[i] += (delta *-1);
         if (Energy->kWhtoday_export[i] > 100) {


### PR DESCRIPTION
## Description:

I had an issue that energy today, energy yesterday and energy total where counting down when my solar panels where delivering more energy than I was using. 

For me this is unwanted behaviour because I have to know import and export energy separately for calculating the energy costs. I read that SetOption72 does this for some devices but it didnt't work for Shelly 3EM.

This code is a minor change so SetOption72 will also only count import energy llike mentioned in _https://github.com/arendst/Tasmota/issues/18446#issuecomment-1513006541_ and code https://github.com/arendst/Tasmota/blob/341cc87527be5e931bd69ce9720e9f3712302fa6/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino#L377

I don't know if this is the correct way to do this change, it works fine for me, but if it has to be another way, please change it or guide me what to change.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/22565

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
