### PR TITLE
Berry add 'bytes().appendhex()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Support for Senseair S88 CO2 sensor (#22733)
 - ESP32 TasmotaLED change dynamically the number of pixels (#22754)
 - ESP32 expand `Pixels` with reverse, height and alternate (#22755)
-- Berry allow `bytes().append(nil)`
+- Berry add `bytes().appendhex()`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -155,10 +155,10 @@ assert(str(b1) == "bytes('AA')")
 b1.append('01')
 assert(str(b1) == "bytes('AA3031')")
 
-#- .. with nil -#
-b1 = bytes("1122")
-assert(str(b1 .. nil) == "bytes('1122')")
-assert(str(b1.append(nil)) == "bytes('1122')")
+#- appendhex -#
+assert(bytes().appendhex(bytes("DEADBEEF")) == bytes("4445414442454546"))
+assert(bytes("AABBCC").appendhex(bytes("DEADBEEF")) == bytes("AABBCC4445414442454546"))
+assert(bytes("AABBCC").appendhex(bytes("")) == bytes("AABBCC"))
 
 #- item -#
 b = bytes("334455")


### PR DESCRIPTION
## Description:

Berry:
- add `bytes().appendhex()` used in async webserver to create an hex payload without allocating a new object
- reverting #22758 which is not needed after all, and not fortunate

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
