### PR TITLE
'Pixels' has backwards compatible arguments fixing #22755

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - GPIOViewer from v1.5.8 to v1.5.9 (No functional change)
+- `Pixels` has backwards compatible arguments fixing #22755
 
 ### Fixed
 - Shutter discovery message regression from v14.4.1 (#22730)

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -799,7 +799,7 @@ void CmndPixels(void)
       Ws2812CanShowWait();
       Settings->light_pixels = parm[0];
       Settings->light_pixels_reverse = parm[1];
-      Settings->light_pixels_height_1 = (parm[2] > 0) ? parm[2] - 1 : 1;
+      Settings->light_pixels_height_1 = (parm[2] > 0) ? parm[2] - 1 : 0;
       Settings->light_pixels_alternate = parm[3];
       Ws2812ChangePixelCount();
       Light.update = true;

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812_esp32.ino
@@ -791,8 +791,8 @@ void CmndLed(void)
 
 void CmndPixels(void)
 {
-  uint32_t parm[4] = { Settings->light_pixels, Settings->light_pixels_reverse,
-                       (uint32_t) Settings->light_pixels_height_1 + 1, Settings->light_pixels_alternate };
+  uint32_t parm[4] = { Settings->light_pixels, 0 /* reverse = 0 */,
+                       0 /* height = 1 (minus 1) */, 0 /* alternate = 0 */ };
   if (ParseParameters(4, parm) > 0) {
     if ((parm[0] > 0) && (parm[0] <= WS2812_MAX_LEDS)) {
       Ws2812Clear();                     // Clear all known pixels


### PR DESCRIPTION
## Description:

Brings back backwards compatibility of arguments after #22755.

Now `Pixels 25` is equivalent to `Pixels 25,0,1,0` or `Pixels 25,0,0,0` so this single command removes the matrix geometry. This is meant to enforce backwards compatibility with existing automation.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.0.241206
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
