### PR TITLE
I2S: add opus stream and file support for opus/aac

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1412,6 +1412,7 @@
   #define MP3_MIC_STREAM
   #define USE_I2S_AUDIO_BERRY
   #define USE_I2S_AAC
+  #define USE_I2S_OPUS
 #endif // USE_I2S_ALL
 
 #endif  // _MY_USER_CONFIG_H_

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -56,6 +56,7 @@ enum : int8_t {
 enum : uint32_t {
   AAC_DECODER = 0,
   MP3_DECODER = 1,
+  OPUS_DECODER = 2,
 };
 
 #define I2S_SLOTS   2


### PR DESCRIPTION
## Description:

Adds optional OPUS decoder, which is off by default. Adds 23076 bytes in test build.
Build flag: `USE_I2S_OPUS`

Internal decoder type is 2.

Adds file play support for all 3 decoders with similar syntax to web radio:
`i2splay2 /clock.opus` - plays raw OPUS file "clock.opus"
`i2splay0 /clock.aac` - plays raw AAC file "clock.aac" (M4A must be converted to AAC, countless online tools available).

Some refactoring with more generic naming and reduced code duplication.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
