### PR TITLE
I2S: AAC support for web radio

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioGeneratorAAC.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioGeneratorAAC.cpp
@@ -18,7 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma GCC optimize ("O3")
+#pragma GCC optimize ("Os")
 
 #include "AudioGeneratorAAC.h"
 

--- a/lib/lib_audio/ESP8266Audio/src/libhelix-aac/aaccommon.h
+++ b/lib/lib_audio/ESP8266Audio/src/libhelix-aac/aaccommon.h
@@ -54,7 +54,7 @@
   #define AAC_ENABLE_SBR 1 
 #endif
 
-#pragma GCC optimize ("O3")
+#pragma GCC optimize ("Os")
 
 #include "aacdec.h"
 #include "statname.h"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1409,6 +1409,7 @@
   #define USE_SHINE
   #define MP3_MIC_STREAM
   #define USE_I2S_AUDIO_BERRY
+  #define USE_I2S_AAC
 #endif // USE_I2S_ALL
 
 #endif  // _MY_USER_CONFIG_H_

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -52,6 +52,12 @@ enum : int8_t {
   I2S_SLOT_PHILIPS = 2,   // Philips
 };
 
+// I2S decoder type
+enum : uint32_t {
+  AAC_DECODER = 0,
+  MP3_DECODER = 1,
+};
+
 #define I2S_SLOTS   2
 #define AUDIO_SETTINGS_VERSION  2
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -30,7 +30,9 @@
 #include "AudioGeneratorTalkie.h"
 #include "AudioFileSourceICYStream.h"
 #include "AudioFileSourceBuffer.h"
+#ifdef USE_I2S_AAC
 #include "AudioGeneratorAAC.h"
+#endif // USE_I2S_AAC
 
 #include <layer3.h>
 
@@ -54,9 +56,9 @@
 extern FS *ufsp;
 extern FS *ffsp;
 
-const int preallocateBufferSize = 16*1024;
-const int preallocateCodecSize = 29192; // MP3 codec max mem needed
-//const int preallocateCodecSize = 85332; // AAC+SBR codec max mem needed
+constexpr int preallocateBufferSize = 16*1024;
+constexpr int preallocateCodecSize  = 29192; // MP3 codec max mem needed
+constexpr int preallocateCodecSizeAAC = 85332; // AAC+SBR codec max mem needed
 
 void sayTime(int hour, int minutes);
 void Cmndwav2mp3(void);
@@ -81,7 +83,7 @@ struct AUDIO_I2S_MP3_t {
 #endif // USE_I2S_MP3
 
 #if defined(USE_I2S_MP3) || defined(USE_I2S_WEBRADIO) || defined(USE_SHINE) || defined(MP3_MIC_STREAM)
-  AudioGeneratorMP3 *decoder = NULL;
+  AudioGenerator *decoder = nullptr;
   TaskHandle_t mp3_task_handle;
   TaskHandle_t mic_task_handle;
 #endif // defined(USE_I2S_MP3) || defined(USE_I2S_WEBRADIO)


### PR DESCRIPTION
## Description:

This allows to build a binary with support for AAC web radio streams with flag: `USE_I2S_AAC` (or `USE_I2S_ALL` if binary size does not matter)
Increases binary size by 75596 bytes in my test build.

Add optional decoder type to command `i2swr` in the form of:
`i2swr<int:type> <string: url>`
types: 
0 - AAC
1 - MP3 (makes it backwards compatible as `i2swr url` == `i2swr1 url`)


Small refactoring and renaming in the web page.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
