### PR TITLE
Add support for LVGL transitions

### DIFF
--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
@@ -112,10 +112,10 @@ end
 class lv_style_prop_arr : bytes
   def init(l)
     if type(l) != 'instance' || !isinstance(l, list)  raise "value_error", "argument must be a list" end
-    super(self).init(size(l) * 4)
+    super(self).init(size(l))
 
     for e: l
-      self.add(int(e), 4)
+      self.add(int(e))
     end
   end
 end

--- a/tasmota/berry/lvgl_examples/lvgl_examples_from_doc/lv_example_btn_2.be
+++ b/tasmota/berry/lvgl_examples/lvgl_examples_from_doc/lv_example_btn_2.be
@@ -4,7 +4,6 @@
 
 # Init the style for the default state
 style = lv.style()
-style.init()
 
 style.set_radius(3)
 
@@ -29,7 +28,6 @@ style.set_pad_all(10)
 
 # Init the pressed style
 style_pr = lv.style()
-style_pr.init()
 
 # Add a large outline when pressed
 style_pr.set_outline_width(30)
@@ -41,9 +39,10 @@ style_pr.set_bg_color(lv.palette_darken(lv.PALETTE_BLUE, 2))
 style_pr.set_bg_grad_color(lv.palette_darken(lv.PALETTE_BLUE, 4))
 
 # Add a transition to the outline
-trans = lv.style_transition_dsc()
 props = lv.style_prop_arr([lv.STYLE_OUTLINE_WIDTH, lv.STYLE_OUTLINE_OPA, 0])
-trans.init(props, lv.anim_path_linear, 300, 0, nil)
+trans = lv.style_transition_dsc(props, lv.anim_path_linear, 300, 0, nil)
+# or directly use the properties array (trailing 0 automatically added):
+#trans = lv.style_transition_dsc([lv.STYLE_OUTLINE_WIDTH, lv.STYLE_OUTLINE_OPA], lv.anim_path_linear, 300, 0, nil)
 
 style_pr.set_transition(trans)
 

--- a/tasmota/berry/lvgl_examples/lvgl_examples_from_doc/lv_example_btn_3.be
+++ b/tasmota/berry/lvgl_examples/lvgl_examples_from_doc/lv_example_btn_3.be
@@ -6,23 +6,19 @@
 props = lv.style_prop_arr([lv.STYLE_TRANSFORM_WIDTH, lv.STYLE_TRANSFORM_HEIGHT, lv.STYLE_TEXT_LETTER_SPACE, 0])
 
 # Transition descriptor when going back to the default state.
-# Add some delay to be sure the press transition is visible even if the press was very short*/
-transition_dsc_def = lv.style_transition_dsc()
-transition_dsc_def.init(props, lv.anim_path_overshoot, 250, 100, nil)
+# Add some delay to be sure the press transition is visible even if the press was very short
+transition_dsc_def = lv.style_transition_dsc(props, lv.anim_path_overshoot, 250, 100, nil)
 
 # Transition descriptor when going to pressed state.
 # No delay, go to pressed state immediately
-transition_dsc_pr = lv.style_transition_dsc()
-transition_dsc_pr.init(props, lv.anim_path_ease_in_out, 250, 0, nil)
+transition_dsc_pr = lv.style_transition_dsc(props, lv.anim_path_ease_in_out, 250, 0, nil)
 
 # Add only the new transition to the default state
 style_def = lv.style()
-style_def.init()
 style_def.set_transition(transition_dsc_def)
 
 # Add the transition and some transformation to the presses state.
 style_pr = lv.style()
-style_pr.init()
 style_pr.set_transform_width(10)
 style_pr.set_transform_height(-10)
 style_pr.set_text_letter_space(10)
@@ -35,4 +31,3 @@ btn1.add_style(style_def, 0)
 
 label = lv.label(btn1)
 label.set_text("Gum")
-


### PR DESCRIPTION
## Description:

This PR enables support for the LVGL transition feature which creates continuous adjustments from one style to another to be performed over a given time duration.

For this the object type `lv.style_transition_dsc` was enabled, and it can be fully initialized via its constructor (which in turn calls the native LVGL function `lv_style_transition_dsc()`). The PR currently only includes the actual code changes as well as an updated LVGL berry example, but does not include the changed generated files. I can add the generated files as soon as all kinks and quirks found in the code during the review were straightened out.

One thing to observe is that passing a `style_transition_dsc` object to `lv.style.set_transition()` does not add a reference to the object, therefore it also has to be kept in some variable to prevent its garbage collection. I am not sure how this is usually solved.

Also please check for any issues in the `lv_berry.c` code because I implemented this glue code mostly be looking up examples in other Tasmota source files. In a stripped down version we could leave out the function `list_to_zbytes()` and require the user to create an `lv.style_prop_arr` object as the first parameter for initialization.

As for the example, it works very well with just copy/pasting it to the Berry console. It also shows the two different ways of creating the `lv.style_transition_dsc` object.

**Related issue (if applicable):** none

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_