### PR TITLE
FIX: custom_berry_solidify does now handle double quotation marks too

### DIFF
--- a/pio-tools/solidify-from-url.py
+++ b/pio-tools/solidify-from-url.py
@@ -53,7 +53,7 @@ def addEntryToModtab(source):
     is_module = False
 
 
-    pattern = (r'''(?<=module\()[^"].*''')  # module??
+    pattern = (r'''(?<=module\([\"\']).*[\"\']''')  # module??
     result =  re.findall(pattern,code)
     if len(result) > 0:
         class_name = result[0].replace("'","").replace('"','').replace(")","")


### PR DESCRIPTION
## Description:

Solidifying custom Berry code did fail in the check for modules, when double quotation marks were used:
```
#@ solidify:fonts
var fonts = module("fonts") # would produce linker failure before, must have been module('fonts') before
```

Make regex more flexible for different quotation marks now. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
