### PR TITLE
Berry 'serial.read()' read only 'n' bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Command `FileLog 10..14` to enable logging to filesystem using up to 16 log files of 100kB (`#define FILE_LOG_SIZE 100`)
 - I2S Opus stream and file support for opus/aac (#22795)
 - I2S command I2sLoop (#22807)
+- Berry `serial.read()` read only `n` bytes
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_serial.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_serial.ino
@@ -143,10 +143,18 @@ extern "C" {
   int32_t b_serial_read(struct bvm *vm) {
     be_getmember(vm, 1, ".p");
     TasmotaSerial * ser = (TasmotaSerial *) be_tocomptr(vm, -1);
+    int32_t max_lex = -1;     // -1 means unlimited
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 2 && be_isint(vm, 2)) {
+      max_lex = be_toint(vm, 2);
+    }
     if (ser) {
       int32_t len = ser->available();
       if (len < 0) { len = 0; }
       if (len > 0) {
+        if (max_lex >= 0 && len > max_lex) {
+          len = max_lex;
+        }
         // read bytes on stack
         char * rx_buf = new char[len];
         len = ser->read(rx_buf, len);


### PR DESCRIPTION
## Description:

Add an optional parameter to `serial.read( [n : bytes] ) -> bytes()` to limit the number of bytes returned. Remaining bytes are kept in the serial internal buffer, to be read later.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
