### PR TITLE
Wrong RMT channels for ESP32S3, now depends on 'soc_caps.h'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Berry parser error in rare case (#22997)
 - ESP32 TasMesh broker MAC address all zeros (#23005)
+- Wrong RMT channels for ESP32S3, now depends on `soc_caps.h`
 
 ### Removed
 

--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -93,24 +93,29 @@ const uint16_t VL53LXX_MAX_SENSORS = 8;     // Max number of VL53L0X sensors
 const uint8_t MAX_SR04 = 3; // Max number of SR04 ultrasonic sensors
 
 #ifdef ESP32
+
+// SPI
 const uint8_t MAX_SPI = 2;                  // Max number of Hardware SPI controllers (ESP32 = 2)
-const uint8_t MAX_I2S = 2;                  // Max number of Hardware I2S controllers (ESP32 = 2)
-  #if CONFIG_IDF_TARGET_ESP32
-  const uint8_t MAX_RMT = 8;                // Max number or RMT channels (ESP32 only)
-  #elif CONFIG_IDF_TARGET_ESP32S2
-  const uint8_t MAX_RMT = 4;                // Max number or RMT channels (ESP32S2 only)
-  #elif CONFIG_IDF_TARGET_ESP32S3
-  const uint8_t MAX_RMT = 1;                // Max number or RMT channels (ESP32S3 only)
-  #elif CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
-  const uint8_t MAX_RMT = 2;                // Max number or RMT channels (ESP32C3 only)
-  #else
-  const uint8_t MAX_RMT = 0;                // Max number or RMT channels (0 if unknown)
-  #endif
-#else
+
+// I2S
+#ifdef SOC_I2S_SUPPORTED
+  const uint8_t MAX_I2S = SOC_I2S_NUM;
+#else  // SOC_I2S_SUPPORTED
+  const uint8_t MAX_I2S = 0;
+#endif // SOC_I2S_SUPPORTED
+
+// RMT
+#ifdef SOC_RMT_SUPPORTED
+  const uint8_t MAX_RMT = (SOC_RMT_GROUPS) * (SOC_RMT_TX_CANDIDATES_PER_GROUP);
+#else // SOC_RMT_SUPPORTED
+  const uint8_t MAX_RMT = 0;
+#endif // SOC_RMT_SUPPORTED
+
+#else // ESP32 - now ESP8266
 const uint8_t MAX_SPI = 1;                  // Max number of Hardware SPI controllers
 const uint8_t MAX_I2S = 0;                  // Max number of Hardware I2S controllers (ESP8266 = 0, no choice)
 const uint8_t MAX_RMT = 0;                  // No RMT channel on ESP8266
-#endif
+#endif // ESP32
 
 // Changes to the following MAX_ defines need to be in line with enum SettingsTextIndex
 const uint8_t MAX_MQTT_PREFIXES = 3;        // Max number of MQTT prefixes (cmnd, stat, tele)


### PR DESCRIPTION
## Description:

Fixed `MAX_RMT` channels for ESP32S3, now depends on `soc_caps.h`. Also changes `MAX_I2S` to depend on `soc_caps.h` and simplify maintenance for existing and future chips.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
