### PR TITLE
CSE7761 reads also the negative power

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -503,6 +503,7 @@
 #define D_CMND_MAXENERGYSTART "MaxEnergyStart"
   #define D_JSON_ENERGYMONITOR "EnergyMonitor"
   #define D_JSON_MAXENERGYREACHED "MaxEnergyReached"
+#define D_CMND_NEGATIVEPOWER "NegativePower"
 
 // xsns_100_ina3221.ino
 #define  D_JSON_CHARGE "Charge"

--- a/tasmota/tasmota_xnrg_energy/xnrg_19_cse7761.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_19_cse7761.ino
@@ -481,7 +481,7 @@ void Cse7761GetData(void) {
     CSE7761Data.current_rms[0], CSE7761Data.current_rms[1],
     CSE7761Data.active_power[0], CSE7761Data.active_power[1]);
 
-  if (Energy->power_on) {  // Powered on
+  if (true || Energy->power_on) {  // Powered on <xxx] ALWAYS
     for (uint32_t channel = 0; channel < Energy->phase_count; channel++) {
       if (0 == channel) {
         // Voltage = RmsU * RmsUC * 10 / 0x400000


### PR DESCRIPTION
## Description:

The chip CSE7761 mounted i.e. in Sonoff POWCT is able to read the sense of the power. It's able to distinct if you consume power from the grid or if you feed the power into the grid. However the actual Tasmota reads always the absolute value.

This patch reads the also the Power Factor registers form the chip and when it's negative (you supply to the grid), inverts the sign of the power. Negative power means feed the grid, positive power means consume from the grid.
The Current and Voltage are always positive, change only the sign of the Active Power.

I've also set the resolution of Voltage resolution to one decimal digit and resolution of frequency to 2 decimal digints. It was 0 decimal digits. 

The second commit makes report values when the relay is off. In many applications the relay does not switch off the load, so it have no sense to do not report the results when the relay is off.

Tested with Sonoff POWCT with one channel only. The patch should handle both channels of the chip, but this is not tested.

## Checklist:
  - [done] The pull request is done against the latest development branch
  - [done] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [done] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241117
  - [done] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).


