### PR TITLE
Add Webcam stats as sensors. (Can be used in home assistant.)

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -1503,6 +1503,18 @@ void WcUpdateStats(void) {
   WcStats.camcnt = 0;
 }
 
+void WcSensorStats(void) {
+  if (!Wc.up) { return; }
+
+  ResponseAppend_P(PSTR(",\"CAMERA\":{"
+                        "\"" D_WEBCAM_STATS_FPS "\":%d,"
+                        "\"" D_WEBCAM_STATS_CAMFAIL "\":%d,"
+                        "\"" D_WEBCAM_STATS_JPEGFAIL "\":%d,"
+                        "\"" D_WEBCAM_STATS_CLIENTFAIL "\":%d}"),
+                   WcStats.camfps, WcStats.camfail,
+                   WcStats.jpegfail, WcStats.clientfail);
+}
+
 const char HTTP_WEBCAM_FPS[] PROGMEM = "{s}%s " D_FRAME_RATE "{m}%d " D_UNIT_FPS  "{e}";
 
 void WcStatsShow(void) {
@@ -1532,6 +1544,8 @@ bool Xdrv81(uint32_t function) {
      break;
     case FUNC_EVERY_SECOND:
       WcUpdateStats();
+    case FUNC_JSON_APPEND:
+      WcSensorStats();
     case FUNC_WEB_SENSOR:
       WcStatsShow();
       break;

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -2950,6 +2950,18 @@ void WcUpdateStats(void) {
   Wc.loopcounter = 0;
 }
 
+void WcSensorStats(void) {
+  if (!Wc.up) { return; }
+
+  ResponseAppend_P(PSTR(",\"CAMERA\":{"
+                        "\"" D_WEBCAM_STATS_FPS "\":%d,"
+                        "\"" D_WEBCAM_STATS_CAMFAIL "\":%d,"
+                        "\"" D_WEBCAM_STATS_JPEGFAIL "\":%d,"
+                        "\"" D_WEBCAM_STATS_CLIENTFAIL "\":%d}"),
+                   WcStats.camfps, WcStats.camfail,
+                   WcStats.jpegfail, WcStats.clientfail);
+}
+
 #ifndef D_WEBCAM_STATE
 #define D_WEBCAM_STATE "State"
 #define D_WEBCAM_POWEREDOFF "PowerOff"
@@ -2993,6 +3005,9 @@ bool Xdrv99(uint32_t function) {
       break;
     case FUNC_EVERY_SECOND:
       WcUpdateStats();
+      break;
+    case FUNC_JSON_APPEND:
+      WcSensorStats();
       break;
     case FUNC_WEB_SENSOR:
       WcStatsShow();


### PR DESCRIPTION
## Description:
Add webcam stats as sensors. These can be used by the home assistant directly.
The field names used are the same as `WcStats` output for consistency.

![image](https://github.com/user-attachments/assets/a8ee7548-b50c-4a32-b7ce-e7b8bfc85041)


**Related issue (if applicable):** NA

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
