### PR TITLE
MI32 legacy: fix missing button when turning on BLE

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -235,7 +235,7 @@ struct {
     uint32_t handleEveryDevice:1;
   } option;
 #ifdef USE_MI_EXT_GUI
-  uint32_t widgetSlot;
+  uint32_t widgetSlot = 0;
 #ifdef USE_ENERGY_SENSOR
   uint8_t energy_history[24];
 #endif //USE_ENERGY_SENSOR

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -2624,7 +2624,6 @@ void MI32sendWidget(uint32_t slot){
 }
 
 void MI32InitGUI(void){
-  MI32.widgetSlot=0;
   WSContentStart_P("m32");
   WSContentSend_P(HTTP_MI32_SCRIPT_1);
   WSContentSendStyle();
@@ -2938,6 +2937,20 @@ int ExtStopBLE(){
 
 bool Xsns62(uint32_t function)
 {
+
+#ifdef USE_WEBSERVER
+#ifdef USE_MI_EXT_GUI
+  switch (function) {
+    case FUNC_WEB_ADD_MAIN_BUTTON:
+      WSContentSend_P(HTTP_BTN_MENU_MI32);
+      break;
+    case FUNC_WEB_ADD_HANDLER:
+      WebServer_on(PSTR("/m32"), MI32HandleWebGUI);
+      break;
+  }
+  #endif  //USE_MI_EXT_GUI
+#endif  //USE_WEBSERVER
+
   if (!Settings->flag5.mi32_enable) { return false; }  // SetOption115 - Enable ESP32 MI32 BLE
 
   bool result = false;
@@ -2977,14 +2990,6 @@ bool Xsns62(uint32_t function)
     case FUNC_WEB_SENSOR:
       MI32Show(0);
       break;
-#ifdef USE_MI_EXT_GUI
-      case FUNC_WEB_ADD_MAIN_BUTTON:
-        if (Settings->flag5.mi32_enable) WSContentSend_P(HTTP_BTN_MENU_MI32);
-        break;
-      case FUNC_WEB_ADD_HANDLER:
-        WebServer_on(PSTR("/m32"), MI32HandleWebGUI);
-        break;
-#endif  //USE_MI_EXT_GUI
 #endif  // USE_WEBSERVER
     }
   return result;


### PR DESCRIPTION
## Description:

Turning on Bluetooth without rebooting with `so115 1` was already possible before, but the web GUI never reflected that correctly.
Saving a few bytes by removing an unnecessary if-statement.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
