### PR TITLE
Berry leds improve reuse of buffer

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/leds.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/leds.be
@@ -124,8 +124,9 @@ class Leds : Leds_ntv
   end
   def pixels_buffer(old_buf)
     var buf = self.call_native(6)   # address of buffer in memory
-    if old_buf == nil
-      return bytes(buf, self.pixel_size() * self.pixel_count())
+    var sz = self.pixel_size() * self.pixel_count()
+    if (old_buf == nil || size(buf) != sz)
+      return bytes(buf, sz)
     else
       old_buf._change_buffer(buf)
       return old_buf


### PR DESCRIPTION
## Description:

Berry improve reuse of bytes() buffer in `leds.pixels_buffer(old_buf)` and create a new buffer in case the number of pixels changed on the fly.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
