### PR TITLE
Berry ULP: no assertion when adc_config fails

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
@@ -23,8 +23,8 @@ BE_FUNC_CTYPE_DECLARE(be_ULP_get_mem, "i", "i");
 extern int32_t be_ULP_gpio_init(int32_t pin, int32_t mode);
 BE_FUNC_CTYPE_DECLARE(be_ULP_gpio_init, "i", "ii");
 
-extern void be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width);
-BE_FUNC_CTYPE_DECLARE(be_ULP_adc_config, "", "@iii");
+extern int32_t be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width);
+BE_FUNC_CTYPE_DECLARE(be_ULP_adc_config, "i", "@iii");
 
 extern void be_ULP_sleep(int32_t wake_up_s);
 BE_FUNC_CTYPE_DECLARE(be_ULP_sleep, "", "[i]");   // optional int arg

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
@@ -21,35 +21,20 @@
 #ifdef USE_BERRY_ULP
 #include <berry.h>
 
-// #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_ULP_COPROC_TYPE_LP_CORE)
 #if defined(CONFIG_ULP_COPROC_ENABLED)
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
 #include "esp32/ulp.h"
 #endif // esp32
-// #if ESP_IDF_VERSION_MAJOR < 5
-//   #if defined(CONFIG_IDF_TARGET_ESP32S2)
-//   #include "esp32s2/ulp.h"
-//   #include "esp32s2/ulp_riscv.h"
-//   #include "esp32s2/ulp_riscv_adc.h"
-//   #endif // s2
-//   #if defined(CONFIG_IDF_TARGET_ESP32S3)
-//   #include "esp32s3/ulp.h"
-//   #include "esp32s3/ulp_riscv.h"
-//   #include "esp32s3/ulp_riscv_adc.h"
-//   #endif //s3
-// #endif // ESP_IDF_VERSION_MAJOR < 5
+
 #include "driver/rtc_io.h"
 #include "driver/gpio.h"
-// #if ESP_IDF_VERSION_MAJOR >= 5
-  #include "esp_adc/adc_oneshot.h"
-  #include "ulp_adc.h"
-  #if defined(CONFIG_ULP_COPROC_TYPE_RISCV) // S2 or S3
-    #include "ulp_riscv.h"
-  #endif // defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
-// #else
-//   #include "driver/adc.h"
-// #endif // ESP_IDF_VERSION_MAJOR >= 5
+
+#include "ulp_adc.h"
+#if defined(CONFIG_ULP_COPROC_TYPE_RISCV) // S2 or S3
+  #include "ulp_riscv.h"
+#endif // defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
+
 #ifdef CONFIG_ULP_COPROC_TYPE_LP_CORE
   #include "ulp_lp_core.h"
   ulp_lp_core_cfg_t be_ulp_lp_core_cfg;
@@ -109,10 +94,10 @@ extern "C" {
     }
   }
 
-  // `ULP.adc_config(channel:int, attenuation:int, width:int) -> nil`
+  // `ULP.adc_config(channel:int, attenuation:int, width:int) -> error:int`
   // 
   // enums: channel 0-7, attenuation 0-3, width  0-3
-  void be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width) {
+  int32_t be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width) {
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ulp_adc_cfg_t cfg = {
         .adc_n    = ADC_UNIT_1,
@@ -141,9 +126,7 @@ extern "C" {
     be_raisef(vm, "ulp_adc_config_error", "ULP: not supported before ESP-IDF 5.4");
     esp_err_t err = ESP_FAIL;
 #endif
-    if (err != ESP_OK) {
-      be_raisef(vm, "ulp_adc_config_error", "ULP: invalid code err=%i", err);
-    }
+    return err;
   }
 
   /**


### PR DESCRIPTION
## Description:

There is change in behavior of the ESP-IDF when configuring multiple ADC channels for the ULP of the ESP32, which make it fail for any attempt after the first one was initialised.
This unresolved issue seems to be related:
https://github.com/espressif/esp-idf/issues/11160

In my tests I could not really see a degradation of functionality for the second ADC channel, although I get the error from the IDF function.

This change will just return the error code instead raising an exception, which is of questionable validity for the moment. It saves a few bytes too and is no breaking change for any program.

Additionally cleaned up the include section a bit.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
