### PR TITLE
LVGL Berry fix lvgl_berry_fix_lv_style_prop_arr

### DIFF
--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
@@ -112,10 +112,10 @@ end
 class lv_style_prop_arr : bytes
   def init(l)
     if type(l) != 'instance' || !isinstance(l, list)  raise "value_error", "argument must be a list" end
-    super(self).init(size(l) * 4)
+    super(self).init(size(l))
 
     for e: l
-      self.add(int(e), 4)
+      self.add(int(e))
     end
   end
 end

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
@@ -436,7 +436,7 @@ be_local_closure(class_lv_style_prop_arr_init,   /* name */
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
+    ( &(const binstruction[35]) {  /* code */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
@@ -455,26 +455,23 @@ be_local_closure(class_lv_style_prop_arr_init,   /* name */
       0x6010000C,  //  000F  GETGBL	R4	G12
       0x5C140200,  //  0010  MOVE	R5	R1
       0x7C100200,  //  0011  CALL	R4	1
-      0x54160003,  //  0012  LDINT	R5	4
-      0x08100805,  //  0013  MUL	R4	R4	R5
-      0x7C080400,  //  0014  CALL	R2	2
-      0x60080010,  //  0015  GETGBL	R2	G16
-      0x5C0C0200,  //  0016  MOVE	R3	R1
-      0x7C080200,  //  0017  CALL	R2	1
-      0xA8020008,  //  0018  EXBLK	0	#0022
-      0x5C0C0400,  //  0019  MOVE	R3	R2
-      0x7C0C0000,  //  001A  CALL	R3	0
-      0x8C100104,  //  001B  GETMET	R4	R0	K4
-      0x60180009,  //  001C  GETGBL	R6	G9
-      0x5C1C0600,  //  001D  MOVE	R7	R3
-      0x7C180200,  //  001E  CALL	R6	1
-      0x541E0003,  //  001F  LDINT	R7	4
-      0x7C100600,  //  0020  CALL	R4	3
-      0x7001FFF6,  //  0021  JMP		#0019
-      0x58080005,  //  0022  LDCONST	R2	K5
-      0xAC080200,  //  0023  CATCH	R2	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x80000000,  //  0025  RET	0
+      0x7C080400,  //  0012  CALL	R2	2
+      0x60080010,  //  0013  GETGBL	R2	G16
+      0x5C0C0200,  //  0014  MOVE	R3	R1
+      0x7C080200,  //  0015  CALL	R2	1
+      0xA8020007,  //  0016  EXBLK	0	#001F
+      0x5C0C0400,  //  0017  MOVE	R3	R2
+      0x7C0C0000,  //  0018  CALL	R3	0
+      0x8C100104,  //  0019  GETMET	R4	R0	K4
+      0x60180009,  //  001A  GETGBL	R6	G9
+      0x5C1C0600,  //  001B  MOVE	R7	R3
+      0x7C180200,  //  001C  CALL	R6	1
+      0x7C100400,  //  001D  CALL	R4	2
+      0x7001FFF7,  //  001E  JMP		#0017
+      0x58080005,  //  001F  LDCONST	R2	K5
+      0xAC080200,  //  0020  CATCH	R2	1	0
+      0xB0080000,  //  0021  RAISE	2	R0	R0
+      0x80000000,  //  0022  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Fix `lv_style_prop_arr` that is a list of bytes, not a list of int32.

Change extracted from #23020

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
