### PR TITLE
Use 75% of the buffer for speeds higher than 115200

### DIFF
--- a/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
+++ b/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
@@ -172,10 +172,13 @@ void TasmotaSerial::Esp32Begin(void) {
     // At 19200, 120 chars are ~60ms
     // At 76800, 120 chars are ~15ms
     uart_set_rx_full_threshold(m_uart, 120);
-  } else {
+  } else if (m_speed == 115200) {
     // At 115200, 256 chars are ~20ms
     // Zigbee requires to keep frames together, i.e. 256 bytes max
     uart_set_rx_full_threshold(m_uart, 256);
+  } else {
+    // At even higher speeds set 75% of the buffer
+    uart_set_rx_full_threshold(m_uart, serial_buffer_size * 3 / 4);
   }
   // For bitrate below 115200, set the Rx time out to 6 chars instead of the default 10
   if (m_speed < 115200) {


### PR DESCRIPTION
Higher speeds need larger buffer. Processing takes longer, so let's put the threshold at 75% of the buffer size to have some headroom. E.g. for 1Mbit with 2.5kB buffer 2048 characters would be roughly still around 20ms, and reserve additional 512 chars / 5ms to handle the buffer after the threshold is reached

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

I do not expect 8266 would be able to handle 1Mbit+ speeds.
To use with TCP Serial Bridge TCP_BRIDGE_BUF_SIZE needs to be increased.
Tested on ESP32-C3 and 1.5Mbit (rockchip serial console speed) with a 4kB buffer