### PR TITLE
Berry 'tasmota.settings' entries for PixelType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Berry `tasmota.add_rule_once` and auto-remove rules with same pattern and id (#22900)
 - Berry example for HeatFan WiFi Controller
 - LVGL add `lv.set_paint_cb()` to register a callback when screen is refreshed
+- Berry `tasmota.settings` entries for PixelType
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -52,15 +52,18 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_settings_struct = {
     sizeof(TSettings),  /* size in bytes */
-    11,  /* number of elements */
+    14,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[11]) {
+    (const be_ctypes_structure_item_t[14]) {
       // Warning: fields below need to be in alphabetical order
       { "bootcount", offsetof(TSettings, bootcount), 0, 0, ctypes_u16, 0 },
       { "light_pixels", 0x496, 0, 15, ctypes_bf, 0 },
       { "light_pixels_alternate", 0xEC5, 7, 1, ctypes_bf, 0 },
       { "light_pixels_height_1", 0xEC4, 0, 15, ctypes_bf, 0 },
+      { "light_pixels_order", 0xFD8, 4, 3, ctypes_bf, 0 },
       { "light_pixels_reverse", 0x497, 7, 1, ctypes_bf, 0 },
+      { "light_pixels_rgbw", 0xFD8, 7, 1, ctypes_bf, 0 },
+      { "light_pixels_w_first", 0xFD9, 0, 1, ctypes_bf, 0 },
       { "mqttlog_level", offsetof(TSettings, mqttlog_level), 0, 0, ctypes_u8, 0 },
       { "seriallog_level", offsetof(TSettings, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },


### PR DESCRIPTION
## Description:

Added:
- `tasmota.settings.light_pixels_order` to set RGB pixel order on Leds
- `tasmota.settings.light_pixels_order`: `0` =  3 channels RGB, `1` = 4 channels RGBW
- `tasmota.settings.light_pixels_w_first`: indicates if W channel comes first, `0` = RGBW, `1` = WRGB

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
