### PR TITLE
TLS disable ECDSA for MQTT to ensure we don't break fingerprints after #22649

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - ESP32 disable PSRAM check (and on restart some relay toggles) with `#define DISABLE_PSRAMCHECK` (#21266)
+- TLS disable ECDSA for MQTT to ensure we don't break fingerprints after #22649
 
 ### Fixed
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -195,6 +195,7 @@ void WiFiClientSecure_light::_clear() {
   _recvapp_buf = nullptr;
   _recvapp_len = 0;
   _insecure = false;  // set to true when calling setPubKeyFingerprint()
+  _rsa_only = true;   // for now we disable ECDSA by default
   _fingerprint_any = true; // by default accept all fingerprints
   _fingerprint1 = nullptr;
   _fingerprint2 = nullptr;
@@ -813,7 +814,10 @@ extern "C" {
 
       // The tag string doesn't really matter, but it should differ depending on
       // key type. For ECDSA it's a fixed string.
-      sha1_update_len(&shactx, "ecdsa-sha2-nistp256", 19); // tag
+      sha1_update_len(&shactx, "ecdsa", 5); // tag
+      int32_t curve = eckey.curve;
+      sha1_update_len(&shactx, &curve, 4);   // curve id as int32
+      sha1_update_len(&shactx, "curve", 5); // tag2
       sha1_update_len(&shactx, eckey.q, eckey.qlen);       // exponent
     }
   #endif
@@ -888,16 +892,27 @@ extern "C" {
     BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     BR_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
   };
+  static const uint16_t suites_RSA_ONLY[] = {
+    BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+  };
 #endif
 
   // Default initializion for our SSL clients
-  static void br_ssl_client_base_init(br_ssl_client_context *cc) {
+  static void br_ssl_client_base_init(br_ssl_client_context *cc, bool _rsa_only) {
     br_ssl_client_zero(cc);
     // forbid SSL renegotiation, as we free the Private Key after handshake
     br_ssl_engine_add_flags(&cc->eng, BR_OPT_NO_RENEGOTIATION);
 
     br_ssl_engine_set_versions(&cc->eng, BR_TLS12, BR_TLS12);
+#ifdef ESP8266
     br_ssl_engine_set_suites(&cc->eng, suites, (sizeof suites) / (sizeof suites[0]));
+#else
+    if (_rsa_only) {
+      br_ssl_engine_set_suites(&cc->eng, suites_RSA_ONLY, (sizeof suites_RSA_ONLY) / (sizeof suites_RSA_ONLY[0]));
+    } else {
+      br_ssl_engine_set_suites(&cc->eng, suites, (sizeof suites) / (sizeof suites[0]));
+    }
+#endif
     br_ssl_client_set_default_rsapub(cc);
     br_ssl_engine_set_default_rsavrfy(&cc->eng);
 
@@ -945,7 +960,7 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
     _ctx_present = true;
     _eng = &_sc->eng; // Allocation/deallocation taken care of by the _sc shared_ptr
 
-    br_ssl_client_base_init(_sc.get());
+    br_ssl_client_base_init(_sc.get(), _rsa_only);
     if (_alpn_names && _alpn_num > 0) {
       br_ssl_engine_set_protocol_names(_eng, _alpn_names, _alpn_num);
     }

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -85,6 +85,10 @@ class WiFiClientSecure_light : public WiFiClient {
       _fingerprint2 = f2;
       _fingerprint_any = f_any;
       _insecure = true;
+      _rsa_only = true;     // if fingerprint, we limit to RSA only
+    }
+    void setRSAOnly(bool rsa_only) {
+      _rsa_only = rsa_only;
     }
     const uint8_t * getRecvPubKeyFingerprint(void) {
       return _recv_fingerprint;
@@ -150,6 +154,7 @@ class WiFiClientSecure_light : public WiFiClient {
 
     bool _fingerprint_any;            // accept all fingerprints
     bool _insecure;                   // force fingerprint
+    bool _rsa_only;                   // restrict to RSA only key exchange (no ECDSA - enabled to force RSA fingerprints)
     const uint8_t *_fingerprint1;          // fingerprint1 to be checked against
     const uint8_t *_fingerprint2;          // fingerprint2 to be checked against
     uint8_t _recv_fingerprint[20];   // fingerprint received

--- a/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
+++ b/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
@@ -89,6 +89,7 @@ public:
     {
         BearSSL::WiFiClientSecure_light& wcs = static_cast<BearSSL::WiFiClientSecure_light&>(client);
         wcs.setPubKeyFingerprint(_fingerprint_any, _fingerprint_any, true); // allow all fingerprints
+        wcs.setRSAOnly(false);          // although we use fingerprint, we allow ECDSA
         return true;
     }
 


### PR DESCRIPTION
## Description:

Since #22649 ECDSA is also accepted. There is however an edge case where the server could prefer ECDSA to RSA, and would break the fingerprint authentication. For now, we will force MQTT to use RSA only. Webclient would be allowed to use ECDSA and RSA.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
