### PR TITLE
Berry `tasmota.global.tele_period` and `tasmota.settings.tele_period`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - I2S command I2sLoop (#22807)
 - Berry `serial.read()` read only `n` bytes (#22835)
 - Display template for Waveshare ESP32-C6 LCD 1.47 (#22863)
+- Berry `tasmota.global.tele_period` and `tasmota.settings.tele_period`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -33,9 +33,9 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_global_struct = {
     sizeof(TasmotaGlobal),  /* size in bytes */
-    10,  /* number of elements */
+    11,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[10]) {
+    (const be_ctypes_structure_item_t[11]) {
       // Warning: fields below need to be in alphabetical order
       { "devices_present", offsetof(TasmotaGlobal_t, devices_present), 0, 0, ctypes_u8, 0 },
       { "energy_driver", offsetof(TasmotaGlobal_t, energy_driver), 0, 0, ctypes_u8, 0 },
@@ -46,14 +46,15 @@ extern "C" {
       { "seriallog_level", offsetof(TasmotaGlobal_t, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TasmotaGlobal_t, sleep), 0, 0, ctypes_u8, 0 },
       { "syslog_level", offsetof(TasmotaGlobal_t, syslog_level), 0, 0, ctypes_u8, 0 },
+      { "tele_period", offsetof(TasmotaGlobal_t, tele_period), 0, 0, ctypes_u16, 0 },
       { "templog_level", offsetof(TasmotaGlobal_t, templog_level), 0, 0, ctypes_u8, 0 },
   }};
 
   extern const be_ctypes_structure_t be_tasmota_settings_struct = {
     sizeof(TSettings),  /* size in bytes */
-    10,  /* number of elements */
+    11,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[10]) {
+    (const be_ctypes_structure_item_t[11]) {
       // Warning: fields below need to be in alphabetical order
       { "bootcount", offsetof(TSettings, bootcount), 0, 0, ctypes_u16, 0 },
       { "light_pixels", 0x496, 0, 15, ctypes_bf, 0 },
@@ -64,6 +65,7 @@ extern "C" {
       { "seriallog_level", offsetof(TSettings, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },
       { "syslog_level", offsetof(TSettings, syslog_level), 0, 0, ctypes_u8, 0 },
+      { "tele_period", offsetof(TSettings, tele_period), 0, 0, ctypes_u16, 0 },
       { "weblog_level", offsetof(TSettings, weblog_level), 0, 0, ctypes_u8, 0 },
   }};
 


### PR DESCRIPTION
## Description:

Berry add `tasmota.global.tele_period` and `tasmota.settings.tele_period`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
