### PR TITLE
reduce false positive chirp sensor detection

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_48_chirp.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_48_chirp.ino
@@ -240,6 +240,8 @@ bool ChirpScan()
     delay(2);
     chirp_sensor[chirp_found_sensors].version = ChirpReadVersion(address);
     if (chirp_sensor[chirp_found_sensors].version > 0) {
+      // try to confirm by reading the address
+      if (address != I2cRead8(address, CHIRP_GET_ADDRESS)) { continue; }
       I2cSetActiveFound(address, "CHIRP");
       if (chirp_found_sensors<CHIRP_MAX_SENSOR_COUNT) {
         chirp_sensor[chirp_found_sensors].address = address; // push next sensor, as long as there is space in the array


### PR DESCRIPTION
## Description:

The Chirp! sensor can be present on many different I2C addresses. I had an issue with Tasmota detecting a BMP680 I2C sensor as a Chirp! sensor, which is resolved with this PR.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
