### PR TITLE
Platform 2025.02.30 Tasmota Arduino Core 3.1.1.250203 based on IDF 5.3.2.250120

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250109
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.01.31/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.02.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- S3 RGB Display Jitter / Crash fix (fixed bug in Arduino Lib Builder)
Now bigger RGB parallel displays (800x480) connected to an esp32-S3 do work

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
