### PR TITLE
Ignore user file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data
 unpacked_fs
 unpacked_boards
 tasmota/user_config_override.h
+include/local_ca_descriptor.h
 variants
 variants3
 build


### PR DESCRIPTION
Since local_ca_descriptor.h is an user file it should be ignored by git as already done for user_config_override.h

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
