### PR TITLE
Berry add light_pixels values to 'tasmota.settings'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -859,6 +859,7 @@ All notable changes to this project will be documented in this file.
 - Berry provide lightweight options for `tasmota.wifi/eth/memory/rtc` (#20448)
 - Berry `tasmota.webcolor` (#20454)
 - Support for pipsolar inverter (#20408)
+- Berry add light_pixels values to `tasmota.settings`
 
 ### Changed
 - Renamed button "Consoles" to "Tools"

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -789,7 +789,7 @@ typedef struct {
 
   uint8_t       free_eb0[20];              // EB0  20 bytes
 
-  uint16_t      light_pixels_height : 15;  // EC4  Pixels height minus 1, default 0 (0 means 1 line)
+  uint16_t      light_pixels_height_1 : 15;// EC4  Pixels height minus 1, default 0 (0 means 1 line)
   uint16_t      light_pixels_alternate : 1;// EC4  Indicates alternate lines in Pixels Matrix
   uint8_t       shift595_device_count;     // EC6
   uint8_t       sta_config;                // EC7

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -51,11 +51,15 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_settings_struct = {
     sizeof(TSettings),  /* size in bytes */
-    6,  /* number of elements */
+    10,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[6]) {
+    (const be_ctypes_structure_item_t[10]) {
       // Warning: fields below need to be in alphabetical order
       { "bootcount", offsetof(TSettings, bootcount), 0, 0, ctypes_u16, 0 },
+      { "light_pixels", 0x496, 0, 15, ctypes_bf, 0 },
+      { "light_pixels_alternate", 0xEC5, 7, 1, ctypes_bf, 0 },
+      { "light_pixels_height_1", 0xEC4, 0, 15, ctypes_bf, 0 },
+      { "light_pixels_reverse", 0x497, 7, 1, ctypes_bf, 0 },
       { "mqttlog_level", offsetof(TSettings, mqttlog_level), 0, 0, ctypes_u8, 0 },
       { "seriallog_level", offsetof(TSettings, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -792,21 +792,21 @@ void CmndLed(void)
 void CmndPixels(void)
 {
   uint32_t parm[4] = { Settings->light_pixels, Settings->light_pixels_reverse,
-                       (uint32_t) Settings->light_pixels_height + 1, Settings->light_pixels_alternate };
+                       (uint32_t) Settings->light_pixels_height_1 + 1, Settings->light_pixels_alternate };
   if (ParseParameters(4, parm) > 0) {
     if ((parm[0] > 0) && (parm[0] <= WS2812_MAX_LEDS)) {
       Ws2812Clear();                     // Clear all known pixels
       Ws2812CanShowWait();
       Settings->light_pixels = parm[0];
       Settings->light_pixels_reverse = parm[1];
-      Settings->light_pixels_height = (parm[2] > 0) ? parm[2] - 1 : 1;
+      Settings->light_pixels_height_1 = (parm[2] > 0) ? parm[2] - 1 : 1;
       Settings->light_pixels_alternate = parm[3];
       Ws2812ChangePixelCount();
       Light.update = true;
     }
   }
   Response_P(PSTR("{\"Pixels\":%i,\"PixelsReverse\":%i,\"PixelsHeight\":%i,\"PixelsAlternate\":%i}"),
-    Settings->light_pixels, Settings->light_pixels_reverse, Settings->light_pixels_height + 1, Settings->light_pixels_alternate);
+    Settings->light_pixels, Settings->light_pixels_reverse, Settings->light_pixels_height_1 + 1, Settings->light_pixels_alternate);
 }
 
 void CmndStepPixels(void)


### PR DESCRIPTION
## Description:

Berry add light_pixels values to `tasmota.settings`: `light_pixels`, `light_pixels_reverse`, `light_pixels_height_1`, `light_pixels_alternate`

Internal renaming of `light_pixels_height` to `light_pixels_height_1` to insist that it's "height - 1"

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
