### PR TITLE
Berry make Leds animate calls reentrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- Berry make Leds animate calls reentrant
 
 ### Fixed
 - ESP32 rules operation priority regression from v13.3.0.4 (#22636)

--- a/lib/libesp32/berry_animate/src/embedded/animate_1_core.be
+++ b/lib/libesp32/berry_animate/src/embedded/animate_1_core.be
@@ -110,6 +110,14 @@ class Animate_core
     self.strip.clear()
   end
   def start()
+    # check if the strip had a different animate object, stop it
+    var prev_animate = self.strip.get_animate()
+    import introspect
+    if (prev_animate != nil) && (type(prev_animate) == 'instance') && (prev_animate != self)
+      prev_animate.stop()
+    end
+    self.strip.set_animate(self)
+
     self.running = true
     var animators = self.animators
     var idx = 0

--- a/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
+++ b/lib/libesp32/berry_animate/src/solidify/solidified_animate_1_core.h
@@ -3,8 +3,8 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'Animate_core' ktab size: 48, total: 98 (saved 400 bytes)
-static const bvalue be_ktab_class_Animate_core[48] = {
+// compact class 'Animate_core' ktab size: 52, total: 104 (saved 416 bytes)
+static const bvalue be_ktab_class_Animate_core[52] = {
   /* K0   */  be_nested_str_weak(stop),
   /* K1   */  be_nested_str_weak(strip),
   /* K2   */  be_nested_str_weak(clear),
@@ -51,8 +51,12 @@ static const bvalue be_ktab_class_Animate_core[48] = {
   /* K43  */  be_nested_str_weak(set_cb),
   /* K44  */  be_nested_str_weak(set_back_color),
   /* K45  */  be_nested_str_weak(add_animator),
-  /* K46  */  be_nested_str_weak(start),
-  /* K47  */  be_nested_str_weak(add_fast_loop),
+  /* K46  */  be_nested_str_weak(get_animate),
+  /* K47  */  be_nested_str_weak(introspect),
+  /* K48  */  be_nested_str_weak(instance),
+  /* K49  */  be_nested_str_weak(set_animate),
+  /* K50  */  be_nested_str_weak(start),
+  /* K51  */  be_nested_str_weak(add_fast_loop),
 };
 
 
@@ -716,7 +720,7 @@ be_local_closure(class_Animate_core_remove,   /* name */
 ********************************************************************/
 be_local_closure(class_Animate_core_start,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -727,27 +731,47 @@ be_local_closure(class_Animate_core_start,   /* name */
     &be_ktab_class_Animate_core,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x50040200,  //  0000  LDBOOL	R1	1	0
-      0x90021601,  //  0001  SETMBR	R0	K11	R1
-      0x8804010C,  //  0002  GETMBR	R1	R0	K12
-      0x58080007,  //  0003  LDCONST	R2	K7
-      0x600C000C,  //  0004  GETGBL	R3	G12
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x140C0403,  //  0007  LT	R3	R2	R3
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C0C072E,  //  000A  GETMET	R3	R3	K46
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x0008050D,  //  000C  ADD	R2	R2	K13
-      0x7001FFF5,  //  000D  JMP		#0004
-      0x90022707,  //  000E  SETMBR	R0	K19	K7
-      0xB80E0800,  //  000F  GETNGBL	R3	K4
-      0x8C0C072F,  //  0010  GETMET	R3	R3	K47
-      0x8814010F,  //  0011  GETMBR	R5	R0	K15
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x80000000,  //  0013  RET	0
+    ( &(const binstruction[40]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x8C04032E,  //  0001  GETMET	R1	R1	K46
+      0x7C040200,  //  0002  CALL	R1	1
+      0xA40A5E00,  //  0003  IMPORT	R2	K47
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x200C0203,  //  0005  NE	R3	R1	R3
+      0x780E0008,  //  0006  JMPF	R3	#0010
+      0x600C0004,  //  0007  GETGBL	R3	G4
+      0x5C100200,  //  0008  MOVE	R4	R1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x1C0C0730,  //  000A  EQ	R3	R3	K48
+      0x780E0003,  //  000B  JMPF	R3	#0010
+      0x200C0200,  //  000C  NE	R3	R1	R0
+      0x780E0001,  //  000D  JMPF	R3	#0010
+      0x8C0C0300,  //  000E  GETMET	R3	R1	K0
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x880C0101,  //  0010  GETMBR	R3	R0	K1
+      0x8C0C0731,  //  0011  GETMET	R3	R3	K49
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x500C0200,  //  0014  LDBOOL	R3	1	0
+      0x90021603,  //  0015  SETMBR	R0	K11	R3
+      0x880C010C,  //  0016  GETMBR	R3	R0	K12
+      0x58100007,  //  0017  LDCONST	R4	K7
+      0x6014000C,  //  0018  GETGBL	R5	G12
+      0x5C180600,  //  0019  MOVE	R6	R3
+      0x7C140200,  //  001A  CALL	R5	1
+      0x14140805,  //  001B  LT	R5	R4	R5
+      0x78160004,  //  001C  JMPF	R5	#0022
+      0x94140604,  //  001D  GETIDX	R5	R3	R4
+      0x8C140B32,  //  001E  GETMET	R5	R5	K50
+      0x7C140200,  //  001F  CALL	R5	1
+      0x0010090D,  //  0020  ADD	R4	R4	K13
+      0x7001FFF5,  //  0021  JMP		#0018
+      0x90022707,  //  0022  SETMBR	R0	K19	K7
+      0xB8160800,  //  0023  GETNGBL	R5	K4
+      0x8C140B33,  //  0024  GETMET	R5	R5	K51
+      0x881C010F,  //  0025  GETMBR	R7	R0	K15
+      0x7C140400,  //  0026  CALL	R5	2
+      0x80000000,  //  0027  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/be_leds_ntv_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_leds_ntv_lib.c
@@ -16,7 +16,6 @@ extern int be_leds_apply_bri_gamma(bvm *vm);
 /* @const_object_info_begin
 class be_class_Leds_ntv (scope: global, name: Leds_ntv, strings: weak) {
   _p, var
-  _t, var
 
   WS2812_GRB, int(ws2812_grb)
   SK6812_GRBW, int(sk6812_grbw)

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -3,9 +3,471 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
+extern const bclass be_class_Leds_segment;
 extern const bclass be_class_Leds;
 extern const bclass be_class_Leds_matrix;
+// compact class 'Leds_segment' ktab size: 16, total: 34 (saved 144 bytes)
+static const bvalue be_ktab_class_Leds_segment[16] = {
+  /* K0   */  be_nested_str(offset),
+  /* K1   */  be_nested_str(bri),
+  /* K2   */  be_nested_str(strip),
+  /* K3   */  be_nested_str(call_native),
+  /* K4   */  be_nested_str(to_gamma),
+  /* K5   */  be_nested_str(leds),
+  /* K6   */  be_nested_str(dirty),
+  /* K7   */  be_nested_str(can_show),
+  /* K8   */  be_nested_str(set_pixel_color),
+  /* K9   */  be_nested_str(is_dirty),
+  /* K10  */  be_nested_str(clear_to),
+  /* K11  */  be_const_int(0),
+  /* K12  */  be_nested_str(show),
+  /* K13  */  be_nested_str(get_pixel_color),
+  /* K14  */  be_nested_str(offseta),
+  /* K15  */  be_nested_str(pixel_size),
+};
+
+
 extern const bclass be_class_Leds_segment;
+
+/********************************************************************
+** Solidified function: pixel_offset
+********************************************************************/
+be_local_closure(class_Leds_segment_pixel_offset,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_offset,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear_to
+********************************************************************/
+be_local_closure(class_Leds_segment_clear_to,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_clear_to,
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
+      0x54160008,  //  0006  LDINT	R5	9
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x8C180D04,  //  0008  GETMET	R6	R6	K4
+      0x5C200200,  //  0009  MOVE	R8	R1
+      0x5C240400,  //  000A  MOVE	R9	R2
+      0x7C180600,  //  000B  CALL	R6	3
+      0x881C0100,  //  000C  GETMBR	R7	R0	K0
+      0x88200105,  //  000D  GETMBR	R8	R0	K5
+      0x7C0C0A00,  //  000E  CALL	R3	5
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_count
+********************************************************************/
+be_local_closure(class_Leds_segment_pixel_count,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_count,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixels_buffer
+********************************************************************/
+be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixels_buffer,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Leds_segment_dirty,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040306,  //  0001  GETMET	R1	R1	K6
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: can_show
+********************************************************************/
+be_local_closure(class_Leds_segment_can_show,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_can_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_set_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120000,  //  0002  JMPF	R4	#0004
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x8C100908,  //  0005  GETMET	R4	R4	K8
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
+      0x00180206,  //  0007  ADD	R6	R1	R6
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x5C200600,  //  0009  MOVE	R8	R3
+      0x7C100800,  //  000A  CALL	R4	4
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_dirty
+********************************************************************/
+be_local_closure(class_Leds_segment_is_dirty,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_is_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_Leds_segment_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
+      0x580C000B,  //  0001  LDCONST	R3	K11
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C04010C,  //  0003  GETMET	R1	R0	K12
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(class_Leds_segment_begin,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pixel_color
+********************************************************************/
+be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_get_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88080102,  //  0000  GETMBR	R2	R0	K2
+      0x8C08050D,  //  0001  GETMET	R2	R2	K13
+      0x8810010E,  //  0002  GETMBR	R4	R0	K14
+      0x00100204,  //  0003  ADD	R4	R1	R4
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_size
+********************************************************************/
+be_local_closure(class_Leds_segment_pixel_size,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_pixel_size,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040102,  //  0000  GETMBR	R1	R0	K2
+      0x8C04030F,  //  0001  GETMET	R1	R1	K15
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Leds_segment_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020401,  //  0000  SETMBR	R0	K2	R1
+      0x60100009,  //  0001  GETGBL	R4	G9
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x90020004,  //  0004  SETMBR	R0	K0	R4
+      0x60100009,  //  0005  GETGBL	R4	G9
+      0x5C140600,  //  0006  MOVE	R5	R3
+      0x7C100200,  //  0007  CALL	R4	1
+      0x90020A04,  //  0008  SETMBR	R0	K5	R4
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show
+********************************************************************/
+be_local_closure(class_Leds_segment_show,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds_segment,     /* shared constants */
+    &be_const_str_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0007,  //  0003  JMPT	R2	#000C
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x1C08050B,  //  0005  EQ	R2	R2	K11
+      0x780A0007,  //  0006  JMPF	R2	#000F
+      0x88080105,  //  0007  GETMBR	R2	R0	K5
+      0x880C0102,  //  0008  GETMBR	R3	R0	K2
+      0x880C0705,  //  0009  GETMBR	R3	R3	K5
+      0x1C080403,  //  000A  EQ	R2	R2	R3
+      0x780A0002,  //  000B  JMPF	R2	#000F
+      0x88080102,  //  000C  GETMBR	R2	R0	K2
+      0x8C08050C,  //  000D  GETMET	R2	R2	K12
+      0x7C080200,  //  000E  CALL	R2	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Leds_segment
+********************************************************************/
+be_local_class(Leds_segment,
+    3,
+    NULL,
+    be_nested_map(17,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(pixel_offset, 9), be_const_closure(class_Leds_segment_pixel_offset_closure) },
+        { be_const_key(clear_to, -1), be_const_closure(class_Leds_segment_clear_to_closure) },
+        { be_const_key(show, -1), be_const_closure(class_Leds_segment_show_closure) },
+        { be_const_key(pixels_buffer, 10), be_const_closure(class_Leds_segment_pixels_buffer_closure) },
+        { be_const_key(offset, -1), be_const_var(1) },
+        { be_const_key(dirty, -1), be_const_closure(class_Leds_segment_dirty_closure) },
+        { be_const_key(can_show, -1), be_const_closure(class_Leds_segment_can_show_closure) },
+        { be_const_key(set_pixel_color, 6), be_const_closure(class_Leds_segment_set_pixel_color_closure) },
+        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_segment_get_pixel_color_closure) },
+        { be_const_key(pixel_count, -1), be_const_closure(class_Leds_segment_pixel_count_closure) },
+        { be_const_key(strip, 7), be_const_var(0) },
+        { be_const_key(leds, -1), be_const_var(2) },
+        { be_const_key(begin, -1), be_const_closure(class_Leds_segment_begin_closure) },
+        { be_const_key(is_dirty, 8), be_const_closure(class_Leds_segment_is_dirty_closure) },
+        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_segment_pixel_size_closure) },
+        { be_const_key(init, -1), be_const_closure(class_Leds_segment_init_closure) },
+        { be_const_key(clear, 2), be_const_closure(class_Leds_segment_clear_closure) },
+    })),
+    (bstring*) &be_const_str_Leds_segment
+);
 // compact class 'Leds_matrix' ktab size: 24, total: 62 (saved 304 bytes)
 static const bvalue be_ktab_class_Leds_matrix[24] = {
   /* K0   */  be_nested_str(strip),
@@ -649,60 +1111,58 @@ be_local_class(Leds_matrix,
     })),
     (bstring*) &be_const_str_Leds_matrix
 );
-// compact class 'Leds_segment' ktab size: 16, total: 34 (saved 144 bytes)
-static const bvalue be_ktab_class_Leds_segment[16] = {
-  /* K0   */  be_nested_str(offset),
-  /* K1   */  be_nested_str(bri),
-  /* K2   */  be_nested_str(strip),
-  /* K3   */  be_nested_str(call_native),
-  /* K4   */  be_nested_str(to_gamma),
-  /* K5   */  be_nested_str(leds),
-  /* K6   */  be_nested_str(dirty),
-  /* K7   */  be_nested_str(can_show),
-  /* K8   */  be_nested_str(set_pixel_color),
-  /* K9   */  be_nested_str(is_dirty),
-  /* K10  */  be_nested_str(clear_to),
-  /* K11  */  be_const_int(0),
-  /* K12  */  be_nested_str(show),
-  /* K13  */  be_nested_str(get_pixel_color),
-  /* K14  */  be_nested_str(offseta),
-  /* K15  */  be_nested_str(pixel_size),
+// compact class 'Leds' ktab size: 39, total: 74 (saved 280 bytes)
+static const bvalue be_ktab_class_Leds[39] = {
+  /* K0   */  be_nested_str(leds),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str(value_error),
+  /* K3   */  be_nested_str(out_X20of_X20range),
+  /* K4   */  be_const_class(be_class_Leds_segment),
+  /* K5   */  be_nested_str(gamma),
+  /* K6   */  be_const_class(be_class_Leds),
+  /* K7   */  be_nested_str(Leds),
+  /* K8   */  be_nested_str(create_matrix),
+  /* K9   */  be_nested_str(call_native),
+  /* K10  */  be_nested_str(pixel_size),
+  /* K11  */  be_nested_str(pixel_count),
+  /* K12  */  be_nested_str(_change_buffer),
+  /* K13  */  be_nested_str(animate),
+  /* K14  */  be_const_int(2),
+  /* K15  */  be_nested_str(bri),
+  /* K16  */  be_nested_str(to_gamma),
+  /* K17  */  be_nested_str(clear_to),
+  /* K18  */  be_nested_str(show),
+  /* K19  */  be_nested_str(apply_bri_gamma),
+  /* K20  */  be_const_int(1),
+  /* K21  */  be_const_class(be_class_Leds_matrix),
+  /* K22  */  be_const_int(3),
+  /* K23  */  be_nested_str(gpio),
+  /* K24  */  be_nested_str(pin),
+  /* K25  */  be_nested_str(WS2812),
+  /* K26  */  be_nested_str(ctor),
+  /* K27  */  be_nested_str(light),
+  /* K28  */  be_nested_str(get),
+  /* K29  */  be_nested_str(global),
+  /* K30  */  be_nested_str(contains),
+  /* K31  */  be_nested_str(_lhw),
+  /* K32  */  be_nested_str(find),
+  /* K33  */  be_nested_str(number_X20of_X20leds_X20do_X20not_X20match_X20with_X20previous_X20instanciation_X20_X25s_X20vs_X20_X25s),
+  /* K34  */  be_nested_str(_p),
+  /* K35  */  be_nested_str(begin),
+  /* K36  */  be_nested_str(internal_error),
+  /* K37  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
+  /* K38  */  be_nested_str(WS2812_GRB),
 };
 
 
-extern const bclass be_class_Leds_segment;
+extern const bclass be_class_Leds;
 
 /********************************************************************
-** Solidified function: pixel_offset
+** Solidified function: create_segment
 ********************************************************************/
-be_local_closure(class_Leds_segment_pixel_offset,   /* name */
+be_local_closure(class_Leds_create_segment,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_offset,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_to
-********************************************************************/
-be_local_closure(class_Leds_segment_clear_to,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -710,26 +1170,33 @@ be_local_closure(class_Leds_segment_clear_to,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_clear_to,
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_create_segment,
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
-      0x880C0102,  //  0004  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
-      0x54160008,  //  0006  LDINT	R5	9
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x8C180D04,  //  0008  GETMET	R6	R6	K4
-      0x5C200200,  //  0009  MOVE	R8	R1
-      0x5C240400,  //  000A  MOVE	R9	R2
-      0x7C180600,  //  000B  CALL	R6	3
-      0x881C0100,  //  000C  GETMBR	R7	R0	K0
-      0x88200105,  //  000D  GETMBR	R8	R0	K5
-      0x7C0C0A00,  //  000E  CALL	R3	5
-      0x80000000,  //  000F  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x600C0009,  //  0000  GETGBL	R3	G9
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x60100009,  //  0003  GETGBL	R4	G9
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C100200,  //  0005  CALL	R4	1
+      0x000C0604,  //  0006  ADD	R3	R3	R4
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x240C0604,  //  0008  GT	R3	R3	R4
+      0x740E0003,  //  0009  JMPT	R3	#000E
+      0x140C0301,  //  000A  LT	R3	R1	K1
+      0x740E0001,  //  000B  JMPT	R3	#000E
+      0x140C0501,  //  000C  LT	R3	R2	K1
+      0x780E0000,  //  000D  JMPF	R3	#000F
+      0xB0060503,  //  000E  RAISE	1	K2	K3
+      0x580C0004,  //  000F  LDCONST	R3	K4
+      0xB4000004,  //  0010  CLASS	K4
+      0x5C100600,  //  0011  MOVE	R4	R3
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C100600,  //  0015  CALL	R4	3
+      0x80040800,  //  0016  RET	1	R4
     })
   )
 );
@@ -737,9 +1204,9 @@ be_local_closure(class_Leds_segment_clear_to,   /* name */
 
 
 /********************************************************************
-** Solidified function: pixel_count
+** Solidified function: get_gamma
 ********************************************************************/
-be_local_closure(class_Leds_segment_pixel_count,   /* name */
+be_local_closure(class_Leds_get_gamma,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -749,453 +1216,11 @@ be_local_closure(class_Leds_segment_pixel_count,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_count,
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_gamma,
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040105,  //  0000  GETMBR	R1	R0	K5
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixels_buffer
-********************************************************************/
-be_local_closure(class_Leds_segment_pixels_buffer,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixels_buffer,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: dirty
-********************************************************************/
-be_local_closure(class_Leds_segment_dirty,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040306,  //  0001  GETMET	R1	R1	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: can_show
-********************************************************************/
-be_local_closure(class_Leds_segment_can_show,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_can_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040307,  //  0001  GETMET	R1	R1	K7
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_segment_set_pixel_color,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_set_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100604,  //  0001  EQ	R4	R3	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x8C100908,  //  0005  GETMET	R4	R4	K8
-      0x88180100,  //  0006  GETMBR	R6	R0	K0
-      0x00180206,  //  0007  ADD	R6	R1	R6
-      0x5C1C0400,  //  0008  MOVE	R7	R2
-      0x5C200600,  //  0009  MOVE	R8	R3
-      0x7C100800,  //  000A  CALL	R4	4
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_dirty
-********************************************************************/
-be_local_closure(class_Leds_segment_is_dirty,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_is_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C040309,  //  0001  GETMET	R1	R1	K9
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(class_Leds_segment_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C04010A,  //  0000  GETMET	R1	R0	K10
-      0x580C000B,  //  0001  LDCONST	R3	K11
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C04010C,  //  0003  GETMET	R1	R0	K12
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin
-********************************************************************/
-be_local_closure(class_Leds_segment_begin,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_begin,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_segment_get_pixel_color,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88080102,  //  0000  GETMBR	R2	R0	K2
-      0x8C08050D,  //  0001  GETMET	R2	R2	K13
-      0x8810010E,  //  0002  GETMBR	R4	R0	K14
-      0x00100204,  //  0003  ADD	R4	R1	R4
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_size
-********************************************************************/
-be_local_closure(class_Leds_segment_pixel_size,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_pixel_size,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040102,  //  0000  GETMBR	R1	R0	K2
-      0x8C04030F,  //  0001  GETMET	R1	R1	K15
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Leds_segment_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x90020401,  //  0000  SETMBR	R0	K2	R1
-      0x60100009,  //  0001  GETGBL	R4	G9
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x90020004,  //  0004  SETMBR	R0	K0	R4
-      0x60100009,  //  0005  GETGBL	R4	G9
-      0x5C140600,  //  0006  MOVE	R5	R3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x90020A04,  //  0008  SETMBR	R0	K5	R4
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show
-********************************************************************/
-be_local_closure(class_Leds_segment_show,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds_segment,     /* shared constants */
-    &be_const_str_show,
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x740A0007,  //  0003  JMPT	R2	#000C
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x1C08050B,  //  0005  EQ	R2	R2	K11
-      0x780A0007,  //  0006  JMPF	R2	#000F
-      0x88080105,  //  0007  GETMBR	R2	R0	K5
-      0x880C0102,  //  0008  GETMBR	R3	R0	K2
-      0x880C0705,  //  0009  GETMBR	R3	R3	K5
-      0x1C080403,  //  000A  EQ	R2	R2	R3
-      0x780A0002,  //  000B  JMPF	R2	#000F
-      0x88080102,  //  000C  GETMBR	R2	R0	K2
-      0x8C08050C,  //  000D  GETMET	R2	R2	K12
-      0x7C080200,  //  000E  CALL	R2	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: Leds_segment
-********************************************************************/
-be_local_class(Leds_segment,
-    3,
-    NULL,
-    be_nested_map(17,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(pixel_offset, 9), be_const_closure(class_Leds_segment_pixel_offset_closure) },
-        { be_const_key(clear_to, -1), be_const_closure(class_Leds_segment_clear_to_closure) },
-        { be_const_key(show, -1), be_const_closure(class_Leds_segment_show_closure) },
-        { be_const_key(pixels_buffer, 10), be_const_closure(class_Leds_segment_pixels_buffer_closure) },
-        { be_const_key(offset, -1), be_const_var(1) },
-        { be_const_key(dirty, -1), be_const_closure(class_Leds_segment_dirty_closure) },
-        { be_const_key(can_show, -1), be_const_closure(class_Leds_segment_can_show_closure) },
-        { be_const_key(set_pixel_color, 6), be_const_closure(class_Leds_segment_set_pixel_color_closure) },
-        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_segment_get_pixel_color_closure) },
-        { be_const_key(pixel_count, -1), be_const_closure(class_Leds_segment_pixel_count_closure) },
-        { be_const_key(strip, 7), be_const_var(0) },
-        { be_const_key(leds, -1), be_const_var(2) },
-        { be_const_key(begin, -1), be_const_closure(class_Leds_segment_begin_closure) },
-        { be_const_key(is_dirty, 8), be_const_closure(class_Leds_segment_is_dirty_closure) },
-        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_segment_pixel_size_closure) },
-        { be_const_key(init, -1), be_const_closure(class_Leds_segment_init_closure) },
-        { be_const_key(clear, 2), be_const_closure(class_Leds_segment_clear_closure) },
-    })),
-    (bstring*) &be_const_str_Leds_segment
-);
-// compact class 'Leds' ktab size: 33, total: 65 (saved 256 bytes)
-static const bvalue be_ktab_class_Leds[33] = {
-  /* K0   */  be_nested_str(call_native),
-  /* K1   */  be_nested_str(bri),
-  /* K2   */  be_const_class(be_class_Leds),
-  /* K3   */  be_nested_str(Leds),
-  /* K4   */  be_nested_str(create_matrix),
-  /* K5   */  be_const_int(0),
-  /* K6   */  be_const_int(3),
-  /* K7   */  be_nested_str(gamma),
-  /* K8   */  be_const_int(2),
-  /* K9   */  be_nested_str(WS2812_GRB),
-  /* K10  */  be_nested_str(leds),
-  /* K11  */  be_nested_str(value_error),
-  /* K12  */  be_nested_str(out_X20of_X20range),
-  /* K13  */  be_const_class(be_class_Leds_matrix),
-  /* K14  */  be_nested_str(to_gamma),
-  /* K15  */  be_const_class(be_class_Leds_segment),
-  /* K16  */  be_nested_str(gpio),
-  /* K17  */  be_nested_str(pin),
-  /* K18  */  be_nested_str(WS2812),
-  /* K19  */  be_nested_str(ctor),
-  /* K20  */  be_nested_str(pixel_count),
-  /* K21  */  be_nested_str(light),
-  /* K22  */  be_nested_str(get),
-  /* K23  */  be_nested_str(_p),
-  /* K24  */  be_nested_str(internal_error),
-  /* K25  */  be_nested_str(couldn_X27t_X20not_X20initialize_X20noepixelbus),
-  /* K26  */  be_nested_str(begin),
-  /* K27  */  be_nested_str(clear_to),
-  /* K28  */  be_nested_str(show),
-  /* K29  */  be_const_int(1),
-  /* K30  */  be_nested_str(apply_bri_gamma),
-  /* K31  */  be_nested_str(pixel_size),
-  /* K32  */  be_nested_str(_change_buffer),
-};
-
-
-extern const bclass be_class_Leds;
-
-/********************************************************************
-** Solidified function: is_dirty
-********************************************************************/
-be_local_closure(class_Leds_is_dirty,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_is_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0003,  //  0001  LDINT	R3	4
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bri
-********************************************************************/
-be_local_closure(class_Leds_get_bri,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_get_bri,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1220,16 +1245,16 @@ be_local_closure(class_Leds_matrix,   /* name */
     &be_const_str_matrix,
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x58100002,  //  0000  LDCONST	R4	K2
-      0xB8160600,  //  0001  GETNGBL	R5	K3
+      0x58100006,  //  0000  LDCONST	R4	K6
+      0xB8160E00,  //  0001  GETNGBL	R5	K7
       0x08180001,  //  0002  MUL	R6	R0	R1
       0x5C1C0400,  //  0003  MOVE	R7	R2
       0x5C200600,  //  0004  MOVE	R8	R3
       0x7C140600,  //  0005  CALL	R5	3
-      0x8C180B04,  //  0006  GETMET	R6	R5	K4
+      0x8C180B08,  //  0006  GETMET	R6	R5	K8
       0x5C200000,  //  0007  MOVE	R8	R0
       0x5C240200,  //  0008  MOVE	R9	R1
-      0x58280005,  //  0009  LDCONST	R10	K5
+      0x58280001,  //  0009  LDCONST	R10	K1
       0x7C180800,  //  000A  CALL	R6	4
       0x80040C00,  //  000B  RET	1	R6
     })
@@ -1239,11 +1264,55 @@ be_local_closure(class_Leds_matrix,   /* name */
 
 
 /********************************************************************
-** Solidified function: can_show
+** Solidified function: pixels_buffer
 ********************************************************************/
-be_local_closure(class_Leds_can_show,   /* name */
+be_local_closure(class_Leds_pixels_buffer,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_pixels_buffer,
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C080109,  //  0000  GETMET	R2	R0	K9
+      0x54120005,  //  0001  LDINT	R4	6
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0203,  //  0004  EQ	R3	R1	R3
+      0x780E0009,  //  0005  JMPF	R3	#0010
+      0x600C0015,  //  0006  GETGBL	R3	G21
+      0x5C100400,  //  0007  MOVE	R4	R2
+      0x8C14010A,  //  0008  GETMET	R5	R0	K10
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C18010B,  //  000A  GETMET	R6	R0	K11
+      0x7C180200,  //  000B  CALL	R6	1
+      0x08140A06,  //  000C  MUL	R5	R5	R6
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80040600,  //  000E  RET	1	R3
+      0x70020003,  //  000F  JMP		#0014
+      0x8C0C030C,  //  0010  GETMET	R3	R1	K12
+      0x5C140400,  //  0011  MOVE	R5	R2
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x80040200,  //  0013  RET	1	R1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_animate
+********************************************************************/
+be_local_closure(class_Leds_get_animate,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1252,73 +1321,11 @@ be_local_closure(class_Leds_can_show,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_can_show,
+    &be_const_str_get_animate,
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0006,  //  0001  LDCONST	R3	K6
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bri
-********************************************************************/
-be_local_closure(class_Leds_set_bri,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_set_bri,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x14080305,  //  0000  LT	R2	R1	K5
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x58040005,  //  0002  LDCONST	R1	K5
-      0x540A00FE,  //  0003  LDINT	R2	255
-      0x24080202,  //  0004  GT	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540600FE,  //  0006  LDINT	R1	255
-      0x90020201,  //  0007  SETMBR	R0	K1	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_gamma
-********************************************************************/
-be_local_closure(class_Leds_set_gamma,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_set_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020E02,  //  0003  SETMBR	R0	K7	R2
-      0x80000000,  //  0004  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1342,8 +1349,8 @@ be_local_closure(class_Leds_show,   /* name */
     &be_const_str_show,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0008,  //  0001  LDCONST	R3	K8
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x580C000E,  //  0001  LDCONST	R3	K14
       0x7C040400,  //  0002  CALL	R1	2
       0x80000000,  //  0003  RET	0
     })
@@ -1353,12 +1360,12 @@ be_local_closure(class_Leds_show,   /* name */
 
 
 /********************************************************************
-** Solidified function: ctor
+** Solidified function: set_pixel_color
 ********************************************************************/
-be_local_closure(class_Leds_ctor,   /* name */
+be_local_closure(class_Leds_set_pixel_color,   /* name */
   be_nested_proto(
     12,                          /* nstack */
-    5,                          /* argc */
+    4,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1366,28 +1373,78 @@ be_local_closure(class_Leds_ctor,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_ctor,
+    &be_const_str_set_pixel_color,
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140405,  //  0001  EQ	R5	R2	R5
-      0x78160003,  //  0002  JMPF	R5	#0007
-      0x8C140100,  //  0003  GETMET	R5	R0	K0
-      0x581C0005,  //  0004  LDCONST	R7	K5
-      0x7C140400,  //  0005  CALL	R5	2
-      0x7002000A,  //  0006  JMP		#0012
-      0x4C140000,  //  0007  LDNIL	R5
-      0x1C140605,  //  0008  EQ	R5	R3	R5
-      0x78160000,  //  0009  JMPF	R5	#000B
-      0x880C0109,  //  000A  GETMBR	R3	R0	K9
-      0x8C140100,  //  000B  GETMET	R5	R0	K0
-      0x581C0005,  //  000C  LDCONST	R7	K5
-      0x5C200200,  //  000D  MOVE	R8	R1
-      0x5C240400,  //  000E  MOVE	R9	R2
-      0x5C280600,  //  000F  MOVE	R10	R3
-      0x5C2C0800,  //  0010  MOVE	R11	R4
-      0x7C140C00,  //  0011  CALL	R5	6
-      0x80000000,  //  0012  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120000,  //  0002  JMPF	R4	#0004
+      0x880C010F,  //  0003  GETMBR	R3	R0	K15
+      0x8C100109,  //  0004  GETMET	R4	R0	K9
+      0x541A0009,  //  0005  LDINT	R6	10
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x8C200110,  //  0007  GETMET	R8	R0	K16
+      0x5C280400,  //  0008  MOVE	R10	R2
+      0x5C2C0600,  //  0009  MOVE	R11	R3
+      0x7C200600,  //  000A  CALL	R8	3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_dirty
+********************************************************************/
+be_local_closure(class_Leds_is_dirty,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_is_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x540E0003,  //  0001  LDINT	R3	4
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_Leds_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040111,  //  0000  GETMET	R1	R0	K17
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C040112,  //  0003  GETMET	R1	R0	K18
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -1411,7 +1468,7 @@ be_local_closure(class_Leds_pixel_size,   /* name */
     &be_const_str_pixel_size,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
       0x540E0006,  //  0001  LDINT	R3	7
       0x7C040400,  //  0002  CALL	R1	2
       0x80040200,  //  0003  RET	1	R1
@@ -1422,9 +1479,9 @@ be_local_closure(class_Leds_pixel_size,   /* name */
 
 
 /********************************************************************
-** Solidified function: dirty
+** Solidified function: pixel_count
 ********************************************************************/
-be_local_closure(class_Leds_dirty,   /* name */
+be_local_closure(class_Leds_pixel_count,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1435,90 +1492,73 @@ be_local_closure(class_Leds_dirty,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_dirty,
+    &be_const_str_pixel_count,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0004,  //  0001  LDINT	R3	5
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x540E0007,  //  0001  LDINT	R3	8
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_gamma
+********************************************************************/
+be_local_closure(class_Leds_to_gamma,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_to_gamma,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x8808010F,  //  0003  GETMBR	R2	R0	K15
+      0x8C0C0113,  //  0004  GETMET	R3	R0	K19
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x881C0105,  //  0007  GETMBR	R7	R0	K5
+      0x7C0C0800,  //  0008  CALL	R3	4
+      0x80040600,  //  0009  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(class_Leds_begin,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x580C0014,  //  0001  LDCONST	R3	K20
       0x7C040400,  //  0002  CALL	R1	2
       0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_offset
-********************************************************************/
-be_local_closure(class_Leds_pixel_offset,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_pixel_offset,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80060A00,  //  0000  RET	1	K5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pixel_color
-********************************************************************/
-be_local_closure(class_Leds_get_pixel_color,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5412000A,  //  0001  LDINT	R4	11
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C080600,  //  0003  CALL	R2	3
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_gamma
-********************************************************************/
-be_local_closure(class_Leds_get_gamma,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_get_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040107,  //  0000  GETMBR	R1	R0	K7
-      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1557,21 +1597,21 @@ be_local_closure(class_Leds_create_matrix,   /* name */
       0x4C100000,  //  000C  LDNIL	R4
       0x1C100604,  //  000D  EQ	R4	R3	R4
       0x78120000,  //  000E  JMPF	R4	#0010
-      0x580C0005,  //  000F  LDCONST	R3	K5
+      0x580C0001,  //  000F  LDCONST	R3	K1
       0x08100202,  //  0010  MUL	R4	R1	R2
       0x00100803,  //  0011  ADD	R4	R4	R3
-      0x8814010A,  //  0012  GETMBR	R5	R0	K10
+      0x88140100,  //  0012  GETMBR	R5	R0	K0
       0x24100805,  //  0013  GT	R4	R4	R5
       0x74120005,  //  0014  JMPT	R4	#001B
-      0x14100505,  //  0015  LT	R4	R2	K5
+      0x14100501,  //  0015  LT	R4	R2	K1
       0x74120003,  //  0016  JMPT	R4	#001B
-      0x14100305,  //  0017  LT	R4	R1	K5
+      0x14100301,  //  0017  LT	R4	R1	K1
       0x74120001,  //  0018  JMPT	R4	#001B
-      0x14100705,  //  0019  LT	R4	R3	K5
+      0x14100701,  //  0019  LT	R4	R3	K1
       0x78120000,  //  001A  JMPF	R4	#001C
-      0xB006170C,  //  001B  RAISE	1	K11	K12
-      0x5810000D,  //  001C  LDCONST	R4	K13
-      0xB400000D,  //  001D  CLASS	K13
+      0xB0060503,  //  001B  RAISE	1	K2	K3
+      0x58100015,  //  001C  LDCONST	R4	K21
+      0xB4000015,  //  001D  CLASS	K21
       0x5C140800,  //  001E  MOVE	R5	R4
       0x5C180000,  //  001F  MOVE	R6	R0
       0x5C1C0200,  //  0020  MOVE	R7	R1
@@ -1579,6 +1619,142 @@ be_local_closure(class_Leds_create_matrix,   /* name */
       0x5C240600,  //  0022  MOVE	R9	R3
       0x7C140800,  //  0023  CALL	R5	4
       0x80040A00,  //  0024  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dirty
+********************************************************************/
+be_local_closure(class_Leds_dirty,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_dirty,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x540E0004,  //  0001  LDINT	R3	5
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_bri
+********************************************************************/
+be_local_closure(class_Leds_set_bri,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_bri,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x14080301,  //  0000  LT	R2	R1	K1
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0x540A00FE,  //  0003  LDINT	R2	255
+      0x24080202,  //  0004  GT	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540600FE,  //  0006  LDINT	R1	255
+      0x90021E01,  //  0007  SETMBR	R0	K15	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: can_show
+********************************************************************/
+be_local_closure(class_Leds_can_show,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_can_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x580C0016,  //  0001  LDCONST	R3	K22
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_animate
+********************************************************************/
+be_local_closure(class_Leds_set_animate,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_set_animate,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90021A01,  //  0000  SETMBR	R0	K13	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bri
+********************************************************************/
+be_local_closure(class_Leds_get_bri,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_get_bri,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x8804010F,  //  0000  GETMBR	R1	R0	K15
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1605,16 +1781,16 @@ be_local_closure(class_Leds_clear_to,   /* name */
       0x4C140000,  //  0000  LDNIL	R5
       0x1C140405,  //  0001  EQ	R5	R2	R5
       0x78160000,  //  0002  JMPF	R5	#0004
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x8808010F,  //  0003  GETMBR	R2	R0	K15
       0x4C140000,  //  0004  LDNIL	R5
       0x20140605,  //  0005  NE	R5	R3	R5
       0x7816000C,  //  0006  JMPF	R5	#0014
       0x4C140000,  //  0007  LDNIL	R5
       0x20140805,  //  0008  NE	R5	R4	R5
       0x78160009,  //  0009  JMPF	R5	#0014
-      0x8C140100,  //  000A  GETMET	R5	R0	K0
+      0x8C140109,  //  000A  GETMET	R5	R0	K9
       0x541E0008,  //  000B  LDINT	R7	9
-      0x8C20010E,  //  000C  GETMET	R8	R0	K14
+      0x8C200110,  //  000C  GETMET	R8	R0	K16
       0x5C280200,  //  000D  MOVE	R10	R1
       0x5C2C0400,  //  000E  MOVE	R11	R2
       0x7C200600,  //  000F  CALL	R8	3
@@ -1622,9 +1798,9 @@ be_local_closure(class_Leds_clear_to,   /* name */
       0x5C280800,  //  0011  MOVE	R10	R4
       0x7C140A00,  //  0012  CALL	R5	5
       0x70020006,  //  0013  JMP		#001B
-      0x8C140100,  //  0014  GETMET	R5	R0	K0
+      0x8C140109,  //  0014  GETMET	R5	R0	K9
       0x541E0008,  //  0015  LDINT	R7	9
-      0x8C20010E,  //  0016  GETMET	R8	R0	K14
+      0x8C200110,  //  0016  GETMET	R8	R0	K16
       0x5C280200,  //  0017  MOVE	R10	R1
       0x5C2C0400,  //  0018  MOVE	R11	R2
       0x7C200600,  //  0019  CALL	R8	3
@@ -1637,12 +1813,12 @@ be_local_closure(class_Leds_clear_to,   /* name */
 
 
 /********************************************************************
-** Solidified function: create_segment
+** Solidified function: pixel_offset
 ********************************************************************/
-be_local_closure(class_Leds_create_segment,   /* name */
+be_local_closure(class_Leds_pixel_offset,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
+    1,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1650,32 +1826,10 @@ be_local_closure(class_Leds_create_segment,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_create_segment,
+    &be_const_str_pixel_offset,
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x600C0009,  //  0000  GETGBL	R3	G9
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x60100009,  //  0003  GETGBL	R4	G9
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C100200,  //  0005  CALL	R4	1
-      0x000C0604,  //  0006  ADD	R3	R3	R4
-      0x8810010A,  //  0007  GETMBR	R4	R0	K10
-      0x240C0604,  //  0008  GT	R3	R3	R4
-      0x740E0003,  //  0009  JMPT	R3	#000E
-      0x140C0305,  //  000A  LT	R3	R1	K5
-      0x740E0001,  //  000B  JMPT	R3	#000E
-      0x140C0505,  //  000C  LT	R3	R2	K5
-      0x780E0000,  //  000D  JMPF	R3	#000F
-      0xB006170C,  //  000E  RAISE	1	K11	K12
-      0x580C000F,  //  000F  LDCONST	R3	K15
-      0xB400000F,  //  0010  CLASS	K15
-      0x5C100600,  //  0011  MOVE	R4	R3
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C100600,  //  0015  CALL	R4	3
-      0x80040800,  //  0016  RET	1	R4
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80060200,  //  0000  RET	1	K1
     })
   )
 );
@@ -1683,12 +1837,12 @@ be_local_closure(class_Leds_create_segment,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_pixel_color
+** Solidified function: get_pixel_color
 ********************************************************************/
-be_local_closure(class_Leds_set_pixel_color,   /* name */
+be_local_closure(class_Leds_get_pixel_color,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1696,22 +1850,14 @@ be_local_closure(class_Leds_set_pixel_color,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_set_pixel_color,
+    &be_const_str_get_pixel_color,
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100604,  //  0001  EQ	R4	R3	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x8C100100,  //  0004  GETMET	R4	R0	K0
-      0x541A0009,  //  0005  LDINT	R6	10
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x8C20010E,  //  0007  GETMET	R8	R0	K14
-      0x5C280400,  //  0008  MOVE	R10	R2
-      0x5C2C0600,  //  0009  MOVE	R11	R3
-      0x7C200600,  //  000A  CALL	R8	3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C080109,  //  0000  GETMET	R2	R0	K9
+      0x5412000A,  //  0001  LDINT	R4	11
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C080600,  //  0003  CALL	R2	3
+      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -1734,50 +1880,97 @@ be_local_closure(class_Leds_init,   /* name */
     &be_ktab_class_Leds,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA4162000,  //  0000  IMPORT	R5	K16
+    ( &(const binstruction[90]) {  /* code */
+      0xA4162E00,  //  0000  IMPORT	R5	K23
       0x50180200,  //  0001  LDBOOL	R6	1	0
-      0x90020E06,  //  0002  SETMBR	R0	K7	R6
+      0x90020A06,  //  0002  SETMBR	R0	K5	R6
       0x4C180000,  //  0003  LDNIL	R6
-      0x1C180406,  //  0004  EQ	R6	R2	R6
-      0x741A0005,  //  0005  JMPT	R6	#000C
-      0x8C180B11,  //  0006  GETMET	R6	R5	K17
-      0x88200B12,  //  0007  GETMBR	R8	R5	K18
-      0x58240005,  //  0008  LDCONST	R9	K5
-      0x7C180600,  //  0009  CALL	R6	3
-      0x1C180406,  //  000A  EQ	R6	R2	R6
-      0x781A000A,  //  000B  JMPF	R6	#0017
-      0x8C180113,  //  000C  GETMET	R6	R0	K19
-      0x7C180200,  //  000D  CALL	R6	1
-      0x8C180114,  //  000E  GETMET	R6	R0	K20
-      0x7C180200,  //  000F  CALL	R6	1
-      0x90021406,  //  0010  SETMBR	R0	K10	R6
-      0xA41A2A00,  //  0011  IMPORT	R6	K21
-      0x8C1C0D16,  //  0012  GETMET	R7	R6	K22
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x941C0F01,  //  0014  GETIDX	R7	R7	K1
-      0x90020207,  //  0015  SETMBR	R0	K1	R7
-      0x7002000B,  //  0016  JMP		#0023
-      0x60180009,  //  0017  GETGBL	R6	G9
-      0x5C1C0200,  //  0018  MOVE	R7	R1
-      0x7C180200,  //  0019  CALL	R6	1
-      0x90021406,  //  001A  SETMBR	R0	K10	R6
-      0x541A007E,  //  001B  LDINT	R6	127
-      0x90020206,  //  001C  SETMBR	R0	K1	R6
-      0x8C180113,  //  001D  GETMET	R6	R0	K19
-      0x8820010A,  //  001E  GETMBR	R8	R0	K10
-      0x5C240400,  //  001F  MOVE	R9	R2
-      0x5C280600,  //  0020  MOVE	R10	R3
-      0x5C2C0800,  //  0021  MOVE	R11	R4
-      0x7C180A00,  //  0022  CALL	R6	5
-      0x88180117,  //  0023  GETMBR	R6	R0	K23
-      0x4C1C0000,  //  0024  LDNIL	R7
-      0x1C180C07,  //  0025  EQ	R6	R6	R7
-      0x781A0000,  //  0026  JMPF	R6	#0028
-      0xB0063119,  //  0027  RAISE	1	K24	K25
-      0x8C18011A,  //  0028  GETMET	R6	R0	K26
-      0x7C180200,  //  0029  CALL	R6	1
-      0x80000000,  //  002A  RET	0
+      0x1C180206,  //  0004  EQ	R6	R1	R6
+      0x741A0008,  //  0005  JMPT	R6	#000F
+      0x4C180000,  //  0006  LDNIL	R6
+      0x1C180406,  //  0007  EQ	R6	R2	R6
+      0x741A0005,  //  0008  JMPT	R6	#000F
+      0x8C180B18,  //  0009  GETMET	R6	R5	K24
+      0x88200B19,  //  000A  GETMBR	R8	R5	K25
+      0x58240001,  //  000B  LDCONST	R9	K1
+      0x7C180600,  //  000C  CALL	R6	3
+      0x1C180406,  //  000D  EQ	R6	R2	R6
+      0x781A000A,  //  000E  JMPF	R6	#001A
+      0x8C18011A,  //  000F  GETMET	R6	R0	K26
+      0x7C180200,  //  0010  CALL	R6	1
+      0x8C18010B,  //  0011  GETMET	R6	R0	K11
+      0x7C180200,  //  0012  CALL	R6	1
+      0x90020006,  //  0013  SETMBR	R0	K0	R6
+      0xA41A3600,  //  0014  IMPORT	R6	K27
+      0x8C1C0D1C,  //  0015  GETMET	R7	R6	K28
+      0x7C1C0200,  //  0016  CALL	R7	1
+      0x941C0F0F,  //  0017  GETIDX	R7	R7	K15
+      0x90021E07,  //  0018  SETMBR	R0	K15	R7
+      0x70020039,  //  0019  JMP		#0054
+      0x60180009,  //  001A  GETGBL	R6	G9
+      0x5C1C0200,  //  001B  MOVE	R7	R1
+      0x7C180200,  //  001C  CALL	R6	1
+      0x5C040C00,  //  001D  MOVE	R1	R6
+      0x90020001,  //  001E  SETMBR	R0	K0	R1
+      0x541A007E,  //  001F  LDINT	R6	127
+      0x90021E06,  //  0020  SETMBR	R0	K15	R6
+      0xB81A3A00,  //  0021  GETNGBL	R6	K29
+      0x8C180D1E,  //  0022  GETMET	R6	R6	K30
+      0x5820001F,  //  0023  LDCONST	R8	K31
+      0x7C180400,  //  0024  CALL	R6	2
+      0x741A0003,  //  0025  JMPT	R6	#002A
+      0xB81A3A00,  //  0026  GETNGBL	R6	K29
+      0x601C0013,  //  0027  GETGBL	R7	G19
+      0x7C1C0000,  //  0028  CALL	R7	0
+      0x901A3E07,  //  0029  SETMBR	R6	K31	R7
+      0xB81A3A00,  //  002A  GETNGBL	R6	K29
+      0x88180D1F,  //  002B  GETMBR	R6	R6	K31
+      0x8C180D20,  //  002C  GETMET	R6	R6	K32
+      0x5C200200,  //  002D  MOVE	R8	R1
+      0x7C180400,  //  002E  CALL	R6	2
+      0x4C1C0000,  //  002F  LDNIL	R7
+      0x20180C07,  //  0030  NE	R6	R6	R7
+      0x781A0016,  //  0031  JMPF	R6	#0049
+      0xB81A3A00,  //  0032  GETNGBL	R6	K29
+      0x88180D1F,  //  0033  GETMBR	R6	R6	K31
+      0x8C180D20,  //  0034  GETMET	R6	R6	K32
+      0x5C200200,  //  0035  MOVE	R8	R1
+      0x7C180400,  //  0036  CALL	R6	2
+      0x881C0100,  //  0037  GETMBR	R7	R0	K0
+      0x88200D00,  //  0038  GETMBR	R8	R6	K0
+      0x201C0E08,  //  0039  NE	R7	R7	R8
+      0x781E0005,  //  003A  JMPF	R7	#0041
+      0x601C0018,  //  003B  GETGBL	R7	G24
+      0x58200021,  //  003C  LDCONST	R8	K33
+      0x88240100,  //  003D  GETMBR	R9	R0	K0
+      0x88280D00,  //  003E  GETMBR	R10	R6	K0
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0xB0060407,  //  0040  RAISE	1	K2	R7
+      0x881C0D22,  //  0041  GETMBR	R7	R6	K34
+      0x90024407,  //  0042  SETMBR	R0	K34	R7
+      0x881C0D0D,  //  0043  GETMBR	R7	R6	K13
+      0x90021A07,  //  0044  SETMBR	R0	K13	R7
+      0xB81E3A00,  //  0045  GETNGBL	R7	K29
+      0x881C0F1F,  //  0046  GETMBR	R7	R7	K31
+      0x981C0200,  //  0047  SETIDX	R7	R1	R0
+      0x7002000A,  //  0048  JMP		#0054
+      0x8C18011A,  //  0049  GETMET	R6	R0	K26
+      0x5C200200,  //  004A  MOVE	R8	R1
+      0x5C240400,  //  004B  MOVE	R9	R2
+      0x5C280600,  //  004C  MOVE	R10	R3
+      0x5C2C0800,  //  004D  MOVE	R11	R4
+      0x7C180A00,  //  004E  CALL	R6	5
+      0xB81A3A00,  //  004F  GETNGBL	R6	K29
+      0x88180D1F,  //  0050  GETMBR	R6	R6	K31
+      0x98180200,  //  0051  SETIDX	R6	R1	R0
+      0x8C180123,  //  0052  GETMET	R6	R0	K35
+      0x7C180200,  //  0053  CALL	R6	1
+      0x88180122,  //  0054  GETMBR	R6	R0	K34
+      0x4C1C0000,  //  0055  LDNIL	R7
+      0x1C180C07,  //  0056  EQ	R6	R6	R7
+      0x781A0000,  //  0057  JMPF	R6	#0059
+      0xB0064925,  //  0058  RAISE	1	K36	K37
+      0x80000000,  //  0059  RET	0
     })
   )
 );
@@ -1785,127 +1978,53 @@ be_local_closure(class_Leds_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: clear
+** Solidified function: ctor
 ********************************************************************/
-be_local_closure(class_Leds_clear,   /* name */
+be_local_closure(class_Leds_ctor,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Leds,     /* shared constants */
+    &be_const_str_ctor,
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140405,  //  0001  EQ	R5	R2	R5
+      0x78160003,  //  0002  JMPF	R5	#0007
+      0x8C140109,  //  0003  GETMET	R5	R0	K9
+      0x581C0001,  //  0004  LDCONST	R7	K1
+      0x7C140400,  //  0005  CALL	R5	2
+      0x7002000A,  //  0006  JMP		#0012
+      0x4C140000,  //  0007  LDNIL	R5
+      0x1C140605,  //  0008  EQ	R5	R3	R5
+      0x78160000,  //  0009  JMPF	R5	#000B
+      0x880C0126,  //  000A  GETMBR	R3	R0	K38
+      0x8C140109,  //  000B  GETMET	R5	R0	K9
+      0x581C0001,  //  000C  LDCONST	R7	K1
+      0x5C200200,  //  000D  MOVE	R8	R1
+      0x5C240400,  //  000E  MOVE	R9	R2
+      0x5C280600,  //  000F  MOVE	R10	R3
+      0x5C2C0800,  //  0010  MOVE	R11	R4
+      0x7C140C00,  //  0011  CALL	R5	6
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_gamma
+********************************************************************/
+be_local_closure(class_Leds_set_gamma,   /* name */
   be_nested_proto(
     4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C04011B,  //  0000  GETMET	R1	R0	K27
-      0x580C0005,  //  0001  LDCONST	R3	K5
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C04011C,  //  0003  GETMET	R1	R0	K28
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin
-********************************************************************/
-be_local_closure(class_Leds_begin,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_begin,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C001D,  //  0001  LDCONST	R3	K29
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_count
-********************************************************************/
-be_local_closure(class_Leds_pixel_count,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_pixel_count,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0007,  //  0001  LDINT	R3	8
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: to_gamma
-********************************************************************/
-be_local_closure(class_Leds_to_gamma,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_to_gamma,
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
-      0x8C0C011E,  //  0004  GETMET	R3	R0	K30
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x881C0107,  //  0007  GETMBR	R7	R0	K7
-      0x7C0C0800,  //  0008  CALL	R3	4
-      0x80040600,  //  0009  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixels_buffer
-********************************************************************/
-be_local_closure(class_Leds_pixels_buffer,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1914,30 +2033,14 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Leds,     /* shared constants */
-    &be_const_str_pixels_buffer,
+    &be_const_str_set_gamma,
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x54120005,  //  0001  LDINT	R4	6
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0203,  //  0004  EQ	R3	R1	R3
-      0x780E0009,  //  0005  JMPF	R3	#0010
-      0x600C0015,  //  0006  GETGBL	R3	G21
-      0x5C100400,  //  0007  MOVE	R4	R2
-      0x8C14011F,  //  0008  GETMET	R5	R0	K31
-      0x7C140200,  //  0009  CALL	R5	1
-      0x8C180114,  //  000A  GETMET	R6	R0	K20
-      0x7C180200,  //  000B  CALL	R6	1
-      0x08140A06,  //  000C  MUL	R5	R5	R6
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x80040600,  //  000E  RET	1	R3
-      0x70020003,  //  000F  JMP		#0014
-      0x8C0C0320,  //  0010  GETMET	R3	R1	K32
-      0x5C140400,  //  0011  MOVE	R5	R2
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x80040200,  //  0013  RET	1	R1
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020A02,  //  0003  SETMBR	R0	K5	R2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -1949,36 +2052,39 @@ be_local_closure(class_Leds_pixels_buffer,   /* name */
 ********************************************************************/
 extern const bclass be_class_Leds_ntv;
 be_local_class(Leds,
-    3,
+    4,
     &be_class_Leds_ntv,
-    be_nested_map(26,
+    be_nested_map(29,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(is_dirty, -1), be_const_closure(class_Leds_is_dirty_closure) },
         { be_const_key(pixels_buffer, -1), be_const_closure(class_Leds_pixels_buffer_closure) },
-        { be_const_key(to_gamma, -1), be_const_closure(class_Leds_to_gamma_closure) },
-        { be_const_key(can_show, -1), be_const_closure(class_Leds_can_show_closure) },
-        { be_const_key(pixel_offset, -1), be_const_closure(class_Leds_pixel_offset_closure) },
-        { be_const_key(set_bri, 24), be_const_closure(class_Leds_set_bri_closure) },
-        { be_const_key(show, 2), be_const_closure(class_Leds_show_closure) },
-        { be_const_key(ctor, -1), be_const_closure(class_Leds_ctor_closure) },
-        { be_const_key(begin, 22), be_const_closure(class_Leds_begin_closure) },
-        { be_const_key(leds, -1), be_const_var(1) },
-        { be_const_key(set_pixel_color, -1), be_const_closure(class_Leds_set_pixel_color_closure) },
-        { be_const_key(dirty, 4), be_const_closure(class_Leds_dirty_closure) },
-        { be_const_key(get_pixel_color, -1), be_const_closure(class_Leds_get_pixel_color_closure) },
-        { be_const_key(get_gamma, -1), be_const_closure(class_Leds_get_gamma_closure) },
-        { be_const_key(gamma, -1), be_const_var(0) },
-        { be_const_key(create_matrix, -1), be_const_closure(class_Leds_create_matrix_closure) },
-        { be_const_key(matrix, 8), be_const_static_closure(class_Leds_matrix_closure) },
-        { be_const_key(create_segment, -1), be_const_closure(class_Leds_create_segment_closure) },
-        { be_const_key(bri, 10), be_const_var(2) },
-        { be_const_key(init, -1), be_const_closure(class_Leds_init_closure) },
+        { be_const_key(get_gamma, 26), be_const_closure(class_Leds_get_gamma_closure) },
         { be_const_key(clear, -1), be_const_closure(class_Leds_clear_closure) },
-        { be_const_key(get_bri, 9), be_const_closure(class_Leds_get_bri_closure) },
+        { be_const_key(matrix, 13), be_const_static_closure(class_Leds_matrix_closure) },
+        { be_const_key(init, 23), be_const_closure(class_Leds_init_closure) },
+        { be_const_key(get_animate, -1), be_const_closure(class_Leds_get_animate_closure) },
+        { be_const_key(get_pixel_color, 12), be_const_closure(class_Leds_get_pixel_color_closure) },
+        { be_const_key(set_pixel_color, -1), be_const_closure(class_Leds_set_pixel_color_closure) },
+        { be_const_key(animate, -1), be_const_var(3) },
+        { be_const_key(is_dirty, -1), be_const_closure(class_Leds_is_dirty_closure) },
+        { be_const_key(create_segment, 4), be_const_closure(class_Leds_create_segment_closure) },
+        { be_const_key(pixel_offset, -1), be_const_closure(class_Leds_pixel_offset_closure) },
         { be_const_key(clear_to, -1), be_const_closure(class_Leds_clear_to_closure) },
+        { be_const_key(begin, 0), be_const_closure(class_Leds_begin_closure) },
+        { be_const_key(set_animate, -1), be_const_closure(class_Leds_set_animate_closure) },
+        { be_const_key(can_show, 24), be_const_closure(class_Leds_can_show_closure) },
+        { be_const_key(create_matrix, -1), be_const_closure(class_Leds_create_matrix_closure) },
+        { be_const_key(dirty, -1), be_const_closure(class_Leds_dirty_closure) },
+        { be_const_key(set_bri, -1), be_const_closure(class_Leds_set_bri_closure) },
+        { be_const_key(leds, 15), be_const_var(1) },
+        { be_const_key(gamma, -1), be_const_var(0) },
+        { be_const_key(bri, 14), be_const_var(2) },
+        { be_const_key(get_bri, 11), be_const_closure(class_Leds_get_bri_closure) },
+        { be_const_key(to_gamma, 2), be_const_closure(class_Leds_to_gamma_closure) },
         { be_const_key(pixel_count, -1), be_const_closure(class_Leds_pixel_count_closure) },
+        { be_const_key(show, 6), be_const_closure(class_Leds_show_closure) },
+        { be_const_key(pixel_size, -1), be_const_closure(class_Leds_pixel_size_closure) },
+        { be_const_key(ctor, -1), be_const_closure(class_Leds_ctor_closure) },
         { be_const_key(set_gamma, -1), be_const_closure(class_Leds_set_gamma_closure) },
-        { be_const_key(pixel_size, 1), be_const_closure(class_Leds_pixel_size_closure) },
     })),
     (bstring*) &be_const_str_Leds
 );

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -78,15 +78,6 @@ extern "C" {
     be_pop(vm, 1);
     return strip;
   }
-  int32_t be_get_leds_type(bvm *vm) {
-    be_getmember(vm, 1, "_t");
-    int32_t type = be_toint(vm, -1);
-    be_pop(vm, 1);
-    if (type < 0) {
-      be_raise(vm, "internal_error", "invalid leds type");
-    }
-    return type;
-  }
 
   int be_tasmotaled_call_native(bvm *vm);
   int be_tasmotaled_call_native(bvm *vm) {
@@ -126,19 +117,12 @@ extern "C" {
           strip->SetPusher(pusher);
         }
 
-        // AddLog(LOG_LEVEL_DEBUG, "LED: leds %i gpio %i type %i", leds, gpio, led_type);
-        // store type in attribute `_t`
-        be_pushint(vm, led_type);
-        be_setmember(vm, 1, "_t");
-        be_pop(vm, 1);
-
         be_pushcomptr(vm, (void*) strip);   // if native driver, it is NULL
         be_setmember(vm, 1, "_p");
         be_pop(vm, 1);
         be_pushnil(vm);
       } else {
         // all other commands need a valid tasmotaled pointer
-        int32_t leds_type = be_get_leds_type(vm);
         TasmotaLED * strip = (TasmotaLED*) be_get_tasmotaled(vm);    // raises an exception if pointer is invalid
         // detect native driver means strip == nullptr
         be_pushnil(vm);     // push a default `nil` return value


### PR DESCRIPTION
## Description:

Since the new TasmotaLED driver, it was not possible to apply multiple times the same animation code because resources were exclusive. Now automagic is done so that previous Led and animate are reused or stopped.

Ex, you can enter mulitple times the following code:
```berry
import animate

#var strip = Leds(5*5, gpio.pin(gpio.WS2812, 1), Leds.WS2812_GRB, Leds.SPI)
var strip = Leds(5*5, gpio.pin(gpio.WS2812, 1))
#var strip = Leds()
var anim = animate.core(strip)
anim.set_back_color(0x000022)
var pulse = animate.pulse(0xFF0000, 3, 2)
var osc1 = animate.oscillator(0, 5*5, 5000, animate.TRIANGLE)
osc1.set_cb(pulse, pulse.set_pos)

anim.start()
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
