### PR TITLE
Expand 'Pixels' with reverse, height and alternate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for ESP32 Two-Wire Automotive Interface (TWAI) or Controller Area Network (CAN) busses
 - Support for Senseair S88 CO2 sensor (#22733)
 - TasmotaLED change dynamically the number of pixels
+- Expand `Pixels` with reverse, height and alternate
 
 ### Breaking Changed
 

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -665,7 +665,8 @@ typedef struct {
   // ----------------------------------------
 #endif // ESP32S3
 
-  uint16_t      light_pixels;              // 496
+  uint16_t      light_pixels : 15;         // 496
+  uint16_t      light_pixels_reverse : 1;  // 496
   uint8_t       light_color[LST_MAX];      // 498  LST_MAX = 5
   uint8_t       light_correction;          // 49D
   uint8_t       light_dimmer;              // 49E
@@ -786,8 +787,10 @@ typedef struct {
   uint8_t       web_color2[2][3];          // EA0  Needs to be on integer / 3 distance from web_color
   uint16_t      zcdimmerset[5];            // EA6
 
-  uint8_t       free_eb0[22];              // EB0  22 bytes
+  uint8_t       free_eb0[20];              // EB0  20 bytes
 
+  uint16_t      light_pixels_height : 15;  // EC4  Pixels height minus 1, default 0 (0 means 1 line)
+  uint16_t      light_pixels_alternate : 1;// EC4  Indicates alternate lines in Pixels Matrix
   uint8_t       shift595_device_count;     // EC6
   uint8_t       sta_config;                // EC7
   uint8_t       sta_active;                // EC8

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -633,6 +633,16 @@ bool Ws2812InitStrip(void)
   return false;
 }
 
+bool Ws2812ChangePixelCount(void)
+{
+  if (strip == nullptr) {
+    return true;
+  }
+  strip->SetPixelCount(Settings->light_pixels);
+  Ws2812Clear();
+  return true;
+}
+
 void Ws2812ModuleSelected(void)
 {
   if (Ws2812InitStrip()) {
@@ -680,6 +690,14 @@ uint32_t Ws2812PixelsSize(void) {
 bool Ws2812CanShow(void) {
   if (strip) { return strip->CanShow(); }
   return false;
+}
+
+void Ws2812CanShowWait(void) {
+  if (strip) {
+    while (!strip->CanShow()) {
+      yield();
+    }
+  }
 }
 
 bool Ws2812IsDirty(void) {
@@ -773,19 +791,22 @@ void CmndLed(void)
 
 void CmndPixels(void)
 {
-  if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= WS2812_MAX_LEDS)) {
-/*
-    Settings->light_pixels = XdrvMailbox.payload;
-    Settings->light_rotation = 0;
-    Ws2812ReinitStrip();   -- does not work with latest NeoPixelBus driver
-    Light.update = true;
-*/
-    Ws2812Clear();                     // Clear all known pixels
-    Settings->light_pixels = XdrvMailbox.payload;
-    Settings->light_rotation = 0;
-    TasmotaGlobal.restart_flag = 2;    // reboot instead
+  uint32_t parm[4] = { Settings->light_pixels, Settings->light_pixels_reverse,
+                       (uint32_t) Settings->light_pixels_height + 1, Settings->light_pixels_alternate };
+  if (ParseParameters(4, parm) > 0) {
+    if ((parm[0] > 0) && (parm[0] <= WS2812_MAX_LEDS)) {
+      Ws2812Clear();                     // Clear all known pixels
+      Ws2812CanShowWait();
+      Settings->light_pixels = parm[0];
+      Settings->light_pixels_reverse = parm[1];
+      Settings->light_pixels_height = (parm[2] > 0) ? parm[2] - 1 : 1;
+      Settings->light_pixels_alternate = parm[3];
+      Ws2812ChangePixelCount();
+      Light.update = true;
+    }
   }
-  ResponseCmndNumber(Settings->light_pixels);
+  Response_P(PSTR("{\"Pixels\":%i,\"PixelsReverse\":%i,\"PixelsHeight\":%i,\"PixelsAlternate\":%i}"),
+    Settings->light_pixels, Settings->light_pixels_reverse, Settings->light_pixels_height + 1, Settings->light_pixels_alternate);
 }
 
 void CmndStepPixels(void)


### PR DESCRIPTION
## Description:

(ESP32 only) Expand `Pixels` command to support the following parameters:
`Pixels <pixels>` or `Pixels <pixels>,<reverse>,<height>,<alternate>`:
- `<pixels>`: total number of pixels in the strip (identical to legacy `Pixels` command)
- `<reverse>`: `0` or `1`, `1`= the leds are in reverse order (not yet implemented)
- `<height>`: number of lines in a leds matrix
- `<alternate>`: `0` or `1`, `1`= lines in the matrix are in alternate order (zig-zag)

Example: for Ulanzi clock:
```
Pixels 256,0,8,1

RSL: RESULT = {"Pixels":256,"PixelsReverse":0,"PixelsHeight":8,"PixelsAlternate":1}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
