### PR TITLE
LVGL, prepare for HASPmota theme, change: no-grow when clicked, DPI set to 160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- LVGL, prepare for HASPmota theme, change: no-grow when clicked, DPI set to 160
 
 ### Fixed
 

--- a/tasmota/lvgl_berry/tasmota_lv_conf.h
+++ b/tasmota/lvgl_berry/tasmota_lv_conf.h
@@ -747,10 +747,10 @@
 #if LV_USE_THEME_DEFAULT
 
     /*0: Light mode; 1: Dark mode*/
-    #define LV_THEME_DEFAULT_DARK 0
+    #define LV_THEME_DEFAULT_DARK 1
 
     /*1: Enable grow on press*/
-    #define LV_THEME_DEFAULT_GROW 1
+    #define LV_THEME_DEFAULT_GROW 0
 
     /*Default transition time in [ms]*/
     #define LV_THEME_DEFAULT_TRANSITION_TIME 80

--- a/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
@@ -459,6 +459,7 @@ void start_lvgl(const char * uconfig) {
 
   // Initialize LvGL display driver
   lvgl_glue->lv_display = lv_display_create(renderer->width(), renderer->height());
+  lv_display_set_dpi(lvgl_glue->lv_display, 160);          // set display to 160 DPI instead of default 130 DPI to avoid some rounding in styles
   lv_display_set_flush_cb(lvgl_glue->lv_display, lv_flush_callback);
   lv_display_set_buffers(lvgl_glue->lv_display, lvgl_glue->lv_pixel_buf, lvgl_glue->lv_pixel_buf2, lvgl_buffer_size * (LV_COLOR_DEPTH / 8), LV_DISPLAY_RENDER_MODE_PARTIAL);
 


### PR DESCRIPTION
## Description:

Changes in LVGL config, to prepare for a forthcoming default theme for HASPmota that uses Tasmota-like graphics:
- when pressed, change animation from "grow" to "darken" to simplify positioning of buttons
- device DPI changed from 130 dpi to 160 dpi, to avoid rounding problems with LVGL default values

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
