### PR TITLE
Berry callback now passes 5 arguments instead of 4 (in line with documentation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Platform from 2025.01.30 to 2025.01.31 (#22832)
 - Berry `gpio.pin_mode` frees PWM on pin
 - GPIOViewer from v1.6.0 to v1.6.1 (No functional change)
+- Berry callback now passes 5 arguments instead of 4 (in line with documentation)
 
 ### Fixed
 - Sonoff SPM `PowerOnState` overrules `SSPMPowerOnState` in mixed 4Relay setup with 4Relay version 1.0.0

--- a/lib/libesp32/berry_mapping/src/be_cb_module.c
+++ b/lib/libesp32/berry_mapping/src/be_cb_module.c
@@ -19,13 +19,13 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
 /*********************************************************************************************\
  * Callback structures
  * 
- * We allow 4 parameters, or 3 if method (first arg is `self`)
+ * We allow 5 parameters, or 4 if method (first arg is `self`)
  * This could be extended if needed
 \*********************************************************************************************/
-typedef int (*berry_callback_t)(int v0, int v1, int v2, int v3);
-static int call_berry_cb(int num, int v0, int v1, int v2, int v3);
+typedef int (*berry_callback_t)(int v0, int v1, int v2, int v3, int v4);
+static int call_berry_cb(int num, int v0, int v1, int v2, int v3, int v4);
 
-#define BERRY_CB(n) int berry_cb_##n(int v0, int v1, int v2, int v3) { return call_berry_cb(n, v0, v1, v2, v3); }
+#define BERRY_CB(n) int berry_cb_##n(int v0, int v1, int v2, int v3, int v4) { return call_berry_cb(n, v0, v1, v2, v3, v4); }
 // list the callbacks
 BERRY_CB(0);
 BERRY_CB(1);
@@ -242,7 +242,7 @@ static int be_cb_get_cb_list(bvm *vm) {
  * We allow 4 parameters, or 3 if method (first arg is `self`)
  * This could be extended if needed
 \*********************************************************************************************/
-static int call_berry_cb(int num, int v0, int v1, int v2, int v3) {
+static int call_berry_cb(int num, int v0, int v1, int v2, int v3, int v4) {
   // call berry cb dispatcher
   int32_t ret = 0;
   // retrieve vm and function
@@ -259,15 +259,16 @@ static int call_berry_cb(int num, int v0, int v1, int v2, int v3) {
   be_pushint(vm, v1);
   be_pushint(vm, v2);
   be_pushint(vm, v3);
+  be_pushint(vm, v4);
 
-  ret = be_pcall(vm, 4);   // 4 arguments
+  ret = be_pcall(vm, 5);   // 4 arguments
   if (ret != 0) {
     if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_PCALL_ERROR);
     be_pop(vm, be_top(vm));       // clear Berry stack
     return 0;
   }
-  ret = be_toint(vm, -5);
-  be_pop(vm, 5);    // remove result
+  ret = be_toint(vm, -6);
+  be_pop(vm, 6);    // remove result
   return ret;
 }
 


### PR DESCRIPTION
## Description:

Berry callback now passes 5 arguments instead of 4 (in line with documentation)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
