### PR TITLE
Berry Zigbee fix attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - TLS disable ECDSA for MQTT to ensure we don't break fingerprints after #22649
 
 ### Fixed
+- Berry Zigbee fix wrong attributes
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/zigbee_zb_coord.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/zigbee_zb_coord.be
@@ -59,8 +59,6 @@ class zb_coord : zb_coord_ntv
     if zcl_attribute_list_ptr != nullptr
       attr_list = self.zcl_attribute_list(zcl_attribute_list_ptr)
     end
-    
-    #print(format(">ZIG: cmd=%s data_type=%s data=%s idx=%i", event_type, data_type, str(data), idx))
 
     var i = 0
     while i < size(self._handlers)

--- a/lib/libesp32/berry_tasmota/src/embedded/zigbee_zcl_attribute.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/zigbee_zcl_attribute.be
@@ -205,11 +205,13 @@ class zcl_attribute_list : zcl_attribute_list_ntv
     var v
 
     # shortaddr
-    if (v := self.shortaddr) != nil
+    v = self.shortaddr
+    if v != nil
       items.push(f'"Device":"0x{v:04X}"')
     end
     # groupaddr
-    if (v := self.groupaddr) != nil
+    v = self.groupaddr
+    if v != nil
       items.push(f'"Group":"0x{v:04X}"')
     end
 
@@ -223,13 +225,15 @@ class zcl_attribute_list : zcl_attribute_list_ntv
     end
 
     # Endpoint
-    if (v := self.src_ep) != nil
+    v = self.src_ep
+    if v != nil
       items.push(f'"Endpoint":{v}')
     end
 
     # LQI
-    if (v := self.lqi) != nil
-      items.push(f'"LinkQuality":{v}')
+    v := self.lqi
+    if v != nil
+      items.push(f'"LinkQuality":{v:i}')
     end
 
     var s = "{" + items.concat(",") + "}"


### PR DESCRIPTION
## Description:

This is linked to a remaining bug in Berry walrus operator. Fixing for now by avoiding the walrus operator.

**Related issue (if applicable):** fixes #22623

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
