### PR TITLE
improved zopfli compression

### DIFF
--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -21,6 +21,7 @@ map_dir = /tmp/map_files/
 Values in .ini files override environment variables
 
 """
+import zlib
 import pathlib
 import os
 
@@ -41,7 +42,6 @@ MAP_DIR = "map_dir"
 
 # This is the default output directory
 OUTPUT_DIR = pathlib.Path("build_output")
-
 
 def get_variant(env) -> str:
     """Get the current build variant."""
@@ -125,3 +125,75 @@ def is_env_set(name: str, env):
         val = val.strip()
         return val == "1"
     return False
+
+def _compress_with_gzip(data, level=9):
+    import zlib
+    if   level < 0: level = 0
+    elif level > 9: level = 9
+    # gzip header without timestamp
+    zobj = zlib.compressobj(level=level, wbits=16 + zlib.MAX_WBITS)
+    return zobj.compress(data) + zobj.flush()
+
+try:
+    import zopfli
+
+    # two python modules call themselves `zopfli`, which one is this?
+    if hasattr(zopfli, 'ZopfliCompressor'):
+        # we seem to have zopflipy
+        from zopfli import ZopfliCompressor, ZOPFLI_FORMAT_GZIP
+        def _compress_with_zopfli(data, iterations=15, maxsplit=15, **kw):
+            zobj = ZopfliCompressor(
+                ZOPFLI_FORMAT_GZIP,
+                iterations=iterations,
+                block_splitting_max=maxsplit,
+                **kw,
+            )
+            return zobj.compress(data) + zobj.flush()
+
+    else:
+        # we seem to have pyzopfli
+        import zopfli.gzip
+        def _compress_with_zopfli(data, iterations=15, maxsplit=15, **kw):
+            return zopfli.gzip.compress(
+                data,
+                numiterations=iterations,
+                blocksplittingmax=maxsplit,
+                **kw,
+            )
+
+    # values based on limited manual testing
+    def _level_to_params(level):
+        if   level == 10: return (15, 15)
+        elif level == 11: return (15, 20)
+        elif level == 12: return (15, 25)
+        elif level == 13: return (15, 30)
+        elif level == 14: return (15, 35)
+        elif level == 15: return (33, 40)
+        elif level == 16: return (67, 45)
+        elif level == 17: return (100, 50)
+        elif level == 18: return (500, 100)
+        elif level >= 19: return (2500, 250)
+        else:
+            raise ValueError(f'Invalid level: {repr(level)}')
+
+    def compress(data, level=None, *, iterations=None, maxsplit=None, **kw):
+        if level is not None and (iterations is not None or maxsplit is not None):
+            raise ValueError("The `level` argument can't be used with `iterations` and/or `maxsplit`!")
+
+        # set parameters based on level or to defaults
+        if iterations is None and maxsplit is None:
+            if level is None: level = 10
+            elif level < 10: return _compress_with_gzip(data, level)
+            iterations, maxsplit = _level_to_params(level)
+
+        if maxsplit is not None:
+            kw['maxsplit'] = maxsplit
+
+        if iterations is not None:
+            kw['iterations'] = iterations
+
+        return _compress_with_zopfli(data, **kw)
+
+except ModuleNotFoundError:
+    def compress(data, level=9, **kw):
+        return _compress_with_gzip(data, level)


### PR DESCRIPTION
## Description:

This improves Tasmota's code for compressing firmware with zopfli. Support for a second Python zopfli wrapper is added with the possibility of using more aggressive compression settings (set the `GZIP_LEVEL` environment variable to a value from 11 to 19).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
