### PR TITLE
Berry experimental driver for AXP2101 for M5Core2v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.5.0.1] 
 ### Added
+- Berry experimental driver for AXP2101 for M5Core2v1.1
 
 ### Breaking Changed
 

--- a/tasmota/berry/drivers/AXP2102_M5Core2v1_1.be
+++ b/tasmota/berry/drivers/AXP2102_M5Core2v1_1.be
@@ -1,0 +1,64 @@
+#-------------------------------------------------------------
+ - Specialized driver for AXP2102 of M5Core2v1_1
+ -------------------------------------------------------------#
+class AXP2102_M5Core2v1_1 : AXP2102
+  def init()
+    super(self).init()
+    if self.wire
+      # From https://github.com/m5stack/M5Unified/blob/b8cfec7fed046242da7f7b8024a4e92004a51ff7/src/utility/Power_Class.cpp#L351-L360
+      # for Core2 v1.1
+      # static constexpr std::uint8_t reg_data_array[] =
+      # { 0x27, 0x00 // PowerKey Hold=1sec / PowerOff=4sec
+      # , 0x10, 0x30 // PMU common config (internal off-discharge enable)
+      # , 0x12, 0x00 // BATFET disable
+      # , 0x68, 0x01 // Battery detection enabled.
+      # , 0x69, 0x13 // CHGLED setting
+      # , 0x99, 0x00 // DLDO1 set 0.5v (vibration motor)
+      # , 0x30, 0x0F // ADC enabled (for voltage measurement)
+      # // , 0x18, 0x0E
+      # };
+      self.write8(0x90, 0xBE)     # LDOS ON/OFF control 0
+      self.write8(0x92, 0x00)     # ALDO1 off
+      self.write8(0x93, 33 -5)    # ALDO2 on, set to 3.3v // AXP_ILI9342C_RTS
+      self.write8(0x94, 0x00)     # ALDO3 on, set to 0.5V // AXP_SPK_EN off
+      self.write8(0x95, 33 -5)    # ALDO4 on, set to 3.3v // AXP_ILI9342C_POWER
+      self.write8(0x96, 0x00)     # BLDO1 on, set to 0.5V // AXP_ILI9342C_BL off
+      self.write8(0x99, 0x00)     # DLDO1 on, set to 0.5V // AXP_VIB off
+      self.write8(0x27, 0x00)     # PowerKey Hold=1sec // PowerOff=4sec
+      self.write8(0x22, 0x06)     # PWROFF_EN behavior
+      self.write8(0x10, 0x30)     # PMU common config
+      self.write8(0x12, 0x00)     # BATFET disabled
+      self.write8(0x68, 0x01)     # Battery detection enabled
+      self.write8(0x69, 0x13)     # CHGLED setting
+      self.write8(0x30, 0x0F)     # ADC enabled (for voltage measurement)
+      tasmota.add_driver(self)
+    end
+  end
+
+  # set LCD backlight voltage on BLDO1
+  def set_lcd_voltage(voltage)
+    if (voltage < 2500)  voltage = 2500 end
+    if (voltage > 3300)  voltage = 3300 end
+    self.set_ldo_voltage(4, voltage) # 4=BLD01
+  end
+
+  # Speaker enable
+  def set_speaker_enable(state)
+    self.set_ldo_voltage(2, state ? 3300 : 0)   # 2 = ALDO3
+  end
+
+  # Dimmer in percentage
+  def set_displaydimmer(x)
+    var v = tasmota.scale_uint(x, 0, 100, 2500, 3300)
+    self.set_lcd_voltage(v)
+  end
+
+  # respond to display events
+  def display(cmd, idx, payload, raw)
+    if cmd == "dim" || cmd == "power"
+      self.set_displaydimmer(idx)
+    end
+  end
+
+end
+return AXP2102_M5Core2v1_1()


### PR DESCRIPTION
## Description:

Add Berry experimental driver for AXP2101 for M5Core2v1.1.

**Related issue (if applicable):** fixes #22858

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
