### PR TITLE
clean up remnents of old fingerprint algo

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -152,12 +152,7 @@ class WiFiClientSecure_light : public WiFiClient {
     bool _insecure;                   // force fingerprint
     const uint8_t *_fingerprint1;          // fingerprint1 to be checked against
     const uint8_t *_fingerprint2;          // fingerprint2 to be checked against
-// **** Start patch Castellucci
-/*
     uint8_t _recv_fingerprint[20];   // fingerprint received
-*/
-    uint8_t _recv_fingerprint[21];   // fingerprint received
-// **** End patch Castellucci
 
     unsigned char *_recvapp_buf;
     size_t _recvapp_len;


### PR DESCRIPTION
## Description:

Cleans up the now unused compat flag when computing TLS public key fingerprints.

Marked 'draft' until I get around to testing it.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
