### PR TITLE
Berry allow 'bytes().append(nil)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Support for Senseair S88 CO2 sensor (#22733)
 - ESP32 TasmotaLED change dynamically the number of pixels (#22754)
 - ESP32 expand `Pixels` with reverse, height and alternate (#22755)
+- Berry allow `bytes().append(nil)`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -1324,13 +1324,13 @@ static int m_connect(bvm *vm)
     buf_impl attr = m_read_attributes(vm, 1);
     check_ptr_modifiable(vm, &attr);
     if (attr.fixed) { be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); }
-    if (argc >= 2 && (be_isbytes(vm, 2) || be_isint(vm, 2) || be_isstring(vm, 2))) {
-        if (be_isint(vm, 2)) {
+    if (argc >= 2 && (be_isbytes(vm, 2) || be_isint(vm, 2) || be_isstring(vm, 2) || be_isnil(vm, 2))) {
+        if (be_isnil(vm, 2)) {
+            // do nothing
+        } else if (be_isint(vm, 2)) {
             bytes_resize(vm, &attr, attr.len + 1); /* resize */
             buf_add1(&attr, be_toint(vm, 2));
             m_write_attributes(vm, 1, &attr);  /* update instance */
-            be_pushvalue(vm, 1);
-            be_return(vm); /* return self */
         } else if (be_isstring(vm, 2)) {
             const char *str = be_tostring(vm, 2);
             size_t str_len = strlen(str);
@@ -1339,17 +1339,15 @@ static int m_connect(bvm *vm)
                 buf_add_raw(&attr, str, str_len);
                 m_write_attributes(vm, 1, &attr);  /* update instance */
             }
-            be_pushvalue(vm, 1);
-            be_return(vm); /* return self */
         } else {
             buf_impl attr2 = m_read_attributes(vm, 2);
             check_ptr(vm, &attr2);
             bytes_resize(vm, &attr, attr.len + attr2.len); /* resize buf1 for total size */
             buf_add_buf(&attr, &attr2);
             m_write_attributes(vm, 1, &attr);  /* update instance */
-            be_pushvalue(vm, 1);
-            be_return(vm); /* return self */
         }
+        be_pushvalue(vm, 1);
+        be_return(vm); /* return self */
     }
     be_raise(vm, "type_error", "operand must be bytes or int or string");
     be_return_nil(vm); /* return self */

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -155,6 +155,11 @@ assert(str(b1) == "bytes('AA')")
 b1.append('01')
 assert(str(b1) == "bytes('AA3031')")
 
+#- .. with nil -#
+b1 = bytes("1122")
+assert(str(b1 .. nil) == "bytes('1122')")
+assert(str(b1.append(nil)) == "bytes('1122')")
+
 #- item -#
 b = bytes("334455")
 assert(b[0] == 0x33)


### PR DESCRIPTION
## Description:

Berry allow `bytes().append(nil)` as do-nothing instead of raising an error.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
