### PR TITLE
Fix missing val and text on change event

### DIFF
--- a/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
+++ b/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
@@ -670,11 +670,11 @@ class lvh_obj : lvh_root
       var tas_event_more = ""   # complementary data
       if code == lv.EVENT_VALUE_CHANGED
         import introspect
-        var val = introspect.get(self, true)     # does not raise an exception if not found
+        var val = introspect.get(self, "val")     # does not raise an exception if not found
         if (val != nil && type(val) != 'module')
           tas_event_more = f',"val":{json.dump(val)}'
         end
-        var text = introspect.get(self, true)     # does not raise an exception if not found
+        var text = introspect.get(self, "text")     # does not raise an exception if not found
         if (text != nil && type(text) != 'module')
           tas_event_more += f',"text":{json.dump(text)}'
         end

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -1660,8 +1660,8 @@ be_local_class(lvh_root,
     })),
     be_str_weak(lvh_root)
 );
-// compact class 'lvh_obj' ktab size: 138, total: 285 (saved 1176 bytes)
-static const bvalue be_ktab_class_lvh_obj[138] = {
+// compact class 'lvh_obj' ktab size: 140, total: 287 (saved 1176 bytes)
+static const bvalue be_ktab_class_lvh_obj[140] = {
   /* K0   */  be_nested_str_weak(_action),
   /* K1   */  be_nested_str_weak(_lv_label),
   /* K2   */  be_nested_str_weak(get_text),
@@ -1764,42 +1764,44 @@ static const bvalue be_ktab_class_lvh_obj[138] = {
   /* K99  */  be_nested_str_weak(_event_map),
   /* K100 */  be_nested_str_weak(json),
   /* K101 */  be_nested_str_weak(EVENT_VALUE_CHANGED),
-  /* K102 */  be_nested_str_weak(module),
-  /* K103 */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
-  /* K104 */  be_nested_str_weak(dump),
-  /* K105 */  be_nested_str_weak(_X2C_X22text_X22_X3A_X25s),
-  /* K106 */  be_nested_str_weak(_tag),
-  /* K107 */  be_nested_str_weak(_X2C_X22tag_X22_X3A_X25s),
-  /* K108 */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
-  /* K109 */  be_nested_str_weak(_page_id),
-  /* K110 */  be_nested_str_weak(id),
-  /* K111 */  be_nested_str_weak(get_style_pad_bottom),
-  /* K112 */  be_nested_str_weak(get_y),
-  /* K113 */  be_nested_str_weak(set_style_pad_bottom),
-  /* K114 */  be_nested_str_weak(add_flag),
-  /* K115 */  be_nested_str_weak(clear_flag),
-  /* K116 */  be_nested_str_weak(get_style_pad_left),
-  /* K117 */  be_nested_str_weak(set_y),
-  /* K118 */  be_nested_str_weak(get_value_color),
-  /* K119 */  be_nested_str_weak(get_value),
-  /* K120 */  be_nested_str_weak(expand),
-  /* K121 */  be_nested_str_weak(set_width),
-  /* K122 */  be_nested_str_weak(SIZE_CONTENT),
-  /* K123 */  be_nested_str_weak(break),
-  /* K124 */  be_nested_str_weak(LABEL_LONG_WRAP),
-  /* K125 */  be_nested_str_weak(dots),
-  /* K126 */  be_nested_str_weak(LABEL_LONG_DOT),
-  /* K127 */  be_nested_str_weak(scroll),
-  /* K128 */  be_nested_str_weak(LABEL_LONG_SCROLL),
-  /* K129 */  be_nested_str_weak(loop),
-  /* K130 */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
-  /* K131 */  be_nested_str_weak(crop),
-  /* K132 */  be_nested_str_weak(LABEL_LONG_CLIP),
-  /* K133 */  be_nested_str_weak(set_long_mode),
-  /* K134 */  be_const_int(2),
-  /* K135 */  be_nested_str_weak(set_style_text_align),
-  /* K136 */  be_nested_str_weak(get_style_line_width),
-  /* K137 */  be_nested_str_weak(set_style_pad_left),
+  /* K102 */  be_nested_str_weak(val),
+  /* K103 */  be_nested_str_weak(module),
+  /* K104 */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
+  /* K105 */  be_nested_str_weak(dump),
+  /* K106 */  be_nested_str_weak(text),
+  /* K107 */  be_nested_str_weak(_X2C_X22text_X22_X3A_X25s),
+  /* K108 */  be_nested_str_weak(_tag),
+  /* K109 */  be_nested_str_weak(_X2C_X22tag_X22_X3A_X25s),
+  /* K110 */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
+  /* K111 */  be_nested_str_weak(_page_id),
+  /* K112 */  be_nested_str_weak(id),
+  /* K113 */  be_nested_str_weak(get_style_pad_bottom),
+  /* K114 */  be_nested_str_weak(get_y),
+  /* K115 */  be_nested_str_weak(set_style_pad_bottom),
+  /* K116 */  be_nested_str_weak(add_flag),
+  /* K117 */  be_nested_str_weak(clear_flag),
+  /* K118 */  be_nested_str_weak(get_style_pad_left),
+  /* K119 */  be_nested_str_weak(set_y),
+  /* K120 */  be_nested_str_weak(get_value_color),
+  /* K121 */  be_nested_str_weak(get_value),
+  /* K122 */  be_nested_str_weak(expand),
+  /* K123 */  be_nested_str_weak(set_width),
+  /* K124 */  be_nested_str_weak(SIZE_CONTENT),
+  /* K125 */  be_nested_str_weak(break),
+  /* K126 */  be_nested_str_weak(LABEL_LONG_WRAP),
+  /* K127 */  be_nested_str_weak(dots),
+  /* K128 */  be_nested_str_weak(LABEL_LONG_DOT),
+  /* K129 */  be_nested_str_weak(scroll),
+  /* K130 */  be_nested_str_weak(LABEL_LONG_SCROLL),
+  /* K131 */  be_nested_str_weak(loop),
+  /* K132 */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
+  /* K133 */  be_nested_str_weak(crop),
+  /* K134 */  be_nested_str_weak(LABEL_LONG_CLIP),
+  /* K135 */  be_nested_str_weak(set_long_mode),
+  /* K136 */  be_const_int(2),
+  /* K137 */  be_nested_str_weak(set_style_text_align),
+  /* K138 */  be_nested_str_weak(get_style_line_width),
+  /* K139 */  be_nested_str_weak(set_style_pad_left),
 };
 
 
@@ -3500,7 +3502,7 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
       0xA41E1C00,  //  001D  IMPORT	R7	K14
       0x8C200F36,  //  001E  GETMET	R8	R7	K54
       0x5C280000,  //  001F  MOVE	R10	R0
-      0x502C0200,  //  0020  LDBOOL	R11	1	0
+      0x582C0066,  //  0020  LDCONST	R11	K102
       0x7C200600,  //  0021  CALL	R8	3
       0x4C240000,  //  0022  LDNIL	R9
       0x20241009,  //  0023  NE	R9	R8	R9
@@ -3508,18 +3510,18 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
       0x60240004,  //  0025  GETGBL	R9	G4
       0x5C281000,  //  0026  MOVE	R10	R8
       0x7C240200,  //  0027  CALL	R9	1
-      0x20241366,  //  0028  NE	R9	R9	K102
+      0x20241367,  //  0028  NE	R9	R9	K103
       0x78260006,  //  0029  JMPF	R9	#0031
       0x60240018,  //  002A  GETGBL	R9	G24
-      0x58280067,  //  002B  LDCONST	R10	K103
-      0x8C2C0B68,  //  002C  GETMET	R11	R5	K104
+      0x58280068,  //  002B  LDCONST	R10	K104
+      0x8C2C0B69,  //  002C  GETMET	R11	R5	K105
       0x5C341000,  //  002D  MOVE	R13	R8
       0x7C2C0400,  //  002E  CALL	R11	2
       0x7C240400,  //  002F  CALL	R9	2
       0x5C181200,  //  0030  MOVE	R6	R9
       0x8C240F36,  //  0031  GETMET	R9	R7	K54
       0x5C2C0000,  //  0032  MOVE	R11	R0
-      0x50300200,  //  0033  LDBOOL	R12	1	0
+      0x5830006A,  //  0033  LDCONST	R12	K106
       0x7C240600,  //  0034  CALL	R9	3
       0x4C280000,  //  0035  LDNIL	R10
       0x2028120A,  //  0036  NE	R10	R9	R10
@@ -3527,31 +3529,31 @@ be_local_closure(class_lvh_obj_event_cb,   /* name */
       0x60280004,  //  0038  GETGBL	R10	G4
       0x5C2C1200,  //  0039  MOVE	R11	R9
       0x7C280200,  //  003A  CALL	R10	1
-      0x20281566,  //  003B  NE	R10	R10	K102
+      0x20281567,  //  003B  NE	R10	R10	K103
       0x782A0006,  //  003C  JMPF	R10	#0044
       0x60280018,  //  003D  GETGBL	R10	G24
-      0x582C0069,  //  003E  LDCONST	R11	K105
-      0x8C300B68,  //  003F  GETMET	R12	R5	K104
+      0x582C006B,  //  003E  LDCONST	R11	K107
+      0x8C300B69,  //  003F  GETMET	R12	R5	K105
       0x5C381200,  //  0040  MOVE	R14	R9
       0x7C300400,  //  0041  CALL	R12	2
       0x7C280400,  //  0042  CALL	R10	2
       0x00180C0A,  //  0043  ADD	R6	R6	R10
-      0x881C016A,  //  0044  GETMBR	R7	R0	K106
+      0x881C016C,  //  0044  GETMBR	R7	R0	K108
       0x4C200000,  //  0045  LDNIL	R8
       0x201C0E08,  //  0046  NE	R7	R7	R8
       0x781E0006,  //  0047  JMPF	R7	#004F
       0x601C0018,  //  0048  GETGBL	R7	G24
-      0x5820006B,  //  0049  LDCONST	R8	K107
-      0x8C240B68,  //  004A  GETMET	R9	R5	K104
-      0x882C016A,  //  004B  GETMBR	R11	R0	K106
+      0x5820006D,  //  0049  LDCONST	R8	K109
+      0x8C240B69,  //  004A  GETMET	R9	R5	K105
+      0x882C016C,  //  004B  GETMBR	R11	R0	K108
       0x7C240400,  //  004C  CALL	R9	2
       0x7C1C0400,  //  004D  CALL	R7	2
       0x00180C07,  //  004E  ADD	R6	R6	R7
       0x601C0018,  //  004F  GETGBL	R7	G24
-      0x5820006C,  //  0050  LDCONST	R8	K108
+      0x5820006E,  //  0050  LDCONST	R8	K110
       0x88240115,  //  0051  GETMBR	R9	R0	K21
-      0x8824136D,  //  0052  GETMBR	R9	R9	K109
-      0x8828016E,  //  0053  GETMBR	R10	R0	K110
+      0x8824136F,  //  0052  GETMBR	R9	R9	K111
+      0x88280170,  //  0053  GETMBR	R10	R0	K112
       0x5C2C0800,  //  0054  MOVE	R11	R4
       0x5C300C00,  //  0055  MOVE	R12	R6
       0x7C1C0A00,  //  0056  CALL	R7	5
@@ -3615,7 +3617,7 @@ be_local_closure(class_lvh_obj_get_pad_bottom,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C04036F,  //  0005  GETMET	R1	R1	K111
+      0x8C040371,  //  0005  GETMET	R1	R1	K113
       0x880C0107,  //  0006  GETMBR	R3	R0	K7
       0xB8120A00,  //  0007  GETNGBL	R4	K5
       0x88100909,  //  0008  GETMBR	R4	R4	K9
@@ -3647,7 +3649,7 @@ be_local_closure(class_lvh_obj_get_value_ofs_y,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x8C040370,  //  0001  GETMET	R1	R1	K112
+      0x8C040372,  //  0001  GETMET	R1	R1	K114
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -3678,7 +3680,7 @@ be_local_closure(class_lvh_obj_set_pad_bottom2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080103,  //  0004  GETMBR	R2	R0	K3
-      0x8C080571,  //  0005  GETMET	R2	R2	K113
+      0x8C080573,  //  0005  GETMET	R2	R2	K115
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1
@@ -3713,13 +3715,13 @@ be_local_closure(class_lvh_obj_set_flex_in_new_track,   /* name */
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
       0x88080103,  //  0001  GETMBR	R2	R0	K3
-      0x8C080572,  //  0002  GETMET	R2	R2	K114
+      0x8C080574,  //  0002  GETMET	R2	R2	K116
       0xB8120A00,  //  0003  GETNGBL	R4	K5
       0x88100906,  //  0004  GETMBR	R4	R4	K6
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
       0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x8C080573,  //  0008  GETMET	R2	R2	K115
+      0x8C080575,  //  0008  GETMET	R2	R2	K117
       0xB8120A00,  //  0009  GETNGBL	R4	K5
       0x88100906,  //  000A  GETMBR	R4	R4	K6
       0x7C080400,  //  000B  CALL	R2	2
@@ -3752,7 +3754,7 @@ be_local_closure(class_lvh_obj_get_pad_left,   /* name */
       0x20040202,  //  0002  NE	R1	R1	R2
       0x78060007,  //  0003  JMPF	R1	#000C
       0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C040374,  //  0005  GETMET	R1	R1	K116
+      0x8C040376,  //  0005  GETMET	R1	R1	K118
       0x880C0107,  //  0006  GETMBR	R3	R0	K7
       0xB8120A00,  //  0007  GETNGBL	R4	K5
       0x88100909,  //  0008  GETMBR	R4	R4	K9
@@ -3785,13 +3787,13 @@ be_local_closure(class_lvh_obj_set_adjustable,   /* name */
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
       0x88080103,  //  0001  GETMBR	R2	R0	K3
-      0x8C080572,  //  0002  GETMET	R2	R2	K114
+      0x8C080574,  //  0002  GETMET	R2	R2	K116
       0xB8120A00,  //  0003  GETNGBL	R4	K5
       0x88100954,  //  0004  GETMBR	R4	R4	K84
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
       0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x8C080573,  //  0008  GETMET	R2	R2	K115
+      0x8C080575,  //  0008  GETMET	R2	R2	K117
       0xB8120A00,  //  0009  GETNGBL	R4	K5
       0x88100954,  //  000A  GETMBR	R4	R4	K84
       0x7C080400,  //  000B  CALL	R2	2
@@ -3854,7 +3856,7 @@ be_local_closure(class_lvh_obj_set_value_ofs_y,   /* name */
       0x8C08013E,  //  0000  GETMET	R2	R0	K62
       0x7C080200,  //  0001  CALL	R2	1
       0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080575,  //  0003  GETMET	R2	R2	K117
+      0x8C080577,  //  0003  GETMET	R2	R2	K119
       0x60100009,  //  0004  GETGBL	R4	G9
       0x5C140200,  //  0005  MOVE	R5	R1
       0x7C100200,  //  0006  CALL	R4	1
@@ -3883,7 +3885,7 @@ be_local_closure(class_lvh_obj_get_value_color,   /* name */
     be_str_weak(get_value_color),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x8C040176,  //  0000  GETMET	R1	R0	K118
+      0x8C040178,  //  0000  GETMET	R1	R0	K120
       0x7C040200,  //  0001  CALL	R1	1
       0x80040200,  //  0002  RET	1	R1
     })
@@ -3910,7 +3912,7 @@ be_local_closure(class_lvh_obj_get_val,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040103,  //  0000  GETMBR	R1	R0	K3
-      0x8C040377,  //  0001  GETMET	R1	R1	K119
+      0x8C040379,  //  0001  GETMET	R1	R1	K121
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
     })
@@ -3937,45 +3939,45 @@ be_local_closure(class_lvh_obj_set_label_mode,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[43]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
-      0x1C0C0378,  //  0001  EQ	R3	R1	K120
+      0x1C0C037A,  //  0001  EQ	R3	R1	K122
       0x780E0005,  //  0002  JMPF	R3	#0009
       0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x8C0C0779,  //  0004  GETMET	R3	R3	K121
+      0x8C0C077B,  //  0004  GETMET	R3	R3	K123
       0xB8160A00,  //  0005  GETNGBL	R5	K5
-      0x88140B7A,  //  0006  GETMBR	R5	R5	K122
+      0x88140B7C,  //  0006  GETMBR	R5	R5	K124
       0x7C0C0400,  //  0007  CALL	R3	2
       0x70020017,  //  0008  JMP		#0021
-      0x1C0C037B,  //  0009  EQ	R3	R1	K123
+      0x1C0C037D,  //  0009  EQ	R3	R1	K125
       0x780E0002,  //  000A  JMPF	R3	#000E
       0xB80E0A00,  //  000B  GETNGBL	R3	K5
-      0x8808077C,  //  000C  GETMBR	R2	R3	K124
+      0x8808077E,  //  000C  GETMBR	R2	R3	K126
       0x70020012,  //  000D  JMP		#0021
-      0x1C0C037D,  //  000E  EQ	R3	R1	K125
+      0x1C0C037F,  //  000E  EQ	R3	R1	K127
       0x780E0002,  //  000F  JMPF	R3	#0013
       0xB80E0A00,  //  0010  GETNGBL	R3	K5
-      0x8808077E,  //  0011  GETMBR	R2	R3	K126
+      0x88080780,  //  0011  GETMBR	R2	R3	K128
       0x7002000D,  //  0012  JMP		#0021
-      0x1C0C037F,  //  0013  EQ	R3	R1	K127
+      0x1C0C0381,  //  0013  EQ	R3	R1	K129
       0x780E0002,  //  0014  JMPF	R3	#0018
       0xB80E0A00,  //  0015  GETNGBL	R3	K5
-      0x88080780,  //  0016  GETMBR	R2	R3	K128
+      0x88080782,  //  0016  GETMBR	R2	R3	K130
       0x70020008,  //  0017  JMP		#0021
-      0x1C0C0381,  //  0018  EQ	R3	R1	K129
+      0x1C0C0383,  //  0018  EQ	R3	R1	K131
       0x780E0002,  //  0019  JMPF	R3	#001D
       0xB80E0A00,  //  001A  GETNGBL	R3	K5
-      0x88080782,  //  001B  GETMBR	R2	R3	K130
+      0x88080784,  //  001B  GETMBR	R2	R3	K132
       0x70020003,  //  001C  JMP		#0021
-      0x1C0C0383,  //  001D  EQ	R3	R1	K131
+      0x1C0C0385,  //  001D  EQ	R3	R1	K133
       0x780E0001,  //  001E  JMPF	R3	#0021
       0xB80E0A00,  //  001F  GETNGBL	R3	K5
-      0x88080784,  //  0020  GETMBR	R2	R3	K132
+      0x88080786,  //  0020  GETMBR	R2	R3	K134
       0x4C0C0000,  //  0021  LDNIL	R3
       0x200C0403,  //  0022  NE	R3	R2	R3
       0x780E0005,  //  0023  JMPF	R3	#002A
       0x8C0C013E,  //  0024  GETMET	R3	R0	K62
       0x7C0C0200,  //  0025  CALL	R3	1
       0x880C0101,  //  0026  GETMBR	R3	R0	K1
-      0x8C0C0785,  //  0027  GETMET	R3	R3	K133
+      0x8C0C0787,  //  0027  GETMET	R3	R3	K135
       0x5C140400,  //  0028  MOVE	R5	R2
       0x7C0C0400,  //  0029  CALL	R3	2
       0x80000000,  //  002A  RET	0
@@ -4004,13 +4006,13 @@ be_local_closure(class_lvh_obj_set_hidden,   /* name */
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
       0x88080103,  //  0001  GETMBR	R2	R0	K3
-      0x8C080572,  //  0002  GETMET	R2	R2	K114
+      0x8C080574,  //  0002  GETMET	R2	R2	K116
       0xB8120A00,  //  0003  GETNGBL	R4	K5
       0x8810090A,  //  0004  GETMBR	R4	R4	K10
       0x7C080400,  //  0005  CALL	R2	2
       0x70020004,  //  0006  JMP		#000C
       0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x8C080573,  //  0008  GETMET	R2	R2	K115
+      0x8C080575,  //  0008  GETMET	R2	R2	K117
       0xB8120A00,  //  0009  GETNGBL	R4	K5
       0x8810090A,  //  000A  GETMBR	R4	R4	K10
       0x7C080400,  //  000B  CALL	R2	2
@@ -4058,14 +4060,14 @@ be_local_closure(class_lvh_obj_set_align,   /* name */
       0xB8120A00,  //  0011  GETNGBL	R4	K5
       0x880C0958,  //  0012  GETMBR	R3	R4	K88
       0x70020005,  //  0013  JMP		#001A
-      0x1C100386,  //  0014  EQ	R4	R1	K134
+      0x1C100388,  //  0014  EQ	R4	R1	K136
       0x74120001,  //  0015  JMPT	R4	#0018
       0x1C10035B,  //  0016  EQ	R4	R1	K91
       0x78120001,  //  0017  JMPF	R4	#001A
       0xB8120A00,  //  0018  GETNGBL	R4	K5
       0x880C095A,  //  0019  GETMBR	R3	R4	K90
       0x88100101,  //  001A  GETMBR	R4	R0	K1
-      0x8C100987,  //  001B  GETMET	R4	R4	K135
+      0x8C100989,  //  001B  GETMET	R4	R4	K137
       0x5C180600,  //  001C  MOVE	R6	R3
       0x5C1C0400,  //  001D  MOVE	R7	R2
       0x7C100600,  //  001E  CALL	R4	3
@@ -4094,7 +4096,7 @@ be_local_closure(class_lvh_obj_get_line_width,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x88080103,  //  0000  GETMBR	R2	R0	K3
-      0x8C080588,  //  0001  GETMET	R2	R2	K136
+      0x8C08058A,  //  0001  GETMET	R2	R2	K138
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -4126,7 +4128,7 @@ be_local_closure(class_lvh_obj_set_pad_left2,   /* name */
       0x20080403,  //  0002  NE	R2	R2	R3
       0x780A0009,  //  0003  JMPF	R2	#000E
       0x88080103,  //  0004  GETMBR	R2	R0	K3
-      0x8C080589,  //  0005  GETMET	R2	R2	K137
+      0x8C08058B,  //  0005  GETMET	R2	R2	K139
       0x60100009,  //  0006  GETGBL	R4	G9
       0x5C140200,  //  0007  MOVE	R5	R1
       0x7C100200,  //  0008  CALL	R4	1


### PR DESCRIPTION
## Description:
Currently `changed` events are not sent with their associated `val`s or `text`s.

This can be reproduced by using the following `pages.json`:
```
{"page":1}
{"id":41,"obj":"roller","x":10,"y":55,"options":"Option 1\nOption 2\nOption 3\nOption 4","val":1,"bg_color50":"#FF4400","text_color":"#FFFF88","text_color50":"#000000","border_color":"#FFFF88"}
```

and entering the following code in the berry console:
```
tasmota.add_rule("hasp#p1b41", / text -> print(text))
```

The current version gives this result:
```
{'event': 'down'}
{'event': 'changed'}
{'event': 'release'}
{'event': 'up'}
{'event': 'down'}
{'event': 'changed'}
{'event': 'release'}
{'event': 'up'}
```

With the changes the result is the following as it should be according to the [documentation](https://tasmota.github.io/docs/HASPmota/#react-to-user-actions):
```
{'event': 'down'}
{'val': 2, 'text': 'Option 3', 'event': 'changed'}
{'event': 'release'}
{'event': 'up'}
{'event': 'down'}
{'val': 3, 'text': 'Option 4', 'event': 'changed'}
{'event': 'release'}
{'event': 'up'}
```

This allows matching those values with `tasmota.add_rule("hasp#p1b41#text", / text -> print(text))` and `tasmota.add_rule("hasp#p1b41#val", / val -> print(val))`

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
