### PR TITLE
BUGFIX: fix 8266 builds, add missing guards

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxer.cc
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxer.cc
@@ -7,6 +7,7 @@
 // be found in the AUTHORS file in the root of the source tree.
 
 #include "mkvmuxer.h"
+#ifdef ESP32
 
 #include <stdint.h>
 
@@ -4202,3 +4203,5 @@ bool Segment::DocTypeIsWebm() const {
 }
 
 }  // namespace mkvmuxer
+
+#endif //ESP32

--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxer.h
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxer.h
@@ -8,6 +8,7 @@
 
 #ifndef MKVMUXER_MKVMUXER_H_
 #define MKVMUXER_MKVMUXER_H_
+#ifdef ESP32
 
 #include <stdint.h>
 
@@ -1921,4 +1922,5 @@ class Segment {
 
 }  // namespace mkvmuxer
 
+#endif // ESP32
 #endif  // MKVMUXER_MKVMUXER_H_

--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxerutil.cc
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxerutil.cc
@@ -7,6 +7,7 @@
 // be found in the AUTHORS file in the root of the source tree.
 
 #include "mkvmuxerutil.h"
+#ifdef ESP32
 
 #ifdef __ANDROID__
 #include <fcntl.h>
@@ -735,3 +736,4 @@ bool IsPrimariesValueValid(uint64_t value) {
 }
 
 }  // namespace mkvmuxer
+#endif // ESP32

--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxerutil.h
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvmuxerutil.h
@@ -7,6 +7,7 @@
 // be found in the AUTHORS file in the root of the source tree.
 #ifndef MKVMUXER_MKVMUXERUTIL_H_
 #define MKVMUXER_MKVMUXERUTIL_H_
+#ifdef ESP32
 
 #include <stdint.h>
 
@@ -112,4 +113,5 @@ bool IsPrimariesValueValid(uint64_t value);
 
 }  // namespace mkvmuxer
 
+#endif // ESP32
 #endif  // MKVMUXER_MKVMUXERUTIL_H_

--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.cc
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.cc
@@ -7,6 +7,7 @@
 // be found in the AUTHORS file in the root of the source tree.
 
 #include "mkvwriter.h"
+#ifdef ESP32
 
 #include <sys/types.h>
 
@@ -97,3 +98,4 @@ bool MkvWriter::Seekable() const {
 void MkvWriter::ElementStartNotify(uint64, int64) {}
 
 }  // namespace mkvmuxer
+#endif // ESP32

--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.h
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.h
@@ -9,9 +9,10 @@
 #ifndef MKVMUXER_MKVWRITER_H_
 #define MKVMUXER_MKVWRITER_H_
 
+#ifdef ESP32
 #include <stdio.h>
-#include "Fs.h"
 
+#include "Fs.h"
 #include "mkvmuxer.h"
 #include "mkvmuxertypes.h"
 
@@ -55,4 +56,5 @@ class MkvWriter : public IMkvWriter {
 
 }  // namespace mkvmuxer
 
+#endif // ESP32
 #endif  // MKVMUXER_MKVWRITER_H_


### PR DESCRIPTION
## Description:

Add the missing guards for the libwebm files to fix builds for ESP8266.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
