### PR TITLE
Improved auto-selection of LED hardware support (RMT, SPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Command `SetOption162 1` to disable adding export energy to energy today (#22578)
 - ESP32 support for WPA2/3 Enterprise conditional in core v3.1.0.241206 (#22600)
 - Support for Sonoff POWCT Energy Export Active (#22596)
+- Improved auto-selection of LED hardware support (RMT, SPI)
 
 ### Breaking Changed
 - ESP32 ArtNet switches from GRB to RGB encoding (#22556)

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
@@ -44,10 +44,10 @@ enum TasmotaLEDTypesEncoding : uint16_t {
 enum TasmotaLEDHardware : uint32_t {
   // low-order bits are reserved for channels numbers and hardware flags - currenlty not useds
   // bits 16..23
-  TasmotaLed_HW_Default = 0x0 << 16,
-  TasmotaLed_RMT  = 1 << 16,
-  TasmotaLed_SPI  = 2 << 16,
-  TasmotaLed_I2S  = 3 << 16,
+  TasmotaLed_HW_Default = 0x000000,
+  TasmotaLed_RMT  = (1 << 0) << 16,
+  TasmotaLed_SPI  = (1 << 1) << 16,
+  TasmotaLed_I2S  = (1 << 2) << 16,
   TasmotaLed_HW_None = 0xFF << 16,    // indicates that the specified HW is not supported
 };
 

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
@@ -80,9 +80,11 @@ typedef struct TasmotaLED_Timing {
 \*******************************************************************************************/
 class TasmotaLEDPusher {
 public:
-  TasmotaLEDPusher() : _pixel_count(0), _pixel_size(0), _led_timing(nullptr) {};
+  TasmotaLEDPusher() : _initialized(false), _err(ESP_OK), _pixel_count(0), _pixel_size(0), _led_timing(nullptr) {};
   virtual ~TasmotaLEDPusher() {};
 
+  bool Initialized(void) const { return _initialized; }
+  esp_err_t Error(void) const { return _err; }
   virtual bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) {
     _pixel_count = pixel_count;
     _pixel_size = pixel_size;
@@ -96,6 +98,8 @@ public:
   static TasmotaLEDPusher * Create(uint32_t hw, int8_t gpio);   // create instance for the provided type, or nullptr if failed
   
 protected:
+  bool _initialized;                              // did the hardware got correctly initialized
+  esp_err_t _err;
   uint16_t _pixel_count;
   uint16_t _pixel_size;
   const TasmotaLED_Timing * _led_timing;
@@ -110,7 +114,7 @@ protected:
 #include "driver/rmt_tx.h"
 class TasmotaLEDPusherRMT : public TasmotaLEDPusher {
 public:
-  TasmotaLEDPusherRMT(int8_t pin) : _pin(pin) {};
+  TasmotaLEDPusherRMT(int8_t pin);
   ~TasmotaLEDPusherRMT();
 
   bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) override;
@@ -144,7 +148,7 @@ typedef struct led_strip_spi_obj_t {
 
 class TasmotaLEDPusherSPI : public TasmotaLEDPusher {
 public:
-  TasmotaLEDPusherSPI(int8_t pin) : _pin(pin), _spi_strip({}) {};
+  TasmotaLEDPusherSPI(int8_t pin);
   ~TasmotaLEDPusherSPI();
 
   bool Begin(uint16_t pixel_count, uint16_t pixel_size, const TasmotaLED_Timing * led_timing) override;
@@ -154,7 +158,8 @@ public:
   
 protected:
   int8_t _pin;
-  struct led_strip_spi_obj_t _spi_strip;
+  struct led_strip_spi_obj_t _spi_strip = {};;
+  const bool _with_dma = true;
 };
 #endif  // TASMOTALED_HARDWARE_SPI
 

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -95,20 +95,8 @@ const uint16_t kTasLed_PixelWhite = TasmotaLed_xxxW;
 
 const uint16_t kTasLed_Type = kTasLed_PixelSize | kTasLed_PixelOrder | kTasLed_PixelWhite | kTasLed_Timing;
 
-// select hardware acceleration - bitbanging is not supported on ESP32 due to interference of interrupts
-#if CONFIG_IDF_TARGET_ESP32C2
-  const uint32_t kTasLed_Hardware = TasmotaLed_SPI;   // no I2S for the C2
-#else // all other ESP32 variants
-  #if defined(USE_WS2812_DMA)
-    const uint32_t kTasLed_Hardware = TasmotaLed_RMT;   // default DMA to RMT
-  #elif defined(USE_WS2812_RMT)
-    const uint32_t kTasLed_Hardware = TasmotaLed_RMT;   // default DMA to RMT
-  #elif defined(USE_WS2812_I2S)
-    const uint32_t kTasLed_Hardware = TasmotaLed_I2S;   // I2S
-  #else
-    const uint32_t kTasLed_Hardware = TasmotaLed_RMT;   // default DMA to RMT
-  #endif
-#endif
+// select hardware acceleration - bitbanging is not supported on ESP32 due to interference of interrupts - use default
+const uint32_t kTasLed_Hardware = TasmotaLed_HW_Default;   // use whatever is available
 
 #if (USE_WS2812_HARDWARE == NEO_HW_P9813)
   #error "P9813 is not supported by this library"


### PR DESCRIPTION
## Description:

Improved hardware support selection for LEDs. Selection is now a bit-field for RMT, SPI, I2S. Hardware fallbacks to SPI if RMT is already full (if SPI is supported at compile time)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
