### PR TITLE
DS3231 bus2 support

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_56_rtc_chips.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_56_rtc_chips.ino
@@ -92,7 +92,7 @@ uint32_t DS3231ReadTime(void) {
   tm.hour = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_HOURS, RtcChip.bus) & ~_BV(DS3231_HR1224)); // 24h mode
   tm.day_of_week = I2cRead8(RtcChip.address, DS3231_DAY, RtcChip.bus);
   tm.day_of_month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_DATE, RtcChip.bus));
-  tm.month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MONTH, RtcChip.bus) & ~_BV(DS3231_CENTURY)); ;  // Don't use the Century bit
+  tm.month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MONTH, RtcChip.bus) & ~_BV(DS3231_CENTURY));  // Don't use the Century bit
   // MakeTime requires tm.year as number of years since 1970, 
   // However DS3231 is supposed to hold the true year but before this PR it was written tm.year directly
   // Assuming we read ... means ...

--- a/tasmota/tasmota_xdrv_driver/xdrv_56_rtc_chips.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_56_rtc_chips.ino
@@ -87,29 +87,28 @@ struct {
 \*-------------------------------------------------------------------------------------------*/
 uint32_t DS3231ReadTime(void) {
   TIME_T tm;
-  tm.second = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_SECONDS));
-  tm.minute = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MINUTES));
-  tm.hour = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_HOURS) & ~_BV(DS3231_HR1224));    // Assumes 24hr clock
-  tm.day_of_week = I2cRead8(RtcChip.address, DS3231_DAY);
-  tm.day_of_month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_DATE));
-  tm.month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MONTH) & ~_BV(DS3231_CENTURY));  // Don't use the Century bit
+  tm.second = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_SECONDS, RtcChip.bus));
+  tm.minute = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MINUTES, RtcChip.bus));
+  tm.hour = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_HOURS, RtcChip.bus) & ~_BV(DS3231_HR1224)); // 24h mode
+  tm.day_of_week = I2cRead8(RtcChip.address, DS3231_DAY, RtcChip.bus);
+  tm.day_of_month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_DATE, RtcChip.bus));
+  tm.month = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_MONTH, RtcChip.bus) & ~_BV(DS3231_CENTURY)); ;  // Don't use the Century bit
   // MakeTime requires tm.year as number of years since 1970, 
   // However DS3231 is supposed to hold the true year but before this PR it was written tm.year directly
   // Assuming we read ... means ...
   //   00..21   = 1970..1990 written before PR (to support a RTC written with 1970) => don't apply correction
   //   22..51   = 2022..2051 written after PR => apply +30 years correction
   //   52..99   = 2022..2069 written before PR => don't apply correction
-  uint8_t year = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_YEAR));
-  tm.year = ((year <= 21) || (year >= 52)) ? (year) : (year+30);
+  uint8_t year = Bcd2Dec(I2cRead8(RtcChip.address, DS3231_YEAR, RtcChip.bus));
+  tm.year = ((year <= 21) || (year >= 52)) ? year : (year + 30);
   return MakeTime(tm);
 }
-
 /*-------------------------------------------------------------------------------------------*\
  * Read temperature from DS3231 internal sensor, return as float
 \*-------------------------------------------------------------------------------------------*/
 #ifdef DS3231_ENABLE_TEMP
 float DS3231ReadTemp(void) {
-  int16_t temp_reg = I2cReadS16(RtcChip.address, DS3231_TEMP_MSB) >> 6;
+  int16_t temp_reg = I2cReadS16(RtcChip.address, DS3231_TEMP_MSB, RtcChip.bus) >> 6;
   float temp = temp_reg * 0.25;
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("RTC: DS3231 temp_reg=%d"), temp_reg);
   return temp;
@@ -151,16 +150,15 @@ void D3231ShowSensor(bool json) {
 void DS3231SetTime(uint32_t epoch_time) {
   TIME_T tm;
   BreakTime(epoch_time, tm);
-  I2cWrite8(RtcChip.address, DS3231_SECONDS, Dec2Bcd(tm.second));
-  I2cWrite8(RtcChip.address, DS3231_MINUTES, Dec2Bcd(tm.minute));
-  I2cWrite8(RtcChip.address, DS3231_HOURS, Dec2Bcd(tm.hour));
-  I2cWrite8(RtcChip.address, DS3231_DAY, tm.day_of_week);
-  I2cWrite8(RtcChip.address, DS3231_DATE, Dec2Bcd(tm.day_of_month));
-  I2cWrite8(RtcChip.address, DS3231_MONTH, Dec2Bcd(tm.month));
-  // BreakTime returns tm.year as number of years since 1970, while DS3231 expect the true year. Adusting to avoir leap year error
+  I2cWrite8(RtcChip.address, DS3231_SECONDS, Dec2Bcd(tm.second), RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_MINUTES, Dec2Bcd(tm.minute), RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_HOURS, Dec2Bcd(tm.hour), RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_DAY, tm.day_of_week, RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_DATE, Dec2Bcd(tm.day_of_month), RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_MONTH, Dec2Bcd(tm.month), RtcChip.bus);
   uint8_t true_year = (tm.year < 30) ? (tm.year + 70) : (tm.year - 30);
-  I2cWrite8(RtcChip.address, DS3231_YEAR, Dec2Bcd(true_year));
-  I2cWrite8(RtcChip.address, DS3231_STATUS, I2cRead8(RtcChip.address, DS3231_STATUS) & ~_BV(DS3231_OSF));  // Clear the Oscillator Stop Flag
+  I2cWrite8(RtcChip.address, DS3231_YEAR, Dec2Bcd(true_year), RtcChip.bus);
+  I2cWrite8(RtcChip.address, DS3231_STATUS, I2cRead8(RtcChip.address, DS3231_STATUS, RtcChip.bus) & ~_BV(DS3231_OSF), RtcChip.bus);
 }
 
 /*-------------------------------------------------------------------------------------------*\
@@ -169,8 +167,11 @@ void DS3231SetTime(uint32_t epoch_time) {
 void DS3231Detected(void) {
   if (!RtcChip.detected && I2cEnabled(XI2C_26)) {
     RtcChip.address = DS3231_ADDRESS;
-    if (I2cSetDevice(RtcChip.address)) {
-      if (I2cValidRead(RtcChip.address, DS3231_STATUS, 1)) {
+    for (RtcChip.bus = 0; RtcChip.bus < 2; RtcChip.bus++) {
+      if (!I2cSetDevice(RtcChip.address, RtcChip.bus)) {
+        continue; 
+      }
+      if (I2cValidRead(RtcChip.address, DS3231_STATUS, 1, RtcChip.bus)) {
         RtcChip.detected = 1;
         strcpy_P(RtcChip.name, PSTR("DS3231"));
         RtcChip.ReadTime = &DS3231ReadTime;
@@ -179,6 +180,7 @@ void DS3231Detected(void) {
         RtcChip.ShowSensor = &D3231ShowSensor;
 #endif
         RtcChip.mem_size = -1;
+        break; 
       }
     }
   }


### PR DESCRIPTION
Added BUS2 suport for DS3231. Tested on ESP32 S3

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
