### PR TITLE
Fix reboot with no private key

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/ssl/ssl_ccert_single_ec.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ssl/ssl_ccert_single_ec.c
@@ -59,7 +59,7 @@ cc_choose(const br_ssl_client_certificate_class **pctx,
 	scurve = br_ssl_client_get_server_curve(cc);
 
 	if ((zc->allowed_usages & BR_KEYTYPE_KEYX) != 0
-		&& scurve == zc->sk->curve)
+		&& zc->sk && scurve == zc->sk->curve)
 	{
 		int x;
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -1000,7 +1000,7 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
     // ============================================================
     // Set the EC Private Key, only USE_MQTT_AWS_IOT
     // limited to P256 curve
-    br_ssl_client_set_single_ec(_sc.get(), _chain_P, 1,
+    br_ssl_client_set_single_ec(_sc.get(), _chain_P, _chain_P ? 1 : 0,
                                 _sk_ec_P, _allowed_usages,
                                 _cert_issuer_key_type, &br_ec_p256_m15, br_ecdsa_sign_asn1_get_default());
   #endif // USE_MQTT_AWS_IOT


### PR DESCRIPTION
When USE_MQTT_AWS_IOT is defined but private key is not defined, if mqtt connection is done, system will raise an exception and reboot. On web page it seems that it's working, just slower then usual. Opening console you can see something weird. This seems to fix.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).