### PR TITLE
WS2812 remove waits for RMT and SPI

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -186,12 +186,6 @@ extern "C" {
               pixels_size = strip->PixelCount() * strip->PixelSize();
               update_completed = strip->CanShow();
             }
-
-            // Wait for RMT/I2S to complete fixes distortion due to analogRead
-            // 1ms is needed for 96 bytes
-            if (!update_completed) {
-              SystemBusyDelay((pixels_size + 95) / 96);
-            }
             }
             break;
           case 3: // # 03 : CanShow      void -> bool

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -186,12 +186,6 @@ long wsmap(long x, long in_min, long in_max, long out_min, long out_max) {
 
 void Ws2812LibStripShow(void) {
   strip->Show();
-
-#if defined(USE_WS2812_DMA) || defined(USE_WS2812_RMT) || defined(USE_WS2812_I2S)
-  // Wait for DMA/RMT/I2S to complete fixes distortion due to analogRead
-//  delay((Settings->light_pixels >> 6) +1);  // 256 / 64 = 4 +1 = 5
-  SystemBusyDelay( (Settings->light_pixels + 31) >> 5);  // (256 + 32) / 32 = 8
-#endif
 }
 
 void Ws2812StripShow(void)


### PR DESCRIPTION
## Description:

With the new TasmotaLED, waits don't seem to be needed anymore for RMT and SPI. I tested with Ulanzi clock with ADC and SPI writes without any glitch

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
