### PR TITLE
Berry rename axp drivers

### DIFF
--- a/lib/libesp32/berry_tasmota/solidify_all.be
+++ b/lib/libesp32/berry_tasmota/solidify_all.be
@@ -13,14 +13,20 @@ import sys
 sys.path().push('src/embedded')   # allow to import from src/embedded
 
 # globals that need to exist to make compilation succeed
-var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,I2C_Driver,tcpserver,log,"
+var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,tcpserver,log,"
             "lv_clock,lv_clock_icon,lv_signal_arcs,lv_signal_bars,lv_wifi_arcs_icon,lv_wifi_arcs,"
             "lv_wifi_bars_icon,lv_wifi_bars,"
             "_lvgl,"
             "int64"
 
+var glob_classes = "I2C_Driver"
+
 for g:string2.split(globs, ",")
   global.(g) = nil
+end
+
+for g:string2.split(glob_classes, ",")
+  compile(f"class {g} end")()
 end
 
 var prefix_dir = "src/embedded/"

--- a/lib/libesp32/berry_tasmota/src/be_i2c_axp192_axp202_axp2102_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_i2c_axp192_axp202_axp2102_lib.c
@@ -1,5 +1,6 @@
 /********************************************************************
  * Drivers for AXP192 and AXP202 I2C Solidified
  *******************************************************************/
-#include "solidify/solidified_i2c_axp192.h"
-#include "solidify/solidified_i2c_axp202.h"
+#include "solidify/solidified_AXP192.h"
+#include "solidify/solidified_AXP202.h"
+#include "solidify/solidified_AXP2102.h"

--- a/lib/libesp32/berry_tasmota/src/be_i2c_axp192_axp202_axp2102_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_i2c_axp192_axp202_axp2102_lib.c
@@ -3,4 +3,3 @@
  *******************************************************************/
 #include "solidify/solidified_AXP192.h"
 #include "solidify/solidified_AXP202.h"
-#include "solidify/solidified_AXP2102.h"

--- a/lib/libesp32/berry_tasmota/src/embedded/AXP192.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/AXP192.be
@@ -1,11 +1,11 @@
 #-------------------------------------------------------------
  - Generic driver for AXP192 - solidified
  -------------------------------------------------------------#
-class I2C_Driver end    # for solidification
 
 #@ solidify:AXP192
 class AXP192 : I2C_Driver
-  def init()
+  def init(addr)
+    if (addr == nil)  addr = 0x34   end   # default address is 0x34
     super(self, I2C_Driver).init("AXP192", 0x34)
   end
 
@@ -27,7 +27,7 @@ class AXP192 : I2C_Driver
   end
 
   # Battery Charging Status
-  def get_battery_chargin_status()
+  def get_battery_charging_status()
     return self.wire.read(self.addr, 0x01, 1)
   end
 
@@ -187,3 +187,4 @@ class AXP192 : I2C_Driver
     tasmota.response_append(msg)
   end
 end
+return AXP192

--- a/lib/libesp32/berry_tasmota/src/embedded/AXP202.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/AXP202.be
@@ -1,11 +1,11 @@
 #-------------------------------------------------------------
  - Generic driver for AXP202 - solidified
  -------------------------------------------------------------#
-class I2C_Driver end    # for solidification
 
- #@ solidify:AXP202
+#@ solidify:AXP202
 class AXP202 : I2C_Driver
-  def init()
+  def init(addr)
+    if (addr == nil)  addr = 0x35   end   # default address is 0x35
     super(self, I2C_Driver).init("AXP202", 0x35)
   end
 
@@ -22,7 +22,7 @@ class AXP202 : I2C_Driver
   end
 
   # Battery Charging Status
-  def get_battery_chargin_status()
+  def get_battery_charging_status()
     return self.wire.read(self.addr, 0x01, 1)
   end
 
@@ -189,3 +189,4 @@ class AXP202 : I2C_Driver
 #     # tasmota.response_append(msg)
 #   end
 end
+return AXP202

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_AXP192.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_AXP192.h
@@ -1,4 +1,4 @@
-/* Solidification of i2c_axp192.h */
+/* Solidification of AXP192.h */
 /********************************************************************\
 * Generated code, don't edit                                         *
 \********************************************************************/
@@ -11,7 +11,7 @@ static const bvalue be_ktab_class_AXP192[37] = {
   /* K3   */  be_const_int(2),
   /* K4   */  be_const_int(3),
   /* K5   */  be_nested_str(read24),
-  /* K6   */  be_const_real_hex(0x3A102DE0),
+  /* K6   */  be_const_real_hex(0x3A102DE1),
   /* K7   */  be_nested_str(read12),
   /* K8   */  be_const_real_hex(0x3A902DE0),
   /* K9   */  be_const_real_hex(0x3EC00000),
@@ -551,8 +551,8 @@ be_local_closure(class_AXP192_json_append,   /* name */
 ********************************************************************/
 be_local_closure(class_AXP192_init,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -562,16 +562,20 @@ be_local_closure(class_AXP192_init,   /* name */
     &be_ktab_class_AXP192,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040003,  //  0000  GETGBL	R1	G3
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E3000,  //  0002  GETNGBL	R3	K24
-      0x7C040400,  //  0003  CALL	R1	2
-      0x8C040319,  //  0004  GETMET	R1	R1	K25
-      0x580C001A,  //  0005  LDCONST	R3	K26
-      0x54120033,  //  0006  LDINT	R4	52
-      0x7C040600,  //  0007  CALL	R1	3
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x54060033,  //  0003  LDINT	R1	52
+      0x60080003,  //  0004  GETGBL	R2	G3
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0xB8123000,  //  0006  GETNGBL	R4	K24
+      0x7C080400,  //  0007  CALL	R2	2
+      0x8C080519,  //  0008  GETMET	R2	R2	K25
+      0x5810001A,  //  0009  LDCONST	R4	K26
+      0x54160033,  //  000A  LDINT	R5	52
+      0x7C080600,  //  000B  CALL	R2	3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -659,12 +663,12 @@ be_local_closure(class_AXP192_web_sensor,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_chg_current
+** Solidified function: get_battery_charging_status
 ********************************************************************/
-be_local_closure(class_AXP192_set_chg_current,   /* name */
+be_local_closure(class_AXP192_get_battery_charging_status,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
+    6,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -672,21 +676,16 @@ be_local_closure(class_AXP192_set_chg_current,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_AXP192,     /* shared constants */
-    &be_const_str_set_chg_current,
+    &be_const_str_get_battery_charging_status,
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8C08010F,  //  0000  GETMET	R2	R0	K15
-      0x54120032,  //  0001  LDINT	R4	51
-      0x8C140110,  //  0002  GETMET	R5	R0	K16
-      0x541E0032,  //  0003  LDINT	R7	51
-      0x7C140400,  //  0004  CALL	R5	2
-      0x541A00EF,  //  0005  LDINT	R6	240
-      0x2C140A06,  //  0006  AND	R5	R5	R6
-      0x541A000E,  //  0007  LDINT	R6	15
-      0x2C180206,  //  0008  AND	R6	R1	R6
-      0x30140A06,  //  0009  OR	R5	R5	R6
-      0x7C080600,  //  000A  CALL	R2	3
-      0x80000000,  //  000B  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804010A,  //  0000  GETMBR	R1	R0	K10
+      0x8C04030B,  //  0001  GETMET	R1	R1	K11
+      0x880C010C,  //  0002  GETMBR	R3	R0	K12
+      0x58100000,  //  0003  LDCONST	R4	K0
+      0x58140000,  //  0004  LDCONST	R5	K0
+      0x7C040800,  //  0005  CALL	R1	4
+      0x80040200,  //  0006  RET	1	R1
     })
   )
 );
@@ -823,12 +822,12 @@ be_local_closure(class_AXP192_power_off,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_battery_chargin_status
+** Solidified function: set_chg_current
 ********************************************************************/
-be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
+be_local_closure(class_AXP192_set_chg_current,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -836,16 +835,21 @@ be_local_closure(class_AXP192_get_battery_chargin_status,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_AXP192,     /* shared constants */
-    &be_const_str_get_battery_chargin_status,
+    &be_const_str_set_chg_current,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8804010A,  //  0000  GETMBR	R1	R0	K10
-      0x8C04030B,  //  0001  GETMET	R1	R1	K11
-      0x880C010C,  //  0002  GETMBR	R3	R0	K12
-      0x58100000,  //  0003  LDCONST	R4	K0
-      0x58140000,  //  0004  LDCONST	R5	K0
-      0x7C040800,  //  0005  CALL	R1	4
-      0x80040200,  //  0006  RET	1	R1
+    ( &(const binstruction[12]) {  /* code */
+      0x8C08010F,  //  0000  GETMET	R2	R0	K15
+      0x54120032,  //  0001  LDINT	R4	51
+      0x8C140110,  //  0002  GETMET	R5	R0	K16
+      0x541E0032,  //  0003  LDINT	R7	51
+      0x7C140400,  //  0004  CALL	R5	2
+      0x541A00EF,  //  0005  LDINT	R6	240
+      0x2C140A06,  //  0006  AND	R5	R5	R6
+      0x541A000E,  //  0007  LDINT	R6	15
+      0x2C180206,  //  0008  AND	R6	R1	R6
+      0x30140A06,  //  0009  OR	R5	R5	R6
+      0x7C080600,  //  000A  CALL	R2	3
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -891,12 +895,12 @@ be_local_class(AXP192,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key(set_dcdc_enable, -1), be_const_closure(class_AXP192_set_dcdc_enable_closure) },
         { be_const_key(get_bat_power, -1), be_const_closure(class_AXP192_get_bat_power_closure) },
-        { be_const_key(get_bat_charge_current, 3), be_const_closure(class_AXP192_get_bat_charge_current_closure) },
-        { be_const_key(get_battery_chargin_status, -1), be_const_closure(class_AXP192_get_battery_chargin_status_closure) },
+        { be_const_key(get_bat_charge_current, -1), be_const_closure(class_AXP192_get_bat_charge_current_closure) },
+        { be_const_key(set_chg_current, -1), be_const_closure(class_AXP192_set_chg_current_closure) },
         { be_const_key(get_warning_level, -1), be_const_closure(class_AXP192_get_warning_level_closure) },
         { be_const_key(power_off, -1), be_const_closure(class_AXP192_power_off_closure) },
         { be_const_key(get_vbus_current, 22), be_const_closure(class_AXP192_get_vbus_current_closure) },
-        { be_const_key(get_aps_voltage, -1), be_const_closure(class_AXP192_get_aps_voltage_closure) },
+        { be_const_key(get_aps_voltage, 17), be_const_closure(class_AXP192_get_aps_voltage_closure) },
         { be_const_key(set_exten, -1), be_const_closure(class_AXP192_set_exten_closure) },
         { be_const_key(battery_present, -1), be_const_closure(class_AXP192_battery_present_closure) },
         { be_const_key(get_vbus_voltage, -1), be_const_closure(class_AXP192_get_vbus_voltage_closure) },
@@ -906,9 +910,9 @@ be_local_class(AXP192,
         { be_const_key(init, 2), be_const_closure(class_AXP192_init_closure) },
         { be_const_key(get_bat_current, -1), be_const_closure(class_AXP192_get_bat_current_closure) },
         { be_const_key(web_sensor, -1), be_const_closure(class_AXP192_web_sensor_closure) },
-        { be_const_key(set_dc_voltage, -1), be_const_closure(class_AXP192_set_dc_voltage_closure) },
+        { be_const_key(get_battery_charging_status, -1), be_const_closure(class_AXP192_get_battery_charging_status_closure) },
         { be_const_key(get_temp, -1), be_const_closure(class_AXP192_get_temp_closure) },
-        { be_const_key(set_chg_current, 17), be_const_closure(class_AXP192_set_chg_current_closure) },
+        { be_const_key(set_dc_voltage, 3), be_const_closure(class_AXP192_set_dc_voltage_closure) },
         { be_const_key(get_bat_voltage, 5), be_const_closure(class_AXP192_get_bat_voltage_closure) },
         { be_const_key(json_append, -1), be_const_closure(class_AXP192_json_append_closure) },
         { be_const_key(get_input_power_status, -1), be_const_closure(class_AXP192_get_input_power_status_closure) },

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_AXP202.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_AXP202.h
@@ -1,4 +1,4 @@
-/* Solidification of i2c_axp202.h */
+/* Solidification of AXP202.h */
 /********************************************************************\
 * Generated code, don't edit                                         *
 \********************************************************************/
@@ -13,20 +13,20 @@ static const bvalue be_ktab_class_AXP202[24] = {
   /* K5   */  be_nested_str(read8),
   /* K6   */  be_nested_str(read12),
   /* K7   */  be_const_real_hex(0x3EC00000),
-  /* K8   */  be_const_real_hex(0x3A902DE0),
-  /* K9   */  be_nested_str(read13),
-  /* K10  */  be_const_real_hex(0x3F000000),
-  /* K11  */  be_nested_str(read24),
-  /* K12  */  be_const_real_hex(0x3A102DE0),
-  /* K13  */  be_const_real_hex(0x3AB78035),
-  /* K14  */  be_const_real_hex(0x3ADED28A),
-  /* K15  */  be_nested_str(write_bit),
-  /* K16  */  be_nested_str(wire),
-  /* K17  */  be_nested_str(read),
-  /* K18  */  be_nested_str(addr),
-  /* K19  */  be_nested_str(I2C_Driver),
-  /* K20  */  be_nested_str(init),
-  /* K21  */  be_nested_str(AXP202),
+  /* K8   */  be_nested_str(read13),
+  /* K9   */  be_const_real_hex(0x3F000000),
+  /* K10  */  be_nested_str(read24),
+  /* K11  */  be_const_real_hex(0x3A102DE1),
+  /* K12  */  be_nested_str(wire),
+  /* K13  */  be_nested_str(read),
+  /* K14  */  be_nested_str(addr),
+  /* K15  */  be_const_real_hex(0x3ADED28A),
+  /* K16  */  be_const_real_hex(0x3AB78035),
+  /* K17  */  be_nested_str(write_bit),
+  /* K18  */  be_nested_str(I2C_Driver),
+  /* K19  */  be_nested_str(init),
+  /* K20  */  be_nested_str(AXP202),
+  /* K21  */  be_const_real_hex(0x3A902DE0),
   /* K22  */  be_const_real_hex(0x3DCCCCCD),
   /* K23  */  be_const_real_hex(0x4310B333),
 };
@@ -110,9 +110,9 @@ be_local_closure(class_AXP202_get_vbus_current,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_bat_voltage
+** Solidified function: get_bat_charge_current
 ********************************************************************/
-be_local_closure(class_AXP202_get_bat_voltage,   /* name */
+be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -123,13 +123,13 @@ be_local_closure(class_AXP202_get_bat_voltage,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_get_bat_voltage,
+    &be_const_str_get_bat_charge_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E0077,  //  0001  LDINT	R3	120
+      0x8C040108,  //  0000  GETMET	R1	R0	K8
+      0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x08040308,  //  0003  MUL	R1	R1	K8
+      0x08040309,  //  0003  MUL	R1	R1	K9
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -154,14 +154,14 @@ be_local_closure(class_AXP202_get_bat_current,   /* name */
     &be_const_str_get_bat_current,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C040109,  //  0000  GETMET	R1	R0	K9
+      0x8C040108,  //  0000  GETMET	R1	R0	K8
       0x540E0079,  //  0001  LDINT	R3	122
       0x7C040400,  //  0002  CALL	R1	2
-      0x8C080109,  //  0003  GETMET	R2	R0	K9
+      0x8C080108,  //  0003  GETMET	R2	R0	K8
       0x5412007B,  //  0004  LDINT	R4	124
       0x7C080400,  //  0005  CALL	R2	2
       0x04040202,  //  0006  SUB	R1	R1	R2
-      0x0804030A,  //  0007  MUL	R1	R1	K10
+      0x08040309,  //  0007  MUL	R1	R1	K9
       0x80040200,  //  0008  RET	1	R1
     })
   )
@@ -186,10 +186,68 @@ be_local_closure(class_AXP202_get_bat_power,   /* name */
     &be_const_str_get_bat_power,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C04010B,  //  0000  GETMET	R1	R0	K11
+      0x8C04010A,  //  0000  GETMET	R1	R0	K10
       0x540E006F,  //  0001  LDINT	R3	112
       0x7C040400,  //  0002  CALL	R1	2
-      0x0804030C,  //  0003  MUL	R1	R1	K12
+      0x0804030B,  //  0003  MUL	R1	R1	K11
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_battery_charging_status
+********************************************************************/
+be_local_closure(class_AXP202_get_battery_charging_status,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_get_battery_charging_status,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x880C010E,  //  0002  GETMBR	R3	R0	K14
+      0x58100001,  //  0003  LDCONST	R4	K1
+      0x58140001,  //  0004  LDCONST	R5	K1
+      0x7C040800,  //  0005  CALL	R1	4
+      0x80040200,  //  0006  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_vbus_voltage
+********************************************************************/
+be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_get_vbus_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E0059,  //  0001  LDINT	R3	90
+      0x7C040400,  //  0002  CALL	R1	2
+      0x0804030F,  //  0003  MUL	R1	R1	K15
       0x80040200,  //  0004  RET	1	R1
     })
   )
@@ -217,82 +275,8 @@ be_local_closure(class_AXP202_get_aps_voltage,   /* name */
       0x8C040106,  //  0000  GETMET	R1	R0	K6
       0x540E007D,  //  0001  LDINT	R3	126
       0x7C040400,  //  0002  CALL	R1	2
-      0x0804030D,  //  0003  MUL	R1	R1	K13
+      0x08040310,  //  0003  MUL	R1	R1	K16
       0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_vbus_voltage
-********************************************************************/
-be_local_closure(class_AXP202_get_vbus_voltage,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_get_vbus_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E0059,  //  0001  LDINT	R3	90
-      0x7C040400,  //  0002  CALL	R1	2
-      0x0804030E,  //  0003  MUL	R1	R1	K14
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ldo_enable
-********************************************************************/
-be_local_closure(class_AXP202_set_ldo_enable,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_set_ldo_enable,
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x1C0C0302,  //  0000  EQ	R3	R1	K2
-      0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C010F,  //  0002  GETMET	R3	R0	K15
-      0x54160011,  //  0003  LDINT	R5	18
-      0x58180002,  //  0004  LDCONST	R6	K2
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0303,  //  0007  EQ	R3	R1	K3
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C010F,  //  0009  GETMET	R3	R0	K15
-      0x54160011,  //  000A  LDINT	R5	18
-      0x541A0005,  //  000B  LDINT	R6	6
-      0x5C1C0400,  //  000C  MOVE	R7	R2
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x540E0003,  //  000E  LDINT	R3	4
-      0x1C0C0203,  //  000F  EQ	R3	R1	R3
-      0x780E0004,  //  0010  JMPF	R3	#0016
-      0x8C0C010F,  //  0011  GETMET	R3	R0	K15
-      0x54160011,  //  0012  LDINT	R5	18
-      0x58180003,  //  0013  LDCONST	R6	K3
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C0C0800,  //  0015  CALL	R3	4
-      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -316,9 +300,9 @@ be_local_closure(class_AXP202_battery_present,   /* name */
     &be_const_str_battery_present,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x88040110,  //  0000  GETMBR	R1	R0	K16
-      0x8C040311,  //  0001  GETMET	R1	R1	K17
-      0x880C0112,  //  0002  GETMBR	R3	R0	K18
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x880C010E,  //  0002  GETMBR	R3	R0	K14
       0x58100001,  //  0003  LDCONST	R4	K1
       0x58140001,  //  0004  LDCONST	R5	K1
       0x7C040800,  //  0005  CALL	R1	4
@@ -395,14 +379,14 @@ be_local_closure(class_AXP202_set_dcdc_enable,   /* name */
     ( &(const binstruction[15]) {  /* code */
       0x1C0C0302,  //  0000  EQ	R3	R1	K2
       0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C010F,  //  0002  GETMET	R3	R0	K15
+      0x8C0C0111,  //  0002  GETMET	R3	R0	K17
       0x54160011,  //  0003  LDINT	R5	18
       0x541A0003,  //  0004  LDINT	R6	4
       0x5C1C0400,  //  0005  MOVE	R7	R2
       0x7C0C0800,  //  0006  CALL	R3	4
       0x1C0C0303,  //  0007  EQ	R3	R1	K3
       0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C010F,  //  0009  GETMET	R3	R0	K15
+      0x8C0C0111,  //  0009  GETMET	R3	R0	K17
       0x54160011,  //  000A  LDINT	R5	18
       0x58180001,  //  000B  LDCONST	R6	K1
       0x5C1C0400,  //  000C  MOVE	R7	R2
@@ -459,8 +443,8 @@ be_local_closure(class_AXP202_set_chg_led_mode,   /* name */
 ********************************************************************/
 be_local_closure(class_AXP202_init,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -470,16 +454,20 @@ be_local_closure(class_AXP202_init,   /* name */
     &be_ktab_class_AXP202,     /* shared constants */
     &be_const_str_init,
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040003,  //  0000  GETGBL	R1	G3
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E2600,  //  0002  GETNGBL	R3	K19
-      0x7C040400,  //  0003  CALL	R1	2
-      0x8C040314,  //  0004  GETMET	R1	R1	K20
-      0x580C0015,  //  0005  LDCONST	R3	K21
-      0x54120034,  //  0006  LDINT	R4	53
-      0x7C040600,  //  0007  CALL	R1	3
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x54060034,  //  0003  LDINT	R1	53
+      0x60080003,  //  0004  GETGBL	R2	G3
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0xB8122400,  //  0006  GETNGBL	R4	K18
+      0x7C080400,  //  0007  CALL	R2	2
+      0x8C080513,  //  0008  GETMET	R2	R2	K19
+      0x58100014,  //  0009  LDCONST	R4	K20
+      0x54160034,  //  000A  LDINT	R5	53
+      0x7C080600,  //  000B  CALL	R2	3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -503,166 +491,12 @@ be_local_closure(class_AXP202_set_exten,   /* name */
     &be_const_str_set_exten,
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
-      0x8C08010F,  //  0000  GETMET	R2	R0	K15
+      0x8C080111,  //  0000  GETMET	R2	R0	K17
       0x54120011,  //  0001  LDINT	R4	18
       0x58140000,  //  0002  LDCONST	R5	K0
       0x5C180200,  //  0003  MOVE	R6	R1
       0x7C080800,  //  0004  CALL	R2	4
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_battery_chargin_status
-********************************************************************/
-be_local_closure(class_AXP202_get_battery_chargin_status,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_get_battery_chargin_status,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040110,  //  0000  GETMBR	R1	R0	K16
-      0x8C040311,  //  0001  GETMET	R1	R1	K17
-      0x880C0112,  //  0002  GETMBR	R3	R0	K18
-      0x58100001,  //  0003  LDCONST	R4	K1
-      0x58140001,  //  0004  LDCONST	R5	K1
-      0x7C040800,  //  0005  CALL	R1	4
-      0x80040200,  //  0006  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_dc_voltage
-********************************************************************/
-be_local_closure(class_AXP202_set_dc_voltage,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_set_dc_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x140C0302,  //  0000  LT	R3	R1	K2
-      0x740E0001,  //  0001  JMPT	R3	#0004
-      0x240C0303,  //  0002  GT	R3	R1	K3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x80000600,  //  0004  RET	0
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x541202BB,  //  0006  LDINT	R4	700
-      0x14100404,  //  0007  LT	R4	R2	R4
-      0x78120001,  //  0008  JMPF	R4	#000B
-      0x580C0000,  //  0009  LDCONST	R3	K0
-      0x70020010,  //  000A  JMP		#001C
-      0x54120DAB,  //  000B  LDINT	R4	3500
-      0x24100404,  //  000C  GT	R4	R2	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x540E006F,  //  000E  LDINT	R3	112
-      0x7002000B,  //  000F  JMP		#001C
-      0x1C100302,  //  0010  EQ	R4	R1	K2
-      0x78120004,  //  0011  JMPF	R4	#0017
-      0x541208E2,  //  0012  LDINT	R4	2275
-      0x24100404,  //  0013  GT	R4	R2	R4
-      0x78120001,  //  0014  JMPF	R4	#0017
-      0x540E003E,  //  0015  LDINT	R3	63
-      0x70020004,  //  0016  JMP		#001C
-      0x541202BB,  //  0017  LDINT	R4	700
-      0x04100404,  //  0018  SUB	R4	R2	R4
-      0x54160018,  //  0019  LDINT	R5	25
-      0x0C100805,  //  001A  DIV	R4	R4	R5
-      0x5C0C0800,  //  001B  MOVE	R3	R4
-      0x54120022,  //  001C  LDINT	R4	35
-      0x1C140303,  //  001D  EQ	R5	R1	K3
-      0x78160000,  //  001E  JMPF	R5	#0020
-      0x54120026,  //  001F  LDINT	R4	39
-      0x8C140104,  //  0020  GETMET	R5	R0	K4
-      0x5C1C0800,  //  0021  MOVE	R7	R4
-      0x8C200105,  //  0022  GETMET	R8	R0	K5
-      0x5C280800,  //  0023  MOVE	R10	R4
-      0x7C200400,  //  0024  CALL	R8	2
-      0x5426007F,  //  0025  LDINT	R9	128
-      0x2C201009,  //  0026  AND	R8	R8	R9
-      0x5426007E,  //  0027  LDINT	R9	127
-      0x2C240609,  //  0028  AND	R9	R3	R9
-      0x30201009,  //  0029  OR	R8	R8	R9
-      0x7C140600,  //  002A  CALL	R5	3
-      0x80000000,  //  002B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bat_charge_current
-********************************************************************/
-be_local_closure(class_AXP202_get_bat_charge_current,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_get_bat_charge_current,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040109,  //  0000  GETMET	R1	R0	K9
-      0x540E0079,  //  0001  LDINT	R3	122
-      0x7C040400,  //  0002  CALL	R1	2
-      0x0804030A,  //  0003  MUL	R1	R1	K10
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_temp
-********************************************************************/
-be_local_closure(class_AXP202_get_temp,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AXP202,     /* shared constants */
-    &be_const_str_get_temp,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040106,  //  0000  GETMET	R1	R0	K6
-      0x540E005D,  //  0001  LDINT	R3	94
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040316,  //  0003  MUL	R1	R1	K22
-      0x04040317,  //  0004  SUB	R1	R1	K23
-      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -752,6 +586,176 @@ be_local_closure(class_AXP202_set_ldo_voltage,   /* name */
 
 
 /********************************************************************
+** Solidified function: set_dc_voltage
+********************************************************************/
+be_local_closure(class_AXP202_set_dc_voltage,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_set_dc_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x140C0302,  //  0000  LT	R3	R1	K2
+      0x740E0001,  //  0001  JMPT	R3	#0004
+      0x240C0303,  //  0002  GT	R3	R1	K3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80000600,  //  0004  RET	0
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x541202BB,  //  0006  LDINT	R4	700
+      0x14100404,  //  0007  LT	R4	R2	R4
+      0x78120001,  //  0008  JMPF	R4	#000B
+      0x580C0000,  //  0009  LDCONST	R3	K0
+      0x70020010,  //  000A  JMP		#001C
+      0x54120DAB,  //  000B  LDINT	R4	3500
+      0x24100404,  //  000C  GT	R4	R2	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x540E006F,  //  000E  LDINT	R3	112
+      0x7002000B,  //  000F  JMP		#001C
+      0x1C100302,  //  0010  EQ	R4	R1	K2
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x541208E2,  //  0012  LDINT	R4	2275
+      0x24100404,  //  0013  GT	R4	R2	R4
+      0x78120001,  //  0014  JMPF	R4	#0017
+      0x540E003E,  //  0015  LDINT	R3	63
+      0x70020004,  //  0016  JMP		#001C
+      0x541202BB,  //  0017  LDINT	R4	700
+      0x04100404,  //  0018  SUB	R4	R2	R4
+      0x54160018,  //  0019  LDINT	R5	25
+      0x0C100805,  //  001A  DIV	R4	R4	R5
+      0x5C0C0800,  //  001B  MOVE	R3	R4
+      0x54120022,  //  001C  LDINT	R4	35
+      0x1C140303,  //  001D  EQ	R5	R1	K3
+      0x78160000,  //  001E  JMPF	R5	#0020
+      0x54120026,  //  001F  LDINT	R4	39
+      0x8C140104,  //  0020  GETMET	R5	R0	K4
+      0x5C1C0800,  //  0021  MOVE	R7	R4
+      0x8C200105,  //  0022  GETMET	R8	R0	K5
+      0x5C280800,  //  0023  MOVE	R10	R4
+      0x7C200400,  //  0024  CALL	R8	2
+      0x5426007F,  //  0025  LDINT	R9	128
+      0x2C201009,  //  0026  AND	R8	R8	R9
+      0x5426007E,  //  0027  LDINT	R9	127
+      0x2C240609,  //  0028  AND	R9	R3	R9
+      0x30201009,  //  0029  OR	R8	R8	R9
+      0x7C140600,  //  002A  CALL	R5	3
+      0x80000000,  //  002B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bat_voltage
+********************************************************************/
+be_local_closure(class_AXP202_get_bat_voltage,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_get_bat_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E0077,  //  0001  LDINT	R3	120
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040315,  //  0003  MUL	R1	R1	K21
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_temp
+********************************************************************/
+be_local_closure(class_AXP202_get_temp,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_get_temp,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040106,  //  0000  GETMET	R1	R0	K6
+      0x540E005D,  //  0001  LDINT	R3	94
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040316,  //  0003  MUL	R1	R1	K22
+      0x04040317,  //  0004  SUB	R1	R1	K23
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ldo_enable
+********************************************************************/
+be_local_closure(class_AXP202_set_ldo_enable,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AXP202,     /* shared constants */
+    &be_const_str_set_ldo_enable,
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x1C0C0302,  //  0000  EQ	R3	R1	K2
+      0x780E0004,  //  0001  JMPF	R3	#0007
+      0x8C0C0111,  //  0002  GETMET	R3	R0	K17
+      0x54160011,  //  0003  LDINT	R5	18
+      0x58180002,  //  0004  LDCONST	R6	K2
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x7C0C0800,  //  0006  CALL	R3	4
+      0x1C0C0303,  //  0007  EQ	R3	R1	K3
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x8C0C0111,  //  0009  GETMET	R3	R0	K17
+      0x54160011,  //  000A  LDINT	R5	18
+      0x541A0005,  //  000B  LDINT	R6	6
+      0x5C1C0400,  //  000C  MOVE	R7	R2
+      0x7C0C0800,  //  000D  CALL	R3	4
+      0x540E0003,  //  000E  LDINT	R3	4
+      0x1C0C0203,  //  000F  EQ	R3	R1	R3
+      0x780E0004,  //  0010  JMPF	R3	#0016
+      0x8C0C0111,  //  0011  GETMET	R3	R0	K17
+      0x54160011,  //  0012  LDINT	R5	18
+      0x58180003,  //  0013  LDCONST	R6	K3
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C0C0800,  //  0015  CALL	R3	4
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: set_limiting_off
 ********************************************************************/
 be_local_closure(class_AXP202_set_limiting_off,   /* name */
@@ -799,9 +803,9 @@ be_local_closure(class_AXP202_get_input_power_status,   /* name */
     &be_const_str_get_input_power_status,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040110,  //  0000  GETMBR	R1	R0	K16
-      0x8C040311,  //  0001  GETMET	R1	R1	K17
-      0x880C0112,  //  0002  GETMBR	R3	R0	K18
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x880C010E,  //  0002  GETMBR	R3	R0	K14
       0x58100000,  //  0003  LDCONST	R4	K0
       0x58140001,  //  0004  LDCONST	R5	K1
       0x7C040800,  //  0005  CALL	R1	4
@@ -826,20 +830,20 @@ be_local_class(AXP202,
         { be_const_key(get_aps_voltage, -1), be_const_closure(class_AXP202_get_aps_voltage_closure) },
         { be_const_key(get_bat_current, -1), be_const_closure(class_AXP202_get_bat_current_closure) },
         { be_const_key(get_bat_power, 2), be_const_closure(class_AXP202_get_bat_power_closure) },
-        { be_const_key(init, -1), be_const_closure(class_AXP202_init_closure) },
+        { be_const_key(get_battery_charging_status, -1), be_const_closure(class_AXP202_get_battery_charging_status_closure) },
         { be_const_key(get_vbus_voltage, -1), be_const_closure(class_AXP202_get_vbus_voltage_closure) },
-        { be_const_key(set_ldo_voltage, 14), be_const_closure(class_AXP202_set_ldo_voltage_closure) },
+        { be_const_key(set_ldo_voltage, -1), be_const_closure(class_AXP202_set_ldo_voltage_closure) },
         { be_const_key(battery_present, -1), be_const_closure(class_AXP202_battery_present_closure) },
         { be_const_key(set_chg_current_ma, -1), be_const_closure(class_AXP202_set_chg_current_ma_closure) },
         { be_const_key(set_dcdc_enable, -1), be_const_closure(class_AXP202_set_dcdc_enable_closure) },
-        { be_const_key(set_chg_led_mode, 7), be_const_closure(class_AXP202_set_chg_led_mode_closure) },
-        { be_const_key(set_ldo_enable, 5), be_const_closure(class_AXP202_set_ldo_enable_closure) },
+        { be_const_key(set_chg_led_mode, 16), be_const_closure(class_AXP202_set_chg_led_mode_closure) },
+        { be_const_key(init, 14), be_const_closure(class_AXP202_init_closure) },
         { be_const_key(set_exten, -1), be_const_closure(class_AXP202_set_exten_closure) },
-        { be_const_key(get_temp, -1), be_const_closure(class_AXP202_get_temp_closure) },
-        { be_const_key(get_bat_voltage, 16), be_const_closure(class_AXP202_get_bat_voltage_closure) },
+        { be_const_key(set_ldo_enable, -1), be_const_closure(class_AXP202_set_ldo_enable_closure) },
         { be_const_key(get_bat_charge_current, 17), be_const_closure(class_AXP202_get_bat_charge_current_closure) },
-        { be_const_key(set_dc_voltage, 18), be_const_closure(class_AXP202_set_dc_voltage_closure) },
-        { be_const_key(get_battery_chargin_status, -1), be_const_closure(class_AXP202_get_battery_chargin_status_closure) },
+        { be_const_key(get_temp, 7), be_const_closure(class_AXP202_get_temp_closure) },
+        { be_const_key(get_bat_voltage, 18), be_const_closure(class_AXP202_get_bat_voltage_closure) },
+        { be_const_key(set_dc_voltage, -1), be_const_closure(class_AXP202_set_dc_voltage_closure) },
         { be_const_key(set_limiting_off, -1), be_const_closure(class_AXP202_set_limiting_off_closure) },
         { be_const_key(get_input_power_status, -1), be_const_closure(class_AXP202_get_input_power_status_closure) },
     })),


### PR DESCRIPTION
## Description:

Berry rename AXP192 and AXP202 drivers for consistency so they can be used standalone or solidified.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
