### PR TITLE
Command 'PixelType' to change the WS2812 color order and channel number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Berry `serial.read()` read only `n` bytes (#22835)
 - Display template for Waveshare ESP32-C6 LCD 1.47 (#22863)
 - Berry `tasmota.global.tele_period` and `tasmota.settings.tele_period` (#22865)
+- Command `PixelType` to change the WS2812 color order and channel number
 
 ### Breaking Changed
 

--- a/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLED.h
@@ -22,16 +22,17 @@
 
 enum TasmotaLEDTypesEncoding : uint16_t {
   // bits 0..3 encode for number of bytes per pixel
-  TasmotaLed_1_W    = 0x0,    // 1 byte per pixel (not used yet)
-  TasmotaLed_3_RGB  = 0x1,    // 3 bytes per pixel
-  TasmotaLed_4_WRGB = 0x2,    // 4 bytes per pixel
+  TasmotaLed_1_Def  = 0x0,      // Default value - identical to TasmotaLed_3_RGB
+  TasmotaLed_3_RGB  = 0x1,      // 3 bytes per pixel
+  TasmotaLed_4_WRGB = 0x2,      // 4 bytes per pixel
   // bits 4..6 encode for pixel order
-  TasmotaLed_GRB = 0b000 << 4,
-  TasmotaLed_GBR = 0b001 << 4,
+  TasmotaLed_Def = 0b000 << 4,  // Default value - identical to TasmotaLed_GRB
+  TasmotaLed_GRB = 0b001 << 4,
   TasmotaLed_RGB = 0b010 << 4,
   TasmotaLed_RBG = 0b011 << 4,
   TasmotaLed_BRG = 0b100 << 4,
   TasmotaLed_BGR = 0b101 << 4,
+  TasmotaLed_GBR = 0b110 << 4,
   // bit 7 sets the position for W channel
   TasmotaLed_xxxW = 0b0 << 7,   // W channel after color
   TasmotaLed_Wxxx = 0b1 << 7,   // W channel before color
@@ -92,6 +93,8 @@ public:
   ~TasmotaLED();
 
   void SetPixelCount(uint16_t num_leds);
+  void SetPixelSubType(uint8_t type);         // change only Pixel order and pixel size
+  void _adjustSubType(void);
 
   bool Begin(void);
   void SetPusher(TasmotaLEDPusher *pusher);   // needs to be called before `Begin()`, sets the hardware implementation

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -532,6 +532,7 @@
 #define D_CMND_PALETTE "Palette"
 #define D_CMND_PIXELS "Pixels"
 #define D_CMND_STEPPIXELS "StepPixels"
+#define D_CMND_PIXELTYPE "PixelType"
 #define D_CMND_ARTNET "ArtNet"
 #define D_CMND_ARTNET_CONFIG "ArtNetConfig"
 #define D_SO_ARTNET_AUTORUN "ArtNetAutorun"

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -242,11 +242,9 @@ typedef union {
   uint32_t data;                           // Allow bit manipulation
   struct {
     uint32_t log_file_idx : 4;             // bit 0.3   (v14.4.1.2) - FileLog log rotate index
-    uint32_t spare04 : 1;                  // bit 4
-    uint32_t spare05 : 1;                  // bit 5
-    uint32_t spare06 : 1;                  // bit 6
-    uint32_t spare07 : 1;                  // bit 7
-    uint32_t spare08 : 1;                  // bit 8
+    uint32_t light_pixels_order : 3;       // bit 4.6   (v14.4.1.3) - LED light order <Compile>/GRB/RGB/RBG/BRG/BGR/GBR, high bit indicates W before (for RGBW)
+    uint32_t light_pixels_rgbw : 1;        // bit 7     (v14.4.1.3) - LED true is 4 channels RGBW, false is 3 channels RGB
+    uint32_t light_pixels_w_first : 1;     // bit 8     (v14.4.1.3) - LED true if W channel comes first, default is <RGB>W
     uint32_t spare09 : 1;                  // bit 9
     uint32_t spare10 : 1;                  // bit 10
     uint32_t spare11 : 1;                  // bit 11


### PR DESCRIPTION
## Description:

Command `PixelType`:

(ESP32 only) Set the number of channels per led in the strip, and the color order<BR>`0` = use compile-time options, like on ESP8266 (default)<BR>`1` = `GRB` (typical for WS2812)<BR>`2` = `RGB`<BR>`3` = `RBG`<BR>`4` = `BRG`<BR>`5` = `BGR`<BR>`6` = `GBR`<BR>add `8` = 4 channels strip (RGBW), default 3 channels<BR>add `16` = if `W` is sent first, default `W` is sent last<BR><BR>Examples:<BR>`1` = `GRB`<BR>`9` = `GRBW`<BR>`25` = `WGRB`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
