### PR TITLE
Add indices for GPS baudrate selection

### DIFF
--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -533,6 +533,7 @@ const char kSensorNamesFixed[] PROGMEM =
 #define MAX_BL0942_RX            8  // Baudrates 1/5 (4800), 2/6 (9600), 3/7 (19200), 4/8 (38400), Support Positive values only 1..4, Support also negative values 5..8
 #define MAX_CSE7761              2  // Model 1/2 (DUALR3), 2/2 (POWCT)
 #define MAX_TWAI                 SOC_TWAI_CONTROLLER_NUM
+#define MAX_GPS_RX               4  // Baudrates 1 (4800), 2 (9600), 3 (19200), 4 (38400)
 
 const uint16_t kGpioNiceList[] PROGMEM = {
   GPIO_NONE,                                     // Not used
@@ -1091,7 +1092,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_GPS
   AGPIO(GPIO_GPS_TX),                            // GPS serial interface
-  AGPIO(GPIO_GPS_RX),                            // GPS serial interface
+  AGPIO(GPIO_GPS_RX) + MAX_GPS_RX,               // GPS serial interface
 #endif
 #ifdef USE_HM10
   AGPIO(GPIO_HM10_TX),                           // HM10 serial interface

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -1092,7 +1092,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_GPS
   AGPIO(GPIO_GPS_TX),                            // GPS serial interface
-  AGPIO(GPIO_GPS_RX) + MAX_GPS_RX,               // GPS serial interface
+  AGPIO(GPIO_GPS_RX) + AGMAX(MAX_GPS_RX),        // GPS serial interface
 #endif
 #ifdef USE_HM10
   AGPIO(GPIO_HM10_TX),                           // HM10 serial interface


### PR DESCRIPTION
## Description:

**Related discussion and explanation** https://github.com/arendst/Tasmota/discussions/22869

Supports the following baud rate setting: 1 (4800), 2 (9600), 3 (19200), 4 (38400)
Enables support for GNSS modules like https://docs.m5stack.com/en/module/GNSS%20Module
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
