### PR TITLE
Berry fix walrus operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Berry Zigbee fix wrong attributes (#22684)
+- Berry fix walrus operator
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -716,6 +716,8 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
                 free_expreg(finfo, e2); /* free source (checks only ETREG) */
                 *e2 = *e1;      /* now e2 is e1 ETLOCAL */
             }
+        } else {
+            *e2 = *e1;          /* ETLOCAL wins over ETREG */
         }
         break;
     case ETGLOBAL: /* store to grobal R(A) -> G(Bx) by global index */

--- a/lib/libesp32/berry_tasmota/src/embedded/zigbee_zcl_attribute.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/zigbee_zcl_attribute.be
@@ -205,13 +205,11 @@ class zcl_attribute_list : zcl_attribute_list_ntv
     var v
 
     # shortaddr
-    v = self.shortaddr
-    if v != nil
+    if (v := self.shortaddr) != nil
       items.push(f'"Device":"0x{v:04X}"')
     end
     # groupaddr
-    v = self.groupaddr
-    if v != nil
+    if (v := self.groupaddr) != nil
       items.push(f'"Group":"0x{v:04X}"')
     end
 
@@ -225,15 +223,13 @@ class zcl_attribute_list : zcl_attribute_list_ntv
     end
 
     # Endpoint
-    v = self.src_ep
-    if v != nil
+    if (v := self.src_ep) != nil
       items.push(f'"Endpoint":{v}')
     end
 
     # LQI
-    v := self.lqi
-    if v != nil
-      items.push(f'"LinkQuality":{v:i}')
+    if (v := self.lqi) != nil
+      items.push(f'"LinkQuality":{v}')
     end
 
     var s = "{" + items.concat(",") + "}"

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_zigbee_zcl_attribute.h
@@ -553,7 +553,7 @@ static const bvalue be_ktab_class_zcl_attribute_list[27] = {
   /* K19  */  be_nested_str_weak(tostring),
   /* K20  */  be_const_int(1),
   /* K21  */  be_nested_str_weak(_X22Endpoint_X22_X3A_X25s),
-  /* K22  */  be_nested_str_weak(_X22LinkQuality_X22_X3A_X25i),
+  /* K22  */  be_nested_str_weak(_X22LinkQuality_X22_X3A_X25s),
   /* K23  */  be_nested_str_weak(_X7B),
   /* K24  */  be_nested_str_weak(concat),
   /* K25  */  be_nested_str_weak(_X2C),


### PR DESCRIPTION
## Description:

Fix Berry walrus operator, and revert #22684 which is now fixed with the original code

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
