### PR TITLE
Housekeeping: faster 8266 builds, ignore audio libs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -121,7 +121,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               -DMIMETYPE_MINIMAL
                               ; uncomment the following to enable TLS with 4096 RSA certificates
                               ;-DUSE_4K_RSA
-lib_ignore                  =
+lib_ignore                  = ESP8266Audio
+                              ESP8266SAM
                               ESP8266LLMNR
                               ESP8266NetBIOS
                               ESP8266SSDP


### PR DESCRIPTION
## Description:

Prevents unnecessary compilations. Did save 4-8 seconds on my test rigs, thus will accelerate every GH action in this repo.

We have no official audio builds for the ESP8266. It could be reenabled in the build section of an `env` in a personal use case for the ESP8266.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
