### PR TITLE
Berry 'tasmota.when_network_up()' and simplified Matter using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Berry experimental driver for AXP2101 for M5Core2v1.1 (#23039)
 - LVGL experimental mirroring of display on Web UI (#23041)
 - Allow acl in mqtt when client certificate is in use with `#define USE_MQTT_CLIENT_CERT` (#22998)
+- Berry `tasmota.when_network_up()` and simplified Matter using it
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_z_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_z_Commissioning.be
@@ -110,18 +110,7 @@ class Matter_Commissioning
     self.commissioning_L  = L
     self.commissioning_admin_fabric = admin_fabric
 
-    if tasmota.wifi()['up'] || tasmota.eth()['up']
-      self.mdns_announce_PASE()
-    else
-      tasmota.add_rule("Wifi#Connected", def ()
-          self.mdns_announce_PASE()
-          tasmota.remove_rule("Wifi#Connected", "mdns_announce_PASE")
-        end, "mdns_announce_PASE")
-        tasmota.add_rule("Eth#Connected", def ()
-            self.mdns_announce_PASE()
-            tasmota.remove_rule("Eth#Connected", "mdns_announce_PASE")
-          end, "mdns_announce_PASE")
-    end
+    tasmota.when_network_up(def () self.mdns_announce_PASE() end)
   end
 
   #############################################################
@@ -236,23 +225,16 @@ class Matter_Commissioning
   # When the announce is active, `hostname_wifi` and `hostname_eth`
   # are defined
   def start_mdns_announce_hostnames()
-    if tasmota.wifi()['up']
-      self._mdns_announce_hostname(false)
-    else
-      tasmota.add_rule("Wifi#Connected", def ()
-          self._mdns_announce_hostname(false)
-          tasmota.remove_rule("Wifi#Connected", "matter_mdns_host")
-        end, "matter_mdns_host")
-    end
+    tasmota.when_network_up(def ()
 
-    if tasmota.eth()['up']
-      self._mdns_announce_hostname(true)
-    else
-      tasmota.add_rule("Eth#Connected", def ()
-          self._mdns_announce_hostname(true)
-          tasmota.remove_rule("Eth#Connected", "matter_mdns_host")
-        end, "matter_mdns_host")
-    end
+      if tasmota.wifi('up')
+        self._mdns_announce_hostname(false)
+      end
+      if tasmota.eth('up')
+        self._mdns_announce_hostname(true)
+      end
+
+    end)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Commissioning.h
@@ -3,8 +3,8 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'Matter_Commissioning' ktab size: 132, total: 272 (saved 1120 bytes)
-static const bvalue be_ktab_class_Matter_Commissioning[132] = {
+// compact class 'Matter_Commissioning' ktab size: 127, total: 259 (saved 1056 bytes)
+static const bvalue be_ktab_class_Matter_Commissioning[127] = {
   /* K0   */  be_nested_str_weak(device),
   /* K1   */  be_nested_str_weak(sessions),
   /* K2   */  be_nested_str_weak(active_fabrics),
@@ -128,15 +128,10 @@ static const bvalue be_ktab_class_Matter_Commissioning[132] = {
   /* K120 */  be_nested_str_weak(_CM1),
   /* K121 */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
   /* K122 */  be_nested_str_weak(millis),
-  /* K123 */  be_nested_str_weak(mdns_announce_PASE),
-  /* K124 */  be_nested_str_weak(add_rule),
-  /* K125 */  be_nested_str_weak(Wifi_X23Connected),
-  /* K126 */  be_nested_str_weak(Eth_X23Connected),
-  /* K127 */  be_nested_str_weak(_mdns_announce_hostname),
-  /* K128 */  be_nested_str_weak(matter_mdns_host),
-  /* K129 */  be_nested_str_weak(get_fabric),
-  /* K130 */  be_nested_str_weak(get_admin_vendor_name),
-  /* K131 */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
+  /* K123 */  be_nested_str_weak(when_network_up),
+  /* K124 */  be_nested_str_weak(get_fabric),
+  /* K125 */  be_nested_str_weak(get_admin_vendor_name),
+  /* K126 */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
 };
 
 
@@ -1551,15 +1546,15 @@ be_local_closure(class_Matter_Commissioning_mdns_announce_PASE,   /* name */
 ********************************************************************/
 be_local_closure(class_Matter_Commissioning_start_basic_commissioning,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     8,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
-        4,                          /* nstack */
+        2,                          /* nstack */
         0,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -1569,55 +1564,16 @@ be_local_closure(class_Matter_Commissioning_start_basic_commissioning,   /* name
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
+        ( &(const bvalue[ 1]) {     /* constants */
         /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
         }),
         be_str_weak(_anonymous_),
         &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
+        ( &(const binstruction[ 4]) {  /* code */
           0x68000000,  //  0000  GETUPV	R0	U0
           0x8C000100,  //  0001  GETMET	R0	R0	K0
           0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
+          0x80000000,  //  0003  RET	0
         })
       ),
     }),
@@ -1625,7 +1581,7 @@ be_local_closure(class_Matter_Commissioning_start_basic_commissioning,   /* name
     &be_ktab_class_Matter_Commissioning,     /* shared constants */
     be_str_weak(start_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
+    ( &(const binstruction[19]) {  /* code */
       0xB8221000,  //  0000  GETNGBL	R8	K8
       0x8C20117A,  //  0001  GETMET	R8	R8	K122
       0x7C200200,  //  0002  CALL	R8	1
@@ -1640,32 +1596,11 @@ be_local_closure(class_Matter_Commissioning_start_basic_commissioning,   /* name
       0x90022406,  //  000B  SETMBR	R0	K18	R6
       0x90022607,  //  000C  SETMBR	R0	K19	R7
       0xB8221000,  //  000D  GETNGBL	R8	K8
-      0x8C201131,  //  000E  GETMET	R8	R8	K49
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420113E,  //  0010  GETIDX	R8	R8	K62
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8221000,  //  0012  GETNGBL	R8	K8
-      0x8C20112C,  //  0013  GETMET	R8	R8	K44
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420113E,  //  0015  GETIDX	R8	R8	K62
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20017B,  //  0017  GETMET	R8	R0	K123
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8221000,  //  001A  GETNGBL	R8	K8
-      0x8C20117C,  //  001B  GETMET	R8	R8	K124
-      0x5828007D,  //  001C  LDCONST	R10	K125
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830007B,  //  001E  LDCONST	R12	K123
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8221000,  //  0020  GETNGBL	R8	K8
-      0x8C20117C,  //  0021  GETMET	R8	R8	K124
-      0x5828007E,  //  0022  LDCONST	R10	K126
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830007B,  //  0024  LDCONST	R12	K123
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
+      0x8C20117B,  //  000E  GETMET	R8	R8	K123
+      0x84280000,  //  000F  CLOSURE	R10	P0
+      0x7C200400,  //  0010  CALL	R8	2
+      0xA0000000,  //  0011  CLOSE	R0
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -1677,15 +1612,15 @@ be_local_closure(class_Matter_Commissioning_start_basic_commissioning,   /* name
 ********************************************************************/
 be_local_closure(class_Matter_Commissioning_start_mdns_announce_hostnames,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
-        4,                          /* nstack */
+        3,                          /* nstack */
         0,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -1696,58 +1631,34 @@ be_local_closure(class_Matter_Commissioning_start_mdns_announce_hostnames,   /* 
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        /* K0   */  be_nested_str_weak(tasmota),
+        /* K1   */  be_nested_str_weak(wifi),
+        /* K2   */  be_nested_str_weak(up),
+        /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K4   */  be_nested_str_weak(eth),
         }),
         be_str_weak(_anonymous_),
         &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080000,  //  0002  LDBOOL	R2	0	0
+        ( &(const binstruction[19]) {  /* code */
+          0xB8020000,  //  0000  GETNGBL	R0	K0
+          0x8C000101,  //  0001  GETMET	R0	R0	K1
+          0x58080002,  //  0002  LDCONST	R2	K2
           0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080200,  //  0002  LDBOOL	R2	1	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
+          0x78020003,  //  0004  JMPF	R0	#0009
+          0x68000000,  //  0005  GETUPV	R0	U0
+          0x8C000103,  //  0006  GETMET	R0	R0	K3
+          0x50080000,  //  0007  LDBOOL	R2	0	0
+          0x7C000400,  //  0008  CALL	R0	2
+          0xB8020000,  //  0009  GETNGBL	R0	K0
+          0x8C000104,  //  000A  GETMET	R0	R0	K4
+          0x58080002,  //  000B  LDCONST	R2	K2
+          0x7C000400,  //  000C  CALL	R0	2
+          0x78020003,  //  000D  JMPF	R0	#0012
+          0x68000000,  //  000E  GETUPV	R0	U0
+          0x8C000103,  //  000F  GETMET	R0	R0	K3
+          0x50080200,  //  0010  LDBOOL	R2	1	0
+          0x7C000400,  //  0011  CALL	R0	2
+          0x80000000,  //  0012  RET	0
         })
       ),
     }),
@@ -1755,39 +1666,13 @@ be_local_closure(class_Matter_Commissioning_start_mdns_announce_hostnames,   /* 
     &be_ktab_class_Matter_Commissioning,     /* shared constants */
     be_str_weak(start_mdns_announce_hostnames),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
+    ( &(const binstruction[ 6]) {  /* code */
       0xB8061000,  //  0000  GETNGBL	R1	K8
-      0x8C040331,  //  0001  GETMET	R1	R1	K49
-      0x7C040200,  //  0002  CALL	R1	1
-      0x9404033E,  //  0003  GETIDX	R1	R1	K62
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8C04017F,  //  0005  GETMET	R1	R0	K127
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x70020005,  //  0008  JMP		#000F
-      0xB8061000,  //  0009  GETNGBL	R1	K8
-      0x8C04037C,  //  000A  GETMET	R1	R1	K124
-      0x580C007D,  //  000B  LDCONST	R3	K125
-      0x84100000,  //  000C  CLOSURE	R4	P0
-      0x58140080,  //  000D  LDCONST	R5	K128
-      0x7C040800,  //  000E  CALL	R1	4
-      0xB8061000,  //  000F  GETNGBL	R1	K8
-      0x8C04032C,  //  0010  GETMET	R1	R1	K44
-      0x7C040200,  //  0011  CALL	R1	1
-      0x9404033E,  //  0012  GETIDX	R1	R1	K62
-      0x78060003,  //  0013  JMPF	R1	#0018
-      0x8C04017F,  //  0014  GETMET	R1	R0	K127
-      0x500C0200,  //  0015  LDBOOL	R3	1	0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x70020005,  //  0017  JMP		#001E
-      0xB8061000,  //  0018  GETNGBL	R1	K8
-      0x8C04037C,  //  0019  GETMET	R1	R1	K124
-      0x580C007E,  //  001A  LDCONST	R3	K126
-      0x84100001,  //  001B  CLOSURE	R4	P1
-      0x58140080,  //  001C  LDCONST	R5	K128
-      0x7C040800,  //  001D  CALL	R1	4
-      0xA0000000,  //  001E  CLOSE	R0
-      0x80000000,  //  001F  RET	0
+      0x8C04037B,  //  0001  GETMET	R1	R1	K123
+      0x840C0000,  //  0002  CLOSURE	R3	P0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xA0000000,  //  0004  CLOSE	R0
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -1872,7 +1757,7 @@ be_local_closure(class_Matter_Commissioning_start_commissioning_complete,   /* n
     be_str_weak(start_commissioning_complete),
     &be_const_str_solidified,
     ( &(const binstruction[23]) {  /* code */
-      0x8C080381,  //  0000  GETMET	R2	R1	K129
+      0x8C08037C,  //  0000  GETMET	R2	R1	K124
       0x7C080200,  //  0001  CALL	R2	1
       0x8C0C0504,  //  0002  GETMET	R3	R2	K4
       0x7C0C0200,  //  0003  CALL	R3	1
@@ -1882,11 +1767,11 @@ be_local_closure(class_Matter_Commissioning_start_commissioning_complete,   /* n
       0x7C0C0200,  //  0007  CALL	R3	1
       0x8C0C073B,  //  0008  GETMET	R3	R3	K59
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C100582,  //  000A  GETMET	R4	R2	K130
+      0x8C10057D,  //  000A  GETMET	R4	R2	K125
       0x7C100200,  //  000B  CALL	R4	1
       0xB8164A00,  //  000C  GETNGBL	R5	K37
       0x60180018,  //  000D  GETGBL	R6	G24
-      0x581C0083,  //  000E  LDCONST	R7	K131
+      0x581C007E,  //  000E  LDCONST	R7	K126
       0x5C200600,  //  000F  MOVE	R8	R3
       0x5C240800,  //  0010  MOVE	R9	R4
       0x7C180600,  //  0011  CALL	R6	3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -4,263 +4,231 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_Device;
-// compact class 'Matter_Device' ktab size: 216, total: 463 (saved 1976 bytes)
-static const bvalue be_ktab_class_Matter_Device[216] = {
-  /* K0   */  be_nested_str_weak(udp_server),
-  /* K1   */  be_nested_str_weak(send_UDP),
-  /* K2   */  be_nested_str_weak(is_zigbee_present),
-  /* K3   */  be_nested_str_weak(matter_zigbee),
-  /* K4   */  be_const_class(be_class_Matter_Device),
-  /* K5   */  be_nested_str_weak(keys),
-  /* K6   */  be_nested_str_weak(push),
-  /* K7   */  be_nested_str_weak(stop_iteration),
-  /* K8   */  be_const_int(1),
-  /* K9   */  be_const_int(0),
-  /* K10  */  be_nested_str_weak(),
-  /* K11  */  be_nested_str_weak(plugins),
-  /* K12  */  be_nested_str_weak(MtrInfo_one),
-  /* K13  */  be_nested_str_weak(endpoint),
-  /* K14  */  be_nested_str_weak(int),
-  /* K15  */  be_nested_str_weak(find_plugin_by_friendly_name),
-  /* K16  */  be_nested_str_weak(tasmota),
-  /* K17  */  be_nested_str_weak(resp_cmnd_done),
-  /* K18  */  be_nested_str_weak(read_sensors_scheduler),
-  /* K19  */  be_nested_str_weak(every_250ms),
-  /* K20  */  be_nested_str_weak(matter),
-  /* K21  */  be_nested_str_weak(Path),
-  /* K22  */  be_nested_str_weak(cluster),
-  /* K23  */  be_nested_str_weak(attribute),
-  /* K24  */  be_nested_str_weak(message_handler),
-  /* K25  */  be_nested_str_weak(im),
-  /* K26  */  be_nested_str_weak(subs_shop),
-  /* K27  */  be_nested_str_weak(attribute_updated_ctx),
-  /* K28  */  be_nested_str_weak(get_endpoint),
-  /* K29  */  be_nested_str_weak(find),
-  /* K30  */  be_nested_str_weak(plugins_config_remotes),
-  /* K31  */  be_nested_str_weak(json),
-  /* K32  */  be_nested_str_weak(update_remotes_info),
-  /* K33  */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-  /* K34  */  be_nested_str_weak(root_discriminator),
-  /* K35  */  be_nested_str_weak(root_passcode),
-  /* K36  */  be_nested_str_weak(ipv4only),
-  /* K37  */  be_nested_str_weak(true),
-  /* K38  */  be_nested_str_weak(false),
-  /* K39  */  be_nested_str_weak(disable_bridge_mode),
-  /* K40  */  be_nested_str_weak(next_ep),
-  /* K41  */  be_nested_str_weak(debug),
-  /* K42  */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
-  /* K43  */  be_nested_str_weak(plugins_persist),
-  /* K44  */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
-  /* K45  */  be_nested_str_weak(dump),
-  /* K46  */  be_nested_str_weak(plugins_config),
-  /* K47  */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
-  /* K48  */  be_nested_str_weak(_X7D),
-  /* K49  */  be_nested_str_weak(FILENAME),
-  /* K50  */  be_nested_str_weak(w),
-  /* K51  */  be_nested_str_weak(write),
-  /* K52  */  be_nested_str_weak(close),
-  /* K53  */  be_nested_str_weak(log),
-  /* K54  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-  /* K55  */  be_nested_str_weak(_X20and_X20configuration),
-  /* K56  */  be_const_int(2),
-  /* K57  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+// compact class 'Matter_Device' ktab size: 212, total: 455 (saved 1944 bytes)
+static const bvalue be_ktab_class_Matter_Device[212] = {
+  /* K0   */  be_nested_str_weak(json),
+  /* K1   */  be_nested_str_weak(tasmota),
+  /* K2   */  be_nested_str_weak(read_sensors),
+  /* K3   */  be_nested_str_weak(loglevel),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_nested_str_weak(log),
+  /* K6   */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
+  /* K7   */  be_nested_str_weak(load),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(plugins),
+  /* K10  */  be_nested_str_weak(parse_sensors),
+  /* K11  */  be_const_int(1),
+  /* K12  */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+  /* K13  */  be_nested_str_weak(probe_sensor_time),
+  /* K14  */  be_nested_str_weak(probe_sensor_timestamp),
+  /* K15  */  be_nested_str_weak(time_reached),
+  /* K16  */  be_nested_str_weak(_trigger_read_sensors),
+  /* K17  */  be_nested_str_weak(millis),
+  /* K18  */  be_nested_str_weak(button_handler),
+  /* K19  */  be_nested_str_weak(plugins_config),
+  /* K20  */  be_nested_str_weak(keys),
+  /* K21  */  be_nested_str_weak(push),
+  /* K22  */  be_nested_str_weak(stop_iteration),
+  /* K23  */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
+  /* K24  */  be_const_int(2),
+  /* K25  */  be_nested_str_weak(remove),
+  /* K26  */  be_nested_str_weak(matter),
+  /* K27  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K28  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
+  /* K29  */  be_nested_str_weak(next_ep),
+  /* K30  */  be_nested_str_weak(endpoint),
+  /* K31  */  be_nested_str_weak(invoke_request),
+  /* K32  */  be_nested_str_weak(status),
+  /* K33  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+  /* K34  */  be_nested_str_weak(attribute_updated),
+  /* K35  */  be_nested_str_weak(crypto),
+  /* K36  */  be_nested_str_weak(FILENAME),
+  /* K37  */  be_nested_str_weak(read),
+  /* K38  */  be_nested_str_weak(close),
+  /* K39  */  be_nested_str_weak(root_discriminator),
+  /* K40  */  be_nested_str_weak(find),
+  /* K41  */  be_nested_str_weak(distinguish),
+  /* K42  */  be_nested_str_weak(root_passcode),
+  /* K43  */  be_nested_str_weak(passcode),
+  /* K44  */  be_nested_str_weak(ipv4only),
+  /* K45  */  be_nested_str_weak(disable_bridge_mode),
+  /* K46  */  be_nested_str_weak(nextep),
+  /* K47  */  be_nested_str_weak(config),
+  /* K48  */  be_nested_str_weak(debug),
+  /* K49  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
+  /* K50  */  be_nested_str_weak(adjust_next_ep),
+  /* K51  */  be_nested_str_weak(check_config_ep),
+  /* K52  */  be_nested_str_weak(plugins_persist),
+  /* K53  */  be_nested_str_weak(plugins_config_remotes),
+  /* K54  */  be_nested_str_weak(remotes),
+  /* K55  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+  /* K56  */  be_nested_str_weak(io_error),
+  /* K57  */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
   /* K58  */  be_nested_str_weak(_X7C),
-  /* K59  */  be_nested_str_weak(remove_driver),
-  /* K60  */  be_nested_str_weak(stop),
-  /* K61  */  be_nested_str_weak(remove),
-  /* K62  */  be_nested_str_weak(sessions),
-  /* K63  */  be_nested_str_weak(count_active_fabrics),
-  /* K64  */  be_nested_str_weak(save_param),
-  /* K65  */  be_nested_str_weak(autoconf),
-  /* K66  */  be_nested_str_weak(Autoconf),
-  /* K67  */  be_nested_str_weak(autoconf_device_map),
-  /* K68  */  be_nested_str_weak(adjust_next_ep),
-  /* K69  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-  /* K70  */  be_const_int(3),
-  /* K71  */  be_nested_str_weak(instantiate_plugins_from_config),
-  /* K72  */  be_nested_str_weak(msg_received),
-  /* K73  */  be_nested_str_weak(find_plugin_by_endpoint),
-  /* K74  */  be_nested_str_weak(status),
-  /* K75  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-  /* K76  */  be_nested_str_weak(contains_cluster),
-  /* K77  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-  /* K78  */  be_nested_str_weak(contains_attribute),
-  /* K79  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-  /* K80  */  be_nested_str_weak(introspect),
-  /* K81  */  be_nested_str_weak(http_remotes),
-  /* K82  */  be_nested_str_weak(get),
-  /* K83  */  be_nested_str_weak(http_remote),
-  /* K84  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-  /* K85  */  be_nested_str_weak(addr),
-  /* K86  */  be_nested_str_weak(invoke_request),
-  /* K87  */  be_nested_str_weak(crypto),
-  /* K88  */  be_nested_str_weak(get_option),
-  /* K89  */  be_nested_str_weak(MATTER_OPTION),
-  /* K90  */  be_nested_str_weak(ui),
-  /* K91  */  be_nested_str_weak(UI),
-  /* K92  */  be_nested_str_weak(profiler),
-  /* K93  */  be_nested_str_weak(Profiler),
-  /* K94  */  be_nested_str_weak(started),
-  /* K95  */  be_nested_str_weak(tick),
-  /* K96  */  be_nested_str_weak(EP),
-  /* K97  */  be_nested_str_weak(commissioning),
-  /* K98  */  be_nested_str_weak(Commissioning),
-  /* K99  */  be_nested_str_weak(load_param),
-  /* K100 */  be_nested_str_weak(Session_Store),
-  /* K101 */  be_nested_str_weak(load_fabrics),
-  /* K102 */  be_nested_str_weak(MessageHandler),
-  /* K103 */  be_nested_str_weak(events),
-  /* K104 */  be_nested_str_weak(EventHandler),
-  /* K105 */  be_nested_str_weak(zigbee),
-  /* K106 */  be_nested_str_weak(init_zigbee),
-  /* K107 */  be_nested_str_weak(init_basic_commissioning),
-  /* K108 */  be_nested_str_weak(add_driver),
-  /* K109 */  be_nested_str_weak(register_commands),
-  /* K110 */  be_nested_str_weak(button_handler),
-  /* K111 */  be_nested_str_weak(get_name),
-  /* K112 */  be_nested_str_weak(wifi),
-  /* K113 */  be_nested_str_weak(up),
-  /* K114 */  be_nested_str_weak(eth),
-  /* K115 */  be_nested_str_weak(start),
-  /* K116 */  be_nested_str_weak(resp_cmnd_str),
-  /* K117 */  be_nested_str_weak(Invalid_X20JSON),
-  /* K118 */  be_nested_str_weak(find_key_i),
-  /* K119 */  be_nested_str_weak(Ep),
-  /* K120 */  be_nested_str_weak(Name),
-  /* K121 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
-  /* K122 */  be_nested_str_weak(Invalid_X20Device),
-  /* K123 */  be_nested_str_weak(VIRTUAL),
-  /* K124 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
-  /* K125 */  be_nested_str_weak(consolidate_update_commands),
-  /* K126 */  be_nested_str_weak(find_list_i),
-  /* K127 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
-  /* K128 */  be_nested_str_weak(update_virtual),
-  /* K129 */  be_nested_str_weak(state_json),
-  /* K130 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
-  /* K131 */  be_nested_str_weak(resp_cmnd),
-  /* K132 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
-  /* K133 */  be_nested_str_weak(check_network),
-  /* K134 */  be_nested_str_weak(every_50ms),
-  /* K135 */  be_nested_str_weak(every_second),
-  /* K136 */  be_nested_str_weak(probe_sensor_time),
-  /* K137 */  be_nested_str_weak(probe_sensor_timestamp),
-  /* K138 */  be_nested_str_weak(jitter),
-  /* K139 */  be_nested_str_weak(plugins_classes),
-  /* K140 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-  /* K141 */  be_nested_str_weak(_X27_X20skipping),
-  /* K142 */  be_nested_str_weak(type),
-  /* K143 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-  /* K144 */  be_nested_str_weak(conf_to_log),
-  /* K145 */  be_nested_str_weak(signal_endpoints_changed),
-  /* K146 */  be_nested_str_weak(contains),
-  /* K147 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-  /* K148 */  be_nested_str_weak(UDPServer),
-  /* K149 */  be_nested_str_weak(attribute_updated),
-  /* K150 */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-  /* K151 */  be_nested_str_weak(module),
-  /* K152 */  be_nested_str_weak(ARG),
-  /* K153 */  be_nested_str_weak(get_info),
-  /* K154 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-  /* K155 */  be_nested_str_weak(get_fabric_id),
-  /* K156 */  be_nested_str_weak(copy),
-  /* K157 */  be_nested_str_weak(reverse),
-  /* K158 */  be_nested_str_weak(tohex),
-  /* K159 */  be_nested_str_weak(remove_by_fabric),
-  /* K160 */  be_nested_str_weak(mdns_remove_op_discovery),
-  /* K161 */  be_nested_str_weak(remove_fabric),
-  /* K162 */  be_nested_str_weak(save_fabrics),
-  /* K163 */  be_nested_str_weak(k2l),
-  /* K164 */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-  /* K165 */  be_nested_str_weak(DISPLAY_NAME),
-  /* K166 */  be_nested_str_weak(time_reached),
-  /* K167 */  be_nested_str_weak(_trigger_read_sensors),
-  /* K168 */  be_nested_str_weak(millis),
-  /* K169 */  be_nested_str_weak(get_timeout),
-  /* K170 */  be_nested_str_weak(set_timeout),
-  /* K171 */  be_nested_str_weak(HTTP_remote),
-  /* K172 */  be_nested_str_weak(set_info),
-  /* K173 */  be_nested_str_weak(PathGenerator),
-  /* K174 */  be_nested_str_weak(is_direct),
-  /* K175 */  be_nested_str_weak(next_attribute),
-  /* K176 */  be_nested_str_weak(get_pi),
-  /* K177 */  be_nested_str_weak(read),
-  /* K178 */  be_nested_str_weak(load),
-  /* K179 */  be_nested_str_weak(distinguish),
-  /* K180 */  be_nested_str_weak(passcode),
-  /* K181 */  be_nested_str_weak(nextep),
-  /* K182 */  be_nested_str_weak(config),
-  /* K183 */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
-  /* K184 */  be_nested_str_weak(check_config_ep),
-  /* K185 */  be_nested_str_weak(remotes),
-  /* K186 */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-  /* K187 */  be_nested_str_weak(io_error),
-  /* K188 */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
-  /* K189 */  be_nested_str_weak(random),
-  /* K190 */  be_nested_str_weak(generate_random_passcode),
-  /* K191 */  be_nested_str_weak(read_sensors),
-  /* K192 */  be_nested_str_weak(loglevel),
-  /* K193 */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
-  /* K194 */  be_nested_str_weak(parse_sensors),
-  /* K195 */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-  /* K196 */  be_nested_str_weak(received_ack),
-  /* K197 */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
-  /* K198 */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
-  /* K199 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-  /* K200 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-  /* K201 */  be_nested_str_weak(clean_remotes),
-  /* K202 */  be_nested_str_weak(add_cmd),
-  /* K203 */  be_nested_str_weak(MtrJoin),
-  /* K204 */  be_nested_str_weak(MtrUpdate),
-  /* K205 */  be_nested_str_weak(MtrInfo),
-  /* K206 */  be_nested_str_weak(stop_basic_commissioning),
-  /* K207 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-  /* K208 */  be_nested_str_weak(start_root_basic_commissioning),
-  /* K209 */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
-  /* K210 */  be_nested_str_weak(publish_result),
-  /* K211 */  be_nested_str_weak(Matter_Zigbee_Mapper),
-  /* K212 */  be_nested_str_weak(autoconf_device),
-  /* K213 */  be_nested_str_weak(_start_udp),
-  /* K214 */  be_nested_str_weak(UDP_PORT),
-  /* K215 */  be_nested_str_weak(start_mdns_announce_hostnames),
+  /* K59  */  be_nested_str_weak(random),
+  /* K60  */  be_nested_str_weak(get),
+  /* K61  */  be_nested_str_weak(commissioning),
+  /* K62  */  be_nested_str_weak(generate_random_passcode),
+  /* K63  */  be_nested_str_weak(save_param),
+  /* K64  */  be_const_class(be_class_Matter_Device),
+  /* K65  */  be_nested_str_weak(),
+  /* K66  */  be_nested_str_weak(k2l),
+  /* K67  */  be_nested_str_weak(type),
+  /* K68  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+  /* K69  */  be_nested_str_weak(introspect),
+  /* K70  */  be_nested_str_weak(module),
+  /* K71  */  be_nested_str_weak(matter_zigbee),
+  /* K72  */  be_nested_str_weak(remove_driver),
+  /* K73  */  be_nested_str_weak(udp_server),
+  /* K74  */  be_nested_str_weak(stop),
+  /* K75  */  be_nested_str_weak(get_name),
+  /* K76  */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K77  */  be_nested_str_weak(stop_basic_commissioning),
+  /* K78  */  be_nested_str_weak(resp_cmnd_done),
+  /* K79  */  be_nested_str_weak(MtrInfo_one),
+  /* K80  */  be_nested_str_weak(int),
+  /* K81  */  be_nested_str_weak(find_plugin_by_friendly_name),
+  /* K82  */  be_nested_str_weak(find_plugin_by_endpoint),
+  /* K83  */  be_nested_str_weak(state_json),
+  /* K84  */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
+  /* K85  */  be_nested_str_weak(publish_result),
+  /* K86  */  be_nested_str_weak(cluster),
+  /* K87  */  be_nested_str_weak(attribute),
+  /* K88  */  be_nested_str_weak(contains_cluster),
+  /* K89  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+  /* K90  */  be_nested_str_weak(contains_attribute),
+  /* K91  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+  /* K92  */  be_nested_str_weak(sessions),
+  /* K93  */  be_nested_str_weak(every_second),
+  /* K94  */  be_nested_str_weak(message_handler),
+  /* K95  */  be_nested_str_weak(events),
+  /* K96  */  be_nested_str_weak(plugins_classes),
+  /* K97  */  be_nested_str_weak(DISPLAY_NAME),
+  /* K98  */  be_nested_str_weak(ARG),
+  /* K99  */  be_nested_str_weak(PathGenerator),
+  /* K100 */  be_nested_str_weak(start),
+  /* K101 */  be_nested_str_weak(is_direct),
+  /* K102 */  be_nested_str_weak(next_attribute),
+  /* K103 */  be_nested_str_weak(get_pi),
+  /* K104 */  be_nested_str_weak(get_endpoint),
+  /* K105 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+  /* K106 */  be_nested_str_weak(get_fabric_id),
+  /* K107 */  be_nested_str_weak(copy),
+  /* K108 */  be_nested_str_weak(reverse),
+  /* K109 */  be_nested_str_weak(tohex),
+  /* K110 */  be_nested_str_weak(im),
+  /* K111 */  be_nested_str_weak(subs_shop),
+  /* K112 */  be_nested_str_weak(remove_by_fabric),
+  /* K113 */  be_nested_str_weak(mdns_remove_op_discovery),
+  /* K114 */  be_nested_str_weak(remove_fabric),
+  /* K115 */  be_nested_str_weak(save_fabrics),
+  /* K116 */  be_nested_str_weak(Path),
+  /* K117 */  be_nested_str_weak(attribute_updated_ctx),
+  /* K118 */  be_nested_str_weak(add_cmd),
+  /* K119 */  be_nested_str_weak(MtrJoin),
+  /* K120 */  be_nested_str_weak(MtrUpdate),
+  /* K121 */  be_nested_str_weak(MtrInfo),
+  /* K122 */  be_nested_str_weak(update_remotes_info),
+  /* K123 */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+  /* K124 */  be_nested_str_weak(true),
+  /* K125 */  be_nested_str_weak(false),
+  /* K126 */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
+  /* K127 */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
+  /* K128 */  be_nested_str_weak(dump),
+  /* K129 */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
+  /* K130 */  be_nested_str_weak(_X7D),
+  /* K131 */  be_nested_str_weak(w),
+  /* K132 */  be_nested_str_weak(write),
+  /* K133 */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+  /* K134 */  be_nested_str_weak(_X20and_X20configuration),
+  /* K135 */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+  /* K136 */  be_nested_str_weak(http_remotes),
+  /* K137 */  be_nested_str_weak(http_remote),
+  /* K138 */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+  /* K139 */  be_nested_str_weak(addr),
+  /* K140 */  be_nested_str_weak(contains),
+  /* K141 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+  /* K142 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+  /* K143 */  be_nested_str_weak(clean_remotes),
+  /* K144 */  be_nested_str_weak(signal_endpoints_changed),
+  /* K145 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+  /* K146 */  be_nested_str_weak(UDPServer),
+  /* K147 */  be_nested_str_weak(count_active_fabrics),
+  /* K148 */  be_nested_str_weak(get_option),
+  /* K149 */  be_nested_str_weak(MATTER_OPTION),
+  /* K150 */  be_nested_str_weak(ui),
+  /* K151 */  be_nested_str_weak(UI),
+  /* K152 */  be_nested_str_weak(profiler),
+  /* K153 */  be_nested_str_weak(Profiler),
+  /* K154 */  be_nested_str_weak(tick),
+  /* K155 */  be_nested_str_weak(EP),
+  /* K156 */  be_nested_str_weak(Commissioning),
+  /* K157 */  be_nested_str_weak(load_param),
+  /* K158 */  be_nested_str_weak(Session_Store),
+  /* K159 */  be_nested_str_weak(load_fabrics),
+  /* K160 */  be_nested_str_weak(MessageHandler),
+  /* K161 */  be_nested_str_weak(EventHandler),
+  /* K162 */  be_nested_str_weak(zigbee),
+  /* K163 */  be_nested_str_weak(init_zigbee),
+  /* K164 */  be_nested_str_weak(when_network_up),
+  /* K165 */  be_nested_str_weak(init_basic_commissioning),
+  /* K166 */  be_nested_str_weak(add_driver),
+  /* K167 */  be_nested_str_weak(register_commands),
+  /* K168 */  be_nested_str_weak(received_ack),
+  /* K169 */  be_nested_str_weak(read_sensors_scheduler),
+  /* K170 */  be_nested_str_weak(every_250ms),
+  /* K171 */  be_nested_str_weak(send_UDP),
+  /* K172 */  be_nested_str_weak(autoconf_device),
+  /* K173 */  be_nested_str_weak(_start_udp),
+  /* K174 */  be_nested_str_weak(UDP_PORT),
+  /* K175 */  be_nested_str_weak(start_mdns_announce_hostnames),
+  /* K176 */  be_nested_str_weak(get_info),
+  /* K177 */  be_nested_str_weak(every_50ms),
+  /* K178 */  be_nested_str_weak(get_timeout),
+  /* K179 */  be_nested_str_weak(set_timeout),
+  /* K180 */  be_nested_str_weak(HTTP_remote),
+  /* K181 */  be_nested_str_weak(set_info),
+  /* K182 */  be_nested_str_weak(msg_received),
+  /* K183 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+  /* K184 */  be_nested_str_weak(_X27_X20skipping),
+  /* K185 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+  /* K186 */  be_nested_str_weak(conf_to_log),
+  /* K187 */  be_nested_str_weak(autoconf),
+  /* K188 */  be_nested_str_weak(Autoconf),
+  /* K189 */  be_nested_str_weak(autoconf_device_map),
+  /* K190 */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+  /* K191 */  be_nested_str_weak(instantiate_plugins_from_config),
+  /* K192 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+  /* K193 */  be_nested_str_weak(resp_cmnd_str),
+  /* K194 */  be_nested_str_weak(Invalid_X20JSON),
+  /* K195 */  be_nested_str_weak(find_key_i),
+  /* K196 */  be_nested_str_weak(Ep),
+  /* K197 */  be_nested_str_weak(Name),
+  /* K198 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
+  /* K199 */  be_nested_str_weak(Invalid_X20Device),
+  /* K200 */  be_nested_str_weak(VIRTUAL),
+  /* K201 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
+  /* K202 */  be_nested_str_weak(consolidate_update_commands),
+  /* K203 */  be_nested_str_weak(find_list_i),
+  /* K204 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
+  /* K205 */  be_nested_str_weak(update_virtual),
+  /* K206 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
+  /* K207 */  be_nested_str_weak(resp_cmnd),
+  /* K208 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
+  /* K209 */  be_nested_str_weak(Matter_Zigbee_Mapper),
+  /* K210 */  be_nested_str_weak(is_zigbee_present),
+  /* K211 */  be_nested_str_weak(jitter),
 };
 
 
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: msg_send
+** Solidified function: _trigger_read_sensors
 ********************************************************************/
-be_local_closure(class_Matter_Device_msg_send,   /* name */
+be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init_zigbee
-********************************************************************/
-be_local_closure(class_Matter_Device_init_zigbee,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -269,842 +237,57 @@ be_local_closure(class_Matter_Device_init_zigbee,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(init_zigbee),
+    be_str_weak(_trigger_read_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C040102,  //  0000  GETMET	R1	R0	K2
-      0x7C040200,  //  0001  CALL	R1	1
-      0x78060004,  //  0002  JMPF	R1	#0008
-      0xA4060600,  //  0003  IMPORT	R1	K3
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x5C0C0000,  //  0005  MOVE	R3	R0
-      0x7C080200,  //  0006  CALL	R2	1
-      0x80040400,  //  0007  RET	1	R2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l_num
-********************************************************************/
-be_local_closure(class_Matter_Device_k2l_num,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(k2l_num),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x58040004,  //  0000  LDCONST	R1	K4
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100105,  //  0008  GETMET	R4	R0	K5
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020007,  //  000B  EXBLK	0	#0014
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140506,  //  000E  GETMET	R5	R2	K6
-      0x601C0009,  //  000F  GETGBL	R7	G9
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C140400,  //  0012  CALL	R5	2
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x580C0007,  //  0014  LDCONST	R3	K7
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x600C0010,  //  0017  GETGBL	R3	G16
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x7C100200,  //  001A  CALL	R4	1
-      0x04100908,  //  001B  SUB	R4	R4	K8
-      0x40121004,  //  001C  CONNECT	R4	K8	R4
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x94140404,  //  0021  GETIDX	R5	R2	R4
-      0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D09,  //  0023  GT	R7	R6	K9
-      0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D08,  //  0025  SUB	R7	R6	K8
-      0x941C0407,  //  0026  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0027  GT	R7	R7	R5
-      0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D08,  //  0029  SUB	R7	R6	K8
-      0x941C0407,  //  002A  GETIDX	R7	R2	R7
-      0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D08,  //  002C  SUB	R6	R6	K8
-      0x7001FFF4,  //  002D  JMP		#0023
-      0x98080C05,  //  002E  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C0007,  //  0030  LDCONST	R3	K7
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80040400,  //  0033  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrInfo
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrInfo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrInfo),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x1C14070A,  //  0000  EQ	R5	R3	K10
-      0x7815FFFF,  //  0001  JMPF	R5	#0002
-      0x1C14070A,  //  0002  EQ	R5	R3	K10
-      0x7816000D,  //  0003  JMPF	R5	#0012
-      0x60140010,  //  0004  GETGBL	R5	G16
-      0x8818010B,  //  0005  GETMBR	R6	R0	K11
-      0x7C140200,  //  0006  CALL	R5	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C180A00,  //  0008  MOVE	R6	R5
-      0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C010C,  //  000A  GETMET	R7	R0	K12
-      0x88240D0D,  //  000B  GETMBR	R9	R6	K13
-      0x7C1C0400,  //  000C  CALL	R7	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0xAC140200,  //  000F  CATCH	R5	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x70020011,  //  0011  JMP		#0024
-      0x60140004,  //  0012  GETGBL	R5	G4
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x1C140B0E,  //  0015  EQ	R5	R5	K14
-      0x78160003,  //  0016  JMPF	R5	#001B
-      0x8C14010C,  //  0017  GETMET	R5	R0	K12
-      0x5C1C0800,  //  0018  MOVE	R7	R4
-      0x7C140400,  //  0019  CALL	R5	2
-      0x70020008,  //  001A  JMP		#0024
-      0x8C14010F,  //  001B  GETMET	R5	R0	K15
-      0x5C1C0600,  //  001C  MOVE	R7	R3
-      0x7C140400,  //  001D  CALL	R5	2
-      0x4C180000,  //  001E  LDNIL	R6
-      0x20180A06,  //  001F  NE	R6	R5	R6
-      0x781A0002,  //  0020  JMPF	R6	#0024
-      0x8C18010C,  //  0021  GETMET	R6	R0	K12
-      0x88200B0D,  //  0022  GETMBR	R8	R5	K13
-      0x7C180400,  //  0023  CALL	R6	2
-      0xB8162000,  //  0024  GETNGBL	R5	K16
-      0x8C140B11,  //  0025  GETMET	R5	R5	K17
-      0x7C140200,  //  0026  CALL	R5	1
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(class_Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x8C040112,  //  0000  GETMET	R1	R0	K18
-      0x7C040200,  //  0001  CALL	R1	1
-      0x58040009,  //  0002  LDCONST	R1	K9
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C010B,  //  0004  GETMBR	R3	R0	K11
-      0x7C080200,  //  0005  CALL	R2	1
-      0x14080202,  //  0006  LT	R2	R1	R2
-      0x780A0005,  //  0007  JMPF	R2	#000E
-      0x8808010B,  //  0008  GETMBR	R2	R0	K11
-      0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C080513,  //  000A  GETMET	R2	R2	K19
-      0x7C080200,  //  000B  CALL	R2	1
-      0x00040308,  //  000C  ADD	R1	R1	K8
-      0x7001FFF4,  //  000D  JMP		#0003
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(class_Matter_Device_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8162800,  //  0004  GETNGBL	R5	K20
-      0x8C140B15,  //  0005  GETMET	R5	R5	K21
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90161A01,  //  0007  SETMBR	R5	K13	R1
-      0x90162C02,  //  0008  SETMBR	R5	K22	R2
-      0x90162E03,  //  0009  SETMBR	R5	K23	R3
-      0x88180118,  //  000A  GETMBR	R6	R0	K24
-      0x88180D19,  //  000B  GETMBR	R6	R6	K25
-      0x88180D1A,  //  000C  GETMBR	R6	R6	K26
-      0x8C180D1B,  //  000D  GETMET	R6	R6	K27
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8810010B,  //  0003  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C14091C,  //  0008  GETMET	R5	R4	K28
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B09,  //  000B  EQ	R6	R5	K9
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C18051D,  //  000E  GETMET	R6	R2	K29
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180506,  //  0014  GETMET	R6	R2	K6
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0007,  //  0018  LDCONST	R3	K7
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_remote_info
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_remote_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8808011E,  //  0000  GETMBR	R2	R0	K30
-      0x8C08051D,  //  0001  GETMET	R2	R2	K29
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C140000,  //  0004  CALL	R5	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(class_Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4063E00,  //  0000  IMPORT	R1	K31
-      0x8C080120,  //  0001  GETMET	R2	R0	K32
-      0x7C080200,  //  0002  CALL	R2	1
-      0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0021,  //  0004  LDCONST	R3	K33
-      0x88100122,  //  0005  GETMBR	R4	R0	K34
-      0x88140123,  //  0006  GETMBR	R5	R0	K35
-      0x88180124,  //  0007  GETMBR	R6	R0	K36
-      0x781A0001,  //  0008  JMPF	R6	#000B
-      0x58180025,  //  0009  LDCONST	R6	K37
-      0x70020000,  //  000A  JMP		#000C
-      0x58180026,  //  000B  LDCONST	R6	K38
-      0x881C0127,  //  000C  GETMBR	R7	R0	K39
-      0x781E0001,  //  000D  JMPF	R7	#0010
-      0x581C0025,  //  000E  LDCONST	R7	K37
-      0x70020000,  //  000F  JMP		#0011
-      0x581C0026,  //  0010  LDCONST	R7	K38
-      0x88200128,  //  0011  GETMBR	R8	R0	K40
-      0x7C080C00,  //  0012  CALL	R2	6
-      0x880C0129,  //  0013  GETMBR	R3	R0	K41
-      0x780E0000,  //  0014  JMPF	R3	#0016
-      0x0008052A,  //  0015  ADD	R2	R2	K42
-      0x880C012B,  //  0016  GETMBR	R3	R0	K43
-      0x780E000E,  //  0017  JMPF	R3	#0027
-      0x0008052C,  //  0018  ADD	R2	R2	K44
-      0x8C0C032D,  //  0019  GETMET	R3	R1	K45
-      0x8814012E,  //  001A  GETMBR	R5	R0	K46
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x00080403,  //  001C  ADD	R2	R2	R3
-      0x600C000C,  //  001D  GETGBL	R3	G12
-      0x8810011E,  //  001E  GETMBR	R4	R0	K30
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x240C0709,  //  0020  GT	R3	R3	K9
-      0x780E0004,  //  0021  JMPF	R3	#0027
-      0x0008052F,  //  0022  ADD	R2	R2	K47
-      0x8C0C032D,  //  0023  GETMET	R3	R1	K45
-      0x8814011E,  //  0024  GETMBR	R5	R0	K30
-      0x7C0C0400,  //  0025  CALL	R3	2
-      0x00080403,  //  0026  ADD	R2	R2	R3
-      0x00080530,  //  0027  ADD	R2	R2	K48
-      0xA8020017,  //  0028  EXBLK	0	#0041
-      0x600C0011,  //  0029  GETGBL	R3	G17
-      0x88100131,  //  002A  GETMBR	R4	R0	K49
-      0x58140032,  //  002B  LDCONST	R5	K50
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0x8C100733,  //  002D  GETMET	R4	R3	K51
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x8C100734,  //  0030  GETMET	R4	R3	K52
-      0x7C100200,  //  0031  CALL	R4	1
-      0xB8126A00,  //  0032  GETNGBL	R4	K53
-      0x60140018,  //  0033  GETGBL	R5	G24
-      0x58180036,  //  0034  LDCONST	R6	K54
-      0x881C012B,  //  0035  GETMBR	R7	R0	K43
-      0x781E0001,  //  0036  JMPF	R7	#0039
-      0x581C0037,  //  0037  LDCONST	R7	K55
-      0x70020000,  //  0038  JMP		#003A
-      0x581C000A,  //  0039  LDCONST	R7	K10
-      0x7C140400,  //  003A  CALL	R5	2
-      0x58180038,  //  003B  LDCONST	R6	K56
-      0x7C100400,  //  003C  CALL	R4	2
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x80040400,  //  003E  RET	1	R2
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8166A00,  //  0043  GETNGBL	R5	K53
-      0x60180008,  //  0044  GETGBL	R6	G8
-      0x5C1C0600,  //  0045  MOVE	R7	R3
-      0x7C180200,  //  0046  CALL	R6	1
-      0x001A7206,  //  0047  ADD	R6	K57	R6
-      0x00180D3A,  //  0048  ADD	R6	R6	K58
-      0x601C0008,  //  0049  GETGBL	R7	G8
-      0x5C200800,  //  004A  MOVE	R8	R4
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0038,  //  004D  LDCONST	R7	K56
-      0x7C140400,  //  004E  CALL	R5	2
-      0x80040400,  //  004F  RET	1	R2
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8062000,  //  0000  GETNGBL	R1	K16
-      0x8C04033B,  //  0001  GETMET	R1	R1	K59
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x8C04033C,  //  0007  GETMET	R1	R1	K60
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort_distinct
-********************************************************************/
-be_local_closure(class_Matter_Device_sort_distinct,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(sort_distinct),
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58040004,  //  0000  LDCONST	R1	K4
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0708,  //  0005  SUB	R3	R3	K8
-      0x400E1003,  //  0006  CONNECT	R3	K8	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B09,  //  000D  GT	R6	R5	K9
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B08,  //  000F  SUB	R6	R5	K8
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B08,  //  0013  SUB	R6	R5	K8
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B08,  //  0016  SUB	R5	R5	K8
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080007,  //  001A  LDCONST	R2	K7
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080008,  //  001D  LDCONST	R2	K8
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0708,  //  0021  LE	R3	R3	K8
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0109,  //  0024  GETIDX	R3	R0	K9
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C10013D,  //  002D  GETMET	R4	R0	K61
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080508,  //  0032  ADD	R2	R2	K8
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_fabrics_saved
-********************************************************************/
-be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8804013E,  //  0000  GETMBR	R1	R0	K62
-      0x8C04033F,  //  0001  GETMET	R1	R1	K63
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040309,  //  0003  GT	R1	R1	K9
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x8804012B,  //  0005  GETMBR	R1	R0	K43
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90025601,  //  0008  SETMBR	R0	K43	R1
-      0x8C040140,  //  0009  GETMET	R1	R0	K64
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_device
-********************************************************************/
-be_local_closure(class_Matter_Device_autoconf_device,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(autoconf_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0xA4063E00,  //  0000  IMPORT	R1	K31
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C010B,  //  0002  GETMBR	R3	R0	K11
+    ( &(const binstruction[48]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
       0x7C080200,  //  0003  CALL	R2	1
-      0x24080509,  //  0004  GT	R2	R2	K9
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x88080141,  //  0007  GETMBR	R2	R0	K65
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x1C080403,  //  0009  EQ	R2	R2	R3
-      0x780A0004,  //  000A  JMPF	R2	#0010
-      0xB80A2800,  //  000B  GETNGBL	R2	K20
-      0x8C080542,  //  000C  GETMET	R2	R2	K66
-      0x5C100000,  //  000D  MOVE	R4	R0
-      0x7C080400,  //  000E  CALL	R2	2
-      0x90028202,  //  000F  SETMBR	R0	K65	R2
-      0x8808012B,  //  0010  GETMBR	R2	R0	K43
-      0x740A000F,  //  0011  JMPT	R2	#0022
-      0x88080141,  //  0012  GETMBR	R2	R0	K65
-      0x8C080543,  //  0013  GETMET	R2	R2	K67
-      0x7C080200,  //  0014  CALL	R2	1
-      0x90025C02,  //  0015  SETMBR	R0	K46	R2
-      0x60080013,  //  0016  GETGBL	R2	G19
-      0x7C080000,  //  0017  CALL	R2	0
-      0x90023C02,  //  0018  SETMBR	R0	K30	R2
-      0x8C080144,  //  0019  GETMET	R2	R0	K68
-      0x7C080200,  //  001A  CALL	R2	1
-      0xB80A6A00,  //  001B  GETNGBL	R2	K53
-      0x600C0008,  //  001C  GETGBL	R3	G8
-      0x8810012E,  //  001D  GETMBR	R4	R0	K46
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x000E8A03,  //  001F  ADD	R3	K69	R3
-      0x58100046,  //  0020  LDCONST	R4	K70
-      0x7C080400,  //  0021  CALL	R2	2
-      0x88080141,  //  0022  GETMBR	R2	R0	K65
-      0x8C080547,  //  0023  GETMET	R2	R2	K71
-      0x8810012E,  //  0024  GETMBR	R4	R0	K46
-      0x7C080400,  //  0025  CALL	R2	2
-      0x8808012B,  //  0026  GETMBR	R2	R0	K43
-      0x740A0008,  //  0027  JMPT	R2	#0031
-      0x8808013E,  //  0028  GETMBR	R2	R0	K62
-      0x8C08053F,  //  0029  GETMET	R2	R2	K63
-      0x7C080200,  //  002A  CALL	R2	1
-      0x24080509,  //  002B  GT	R2	R2	K9
-      0x780A0003,  //  002C  JMPF	R2	#0031
-      0x50080200,  //  002D  LDBOOL	R2	1	0
-      0x90025602,  //  002E  SETMBR	R0	K43	R2
-      0x8C080140,  //  002F  GETMET	R2	R0	K64
-      0x7C080200,  //  0030  CALL	R2	1
-      0x80000000,  //  0031  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(class_Matter_Device_msg_received,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(msg_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100118,  //  0000  GETMBR	R4	R0	K24
-      0x8C100948,  //  0001  GETMET	R4	R4	K72
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resolve_attribute_read_solo
-********************************************************************/
-be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(resolve_attribute_read_solo),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x8808030D,  //  0000  GETMBR	R2	R1	K13
-      0x880C0316,  //  0001  GETMBR	R3	R1	K22
-      0x88100317,  //  0002  GETMBR	R4	R1	K23
-      0x4C140000,  //  0003  LDNIL	R5
-      0x1C140405,  //  0004  EQ	R5	R2	R5
-      0x74160005,  //  0005  JMPT	R5	#000C
-      0x4C140000,  //  0006  LDNIL	R5
-      0x1C140605,  //  0007  EQ	R5	R3	R5
-      0x74160002,  //  0008  JMPT	R5	#000C
-      0x4C140000,  //  0009  LDNIL	R5
-      0x1C140805,  //  000A  EQ	R5	R4	R5
-      0x78160001,  //  000B  JMPF	R5	#000E
-      0x4C140000,  //  000C  LDNIL	R5
-      0x80040A00,  //  000D  RET	1	R5
-      0x8C140149,  //  000E  GETMET	R5	R0	K73
-      0x5C1C0400,  //  000F  MOVE	R7	R2
-      0x7C140400,  //  0010  CALL	R5	2
-      0x4C180000,  //  0011  LDNIL	R6
-      0x1C180A06,  //  0012  EQ	R6	R5	R6
-      0x781A0005,  //  0013  JMPF	R6	#001A
-      0xB81A2800,  //  0014  GETNGBL	R6	K20
-      0x88180D4B,  //  0015  GETMBR	R6	R6	K75
-      0x90069406,  //  0016  SETMBR	R1	K74	R6
-      0x4C180000,  //  0017  LDNIL	R6
-      0x80040C00,  //  0018  RET	1	R6
-      0x70020013,  //  0019  JMP		#002E
-      0x8C180B4C,  //  001A  GETMET	R6	R5	K76
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x741A0005,  //  001D  JMPT	R6	#0024
-      0xB81A2800,  //  001E  GETNGBL	R6	K20
-      0x88180D4D,  //  001F  GETMBR	R6	R6	K77
-      0x90069406,  //  0020  SETMBR	R1	K74	R6
-      0x4C180000,  //  0021  LDNIL	R6
-      0x80040C00,  //  0022  RET	1	R6
-      0x70020009,  //  0023  JMP		#002E
-      0x8C180B4E,  //  0024  GETMET	R6	R5	K78
-      0x5C200600,  //  0025  MOVE	R8	R3
-      0x5C240800,  //  0026  MOVE	R9	R4
-      0x7C180600,  //  0027  CALL	R6	3
-      0x741A0004,  //  0028  JMPT	R6	#002E
-      0xB81A2800,  //  0029  GETNGBL	R6	K20
-      0x88180D4F,  //  002A  GETMBR	R6	R6	K79
-      0x90069406,  //  002B  SETMBR	R1	K74	R6
-      0x4C180000,  //  002C  LDNIL	R6
-      0x80040C00,  //  002D  RET	1	R6
-      0x80040A00,  //  002E  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clean_remotes
-********************************************************************/
-be_local_closure(class_Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA406A000,  //  0000  IMPORT	R1	K80
-      0x88080151,  //  0001  GETMBR	R2	R0	K81
-      0x780A004B,  //  0002  JMPF	R2	#004F
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100151,  //  0006  GETMBR	R4	R0	K81
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x98080909,  //  000B  SETIDX	R2	R4	K9
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C0007,  //  000D  LDCONST	R3	K7
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x8810010B,  //  0011  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140352,  //  0016  GETMET	R5	R1	K82
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200053,  //  0018  LDCONST	R8	K83
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C18051D,  //  001D  GETMET	R6	R2	K29
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x58240009,  //  001F  LDCONST	R9	K9
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D08,  //  0021  ADD	R6	R6	K8
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C0007,  //  0024  LDCONST	R3	K7
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0012,  //  0027  GETGBL	R3	G18
-      0x7C0C0000,  //  0028  CALL	R3	0
-      0x60100010,  //  0029  GETGBL	R4	G16
-      0x8C140505,  //  002A  GETMET	R5	R2	K5
+      0xB80E0200,  //  0004  GETNGBL	R3	K1
+      0x8C0C0703,  //  0005  GETMET	R3	R3	K3
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0006,  //  0008  JMPF	R3	#0010
+      0xB80E0A00,  //  0009  GETNGBL	R3	K5
+      0x60100008,  //  000A  GETGBL	R4	G8
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00120C04,  //  000D  ADD	R4	K6	R4
+      0x58140004,  //  000E  LDCONST	R5	K4
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x4C0C0000,  //  0010  LDNIL	R3
+      0x1C0C0403,  //  0011  EQ	R3	R2	R3
+      0x780E0000,  //  0012  JMPF	R3	#0014
+      0x80000600,  //  0013  RET	0
+      0x8C0C0307,  //  0014  GETMET	R3	R1	K7
+      0x5C140400,  //  0015  MOVE	R5	R2
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x4C100000,  //  0017  LDNIL	R4
+      0x20100604,  //  0018  NE	R4	R3	R4
+      0x7812000D,  //  0019  JMPF	R4	#0028
+      0x58100008,  //  001A  LDCONST	R4	K8
+      0x6014000C,  //  001B  GETGBL	R5	G12
+      0x88180109,  //  001C  GETMBR	R6	R0	K9
+      0x7C140200,  //  001D  CALL	R5	1
+      0x14140805,  //  001E  LT	R5	R4	R5
+      0x78160006,  //  001F  JMPF	R5	#0027
+      0x88140109,  //  0020  GETMBR	R5	R0	K9
+      0x94140A04,  //  0021  GETIDX	R5	R5	R4
+      0x8C140B0A,  //  0022  GETMET	R5	R5	K10
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C140400,  //  0024  CALL	R5	2
+      0x0010090B,  //  0025  ADD	R4	R4	K11
+      0x7001FFF3,  //  0026  JMP		#001B
+      0x70020006,  //  0027  JMP		#002F
+      0xB8120A00,  //  0028  GETNGBL	R4	K5
+      0x60140008,  //  0029  GETGBL	R5	G8
+      0x5C180400,  //  002A  MOVE	R6	R2
       0x7C140200,  //  002B  CALL	R5	1
-      0x7C100200,  //  002C  CALL	R4	1
-      0xA8020008,  //  002D  EXBLK	0	#0037
-      0x5C140800,  //  002E  MOVE	R5	R4
-      0x7C140000,  //  002F  CALL	R5	0
-      0x94180405,  //  0030  GETIDX	R6	R2	R5
-      0x1C180D09,  //  0031  EQ	R6	R6	K9
-      0x781A0002,  //  0032  JMPF	R6	#0036
-      0x8C180706,  //  0033  GETMET	R6	R3	K6
-      0x5C200A00,  //  0034  MOVE	R8	R5
-      0x7C180400,  //  0035  CALL	R6	2
-      0x7001FFF6,  //  0036  JMP		#002E
-      0x58100007,  //  0037  LDCONST	R4	K7
-      0xAC100200,  //  0038  CATCH	R4	1	0
-      0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x60100010,  //  003A  GETGBL	R4	G16
-      0x5C140600,  //  003B  MOVE	R5	R3
-      0x7C100200,  //  003C  CALL	R4	1
-      0xA802000D,  //  003D  EXBLK	0	#004C
-      0x5C140800,  //  003E  MOVE	R5	R4
-      0x7C140000,  //  003F  CALL	R5	0
-      0xB81A6A00,  //  0040  GETNGBL	R6	K53
-      0x881C0B55,  //  0041  GETMBR	R7	R5	K85
-      0x001EA807,  //  0042  ADD	R7	K84	R7
-      0x58200046,  //  0043  LDCONST	R8	K70
-      0x7C180400,  //  0044  CALL	R6	2
-      0x8C180B34,  //  0045  GETMET	R6	R5	K52
-      0x7C180200,  //  0046  CALL	R6	1
-      0x88180151,  //  0047  GETMBR	R6	R0	K81
-      0x8C180D3D,  //  0048  GETMET	R6	R6	K61
-      0x88200B55,  //  0049  GETMBR	R8	R5	K85
-      0x7C180400,  //  004A  CALL	R6	2
-      0x7001FFF1,  //  004B  JMP		#003E
-      0x58100007,  //  004C  LDCONST	R4	K7
-      0xAC100200,  //  004D  CATCH	R4	1	0
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
+      0x00161805,  //  002C  ADD	R5	K12	R5
+      0x58180004,  //  002D  LDCONST	R6	K4
+      0x7C100400,  //  002E  CALL	R4	2
+      0x80000000,  //  002F  RET	0
     })
   )
 );
@@ -1112,58 +295,11 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
 
 
 /********************************************************************
-** Solidified function: invoke_request
+** Solidified function: read_sensors_scheduler
 ********************************************************************/
-be_local_closure(class_Matter_Device_invoke_request,   /* name */
+be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100009,  //  0000  LDCONST	R4	K9
-      0x8814070D,  //  0001  GETMBR	R5	R3	K13
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C010B,  //  0003  GETMBR	R7	R0	K11
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x8818010B,  //  0007  GETMBR	R6	R0	K11
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D0D,  //  0009  GETMBR	R7	R6	K13
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D56,  //  000C  GETMET	R7	R6	K86
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100908,  //  0012  ADD	R4	R4	K8
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A2800,  //  0014  GETNGBL	R6	K20
-      0x88180D4B,  //  0015  GETMBR	R6	R6	K75
-      0x900E9406,  //  0016  SETMBR	R3	K74	R6
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Matter_Device_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1172,89 +308,30 @@ be_local_closure(class_Matter_Device_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(init),
+    be_str_weak(read_sensors_scheduler),
     &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA406AE00,  //  0000  IMPORT	R1	K87
-      0xB80A2000,  //  0001  GETNGBL	R2	K16
-      0x8C080558,  //  0002  GETMET	R2	R2	K88
-      0xB8122800,  //  0003  GETNGBL	R4	K20
-      0x88100959,  //  0004  GETMBR	R4	R4	K89
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0006,  //  0006  JMPT	R2	#000E
-      0xB80A2800,  //  0007  GETNGBL	R2	K20
-      0x8C08055B,  //  0008  GETMET	R2	R2	K91
-      0x5C100000,  //  0009  MOVE	R4	R0
-      0x50140000,  //  000A  LDBOOL	R5	0	0
-      0x7C080600,  //  000B  CALL	R2	3
-      0x9002B402,  //  000C  SETMBR	R0	K90	R2
-      0x80000400,  //  000D  RET	0
-      0xB80A2800,  //  000E  GETNGBL	R2	K20
-      0xB80E2800,  //  000F  GETNGBL	R3	K20
-      0x8C0C075D,  //  0010  GETMET	R3	R3	K93
-      0x7C0C0200,  //  0011  CALL	R3	1
-      0x900AB803,  //  0012  SETMBR	R2	K92	R3
-      0x50080000,  //  0013  LDBOOL	R2	0	0
-      0x9002BC02,  //  0014  SETMBR	R0	K94	R2
-      0x9002BF09,  //  0015  SETMBR	R0	K95	K9
-      0x60080012,  //  0016  GETGBL	R2	G18
-      0x7C080000,  //  0017  CALL	R2	0
-      0x90021602,  //  0018  SETMBR	R0	K11	R2
-      0x50080000,  //  0019  LDBOOL	R2	0	0
-      0x90025602,  //  001A  SETMBR	R0	K43	R2
-      0x60080013,  //  001B  GETGBL	R2	G19
-      0x7C080000,  //  001C  CALL	R2	0
-      0x90023C02,  //  001D  SETMBR	R0	K30	R2
-      0x88080160,  //  001E  GETMBR	R2	R0	K96
-      0x90025002,  //  001F  SETMBR	R0	K40	R2
-      0x50080000,  //  0020  LDBOOL	R2	0	0
-      0x90024802,  //  0021  SETMBR	R0	K36	R2
-      0x50080000,  //  0022  LDBOOL	R2	0	0
-      0x90024E02,  //  0023  SETMBR	R0	K39	R2
-      0xB80A2800,  //  0024  GETNGBL	R2	K20
-      0x8C080562,  //  0025  GETMET	R2	R2	K98
-      0x5C100000,  //  0026  MOVE	R4	R0
-      0x7C080400,  //  0027  CALL	R2	2
-      0x9002C202,  //  0028  SETMBR	R0	K97	R2
-      0x8C080163,  //  0029  GETMET	R2	R0	K99
-      0x7C080200,  //  002A  CALL	R2	1
-      0xB80A2800,  //  002B  GETNGBL	R2	K20
-      0x8C080564,  //  002C  GETMET	R2	R2	K100
-      0x5C100000,  //  002D  MOVE	R4	R0
-      0x7C080400,  //  002E  CALL	R2	2
-      0x90027C02,  //  002F  SETMBR	R0	K62	R2
-      0x8808013E,  //  0030  GETMBR	R2	R0	K62
-      0x8C080565,  //  0031  GETMET	R2	R2	K101
-      0x7C080200,  //  0032  CALL	R2	1
-      0xB80A2800,  //  0033  GETNGBL	R2	K20
-      0x8C080566,  //  0034  GETMET	R2	R2	K102
-      0x5C100000,  //  0035  MOVE	R4	R0
-      0x7C080400,  //  0036  CALL	R2	2
-      0x90023002,  //  0037  SETMBR	R0	K24	R2
-      0xB80A2800,  //  0038  GETNGBL	R2	K20
-      0x8C080568,  //  0039  GETMET	R2	R2	K104
-      0x5C100000,  //  003A  MOVE	R4	R0
-      0x7C080400,  //  003B  CALL	R2	2
-      0x9002CE02,  //  003C  SETMBR	R0	K103	R2
-      0x8C08016A,  //  003D  GETMET	R2	R0	K106
-      0x7C080200,  //  003E  CALL	R2	1
-      0x9002D202,  //  003F  SETMBR	R0	K105	R2
-      0xB80A2800,  //  0040  GETNGBL	R2	K20
-      0x8C08055B,  //  0041  GETMET	R2	R2	K91
-      0x5C100000,  //  0042  MOVE	R4	R0
-      0x50140200,  //  0043  LDBOOL	R5	1	0
-      0x7C080600,  //  0044  CALL	R2	3
-      0x9002B402,  //  0045  SETMBR	R0	K90	R2
-      0x88080161,  //  0046  GETMBR	R2	R0	K97
-      0x8C08056B,  //  0047  GETMET	R2	R2	K107
-      0x7C080200,  //  0048  CALL	R2	1
-      0xB80A2000,  //  0049  GETNGBL	R2	K16
-      0x8C08056C,  //  004A  GETMET	R2	R2	K108
-      0x5C100000,  //  004B  MOVE	R4	R0
-      0x7C080400,  //  004C  CALL	R2	2
-      0x8C08016D,  //  004D  GETMET	R2	R0	K109
-      0x7C080200,  //  004E  CALL	R2	1
-      0x80000000,  //  004F  RET	0
+    ( &(const binstruction[21]) {  /* code */
+      0x8804010D,  //  0000  GETMBR	R1	R0	K13
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0x8804010E,  //  0005  GETMBR	R1	R0	K14
+      0x1C040308,  //  0006  EQ	R1	R1	K8
+      0x74060004,  //  0007  JMPT	R1	#000D
+      0xB8060200,  //  0008  GETNGBL	R1	K1
+      0x8C04030F,  //  0009  GETMET	R1	R1	K15
+      0x880C010E,  //  000A  GETMBR	R3	R0	K14
+      0x7C040400,  //  000B  CALL	R1	2
+      0x78060006,  //  000C  JMPF	R1	#0014
+      0x8C040110,  //  000D  GETMET	R1	R0	K16
+      0x7C040200,  //  000E  CALL	R1	1
+      0xB8060200,  //  000F  GETNGBL	R1	K1
+      0x8C040311,  //  0010  GETMET	R1	R1	K17
+      0x880C010D,  //  0011  GETMBR	R3	R0	K13
+      0x7C040400,  //  0012  CALL	R1	2
+      0x90021C01,  //  0013  SETMBR	R0	K14	R1
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -1292,20 +369,546 @@ be_local_closure(class_Matter_Device_button_pressed,   /* name */
       0x3C180406,  //  000B  SHR	R6	R2	R6
       0x541E00FE,  //  000C  LDINT	R7	255
       0x2C180C07,  //  000D  AND	R6	R6	R7
-      0x8C1C016E,  //  000E  GETMET	R7	R0	K110
-      0x00240B08,  //  000F  ADD	R9	R5	K8
+      0x8C1C0112,  //  000E  GETMET	R7	R0	K18
+      0x00240B0B,  //  000F  ADD	R9	R5	K11
       0x20280604,  //  0010  NE	R10	R3	R4
       0x782A0001,  //  0011  JMPF	R10	#0014
-      0x58280008,  //  0012  LDCONST	R10	K8
+      0x5828000B,  //  0012  LDCONST	R10	K11
       0x70020000,  //  0013  JMP		#0015
-      0x58280009,  //  0014  LDCONST	R10	K9
+      0x58280008,  //  0014  LDCONST	R10	K8
       0x780E0001,  //  0015  JMPF	R3	#0018
-      0x582C0009,  //  0016  LDCONST	R11	K9
+      0x582C0008,  //  0016  LDCONST	R11	K8
       0x70020000,  //  0017  JMP		#0019
-      0x582C0008,  //  0018  LDCONST	R11	K8
+      0x582C000B,  //  0018  LDCONST	R11	K11
       0x5C300C00,  //  0019  MOVE	R12	R6
       0x7C1C0A00,  //  001A  CALL	R7	5
       0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_config_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_check_config_ep,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(check_config_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x600C0010,  //  0003  GETGBL	R3	G16
+      0x88100113,  //  0004  GETMBR	R4	R0	K19
+      0x8C100914,  //  0005  GETMET	R4	R4	K20
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020007,  //  0008  EXBLK	0	#0011
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x8C140515,  //  000B  GETMET	R5	R2	K21
+      0x601C0009,  //  000C  GETGBL	R7	G9
+      0x5C200800,  //  000D  MOVE	R8	R4
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x7001FFF7,  //  0010  JMP		#0009
+      0x580C0016,  //  0011  LDCONST	R3	K22
+      0xAC0C0200,  //  0012  CATCH	R3	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x600C0010,  //  0014  GETGBL	R3	G16
+      0x5C100400,  //  0015  MOVE	R4	R2
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0xA8020030,  //  0017  EXBLK	0	#0049
+      0x5C100600,  //  0018  MOVE	R4	R3
+      0x7C100000,  //  0019  CALL	R4	0
+      0x1C140908,  //  001A  EQ	R5	R4	K8
+      0x7816000B,  //  001B  JMPF	R5	#0028
+      0xB8160A00,  //  001C  GETNGBL	R5	K5
+      0x58180017,  //  001D  LDCONST	R6	K23
+      0x581C0018,  //  001E  LDCONST	R7	K24
+      0x7C140400,  //  001F  CALL	R5	2
+      0x88140113,  //  0020  GETMBR	R5	R0	K19
+      0x8C140B19,  //  0021  GETMET	R5	R5	K25
+      0x601C0008,  //  0022  GETGBL	R7	G8
+      0x5C200800,  //  0023  MOVE	R8	R4
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x7C140400,  //  0025  CALL	R5	2
+      0x50040200,  //  0026  LDBOOL	R1	1	0
+      0x7002001F,  //  0027  JMP		#0048
+      0xB8163400,  //  0028  GETNGBL	R5	K26
+      0x88140B1B,  //  0029  GETMBR	R5	R5	K27
+      0x1C140805,  //  002A  EQ	R5	R4	R5
+      0x7816001B,  //  002B  JMPF	R5	#0048
+      0x50040200,  //  002C  LDBOOL	R1	1	0
+      0xB8160A00,  //  002D  GETNGBL	R5	K5
+      0x60180018,  //  002E  GETGBL	R6	G24
+      0x581C001C,  //  002F  LDCONST	R7	K28
+      0x5C200800,  //  0030  MOVE	R8	R4
+      0x8824011D,  //  0031  GETMBR	R9	R0	K29
+      0x7C180600,  //  0032  CALL	R6	3
+      0x581C0018,  //  0033  LDCONST	R7	K24
+      0x7C140400,  //  0034  CALL	R5	2
+      0x60140008,  //  0035  GETGBL	R5	G8
+      0x8818011D,  //  0036  GETMBR	R6	R0	K29
+      0x7C140200,  //  0037  CALL	R5	1
+      0x88180113,  //  0038  GETMBR	R6	R0	K19
+      0x601C0008,  //  0039  GETGBL	R7	G8
+      0x5C200800,  //  003A  MOVE	R8	R4
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x88200113,  //  003C  GETMBR	R8	R0	K19
+      0x941C1007,  //  003D  GETIDX	R7	R8	R7
+      0x98180A07,  //  003E  SETIDX	R6	R5	R7
+      0x88140113,  //  003F  GETMBR	R5	R0	K19
+      0x8C140B19,  //  0040  GETMET	R5	R5	K25
+      0x601C0008,  //  0041  GETGBL	R7	G8
+      0x5C200800,  //  0042  MOVE	R8	R4
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x7C140400,  //  0044  CALL	R5	2
+      0x8814011D,  //  0045  GETMBR	R5	R0	K29
+      0x00140B0B,  //  0046  ADD	R5	R5	K11
+      0x90023A05,  //  0047  SETMBR	R0	K29	R5
+      0x7001FFCE,  //  0048  JMP		#0018
+      0x580C0016,  //  0049  LDCONST	R3	K22
+      0xAC0C0200,  //  004A  CATCH	R3	1	0
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80040200,  //  004C  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(class_Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100008,  //  0000  LDCONST	R4	K8
+      0x8814071E,  //  0001  GETMBR	R5	R3	K30
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0109,  //  0003  GETMBR	R7	R0	K9
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180109,  //  0007  GETMBR	R6	R0	K9
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D1E,  //  0009  GETMBR	R7	R6	K30
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D1F,  //  000C  GETMET	R7	R6	K31
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x0010090B,  //  0012  ADD	R4	R4	K11
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A3400,  //  0014  GETNGBL	R6	K26
+      0x88180D21,  //  0015  GETMBR	R6	R6	K33
+      0x900E4006,  //  0016  SETMBR	R3	K32	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: signal_endpoints_changed
+********************************************************************/
+be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(signal_endpoints_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C040122,  //  0000  GETMET	R1	R0	K34
+      0x580C0008,  //  0001  LDCONST	R3	K8
+      0x5412001C,  //  0002  LDINT	R4	29
+      0x58140004,  //  0003  LDCONST	R5	K4
+      0x50180000,  //  0004  LDBOOL	R6	0	0
+      0x7C040A00,  //  0005  CALL	R1	5
+      0x8C040122,  //  0006  GETMET	R1	R0	K34
+      0xB80E3400,  //  0007  GETNGBL	R3	K26
+      0x880C071B,  //  0008  GETMBR	R3	R3	K27
+      0x5412001C,  //  0009  LDINT	R4	29
+      0x58140004,  //  000A  LDCONST	R5	K4
+      0x50180000,  //  000B  LDBOOL	R6	0	0
+      0x7C040A00,  //  000C  CALL	R1	5
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(class_Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[136]) {  /* code */
+      0xA4064600,  //  0000  IMPORT	R1	K35
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0xA8020056,  //  0002  EXBLK	0	#005A
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x88100124,  //  0004  GETMBR	R4	R0	K36
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C100725,  //  0006  GETMET	R4	R3	K37
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C140726,  //  0008  GETMET	R5	R3	K38
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4160000,  //  000A  IMPORT	R5	K0
+      0x8C180B07,  //  000B  GETMET	R6	R5	K7
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D28,  //  000E  GETMET	R7	R6	K40
+      0x58240029,  //  000F  LDCONST	R9	K41
+      0x88280127,  //  0010  GETMBR	R10	R0	K39
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90024E07,  //  0012  SETMBR	R0	K39	R7
+      0x8C1C0D28,  //  0013  GETMET	R7	R6	K40
+      0x5824002B,  //  0014  LDCONST	R9	K43
+      0x8828012A,  //  0015  GETMBR	R10	R0	K42
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90025407,  //  0017  SETMBR	R0	K42	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D28,  //  0019  GETMET	R8	R6	K40
+      0x5828002C,  //  001A  LDCONST	R10	K44
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90025807,  //  001E  SETMBR	R0	K44	R7
+      0x601C0017,  //  001F  GETGBL	R7	G23
+      0x8C200D28,  //  0020  GETMET	R8	R6	K40
+      0x5828002D,  //  0021  LDCONST	R10	K45
+      0x502C0000,  //  0022  LDBOOL	R11	0	0
+      0x7C200600,  //  0023  CALL	R8	3
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x90025A07,  //  0025  SETMBR	R0	K45	R7
+      0x8C1C0D28,  //  0026  GETMET	R7	R6	K40
+      0x5824002E,  //  0027  LDCONST	R9	K46
+      0x8828011D,  //  0028  GETMBR	R10	R0	K29
+      0x7C1C0600,  //  0029  CALL	R7	3
+      0x90023A07,  //  002A  SETMBR	R0	K29	R7
+      0x8C1C0D28,  //  002B  GETMET	R7	R6	K40
+      0x5824002F,  //  002C  LDCONST	R9	K47
+      0x60280013,  //  002D  GETGBL	R10	G19
+      0x7C280000,  //  002E  CALL	R10	0
+      0x7C1C0600,  //  002F  CALL	R7	3
+      0x90022607,  //  0030  SETMBR	R0	K19	R7
+      0x601C0017,  //  0031  GETGBL	R7	G23
+      0x8C200D28,  //  0032  GETMET	R8	R6	K40
+      0x58280030,  //  0033  LDCONST	R10	K48
+      0x7C200400,  //  0034  CALL	R8	2
+      0x7C1C0200,  //  0035  CALL	R7	1
+      0x90026007,  //  0036  SETMBR	R0	K48	R7
+      0x881C0113,  //  0037  GETMBR	R7	R0	K19
+      0x4C200000,  //  0038  LDNIL	R8
+      0x201C0E08,  //  0039  NE	R7	R7	R8
+      0x781E000D,  //  003A  JMPF	R7	#0049
+      0xB81E0A00,  //  003B  GETNGBL	R7	K5
+      0x60200018,  //  003C  GETGBL	R8	G24
+      0x58240031,  //  003D  LDCONST	R9	K49
+      0x88280113,  //  003E  GETMBR	R10	R0	K19
+      0x7C200400,  //  003F  CALL	R8	2
+      0x58240004,  //  0040  LDCONST	R9	K4
+      0x7C1C0400,  //  0041  CALL	R7	2
+      0x8C1C0132,  //  0042  GETMET	R7	R0	K50
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x8C1C0133,  //  0044  GETMET	R7	R0	K51
+      0x7C1C0200,  //  0045  CALL	R7	1
+      0x5C080E00,  //  0046  MOVE	R2	R7
+      0x501C0200,  //  0047  LDBOOL	R7	1	0
+      0x90026807,  //  0048  SETMBR	R0	K52	R7
+      0x8C1C0D28,  //  0049  GETMET	R7	R6	K40
+      0x58240036,  //  004A  LDCONST	R9	K54
+      0x60280013,  //  004B  GETGBL	R10	G19
+      0x7C280000,  //  004C  CALL	R10	0
+      0x7C1C0600,  //  004D  CALL	R7	3
+      0x90026A07,  //  004E  SETMBR	R0	K53	R7
+      0x881C0135,  //  004F  GETMBR	R7	R0	K53
+      0x781E0006,  //  0050  JMPF	R7	#0058
+      0xB81E0A00,  //  0051  GETNGBL	R7	K5
+      0x60200008,  //  0052  GETGBL	R8	G8
+      0x88240135,  //  0053  GETMBR	R9	R0	K53
+      0x7C200200,  //  0054  CALL	R8	1
+      0x00226E08,  //  0055  ADD	R8	K55	R8
+      0x58240004,  //  0056  LDCONST	R9	K4
+      0x7C1C0400,  //  0057  CALL	R7	2
+      0xA8040001,  //  0058  EXBLK	1	1
+      0x70020011,  //  0059  JMP		#006C
+      0xAC0C0002,  //  005A  CATCH	R3	0	2
+      0x7002000E,  //  005B  JMP		#006B
+      0x20140738,  //  005C  NE	R5	R3	K56
+      0x7816000B,  //  005D  JMPF	R5	#006A
+      0xB8160A00,  //  005E  GETNGBL	R5	K5
+      0x60180008,  //  005F  GETGBL	R6	G8
+      0x5C1C0600,  //  0060  MOVE	R7	R3
+      0x7C180200,  //  0061  CALL	R6	1
+      0x001A7206,  //  0062  ADD	R6	K57	R6
+      0x00180D3A,  //  0063  ADD	R6	R6	K58
+      0x601C0008,  //  0064  GETGBL	R7	G8
+      0x5C200800,  //  0065  MOVE	R8	R4
+      0x7C1C0200,  //  0066  CALL	R7	1
+      0x00180C07,  //  0067  ADD	R6	R6	R7
+      0x581C0018,  //  0068  LDCONST	R7	K24
+      0x7C140400,  //  0069  CALL	R5	2
+      0x70020000,  //  006A  JMP		#006C
+      0xB0080000,  //  006B  RAISE	2	R0	R0
+      0x880C0127,  //  006C  GETMBR	R3	R0	K39
+      0x4C100000,  //  006D  LDNIL	R4
+      0x1C0C0604,  //  006E  EQ	R3	R3	R4
+      0x780E000A,  //  006F  JMPF	R3	#007B
+      0x8C0C033B,  //  0070  GETMET	R3	R1	K59
+      0x58140018,  //  0071  LDCONST	R5	K24
+      0x7C0C0400,  //  0072  CALL	R3	2
+      0x8C0C073C,  //  0073  GETMET	R3	R3	K60
+      0x58140008,  //  0074  LDCONST	R5	K8
+      0x58180018,  //  0075  LDCONST	R6	K24
+      0x7C0C0600,  //  0076  CALL	R3	3
+      0x54120FFE,  //  0077  LDINT	R4	4095
+      0x2C0C0604,  //  0078  AND	R3	R3	R4
+      0x90024E03,  //  0079  SETMBR	R0	K39	R3
+      0x50080200,  //  007A  LDBOOL	R2	1	0
+      0x880C012A,  //  007B  GETMBR	R3	R0	K42
+      0x4C100000,  //  007C  LDNIL	R4
+      0x1C0C0604,  //  007D  EQ	R3	R3	R4
+      0x780E0004,  //  007E  JMPF	R3	#0084
+      0x880C013D,  //  007F  GETMBR	R3	R0	K61
+      0x8C0C073E,  //  0080  GETMET	R3	R3	K62
+      0x7C0C0200,  //  0081  CALL	R3	1
+      0x90025403,  //  0082  SETMBR	R0	K42	R3
+      0x50080200,  //  0083  LDBOOL	R2	1	0
+      0x780A0001,  //  0084  JMPF	R2	#0087
+      0x8C0C013F,  //  0085  GETMET	R3	R0	K63
+      0x7C0C0200,  //  0086  CALL	R3	1
+      0x80000000,  //  0087  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: conf_to_log
+********************************************************************/
+be_local_closure(class_Matter_Device_conf_to_log,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(conf_to_log),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040040,  //  0000  LDCONST	R1	K64
+      0x58080041,  //  0001  LDCONST	R2	K65
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100342,  //  0003  GETMET	R4	R1	K66
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C140943,  //  000A  EQ	R5	R4	K67
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180044,  //  000E  LDCONST	R6	K68
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0016,  //  0014  LDCONST	R3	K22
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_zigbee_present
+********************************************************************/
+be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(is_zigbee_present),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA4068A00,  //  0000  IMPORT	R1	K69
+      0x8C080346,  //  0001  GETMET	R2	R1	K70
+      0x58100047,  //  0002  LDCONST	R4	K71
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x20080403,  //  0005  NE	R2	R2	R3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l
+********************************************************************/
+be_local_closure(class_Matter_Device_k2l,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(k2l),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0x58040040,  //  0000  LDCONST	R1	K64
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100114,  //  0008  GETMET	R4	R0	K20
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140515,  //  000E  GETMET	R5	R2	K21
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0016,  //  0012  LDCONST	R3	K22
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x0410090B,  //  0019  SUB	R4	R4	K11
+      0x40121604,  //  001A  CONNECT	R4	K11	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D08,  //  0021  GT	R7	R6	K8
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D0B,  //  0023  SUB	R7	R6	K11
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D0B,  //  0027  SUB	R7	R6	K11
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D0B,  //  002A  SUB	R6	R6	K11
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0016,  //  002E  LDCONST	R3	K22
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040348,  //  0001  GETMET	R1	R1	K72
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040149,  //  0004  GETMBR	R1	R0	K73
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040149,  //  0006  GETMBR	R1	R0	K73
+      0x8C04034A,  //  0007  GETMET	R1	R1	K74
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -1335,19 +938,19 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
       0x6008000C,  //  0003  GETGBL	R2	G12
       0x5C0C0200,  //  0004  MOVE	R3	R1
       0x7C080200,  //  0005  CALL	R2	1
-      0x1C080509,  //  0006  EQ	R2	R2	K9
+      0x1C080508,  //  0006  EQ	R2	R2	K8
       0x780A0001,  //  0007  JMPF	R2	#000A
       0x4C080000,  //  0008  LDNIL	R2
       0x80040400,  //  0009  RET	1	R2
-      0x58080009,  //  000A  LDCONST	R2	K9
+      0x58080008,  //  000A  LDCONST	R2	K8
       0x600C000C,  //  000B  GETGBL	R3	G12
-      0x8810010B,  //  000C  GETMBR	R4	R0	K11
+      0x88100109,  //  000C  GETMBR	R4	R0	K9
       0x7C0C0200,  //  000D  CALL	R3	1
       0x140C0403,  //  000E  LT	R3	R2	R3
       0x780E0010,  //  000F  JMPF	R3	#0021
-      0x880C010B,  //  0010  GETMBR	R3	R0	K11
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
       0x940C0602,  //  0011  GETIDX	R3	R3	R2
-      0x8C10076F,  //  0012  GETMET	R4	R3	K111
+      0x8C10074B,  //  0012  GETMET	R4	R3	K75
       0x7C100200,  //  0013  CALL	R4	1
       0x4C140000,  //  0014  LDNIL	R5
       0x20140805,  //  0015  NE	R5	R4	R5
@@ -1355,12 +958,12 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
       0x6014000C,  //  0017  GETGBL	R5	G12
       0x5C180800,  //  0018  MOVE	R6	R4
       0x7C140200,  //  0019  CALL	R5	1
-      0x24140B09,  //  001A  GT	R5	R5	K9
+      0x24140B08,  //  001A  GT	R5	R5	K8
       0x78160002,  //  001B  JMPF	R5	#001F
       0x1C140801,  //  001C  EQ	R5	R4	R1
       0x78160000,  //  001D  JMPF	R5	#001F
       0x80040600,  //  001E  RET	1	R3
-      0x00080508,  //  001F  ADD	R2	R2	K8
+      0x0008050B,  //  001F  ADD	R2	R2	K11
       0x7001FFE9,  //  0020  JMP		#000B
       0x4C0C0000,  //  0021  LDNIL	R3
       0x80040600,  //  0022  RET	1	R3
@@ -1371,50 +974,11 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
 
 
 /********************************************************************
-** Solidified function: check_network
+** Solidified function: MtrJoin
 ********************************************************************/
-be_local_closure(class_Matter_Device_check_network,   /* name */
+be_local_closure(class_Matter_Device_MtrJoin,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(check_network),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x8804015E,  //  0000  GETMBR	R1	R0	K94
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0xB8062000,  //  0003  GETNGBL	R1	K16
-      0x8C040370,  //  0004  GETMET	R1	R1	K112
-      0x7C040200,  //  0005  CALL	R1	1
-      0x94040371,  //  0006  GETIDX	R1	R1	K113
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8062000,  //  0008  GETNGBL	R1	K16
-      0x8C040372,  //  0009  GETMET	R1	R1	K114
-      0x7C040200,  //  000A  CALL	R1	1
-      0x94040371,  //  000B  GETIDX	R1	R1	K113
-      0x78060001,  //  000C  JMPF	R1	#000F
-      0x8C040173,  //  000D  GETMET	R1	R0	K115
-      0x7C040200,  //  000E  CALL	R1	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrUpdate
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
+    8,                          /* nstack */
     5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1423,135 +987,24 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrUpdate),
+    be_str_weak(MtrJoin),
     &be_const_str_solidified,
-    ( &(const binstruction[126]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160004,  //  0002  JMPF	R5	#0008
-      0xB8162000,  //  0003  GETNGBL	R5	K16
-      0x8C140B74,  //  0004  GETMET	R5	R5	K116
-      0x581C0075,  //  0005  LDCONST	R7	K117
-      0x7C140400,  //  0006  CALL	R5	2
-      0x80040A00,  //  0007  RET	1	R5
-      0xB8162000,  //  0008  GETNGBL	R5	K16
-      0x8C140B76,  //  0009  GETMET	R5	R5	K118
-      0x5C1C0800,  //  000A  MOVE	R7	R4
-      0x58200077,  //  000B  LDCONST	R8	K119
-      0x7C140600,  //  000C  CALL	R5	3
-      0xB81A2000,  //  000D  GETNGBL	R6	K16
-      0x8C180D76,  //  000E  GETMET	R6	R6	K118
-      0x5C200800,  //  000F  MOVE	R8	R4
-      0x58240078,  //  0010  LDCONST	R9	K120
-      0x7C180600,  //  0011  CALL	R6	3
-      0x74160000,  //  0012  JMPT	R5	#0014
-      0x781A0064,  //  0013  JMPF	R6	#0079
-      0x4C1C0000,  //  0014  LDNIL	R7
-      0x78160010,  //  0015  JMPF	R5	#0027
-      0x60200009,  //  0016  GETGBL	R8	G9
-      0x94240805,  //  0017  GETIDX	R9	R4	R5
-      0x7C200200,  //  0018  CALL	R8	1
-      0x18241109,  //  0019  LE	R9	R8	K9
-      0x78260004,  //  001A  JMPF	R9	#0020
-      0xB8262000,  //  001B  GETNGBL	R9	K16
-      0x8C241374,  //  001C  GETMET	R9	R9	K116
-      0x582C0079,  //  001D  LDCONST	R11	K121
-      0x7C240400,  //  001E  CALL	R9	2
-      0x80041200,  //  001F  RET	1	R9
-      0x8C240149,  //  0020  GETMET	R9	R0	K73
-      0x5C2C1000,  //  0021  MOVE	R11	R8
-      0x7C240400,  //  0022  CALL	R9	2
-      0x5C1C1200,  //  0023  MOVE	R7	R9
-      0x8C24093D,  //  0024  GETMET	R9	R4	K61
-      0x5C2C0A00,  //  0025  MOVE	R11	R5
-      0x7C240400,  //  0026  CALL	R9	2
-      0x781A0009,  //  0027  JMPF	R6	#0032
-      0x4C200000,  //  0028  LDNIL	R8
-      0x1C200E08,  //  0029  EQ	R8	R7	R8
-      0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C20010F,  //  002B  GETMET	R8	R0	K15
-      0x94280806,  //  002C  GETIDX	R10	R4	R6
-      0x7C200400,  //  002D  CALL	R8	2
-      0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x8C20093D,  //  002F  GETMET	R8	R4	K61
-      0x5C280C00,  //  0030  MOVE	R10	R6
-      0x7C200400,  //  0031  CALL	R8	2
-      0x4C200000,  //  0032  LDNIL	R8
-      0x1C200E08,  //  0033  EQ	R8	R7	R8
-      0x78220004,  //  0034  JMPF	R8	#003A
-      0xB8222000,  //  0035  GETNGBL	R8	K16
-      0x8C201174,  //  0036  GETMET	R8	R8	K116
-      0x5828007A,  //  0037  LDCONST	R10	K122
-      0x7C200400,  //  0038  CALL	R8	2
-      0x80041000,  //  0039  RET	1	R8
-      0x88200F7B,  //  003A  GETMBR	R8	R7	K123
-      0x74220004,  //  003B  JMPT	R8	#0041
-      0xB8222000,  //  003C  GETNGBL	R8	K16
-      0x8C201174,  //  003D  GETMET	R8	R8	K116
-      0x5828007C,  //  003E  LDCONST	R10	K124
-      0x7C200400,  //  003F  CALL	R8	2
-      0x80041000,  //  0040  RET	1	R8
-      0x8C200F7D,  //  0041  GETMET	R8	R7	K125
-      0x7C200200,  //  0042  CALL	R8	1
-      0x60240013,  //  0043  GETGBL	R9	G19
-      0x7C240000,  //  0044  CALL	R9	0
-      0x60280010,  //  0045  GETGBL	R10	G16
-      0x8C2C0905,  //  0046  GETMET	R11	R4	K5
-      0x7C2C0200,  //  0047  CALL	R11	1
-      0x7C280200,  //  0048  CALL	R10	1
-      0xA8020016,  //  0049  EXBLK	0	#0061
-      0x5C2C1400,  //  004A  MOVE	R11	R10
-      0x7C2C0000,  //  004B  CALL	R11	0
-      0xB8322000,  //  004C  GETNGBL	R12	K16
-      0x8C30197E,  //  004D  GETMET	R12	R12	K126
-      0x5C381000,  //  004E  MOVE	R14	R8
-      0x5C3C1600,  //  004F  MOVE	R15	R11
-      0x7C300600,  //  0050  CALL	R12	3
-      0x4C340000,  //  0051  LDNIL	R13
-      0x1C34180D,  //  0052  EQ	R13	R12	R13
-      0x78360008,  //  0053  JMPF	R13	#005D
-      0xB8362000,  //  0054  GETNGBL	R13	K16
-      0x8C341B74,  //  0055  GETMET	R13	R13	K116
-      0x603C0018,  //  0056  GETGBL	R15	G24
-      0x5840007F,  //  0057  LDCONST	R16	K127
-      0x5C441600,  //  0058  MOVE	R17	R11
-      0x7C3C0400,  //  0059  CALL	R15	2
-      0x7C340400,  //  005A  CALL	R13	2
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x80001A00,  //  005C  RET	0
-      0x9434100C,  //  005D  GETIDX	R13	R8	R12
-      0x9438080B,  //  005E  GETIDX	R14	R4	R11
-      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
-      0x7001FFE8,  //  0060  JMP		#004A
-      0x58280007,  //  0061  LDCONST	R10	K7
-      0xAC280200,  //  0062  CATCH	R10	1	0
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x8C280F80,  //  0064  GETMET	R10	R7	K128
-      0x5C301200,  //  0065  MOVE	R12	R9
-      0x7C280400,  //  0066  CALL	R10	2
-      0x8C280F81,  //  0067  GETMET	R10	R7	K129
-      0x7C280200,  //  0068  CALL	R10	1
-      0x782A000A,  //  0069  JMPF	R10	#0075
-      0x602C0018,  //  006A  GETGBL	R11	G24
-      0x58300082,  //  006B  LDCONST	R12	K130
-      0x5C340200,  //  006C  MOVE	R13	R1
-      0x5C381400,  //  006D  MOVE	R14	R10
-      0x7C2C0600,  //  006E  CALL	R11	3
-      0xB8322000,  //  006F  GETNGBL	R12	K16
-      0x8C301983,  //  0070  GETMET	R12	R12	K131
-      0x5C381600,  //  0071  MOVE	R14	R11
-      0x7C300400,  //  0072  CALL	R12	2
-      0x80041800,  //  0073  RET	1	R12
-      0x70020003,  //  0074  JMP		#0079
-      0xB82E2000,  //  0075  GETNGBL	R11	K16
-      0x8C2C1711,  //  0076  GETMET	R11	R11	K17
-      0x7C2C0200,  //  0077  CALL	R11	1
-      0x80041600,  //  0078  RET	1	R11
-      0xB81E2000,  //  0079  GETNGBL	R7	K16
-      0x8C1C0F74,  //  007A  GETMET	R7	R7	K116
-      0x58240084,  //  007B  LDCONST	R9	K132
-      0x7C1C0400,  //  007C  CALL	R7	2
-      0x80000000,  //  007D  RET	0
+    ( &(const binstruction[15]) {  /* code */
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160003,  //  0003  JMPF	R5	#0008
+      0x8818013D,  //  0004  GETMBR	R6	R0	K61
+      0x8C180D4C,  //  0005  GETMET	R6	R6	K76
+      0x7C180200,  //  0006  CALL	R6	1
+      0x70020002,  //  0007  JMP		#000B
+      0x8818013D,  //  0008  GETMBR	R6	R0	K61
+      0x8C180D4D,  //  0009  GETMET	R6	R6	K77
+      0x7C180200,  //  000A  CALL	R6	1
+      0xB81A0200,  //  000B  GETNGBL	R6	K1
+      0x8C180D4E,  //  000C  GETMET	R6	R6	K78
+      0x7C180200,  //  000D  CALL	R6	1
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -1559,12 +1012,12 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_50ms
+** Solidified function: get_plugin_remote_info
 ********************************************************************/
-be_local_closure(class_Matter_Device_every_50ms,   /* name */
+be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1572,18 +1025,192 @@ be_local_closure(class_Matter_Device_every_50ms,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_50ms),
+    be_str_weak(get_plugin_remote_info),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C040185,  //  0000  GETMET	R1	R0	K133
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8804015F,  //  0002  GETMBR	R1	R0	K95
-      0x00040308,  //  0003  ADD	R1	R1	K8
-      0x9002BE01,  //  0004  SETMBR	R0	K95	R1
-      0x88040118,  //  0005  GETMBR	R1	R0	K24
-      0x8C040386,  //  0006  GETMET	R1	R1	K134
-      0x7C040200,  //  0007  CALL	R1	1
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080135,  //  0000  GETMBR	R2	R0	K53
+      0x8C080528,  //  0001  GETMET	R2	R2	K40
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrInfo
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrInfo,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrInfo),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x1C140741,  //  0000  EQ	R5	R3	K65
+      0x7815FFFF,  //  0001  JMPF	R5	#0002
+      0x1C140741,  //  0002  EQ	R5	R3	K65
+      0x7816000D,  //  0003  JMPF	R5	#0012
+      0x60140010,  //  0004  GETGBL	R5	G16
+      0x88180109,  //  0005  GETMBR	R6	R0	K9
+      0x7C140200,  //  0006  CALL	R5	1
+      0xA8020005,  //  0007  EXBLK	0	#000E
+      0x5C180A00,  //  0008  MOVE	R6	R5
+      0x7C180000,  //  0009  CALL	R6	0
+      0x8C1C014F,  //  000A  GETMET	R7	R0	K79
+      0x88240D1E,  //  000B  GETMBR	R9	R6	K30
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x58140016,  //  000E  LDCONST	R5	K22
+      0xAC140200,  //  000F  CATCH	R5	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x70020011,  //  0011  JMP		#0024
+      0x60140004,  //  0012  GETGBL	R5	G4
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x1C140B50,  //  0015  EQ	R5	R5	K80
+      0x78160003,  //  0016  JMPF	R5	#001B
+      0x8C14014F,  //  0017  GETMET	R5	R0	K79
+      0x5C1C0800,  //  0018  MOVE	R7	R4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x70020008,  //  001A  JMP		#0024
+      0x8C140151,  //  001B  GETMET	R5	R0	K81
+      0x5C1C0600,  //  001C  MOVE	R7	R3
+      0x7C140400,  //  001D  CALL	R5	2
+      0x4C180000,  //  001E  LDNIL	R6
+      0x20180A06,  //  001F  NE	R6	R5	R6
+      0x781A0002,  //  0020  JMPF	R6	#0024
+      0x8C18014F,  //  0021  GETMET	R6	R0	K79
+      0x88200B1E,  //  0022  GETMBR	R8	R5	K30
+      0x7C180400,  //  0023  CALL	R6	2
+      0xB8160200,  //  0024  GETNGBL	R5	K1
+      0x8C140B4E,  //  0025  GETMET	R5	R5	K78
+      0x7C140200,  //  0026  CALL	R5	1
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrInfo_one
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrInfo_one),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x8C080152,  //  0000  GETMET	R2	R0	K82
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80000600,  //  0006  RET	0
+      0x8C0C0553,  //  0007  GETMET	R3	R2	K83
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x780E0008,  //  0009  JMPF	R3	#0013
+      0x60100018,  //  000A  GETGBL	R4	G24
+      0x58140054,  //  000B  LDCONST	R5	K84
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x7C100400,  //  000D  CALL	R4	2
+      0xB8160200,  //  000E  GETNGBL	R5	K1
+      0x8C140B55,  //  000F  GETMET	R5	R5	K85
+      0x5C1C0800,  //  0010  MOVE	R7	R4
+      0x58200041,  //  0011  LDCONST	R8	K65
+      0x7C140600,  //  0012  CALL	R5	3
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resolve_attribute_read_solo
+********************************************************************/
+be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(resolve_attribute_read_solo),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x8808031E,  //  0000  GETMBR	R2	R1	K30
+      0x880C0356,  //  0001  GETMBR	R3	R1	K86
+      0x88100357,  //  0002  GETMBR	R4	R1	K87
+      0x4C140000,  //  0003  LDNIL	R5
+      0x1C140405,  //  0004  EQ	R5	R2	R5
+      0x74160005,  //  0005  JMPT	R5	#000C
+      0x4C140000,  //  0006  LDNIL	R5
+      0x1C140605,  //  0007  EQ	R5	R3	R5
+      0x74160002,  //  0008  JMPT	R5	#000C
+      0x4C140000,  //  0009  LDNIL	R5
+      0x1C140805,  //  000A  EQ	R5	R4	R5
+      0x78160001,  //  000B  JMPF	R5	#000E
+      0x4C140000,  //  000C  LDNIL	R5
+      0x80040A00,  //  000D  RET	1	R5
+      0x8C140152,  //  000E  GETMET	R5	R0	K82
+      0x5C1C0400,  //  000F  MOVE	R7	R2
+      0x7C140400,  //  0010  CALL	R5	2
+      0x4C180000,  //  0011  LDNIL	R6
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0xB81A3400,  //  0014  GETNGBL	R6	K26
+      0x88180D21,  //  0015  GETMBR	R6	R6	K33
+      0x90064006,  //  0016  SETMBR	R1	K32	R6
+      0x4C180000,  //  0017  LDNIL	R6
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020013,  //  0019  JMP		#002E
+      0x8C180B58,  //  001A  GETMET	R6	R5	K88
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x741A0005,  //  001D  JMPT	R6	#0024
+      0xB81A3400,  //  001E  GETNGBL	R6	K26
+      0x88180D59,  //  001F  GETMBR	R6	R6	K89
+      0x90064006,  //  0020  SETMBR	R1	K32	R6
+      0x4C180000,  //  0021  LDNIL	R6
+      0x80040C00,  //  0022  RET	1	R6
+      0x70020009,  //  0023  JMP		#002E
+      0x8C180B5A,  //  0024  GETMET	R6	R5	K90
+      0x5C200600,  //  0025  MOVE	R8	R3
+      0x5C240800,  //  0026  MOVE	R9	R4
+      0x7C180600,  //  0027  CALL	R6	3
+      0x741A0004,  //  0028  JMPT	R6	#002E
+      0xB81A3400,  //  0029  GETNGBL	R6	K26
+      0x88180D5B,  //  002A  GETMBR	R6	R6	K91
+      0x90064006,  //  002B  SETMBR	R1	K32	R6
+      0x4C180000,  //  002C  LDNIL	R6
+      0x80040C00,  //  002D  RET	1	R6
+      0x80040A00,  //  002E  RET	1	R5
     })
   )
 );
@@ -1607,17 +1234,17 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x8804013E,  //  0000  GETMBR	R1	R0	K62
-      0x8C040387,  //  0001  GETMET	R1	R1	K135
+      0x8804015C,  //  0000  GETMBR	R1	R0	K92
+      0x8C04035D,  //  0001  GETMET	R1	R1	K93
       0x7C040200,  //  0002  CALL	R1	1
-      0x88040118,  //  0003  GETMBR	R1	R0	K24
-      0x8C040387,  //  0004  GETMET	R1	R1	K135
+      0x8804015E,  //  0003  GETMBR	R1	R0	K94
+      0x8C04035D,  //  0004  GETMET	R1	R1	K93
       0x7C040200,  //  0005  CALL	R1	1
-      0x88040167,  //  0006  GETMBR	R1	R0	K103
-      0x8C040387,  //  0007  GETMET	R1	R1	K135
+      0x8804015F,  //  0006  GETMBR	R1	R0	K95
+      0x8C04035D,  //  0007  GETMET	R1	R1	K93
       0x7C040200,  //  0008  CALL	R1	1
-      0x88040161,  //  0009  GETMBR	R1	R0	K97
-      0x8C040387,  //  000A  GETMET	R1	R1	K135
+      0x8804013D,  //  0009  GETMBR	R1	R0	K61
+      0x8C04035D,  //  000A  GETMET	R1	R1	K93
       0x7C040200,  //  000B  CALL	R1	1
       0x80000000,  //  000C  RET	0
     })
@@ -1627,9 +1254,85 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_read_sensors_schedule
+** Solidified function: sort_distinct
 ********************************************************************/
-be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
+be_local_closure(class_Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040040,  //  0000  LDCONST	R1	K64
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C070B,  //  0005  SUB	R3	R3	K11
+      0x400E1603,  //  0006  CONNECT	R3	K11	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B08,  //  000D  GT	R6	R5	K8
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B0B,  //  000F  SUB	R6	R5	K11
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B0B,  //  0013  SUB	R6	R5	K11
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B0B,  //  0016  SUB	R5	R5	K11
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080016,  //  001A  LDCONST	R2	K22
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x5808000B,  //  001D  LDCONST	R2	K11
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C070B,  //  0021  LE	R3	R3	K11
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0108,  //  0024  GETIDX	R3	R0	K8
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100119,  //  002D  GETMET	R4	R0	K25
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x0008050B,  //  0032  ADD	R2	R2	K11
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_displayname
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -1640,306 +1343,18 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(add_read_sensors_schedule),
+    be_str_weak(get_plugin_class_displayname),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080188,  //  0000  GETMBR	R2	R0	K136
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C080403,  //  0002  EQ	R2	R2	R3
-      0x740A0002,  //  0003  JMPT	R2	#0007
-      0x88080188,  //  0004  GETMBR	R2	R0	K136
-      0x24080401,  //  0005  GT	R2	R2	R1
-      0x780A0005,  //  0006  JMPF	R2	#000D
-      0x90031001,  //  0007  SETMBR	R0	K136	R1
-      0xB80A2800,  //  0008  GETNGBL	R2	K20
-      0x8C08058A,  //  0009  GETMET	R2	R2	K138
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x90031202,  //  000C  SETMBR	R0	K137	R2
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_add_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(bridge_add_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0x880C018B,  //  0000  GETMBR	R3	R0	K139
-      0x8C0C071D,  //  0001  GETMET	R3	R3	K29
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0xB8126A00,  //  0007  GETNGBL	R4	K53
-      0x60140008,  //  0008  GETGBL	R5	G8
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C140200,  //  000A  CALL	R5	1
-      0x00171805,  //  000B  ADD	R5	K140	R5
-      0x00140B8D,  //  000C  ADD	R5	R5	K141
-      0x58180046,  //  000D  LDCONST	R6	K70
-      0x7C100400,  //  000E  CALL	R4	2
-      0x80000800,  //  000F  RET	0
-      0x88100128,  //  0010  GETMBR	R4	R0	K40
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x5C180800,  //  0012  MOVE	R6	R4
-      0x7C140200,  //  0013  CALL	R5	1
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x5C1C0000,  //  0015  MOVE	R7	R0
-      0x5C200800,  //  0016  MOVE	R8	R4
-      0x5C240400,  //  0017  MOVE	R9	R2
-      0x7C180600,  //  0018  CALL	R6	3
-      0x881C010B,  //  0019  GETMBR	R7	R0	K11
-      0x8C1C0F06,  //  001A  GETMET	R7	R7	K6
-      0x5C240C00,  //  001B  MOVE	R9	R6
-      0x7C1C0400,  //  001C  CALL	R7	2
-      0x601C0013,  //  001D  GETGBL	R7	G19
-      0x7C1C0000,  //  001E  CALL	R7	0
-      0x981F1C01,  //  001F  SETIDX	R7	K142	R1
-      0x60200010,  //  0020  GETGBL	R8	G16
-      0x8C240505,  //  0021  GETMET	R9	R2	K5
-      0x7C240200,  //  0022  CALL	R9	1
-      0x7C200200,  //  0023  CALL	R8	1
-      0xA8020004,  //  0024  EXBLK	0	#002A
-      0x5C241000,  //  0025  MOVE	R9	R8
-      0x7C240000,  //  0026  CALL	R9	0
-      0x94280409,  //  0027  GETIDX	R10	R2	R9
-      0x981C120A,  //  0028  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  0029  JMP		#0025
-      0x58200007,  //  002A  LDCONST	R8	K7
-      0xAC200200,  //  002B  CATCH	R8	1	0
-      0xB0080000,  //  002C  RAISE	2	R0	R0
-      0xB8226A00,  //  002D  GETNGBL	R8	K53
-      0x60240018,  //  002E  GETGBL	R9	G24
-      0x5828008F,  //  002F  LDCONST	R10	K143
-      0x5C2C0800,  //  0030  MOVE	R11	R4
-      0x5C300200,  //  0031  MOVE	R12	R1
-      0x8C340190,  //  0032  GETMET	R13	R0	K144
-      0x5C3C0400,  //  0033  MOVE	R15	R2
-      0x7C340400,  //  0034  CALL	R13	2
-      0x7C240800,  //  0035  CALL	R9	4
-      0x58280038,  //  0036  LDCONST	R10	K56
-      0x7C200400,  //  0037  CALL	R8	2
-      0x8820012E,  //  0038  GETMBR	R8	R0	K46
-      0x98200A07,  //  0039  SETIDX	R8	R5	R7
-      0x50200200,  //  003A  LDBOOL	R8	1	0
-      0x90025608,  //  003B  SETMBR	R0	K43	R8
-      0x88200128,  //  003C  GETMBR	R8	R0	K40
-      0x00201108,  //  003D  ADD	R8	R8	K8
-      0x90025008,  //  003E  SETMBR	R0	K40	R8
-      0x8C200140,  //  003F  GETMET	R8	R0	K64
-      0x7C200200,  //  0040  CALL	R8	1
-      0x8C200191,  //  0041  GETMET	R8	R0	K145
-      0x7C200200,  //  0042  CALL	R8	1
-      0x80040800,  //  0043  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: button_handler
-********************************************************************/
-be_local_closure(class_Matter_Device_button_handler,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(button_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x58140009,  //  0000  LDCONST	R5	K9
-      0xA41AA000,  //  0001  IMPORT	R6	K80
-      0x601C000C,  //  0002  GETGBL	R7	G12
-      0x8820010B,  //  0003  GETMBR	R8	R0	K11
-      0x7C1C0200,  //  0004  CALL	R7	1
-      0x141C0A07,  //  0005  LT	R7	R5	R7
-      0x781E0010,  //  0006  JMPF	R7	#0018
-      0x881C010B,  //  0007  GETMBR	R7	R0	K11
-      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
-      0x8C200D92,  //  0009  GETMET	R8	R6	K146
-      0x5C280E00,  //  000A  MOVE	R10	R7
-      0x582C006E,  //  000B  LDCONST	R11	K110
-      0x7C200600,  //  000C  CALL	R8	3
-      0x78220007,  //  000D  JMPF	R8	#0016
-      0x8820010B,  //  000E  GETMBR	R8	R0	K11
-      0x94201005,  //  000F  GETIDX	R8	R8	R5
-      0x8C20116E,  //  0010  GETMET	R8	R8	K110
-      0x5C280200,  //  0011  MOVE	R10	R1
-      0x5C2C0400,  //  0012  MOVE	R11	R2
-      0x5C300600,  //  0013  MOVE	R12	R3
-      0x5C340800,  //  0014  MOVE	R13	R4
-      0x7C200A00,  //  0015  CALL	R8	5
-      0x00140B08,  //  0016  ADD	R5	R5	K8
-      0x7001FFE9,  //  0017  JMP		#0002
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(class_Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A6A00,  //  0007  GETNGBL	R2	K53
-      0x600C0008,  //  0008  GETGBL	R3	G8
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x000F2603,  //  000B  ADD	R3	K147	R3
-      0x58100038,  //  000C  LDCONST	R4	K56
-      0x7C080400,  //  000D  CALL	R2	2
-      0xB80A2800,  //  000E  GETNGBL	R2	K20
-      0x8C080594,  //  000F  GETMET	R2	R2	K148
-      0x5C100000,  //  0010  MOVE	R4	R0
-      0x5814000A,  //  0011  LDCONST	R5	K10
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x7C080800,  //  0013  CALL	R2	4
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080573,  //  0016  GETMET	R2	R2	K115
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: signal_endpoints_changed
-********************************************************************/
-be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(signal_endpoints_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8C040195,  //  0000  GETMET	R1	R0	K149
-      0x580C0009,  //  0001  LDCONST	R3	K9
-      0x5412001C,  //  0002  LDINT	R4	29
-      0x58140046,  //  0003  LDCONST	R5	K70
-      0x50180000,  //  0004  LDBOOL	R6	0	0
-      0x7C040A00,  //  0005  CALL	R1	5
-      0x8C040195,  //  0006  GETMET	R1	R0	K149
-      0xB80E2800,  //  0007  GETNGBL	R3	K20
-      0x880C0796,  //  0008  GETMBR	R3	R3	K150
-      0x5412001C,  //  0009  LDINT	R4	29
-      0x58140046,  //  000A  LDCONST	R5	K70
-      0x50180000,  //  000B  LDBOOL	R6	0	0
-      0x7C040A00,  //  000C  CALL	R1	5
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_zigbee_present
-********************************************************************/
-be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(is_zigbee_present),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xA406A000,  //  0000  IMPORT	R1	K80
-      0x8C080397,  //  0001  GETMET	R2	R1	K151
-      0x58100003,  //  0002  LDCONST	R4	K3
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080160,  //  0000  GETMBR	R2	R0	K96
+      0x8C080528,  //  0001  GETMET	R2	R2	K40
+      0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x20080403,  //  0005  NE	R2	R2	R3
-      0x80040400,  //  0006  RET	1	R2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0561,  //  0005  GETMBR	R3	R2	K97
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0041,  //  0007  LDCONST	R3	K65
+      0x80040600,  //  0008  RET	1	R3
     })
   )
 );
@@ -1963,14 +1378,14 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
     be_str_weak(get_plugin_class_arg),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8808018B,  //  0000  GETMBR	R2	R0	K139
-      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+      0x88080160,  //  0000  GETMBR	R2	R0	K96
+      0x8C080528,  //  0001  GETMET	R2	R2	K40
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0598,  //  0005  GETMBR	R3	R2	K152
+      0x880C0562,  //  0005  GETMBR	R3	R2	K98
       0x70020000,  //  0006  JMP		#0008
-      0x580C000A,  //  0007  LDCONST	R3	K10
+      0x580C0041,  //  0007  LDCONST	R3	K65
       0x80040600,  //  0008  RET	1	R3
     })
   )
@@ -1979,12 +1394,12 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
 
 
 /********************************************************************
-** Solidified function: update_remotes_info
+** Solidified function: process_attribute_expansion
 ********************************************************************/
-be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
+be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
+    12,                          /* nstack */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1992,42 +1407,77 @@ be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(update_remotes_info),
+    be_str_weak(process_attribute_expansion),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080151,  //  0002  GETMBR	R2	R0	K81
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0018,  //  0005  JMPF	R2	#001F
-      0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C0151,  //  0007  GETMBR	R3	R0	K81
-      0x8C0C0705,  //  0008  GETMET	R3	R3	K5
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7C080200,  //  000A  CALL	R2	1
-      0xA802000F,  //  000B  EXBLK	0	#001C
-      0x5C0C0400,  //  000C  MOVE	R3	R2
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x88100151,  //  000E  GETMBR	R4	R0	K81
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C100999,  //  0010  GETMET	R4	R4	K153
-      0x7C100200,  //  0011  CALL	R4	1
-      0x4C140000,  //  0012  LDNIL	R5
-      0x20140805,  //  0013  NE	R5	R4	R5
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180800,  //  0016  MOVE	R6	R4
-      0x7C140200,  //  0017  CALL	R5	1
-      0x24140B09,  //  0018  GT	R5	R5	K9
-      0x78160000,  //  0019  JMPF	R5	#001B
-      0x98040604,  //  001A  SETIDX	R1	R3	R4
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x58080007,  //  001C  LDCONST	R2	K7
-      0xAC080200,  //  001D  CATCH	R2	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90023C01,  //  001F  SETMBR	R0	K30	R1
-      0x80040200,  //  0020  RET	1	R1
+    ( &(const binstruction[28]) {  /* code */
+      0x880C031E,  //  0000  GETMBR	R3	R1	K30
+      0x88100356,  //  0001  GETMBR	R4	R1	K86
+      0x88140357,  //  0002  GETMBR	R5	R1	K87
+      0xB81A3400,  //  0003  GETNGBL	R6	K26
+      0x8C180D63,  //  0004  GETMET	R6	R6	K99
+      0x5C200000,  //  0005  MOVE	R8	R0
+      0x7C180400,  //  0006  CALL	R6	2
+      0x8C1C0D64,  //  0007  GETMET	R7	R6	K100
+      0x5C240600,  //  0008  MOVE	R9	R3
+      0x5C280800,  //  0009  MOVE	R10	R4
+      0x5C2C0A00,  //  000A  MOVE	R11	R5
+      0x7C1C0800,  //  000B  CALL	R7	4
+      0x8C1C0D65,  //  000C  GETMET	R7	R6	K101
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0x4C200000,  //  000E  LDNIL	R8
+      0x8C240D66,  //  000F  GETMET	R9	R6	K102
+      0x7C240200,  //  0010  CALL	R9	1
+      0x5C201200,  //  0011  MOVE	R8	R9
+      0x4C280000,  //  0012  LDNIL	R10
+      0x2024120A,  //  0013  NE	R9	R9	R10
+      0x78260005,  //  0014  JMPF	R9	#001B
+      0x5C240400,  //  0015  MOVE	R9	R2
+      0x8C280D67,  //  0016  GETMET	R10	R6	K103
+      0x7C280200,  //  0017  CALL	R10	1
+      0x5C2C1000,  //  0018  MOVE	R11	R8
+      0x7C240400,  //  0019  CALL	R9	2
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(find_plugin_by_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080008,  //  0000  LDCONST	R2	K8
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100109,  //  0002  GETMBR	R4	R0	K9
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C0109,  //  0006  GETMBR	R3	R0	K9
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100768,  //  0008  GETMET	R4	R3	K104
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x0008050B,  //  000D  ADD	R2	R2	K11
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
     })
   )
 );
@@ -2054,34 +1504,34 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
       0x4C080000,  //  0000  LDNIL	R2
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0019,  //  0002  JMPF	R2	#001D
-      0xB80A6A00,  //  0003  GETNGBL	R2	K53
-      0x8C0C039B,  //  0004  GETMET	R3	R1	K155
+      0xB80A0A00,  //  0003  GETNGBL	R2	K5
+      0x8C0C036A,  //  0004  GETMET	R3	R1	K106
       0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C079C,  //  0006  GETMET	R3	R3	K156
+      0x8C0C076B,  //  0006  GETMET	R3	R3	K107
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C079D,  //  0008  GETMET	R3	R3	K157
+      0x8C0C076C,  //  0008  GETMET	R3	R3	K108
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C0C079E,  //  000A  GETMET	R3	R3	K158
+      0x8C0C076D,  //  000A  GETMET	R3	R3	K109
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x000F3403,  //  000C  ADD	R3	K154	R3
-      0x58100038,  //  000D  LDCONST	R4	K56
+      0x000ED203,  //  000C  ADD	R3	K105	R3
+      0x58100018,  //  000D  LDCONST	R4	K24
       0x7C080400,  //  000E  CALL	R2	2
-      0x88080118,  //  000F  GETMBR	R2	R0	K24
-      0x88080519,  //  0010  GETMBR	R2	R2	K25
-      0x8808051A,  //  0011  GETMBR	R2	R2	K26
-      0x8C08059F,  //  0012  GETMET	R2	R2	K159
+      0x8808015E,  //  000F  GETMBR	R2	R0	K94
+      0x8808056E,  //  0010  GETMBR	R2	R2	K110
+      0x8808056F,  //  0011  GETMBR	R2	R2	K111
+      0x8C080570,  //  0012  GETMET	R2	R2	K112
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
-      0x88080161,  //  0015  GETMBR	R2	R0	K97
-      0x8C0805A0,  //  0016  GETMET	R2	R2	K160
+      0x8808013D,  //  0015  GETMBR	R2	R0	K61
+      0x8C080571,  //  0016  GETMET	R2	R2	K113
       0x5C100200,  //  0017  MOVE	R4	R1
       0x7C080400,  //  0018  CALL	R2	2
-      0x8808013E,  //  0019  GETMBR	R2	R0	K62
-      0x8C0805A1,  //  001A  GETMET	R2	R2	K161
+      0x8808015C,  //  0019  GETMBR	R2	R0	K92
+      0x8C080572,  //  001A  GETMET	R2	R2	K114
       0x5C100200,  //  001B  MOVE	R4	R1
       0x7C080400,  //  001C  CALL	R2	2
-      0x8808013E,  //  001D  GETMBR	R2	R0	K62
-      0x8C0805A2,  //  001E  GETMET	R2	R2	K162
+      0x8808015C,  //  001D  GETMBR	R2	R0	K92
+      0x8C080573,  //  001E  GETMET	R2	R2	K115
       0x7C080200,  //  001F  CALL	R2	1
       0x80000000,  //  0020  RET	0
     })
@@ -2091,583 +1541,12 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: conf_to_log
+** Solidified function: attribute_updated
 ********************************************************************/
-be_local_closure(class_Matter_Device_conf_to_log,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(conf_to_log),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040004,  //  0000  LDCONST	R1	K4
-      0x5808000A,  //  0001  LDCONST	R2	K10
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C1003A3,  //  0003  GETMET	R4	R1	K163
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA802000B,  //  0007  EXBLK	0	#0014
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x1C14098E,  //  000A  EQ	R5	R4	K142
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x7001FFFA,  //  000C  JMP		#0008
-      0x60140018,  //  000D  GETGBL	R5	G24
-      0x581800A4,  //  000E  LDCONST	R6	K164
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x94200004,  //  0010  GETIDX	R8	R0	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x00080405,  //  0012  ADD	R2	R2	R5
-      0x7001FFF3,  //  0013  JMP		#0008
-      0x580C0007,  //  0014  LDCONST	R3	K7
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x8808012E,  //  0001  GETMBR	R2	R0	K46
-      0x8C080505,  //  0002  GETMET	R2	R2	K5
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x88100128,  //  000B  GETMBR	R4	R0	K40
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x00100708,  //  000E  ADD	R4	R3	K8
-      0x90025004,  //  000F  SETMBR	R0	K40	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x58040007,  //  0011  LDCONST	R1	K7
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reset_param
-********************************************************************/
-be_local_closure(class_Matter_Device_reset_param,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(reset_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90025601,  //  0001  SETMBR	R0	K43	R1
-      0x88040160,  //  0002  GETMBR	R1	R0	K96
-      0x90025001,  //  0003  SETMBR	R0	K40	R1
-      0x8C040140,  //  0004  GETMET	R1	R0	K64
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8808018B,  //  0000  GETMBR	R2	R0	K139
-      0x8C08051D,  //  0001  GETMET	R2	R2	K29
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C05A5,  //  0005  GETMBR	R3	R2	K165
-      0x70020000,  //  0006  JMP		#0008
-      0x580C000A,  //  0007  LDCONST	R3	K10
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_sensors_scheduler
-********************************************************************/
-be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(read_sensors_scheduler),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040188,  //  0000  GETMBR	R1	R0	K136
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0x88040189,  //  0005  GETMBR	R1	R0	K137
-      0x1C040309,  //  0006  EQ	R1	R1	K9
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8062000,  //  0008  GETNGBL	R1	K16
-      0x8C0403A6,  //  0009  GETMET	R1	R1	K166
-      0x880C0189,  //  000A  GETMBR	R3	R0	K137
-      0x7C040400,  //  000B  CALL	R1	2
-      0x78060006,  //  000C  JMPF	R1	#0014
-      0x8C0401A7,  //  000D  GETMET	R1	R0	K167
-      0x7C040200,  //  000E  CALL	R1	1
-      0xB8062000,  //  000F  GETNGBL	R1	K16
-      0x8C0403A8,  //  0010  GETMET	R1	R1	K168
-      0x880C0188,  //  0011  GETMBR	R3	R0	K136
-      0x7C040400,  //  0012  CALL	R1	2
-      0x90031201,  //  0013  SETMBR	R0	K137	R1
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(class_Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x880C0151,  //  0000  GETMBR	R3	R0	K81
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x9002A203,  //  0006  SETMBR	R0	K81	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100151,  //  0008  GETMBR	R4	R0	K81
-      0x8C100992,  //  0009  GETMET	R4	R4	K146
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100151,  //  000D  GETMBR	R4	R0	K81
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C1007A9,  //  000F  GETMET	R4	R3	K169
-      0x7C100200,  //  0010  CALL	R4	1
-      0x14100404,  //  0011  LT	R4	R2	R4
-      0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C1007AA,  //  0013  GETMET	R4	R3	K170
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020011,  //  0016  JMP		#0029
-      0xB8122800,  //  0017  GETNGBL	R4	K20
-      0x8C1009AB,  //  0018  GETMET	R4	R4	K171
-      0x5C180000,  //  0019  MOVE	R6	R0
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x5C200400,  //  001B  MOVE	R8	R2
-      0x7C100800,  //  001C  CALL	R4	4
-      0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x8810011E,  //  001E  GETMBR	R4	R0	K30
-      0x8C100992,  //  001F  GETMET	R4	R4	K146
-      0x5C180200,  //  0020  MOVE	R6	R1
-      0x7C100400,  //  0021  CALL	R4	2
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C1007AC,  //  0023  GETMET	R4	R3	K172
-      0x8818011E,  //  0024  GETMBR	R6	R0	K30
-      0x94180C01,  //  0025  GETIDX	R6	R6	R1
-      0x7C100400,  //  0026  CALL	R4	2
-      0x88100151,  //  0027  GETMBR	R4	R0	K81
-      0x98100203,  //  0028  SETIDX	R4	R1	R3
-      0x80040600,  //  0029  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_attribute_expansion
-********************************************************************/
-be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(process_attribute_expansion),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x880C030D,  //  0000  GETMBR	R3	R1	K13
-      0x88100316,  //  0001  GETMBR	R4	R1	K22
-      0x88140317,  //  0002  GETMBR	R5	R1	K23
-      0xB81A2800,  //  0003  GETNGBL	R6	K20
-      0x8C180DAD,  //  0004  GETMET	R6	R6	K173
-      0x5C200000,  //  0005  MOVE	R8	R0
-      0x7C180400,  //  0006  CALL	R6	2
-      0x8C1C0D73,  //  0007  GETMET	R7	R6	K115
-      0x5C240600,  //  0008  MOVE	R9	R3
-      0x5C280800,  //  0009  MOVE	R10	R4
-      0x5C2C0A00,  //  000A  MOVE	R11	R5
-      0x7C1C0800,  //  000B  CALL	R7	4
-      0x8C1C0DAE,  //  000C  GETMET	R7	R6	K174
-      0x7C1C0200,  //  000D  CALL	R7	1
-      0x4C200000,  //  000E  LDNIL	R8
-      0x8C240DAF,  //  000F  GETMET	R9	R6	K175
-      0x7C240200,  //  0010  CALL	R9	1
-      0x5C201200,  //  0011  MOVE	R8	R9
-      0x4C280000,  //  0012  LDNIL	R10
-      0x2024120A,  //  0013  NE	R9	R9	R10
-      0x78260005,  //  0014  JMPF	R9	#001B
-      0x5C240400,  //  0015  MOVE	R9	R2
-      0x8C280DB0,  //  0016  GETMET	R10	R6	K176
-      0x7C280200,  //  0017  CALL	R10	1
-      0x5C2C1000,  //  0018  MOVE	R11	R8
-      0x7C240400,  //  0019  CALL	R9	2
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(class_Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[136]) {  /* code */
-      0xA406AE00,  //  0000  IMPORT	R1	K87
-      0x50080000,  //  0001  LDBOOL	R2	0	0
-      0xA8020056,  //  0002  EXBLK	0	#005A
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100131,  //  0004  GETMBR	R4	R0	K49
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C1007B1,  //  0006  GETMET	R4	R3	K177
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140734,  //  0008  GETMET	R5	R3	K52
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4163E00,  //  000A  IMPORT	R5	K31
-      0x8C180BB2,  //  000B  GETMET	R6	R5	K178
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D1D,  //  000E  GETMET	R7	R6	K29
-      0x582400B3,  //  000F  LDCONST	R9	K179
-      0x88280122,  //  0010  GETMBR	R10	R0	K34
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x90024407,  //  0012  SETMBR	R0	K34	R7
-      0x8C1C0D1D,  //  0013  GETMET	R7	R6	K29
-      0x582400B4,  //  0014  LDCONST	R9	K180
-      0x88280123,  //  0015  GETMBR	R10	R0	K35
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x90024607,  //  0017  SETMBR	R0	K35	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D1D,  //  0019  GETMET	R8	R6	K29
-      0x58280024,  //  001A  LDCONST	R10	K36
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90024807,  //  001E  SETMBR	R0	K36	R7
-      0x601C0017,  //  001F  GETGBL	R7	G23
-      0x8C200D1D,  //  0020  GETMET	R8	R6	K29
-      0x58280027,  //  0021  LDCONST	R10	K39
-      0x502C0000,  //  0022  LDBOOL	R11	0	0
-      0x7C200600,  //  0023  CALL	R8	3
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x90024E07,  //  0025  SETMBR	R0	K39	R7
-      0x8C1C0D1D,  //  0026  GETMET	R7	R6	K29
-      0x582400B5,  //  0027  LDCONST	R9	K181
-      0x88280128,  //  0028  GETMBR	R10	R0	K40
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x90025007,  //  002A  SETMBR	R0	K40	R7
-      0x8C1C0D1D,  //  002B  GETMET	R7	R6	K29
-      0x582400B6,  //  002C  LDCONST	R9	K182
-      0x60280013,  //  002D  GETGBL	R10	G19
-      0x7C280000,  //  002E  CALL	R10	0
-      0x7C1C0600,  //  002F  CALL	R7	3
-      0x90025C07,  //  0030  SETMBR	R0	K46	R7
-      0x601C0017,  //  0031  GETGBL	R7	G23
-      0x8C200D1D,  //  0032  GETMET	R8	R6	K29
-      0x58280029,  //  0033  LDCONST	R10	K41
-      0x7C200400,  //  0034  CALL	R8	2
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0x90025207,  //  0036  SETMBR	R0	K41	R7
-      0x881C012E,  //  0037  GETMBR	R7	R0	K46
-      0x4C200000,  //  0038  LDNIL	R8
-      0x201C0E08,  //  0039  NE	R7	R7	R8
-      0x781E000D,  //  003A  JMPF	R7	#0049
-      0xB81E6A00,  //  003B  GETNGBL	R7	K53
-      0x60200018,  //  003C  GETGBL	R8	G24
-      0x582400B7,  //  003D  LDCONST	R9	K183
-      0x8828012E,  //  003E  GETMBR	R10	R0	K46
-      0x7C200400,  //  003F  CALL	R8	2
-      0x58240046,  //  0040  LDCONST	R9	K70
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x8C1C0144,  //  0042  GETMET	R7	R0	K68
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x8C1C01B8,  //  0044  GETMET	R7	R0	K184
-      0x7C1C0200,  //  0045  CALL	R7	1
-      0x5C080E00,  //  0046  MOVE	R2	R7
-      0x501C0200,  //  0047  LDBOOL	R7	1	0
-      0x90025607,  //  0048  SETMBR	R0	K43	R7
-      0x8C1C0D1D,  //  0049  GETMET	R7	R6	K29
-      0x582400B9,  //  004A  LDCONST	R9	K185
-      0x60280013,  //  004B  GETGBL	R10	G19
-      0x7C280000,  //  004C  CALL	R10	0
-      0x7C1C0600,  //  004D  CALL	R7	3
-      0x90023C07,  //  004E  SETMBR	R0	K30	R7
-      0x881C011E,  //  004F  GETMBR	R7	R0	K30
-      0x781E0006,  //  0050  JMPF	R7	#0058
-      0xB81E6A00,  //  0051  GETNGBL	R7	K53
-      0x60200008,  //  0052  GETGBL	R8	G8
-      0x8824011E,  //  0053  GETMBR	R9	R0	K30
-      0x7C200200,  //  0054  CALL	R8	1
-      0x00237408,  //  0055  ADD	R8	K186	R8
-      0x58240046,  //  0056  LDCONST	R9	K70
-      0x7C1C0400,  //  0057  CALL	R7	2
-      0xA8040001,  //  0058  EXBLK	1	1
-      0x70020011,  //  0059  JMP		#006C
-      0xAC0C0002,  //  005A  CATCH	R3	0	2
-      0x7002000E,  //  005B  JMP		#006B
-      0x201407BB,  //  005C  NE	R5	R3	K187
-      0x7816000B,  //  005D  JMPF	R5	#006A
-      0xB8166A00,  //  005E  GETNGBL	R5	K53
-      0x60180008,  //  005F  GETGBL	R6	G8
-      0x5C1C0600,  //  0060  MOVE	R7	R3
-      0x7C180200,  //  0061  CALL	R6	1
-      0x001B7806,  //  0062  ADD	R6	K188	R6
-      0x00180D3A,  //  0063  ADD	R6	R6	K58
-      0x601C0008,  //  0064  GETGBL	R7	G8
-      0x5C200800,  //  0065  MOVE	R8	R4
-      0x7C1C0200,  //  0066  CALL	R7	1
-      0x00180C07,  //  0067  ADD	R6	R6	R7
-      0x581C0038,  //  0068  LDCONST	R7	K56
-      0x7C140400,  //  0069  CALL	R5	2
-      0x70020000,  //  006A  JMP		#006C
-      0xB0080000,  //  006B  RAISE	2	R0	R0
-      0x880C0122,  //  006C  GETMBR	R3	R0	K34
-      0x4C100000,  //  006D  LDNIL	R4
-      0x1C0C0604,  //  006E  EQ	R3	R3	R4
-      0x780E000A,  //  006F  JMPF	R3	#007B
-      0x8C0C03BD,  //  0070  GETMET	R3	R1	K189
-      0x58140038,  //  0071  LDCONST	R5	K56
-      0x7C0C0400,  //  0072  CALL	R3	2
-      0x8C0C0752,  //  0073  GETMET	R3	R3	K82
-      0x58140009,  //  0074  LDCONST	R5	K9
-      0x58180038,  //  0075  LDCONST	R6	K56
-      0x7C0C0600,  //  0076  CALL	R3	3
-      0x54120FFE,  //  0077  LDINT	R4	4095
-      0x2C0C0604,  //  0078  AND	R3	R3	R4
-      0x90024403,  //  0079  SETMBR	R0	K34	R3
-      0x50080200,  //  007A  LDBOOL	R2	1	0
-      0x880C0123,  //  007B  GETMBR	R3	R0	K35
-      0x4C100000,  //  007C  LDNIL	R4
-      0x1C0C0604,  //  007D  EQ	R3	R3	R4
-      0x780E0004,  //  007E  JMPF	R3	#0084
-      0x880C0161,  //  007F  GETMBR	R3	R0	K97
-      0x8C0C07BE,  //  0080  GETMET	R3	R3	K190
-      0x7C0C0200,  //  0081  CALL	R3	1
-      0x90024603,  //  0082  SETMBR	R0	K35	R3
-      0x50080200,  //  0083  LDBOOL	R2	1	0
-      0x780A0001,  //  0084  JMPF	R2	#0087
-      0x8C0C0140,  //  0085  GETMET	R3	R0	K64
-      0x7C0C0200,  //  0086  CALL	R3	1
-      0x80000000,  //  0087  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0xA4063E00,  //  0000  IMPORT	R1	K31
-      0xB80A2000,  //  0001  GETNGBL	R2	K16
-      0x8C0805BF,  //  0002  GETMET	R2	R2	K191
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E2000,  //  0004  GETNGBL	R3	K16
-      0x8C0C07C0,  //  0005  GETMET	R3	R3	K192
-      0x58140046,  //  0006  LDCONST	R5	K70
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0006,  //  0008  JMPF	R3	#0010
-      0xB80E6A00,  //  0009  GETNGBL	R3	K53
-      0x60100008,  //  000A  GETGBL	R4	G8
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C100200,  //  000C  CALL	R4	1
-      0x00138204,  //  000D  ADD	R4	K193	R4
-      0x58140046,  //  000E  LDCONST	R5	K70
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x4C0C0000,  //  0010  LDNIL	R3
-      0x1C0C0403,  //  0011  EQ	R3	R2	R3
-      0x780E0000,  //  0012  JMPF	R3	#0014
-      0x80000600,  //  0013  RET	0
-      0x8C0C03B2,  //  0014  GETMET	R3	R1	K178
-      0x5C140400,  //  0015  MOVE	R5	R2
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x4C100000,  //  0017  LDNIL	R4
-      0x20100604,  //  0018  NE	R4	R3	R4
-      0x7812000D,  //  0019  JMPF	R4	#0028
-      0x58100009,  //  001A  LDCONST	R4	K9
-      0x6014000C,  //  001B  GETGBL	R5	G12
-      0x8818010B,  //  001C  GETMBR	R6	R0	K11
-      0x7C140200,  //  001D  CALL	R5	1
-      0x14140805,  //  001E  LT	R5	R4	R5
-      0x78160006,  //  001F  JMPF	R5	#0027
-      0x8814010B,  //  0020  GETMBR	R5	R0	K11
-      0x94140A04,  //  0021  GETIDX	R5	R5	R4
-      0x8C140BC2,  //  0022  GETMET	R5	R5	K194
-      0x5C1C0600,  //  0023  MOVE	R7	R3
-      0x7C140400,  //  0024  CALL	R5	2
-      0x00100908,  //  0025  ADD	R4	R4	K8
-      0x7001FFF3,  //  0026  JMP		#001B
-      0x70020006,  //  0027  JMP		#002F
-      0xB8126A00,  //  0028  GETNGBL	R4	K53
-      0x60140008,  //  0029  GETGBL	R5	G8
-      0x5C180400,  //  002A  MOVE	R6	R2
-      0x7C140200,  //  002B  CALL	R5	1
-      0x00178605,  //  002C  ADD	R5	K195	R5
-      0x58180046,  //  002D  LDCONST	R6	K70
-      0x7C100400,  //  002E  CALL	R4	2
-      0x80000000,  //  002F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(class_Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C0805C4,  //  0001  GETMET	R2	R2	K196
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_config_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_check_config_ep,   /* name */
+be_local_closure(class_Matter_Device_attribute_updated,   /* name */
   be_nested_proto(
     10,                          /* nstack */
-    1,                          /* argc */
+    5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2675,86 +1554,27 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(check_config_ep),
+    be_str_weak(attribute_updated),
     &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x600C0010,  //  0003  GETGBL	R3	G16
-      0x8810012E,  //  0004  GETMBR	R4	R0	K46
-      0x8C100905,  //  0005  GETMET	R4	R4	K5
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020007,  //  0008  EXBLK	0	#0011
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x8C140506,  //  000B  GETMET	R5	R2	K6
-      0x601C0009,  //  000C  GETGBL	R7	G9
-      0x5C200800,  //  000D  MOVE	R8	R4
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x7001FFF7,  //  0010  JMP		#0009
-      0x580C0007,  //  0011  LDCONST	R3	K7
-      0xAC0C0200,  //  0012  CATCH	R3	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x600C0010,  //  0014  GETGBL	R3	G16
-      0x5C100400,  //  0015  MOVE	R4	R2
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0xA8020030,  //  0017  EXBLK	0	#0049
-      0x5C100600,  //  0018  MOVE	R4	R3
-      0x7C100000,  //  0019  CALL	R4	0
-      0x1C140909,  //  001A  EQ	R5	R4	K9
-      0x7816000B,  //  001B  JMPF	R5	#0028
-      0xB8166A00,  //  001C  GETNGBL	R5	K53
-      0x581800C5,  //  001D  LDCONST	R6	K197
-      0x581C0038,  //  001E  LDCONST	R7	K56
-      0x7C140400,  //  001F  CALL	R5	2
-      0x8814012E,  //  0020  GETMBR	R5	R0	K46
-      0x8C140B3D,  //  0021  GETMET	R5	R5	K61
-      0x601C0008,  //  0022  GETGBL	R7	G8
-      0x5C200800,  //  0023  MOVE	R8	R4
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x7C140400,  //  0025  CALL	R5	2
-      0x50040200,  //  0026  LDBOOL	R1	1	0
-      0x7002001F,  //  0027  JMP		#0048
-      0xB8162800,  //  0028  GETNGBL	R5	K20
-      0x88140B96,  //  0029  GETMBR	R5	R5	K150
-      0x1C140805,  //  002A  EQ	R5	R4	R5
-      0x7816001B,  //  002B  JMPF	R5	#0048
-      0x50040200,  //  002C  LDBOOL	R1	1	0
-      0xB8166A00,  //  002D  GETNGBL	R5	K53
-      0x60180018,  //  002E  GETGBL	R6	G24
-      0x581C00C6,  //  002F  LDCONST	R7	K198
-      0x5C200800,  //  0030  MOVE	R8	R4
-      0x88240128,  //  0031  GETMBR	R9	R0	K40
-      0x7C180600,  //  0032  CALL	R6	3
-      0x581C0038,  //  0033  LDCONST	R7	K56
-      0x7C140400,  //  0034  CALL	R5	2
-      0x60140008,  //  0035  GETGBL	R5	G8
-      0x88180128,  //  0036  GETMBR	R6	R0	K40
-      0x7C140200,  //  0037  CALL	R5	1
-      0x8818012E,  //  0038  GETMBR	R6	R0	K46
-      0x601C0008,  //  0039  GETGBL	R7	G8
-      0x5C200800,  //  003A  MOVE	R8	R4
-      0x7C1C0200,  //  003B  CALL	R7	1
-      0x8820012E,  //  003C  GETMBR	R8	R0	K46
-      0x941C1007,  //  003D  GETIDX	R7	R8	R7
-      0x98180A07,  //  003E  SETIDX	R6	R5	R7
-      0x8814012E,  //  003F  GETMBR	R5	R0	K46
-      0x8C140B3D,  //  0040  GETMET	R5	R5	K61
-      0x601C0008,  //  0041  GETGBL	R7	G8
-      0x5C200800,  //  0042  MOVE	R8	R4
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x7C140400,  //  0044  CALL	R5	2
-      0x88140128,  //  0045  GETMBR	R5	R0	K40
-      0x00140B08,  //  0046  ADD	R5	R5	K8
-      0x90025005,  //  0047  SETMBR	R0	K40	R5
-      0x7001FFCE,  //  0048  JMP		#0018
-      0x580C0007,  //  0049  LDCONST	R3	K7
-      0xAC0C0200,  //  004A  CATCH	R3	1	0
-      0xB0080000,  //  004B  RAISE	2	R0	R0
-      0x80040200,  //  004C  RET	1	R1
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8163400,  //  0004  GETNGBL	R5	K26
+      0x8C140B74,  //  0005  GETMET	R5	R5	K116
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90163C01,  //  0007  SETMBR	R5	K30	R1
+      0x9016AC02,  //  0008  SETMBR	R5	K86	R2
+      0x9016AE03,  //  0009  SETMBR	R5	K87	R3
+      0x8818015E,  //  000A  GETMBR	R6	R0	K94
+      0x88180D6E,  //  000B  GETMBR	R6	R6	K110
+      0x88180D6F,  //  000C  GETMBR	R6	R6	K111
+      0x8C180D75,  //  000D  GETMET	R6	R6	K117
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -2784,132 +1604,13 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
       0x2C0C0604,  //  0003  AND	R3	R3	R4
       0x541200FE,  //  0004  LDINT	R4	255
       0x2C100404,  //  0005  AND	R4	R2	R4
-      0x8C14016E,  //  0006  GETMET	R5	R0	K110
-      0x001C0908,  //  0007  ADD	R7	R4	K8
-      0x58200038,  //  0008  LDCONST	R8	K56
-      0x58240009,  //  0009  LDCONST	R9	K9
+      0x8C140112,  //  0006  GETMET	R5	R0	K18
+      0x001C090B,  //  0007  ADD	R7	R4	K11
+      0x58200018,  //  0008  LDCONST	R8	K24
+      0x58240008,  //  0009  LDCONST	R9	K8
       0x5C280600,  //  000A  MOVE	R10	R3
       0x7C140A00,  //  000B  CALL	R5	5
       0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_remove_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(bridge_remove_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0xA40A3E00,  //  0000  IMPORT	R2	K31
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x4C140000,  //  0005  LDNIL	R5
-      0x8818012E,  //  0006  GETMBR	R6	R0	K46
-      0x8C180D92,  //  0007  GETMET	R6	R6	K146
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x741A0004,  //  000A  JMPT	R6	#0010
-      0xB81A6A00,  //  000B  GETNGBL	R6	K53
-      0x001F8E03,  //  000C  ADD	R7	K199	R3
-      0x58200046,  //  000D  LDCONST	R8	K70
-      0x7C180400,  //  000E  CALL	R6	2
-      0x80000C00,  //  000F  RET	0
-      0xB81A6A00,  //  0010  GETNGBL	R6	K53
-      0x601C0018,  //  0011  GETGBL	R7	G24
-      0x582000C8,  //  0012  LDCONST	R8	K200
-      0x5C240200,  //  0013  MOVE	R9	R1
-      0x7C1C0400,  //  0014  CALL	R7	2
-      0x58200038,  //  0015  LDCONST	R8	K56
-      0x7C180400,  //  0016  CALL	R6	2
-      0x8818012E,  //  0017  GETMBR	R6	R0	K46
-      0x8C180D3D,  //  0018  GETMET	R6	R6	K61
-      0x5C200600,  //  0019  MOVE	R8	R3
-      0x7C180400,  //  001A  CALL	R6	2
-      0x50180200,  //  001B  LDBOOL	R6	1	0
-      0x90025606,  //  001C  SETMBR	R0	K43	R6
-      0x58180009,  //  001D  LDCONST	R6	K9
-      0x601C000C,  //  001E  GETGBL	R7	G12
-      0x8820010B,  //  001F  GETMBR	R8	R0	K11
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x141C0C07,  //  0021  LT	R7	R6	R7
-      0x781E000D,  //  0022  JMPF	R7	#0031
-      0x881C010B,  //  0023  GETMBR	R7	R0	K11
-      0x941C0E06,  //  0024  GETIDX	R7	R7	R6
-      0x8C1C0F1C,  //  0025  GETMET	R7	R7	K28
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x1C1C0207,  //  0027  EQ	R7	R1	R7
-      0x781E0005,  //  0028  JMPF	R7	#002F
-      0x881C010B,  //  0029  GETMBR	R7	R0	K11
-      0x8C1C0F3D,  //  002A  GETMET	R7	R7	K61
-      0x5C240C00,  //  002B  MOVE	R9	R6
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x70020002,  //  002D  JMP		#0031
-      0x70020000,  //  002E  JMP		#0030
-      0x00180D08,  //  002F  ADD	R6	R6	K8
-      0x7001FFEC,  //  0030  JMP		#001E
-      0x8C1C01C9,  //  0031  GETMET	R7	R0	K201
-      0x7C1C0200,  //  0032  CALL	R7	1
-      0x8C1C0140,  //  0033  GETMET	R7	R0	K64
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0191,  //  0035  GETMET	R7	R0	K145
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0x80000000,  //  0037  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(find_plugin_by_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080009,  //  0000  LDCONST	R2	K9
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x8810010B,  //  0002  GETMBR	R4	R0	K11
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C010B,  //  0006  GETMBR	R3	R0	K11
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C10071C,  //  0008  GETMET	R4	R3	K28
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x00080508,  //  000D  ADD	R2	R2	K8
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
     })
   )
 );
@@ -3015,23 +1716,1272 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
     be_str_weak(register_commands),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xB8062000,  //  0000  GETNGBL	R1	K16
-      0x8C0403CA,  //  0001  GETMET	R1	R1	K202
-      0x580C00CB,  //  0002  LDCONST	R3	K203
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040376,  //  0001  GETMET	R1	R1	K118
+      0x580C0077,  //  0002  LDCONST	R3	K119
       0x84100000,  //  0003  CLOSURE	R4	P0
       0x7C040600,  //  0004  CALL	R1	3
-      0xB8062000,  //  0005  GETNGBL	R1	K16
-      0x8C0403CA,  //  0006  GETMET	R1	R1	K202
-      0x580C00CC,  //  0007  LDCONST	R3	K204
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040376,  //  0006  GETMET	R1	R1	K118
+      0x580C0078,  //  0007  LDCONST	R3	K120
       0x84100001,  //  0008  CLOSURE	R4	P1
       0x7C040600,  //  0009  CALL	R1	3
-      0xB8062000,  //  000A  GETNGBL	R1	K16
-      0x8C0403CA,  //  000B  GETMET	R1	R1	K202
-      0x580C00CD,  //  000C  LDCONST	R3	K205
+      0xB8060200,  //  000A  GETNGBL	R1	K1
+      0x8C040376,  //  000B  GETMET	R1	R1	K118
+      0x580C0079,  //  000C  LDCONST	R3	K121
       0x84100002,  //  000D  CLOSURE	R4	P2
       0x7C040600,  //  000E  CALL	R1	3
       0xA0000000,  //  000F  CLOSE	R0
       0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(class_Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C08017A,  //  0001  GETMET	R2	R0	K122
+      0x7C080200,  //  0002  CALL	R2	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C007B,  //  0004  LDCONST	R3	K123
+      0x88100127,  //  0005  GETMBR	R4	R0	K39
+      0x8814012A,  //  0006  GETMBR	R5	R0	K42
+      0x8818012C,  //  0007  GETMBR	R6	R0	K44
+      0x781A0001,  //  0008  JMPF	R6	#000B
+      0x5818007C,  //  0009  LDCONST	R6	K124
+      0x70020000,  //  000A  JMP		#000C
+      0x5818007D,  //  000B  LDCONST	R6	K125
+      0x881C012D,  //  000C  GETMBR	R7	R0	K45
+      0x781E0001,  //  000D  JMPF	R7	#0010
+      0x581C007C,  //  000E  LDCONST	R7	K124
+      0x70020000,  //  000F  JMP		#0011
+      0x581C007D,  //  0010  LDCONST	R7	K125
+      0x8820011D,  //  0011  GETMBR	R8	R0	K29
+      0x7C080C00,  //  0012  CALL	R2	6
+      0x880C0130,  //  0013  GETMBR	R3	R0	K48
+      0x780E0000,  //  0014  JMPF	R3	#0016
+      0x0008057E,  //  0015  ADD	R2	R2	K126
+      0x880C0134,  //  0016  GETMBR	R3	R0	K52
+      0x780E000E,  //  0017  JMPF	R3	#0027
+      0x0008057F,  //  0018  ADD	R2	R2	K127
+      0x8C0C0380,  //  0019  GETMET	R3	R1	K128
+      0x88140113,  //  001A  GETMBR	R5	R0	K19
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x00080403,  //  001C  ADD	R2	R2	R3
+      0x600C000C,  //  001D  GETGBL	R3	G12
+      0x88100135,  //  001E  GETMBR	R4	R0	K53
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x240C0708,  //  0020  GT	R3	R3	K8
+      0x780E0004,  //  0021  JMPF	R3	#0027
+      0x00080581,  //  0022  ADD	R2	R2	K129
+      0x8C0C0380,  //  0023  GETMET	R3	R1	K128
+      0x88140135,  //  0024  GETMBR	R5	R0	K53
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x00080403,  //  0026  ADD	R2	R2	R3
+      0x00080582,  //  0027  ADD	R2	R2	K130
+      0xA8020017,  //  0028  EXBLK	0	#0041
+      0x600C0011,  //  0029  GETGBL	R3	G17
+      0x88100124,  //  002A  GETMBR	R4	R0	K36
+      0x58140083,  //  002B  LDCONST	R5	K131
+      0x7C0C0400,  //  002C  CALL	R3	2
+      0x8C100784,  //  002D  GETMET	R4	R3	K132
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x8C100726,  //  0030  GETMET	R4	R3	K38
+      0x7C100200,  //  0031  CALL	R4	1
+      0xB8120A00,  //  0032  GETNGBL	R4	K5
+      0x60140018,  //  0033  GETGBL	R5	G24
+      0x58180085,  //  0034  LDCONST	R6	K133
+      0x881C0134,  //  0035  GETMBR	R7	R0	K52
+      0x781E0001,  //  0036  JMPF	R7	#0039
+      0x581C0086,  //  0037  LDCONST	R7	K134
+      0x70020000,  //  0038  JMP		#003A
+      0x581C0041,  //  0039  LDCONST	R7	K65
+      0x7C140400,  //  003A  CALL	R5	2
+      0x58180018,  //  003B  LDCONST	R6	K24
+      0x7C100400,  //  003C  CALL	R4	2
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x80040400,  //  003E  RET	1	R2
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8160A00,  //  0043  GETNGBL	R5	K5
+      0x60180008,  //  0044  GETGBL	R6	G8
+      0x5C1C0600,  //  0045  MOVE	R7	R3
+      0x7C180200,  //  0046  CALL	R6	1
+      0x001B0E06,  //  0047  ADD	R6	K135	R6
+      0x00180D3A,  //  0048  ADD	R6	R6	K58
+      0x601C0008,  //  0049  GETGBL	R7	G8
+      0x5C200800,  //  004A  MOVE	R8	R4
+      0x7C1C0200,  //  004B  CALL	R7	1
+      0x00180C07,  //  004C  ADD	R6	R6	R7
+      0x581C0018,  //  004D  LDCONST	R7	K24
+      0x7C140400,  //  004E  CALL	R5	2
+      0x80040400,  //  004F  RET	1	R2
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(class_Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA4068A00,  //  0000  IMPORT	R1	K69
+      0x88080188,  //  0001  GETMBR	R2	R0	K136
+      0x780A004B,  //  0002  JMPF	R2	#004F
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100188,  //  0006  GETMBR	R4	R0	K136
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080908,  //  000B  SETIDX	R2	R4	K8
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0016,  //  000D  LDCONST	R3	K22
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100109,  //  0011  GETMBR	R4	R0	K9
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C14033C,  //  0016  GETMET	R5	R1	K60
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200089,  //  0018  LDCONST	R8	K137
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180528,  //  001D  GETMET	R6	R2	K40
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240008,  //  001F  LDCONST	R9	K8
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D0B,  //  0021  ADD	R6	R6	K11
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0016,  //  0024  LDCONST	R3	K22
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0012,  //  0027  GETGBL	R3	G18
+      0x7C0C0000,  //  0028  CALL	R3	0
+      0x60100010,  //  0029  GETGBL	R4	G16
+      0x8C140514,  //  002A  GETMET	R5	R2	K20
+      0x7C140200,  //  002B  CALL	R5	1
+      0x7C100200,  //  002C  CALL	R4	1
+      0xA8020008,  //  002D  EXBLK	0	#0037
+      0x5C140800,  //  002E  MOVE	R5	R4
+      0x7C140000,  //  002F  CALL	R5	0
+      0x94180405,  //  0030  GETIDX	R6	R2	R5
+      0x1C180D08,  //  0031  EQ	R6	R6	K8
+      0x781A0002,  //  0032  JMPF	R6	#0036
+      0x8C180715,  //  0033  GETMET	R6	R3	K21
+      0x5C200A00,  //  0034  MOVE	R8	R5
+      0x7C180400,  //  0035  CALL	R6	2
+      0x7001FFF6,  //  0036  JMP		#002E
+      0x58100016,  //  0037  LDCONST	R4	K22
+      0xAC100200,  //  0038  CATCH	R4	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x60100010,  //  003A  GETGBL	R4	G16
+      0x5C140600,  //  003B  MOVE	R5	R3
+      0x7C100200,  //  003C  CALL	R4	1
+      0xA802000D,  //  003D  EXBLK	0	#004C
+      0x5C140800,  //  003E  MOVE	R5	R4
+      0x7C140000,  //  003F  CALL	R5	0
+      0xB81A0A00,  //  0040  GETNGBL	R6	K5
+      0x881C0B8B,  //  0041  GETMBR	R7	R5	K139
+      0x001F1407,  //  0042  ADD	R7	K138	R7
+      0x58200004,  //  0043  LDCONST	R8	K4
+      0x7C180400,  //  0044  CALL	R6	2
+      0x8C180B26,  //  0045  GETMET	R6	R5	K38
+      0x7C180200,  //  0046  CALL	R6	1
+      0x88180188,  //  0047  GETMBR	R6	R0	K136
+      0x8C180D19,  //  0048  GETMET	R6	R6	K25
+      0x88200B8B,  //  0049  GETMBR	R8	R5	K139
+      0x7C180400,  //  004A  CALL	R6	2
+      0x7001FFF1,  //  004B  JMP		#003E
+      0x58100016,  //  004C  LDCONST	R4	K22
+      0xAC100200,  //  004D  CATCH	R4	1	0
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_remove_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(bridge_remove_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x4C140000,  //  0005  LDNIL	R5
+      0x88180113,  //  0006  GETMBR	R6	R0	K19
+      0x8C180D8C,  //  0007  GETMET	R6	R6	K140
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0004,  //  000A  JMPT	R6	#0010
+      0xB81A0A00,  //  000B  GETNGBL	R6	K5
+      0x001F1A03,  //  000C  ADD	R7	K141	R3
+      0x58200004,  //  000D  LDCONST	R8	K4
+      0x7C180400,  //  000E  CALL	R6	2
+      0x80000C00,  //  000F  RET	0
+      0xB81A0A00,  //  0010  GETNGBL	R6	K5
+      0x601C0018,  //  0011  GETGBL	R7	G24
+      0x5820008E,  //  0012  LDCONST	R8	K142
+      0x5C240200,  //  0013  MOVE	R9	R1
+      0x7C1C0400,  //  0014  CALL	R7	2
+      0x58200018,  //  0015  LDCONST	R8	K24
+      0x7C180400,  //  0016  CALL	R6	2
+      0x88180113,  //  0017  GETMBR	R6	R0	K19
+      0x8C180D19,  //  0018  GETMET	R6	R6	K25
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x7C180400,  //  001A  CALL	R6	2
+      0x50180200,  //  001B  LDBOOL	R6	1	0
+      0x90026806,  //  001C  SETMBR	R0	K52	R6
+      0x58180008,  //  001D  LDCONST	R6	K8
+      0x601C000C,  //  001E  GETGBL	R7	G12
+      0x88200109,  //  001F  GETMBR	R8	R0	K9
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x141C0C07,  //  0021  LT	R7	R6	R7
+      0x781E000D,  //  0022  JMPF	R7	#0031
+      0x881C0109,  //  0023  GETMBR	R7	R0	K9
+      0x941C0E06,  //  0024  GETIDX	R7	R7	R6
+      0x8C1C0F68,  //  0025  GETMET	R7	R7	K104
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x1C1C0207,  //  0027  EQ	R7	R1	R7
+      0x781E0005,  //  0028  JMPF	R7	#002F
+      0x881C0109,  //  0029  GETMBR	R7	R0	K9
+      0x8C1C0F19,  //  002A  GETMET	R7	R7	K25
+      0x5C240C00,  //  002B  MOVE	R9	R6
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x70020002,  //  002D  JMP		#0031
+      0x70020000,  //  002E  JMP		#0030
+      0x00180D0B,  //  002F  ADD	R6	R6	K11
+      0x7001FFEC,  //  0030  JMP		#001E
+      0x8C1C018F,  //  0031  GETMET	R7	R0	K143
+      0x7C1C0200,  //  0032  CALL	R7	1
+      0x8C1C013F,  //  0033  GETMET	R7	R0	K63
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x8C1C0190,  //  0035  GETMET	R7	R0	K144
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(class_Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080149,  //  0000  GETMBR	R2	R0	K73
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0A00,  //  0007  GETNGBL	R2	K5
+      0x600C0008,  //  0008  GETGBL	R3	G8
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x000F2203,  //  000B  ADD	R3	K145	R3
+      0x58100018,  //  000C  LDCONST	R4	K24
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80A3400,  //  000E  GETNGBL	R2	K26
+      0x8C080592,  //  000F  GETMET	R2	R2	K146
+      0x5C100000,  //  0010  MOVE	R4	R0
+      0x58140041,  //  0011  LDCONST	R5	K65
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x7C080800,  //  0013  CALL	R2	4
+      0x90029202,  //  0014  SETMBR	R0	K73	R2
+      0x88080149,  //  0015  GETMBR	R2	R0	K73
+      0x8C080564,  //  0016  GETMET	R2	R2	K100
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_fabrics_saved
+********************************************************************/
+be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(event_fabrics_saved),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x8804015C,  //  0000  GETMBR	R1	R0	K92
+      0x8C040393,  //  0001  GETMET	R1	R1	K147
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040308,  //  0003  GT	R1	R1	K8
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040134,  //  0005  GETMBR	R1	R0	K52
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90026801,  //  0008  SETMBR	R0	K52	R1
+      0x8C04013F,  //  0009  GETMET	R1	R0	K63
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_Device_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4064600,  //  0000  IMPORT	R1	K35
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080594,  //  0002  GETMET	R2	R2	K148
+      0xB8123400,  //  0003  GETNGBL	R4	K26
+      0x88100995,  //  0004  GETMBR	R4	R4	K149
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0006,  //  0006  JMPT	R2	#000E
+      0xB80A3400,  //  0007  GETNGBL	R2	K26
+      0x8C080597,  //  0008  GETMET	R2	R2	K151
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x50140000,  //  000A  LDBOOL	R5	0	0
+      0x7C080600,  //  000B  CALL	R2	3
+      0x90032C02,  //  000C  SETMBR	R0	K150	R2
+      0x80000400,  //  000D  RET	0
+      0xB80A3400,  //  000E  GETNGBL	R2	K26
+      0xB80E3400,  //  000F  GETNGBL	R3	K26
+      0x8C0C0799,  //  0010  GETMET	R3	R3	K153
+      0x7C0C0200,  //  0011  CALL	R3	1
+      0x900B3003,  //  0012  SETMBR	R2	K152	R3
+      0x90033508,  //  0013  SETMBR	R0	K154	K8
+      0x60080012,  //  0014  GETGBL	R2	G18
+      0x7C080000,  //  0015  CALL	R2	0
+      0x90021202,  //  0016  SETMBR	R0	K9	R2
+      0x50080000,  //  0017  LDBOOL	R2	0	0
+      0x90026802,  //  0018  SETMBR	R0	K52	R2
+      0x60080013,  //  0019  GETGBL	R2	G19
+      0x7C080000,  //  001A  CALL	R2	0
+      0x90026A02,  //  001B  SETMBR	R0	K53	R2
+      0x8808019B,  //  001C  GETMBR	R2	R0	K155
+      0x90023A02,  //  001D  SETMBR	R0	K29	R2
+      0x50080000,  //  001E  LDBOOL	R2	0	0
+      0x90025802,  //  001F  SETMBR	R0	K44	R2
+      0x50080000,  //  0020  LDBOOL	R2	0	0
+      0x90025A02,  //  0021  SETMBR	R0	K45	R2
+      0xB80A3400,  //  0022  GETNGBL	R2	K26
+      0x8C08059C,  //  0023  GETMET	R2	R2	K156
+      0x5C100000,  //  0024  MOVE	R4	R0
+      0x7C080400,  //  0025  CALL	R2	2
+      0x90027A02,  //  0026  SETMBR	R0	K61	R2
+      0x8C08019D,  //  0027  GETMET	R2	R0	K157
+      0x7C080200,  //  0028  CALL	R2	1
+      0xB80A3400,  //  0029  GETNGBL	R2	K26
+      0x8C08059E,  //  002A  GETMET	R2	R2	K158
+      0x5C100000,  //  002B  MOVE	R4	R0
+      0x7C080400,  //  002C  CALL	R2	2
+      0x9002B802,  //  002D  SETMBR	R0	K92	R2
+      0x8808015C,  //  002E  GETMBR	R2	R0	K92
+      0x8C08059F,  //  002F  GETMET	R2	R2	K159
+      0x7C080200,  //  0030  CALL	R2	1
+      0xB80A3400,  //  0031  GETNGBL	R2	K26
+      0x8C0805A0,  //  0032  GETMET	R2	R2	K160
+      0x5C100000,  //  0033  MOVE	R4	R0
+      0x7C080400,  //  0034  CALL	R2	2
+      0x9002BC02,  //  0035  SETMBR	R0	K94	R2
+      0xB80A3400,  //  0036  GETNGBL	R2	K26
+      0x8C0805A1,  //  0037  GETMET	R2	R2	K161
+      0x5C100000,  //  0038  MOVE	R4	R0
+      0x7C080400,  //  0039  CALL	R2	2
+      0x9002BE02,  //  003A  SETMBR	R0	K95	R2
+      0x8C0801A3,  //  003B  GETMET	R2	R0	K163
+      0x7C080200,  //  003C  CALL	R2	1
+      0x90034402,  //  003D  SETMBR	R0	K162	R2
+      0xB80A3400,  //  003E  GETNGBL	R2	K26
+      0x8C080597,  //  003F  GETMET	R2	R2	K151
+      0x5C100000,  //  0040  MOVE	R4	R0
+      0x50140200,  //  0041  LDBOOL	R5	1	0
+      0x7C080600,  //  0042  CALL	R2	3
+      0x90032C02,  //  0043  SETMBR	R0	K150	R2
+      0xB80A0200,  //  0044  GETNGBL	R2	K1
+      0x8C0805A4,  //  0045  GETMET	R2	R2	K164
+      0x84100000,  //  0046  CLOSURE	R4	P0
+      0x7C080400,  //  0047  CALL	R2	2
+      0x8808013D,  //  0048  GETMBR	R2	R0	K61
+      0x8C0805A5,  //  0049  GETMET	R2	R2	K165
+      0x7C080200,  //  004A  CALL	R2	1
+      0xB80A0200,  //  004B  GETNGBL	R2	K1
+      0x8C0805A6,  //  004C  GETMET	R2	R2	K166
+      0x5C100000,  //  004D  MOVE	R4	R0
+      0x7C080400,  //  004E  CALL	R2	2
+      0x8C0801A7,  //  004F  GETMET	R2	R0	K167
+      0x7C080200,  //  0050  CALL	R2	1
+      0xA0000000,  //  0051  CLOSE	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100109,  //  0003  GETMBR	R4	R0	K9
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140968,  //  0008  GETMET	R5	R4	K104
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B08,  //  000B  EQ	R6	R5	K8
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180528,  //  000E  GETMET	R6	R2	K40
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180515,  //  0014  GETMET	R6	R2	K21
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0016,  //  0018  LDCONST	R3	K22
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(class_Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080149,  //  0000  GETMBR	R2	R0	K73
+      0x8C0805A8,  //  0001  GETMET	R2	R2	K168
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080113,  //  0001  GETMBR	R2	R0	K19
+      0x8C080514,  //  0002  GETMET	R2	R2	K20
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x8810011D,  //  000B  GETMBR	R4	R0	K29
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x0010070B,  //  000E  ADD	R4	R3	K11
+      0x90023A04,  //  000F  SETMBR	R0	K29	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040016,  //  0011  LDCONST	R1	K22
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset_param
+********************************************************************/
+be_local_closure(class_Matter_Device_reset_param,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(reset_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x90026801,  //  0001  SETMBR	R0	K52	R1
+      0x8804019B,  //  0002  GETMBR	R1	R0	K155
+      0x90023A01,  //  0003  SETMBR	R0	K29	R1
+      0x8C04013F,  //  0004  GETMET	R1	R0	K63
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(class_Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8C0401A9,  //  0000  GETMET	R1	R0	K169
+      0x7C040200,  //  0001  CALL	R1	1
+      0x58040008,  //  0002  LDCONST	R1	K8
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C0109,  //  0004  GETMBR	R3	R0	K9
+      0x7C080200,  //  0005  CALL	R2	1
+      0x14080202,  //  0006  LT	R2	R1	R2
+      0x780A0005,  //  0007  JMPF	R2	#000E
+      0x88080109,  //  0008  GETMBR	R2	R0	K9
+      0x94080401,  //  0009  GETIDX	R2	R2	R1
+      0x8C0805AA,  //  000A  GETMET	R2	R2	K170
+      0x7C080200,  //  000B  CALL	R2	1
+      0x0004030B,  //  000C  ADD	R1	R1	K11
+      0x7001FFF4,  //  000D  JMP		#0003
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: button_handler
+********************************************************************/
+be_local_closure(class_Matter_Device_button_handler,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(button_handler),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x58140008,  //  0000  LDCONST	R5	K8
+      0xA41A8A00,  //  0001  IMPORT	R6	K69
+      0x601C000C,  //  0002  GETGBL	R7	G12
+      0x88200109,  //  0003  GETMBR	R8	R0	K9
+      0x7C1C0200,  //  0004  CALL	R7	1
+      0x141C0A07,  //  0005  LT	R7	R5	R7
+      0x781E0010,  //  0006  JMPF	R7	#0018
+      0x881C0109,  //  0007  GETMBR	R7	R0	K9
+      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
+      0x8C200D8C,  //  0009  GETMET	R8	R6	K140
+      0x5C280E00,  //  000A  MOVE	R10	R7
+      0x582C0012,  //  000B  LDCONST	R11	K18
+      0x7C200600,  //  000C  CALL	R8	3
+      0x78220007,  //  000D  JMPF	R8	#0016
+      0x88200109,  //  000E  GETMBR	R8	R0	K9
+      0x94201005,  //  000F  GETIDX	R8	R8	R5
+      0x8C201112,  //  0010  GETMET	R8	R8	K18
+      0x5C280200,  //  0011  MOVE	R10	R1
+      0x5C2C0400,  //  0012  MOVE	R11	R2
+      0x5C300600,  //  0013  MOVE	R12	R3
+      0x5C340800,  //  0014  MOVE	R13	R4
+      0x7C200A00,  //  0015  CALL	R8	5
+      0x00140B0B,  //  0016  ADD	R5	R5	K11
+      0x7001FFE9,  //  0017  JMP		#0002
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(class_Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(msg_send),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080149,  //  0000  GETMBR	R2	R0	K73
+      0x8C0805AB,  //  0001  GETMET	R2	R2	K171
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_Matter_Device_start,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C0401AC,  //  0000  GETMET	R1	R0	K172
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C0401AD,  //  0002  GETMET	R1	R0	K173
+      0x880C01AE,  //  0003  GETMBR	R3	R0	K174
+      0x7C040400,  //  0004  CALL	R1	2
+      0x8804013D,  //  0005  GETMBR	R1	R0	K61
+      0x8C0403AF,  //  0006  GETMET	R1	R1	K175
+      0x7C040200,  //  0007  CALL	R1	1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080188,  //  0002  GETMBR	R2	R0	K136
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C0188,  //  0007  GETMBR	R3	R0	K136
+      0x8C0C0714,  //  0008  GETMET	R3	R3	K20
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x88100188,  //  000E  GETMBR	R4	R0	K136
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C1009B0,  //  0010  GETMET	R4	R4	K176
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B08,  //  0018  GT	R5	R5	K8
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080016,  //  001C  LDCONST	R2	K22
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90026A01,  //  001F  SETMBR	R0	K53	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(class_Matter_Device_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804019A,  //  0000  GETMBR	R1	R0	K154
+      0x0004030B,  //  0001  ADD	R1	R1	K11
+      0x90033401,  //  0002  SETMBR	R0	K154	R1
+      0x8804015E,  //  0003  GETMBR	R1	R0	K94
+      0x8C0403B1,  //  0004  GETMET	R1	R1	K177
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l_num
+********************************************************************/
+be_local_closure(class_Matter_Device_k2l_num,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(k2l_num),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x58040040,  //  0000  LDCONST	R1	K64
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100114,  //  0008  GETMET	R4	R0	K20
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020007,  //  000B  EXBLK	0	#0014
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140515,  //  000E  GETMET	R5	R2	K21
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0016,  //  0014  LDCONST	R3	K22
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x0410090B,  //  001B  SUB	R4	R4	K11
+      0x40121604,  //  001C  CONNECT	R4	K11	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D08,  //  0023  GT	R7	R6	K8
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D0B,  //  0025  SUB	R7	R6	K11
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D0B,  //  0029  SUB	R7	R6	K11
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D0B,  //  002C  SUB	R6	R6	K11
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0016,  //  0030  LDCONST	R3	K22
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_http_remote
+********************************************************************/
+be_local_closure(class_Matter_Device_register_http_remote,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(register_http_remote),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x880C0188,  //  0000  GETMBR	R3	R0	K136
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x90031003,  //  0006  SETMBR	R0	K136	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x88100188,  //  0008  GETMBR	R4	R0	K136
+      0x8C10098C,  //  0009  GETMET	R4	R4	K140
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100188,  //  000D  GETMBR	R4	R0	K136
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C1007B2,  //  000F  GETMET	R4	R3	K178
+      0x7C100200,  //  0010  CALL	R4	1
+      0x14100404,  //  0011  LT	R4	R2	R4
+      0x78120002,  //  0012  JMPF	R4	#0016
+      0x8C1007B3,  //  0013  GETMET	R4	R3	K179
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8123400,  //  0017  GETNGBL	R4	K26
+      0x8C1009B4,  //  0018  GETMET	R4	R4	K180
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x88100135,  //  001E  GETMBR	R4	R0	K53
+      0x8C10098C,  //  001F  GETMET	R4	R4	K140
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C1007B5,  //  0023  GETMET	R4	R3	K181
+      0x88180135,  //  0024  GETMBR	R6	R0	K53
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x88100188,  //  0027  GETMBR	R4	R0	K136
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_received
+********************************************************************/
+be_local_closure(class_Matter_Device_msg_received,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(msg_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8810015E,  //  0000  GETMBR	R4	R0	K94
+      0x8C1009B6,  //  0001  GETMET	R4	R4	K182
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_add_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(bridge_add_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[68]) {  /* code */
+      0x880C0160,  //  0000  GETMBR	R3	R0	K96
+      0x8C0C0728,  //  0001  GETMET	R3	R3	K40
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0xB8120A00,  //  0007  GETNGBL	R4	K5
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00176E05,  //  000B  ADD	R5	K183	R5
+      0x00140BB8,  //  000C  ADD	R5	R5	K184
+      0x58180004,  //  000D  LDCONST	R6	K4
+      0x7C100400,  //  000E  CALL	R4	2
+      0x80000800,  //  000F  RET	0
+      0x8810011D,  //  0010  GETMBR	R4	R0	K29
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x5C180800,  //  0012  MOVE	R6	R4
+      0x7C140200,  //  0013  CALL	R5	1
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x5C1C0000,  //  0015  MOVE	R7	R0
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x5C240400,  //  0017  MOVE	R9	R2
+      0x7C180600,  //  0018  CALL	R6	3
+      0x881C0109,  //  0019  GETMBR	R7	R0	K9
+      0x8C1C0F15,  //  001A  GETMET	R7	R7	K21
+      0x5C240C00,  //  001B  MOVE	R9	R6
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x601C0013,  //  001D  GETGBL	R7	G19
+      0x7C1C0000,  //  001E  CALL	R7	0
+      0x981E8601,  //  001F  SETIDX	R7	K67	R1
+      0x60200010,  //  0020  GETGBL	R8	G16
+      0x8C240514,  //  0021  GETMET	R9	R2	K20
+      0x7C240200,  //  0022  CALL	R9	1
+      0x7C200200,  //  0023  CALL	R8	1
+      0xA8020004,  //  0024  EXBLK	0	#002A
+      0x5C241000,  //  0025  MOVE	R9	R8
+      0x7C240000,  //  0026  CALL	R9	0
+      0x94280409,  //  0027  GETIDX	R10	R2	R9
+      0x981C120A,  //  0028  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  0029  JMP		#0025
+      0x58200016,  //  002A  LDCONST	R8	K22
+      0xAC200200,  //  002B  CATCH	R8	1	0
+      0xB0080000,  //  002C  RAISE	2	R0	R0
+      0xB8220A00,  //  002D  GETNGBL	R8	K5
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x582800B9,  //  002F  LDCONST	R10	K185
+      0x5C2C0800,  //  0030  MOVE	R11	R4
+      0x5C300200,  //  0031  MOVE	R12	R1
+      0x8C3401BA,  //  0032  GETMET	R13	R0	K186
+      0x5C3C0400,  //  0033  MOVE	R15	R2
+      0x7C340400,  //  0034  CALL	R13	2
+      0x7C240800,  //  0035  CALL	R9	4
+      0x58280018,  //  0036  LDCONST	R10	K24
+      0x7C200400,  //  0037  CALL	R8	2
+      0x88200113,  //  0038  GETMBR	R8	R0	K19
+      0x98200A07,  //  0039  SETIDX	R8	R5	R7
+      0x50200200,  //  003A  LDBOOL	R8	1	0
+      0x90026808,  //  003B  SETMBR	R0	K52	R8
+      0x8820011D,  //  003C  GETMBR	R8	R0	K29
+      0x0020110B,  //  003D  ADD	R8	R8	K11
+      0x90023A08,  //  003E  SETMBR	R0	K29	R8
+      0x8C20013F,  //  003F  GETMET	R8	R0	K63
+      0x7C200200,  //  0040  CALL	R8	1
+      0x8C200190,  //  0041  GETMET	R8	R0	K144
+      0x7C200200,  //  0042  CALL	R8	1
+      0x80040800,  //  0043  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(class_Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0109,  //  0002  GETMBR	R3	R0	K9
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080508,  //  0004  GT	R2	R2	K8
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x880801BB,  //  0007  GETMBR	R2	R0	K187
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x1C080403,  //  0009  EQ	R2	R2	R3
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0xB80A3400,  //  000B  GETNGBL	R2	K26
+      0x8C0805BC,  //  000C  GETMET	R2	R2	K188
+      0x5C100000,  //  000D  MOVE	R4	R0
+      0x7C080400,  //  000E  CALL	R2	2
+      0x90037602,  //  000F  SETMBR	R0	K187	R2
+      0x88080134,  //  0010  GETMBR	R2	R0	K52
+      0x740A000F,  //  0011  JMPT	R2	#0022
+      0x880801BB,  //  0012  GETMBR	R2	R0	K187
+      0x8C0805BD,  //  0013  GETMET	R2	R2	K189
+      0x7C080200,  //  0014  CALL	R2	1
+      0x90022602,  //  0015  SETMBR	R0	K19	R2
+      0x60080013,  //  0016  GETGBL	R2	G19
+      0x7C080000,  //  0017  CALL	R2	0
+      0x90026A02,  //  0018  SETMBR	R0	K53	R2
+      0x8C080132,  //  0019  GETMET	R2	R0	K50
+      0x7C080200,  //  001A  CALL	R2	1
+      0xB80A0A00,  //  001B  GETNGBL	R2	K5
+      0x600C0008,  //  001C  GETGBL	R3	G8
+      0x88100113,  //  001D  GETMBR	R4	R0	K19
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x000F7C03,  //  001F  ADD	R3	K190	R3
+      0x58100004,  //  0020  LDCONST	R4	K4
+      0x7C080400,  //  0021  CALL	R2	2
+      0x880801BB,  //  0022  GETMBR	R2	R0	K187
+      0x8C0805BF,  //  0023  GETMET	R2	R2	K191
+      0x88100113,  //  0024  GETMBR	R4	R0	K19
+      0x7C080400,  //  0025  CALL	R2	2
+      0x88080134,  //  0026  GETMBR	R2	R0	K52
+      0x740A0008,  //  0027  JMPT	R2	#0031
+      0x8808015C,  //  0028  GETMBR	R2	R0	K92
+      0x8C080593,  //  0029  GETMET	R2	R2	K147
+      0x7C080200,  //  002A  CALL	R2	1
+      0x24080508,  //  002B  GT	R2	R2	K8
+      0x780A0003,  //  002C  JMPF	R2	#0031
+      0x50080200,  //  002D  LDBOOL	R2	1	0
+      0x90026802,  //  002E  SETMBR	R0	K52	R2
+      0x8C08013F,  //  002F  GETMET	R2	R0	K63
+      0x7C080200,  //  0030  CALL	R2	1
+      0x80000000,  //  0031  RET	0
     })
   )
 );
@@ -3055,11 +3005,11 @@ be_local_closure(class_Matter_Device_save_before_restart,   /* name */
     be_str_weak(save_before_restart),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040161,  //  0000  GETMBR	R1	R0	K97
-      0x8C0403CE,  //  0001  GETMET	R1	R1	K206
+      0x8804013D,  //  0000  GETMBR	R1	R0	K61
+      0x8C04034D,  //  0001  GETMET	R1	R1	K77
       0x7C040200,  //  0002  CALL	R1	1
-      0x88040161,  //  0003  GETMBR	R1	R0	K97
-      0x8C0403CF,  //  0004  GETMET	R1	R1	K207
+      0x8804013D,  //  0003  GETMBR	R1	R0	K61
+      0x8C0403C0,  //  0004  GETMET	R1	R1	K192
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -3069,11 +3019,11 @@ be_local_closure(class_Matter_Device_save_before_restart,   /* name */
 
 
 /********************************************************************
-** Solidified function: MtrJoin
+** Solidified function: MtrUpdate
 ********************************************************************/
-be_local_closure(class_Matter_Device_MtrJoin,   /* name */
+be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    18,                          /* nstack */
     5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -3082,140 +3032,135 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrJoin),
+    be_str_weak(MtrUpdate),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160003,  //  0003  JMPF	R5	#0008
-      0x88180161,  //  0004  GETMBR	R6	R0	K97
-      0x8C180DD0,  //  0005  GETMET	R6	R6	K208
-      0x7C180200,  //  0006  CALL	R6	1
-      0x70020002,  //  0007  JMP		#000B
-      0x88180161,  //  0008  GETMBR	R6	R0	K97
-      0x8C180DCE,  //  0009  GETMET	R6	R6	K206
-      0x7C180200,  //  000A  CALL	R6	1
-      0xB81A2000,  //  000B  GETNGBL	R6	K16
-      0x8C180D11,  //  000C  GETMET	R6	R6	K17
-      0x7C180200,  //  000D  CALL	R6	1
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l
-********************************************************************/
-be_local_closure(class_Matter_Device_k2l,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(k2l),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58040004,  //  0000  LDCONST	R1	K4
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100105,  //  0008  GETMET	R4	R0	K5
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140506,  //  000E  GETMET	R5	R2	K6
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C0007,  //  0012  LDCONST	R3	K7
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100908,  //  0019  SUB	R4	R4	K8
-      0x40121004,  //  001A  CONNECT	R4	K8	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D09,  //  0021  GT	R7	R6	K9
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D08,  //  0023  SUB	R7	R6	K8
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D08,  //  0027  SUB	R7	R6	K8
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D08,  //  002A  SUB	R6	R6	K8
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C0007,  //  002E  LDCONST	R3	K7
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrInfo_one
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrInfo_one),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x8C080149,  //  0000  GETMET	R2	R0	K73
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80000600,  //  0006  RET	0
-      0x8C0C0581,  //  0007  GETMET	R3	R2	K129
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x780E0008,  //  0009  JMPF	R3	#0013
-      0x60100018,  //  000A  GETGBL	R4	G24
-      0x581400D1,  //  000B  LDCONST	R5	K209
-      0x5C180600,  //  000C  MOVE	R6	R3
-      0x7C100400,  //  000D  CALL	R4	2
-      0xB8162000,  //  000E  GETNGBL	R5	K16
-      0x8C140BD2,  //  000F  GETMET	R5	R5	K210
-      0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x5820000A,  //  0011  LDCONST	R8	K10
-      0x7C140600,  //  0012  CALL	R5	3
-      0x80000000,  //  0013  RET	0
+    ( &(const binstruction[126]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160004,  //  0002  JMPF	R5	#0008
+      0xB8160200,  //  0003  GETNGBL	R5	K1
+      0x8C140BC1,  //  0004  GETMET	R5	R5	K193
+      0x581C00C2,  //  0005  LDCONST	R7	K194
+      0x7C140400,  //  0006  CALL	R5	2
+      0x80040A00,  //  0007  RET	1	R5
+      0xB8160200,  //  0008  GETNGBL	R5	K1
+      0x8C140BC3,  //  0009  GETMET	R5	R5	K195
+      0x5C1C0800,  //  000A  MOVE	R7	R4
+      0x582000C4,  //  000B  LDCONST	R8	K196
+      0x7C140600,  //  000C  CALL	R5	3
+      0xB81A0200,  //  000D  GETNGBL	R6	K1
+      0x8C180DC3,  //  000E  GETMET	R6	R6	K195
+      0x5C200800,  //  000F  MOVE	R8	R4
+      0x582400C5,  //  0010  LDCONST	R9	K197
+      0x7C180600,  //  0011  CALL	R6	3
+      0x74160000,  //  0012  JMPT	R5	#0014
+      0x781A0064,  //  0013  JMPF	R6	#0079
+      0x4C1C0000,  //  0014  LDNIL	R7
+      0x78160010,  //  0015  JMPF	R5	#0027
+      0x60200009,  //  0016  GETGBL	R8	G9
+      0x94240805,  //  0017  GETIDX	R9	R4	R5
+      0x7C200200,  //  0018  CALL	R8	1
+      0x18241108,  //  0019  LE	R9	R8	K8
+      0x78260004,  //  001A  JMPF	R9	#0020
+      0xB8260200,  //  001B  GETNGBL	R9	K1
+      0x8C2413C1,  //  001C  GETMET	R9	R9	K193
+      0x582C00C6,  //  001D  LDCONST	R11	K198
+      0x7C240400,  //  001E  CALL	R9	2
+      0x80041200,  //  001F  RET	1	R9
+      0x8C240152,  //  0020  GETMET	R9	R0	K82
+      0x5C2C1000,  //  0021  MOVE	R11	R8
+      0x7C240400,  //  0022  CALL	R9	2
+      0x5C1C1200,  //  0023  MOVE	R7	R9
+      0x8C240919,  //  0024  GETMET	R9	R4	K25
+      0x5C2C0A00,  //  0025  MOVE	R11	R5
+      0x7C240400,  //  0026  CALL	R9	2
+      0x781A0009,  //  0027  JMPF	R6	#0032
+      0x4C200000,  //  0028  LDNIL	R8
+      0x1C200E08,  //  0029  EQ	R8	R7	R8
+      0x78220003,  //  002A  JMPF	R8	#002F
+      0x8C200151,  //  002B  GETMET	R8	R0	K81
+      0x94280806,  //  002C  GETIDX	R10	R4	R6
+      0x7C200400,  //  002D  CALL	R8	2
+      0x5C1C1000,  //  002E  MOVE	R7	R8
+      0x8C200919,  //  002F  GETMET	R8	R4	K25
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C200400,  //  0031  CALL	R8	2
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220004,  //  0034  JMPF	R8	#003A
+      0xB8220200,  //  0035  GETNGBL	R8	K1
+      0x8C2011C1,  //  0036  GETMET	R8	R8	K193
+      0x582800C7,  //  0037  LDCONST	R10	K199
+      0x7C200400,  //  0038  CALL	R8	2
+      0x80041000,  //  0039  RET	1	R8
+      0x88200FC8,  //  003A  GETMBR	R8	R7	K200
+      0x74220004,  //  003B  JMPT	R8	#0041
+      0xB8220200,  //  003C  GETNGBL	R8	K1
+      0x8C2011C1,  //  003D  GETMET	R8	R8	K193
+      0x582800C9,  //  003E  LDCONST	R10	K201
+      0x7C200400,  //  003F  CALL	R8	2
+      0x80041000,  //  0040  RET	1	R8
+      0x8C200FCA,  //  0041  GETMET	R8	R7	K202
+      0x7C200200,  //  0042  CALL	R8	1
+      0x60240013,  //  0043  GETGBL	R9	G19
+      0x7C240000,  //  0044  CALL	R9	0
+      0x60280010,  //  0045  GETGBL	R10	G16
+      0x8C2C0914,  //  0046  GETMET	R11	R4	K20
+      0x7C2C0200,  //  0047  CALL	R11	1
+      0x7C280200,  //  0048  CALL	R10	1
+      0xA8020016,  //  0049  EXBLK	0	#0061
+      0x5C2C1400,  //  004A  MOVE	R11	R10
+      0x7C2C0000,  //  004B  CALL	R11	0
+      0xB8320200,  //  004C  GETNGBL	R12	K1
+      0x8C3019CB,  //  004D  GETMET	R12	R12	K203
+      0x5C381000,  //  004E  MOVE	R14	R8
+      0x5C3C1600,  //  004F  MOVE	R15	R11
+      0x7C300600,  //  0050  CALL	R12	3
+      0x4C340000,  //  0051  LDNIL	R13
+      0x1C34180D,  //  0052  EQ	R13	R12	R13
+      0x78360008,  //  0053  JMPF	R13	#005D
+      0xB8360200,  //  0054  GETNGBL	R13	K1
+      0x8C341BC1,  //  0055  GETMET	R13	R13	K193
+      0x603C0018,  //  0056  GETGBL	R15	G24
+      0x584000CC,  //  0057  LDCONST	R16	K204
+      0x5C441600,  //  0058  MOVE	R17	R11
+      0x7C3C0400,  //  0059  CALL	R15	2
+      0x7C340400,  //  005A  CALL	R13	2
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x80001A00,  //  005C  RET	0
+      0x9434100C,  //  005D  GETIDX	R13	R8	R12
+      0x9438080B,  //  005E  GETIDX	R14	R4	R11
+      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
+      0x7001FFE8,  //  0060  JMP		#004A
+      0x58280016,  //  0061  LDCONST	R10	K22
+      0xAC280200,  //  0062  CATCH	R10	1	0
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x8C280FCD,  //  0064  GETMET	R10	R7	K205
+      0x5C301200,  //  0065  MOVE	R12	R9
+      0x7C280400,  //  0066  CALL	R10	2
+      0x8C280F53,  //  0067  GETMET	R10	R7	K83
+      0x7C280200,  //  0068  CALL	R10	1
+      0x782A000A,  //  0069  JMPF	R10	#0075
+      0x602C0018,  //  006A  GETGBL	R11	G24
+      0x583000CE,  //  006B  LDCONST	R12	K206
+      0x5C340200,  //  006C  MOVE	R13	R1
+      0x5C381400,  //  006D  MOVE	R14	R10
+      0x7C2C0600,  //  006E  CALL	R11	3
+      0xB8320200,  //  006F  GETNGBL	R12	K1
+      0x8C3019CF,  //  0070  GETMET	R12	R12	K207
+      0x5C381600,  //  0071  MOVE	R14	R11
+      0x7C300400,  //  0072  CALL	R12	2
+      0x80041800,  //  0073  RET	1	R12
+      0x70020003,  //  0074  JMP		#0079
+      0xB82E0200,  //  0075  GETNGBL	R11	K1
+      0x8C2C174E,  //  0076  GETMET	R11	R11	K78
+      0x7C2C0200,  //  0077  CALL	R11	1
+      0x80041600,  //  0078  RET	1	R11
+      0xB81E0200,  //  0079  GETNGBL	R7	K1
+      0x8C1C0FC1,  //  007A  GETMET	R7	R7	K193
+      0x582400D0,  //  007B  LDCONST	R9	K208
+      0x7C1C0400,  //  007C  CALL	R7	2
+      0x80000000,  //  007D  RET	0
     })
   )
 );
@@ -3239,10 +3184,10 @@ be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
     be_str_weak(create_zb_mapper),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88080169,  //  0000  GETMBR	R2	R0	K105
+      0x880801A2,  //  0000  GETMBR	R2	R0	K162
       0x780A0004,  //  0001  JMPF	R2	#0007
-      0x88080169,  //  0002  GETMBR	R2	R0	K105
-      0x8C0805D3,  //  0003  GETMET	R2	R2	K211
+      0x880801A2,  //  0002  GETMBR	R2	R0	K162
+      0x8C0805D1,  //  0003  GETMET	R2	R2	K209
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x80040400,  //  0006  RET	1	R2
@@ -3254,9 +3199,9 @@ be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
 
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: init_zigbee
 ********************************************************************/
-be_local_closure(class_Matter_Device_start,   /* name */
+be_local_closure(class_Matter_Device_init_zigbee,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -3267,22 +3212,54 @@ be_local_closure(class_Matter_Device_start,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(start),
+    be_str_weak(init_zigbee),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C0401D2,  //  0000  GETMET	R1	R0	K210
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060004,  //  0002  JMPF	R1	#0008
+      0xA4068E00,  //  0003  IMPORT	R1	K71
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80040400,  //  0007  RET	1	R2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_read_sensors_schedule
+********************************************************************/
+be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(add_read_sensors_schedule),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8804015E,  //  0000  GETMBR	R1	R0	K94
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x8C0401D4,  //  0003  GETMET	R1	R0	K212
-      0x7C040200,  //  0004  CALL	R1	1
-      0x8C0401D5,  //  0005  GETMET	R1	R0	K213
-      0x880C01D6,  //  0006  GETMBR	R3	R0	K214
-      0x7C040400,  //  0007  CALL	R1	2
-      0x88040161,  //  0008  GETMBR	R1	R0	K97
-      0x8C0403D7,  //  0009  GETMET	R1	R1	K215
-      0x7C040200,  //  000A  CALL	R1	1
-      0x50040200,  //  000B  LDBOOL	R1	1	0
-      0x9002BC01,  //  000C  SETMBR	R0	K94	R1
+      0x8808010D,  //  0000  GETMBR	R2	R0	K13
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x740A0002,  //  0003  JMPT	R2	#0007
+      0x8808010D,  //  0004  GETMBR	R2	R0	K13
+      0x24080401,  //  0005  GT	R2	R2	R1
+      0x780A0005,  //  0006  JMPF	R2	#000D
+      0x90021A01,  //  0007  SETMBR	R0	K13	R1
+      0xB80A3400,  //  0008  GETNGBL	R2	K26
+      0x8C0805D3,  //  0009  GETMET	R2	R2	K211
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x90021C02,  //  000C  SETMBR	R0	K14	R2
       0x80000000,  //  000D  RET	0
     })
   )
@@ -3296,61 +3273,47 @@ be_local_closure(class_Matter_Device_start,   /* name */
 be_local_class(Matter_Device,
     24,
     NULL,
-    be_nested_map(84,
+    be_nested_map(83,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(commissioning, -1), be_const_var(8) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
-        { be_const_key_weak(plugins_config, -1), be_const_var(3) },
-        { be_const_key_weak(k2l_num, 73), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(plugins_persist, 7), be_const_var(2) },
-        { be_const_key_weak(EP, -1), be_const_int(2) },
-        { be_const_key_weak(MtrInfo, -1), be_const_closure(class_Matter_Device_MtrInfo_closure) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(class_Matter_Device_msg_received_closure) },
-        { be_const_key_weak(every_250ms, 77), be_const_closure(class_Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(class_Matter_Device_k2l_closure) },
-        { be_const_key_weak(init_zigbee, 12), be_const_closure(class_Matter_Device_init_zigbee_closure) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(MtrJoin, 56), be_const_closure(class_Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(4) },
-        { be_const_key_weak(save_param, 37), be_const_closure(class_Matter_Device_save_param_closure) },
-        { be_const_key_weak(register_commands, -1), be_const_closure(class_Matter_Device_register_commands_closure) },
-        { be_const_key_weak(debug, 48), be_const_var(21) },
-        { be_const_key_weak(stop, 68), be_const_closure(class_Matter_Device_stop_closure) },
-        { be_const_key_weak(udp_server, 33), be_const_var(5) },
-        { be_const_key_weak(find_plugin_by_endpoint, 66), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(events, -1), be_const_var(14) },
-        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
-        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(check_network, -1), be_const_closure(class_Matter_Device_check_network_closure) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(17) },
-        { be_const_key_weak(zigbee, -1), be_const_var(11) },
-        { be_const_key_weak(sessions, -1), be_const_var(10) },
-        { be_const_key_weak(resolve_attribute_read_solo, -1), be_const_closure(class_Matter_Device_resolve_attribute_read_solo_closure) },
-        { be_const_key_weak(clean_remotes, 24), be_const_closure(class_Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(get_plugin_remote_info, 79), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(check_config_ep, 13), be_const_closure(class_Matter_Device_check_config_ep_closure) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(16) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(probe_sensor_time, -1), be_const_var(22) },
-        { be_const_key_weak(button_handler, -1), be_const_closure(class_Matter_Device_button_handler_closure) },
-        { be_const_key_weak(_start_udp, -1), be_const_closure(class_Matter_Device__start_udp_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(find_plugin_by_friendly_name, -1), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
-        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(19) },
+        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(probe_sensor_time, 22), be_const_var(22) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(read_sensors_scheduler, 57), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
+        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
+        { be_const_key_weak(check_config_ep, -1), be_const_closure(class_Matter_Device_check_config_ep_closure) },
+        { be_const_key_weak(invoke_request, 38), be_const_closure(class_Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(started, 0), be_const_var(0) },
         { be_const_key_weak(load_param, -1), be_const_closure(class_Matter_Device_load_param_closure) },
-        { be_const_key_weak(MtrUpdate, 15), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
+        { be_const_key_weak(udp_server, -1), be_const_var(5) },
+        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(4) },
+        { be_const_key_weak(UDP_PORT, 23), be_const_int(5540) },
+        { be_const_key_weak(init_zigbee, 36), be_const_closure(class_Matter_Device_init_zigbee_closure) },
+        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(is_zigbee_present, -1), be_const_closure(class_Matter_Device_is_zigbee_present_closure) },
+        { be_const_key_weak(k2l, 31), be_const_static_closure(class_Matter_Device_k2l_closure) },
+        { be_const_key_weak(autoconf, 75), be_const_var(9) },
+        { be_const_key_weak(stop, -1), be_const_closure(class_Matter_Device_stop_closure) },
+        { be_const_key_weak(create_zb_mapper, -1), be_const_closure(class_Matter_Device_create_zb_mapper_closure) },
+        { be_const_key_weak(EP, 18), be_const_int(2) },
+        { be_const_key_weak(MtrJoin, 29), be_const_closure(class_Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(zigbee, -1), be_const_var(11) },
+        { be_const_key_weak(MtrUpdate, -1), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(class_Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
+        { be_const_key_weak(FILENAME, 80), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(http_remotes, 79), be_const_var(15) },
+        { be_const_key_weak(get_plugin_remote_info, 68), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(MtrInfo, -1), be_const_closure(class_Matter_Device_MtrInfo_closure) },
+        { be_const_key_weak(get_plugin_class_displayname, 32), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(class_Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(sort_distinct, 76), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
+        { be_const_key_weak(tick, -1), be_const_var(13) },
+        { be_const_key_weak(k2l_num, 67), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(ui, 74), be_const_var(12) },
         { be_const_key_weak(every_50ms, -1), be_const_closure(class_Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
-        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
-        { be_const_key_weak(profiler, 49), be_const_var(6) },
-        { be_const_key_weak(register_http_remote, 5), be_const_closure(class_Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(sort_distinct, 38), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(signal_endpoints_changed, 57), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
-        { be_const_key_weak(is_zigbee_present, 65), be_const_closure(class_Matter_Device_is_zigbee_present_closure) },
         { be_const_key_weak(plugins_classes, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(60,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -3415,36 +3378,49 @@ be_local_class(Matter_Device,
         { be_const_key_weak(illuminance, -1), be_const_class(be_class_Matter_Plugin_Sensor_Illuminance) },
         { be_const_key_weak(v_light3, -1), be_const_class(be_class_Matter_Plugin_Virt_Light3) },
     }))    ) } )) },
-        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(class_Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(class_Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(get_plugin_class_displayname, 2), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
-        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(class_Matter_Device_get_plugin_class_arg_closure) },
-        { be_const_key_weak(started, 54), be_const_var(0) },
-        { be_const_key_weak(ui, 62), be_const_var(12) },
-        { be_const_key_weak(bridge_add_endpoint, 61), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(button_multi_pressed, -1), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
         { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
         { be_const_key_weak(message_handler, -1), be_const_var(7) },
-        { be_const_key_weak(read_sensors_scheduler, 42), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
-        { be_const_key_weak(next_ep, 53), be_const_var(20) },
-        { be_const_key_weak(autoconf, -1), be_const_var(9) },
-        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(attribute_updated, 46), be_const_closure(class_Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(debug, 61), be_const_var(21) },
+        { be_const_key_weak(save_param, -1), be_const_closure(class_Matter_Device_save_param_closure) },
+        { be_const_key_weak(plugins, 69), be_const_var(1) },
+        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
         { be_const_key_weak(update_remotes_info, -1), be_const_closure(class_Matter_Device_update_remotes_info_closure) },
-        { be_const_key_weak(http_remotes, 41), be_const_var(15) },
-        { be_const_key_weak(reset_param, 39), be_const_closure(class_Matter_Device_reset_param_closure) },
-        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(event_fabrics_saved, 26), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Device_init_closure) },
+        { be_const_key_weak(profiler, -1), be_const_var(6) },
+        { be_const_key_weak(get_plugin_class_arg, 12), be_const_closure(class_Matter_Device_get_plugin_class_arg_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(10) },
+        { be_const_key_weak(events, -1), be_const_var(14) },
+        { be_const_key_weak(disable_bridge_mode, 47), be_const_var(19) },
+        { be_const_key_weak(next_ep, -1), be_const_var(20) },
         { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_Device_received_ack_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(button_multi_pressed, -1), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
-        { be_const_key_weak(init, 21), be_const_closure(class_Matter_Device_init_closure) },
-        { be_const_key_weak(ipv4only, 19), be_const_var(18) },
-        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
-        { be_const_key_weak(save_before_restart, -1), be_const_closure(class_Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(probe_sensor_timestamp, -1), be_const_var(23) },
-        { be_const_key_weak(tick, 9), be_const_var(13) },
-        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
-        { be_const_key_weak(create_zb_mapper, -1), be_const_closure(class_Matter_Device_create_zb_mapper_closure) },
+        { be_const_key_weak(root_discriminator, 77), be_const_var(16) },
+        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(class_Matter_Device_adjust_next_ep_closure) },
+        { be_const_key_weak(reset_param, 39), be_const_closure(class_Matter_Device_reset_param_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(class_Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(probe_sensor_timestamp, 70), be_const_var(23) },
+        { be_const_key_weak(commissioning, 21), be_const_var(8) },
+        { be_const_key_weak(plugins_config, -1), be_const_var(3) },
+        { be_const_key_weak(button_handler, -1), be_const_closure(class_Matter_Device_button_handler_closure) },
+        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
         { be_const_key_weak(start, -1), be_const_closure(class_Matter_Device_start_closure) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(_start_udp, 78), be_const_closure(class_Matter_Device__start_udp_closure) },
+        { be_const_key_weak(clean_remotes, -1), be_const_closure(class_Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(register_commands, -1), be_const_closure(class_Matter_Device_register_commands_closure) },
+        { be_const_key_weak(find_plugin_by_friendly_name, 35), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
+        { be_const_key_weak(register_http_remote, -1), be_const_closure(class_Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(msg_received, -1), be_const_closure(class_Matter_Device_msg_received_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(class_Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(ipv4only, -1), be_const_var(18) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
+        { be_const_key_weak(root_passcode, -1), be_const_var(17) },
+        { be_const_key_weak(resolve_attribute_read_solo, -1), be_const_closure(class_Matter_Device_resolve_attribute_read_solo_closure) },
+        { be_const_key_weak(bridge_add_endpoint, 1), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -90,6 +90,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     _crons, var                         // list of active crons
     _ccmd, var                          // list of active Tasmota commands implemented in Berry
     _drivers, var                       // list of active drivers
+    _wnu, var                           // list of closures to call when network is connected
     wire1, var                          // Tasmota I2C Wire1
     wire2, var                          // Tasmota I2C Wire2
     cmd_res, var                        // store the command result, nil if disables, true if capture enabled, contains return value
@@ -183,6 +184,8 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     exec_cmd, closure(class_Tasmota_exec_cmd_closure)
     gc, closure(class_Tasmota_gc_closure)
     event, closure(class_Tasmota_event_closure)
+    when_network_up, closure(class_Tasmota_when_network_up_closure)
+    run_network_up, closure(class_Tasmota_run_network_up_closure)
     add_driver, closure(class_Tasmota_add_driver_closure)
     remove_driver, closure(class_Tasmota_remove_driver_closure)
     load, closure(class_Tasmota_load_closure)

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -4,177 +4,233 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Tasmota;
-// compact class 'Tasmota' ktab size: 158, total: 304 (saved 1168 bytes)
-static const bvalue be_ktab_class_Tasmota[158] = {
-  /* K0   */  be_nested_str(i2c_enabled),
-  /* K1   */  be_nested_str(wire1),
-  /* K2   */  be_nested_str(enabled),
-  /* K3   */  be_nested_str(detect),
-  /* K4   */  be_nested_str(wire2),
-  /* K5   */  be_nested_str(_crons),
-  /* K6   */  be_const_int(0),
-  /* K7   */  be_nested_str(size),
-  /* K8   */  be_nested_str(id),
-  /* K9   */  be_nested_str(trig),
-  /* K10  */  be_const_int(1),
-  /* K11  */  be_nested_str(introspect),
-  /* K12  */  be_nested_str(function),
-  /* K13  */  be_nested_str(type_error),
-  /* K14  */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
-  /* K15  */  be_nested_str(ismethod),
-  /* K16  */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
-  /* K17  */  be_nested_str(string),
-  /* K18  */  be_nested_str(toupper),
-  /* K19  */  be_nested_str(time_dump),
-  /* K20  */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
-  /* K21  */  be_nested_str(year),
-  /* K22  */  be_nested_str(month),
-  /* K23  */  be_nested_str(day),
-  /* K24  */  be_nested_str(hour),
-  /* K25  */  be_nested_str(min),
-  /* K26  */  be_nested_str(sec),
-  /* K27  */  be_nested_str(match),
-  /* K28  */  be_nested_str(trigger),
-  /* K29  */  be_nested_str(_drivers),
-  /* K30  */  be_nested_str(find),
-  /* K31  */  be_nested_str(pop),
-  /* K32  */  be_nested_str(_rules),
-  /* K33  */  be_nested_str(json),
-  /* K34  */  be_nested_str(load),
-  /* K35  */  be_nested_str(log),
-  /* K36  */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
-  /* K37  */  be_const_int(3),
-  /* K38  */  be_nested_str(Tele),
-  /* K39  */  be_nested_str(try_rule),
-  /* K40  */  be_nested_str(f),
-  /* K41  */  be_nested_str(ccronexpr),
-  /* K42  */  be_nested_str(now),
-  /* K43  */  be_nested_str(next),
-  /* K44  */  be_nested_str(time_reached),
-  /* K45  */  be_nested_str(_defer),
-  /* K46  */  be_nested_str(push),
-  /* K47  */  be_nested_str(tasmota),
-  /* K48  */  be_nested_str(global),
-  /* K49  */  be_nested_str(deferred_ready),
-  /* K50  */  be_nested_str(scale_uint),
-  /* K51  */  be_const_int(2),
-  /* K52  */  be_nested_str(_fl),
-  /* K53  */  be_nested_str(remove),
-  /* K54  */  be_nested_str(check_not_method),
-  /* K55  */  be_nested_str(remove_rule),
-  /* K56  */  be_nested_str(Trigger),
-  /* K57  */  be_nested_str(Rule_Matcher),
-  /* K58  */  be_nested_str(parse),
-  /* K59  */  be_nested_str(value_error),
-  /* K60  */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
-  /* K61  */  be_nested_str(ctypes_bytes_dyn),
-  /* K62  */  be_nested_str(_global_addr),
-  /* K63  */  be_nested_str(_global_def),
-  /* K64  */  be_nested_str(_settings_ptr),
-  /* K65  */  be_nested_str(get),
-  /* K66  */  be_nested_str(settings),
-  /* K67  */  be_nested_str(toptr),
-  /* K68  */  be_nested_str(_settings_def),
-  /* K69  */  be_nested_str(wd),
-  /* K70  */  be_nested_str(),
-  /* K71  */  be_nested_str(_debug_present),
-  /* K72  */  be_nested_str(contains),
-  /* K73  */  be_nested_str(debug),
-  /* K74  */  be_nested_str(add_cmd),
-  /* K75  */  be_nested_str(UrlFetch),
-  /* K76  */  be_nested_str(_timers),
-  /* K77  */  be_nested_str(millis),
-  /* K78  */  be_nested_str(split),
-  /* K79  */  be_nested_str(_X2F),
-  /* K80  */  be_nested_str(index_X2Ehtml),
-  /* K81  */  be_nested_str(webclient),
-  /* K82  */  be_nested_str(set_follow_redirects),
-  /* K83  */  be_nested_str(begin),
-  /* K84  */  be_nested_str(GET),
-  /* K85  */  be_nested_str(status_X3A_X20),
-  /* K86  */  be_nested_str(connection_error),
-  /* K87  */  be_nested_str(write_file),
-  /* K88  */  be_nested_str(close),
-  /* K89  */  be_nested_str(BRY_X3A_X20Fetched_X20),
-  /* K90  */  be_nested_str(rule),
-  /* K91  */  be_nested_str(instance),
-  /* K92  */  be_nested_str(instance_X20required),
-  /* K93  */  be_nested_str(cmd_res),
-  /* K94  */  be_nested_str(o),
-  /* K95  */  be_const_class(be_class_Tasmota),
-  /* K96  */  be_nested_str(gc),
-  /* K97  */  be_nested_str(collect),
-  /* K98  */  be_nested_str(allocated),
-  /* K99  */  be_nested_str(add_rule),
-  /* K100 */  be_nested_str(every_50ms),
-  /* K101 */  be_nested_str(run_timers),
-  /* K102 */  be_nested_str(every_250ms),
-  /* K103 */  be_nested_str(run_cron),
-  /* K104 */  be_nested_str(mqtt_data),
-  /* K105 */  be_nested_str(cmd),
-  /* K106 */  be_nested_str(exec_cmd),
-  /* K107 */  be_nested_str(tele),
-  /* K108 */  be_nested_str(exec_tele),
-  /* K109 */  be_nested_str(exec_rules),
-  /* K110 */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-  /* K111 */  be_nested_str(traceback),
-  /* K112 */  be_nested_str(save_before_restart),
-  /* K113 */  be_nested_str(persist),
-  /* K114 */  be_nested_str(save),
-  /* K115 */  be_nested_str(keys),
-  /* K116 */  be_nested_str(_X3F),
-  /* K117 */  be_nested_str(stop_iteration),
-  /* K118 */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
-  /* K119 */  be_nested_str(light),
-  /* K120 */  be_nested_str(argument_X20must_X20be_X20a_X20function),
-  /* K121 */  be_nested_str(fast_loop_enabled),
-  /* K122 */  be_nested_str(maxlog_level),
-  /* K123 */  be_nested_str(_cmd),
-  /* K124 */  be_nested_str(run_deferred),
-  /* K125 */  be_nested_str(_ccmd),
-  /* K126 */  be_nested_str(find_key_i),
-  /* K127 */  be_nested_str(resolvecmnd),
-  /* K128 */  be_nested_str(_find_op),
-  /* K129 */  be_const_int(2147483647),
-  /* K130 */  be_nested_str(path),
-  /* K131 */  be_nested_str(startswith),
-  /* K132 */  be_nested_str(_X23),
-  /* K133 */  be_nested_str(_X2E),
-  /* K134 */  be_nested_str(_X2Ebe),
-  /* K135 */  be_nested_str(endswith),
-  /* K136 */  be_nested_str(_X2Ebec),
-  /* K137 */  be_nested_str(c),
-  /* K138 */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
-  /* K139 */  be_nested_str(exists),
-  /* K140 */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
-  /* K141 */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
-  /* K142 */  be_nested_str(BRY_X3A_X20file_X20_X27_X25s_X27_X20does_X20not_X20have_X20_X27_X2Ebe_X27_X20extension),
-  /* K143 */  be_nested_str(BRY_X3A_X20cannot_X20compile_X20file_X20in_X20read_X2Donly_X20archive),
-  /* K144 */  be_nested_str(file),
-  /* K145 */  be_nested_str(BRY_X3A_X20empty_X20compiled_X20file),
-  /* K146 */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_X27_X25s_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29),
-  /* K147 */  be_nested_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29),
-  /* K148 */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
-  /* K149 */  be_nested_str(set),
-  /* K150 */  be_nested_str(cb),
-  /* K151 */  be_nested_str(gen_cb),
-  /* K152 */  be_nested_str(http),
-  /* K153 */  be_nested_str(resp_cmnd_str),
-  /* K154 */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
-  /* K155 */  be_nested_str(urlfetch),
-  /* K156 */  be_nested_str(resp_cmnd_failed),
-  /* K157 */  be_nested_str(resp_cmnd_done),
+// compact class 'Tasmota' ktab size: 164, total: 321 (saved 1256 bytes)
+static const bvalue be_ktab_class_Tasmota[164] = {
+  /* K0   */  be_nested_str(check_not_method),
+  /* K1   */  be_nested_str(_crons),
+  /* K2   */  be_nested_str(ccronexpr),
+  /* K3   */  be_nested_str(next),
+  /* K4   */  be_nested_str(push),
+  /* K5   */  be_nested_str(Trigger),
+  /* K6   */  be_nested_str(_rules),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str(trig),
+  /* K9   */  be_nested_str(rule),
+  /* K10  */  be_nested_str(id),
+  /* K11  */  be_nested_str(remove),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_nested_str(introspect),
+  /* K14  */  be_nested_str(function),
+  /* K15  */  be_nested_str(type_error),
+  /* K16  */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
+  /* K17  */  be_nested_str(ismethod),
+  /* K18  */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
+  /* K19  */  be_nested_str(remove_rule),
+  /* K20  */  be_nested_str(Rule_Matcher),
+  /* K21  */  be_nested_str(parse),
+  /* K22  */  be_nested_str(value_error),
+  /* K23  */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
+  /* K24  */  be_nested_str(tasmota),
+  /* K25  */  be_nested_str(scale_uint),
+  /* K26  */  be_const_int(2),
+  /* K27  */  be_const_int(3),
+  /* K28  */  be_nested_str(_timers),
+  /* K29  */  be_nested_str(millis),
+  /* K30  */  be_nested_str(_ccmd),
+  /* K31  */  be_nested_str(json),
+  /* K32  */  be_nested_str(load),
+  /* K33  */  be_nested_str(find_key_i),
+  /* K34  */  be_nested_str(resolvecmnd),
+  /* K35  */  be_nested_str(wifi),
+  /* K36  */  be_nested_str(up),
+  /* K37  */  be_nested_str(eth),
+  /* K38  */  be_nested_str(_wnu),
+  /* K39  */  be_nested_str(_defer),
+  /* K40  */  be_nested_str(global),
+  /* K41  */  be_nested_str(deferred_ready),
+  /* K42  */  be_nested_str(_fl),
+  /* K43  */  be_nested_str(cmd_res),
+  /* K44  */  be_nested_str(maxlog_level),
+  /* K45  */  be_nested_str(_cmd),
+  /* K46  */  be_nested_str(size),
+  /* K47  */  be_nested_str(instance),
+  /* K48  */  be_nested_str(instance_X20required),
+  /* K49  */  be_nested_str(_drivers),
+  /* K50  */  be_nested_str(find),
+  /* K51  */  be_nested_str(gc),
+  /* K52  */  be_nested_str(collect),
+  /* K53  */  be_nested_str(allocated),
+  /* K54  */  be_const_class(be_class_Tasmota),
+  /* K55  */  be_nested_str(i2c_enabled),
+  /* K56  */  be_nested_str(wire1),
+  /* K57  */  be_nested_str(enabled),
+  /* K58  */  be_nested_str(detect),
+  /* K59  */  be_nested_str(wire2),
+  /* K60  */  be_nested_str(string),
+  /* K61  */  be_nested_str(toupper),
+  /* K62  */  be_nested_str(run_deferred),
+  /* K63  */  be_nested_str(time_reached),
+  /* K64  */  be_nested_str(f),
+  /* K65  */  be_nested_str(ctypes_bytes_dyn),
+  /* K66  */  be_nested_str(_global_addr),
+  /* K67  */  be_nested_str(_global_def),
+  /* K68  */  be_nested_str(_settings_ptr),
+  /* K69  */  be_nested_str(get),
+  /* K70  */  be_nested_str(settings),
+  /* K71  */  be_nested_str(toptr),
+  /* K72  */  be_nested_str(_settings_def),
+  /* K73  */  be_nested_str(wd),
+  /* K74  */  be_nested_str(),
+  /* K75  */  be_nested_str(_debug_present),
+  /* K76  */  be_nested_str(contains),
+  /* K77  */  be_nested_str(debug),
+  /* K78  */  be_nested_str(add_cmd),
+  /* K79  */  be_nested_str(UrlFetch),
+  /* K80  */  be_nested_str(split),
+  /* K81  */  be_nested_str(_X2F),
+  /* K82  */  be_nested_str(pop),
+  /* K83  */  be_nested_str(index_X2Ehtml),
+  /* K84  */  be_nested_str(webclient),
+  /* K85  */  be_nested_str(set_follow_redirects),
+  /* K86  */  be_nested_str(begin),
+  /* K87  */  be_nested_str(GET),
+  /* K88  */  be_nested_str(status_X3A_X20),
+  /* K89  */  be_nested_str(connection_error),
+  /* K90  */  be_nested_str(write_file),
+  /* K91  */  be_nested_str(close),
+  /* K92  */  be_nested_str(log),
+  /* K93  */  be_nested_str(BRY_X3A_X20Fetched_X20),
+  /* K94  */  be_nested_str(http),
+  /* K95  */  be_nested_str(resp_cmnd_str),
+  /* K96  */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
+  /* K97  */  be_nested_str(urlfetch),
+  /* K98  */  be_nested_str(resp_cmnd_failed),
+  /* K99  */  be_nested_str(resp_cmnd_done),
+  /* K100 */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
+  /* K101 */  be_nested_str(Tele),
+  /* K102 */  be_nested_str(try_rule),
+  /* K103 */  be_nested_str(keys),
+  /* K104 */  be_nested_str(_X3F),
+  /* K105 */  be_nested_str(stop_iteration),
+  /* K106 */  be_nested_str(add_rule),
+  /* K107 */  be_nested_str(argument_X20must_X20be_X20a_X20function),
+  /* K108 */  be_nested_str(fast_loop_enabled),
+  /* K109 */  be_nested_str(now),
+  /* K110 */  be_nested_str(path),
+  /* K111 */  be_nested_str(startswith),
+  /* K112 */  be_nested_str(_X23),
+  /* K113 */  be_const_int(2147483647),
+  /* K114 */  be_nested_str(_X2E),
+  /* K115 */  be_nested_str(_X2Ebe),
+  /* K116 */  be_nested_str(endswith),
+  /* K117 */  be_nested_str(_X2Ebec),
+  /* K118 */  be_nested_str(c),
+  /* K119 */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
+  /* K120 */  be_nested_str(exists),
+  /* K121 */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
+  /* K122 */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
+  /* K123 */  be_nested_str(o),
+  /* K124 */  be_nested_str(cb),
+  /* K125 */  be_nested_str(gen_cb),
+  /* K126 */  be_nested_str(every_50ms),
+  /* K127 */  be_nested_str(run_network_up),
+  /* K128 */  be_nested_str(run_timers),
+  /* K129 */  be_nested_str(every_250ms),
+  /* K130 */  be_nested_str(run_cron),
+  /* K131 */  be_nested_str(mqtt_data),
+  /* K132 */  be_nested_str(cmd),
+  /* K133 */  be_nested_str(exec_cmd),
+  /* K134 */  be_nested_str(tele),
+  /* K135 */  be_nested_str(exec_tele),
+  /* K136 */  be_nested_str(exec_rules),
+  /* K137 */  be_nested_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K138 */  be_nested_str(traceback),
+  /* K139 */  be_nested_str(save_before_restart),
+  /* K140 */  be_nested_str(persist),
+  /* K141 */  be_nested_str(save),
+  /* K142 */  be_nested_str(BRY_X3A_X20Exception_X3E_X20run_network_up_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K143 */  be_nested_str(_find_op),
+  /* K144 */  be_nested_str(BRY_X3A_X20file_X20_X27_X25s_X27_X20does_X20not_X20have_X20_X27_X2Ebe_X27_X20extension),
+  /* K145 */  be_nested_str(BRY_X3A_X20cannot_X20compile_X20file_X20in_X20read_X2Donly_X20archive),
+  /* K146 */  be_nested_str(file),
+  /* K147 */  be_nested_str(BRY_X3A_X20empty_X20compiled_X20file),
+  /* K148 */  be_nested_str(BRY_X3A_X20failed_X20to_X20load_X20_X27_X25s_X27_X20_X28_X25s_X20_X2D_X20_X25s_X29),
+  /* K149 */  be_nested_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29),
+  /* K150 */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
+  /* K151 */  be_nested_str(light),
+  /* K152 */  be_nested_str(time_dump),
+  /* K153 */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
+  /* K154 */  be_nested_str(year),
+  /* K155 */  be_nested_str(month),
+  /* K156 */  be_nested_str(day),
+  /* K157 */  be_nested_str(hour),
+  /* K158 */  be_nested_str(min),
+  /* K159 */  be_nested_str(sec),
+  /* K160 */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
+  /* K161 */  be_nested_str(set),
+  /* K162 */  be_nested_str(match),
+  /* K163 */  be_nested_str(trigger),
 };
 
 
 extern const bclass be_class_Tasmota;
 
 /********************************************************************
-** Solidified function: wire_scan
+** Solidified function: add_cron
 ********************************************************************/
-be_local_closure(class_Tasmota_wire_scan,   /* name */
+be_local_closure(class_Tasmota_add_cron,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    13,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_add_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x5C180400,  //  0001  MOVE	R6	R2
+      0x7C100400,  //  0002  CALL	R4	2
+      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x4C140000,  //  0004  LDNIL	R5
+      0x1C100805,  //  0005  EQ	R4	R4	R5
+      0x78120002,  //  0006  JMPF	R4	#000A
+      0x60100012,  //  0007  GETGBL	R4	G18
+      0x7C100000,  //  0008  CALL	R4	0
+      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0xB8120400,  //  000A  GETNGBL	R4	K2
+      0x60140008,  //  000B  GETGBL	R5	G8
+      0x5C180200,  //  000C  MOVE	R6	R1
+      0x7C140200,  //  000D  CALL	R5	1
+      0x7C100200,  //  000E  CALL	R4	1
+      0x8C140903,  //  000F  GETMET	R5	R4	K3
+      0x7C140200,  //  0010  CALL	R5	1
+      0x88180101,  //  0011  GETMBR	R6	R0	K1
+      0x8C180D04,  //  0012  GETMET	R6	R6	K4
+      0xB8220A00,  //  0013  GETNGBL	R8	K5
+      0x5C240A00,  //  0014  MOVE	R9	R5
+      0x5C280400,  //  0015  MOVE	R10	R2
+      0x5C2C0600,  //  0016  MOVE	R11	R3
+      0x5C300800,  //  0017  MOVE	R12	R4
+      0x7C200800,  //  0018  CALL	R8	4
+      0x7C180400,  //  0019  CALL	R6	2
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_rule
+********************************************************************/
+be_local_closure(class_Tasmota_remove_rule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -183,82 +239,36 @@ be_local_closure(class_Tasmota_wire_scan,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_wire_scan,
+    &be_const_str_remove_rule,
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0005,  //  0002  JMPF	R3	#0009
-      0x8C0C0100,  //  0003  GETMET	R3	R0	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x740E0001,  //  0006  JMPT	R3	#0009
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x80040600,  //  0008  RET	1	R3
-      0x880C0101,  //  0009  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x780E0006,  //  000C  JMPF	R3	#0014
-      0x880C0101,  //  000D  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x780E0001,  //  0011  JMPF	R3	#0014
-      0x880C0101,  //  0012  GETMBR	R3	R0	K1
-      0x80040600,  //  0013  RET	1	R3
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x8C0C0702,  //  0015  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0x780E0006,  //  0017  JMPF	R3	#001F
-      0x880C0104,  //  0018  GETMBR	R3	R0	K4
-      0x8C0C0703,  //  0019  GETMET	R3	R3	K3
-      0x5C140200,  //  001A  MOVE	R5	R1
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x780E0001,  //  001C  JMPF	R3	#001F
-      0x880C0104,  //  001D  GETMBR	R3	R0	K4
-      0x80040600,  //  001E  RET	1	R3
-      0x4C0C0000,  //  001F  LDNIL	R3
-      0x80040600,  //  0020  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: next_cron
-********************************************************************/
-be_local_closure(class_Tasmota_next_cron,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_next_cron,
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88080105,  //  0000  GETMBR	R2	R0	K5
-      0x780A000D,  //  0001  JMPF	R2	#0010
-      0x580C0006,  //  0002  LDCONST	R3	K6
-      0x8C100507,  //  0003  GETMET	R4	R2	K7
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100908,  //  0008  GETMBR	R4	R4	K8
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120002,  //  000A  JMPF	R4	#000E
-      0x94100403,  //  000B  GETIDX	R4	R2	R3
-      0x88100909,  //  000C  GETMBR	R4	R4	K9
-      0x80040800,  //  000D  RET	1	R4
-      0x000C070A,  //  000E  ADD	R3	R3	K10
-      0x7001FFF2,  //  000F  JMP		#0003
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[27]) {  /* code */
+      0x880C0106,  //  0000  GETMBR	R3	R0	K6
+      0x780E0017,  //  0001  JMPF	R3	#001A
+      0x580C0007,  //  0002  LDCONST	R3	K7
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x88140106,  //  0004  GETMBR	R5	R0	K6
+      0x7C100200,  //  0005  CALL	R4	1
+      0x14100604,  //  0006  LT	R4	R3	R4
+      0x78120011,  //  0007  JMPF	R4	#001A
+      0x88100106,  //  0008  GETMBR	R4	R0	K6
+      0x94100803,  //  0009  GETIDX	R4	R4	R3
+      0x88100908,  //  000A  GETMBR	R4	R4	K8
+      0x88100909,  //  000B  GETMBR	R4	R4	K9
+      0x1C100801,  //  000C  EQ	R4	R4	R1
+      0x78120009,  //  000D  JMPF	R4	#0018
+      0x88100106,  //  000E  GETMBR	R4	R0	K6
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8810090A,  //  0010  GETMBR	R4	R4	K10
+      0x1C100802,  //  0011  EQ	R4	R4	R2
+      0x78120004,  //  0012  JMPF	R4	#0018
+      0x88100106,  //  0013  GETMBR	R4	R0	K6
+      0x8C10090B,  //  0014  GETMET	R4	R4	K11
+      0x5C180600,  //  0015  MOVE	R6	R3
+      0x7C100400,  //  0016  CALL	R4	2
+      0x70020000,  //  0017  JMP		#0019
+      0x000C070C,  //  0018  ADD	R3	R3	K12
+      0x7001FFE8,  //  0019  JMP		#0003
+      0x80000000,  //  001A  RET	0
     })
   )
 );
@@ -282,20 +292,20 @@ be_local_closure(class_Tasmota_check_not_method,   /* name */
     &be_const_str_check_not_method,
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0xA40A1600,  //  0000  IMPORT	R2	K11
+      0xA40A1A00,  //  0000  IMPORT	R2	K13
       0x600C0004,  //  0001  GETGBL	R3	G4
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x200C070C,  //  0004  NE	R3	R3	K12
+      0x200C070E,  //  0004  NE	R3	R3	K14
       0x780E0000,  //  0005  JMPF	R3	#0007
-      0xB0061B0E,  //  0006  RAISE	1	K13	K14
-      0x8C0C050F,  //  0007  GETMET	R3	R2	K15
+      0xB0061F10,  //  0006  RAISE	1	K15	K16
+      0x8C0C0511,  //  0007  GETMET	R3	R2	K17
       0x5C140200,  //  0008  MOVE	R5	R1
       0x7C0C0400,  //  0009  CALL	R3	2
       0x50100200,  //  000A  LDBOOL	R4	1	0
       0x1C0C0604,  //  000B  EQ	R3	R3	R4
       0x780E0000,  //  000C  JMPF	R3	#000E
-      0xB0061B10,  //  000D  RAISE	1	K13	K16
+      0xB0061F12,  //  000D  RAISE	1	K15	K18
       0x80000000,  //  000E  RET	0
     })
   )
@@ -304,169 +314,12 @@ be_local_closure(class_Tasmota_check_not_method,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_list_i
+** Solidified function: add_rule
 ********************************************************************/
-be_local_closure(class_Tasmota_find_list_i,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_find_list_i,
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xA40E2200,  //  0000  IMPORT	R3	K17
-      0x58100006,  //  0001  LDCONST	R4	K6
-      0x8C140712,  //  0002  GETMET	R5	R3	K18
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x7C140400,  //  0004  CALL	R5	2
-      0x6018000C,  //  0005  GETGBL	R6	G12
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x7C180200,  //  0007  CALL	R6	1
-      0x14180806,  //  0008  LT	R6	R4	R6
-      0x781A0007,  //  0009  JMPF	R6	#0012
-      0x8C180712,  //  000A  GETMET	R6	R3	K18
-      0x94200204,  //  000B  GETIDX	R8	R1	R4
-      0x7C180400,  //  000C  CALL	R6	2
-      0x1C180C05,  //  000D  EQ	R6	R6	R5
-      0x781A0000,  //  000E  JMPF	R6	#0010
-      0x80040800,  //  000F  RET	1	R4
-      0x0010090A,  //  0010  ADD	R4	R4	K10
-      0x7001FFF2,  //  0011  JMP		#0005
-      0x4C180000,  //  0012  LDNIL	R6
-      0x80040C00,  //  0013  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: time_str
-********************************************************************/
-be_local_closure(class_Tasmota_time_str,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_time_str,
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8C080113,  //  0000  GETMET	R2	R0	K19
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x600C0018,  //  0003  GETGBL	R3	G24
-      0x58100014,  //  0004  LDCONST	R4	K20
-      0x94140515,  //  0005  GETIDX	R5	R2	K21
-      0x94180516,  //  0006  GETIDX	R6	R2	K22
-      0x941C0517,  //  0007  GETIDX	R7	R2	K23
-      0x94200518,  //  0008  GETIDX	R8	R2	K24
-      0x94240519,  //  0009  GETIDX	R9	R2	K25
-      0x9428051A,  //  000A  GETIDX	R10	R2	K26
-      0x7C0C0E00,  //  000B  CALL	R3	7
-      0x80040600,  //  000C  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: try_rule
-********************************************************************/
-be_local_closure(class_Tasmota_try_rule,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_try_rule,
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8C10051B,  //  0000  GETMET	R4	R2	K27
-      0x5C180200,  //  0001  MOVE	R6	R1
-      0x7C100400,  //  0002  CALL	R4	2
-      0x4C140000,  //  0003  LDNIL	R5
-      0x20140805,  //  0004  NE	R5	R4	R5
-      0x78160009,  //  0005  JMPF	R5	#0010
-      0x4C140000,  //  0006  LDNIL	R5
-      0x20140605,  //  0007  NE	R5	R3	R5
-      0x78160004,  //  0008  JMPF	R5	#000E
-      0x5C140600,  //  0009  MOVE	R5	R3
-      0x5C180800,  //  000A  MOVE	R6	R4
-      0x881C051C,  //  000B  GETMBR	R7	R2	K28
-      0x5C200200,  //  000C  MOVE	R8	R1
-      0x7C140600,  //  000D  CALL	R5	3
-      0x50140200,  //  000E  LDBOOL	R5	1	0
-      0x80040A00,  //  000F  RET	1	R5
-      0x50140000,  //  0010  LDBOOL	R5	0	0
-      0x80040A00,  //  0011  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_driver
-********************************************************************/
-be_local_closure(class_Tasmota_remove_driver,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_remove_driver,
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8808011D,  //  0000  GETMBR	R2	R0	K29
-      0x780A000A,  //  0001  JMPF	R2	#000D
-      0x8808011D,  //  0002  GETMBR	R2	R0	K29
-      0x8C08051E,  //  0003  GETMET	R2	R2	K30
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x200C0403,  //  0007  NE	R3	R2	R3
-      0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C011D,  //  0009  GETMBR	R3	R0	K29
-      0x8C0C071F,  //  000A  GETMET	R3	R3	K31
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: exec_tele
-********************************************************************/
-be_local_closure(class_Tasmota_exec_tele,   /* name */
+be_local_closure(class_Tasmota_add_rule,   /* name */
   be_nested_proto(
     12,                          /* nstack */
-    2,                          /* argc */
+    5,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -474,145 +327,46 @@ be_local_closure(class_Tasmota_exec_tele,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_exec_tele,
+    &be_const_str_add_rule,
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x88080120,  //  0000  GETMBR	R2	R0	K32
-      0x780A0024,  //  0001  JMPF	R2	#0027
-      0xA40A4200,  //  0002  IMPORT	R2	K33
-      0x8C0C0522,  //  0003  GETMET	R3	R2	K34
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x50100000,  //  0006  LDBOOL	R4	0	0
-      0x4C140000,  //  0007  LDNIL	R5
-      0x1C140605,  //  0008  EQ	R5	R3	R5
-      0x78160004,  //  0009  JMPF	R5	#000F
-      0x8C140123,  //  000A  GETMET	R5	R0	K35
-      0x001E4801,  //  000B  ADD	R7	K36	R1
-      0x58200025,  //  000C  LDCONST	R8	K37
-      0x7C140600,  //  000D  CALL	R5	3
-      0x5C0C0200,  //  000E  MOVE	R3	R1
-      0x60140013,  //  000F  GETGBL	R5	G19
-      0x7C140000,  //  0010  CALL	R5	0
-      0x98164C03,  //  0011  SETIDX	R5	K38	R3
-      0x5C0C0A00,  //  0012  MOVE	R3	R5
-      0x58140006,  //  0013  LDCONST	R5	K6
-      0x6018000C,  //  0014  GETGBL	R6	G12
-      0x881C0120,  //  0015  GETMBR	R7	R0	K32
-      0x7C180200,  //  0016  CALL	R6	1
-      0x14180A06,  //  0017  LT	R6	R5	R6
-      0x781A000C,  //  0018  JMPF	R6	#0026
-      0x88180120,  //  0019  GETMBR	R6	R0	K32
-      0x94180C05,  //  001A  GETIDX	R6	R6	R5
-      0x8C1C0127,  //  001B  GETMET	R7	R0	K39
-      0x5C240600,  //  001C  MOVE	R9	R3
-      0x88280D09,  //  001D  GETMBR	R10	R6	K9
-      0x882C0D28,  //  001E  GETMBR	R11	R6	K40
-      0x7C1C0800,  //  001F  CALL	R7	4
-      0x741E0001,  //  0020  JMPT	R7	#0023
-      0x74120000,  //  0021  JMPT	R4	#0023
-      0x50100001,  //  0022  LDBOOL	R4	0	1
-      0x50100200,  //  0023  LDBOOL	R4	1	0
-      0x00140B0A,  //  0024  ADD	R5	R5	K10
-      0x7001FFED,  //  0025  JMP		#0014
-      0x80040800,  //  0026  RET	1	R4
-      0x50080000,  //  0027  LDBOOL	R2	0	0
-      0x80040400,  //  0028  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: run_cron
-********************************************************************/
-be_local_closure(class_Tasmota_run_cron,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_run_cron,
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x88040105,  //  0000  GETMBR	R1	R0	K5
-      0x7806001E,  //  0001  JMPF	R1	#0021
-      0x58040006,  //  0002  LDCONST	R1	K6
-      0xB80A5200,  //  0003  GETNGBL	R2	K41
-      0x8C08052A,  //  0004  GETMET	R2	R2	K42
-      0x7C080200,  //  0005  CALL	R2	1
-      0x880C0105,  //  0006  GETMBR	R3	R0	K5
-      0x8C0C0707,  //  0007  GETMET	R3	R3	K7
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x140C0203,  //  0009  LT	R3	R1	R3
-      0x780E0015,  //  000A  JMPF	R3	#0021
-      0x880C0105,  //  000B  GETMBR	R3	R0	K5
-      0x940C0601,  //  000C  GETIDX	R3	R3	R1
-      0x88100709,  //  000D  GETMBR	R4	R3	K9
-      0x1C100906,  //  000E  EQ	R4	R4	K6
-      0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C10072B,  //  0010  GETMET	R4	R3	K43
-      0x7C100200,  //  0011  CALL	R4	1
-      0x900E1204,  //  0012  SETMBR	R3	K9	R4
-      0x7002000A,  //  0013  JMP		#001F
-      0x8C10072C,  //  0014  GETMET	R4	R3	K44
-      0x7C100200,  //  0015  CALL	R4	1
-      0x78120007,  //  0016  JMPF	R4	#001F
-      0x88100728,  //  0017  GETMBR	R4	R3	K40
-      0x8C14072B,  //  0018  GETMET	R5	R3	K43
-      0x7C140200,  //  0019  CALL	R5	1
-      0x900E1205,  //  001A  SETMBR	R3	K9	R5
-      0x5C180800,  //  001B  MOVE	R6	R4
-      0x5C1C0400,  //  001C  MOVE	R7	R2
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x0004030A,  //  001F  ADD	R1	R1	K10
-      0x7001FFE4,  //  0020  JMP		#0006
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: defer
-********************************************************************/
-be_local_closure(class_Tasmota_defer,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_defer,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x8808012D,  //  0000  GETMBR	R2	R0	K45
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C080403,  //  0002  EQ	R2	R2	R3
-      0x780A0002,  //  0003  JMPF	R2	#0007
-      0x60080012,  //  0004  GETGBL	R2	G18
-      0x7C080000,  //  0005  CALL	R2	0
-      0x90025A02,  //  0006  SETMBR	R0	K45	R2
-      0x8808012D,  //  0007  GETMBR	R2	R0	K45
-      0x8C08052E,  //  0008  GETMET	R2	R2	K46
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0xB80A5E00,  //  000B  GETNGBL	R2	K47
-      0x88080530,  //  000C  GETMBR	R2	R2	K48
-      0x900A630A,  //  000D  SETMBR	R2	K49	K10
-      0x80000000,  //  000E  RET	0
+    ( &(const binstruction[37]) {  /* code */
+      0x8C140100,  //  0000  GETMET	R5	R0	K0
+      0x5C1C0400,  //  0001  MOVE	R7	R2
+      0x7C140400,  //  0002  CALL	R5	2
+      0x88140106,  //  0003  GETMBR	R5	R0	K6
+      0x4C180000,  //  0004  LDNIL	R6
+      0x1C140A06,  //  0005  EQ	R5	R5	R6
+      0x78160002,  //  0006  JMPF	R5	#000A
+      0x60140012,  //  0007  GETGBL	R5	G18
+      0x7C140000,  //  0008  CALL	R5	0
+      0x90020C05,  //  0009  SETMBR	R0	K6	R5
+      0x60140004,  //  000A  GETGBL	R5	G4
+      0x5C180400,  //  000B  MOVE	R6	R2
+      0x7C140200,  //  000C  CALL	R5	1
+      0x1C140B0E,  //  000D  EQ	R5	R5	K14
+      0x78160013,  //  000E  JMPF	R5	#0023
+      0x4C140000,  //  000F  LDNIL	R5
+      0x20140605,  //  0010  NE	R5	R3	R5
+      0x78160003,  //  0011  JMPF	R5	#0016
+      0x8C140113,  //  0012  GETMET	R5	R0	K19
+      0x5C1C0200,  //  0013  MOVE	R7	R1
+      0x5C200600,  //  0014  MOVE	R8	R3
+      0x7C140600,  //  0015  CALL	R5	3
+      0x88140106,  //  0016  GETMBR	R5	R0	K6
+      0x8C140B04,  //  0017  GETMET	R5	R5	K4
+      0xB81E0A00,  //  0018  GETNGBL	R7	K5
+      0x88200114,  //  0019  GETMBR	R8	R0	K20
+      0x8C201115,  //  001A  GETMET	R8	R8	K21
+      0x5C280200,  //  001B  MOVE	R10	R1
+      0x7C200400,  //  001C  CALL	R8	2
+      0x5C240400,  //  001D  MOVE	R9	R2
+      0x5C280600,  //  001E  MOVE	R10	R3
+      0x5C2C0800,  //  001F  MOVE	R11	R4
+      0x7C1C0800,  //  0020  CALL	R7	4
+      0x7C140400,  //  0021  CALL	R5	2
+      0x70020000,  //  0022  JMP		#0024
+      0xB0062D17,  //  0023  RAISE	1	K22	K23
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -645,7 +399,7 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
       0x541600FE,  //  0006  LDINT	R5	255
       0x541A0167,  //  0007  LDINT	R6	360
       0x10040206,  //  0008  MOD	R1	R1	R6
-      0x24180506,  //  0009  GT	R6	R2	K6
+      0x24180507,  //  0009  GT	R6	R2	K7
       0x781A0031,  //  000A  JMPF	R6	#003D
       0x541A003B,  //  000B  LDINT	R6	60
       0x0C180206,  //  000C  DIV	R6	R1	R6
@@ -653,38 +407,38 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
       0x101C0207,  //  000E  MOD	R7	R1	R7
       0x542200FE,  //  000F  LDINT	R8	255
       0x04201002,  //  0010  SUB	R8	R8	R2
-      0xB8265E00,  //  0011  GETNGBL	R9	K47
-      0x8C241332,  //  0012  GETMET	R9	R9	K50
+      0xB8263000,  //  0011  GETNGBL	R9	K24
+      0x8C241319,  //  0012  GETMET	R9	R9	K25
       0x5C2C0E00,  //  0013  MOVE	R11	R7
-      0x58300006,  //  0014  LDCONST	R12	K6
+      0x58300007,  //  0014  LDCONST	R12	K7
       0x5436003B,  //  0015  LDINT	R13	60
       0x543A00FE,  //  0016  LDINT	R14	255
       0x5C3C1000,  //  0017  MOVE	R15	R8
       0x7C240C00,  //  0018  CALL	R9	6
-      0xB82A5E00,  //  0019  GETNGBL	R10	K47
-      0x8C281532,  //  001A  GETMET	R10	R10	K50
+      0xB82A3000,  //  0019  GETNGBL	R10	K24
+      0x8C281519,  //  001A  GETMET	R10	R10	K25
       0x5C300E00,  //  001B  MOVE	R12	R7
-      0x58340006,  //  001C  LDCONST	R13	K6
+      0x58340007,  //  001C  LDCONST	R13	K7
       0x543A003B,  //  001D  LDINT	R14	60
       0x5C3C1000,  //  001E  MOVE	R15	R8
       0x544200FE,  //  001F  LDINT	R16	255
       0x7C280C00,  //  0020  CALL	R10	6
-      0x1C2C0D06,  //  0021  EQ	R11	R6	K6
+      0x1C2C0D07,  //  0021  EQ	R11	R6	K7
       0x782E0002,  //  0022  JMPF	R11	#0026
       0x5C141400,  //  0023  MOVE	R5	R10
       0x5C101000,  //  0024  MOVE	R4	R8
       0x70020016,  //  0025  JMP		#003D
-      0x1C2C0D0A,  //  0026  EQ	R11	R6	K10
+      0x1C2C0D0C,  //  0026  EQ	R11	R6	K12
       0x782E0002,  //  0027  JMPF	R11	#002B
       0x5C0C1200,  //  0028  MOVE	R3	R9
       0x5C101000,  //  0029  MOVE	R4	R8
       0x70020011,  //  002A  JMP		#003D
-      0x1C2C0D33,  //  002B  EQ	R11	R6	K51
+      0x1C2C0D1A,  //  002B  EQ	R11	R6	K26
       0x782E0002,  //  002C  JMPF	R11	#0030
       0x5C0C1000,  //  002D  MOVE	R3	R8
       0x5C101400,  //  002E  MOVE	R4	R10
       0x7002000C,  //  002F  JMP		#003D
-      0x1C2C0D25,  //  0030  EQ	R11	R6	K37
+      0x1C2C0D1B,  //  0030  EQ	R11	R6	K27
       0x782E0002,  //  0031  JMPF	R11	#0035
       0x5C0C1000,  //  0032  MOVE	R3	R8
       0x5C141200,  //  0033  MOVE	R5	R9
@@ -711,239 +465,6 @@ be_local_closure(class_Tasmota_hs2rgb,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_fast_loop
-********************************************************************/
-be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_remove_fast_loop,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080134,  //  0000  GETMBR	R2	R0	K52
-      0x740A0000,  //  0001  JMPT	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x88080134,  //  0003  GETMBR	R2	R0	K52
-      0x8C08051E,  //  0004  GETMET	R2	R2	K30
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x200C0403,  //  0008  NE	R3	R2	R3
-      0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C0134,  //  000A  GETMBR	R3	R0	K52
-      0x8C0C0735,  //  000B  GETMET	R3	R3	K53
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_rule
-********************************************************************/
-be_local_closure(class_Tasmota_add_rule,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_add_rule,
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x8C140136,  //  0000  GETMET	R5	R0	K54
-      0x5C1C0400,  //  0001  MOVE	R7	R2
-      0x7C140400,  //  0002  CALL	R5	2
-      0x88140120,  //  0003  GETMBR	R5	R0	K32
-      0x4C180000,  //  0004  LDNIL	R6
-      0x1C140A06,  //  0005  EQ	R5	R5	R6
-      0x78160002,  //  0006  JMPF	R5	#000A
-      0x60140012,  //  0007  GETGBL	R5	G18
-      0x7C140000,  //  0008  CALL	R5	0
-      0x90024005,  //  0009  SETMBR	R0	K32	R5
-      0x60140004,  //  000A  GETGBL	R5	G4
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x7C140200,  //  000C  CALL	R5	1
-      0x1C140B0C,  //  000D  EQ	R5	R5	K12
-      0x78160013,  //  000E  JMPF	R5	#0023
-      0x4C140000,  //  000F  LDNIL	R5
-      0x20140605,  //  0010  NE	R5	R3	R5
-      0x78160003,  //  0011  JMPF	R5	#0016
-      0x8C140137,  //  0012  GETMET	R5	R0	K55
-      0x5C1C0200,  //  0013  MOVE	R7	R1
-      0x5C200600,  //  0014  MOVE	R8	R3
-      0x7C140600,  //  0015  CALL	R5	3
-      0x88140120,  //  0016  GETMBR	R5	R0	K32
-      0x8C140B2E,  //  0017  GETMET	R5	R5	K46
-      0xB81E7000,  //  0018  GETNGBL	R7	K56
-      0x88200139,  //  0019  GETMBR	R8	R0	K57
-      0x8C20113A,  //  001A  GETMET	R8	R8	K58
-      0x5C280200,  //  001B  MOVE	R10	R1
-      0x7C200400,  //  001C  CALL	R8	2
-      0x5C240400,  //  001D  MOVE	R9	R2
-      0x5C280600,  //  001E  MOVE	R10	R3
-      0x5C2C0800,  //  001F  MOVE	R11	R4
-      0x7C1C0800,  //  0020  CALL	R7	4
-      0x7C140400,  //  0021  CALL	R5	2
-      0x70020000,  //  0022  JMP		#0024
-      0xB006773C,  //  0023  RAISE	1	K59	K60
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Tasmota_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str(urlfetch_cmd),
-        }),
-        &be_const_str__anonymous_,
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80000000,  //  0007  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0xB8067A00,  //  0000  GETNGBL	R1	K61
-      0x8808013E,  //  0001  GETMBR	R2	R0	K62
-      0x880C013F,  //  0002  GETMBR	R3	R0	K63
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90026001,  //  0004  SETMBR	R0	K48	R1
-      0xA4061600,  //  0005  IMPORT	R1	K11
-      0x60080015,  //  0006  GETGBL	R2	G21
-      0x880C0140,  //  0007  GETMBR	R3	R0	K64
-      0x54120003,  //  0008  LDINT	R4	4
-      0x7C080400,  //  0009  CALL	R2	2
-      0x8C080541,  //  000A  GETMET	R2	R2	K65
-      0x58100006,  //  000B  LDCONST	R4	K6
-      0x54160003,  //  000C  LDINT	R5	4
-      0x7C080600,  //  000D  CALL	R2	3
-      0x780A0006,  //  000E  JMPF	R2	#0016
-      0xB80E7A00,  //  000F  GETNGBL	R3	K61
-      0x8C100343,  //  0010  GETMET	R4	R1	K67
-      0x5C180400,  //  0011  MOVE	R6	R2
-      0x7C100400,  //  0012  CALL	R4	2
-      0x88140144,  //  0013  GETMBR	R5	R0	K68
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x90028403,  //  0015  SETMBR	R0	K66	R3
-      0x90028B46,  //  0016  SETMBR	R0	K69	K70
-      0xB80E6000,  //  0017  GETNGBL	R3	K48
-      0x8C0C0748,  //  0018  GETMET	R3	R3	K72
-      0x58140049,  //  0019  LDCONST	R5	K73
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x90028E03,  //  001B  SETMBR	R0	K71	R3
-      0x8C0C014A,  //  001C  GETMET	R3	R0	K74
-      0x5814004B,  //  001D  LDCONST	R5	K75
-      0x84180000,  //  001E  CLOSURE	R6	P0
-      0x7C0C0600,  //  001F  CALL	R3	3
-      0xA0000000,  //  0020  CLOSE	R0
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_cron
-********************************************************************/
-be_local_closure(class_Tasmota_add_cron,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_add_cron,
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x8C100136,  //  0000  GETMET	R4	R0	K54
-      0x5C180400,  //  0001  MOVE	R6	R2
-      0x7C100400,  //  0002  CALL	R4	2
-      0x88100105,  //  0003  GETMBR	R4	R0	K5
-      0x4C140000,  //  0004  LDNIL	R5
-      0x1C100805,  //  0005  EQ	R4	R4	R5
-      0x78120002,  //  0006  JMPF	R4	#000A
-      0x60100012,  //  0007  GETGBL	R4	G18
-      0x7C100000,  //  0008  CALL	R4	0
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0xB8125200,  //  000A  GETNGBL	R4	K41
-      0x60140008,  //  000B  GETGBL	R5	G8
-      0x5C180200,  //  000C  MOVE	R6	R1
-      0x7C140200,  //  000D  CALL	R5	1
-      0x7C100200,  //  000E  CALL	R4	1
-      0x8C14092B,  //  000F  GETMET	R5	R4	K43
-      0x7C140200,  //  0010  CALL	R5	1
-      0x88180105,  //  0011  GETMBR	R6	R0	K5
-      0x8C180D2E,  //  0012  GETMET	R6	R6	K46
-      0xB8227000,  //  0013  GETNGBL	R8	K56
-      0x5C240A00,  //  0014  MOVE	R9	R5
-      0x5C280400,  //  0015  MOVE	R10	R2
-      0x5C2C0600,  //  0016  MOVE	R11	R3
-      0x5C300800,  //  0017  MOVE	R12	R4
-      0x7C200800,  //  0018  CALL	R8	4
-      0x7C180400,  //  0019  CALL	R6	2
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: set_timer
 ********************************************************************/
 be_local_closure(class_Tasmota_set_timer,   /* name */
@@ -960,20 +481,20 @@ be_local_closure(class_Tasmota_set_timer,   /* name */
     &be_const_str_set_timer,
     &be_const_str_solidified,
     ( &(const binstruction[21]) {  /* code */
-      0x8C100136,  //  0000  GETMET	R4	R0	K54
+      0x8C100100,  //  0000  GETMET	R4	R0	K0
       0x5C180400,  //  0001  MOVE	R6	R2
       0x7C100400,  //  0002  CALL	R4	2
-      0x8810014C,  //  0003  GETMBR	R4	R0	K76
+      0x8810011C,  //  0003  GETMBR	R4	R0	K28
       0x4C140000,  //  0004  LDNIL	R5
       0x1C100805,  //  0005  EQ	R4	R4	R5
       0x78120002,  //  0006  JMPF	R4	#000A
       0x60100012,  //  0007  GETGBL	R4	G18
       0x7C100000,  //  0008  CALL	R4	0
-      0x90029804,  //  0009  SETMBR	R0	K76	R4
-      0x8810014C,  //  000A  GETMBR	R4	R0	K76
-      0x8C10092E,  //  000B  GETMET	R4	R4	K46
-      0xB81A7000,  //  000C  GETNGBL	R6	K56
-      0x8C1C014D,  //  000D  GETMET	R7	R0	K77
+      0x90023804,  //  0009  SETMBR	R0	K28	R4
+      0x8810011C,  //  000A  GETMBR	R4	R0	K28
+      0x8C100904,  //  000B  GETMET	R4	R4	K4
+      0xB81A0A00,  //  000C  GETNGBL	R6	K5
+      0x8C1C011D,  //  000D  GETMET	R7	R0	K29
       0x5C240200,  //  000E  MOVE	R9	R1
       0x7C1C0400,  //  000F  CALL	R7	2
       0x5C200400,  //  0010  MOVE	R8	R2
@@ -988,12 +509,12 @@ be_local_closure(class_Tasmota_set_timer,   /* name */
 
 
 /********************************************************************
-** Solidified function: urlfetch
+** Solidified function: exec_cmd
 ********************************************************************/
-be_local_closure(class_Tasmota_urlfetch,   /* name */
+be_local_closure(class_Tasmota_exec_cmd,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
+    12,                          /* nstack */
+    4,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1001,57 +522,36 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_urlfetch,
+    &be_const_str_exec_cmd,
     &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E000D,  //  0002  JMPF	R3	#0011
-      0xA40E2200,  //  0003  IMPORT	R3	K17
-      0x8C10074E,  //  0004  GETMET	R4	R3	K78
-      0x5C180200,  //  0005  MOVE	R6	R1
-      0x581C004F,  //  0006  LDCONST	R7	K79
-      0x7C100600,  //  0007  CALL	R4	3
-      0x8C10091F,  //  0008  GETMET	R4	R4	K31
-      0x7C100200,  //  0009  CALL	R4	1
-      0x5C080800,  //  000A  MOVE	R2	R4
-      0x6010000C,  //  000B  GETGBL	R4	G12
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x7C100200,  //  000D  CALL	R4	1
-      0x1C100906,  //  000E  EQ	R4	R4	K6
-      0x78120000,  //  000F  JMPF	R4	#0011
-      0x58080050,  //  0010  LDCONST	R2	K80
-      0xB80EA200,  //  0011  GETNGBL	R3	K81
-      0x7C0C0000,  //  0012  CALL	R3	0
-      0x8C100752,  //  0013  GETMET	R4	R3	K82
-      0x50180200,  //  0014  LDBOOL	R6	1	0
-      0x7C100400,  //  0015  CALL	R4	2
-      0x8C100753,  //  0016  GETMET	R4	R3	K83
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x7C100400,  //  0018  CALL	R4	2
-      0x8C100754,  //  0019  GETMET	R4	R3	K84
-      0x7C100200,  //  001A  CALL	R4	1
-      0x541600C7,  //  001B  LDINT	R5	200
-      0x20140805,  //  001C  NE	R5	R4	R5
-      0x78160004,  //  001D  JMPF	R5	#0023
-      0x60140008,  //  001E  GETGBL	R5	G8
-      0x5C180800,  //  001F  MOVE	R6	R4
-      0x7C140200,  //  0020  CALL	R5	1
-      0x0016AA05,  //  0021  ADD	R5	K85	R5
-      0xB006AC05,  //  0022  RAISE	1	K86	R5
-      0x8C140757,  //  0023  GETMET	R5	R3	K87
-      0x5C1C0400,  //  0024  MOVE	R7	R2
-      0x7C140400,  //  0025  CALL	R5	2
-      0x8C180758,  //  0026  GETMET	R6	R3	K88
-      0x7C180200,  //  0027  CALL	R6	1
-      0x8C180123,  //  0028  GETMET	R6	R0	K35
-      0x60200008,  //  0029  GETGBL	R8	G8
-      0x5C240A00,  //  002A  MOVE	R9	R5
-      0x7C200200,  //  002B  CALL	R8	1
-      0x0022B208,  //  002C  ADD	R8	K89	R8
-      0x58240025,  //  002D  LDCONST	R9	K37
-      0x7C180600,  //  002E  CALL	R6	3
-      0x80040800,  //  002F  RET	1	R4
+    ( &(const binstruction[27]) {  /* code */
+      0x8810011E,  //  0000  GETMBR	R4	R0	K30
+      0x78120016,  //  0001  JMPF	R4	#0019
+      0xA4123E00,  //  0002  IMPORT	R4	K31
+      0x8C140920,  //  0003  GETMET	R5	R4	K32
+      0x5C1C0600,  //  0004  MOVE	R7	R3
+      0x7C140400,  //  0005  CALL	R5	2
+      0x8C180121,  //  0006  GETMET	R6	R0	K33
+      0x8820011E,  //  0007  GETMBR	R8	R0	K30
+      0x5C240200,  //  0008  MOVE	R9	R1
+      0x7C180600,  //  0009  CALL	R6	3
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x201C0C07,  //  000B  NE	R7	R6	R7
+      0x781E000B,  //  000C  JMPF	R7	#0019
+      0x8C1C0122,  //  000D  GETMET	R7	R0	K34
+      0x5C240C00,  //  000E  MOVE	R9	R6
+      0x7C1C0400,  //  000F  CALL	R7	2
+      0x881C011E,  //  0010  GETMBR	R7	R0	K30
+      0x941C0E06,  //  0011  GETIDX	R7	R7	R6
+      0x5C200C00,  //  0012  MOVE	R8	R6
+      0x5C240400,  //  0013  MOVE	R9	R2
+      0x5C280600,  //  0014  MOVE	R10	R3
+      0x5C2C0A00,  //  0015  MOVE	R11	R5
+      0x7C1C0800,  //  0016  CALL	R7	4
+      0x501C0200,  //  0017  LDBOOL	R7	1	0
+      0x80040E00,  //  0018  RET	1	R7
+      0x50100000,  //  0019  LDBOOL	R4	0	0
+      0x80040800,  //  001A  RET	1	R4
     })
   )
 );
@@ -1059,11 +559,154 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_rule
+** Solidified function: when_network_up
 ********************************************************************/
-be_local_closure(class_Tasmota_remove_rule,   /* name */
+be_local_closure(class_Tasmota_when_network_up,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_when_network_up,
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0xB80A3000,  //  0003  GETNGBL	R2	K24
+      0x8C080523,  //  0004  GETMET	R2	R2	K35
+      0x7C080200,  //  0005  CALL	R2	1
+      0x94080524,  //  0006  GETIDX	R2	R2	K36
+      0x740A0005,  //  0007  JMPT	R2	#000E
+      0xB80A3000,  //  0008  GETNGBL	R2	K24
+      0x8C080525,  //  0009  GETMET	R2	R2	K37
+      0x7C080200,  //  000A  CALL	R2	1
+      0x94080524,  //  000B  GETIDX	R2	R2	K36
+      0x740A0000,  //  000C  JMPT	R2	#000E
+      0x50080001,  //  000D  LDBOOL	R2	0	1
+      0x50080200,  //  000E  LDBOOL	R2	1	0
+      0x780A0002,  //  000F  JMPF	R2	#0013
+      0x5C0C0200,  //  0010  MOVE	R3	R1
+      0x7C0C0000,  //  0011  CALL	R3	0
+      0x7002000C,  //  0012  JMP		#0020
+      0x880C0126,  //  0013  GETMBR	R3	R0	K38
+      0x4C100000,  //  0014  LDNIL	R4
+      0x1C0C0604,  //  0015  EQ	R3	R3	R4
+      0x780E0004,  //  0016  JMPF	R3	#001C
+      0x600C0012,  //  0017  GETGBL	R3	G18
+      0x7C0C0000,  //  0018  CALL	R3	0
+      0x40100601,  //  0019  CONNECT	R4	R3	R1
+      0x90024C03,  //  001A  SETMBR	R0	K38	R3
+      0x70020003,  //  001B  JMP		#0020
+      0x880C0126,  //  001C  GETMBR	R3	R0	K38
+      0x8C0C0704,  //  001D  GETMET	R3	R3	K4
+      0x5C140200,  //  001E  MOVE	R5	R1
+      0x7C0C0400,  //  001F  CALL	R3	2
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: run_deferred
+********************************************************************/
+be_local_closure(class_Tasmota_run_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_run_deferred,
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x88040127,  //  0000  GETMBR	R1	R0	K39
+      0x78060016,  //  0001  JMPF	R1	#0019
+      0x6004000C,  //  0002  GETGBL	R1	G12
+      0x88080127,  //  0003  GETMBR	R2	R0	K39
+      0x7C040200,  //  0004  CALL	R1	1
+      0x24080307,  //  0005  GT	R2	R1	K7
+      0x780A0009,  //  0006  JMPF	R2	#0011
+      0x88080127,  //  0007  GETMBR	R2	R0	K39
+      0x94080507,  //  0008  GETIDX	R2	R2	K7
+      0x880C0127,  //  0009  GETMBR	R3	R0	K39
+      0x8C0C070B,  //  000A  GETMET	R3	R3	K11
+      0x58140007,  //  000B  LDCONST	R5	K7
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x0404030C,  //  000D  SUB	R1	R1	K12
+      0x5C0C0400,  //  000E  MOVE	R3	R2
+      0x7C0C0000,  //  000F  CALL	R3	0
+      0x7001FFF3,  //  0010  JMP		#0005
+      0x6008000C,  //  0011  GETGBL	R2	G12
+      0x880C0127,  //  0012  GETMBR	R3	R0	K39
+      0x7C080200,  //  0013  CALL	R2	1
+      0x1C080507,  //  0014  EQ	R2	R2	K7
+      0x780A0002,  //  0015  JMPF	R2	#0019
+      0xB80A3000,  //  0016  GETNGBL	R2	K24
+      0x88080528,  //  0017  GETMBR	R2	R2	K40
+      0x900A5307,  //  0018  SETMBR	R2	K41	K7
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fast_loop
+********************************************************************/
+be_local_closure(class_Tasmota_fast_loop,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_fast_loop,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8804012A,  //  0000  GETMBR	R1	R0	K42
+      0x5C080200,  //  0001  MOVE	R2	R1
+      0x740A0000,  //  0002  JMPT	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x58080007,  //  0004  LDCONST	R2	K7
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x940C0202,  //  000A  GETIDX	R3	R1	R2
+      0x7C0C0000,  //  000B  CALL	R3	0
+      0x0008050C,  //  000C  ADD	R2	R2	K12
+      0x7001FFF6,  //  000D  JMP		#0005
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: cmd
+********************************************************************/
+be_local_closure(class_Tasmota_cmd,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1072,36 +715,114 @@ be_local_closure(class_Tasmota_remove_rule,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_remove_rule,
+    &be_const_str_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x880C0120,  //  0000  GETMBR	R3	R0	K32
-      0x780E0017,  //  0001  JMPF	R3	#001A
-      0x580C0006,  //  0002  LDCONST	R3	K6
-      0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140120,  //  0004  GETMBR	R5	R0	K32
-      0x7C100200,  //  0005  CALL	R4	1
-      0x14100604,  //  0006  LT	R4	R3	R4
-      0x78120011,  //  0007  JMPF	R4	#001A
-      0x88100120,  //  0008  GETMBR	R4	R0	K32
-      0x94100803,  //  0009  GETIDX	R4	R4	R3
-      0x88100909,  //  000A  GETMBR	R4	R4	K9
-      0x8810095A,  //  000B  GETMBR	R4	R4	K90
-      0x1C100801,  //  000C  EQ	R4	R4	R1
-      0x78120009,  //  000D  JMPF	R4	#0018
-      0x88100120,  //  000E  GETMBR	R4	R0	K32
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x88100908,  //  0010  GETMBR	R4	R4	K8
-      0x1C100802,  //  0011  EQ	R4	R4	R2
-      0x78120004,  //  0012  JMPF	R4	#0018
-      0x88100120,  //  0013  GETMBR	R4	R0	K32
-      0x8C100935,  //  0014  GETMET	R4	R4	K53
-      0x5C180600,  //  0015  MOVE	R6	R3
-      0x7C100400,  //  0016  CALL	R4	2
-      0x70020000,  //  0017  JMP		#0019
-      0x000C070A,  //  0018  ADD	R3	R3	K10
-      0x7001FFE8,  //  0019  JMP		#0003
-      0x80000000,  //  001A  RET	0
+      0x880C012B,  //  0000  GETMBR	R3	R0	K43
+      0x50100200,  //  0001  LDBOOL	R4	1	0
+      0x90025604,  //  0002  SETMBR	R0	K43	R4
+      0xB8123000,  //  0003  GETNGBL	R4	K24
+      0x88100928,  //  0004  GETMBR	R4	R4	K40
+      0x8810092C,  //  0005  GETMBR	R4	R4	K44
+      0x780A0004,  //  0006  JMPF	R2	#000C
+      0x2814091A,  //  0007  GE	R5	R4	K26
+      0x78160002,  //  0008  JMPF	R5	#000C
+      0xB8163000,  //  0009  GETNGBL	R5	K24
+      0x88140B28,  //  000A  GETMBR	R5	R5	K40
+      0x9016590C,  //  000B  SETMBR	R5	K44	K12
+      0x8C14012D,  //  000C  GETMET	R5	R0	K45
+      0x5C1C0200,  //  000D  MOVE	R7	R1
+      0x7C140400,  //  000E  CALL	R5	2
+      0x4C140000,  //  000F  LDNIL	R5
+      0x8818012B,  //  0010  GETMBR	R6	R0	K43
+      0x501C0200,  //  0011  LDBOOL	R7	1	0
+      0x20180C07,  //  0012  NE	R6	R6	R7
+      0x781A0000,  //  0013  JMPF	R6	#0015
+      0x8814012B,  //  0014  GETMBR	R5	R0	K43
+      0x90025603,  //  0015  SETMBR	R0	K43	R3
+      0x780A0002,  //  0016  JMPF	R2	#001A
+      0xB81A3000,  //  0017  GETNGBL	R6	K24
+      0x88180D28,  //  0018  GETMBR	R6	R6	K40
+      0x901A5804,  //  0019  SETMBR	R6	K44	R4
+      0x80040A00,  //  001A  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: next_cron
+********************************************************************/
+be_local_closure(class_Tasmota_next_cron,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_next_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x780A000D,  //  0001  JMPF	R2	#0010
+      0x580C0007,  //  0002  LDCONST	R3	K7
+      0x8C10052E,  //  0003  GETMET	R4	R2	K46
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100403,  //  0007  GETIDX	R4	R2	R3
+      0x8810090A,  //  0008  GETMBR	R4	R4	K10
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120002,  //  000A  JMPF	R4	#000E
+      0x94100403,  //  000B  GETIDX	R4	R2	R3
+      0x88100908,  //  000C  GETMBR	R4	R4	K8
+      0x80040800,  //  000D  RET	1	R4
+      0x000C070C,  //  000E  ADD	R3	R3	K12
+      0x7001FFF2,  //  000F  JMP		#0003
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: defer
+********************************************************************/
+be_local_closure(class_Tasmota_defer,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_defer,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080127,  //  0000  GETMBR	R2	R0	K39
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x780A0002,  //  0003  JMPF	R2	#0007
+      0x60080012,  //  0004  GETGBL	R2	G18
+      0x7C080000,  //  0005  CALL	R2	0
+      0x90024E02,  //  0006  SETMBR	R0	K39	R2
+      0x88080127,  //  0007  GETMBR	R2	R0	K39
+      0x8C080504,  //  0008  GETMET	R2	R2	K4
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0xB80A3000,  //  000B  GETNGBL	R2	K24
+      0x88080528,  //  000C  GETMBR	R2	R2	K40
+      0x900A530C,  //  000D  SETMBR	R2	K41	K12
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -1128,27 +849,27 @@ be_local_closure(class_Tasmota_add_driver,   /* name */
       0x60080004,  //  0000  GETGBL	R2	G4
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
-      0x2008055B,  //  0003  NE	R2	R2	K91
+      0x2008052F,  //  0003  NE	R2	R2	K47
       0x780A0000,  //  0004  JMPF	R2	#0006
-      0xB006775C,  //  0005  RAISE	1	K59	K92
-      0x8808011D,  //  0006  GETMBR	R2	R0	K29
+      0xB0062D30,  //  0005  RAISE	1	K22	K48
+      0x88080131,  //  0006  GETMBR	R2	R0	K49
       0x780A000B,  //  0007  JMPF	R2	#0014
-      0x8808011D,  //  0008  GETMBR	R2	R0	K29
-      0x8C08051E,  //  0009  GETMET	R2	R2	K30
+      0x88080131,  //  0008  GETMBR	R2	R0	K49
+      0x8C080532,  //  0009  GETMET	R2	R2	K50
       0x5C100200,  //  000A  MOVE	R4	R1
       0x7C080400,  //  000B  CALL	R2	2
       0x4C0C0000,  //  000C  LDNIL	R3
       0x1C080403,  //  000D  EQ	R2	R2	R3
       0x780A0003,  //  000E  JMPF	R2	#0013
-      0x8808011D,  //  000F  GETMBR	R2	R0	K29
-      0x8C08052E,  //  0010  GETMET	R2	R2	K46
+      0x88080131,  //  000F  GETMBR	R2	R0	K49
+      0x8C080504,  //  0010  GETMET	R2	R2	K4
       0x5C100200,  //  0011  MOVE	R4	R1
       0x7C080400,  //  0012  CALL	R2	2
       0x70020003,  //  0013  JMP		#0018
       0x60080012,  //  0014  GETGBL	R2	G18
       0x7C080000,  //  0015  CALL	R2	0
       0x400C0401,  //  0016  CONNECT	R3	R2	R1
-      0x90023A02,  //  0017  SETMBR	R0	K29	R2
+      0x90026202,  //  0017  SETMBR	R0	K49	R2
       0x80000000,  //  0018  RET	0
     })
   )
@@ -1157,12 +878,12 @@ be_local_closure(class_Tasmota_add_driver,   /* name */
 
 
 /********************************************************************
-** Solidified function: exec_rules
+** Solidified function: remove_timer
 ********************************************************************/
-be_local_closure(class_Tasmota_exec_rules,   /* name */
+be_local_closure(class_Tasmota_remove_timer,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
-    3,                          /* argc */
+    7,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1170,69 +891,56 @@ be_local_closure(class_Tasmota_exec_rules,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_exec_rules,
+    &be_const_str_remove_timer,
     &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
-      0x880C015D,  //  0000  GETMBR	R3	R0	K93
-      0x88100120,  //  0001  GETMBR	R4	R0	K32
-      0x74120002,  //  0002  JMPT	R4	#0006
-      0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120033,  //  0005  JMPF	R4	#003A
-      0xA4124200,  //  0006  IMPORT	R4	K33
-      0x4C140000,  //  0007  LDNIL	R5
-      0x9002BA05,  //  0008  SETMBR	R0	K93	R5
-      0x50140000,  //  0009  LDBOOL	R5	0	0
-      0x8C180922,  //  000A  GETMET	R6	R4	K34
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x7C180400,  //  000C  CALL	R6	2
-      0x4C1C0000,  //  000D  LDNIL	R7
-      0x1C1C0C07,  //  000E  EQ	R7	R6	R7
-      0x781E0004,  //  000F  JMPF	R7	#0015
-      0x8C1C0123,  //  0010  GETMET	R7	R0	K35
-      0x00264801,  //  0011  ADD	R9	K36	R1
-      0x58280025,  //  0012  LDCONST	R10	K37
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x5C180200,  //  0014  MOVE	R6	R1
-      0x780A001E,  //  0015  JMPF	R2	#0035
-      0x881C0120,  //  0016  GETMBR	R7	R0	K32
-      0x781E001C,  //  0017  JMPF	R7	#0035
-      0x581C0006,  //  0018  LDCONST	R7	K6
-      0x6020000C,  //  0019  GETGBL	R8	G12
-      0x88240120,  //  001A  GETMBR	R9	R0	K32
-      0x7C200200,  //  001B  CALL	R8	1
-      0x14200E08,  //  001C  LT	R8	R7	R8
-      0x78220016,  //  001D  JMPF	R8	#0035
-      0x88200120,  //  001E  GETMBR	R8	R0	K32
-      0x94201007,  //  001F  GETIDX	R8	R8	R7
-      0x8C240127,  //  0020  GETMET	R9	R0	K39
-      0x5C2C0C00,  //  0021  MOVE	R11	R6
-      0x88301109,  //  0022  GETMBR	R12	R8	K9
-      0x88341128,  //  0023  GETMBR	R13	R8	K40
-      0x7C240800,  //  0024  CALL	R9	4
-      0x74160001,  //  0025  JMPT	R5	#0028
-      0x74260000,  //  0026  JMPT	R9	#0028
-      0x50140001,  //  0027  LDBOOL	R5	0	1
-      0x50140200,  //  0028  LDBOOL	R5	1	0
-      0x78260008,  //  0029  JMPF	R9	#0033
-      0x8828115E,  //  002A  GETMBR	R10	R8	K94
-      0x502C0200,  //  002B  LDBOOL	R11	1	0
-      0x1C28140B,  //  002C  EQ	R10	R10	R11
-      0x782A0004,  //  002D  JMPF	R10	#0033
-      0x88280120,  //  002E  GETMBR	R10	R0	K32
-      0x8C281535,  //  002F  GETMET	R10	R10	K53
-      0x5C300E00,  //  0030  MOVE	R12	R7
-      0x7C280400,  //  0031  CALL	R10	2
-      0x70020000,  //  0032  JMP		#0034
-      0x001C0F0A,  //  0033  ADD	R7	R7	K10
-      0x7001FFE3,  //  0034  JMP		#0019
-      0x4C1C0000,  //  0035  LDNIL	R7
-      0x201C0607,  //  0036  NE	R7	R3	R7
-      0x781E0000,  //  0037  JMPF	R7	#0039
-      0x9002BA06,  //  0038  SETMBR	R0	K93	R6
-      0x80040A00,  //  0039  RET	1	R5
-      0x50100000,  //  003A  LDBOOL	R4	0	0
-      0x80040800,  //  003B  RET	1	R4
+    ( &(const binstruction[18]) {  /* code */
+      0x8808011C,  //  0000  GETMBR	R2	R0	K28
+      0x780A000E,  //  0001  JMPF	R2	#0011
+      0x580C0007,  //  0002  LDCONST	R3	K7
+      0x8C10052E,  //  0003  GETMET	R4	R2	K46
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0x94100403,  //  0007  GETIDX	R4	R2	R3
+      0x8810090A,  //  0008  GETMBR	R4	R4	K10
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120003,  //  000A  JMPF	R4	#000F
+      0x8C10050B,  //  000B  GETMET	R4	R2	K11
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x7C100400,  //  000D  CALL	R4	2
+      0x70020000,  //  000E  JMP		#0010
+      0x000C070C,  //  000F  ADD	R3	R3	K12
+      0x7001FFF1,  //  0010  JMP		#0003
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: gc
+********************************************************************/
+be_local_closure(class_Tasmota_gc,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_gc,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA4066600,  //  0000  IMPORT	R1	K51
+      0x8C080334,  //  0001  GETMET	R2	R1	K52
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080335,  //  0003  GETMET	R2	R1	K53
+      0x7C080200,  //  0004  CALL	R2	1
+      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
@@ -1256,7 +964,7 @@ be_local_closure(class_Tasmota_int,   /* name */
     &be_const_str_int,
     &be_const_str_solidified,
     ( &(const binstruction[46]) {  /* code */
-      0x580C005F,  //  0000  LDCONST	R3	K95
+      0x580C0036,  //  0000  LDCONST	R3	K54
       0x60100009,  //  0001  GETGBL	R4	G9
       0x5C140000,  //  0002  MOVE	R5	R0
       0x7C100200,  //  0003  CALL	R4	1
@@ -1309,41 +1017,12 @@ be_local_closure(class_Tasmota_int,   /* name */
 
 
 /********************************************************************
-** Solidified function: gc
+** Solidified function: wire_scan
 ********************************************************************/
-be_local_closure(class_Tasmota_gc,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_gc,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xA406C000,  //  0000  IMPORT	R1	K96
-      0x8C080361,  //  0001  GETMET	R2	R1	K97
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080362,  //  0003  GETMET	R2	R1	K98
-      0x7C080200,  //  0004  CALL	R2	1
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: run_deferred
-********************************************************************/
-be_local_closure(class_Tasmota_run_deferred,   /* name */
+be_local_closure(class_Tasmota_wire_scan,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    1,                          /* argc */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1351,35 +1030,42 @@ be_local_closure(class_Tasmota_run_deferred,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_run_deferred,
+    &be_const_str_wire_scan,
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x8804012D,  //  0000  GETMBR	R1	R0	K45
-      0x78060016,  //  0001  JMPF	R1	#0019
-      0x6004000C,  //  0002  GETGBL	R1	G12
-      0x8808012D,  //  0003  GETMBR	R2	R0	K45
-      0x7C040200,  //  0004  CALL	R1	1
-      0x24080306,  //  0005  GT	R2	R1	K6
-      0x780A0009,  //  0006  JMPF	R2	#0011
-      0x8808012D,  //  0007  GETMBR	R2	R0	K45
-      0x94080506,  //  0008  GETIDX	R2	R2	K6
-      0x880C012D,  //  0009  GETMBR	R3	R0	K45
-      0x8C0C0735,  //  000A  GETMET	R3	R3	K53
-      0x58140006,  //  000B  LDCONST	R5	K6
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x0404030A,  //  000D  SUB	R1	R1	K10
-      0x5C0C0400,  //  000E  MOVE	R3	R2
-      0x7C0C0000,  //  000F  CALL	R3	0
-      0x7001FFF3,  //  0010  JMP		#0005
-      0x6008000C,  //  0011  GETGBL	R2	G12
-      0x880C012D,  //  0012  GETMBR	R3	R0	K45
-      0x7C080200,  //  0013  CALL	R2	1
-      0x1C080506,  //  0014  EQ	R2	R2	K6
-      0x780A0002,  //  0015  JMPF	R2	#0019
-      0xB80A5E00,  //  0016  GETNGBL	R2	K47
-      0x88080530,  //  0017  GETMBR	R2	R2	K48
-      0x900A6306,  //  0018  SETMBR	R2	K49	K6
-      0x80000000,  //  0019  RET	0
+    ( &(const binstruction[33]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0005,  //  0002  JMPF	R3	#0009
+      0x8C0C0137,  //  0003  GETMET	R3	R0	K55
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x740E0001,  //  0006  JMPT	R3	#0009
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x80040600,  //  0008  RET	1	R3
+      0x880C0138,  //  0009  GETMBR	R3	R0	K56
+      0x8C0C0739,  //  000A  GETMET	R3	R3	K57
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x880C0138,  //  000D  GETMBR	R3	R0	K56
+      0x8C0C073A,  //  000E  GETMET	R3	R3	K58
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x780E0001,  //  0011  JMPF	R3	#0014
+      0x880C0138,  //  0012  GETMBR	R3	R0	K56
+      0x80040600,  //  0013  RET	1	R3
+      0x880C013B,  //  0014  GETMBR	R3	R0	K59
+      0x8C0C0739,  //  0015  GETMET	R3	R3	K57
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0x780E0006,  //  0017  JMPF	R3	#001F
+      0x880C013B,  //  0018  GETMBR	R3	R0	K59
+      0x8C0C073A,  //  0019  GETMET	R3	R3	K58
+      0x5C140200,  //  001A  MOVE	R5	R1
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x780E0001,  //  001C  JMPF	R3	#001F
+      0x880C013B,  //  001D  GETMBR	R3	R0	K59
+      0x80040600,  //  001E  RET	1	R3
+      0x4C0C0000,  //  001F  LDNIL	R3
+      0x80040600,  //  0020  RET	1	R3
     })
   )
 );
@@ -1387,12 +1073,12 @@ be_local_closure(class_Tasmota_run_deferred,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_rule_once
+** Solidified function: remove_fast_loop
 ********************************************************************/
-be_local_closure(class_Tasmota_add_rule_once,   /* name */
+be_local_closure(class_Tasmota_remove_fast_loop,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1400,16 +1086,97 @@ be_local_closure(class_Tasmota_add_rule_once,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_add_rule_once,
+    &be_const_str_remove_fast_loop,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8808012A,  //  0000  GETMBR	R2	R0	K42
+      0x740A0000,  //  0001  JMPT	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x8808012A,  //  0003  GETMBR	R2	R0	K42
+      0x8C080532,  //  0004  GETMET	R2	R2	K50
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x200C0403,  //  0008  NE	R3	R2	R3
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x880C012A,  //  000A  GETMBR	R3	R0	K42
+      0x8C0C070B,  //  000B  GETMET	R3	R3	K11
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_cmd
+********************************************************************/
+be_local_closure(class_Tasmota_remove_cmd,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_remove_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8C100163,  //  0000  GETMET	R4	R0	K99
-      0x5C180200,  //  0001  MOVE	R6	R1
-      0x5C1C0400,  //  0002  MOVE	R7	R2
-      0x5C200600,  //  0003  MOVE	R8	R3
-      0x50240200,  //  0004  LDBOOL	R9	1	0
-      0x7C100A00,  //  0005  CALL	R4	5
+      0x8808011E,  //  0000  GETMBR	R2	R0	K30
+      0x780A0003,  //  0001  JMPF	R2	#0006
+      0x8808011E,  //  0002  GETMBR	R2	R0	K30
+      0x8C08050B,  //  0003  GETMET	R2	R2	K11
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
       0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_list_i
+********************************************************************/
+be_local_closure(class_Tasmota_find_list_i,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_find_list_i,
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0xA40E7800,  //  0000  IMPORT	R3	K60
+      0x58100007,  //  0001  LDCONST	R4	K7
+      0x8C14073D,  //  0002  GETMET	R5	R3	K61
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x7C140400,  //  0004  CALL	R5	2
+      0x6018000C,  //  0005  GETGBL	R6	G12
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x7C180200,  //  0007  CALL	R6	1
+      0x14180806,  //  0008  LT	R6	R4	R6
+      0x781A0007,  //  0009  JMPF	R6	#0012
+      0x8C18073D,  //  000A  GETMET	R6	R3	K61
+      0x94200204,  //  000B  GETIDX	R8	R1	R4
+      0x7C180400,  //  000C  CALL	R6	2
+      0x1C180C05,  //  000D  EQ	R6	R6	R5
+      0x781A0000,  //  000E  JMPF	R6	#0010
+      0x80040800,  //  000F  RET	1	R4
+      0x0010090C,  //  0010  ADD	R4	R4	K12
+      0x7001FFF2,  //  0011  JMP		#0005
+      0x4C180000,  //  0012  LDNIL	R6
+      0x80040C00,  //  0013  RET	1	R6
     })
   )
 );
@@ -1433,381 +1200,24 @@ be_local_closure(class_Tasmota_remove_cron,   /* name */
     &be_const_str_remove_cron,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88080105,  //  0000  GETMBR	R2	R0	K5
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
       0x780A000E,  //  0001  JMPF	R2	#0011
-      0x580C0006,  //  0002  LDCONST	R3	K6
-      0x8C100507,  //  0003  GETMET	R4	R2	K7
+      0x580C0007,  //  0002  LDCONST	R3	K7
+      0x8C10052E,  //  0003  GETMET	R4	R2	K46
       0x7C100200,  //  0004  CALL	R4	1
       0x14100604,  //  0005  LT	R4	R3	R4
       0x78120009,  //  0006  JMPF	R4	#0011
       0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100908,  //  0008  GETMBR	R4	R4	K8
+      0x8810090A,  //  0008  GETMBR	R4	R4	K10
       0x1C100801,  //  0009  EQ	R4	R4	R1
       0x78120003,  //  000A  JMPF	R4	#000F
-      0x8C100535,  //  000B  GETMET	R4	R2	K53
+      0x8C10050B,  //  000B  GETMET	R4	R2	K11
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
       0x70020000,  //  000E  JMP		#0010
-      0x000C070A,  //  000F  ADD	R3	R3	K10
+      0x000C070C,  //  000F  ADD	R3	R3	K12
       0x7001FFF1,  //  0010  JMP		#0003
       0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fast_loop
-********************************************************************/
-be_local_closure(class_Tasmota_fast_loop,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_fast_loop,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88040134,  //  0000  GETMBR	R1	R0	K52
-      0x5C080200,  //  0001  MOVE	R2	R1
-      0x740A0000,  //  0002  JMPT	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x58080006,  //  0004  LDCONST	R2	K6
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x140C0403,  //  0008  LT	R3	R2	R3
-      0x780E0003,  //  0009  JMPF	R3	#000E
-      0x940C0202,  //  000A  GETIDX	R3	R1	R2
-      0x7C0C0000,  //  000B  CALL	R3	0
-      0x0008050A,  //  000C  ADD	R2	R2	K10
-      0x7001FFF6,  //  000D  JMP		#0005
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event
-********************************************************************/
-be_local_closure(class_Tasmota_event,   /* name */
-  be_nested_proto(
-    19,                          /* nstack */
-    6,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_event,
-    &be_const_str_solidified,
-    ( &(const binstruction[108]) {  /* code */
-      0xA41A1600,  //  0000  IMPORT	R6	K11
-      0x1C1C0364,  //  0001  EQ	R7	R1	K100
-      0x781E0001,  //  0002  JMPF	R7	#0005
-      0x8C1C0165,  //  0003  GETMET	R7	R0	K101
-      0x7C1C0200,  //  0004  CALL	R7	1
-      0x1C1C0366,  //  0005  EQ	R7	R1	K102
-      0x781E0001,  //  0006  JMPF	R7	#0009
-      0x8C1C0167,  //  0007  GETMET	R7	R0	K103
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x501C0000,  //  0009  LDBOOL	R7	0	0
-      0x50200000,  //  000A  LDBOOL	R8	0	0
-      0x1C240368,  //  000B  EQ	R9	R1	K104
-      0x78260000,  //  000C  JMPF	R9	#000E
-      0x50200200,  //  000D  LDBOOL	R8	1	0
-      0x1C240369,  //  000E  EQ	R9	R1	K105
-      0x78260006,  //  000F  JMPF	R9	#0017
-      0x8C24016A,  //  0010  GETMET	R9	R0	K106
-      0x5C2C0400,  //  0011  MOVE	R11	R2
-      0x5C300600,  //  0012  MOVE	R12	R3
-      0x5C340800,  //  0013  MOVE	R13	R4
-      0x7C240800,  //  0014  CALL	R9	4
-      0x80041200,  //  0015  RET	1	R9
-      0x7002004E,  //  0016  JMP		#0066
-      0x1C24036B,  //  0017  EQ	R9	R1	K107
-      0x78260004,  //  0018  JMPF	R9	#001E
-      0x8C24016C,  //  0019  GETMET	R9	R0	K108
-      0x5C2C0800,  //  001A  MOVE	R11	R4
-      0x7C240400,  //  001B  CALL	R9	2
-      0x80041200,  //  001C  RET	1	R9
-      0x70020047,  //  001D  JMP		#0066
-      0x1C24035A,  //  001E  EQ	R9	R1	K90
-      0x78260007,  //  001F  JMPF	R9	#0028
-      0x8C24016D,  //  0020  GETMET	R9	R0	K109
-      0x5C2C0800,  //  0021  MOVE	R11	R4
-      0x60300017,  //  0022  GETGBL	R12	G23
-      0x5C340600,  //  0023  MOVE	R13	R3
-      0x7C300200,  //  0024  CALL	R12	1
-      0x7C240600,  //  0025  CALL	R9	3
-      0x80041200,  //  0026  RET	1	R9
-      0x7002003D,  //  0027  JMP		#0066
-      0x1C240360,  //  0028  EQ	R9	R1	K96
-      0x78260003,  //  0029  JMPF	R9	#002E
-      0x8C240160,  //  002A  GETMET	R9	R0	K96
-      0x7C240200,  //  002B  CALL	R9	1
-      0x80041200,  //  002C  RET	1	R9
-      0x70020037,  //  002D  JMP		#0066
-      0x8824011D,  //  002E  GETMBR	R9	R0	K29
-      0x78260035,  //  002F  JMPF	R9	#0066
-      0x58240006,  //  0030  LDCONST	R9	K6
-      0x6028000C,  //  0031  GETGBL	R10	G12
-      0x882C011D,  //  0032  GETMBR	R11	R0	K29
-      0x7C280200,  //  0033  CALL	R10	1
-      0x1428120A,  //  0034  LT	R10	R9	R10
-      0x782A002F,  //  0035  JMPF	R10	#0066
-      0x8828011D,  //  0036  GETMBR	R10	R0	K29
-      0x94281409,  //  0037  GETIDX	R10	R10	R9
-      0x8C2C0D41,  //  0038  GETMET	R11	R6	K65
-      0x5C341400,  //  0039  MOVE	R13	R10
-      0x5C380200,  //  003A  MOVE	R14	R1
-      0x7C2C0600,  //  003B  CALL	R11	3
-      0x60300004,  //  003C  GETGBL	R12	G4
-      0x5C341600,  //  003D  MOVE	R13	R11
-      0x7C300200,  //  003E  CALL	R12	1
-      0x1C30190C,  //  003F  EQ	R12	R12	K12
-      0x78320022,  //  0040  JMPF	R12	#0064
-      0xA8020011,  //  0041  EXBLK	0	#0054
-      0x5C301600,  //  0042  MOVE	R12	R11
-      0x5C341400,  //  0043  MOVE	R13	R10
-      0x5C380400,  //  0044  MOVE	R14	R2
-      0x5C3C0600,  //  0045  MOVE	R15	R3
-      0x5C400800,  //  0046  MOVE	R16	R4
-      0x5C440A00,  //  0047  MOVE	R17	R5
-      0x7C300A00,  //  0048  CALL	R12	5
-      0x74320001,  //  0049  JMPT	R12	#004C
-      0x741E0000,  //  004A  JMPT	R7	#004C
-      0x501C0001,  //  004B  LDBOOL	R7	0	1
-      0x501C0200,  //  004C  LDBOOL	R7	1	0
-      0x781E0003,  //  004D  JMPF	R7	#0052
-      0x5C301000,  //  004E  MOVE	R12	R8
-      0x74320001,  //  004F  JMPT	R12	#0052
-      0xA8040001,  //  0050  EXBLK	1	1
-      0x70020013,  //  0051  JMP		#0066
-      0xA8040001,  //  0052  EXBLK	1	1
-      0x7002000F,  //  0053  JMP		#0064
-      0xAC300002,  //  0054  CATCH	R12	0	2
-      0x7002000C,  //  0055  JMP		#0063
-      0x60380001,  //  0056  GETGBL	R14	G1
-      0x603C0018,  //  0057  GETGBL	R15	G24
-      0x5840006E,  //  0058  LDCONST	R16	K110
-      0x5C441800,  //  0059  MOVE	R17	R12
-      0x5C481A00,  //  005A  MOVE	R18	R13
-      0x7C3C0600,  //  005B  CALL	R15	3
-      0x7C380200,  //  005C  CALL	R14	1
-      0x88380147,  //  005D  GETMBR	R14	R0	K71
-      0x783A0002,  //  005E  JMPF	R14	#0062
-      0xA43A9200,  //  005F  IMPORT	R14	K73
-      0x8C3C1D6F,  //  0060  GETMET	R15	R14	K111
-      0x7C3C0200,  //  0061  CALL	R15	1
-      0x70020000,  //  0062  JMP		#0064
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x0024130A,  //  0064  ADD	R9	R9	K10
-      0x7001FFCA,  //  0065  JMP		#0031
-      0x1C240370,  //  0066  EQ	R9	R1	K112
-      0x78260002,  //  0067  JMPF	R9	#006B
-      0xA426E200,  //  0068  IMPORT	R9	K113
-      0x8C281372,  //  0069  GETMET	R10	R9	K114
-      0x7C280200,  //  006A  CALL	R10	1
-      0x80040E00,  //  006B  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_key_i
-********************************************************************/
-be_local_closure(class_Tasmota_find_key_i,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_find_key_i,
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xA40E2200,  //  0000  IMPORT	R3	K17
-      0x8C100712,  //  0001  GETMET	R4	R3	K18
-      0x5C180400,  //  0002  MOVE	R6	R2
-      0x7C100400,  //  0003  CALL	R4	2
-      0x6014000F,  //  0004  GETGBL	R5	G15
-      0x5C180200,  //  0005  MOVE	R6	R1
-      0x601C0013,  //  0006  GETGBL	R7	G19
-      0x7C140400,  //  0007  CALL	R5	2
-      0x78160013,  //  0008  JMPF	R5	#001D
-      0x60140010,  //  0009  GETGBL	R5	G16
-      0x8C180373,  //  000A  GETMET	R6	R1	K115
-      0x7C180200,  //  000B  CALL	R6	1
-      0x7C140200,  //  000C  CALL	R5	1
-      0xA802000B,  //  000D  EXBLK	0	#001A
-      0x5C180A00,  //  000E  MOVE	R6	R5
-      0x7C180000,  //  000F  CALL	R6	0
-      0x8C1C0712,  //  0010  GETMET	R7	R3	K18
-      0x5C240C00,  //  0011  MOVE	R9	R6
-      0x7C1C0400,  //  0012  CALL	R7	2
-      0x1C1C0E04,  //  0013  EQ	R7	R7	R4
-      0x741E0001,  //  0014  JMPT	R7	#0017
-      0x1C1C0574,  //  0015  EQ	R7	R2	K116
-      0x781E0001,  //  0016  JMPF	R7	#0019
-      0xA8040001,  //  0017  EXBLK	1	1
-      0x80040C00,  //  0018  RET	1	R6
-      0x7001FFF3,  //  0019  JMP		#000E
-      0x58140075,  //  001A  LDCONST	R5	K117
-      0xAC140200,  //  001B  CATCH	R5	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_light
-********************************************************************/
-be_local_closure(class_Tasmota_get_light,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_get_light,
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080001,  //  0000  GETGBL	R2	G1
-      0x580C0076,  //  0001  LDCONST	R3	K118
-      0x7C080200,  //  0002  CALL	R2	1
-      0xA40AEE00,  //  0003  IMPORT	R2	K119
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x200C0203,  //  0005  NE	R3	R1	R3
-      0x780E0004,  //  0006  JMPF	R3	#000C
-      0x8C0C0541,  //  0007  GETMET	R3	R2	K65
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80040600,  //  000A  RET	1	R3
-      0x70020002,  //  000B  JMP		#000F
-      0x8C0C0541,  //  000C  GETMET	R3	R2	K65
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x80040600,  //  000E  RET	1	R3
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_fast_loop
-********************************************************************/
-be_local_closure(class_Tasmota_add_fast_loop,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_add_fast_loop,
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x8C080136,  //  0000  GETMET	R2	R0	K54
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x88080134,  //  0003  GETMBR	R2	R0	K52
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C080403,  //  0005  EQ	R2	R2	R3
-      0x780A0002,  //  0006  JMPF	R2	#000A
-      0x60080012,  //  0007  GETGBL	R2	G18
-      0x7C080000,  //  0008  CALL	R2	0
-      0x90026802,  //  0009  SETMBR	R0	K52	R2
-      0x60080004,  //  000A  GETGBL	R2	G4
-      0x5C0C0200,  //  000B  MOVE	R3	R1
-      0x7C080200,  //  000C  CALL	R2	1
-      0x2008050C,  //  000D  NE	R2	R2	K12
-      0x780A0000,  //  000E  JMPF	R2	#0010
-      0xB0067778,  //  000F  RAISE	1	K59	K120
-      0x88080130,  //  0010  GETMBR	R2	R0	K48
-      0x900AF30A,  //  0011  SETMBR	R2	K121	K10
-      0x88080134,  //  0012  GETMBR	R2	R0	K52
-      0x8C08052E,  //  0013  GETMET	R2	R2	K46
-      0x5C100200,  //  0014  MOVE	R4	R1
-      0x7C080400,  //  0015  CALL	R2	2
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: cmd
-********************************************************************/
-be_local_closure(class_Tasmota_cmd,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x880C015D,  //  0000  GETMBR	R3	R0	K93
-      0x50100200,  //  0001  LDBOOL	R4	1	0
-      0x9002BA04,  //  0002  SETMBR	R0	K93	R4
-      0xB8125E00,  //  0003  GETNGBL	R4	K47
-      0x88100930,  //  0004  GETMBR	R4	R4	K48
-      0x8810097A,  //  0005  GETMBR	R4	R4	K122
-      0x780A0004,  //  0006  JMPF	R2	#000C
-      0x28140933,  //  0007  GE	R5	R4	K51
-      0x78160002,  //  0008  JMPF	R5	#000C
-      0xB8165E00,  //  0009  GETNGBL	R5	K47
-      0x88140B30,  //  000A  GETMBR	R5	R5	K48
-      0x9016F50A,  //  000B  SETMBR	R5	K122	K10
-      0x8C14017B,  //  000C  GETMET	R5	R0	K123
-      0x5C1C0200,  //  000D  MOVE	R7	R1
-      0x7C140400,  //  000E  CALL	R5	2
-      0x4C140000,  //  000F  LDNIL	R5
-      0x8818015D,  //  0010  GETMBR	R6	R0	K93
-      0x501C0200,  //  0011  LDBOOL	R7	1	0
-      0x20180C07,  //  0012  NE	R6	R6	R7
-      0x781A0000,  //  0013  JMPF	R6	#0015
-      0x8814015D,  //  0014  GETMBR	R5	R0	K93
-      0x9002BA03,  //  0015  SETMBR	R0	K93	R3
-      0x780A0002,  //  0016  JMPF	R2	#001A
-      0xB81A5E00,  //  0017  GETNGBL	R6	K47
-      0x88180D30,  //  0018  GETMBR	R6	R6	K48
-      0x901AF404,  //  0019  SETMBR	R6	K122	R4
-      0x80040A00,  //  001A  RET	1	R5
     })
   )
 );
@@ -1831,31 +1241,31 @@ be_local_closure(class_Tasmota_run_timers,   /* name */
     &be_const_str_run_timers,
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x8C04017C,  //  0000  GETMET	R1	R0	K124
+      0x8C04013E,  //  0000  GETMET	R1	R0	K62
       0x7C040200,  //  0001  CALL	R1	1
-      0x8804014C,  //  0002  GETMBR	R1	R0	K76
+      0x8804011C,  //  0002  GETMBR	R1	R0	K28
       0x78060015,  //  0003  JMPF	R1	#001A
-      0x58040006,  //  0004  LDCONST	R1	K6
-      0x8808014C,  //  0005  GETMBR	R2	R0	K76
-      0x8C080507,  //  0006  GETMET	R2	R2	K7
+      0x58040007,  //  0004  LDCONST	R1	K7
+      0x8808011C,  //  0005  GETMBR	R2	R0	K28
+      0x8C08052E,  //  0006  GETMET	R2	R2	K46
       0x7C080200,  //  0007  CALL	R2	1
       0x14080202,  //  0008  LT	R2	R1	R2
       0x780A000F,  //  0009  JMPF	R2	#001A
-      0x8808014C,  //  000A  GETMBR	R2	R0	K76
+      0x8808011C,  //  000A  GETMBR	R2	R0	K28
       0x94080401,  //  000B  GETIDX	R2	R2	R1
-      0x8C0C012C,  //  000C  GETMET	R3	R0	K44
-      0x88140509,  //  000D  GETMBR	R5	R2	K9
+      0x8C0C013F,  //  000C  GETMET	R3	R0	K63
+      0x88140508,  //  000D  GETMBR	R5	R2	K8
       0x7C0C0400,  //  000E  CALL	R3	2
       0x780E0007,  //  000F  JMPF	R3	#0018
-      0x880C0528,  //  0010  GETMBR	R3	R2	K40
-      0x8810014C,  //  0011  GETMBR	R4	R0	K76
-      0x8C100935,  //  0012  GETMET	R4	R4	K53
+      0x880C0540,  //  0010  GETMBR	R3	R2	K64
+      0x8810011C,  //  0011  GETMBR	R4	R0	K28
+      0x8C10090B,  //  0012  GETMET	R4	R4	K11
       0x5C180200,  //  0013  MOVE	R6	R1
       0x7C100400,  //  0014  CALL	R4	2
       0x5C100600,  //  0015  MOVE	R4	R3
       0x7C100000,  //  0016  CALL	R4	0
       0x70020000,  //  0017  JMP		#0019
-      0x0004030A,  //  0018  ADD	R1	R1	K10
+      0x0004030C,  //  0018  ADD	R1	R1	K12
       0x7001FFEA,  //  0019  JMP		#0005
       0x80000000,  //  001A  RET	0
     })
@@ -1865,49 +1275,84 @@ be_local_closure(class_Tasmota_run_timers,   /* name */
 
 
 /********************************************************************
-** Solidified function: exec_cmd
+** Solidified function: init
 ********************************************************************/
-be_local_closure(class_Tasmota_exec_cmd,   /* name */
+be_local_closure(class_Tasmota_init,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    7,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str(urlfetch_cmd),
+        }),
+        &be_const_str__anonymous_,
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80000000,  //  0007  RET	0
+        })
+      ),
+    }),
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_exec_cmd,
+    &be_const_str_init,
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x8810017D,  //  0000  GETMBR	R4	R0	K125
-      0x78120016,  //  0001  JMPF	R4	#0019
-      0xA4124200,  //  0002  IMPORT	R4	K33
-      0x8C140922,  //  0003  GETMET	R5	R4	K34
-      0x5C1C0600,  //  0004  MOVE	R7	R3
-      0x7C140400,  //  0005  CALL	R5	2
-      0x8C18017E,  //  0006  GETMET	R6	R0	K126
-      0x8820017D,  //  0007  GETMBR	R8	R0	K125
-      0x5C240200,  //  0008  MOVE	R9	R1
-      0x7C180600,  //  0009  CALL	R6	3
-      0x4C1C0000,  //  000A  LDNIL	R7
-      0x201C0C07,  //  000B  NE	R7	R6	R7
-      0x781E000B,  //  000C  JMPF	R7	#0019
-      0x8C1C017F,  //  000D  GETMET	R7	R0	K127
-      0x5C240C00,  //  000E  MOVE	R9	R6
-      0x7C1C0400,  //  000F  CALL	R7	2
-      0x881C017D,  //  0010  GETMBR	R7	R0	K125
-      0x941C0E06,  //  0011  GETIDX	R7	R7	R6
-      0x5C200C00,  //  0012  MOVE	R8	R6
-      0x5C240400,  //  0013  MOVE	R9	R2
-      0x5C280600,  //  0014  MOVE	R10	R3
-      0x5C2C0A00,  //  0015  MOVE	R11	R5
-      0x7C1C0800,  //  0016  CALL	R7	4
-      0x501C0200,  //  0017  LDBOOL	R7	1	0
-      0x80040E00,  //  0018  RET	1	R7
-      0x50100000,  //  0019  LDBOOL	R4	0	0
-      0x80040800,  //  001A  RET	1	R4
+    ( &(const binstruction[34]) {  /* code */
+      0xB8068200,  //  0000  GETNGBL	R1	K65
+      0x88080142,  //  0001  GETMBR	R2	R0	K66
+      0x880C0143,  //  0002  GETMBR	R3	R0	K67
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90025001,  //  0004  SETMBR	R0	K40	R1
+      0xA4061A00,  //  0005  IMPORT	R1	K13
+      0x60080015,  //  0006  GETGBL	R2	G21
+      0x880C0144,  //  0007  GETMBR	R3	R0	K68
+      0x54120003,  //  0008  LDINT	R4	4
+      0x7C080400,  //  0009  CALL	R2	2
+      0x8C080545,  //  000A  GETMET	R2	R2	K69
+      0x58100007,  //  000B  LDCONST	R4	K7
+      0x54160003,  //  000C  LDINT	R5	4
+      0x7C080600,  //  000D  CALL	R2	3
+      0x780A0006,  //  000E  JMPF	R2	#0016
+      0xB80E8200,  //  000F  GETNGBL	R3	K65
+      0x8C100347,  //  0010  GETMET	R4	R1	K71
+      0x5C180400,  //  0011  MOVE	R6	R2
+      0x7C100400,  //  0012  CALL	R4	2
+      0x88140148,  //  0013  GETMBR	R5	R0	K72
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x90028C03,  //  0015  SETMBR	R0	K70	R3
+      0x9002934A,  //  0016  SETMBR	R0	K73	K74
+      0xB80E5000,  //  0017  GETNGBL	R3	K40
+      0x8C0C074C,  //  0018  GETMET	R3	R3	K76
+      0x5814004D,  //  0019  LDCONST	R5	K77
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x90029603,  //  001B  SETMBR	R0	K75	R3
+      0x8C0C014E,  //  001C  GETMET	R3	R0	K78
+      0x5814004F,  //  001D  LDCONST	R5	K79
+      0x84180000,  //  001E  CLOSURE	R6	P0
+      0x7C0C0600,  //  001F  CALL	R3	3
+      0xA0000000,  //  0020  CLOSE	R0
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -1931,25 +1376,25 @@ be_local_closure(class_Tasmota_add_cmd,   /* name */
     &be_const_str_add_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x8C0C0136,  //  0000  GETMET	R3	R0	K54
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
       0x5C140400,  //  0001  MOVE	R5	R2
       0x7C0C0400,  //  0002  CALL	R3	2
-      0x880C017D,  //  0003  GETMBR	R3	R0	K125
+      0x880C011E,  //  0003  GETMBR	R3	R0	K30
       0x4C100000,  //  0004  LDNIL	R4
       0x1C0C0604,  //  0005  EQ	R3	R3	R4
       0x780E0002,  //  0006  JMPF	R3	#000A
       0x600C0013,  //  0007  GETGBL	R3	G19
       0x7C0C0000,  //  0008  CALL	R3	0
-      0x9002FA03,  //  0009  SETMBR	R0	K125	R3
+      0x90023C03,  //  0009  SETMBR	R0	K30	R3
       0x600C0004,  //  000A  GETGBL	R3	G4
       0x5C100400,  //  000B  MOVE	R4	R2
       0x7C0C0200,  //  000C  CALL	R3	1
-      0x1C0C070C,  //  000D  EQ	R3	R3	K12
+      0x1C0C070E,  //  000D  EQ	R3	R3	K14
       0x780E0002,  //  000E  JMPF	R3	#0012
-      0x880C017D,  //  000F  GETMBR	R3	R0	K125
+      0x880C011E,  //  000F  GETMBR	R3	R0	K30
       0x980C0202,  //  0010  SETIDX	R3	R1	R2
       0x70020000,  //  0011  JMP		#0013
-      0xB006773C,  //  0012  RAISE	1	K59	K60
+      0xB0062D17,  //  0012  RAISE	1	K22	K23
       0x80000000,  //  0013  RET	0
     })
   )
@@ -1958,11 +1403,139 @@ be_local_closure(class_Tasmota_add_cmd,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_op
+** Solidified function: urlfetch
 ********************************************************************/
-be_local_closure(class_Tasmota_find_op,   /* name */
+be_local_closure(class_Tasmota_urlfetch,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_urlfetch,
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E000D,  //  0002  JMPF	R3	#0011
+      0xA40E7800,  //  0003  IMPORT	R3	K60
+      0x8C100750,  //  0004  GETMET	R4	R3	K80
+      0x5C180200,  //  0005  MOVE	R6	R1
+      0x581C0051,  //  0006  LDCONST	R7	K81
+      0x7C100600,  //  0007  CALL	R4	3
+      0x8C100952,  //  0008  GETMET	R4	R4	K82
+      0x7C100200,  //  0009  CALL	R4	1
+      0x5C080800,  //  000A  MOVE	R2	R4
+      0x6010000C,  //  000B  GETGBL	R4	G12
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C100200,  //  000D  CALL	R4	1
+      0x1C100907,  //  000E  EQ	R4	R4	K7
+      0x78120000,  //  000F  JMPF	R4	#0011
+      0x58080053,  //  0010  LDCONST	R2	K83
+      0xB80EA800,  //  0011  GETNGBL	R3	K84
+      0x7C0C0000,  //  0012  CALL	R3	0
+      0x8C100755,  //  0013  GETMET	R4	R3	K85
+      0x50180200,  //  0014  LDBOOL	R6	1	0
+      0x7C100400,  //  0015  CALL	R4	2
+      0x8C100756,  //  0016  GETMET	R4	R3	K86
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x7C100400,  //  0018  CALL	R4	2
+      0x8C100757,  //  0019  GETMET	R4	R3	K87
+      0x7C100200,  //  001A  CALL	R4	1
+      0x541600C7,  //  001B  LDINT	R5	200
+      0x20140805,  //  001C  NE	R5	R4	R5
+      0x78160004,  //  001D  JMPF	R5	#0023
+      0x60140008,  //  001E  GETGBL	R5	G8
+      0x5C180800,  //  001F  MOVE	R6	R4
+      0x7C140200,  //  0020  CALL	R5	1
+      0x0016B005,  //  0021  ADD	R5	K88	R5
+      0xB006B205,  //  0022  RAISE	1	K89	R5
+      0x8C14075A,  //  0023  GETMET	R5	R3	K90
+      0x5C1C0400,  //  0024  MOVE	R7	R2
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C18075B,  //  0026  GETMET	R6	R3	K91
+      0x7C180200,  //  0027  CALL	R6	1
+      0x8C18015C,  //  0028  GETMET	R6	R0	K92
+      0x60200008,  //  0029  GETGBL	R8	G8
+      0x5C240A00,  //  002A  MOVE	R9	R5
+      0x7C200200,  //  002B  CALL	R8	1
+      0x0022BA08,  //  002C  ADD	R8	K93	R8
+      0x5824001B,  //  002D  LDCONST	R9	K27
+      0x7C180600,  //  002E  CALL	R6	3
+      0x80040800,  //  002F  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: urlfetch_cmd
+********************************************************************/
+be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_urlfetch_cmd,
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0xA4167800,  //  0000  IMPORT	R5	K60
+      0x8C180B32,  //  0001  GETMET	R6	R5	K50
+      0x5C200600,  //  0002  MOVE	R8	R3
+      0x5824005E,  //  0003  LDCONST	R9	K94
+      0x7C180600,  //  0004  CALL	R6	3
+      0x20180D07,  //  0005  NE	R6	R6	K7
+      0x781A0003,  //  0006  JMPF	R6	#000B
+      0x8C18015F,  //  0007  GETMET	R6	R0	K95
+      0x58200060,  //  0008  LDCONST	R8	K96
+      0x7C180400,  //  0009  CALL	R6	2
+      0x80000C00,  //  000A  RET	0
+      0xA802000A,  //  000B  EXBLK	0	#0017
+      0x8C180161,  //  000C  GETMET	R6	R0	K97
+      0x5C200600,  //  000D  MOVE	R8	R3
+      0x7C180400,  //  000E  CALL	R6	2
+      0x141C0D07,  //  000F  LT	R7	R6	K7
+      0x781E0003,  //  0010  JMPF	R7	#0015
+      0x8C1C0162,  //  0011  GETMET	R7	R0	K98
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0xA8040001,  //  0013  EXBLK	1	1
+      0x80000E00,  //  0014  RET	0
+      0xA8040001,  //  0015  EXBLK	1	1
+      0x70020006,  //  0016  JMP		#001E
+      0xAC180002,  //  0017  CATCH	R6	0	2
+      0x70020003,  //  0018  JMP		#001D
+      0x8C200162,  //  0019  GETMET	R8	R0	K98
+      0x7C200200,  //  001A  CALL	R8	1
+      0x80001000,  //  001B  RET	0
+      0x70020000,  //  001C  JMP		#001E
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0xB81A3000,  //  001E  GETNGBL	R6	K24
+      0x8C180D63,  //  001F  GETMET	R6	R6	K99
+      0x7C180200,  //  0020  CALL	R6	1
+      0x80000000,  //  0021  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: exec_tele
+********************************************************************/
+be_local_closure(class_Tasmota_exec_tele,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1971,40 +1544,236 @@ be_local_closure(class_Tasmota_find_op,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_find_op,
+    &be_const_str_exec_tele,
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0x8C080180,  //  0000  GETMET	R2	R0	K128
+    ( &(const binstruction[41]) {  /* code */
+      0x88080106,  //  0000  GETMBR	R2	R0	K6
+      0x780A0024,  //  0001  JMPF	R2	#0027
+      0xA40A3E00,  //  0002  IMPORT	R2	K31
+      0x8C0C0520,  //  0003  GETMET	R3	R2	K32
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x4C140000,  //  0007  LDNIL	R5
+      0x1C140605,  //  0008  EQ	R5	R3	R5
+      0x78160004,  //  0009  JMPF	R5	#000F
+      0x8C14015C,  //  000A  GETMET	R5	R0	K92
+      0x001EC801,  //  000B  ADD	R7	K100	R1
+      0x5820001B,  //  000C  LDCONST	R8	K27
+      0x7C140600,  //  000D  CALL	R5	3
+      0x5C0C0200,  //  000E  MOVE	R3	R1
+      0x60140013,  //  000F  GETGBL	R5	G19
+      0x7C140000,  //  0010  CALL	R5	0
+      0x9816CA03,  //  0011  SETIDX	R5	K101	R3
+      0x5C0C0A00,  //  0012  MOVE	R3	R5
+      0x58140007,  //  0013  LDCONST	R5	K7
+      0x6018000C,  //  0014  GETGBL	R6	G12
+      0x881C0106,  //  0015  GETMBR	R7	R0	K6
+      0x7C180200,  //  0016  CALL	R6	1
+      0x14180A06,  //  0017  LT	R6	R5	R6
+      0x781A000C,  //  0018  JMPF	R6	#0026
+      0x88180106,  //  0019  GETMBR	R6	R0	K6
+      0x94180C05,  //  001A  GETIDX	R6	R6	R5
+      0x8C1C0166,  //  001B  GETMET	R7	R0	K102
+      0x5C240600,  //  001C  MOVE	R9	R3
+      0x88280D08,  //  001D  GETMBR	R10	R6	K8
+      0x882C0D40,  //  001E  GETMBR	R11	R6	K64
+      0x7C1C0800,  //  001F  CALL	R7	4
+      0x741E0001,  //  0020  JMPT	R7	#0023
+      0x74120000,  //  0021  JMPT	R4	#0023
+      0x50100001,  //  0022  LDBOOL	R4	0	1
+      0x50100200,  //  0023  LDBOOL	R4	1	0
+      0x00140B0C,  //  0024  ADD	R5	R5	K12
+      0x7001FFED,  //  0025  JMP		#0014
+      0x80040800,  //  0026  RET	1	R4
+      0x50080000,  //  0027  LDBOOL	R2	0	0
+      0x80040400,  //  0028  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_key_i
+********************************************************************/
+be_local_closure(class_Tasmota_find_key_i,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_find_key_i,
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0xA40E7800,  //  0000  IMPORT	R3	K60
+      0x8C10073D,  //  0001  GETMET	R4	R3	K61
+      0x5C180400,  //  0002  MOVE	R6	R2
+      0x7C100400,  //  0003  CALL	R4	2
+      0x6014000F,  //  0004  GETGBL	R5	G15
+      0x5C180200,  //  0005  MOVE	R6	R1
+      0x601C0013,  //  0006  GETGBL	R7	G19
+      0x7C140400,  //  0007  CALL	R5	2
+      0x78160013,  //  0008  JMPF	R5	#001D
+      0x60140010,  //  0009  GETGBL	R5	G16
+      0x8C180367,  //  000A  GETMET	R6	R1	K103
+      0x7C180200,  //  000B  CALL	R6	1
+      0x7C140200,  //  000C  CALL	R5	1
+      0xA802000B,  //  000D  EXBLK	0	#001A
+      0x5C180A00,  //  000E  MOVE	R6	R5
+      0x7C180000,  //  000F  CALL	R6	0
+      0x8C1C073D,  //  0010  GETMET	R7	R3	K61
+      0x5C240C00,  //  0011  MOVE	R9	R6
+      0x7C1C0400,  //  0012  CALL	R7	2
+      0x1C1C0E04,  //  0013  EQ	R7	R7	R4
+      0x741E0001,  //  0014  JMPT	R7	#0017
+      0x1C1C0568,  //  0015  EQ	R7	R2	K104
+      0x781E0001,  //  0016  JMPF	R7	#0019
+      0xA8040001,  //  0017  EXBLK	1	1
+      0x80040C00,  //  0018  RET	1	R6
+      0x7001FFF3,  //  0019  JMP		#000E
+      0x58140069,  //  001A  LDCONST	R5	K105
+      0xAC140200,  //  001B  CATCH	R5	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_rule_once
+********************************************************************/
+be_local_closure(class_Tasmota_add_rule_once,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_add_rule_once,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C10016A,  //  0000  GETMET	R4	R0	K106
+      0x5C180200,  //  0001  MOVE	R6	R1
+      0x5C1C0400,  //  0002  MOVE	R7	R2
+      0x5C200600,  //  0003  MOVE	R8	R3
+      0x50240200,  //  0004  LDBOOL	R9	1	0
+      0x7C100A00,  //  0005  CALL	R4	5
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_fast_loop
+********************************************************************/
+be_local_closure(class_Tasmota_add_fast_loop,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_add_fast_loop,
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
-      0x280C0506,  //  0003  GE	R3	R2	K6
-      0x780E0011,  //  0004  JMPF	R3	#0017
-      0x540E7FFE,  //  0005  LDINT	R3	32767
-      0x2C0C0403,  //  0006  AND	R3	R2	R3
-      0x5412000F,  //  0007  LDINT	R4	16
-      0x3C100404,  //  0008  SHR	R4	R2	R4
-      0x60140012,  //  0009  GETGBL	R5	G18
-      0x7C140000,  //  000A  CALL	R5	0
-      0x0418070A,  //  000B  SUB	R6	R3	K10
-      0x401A0C06,  //  000C  CONNECT	R6	K6	R6
-      0x94180206,  //  000D  GETIDX	R6	R1	R6
-      0x40180A06,  //  000E  CONNECT	R6	R5	R6
-      0x0418090A,  //  000F  SUB	R6	R4	K10
-      0x40180606,  //  0010  CONNECT	R6	R3	R6
-      0x94180206,  //  0011  GETIDX	R6	R1	R6
-      0x40180A06,  //  0012  CONNECT	R6	R5	R6
-      0x40180981,  //  0013  CONNECT	R6	R4	K129
-      0x94180206,  //  0014  GETIDX	R6	R1	R6
-      0x40180A06,  //  0015  CONNECT	R6	R5	R6
-      0x80040A00,  //  0016  RET	1	R5
-      0x600C0012,  //  0017  GETGBL	R3	G18
-      0x7C0C0000,  //  0018  CALL	R3	0
-      0x40100601,  //  0019  CONNECT	R4	R3	R1
-      0x4C100000,  //  001A  LDNIL	R4
-      0x40100604,  //  001B  CONNECT	R4	R3	R4
-      0x4C100000,  //  001C  LDNIL	R4
-      0x40100604,  //  001D  CONNECT	R4	R3	R4
-      0x80040600,  //  001E  RET	1	R3
+      0x8808012A,  //  0003  GETMBR	R2	R0	K42
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A0002,  //  0006  JMPF	R2	#000A
+      0x60080012,  //  0007  GETGBL	R2	G18
+      0x7C080000,  //  0008  CALL	R2	0
+      0x90025402,  //  0009  SETMBR	R0	K42	R2
+      0x60080004,  //  000A  GETGBL	R2	G4
+      0x5C0C0200,  //  000B  MOVE	R3	R1
+      0x7C080200,  //  000C  CALL	R2	1
+      0x2008050E,  //  000D  NE	R2	R2	K14
+      0x780A0000,  //  000E  JMPF	R2	#0010
+      0xB0062D6B,  //  000F  RAISE	1	K22	K107
+      0x88080128,  //  0010  GETMBR	R2	R0	K40
+      0x900AD90C,  //  0011  SETMBR	R2	K108	K12
+      0x8808012A,  //  0012  GETMBR	R2	R0	K42
+      0x8C080504,  //  0013  GETMET	R2	R2	K4
+      0x5C100200,  //  0014  MOVE	R4	R1
+      0x7C080400,  //  0015  CALL	R2	2
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: run_cron
+********************************************************************/
+be_local_closure(class_Tasmota_run_cron,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_run_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x7806001E,  //  0001  JMPF	R1	#0021
+      0x58040007,  //  0002  LDCONST	R1	K7
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C08056D,  //  0004  GETMET	R2	R2	K109
+      0x7C080200,  //  0005  CALL	R2	1
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C072E,  //  0007  GETMET	R3	R3	K46
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x140C0203,  //  0009  LT	R3	R1	R3
+      0x780E0015,  //  000A  JMPF	R3	#0021
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x940C0601,  //  000C  GETIDX	R3	R3	R1
+      0x88100708,  //  000D  GETMBR	R4	R3	K8
+      0x1C100907,  //  000E  EQ	R4	R4	K7
+      0x78120003,  //  000F  JMPF	R4	#0014
+      0x8C100703,  //  0010  GETMET	R4	R3	K3
+      0x7C100200,  //  0011  CALL	R4	1
+      0x900E1004,  //  0012  SETMBR	R3	K8	R4
+      0x7002000A,  //  0013  JMP		#001F
+      0x8C10073F,  //  0014  GETMET	R4	R3	K63
+      0x7C100200,  //  0015  CALL	R4	1
+      0x78120007,  //  0016  JMPF	R4	#001F
+      0x88100740,  //  0017  GETMBR	R4	R3	K64
+      0x8C140703,  //  0018  GETMET	R5	R3	K3
+      0x7C140200,  //  0019  CALL	R5	1
+      0x900E1005,  //  001A  SETMBR	R3	K8	R5
+      0x5C180800,  //  001B  MOVE	R6	R4
+      0x5C1C0400,  //  001C  MOVE	R7	R2
+      0x5C200A00,  //  001D  MOVE	R8	R5
+      0x7C180400,  //  001E  CALL	R6	2
+      0x0004030C,  //  001F  ADD	R1	R1	K12
+      0x7001FFE4,  //  0020  JMP		#0006
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -2294,72 +2063,72 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x84140003,  //  0003  CLOSURE	R5	P3
       0x84180004,  //  0004  CLOSURE	R6	P4
       0x841C0005,  //  0005  CLOSURE	R7	P5
-      0xA4222200,  //  0006  IMPORT	R8	K17
-      0xA4270400,  //  0007  IMPORT	R9	K130
+      0xA4227800,  //  0006  IMPORT	R8	K60
+      0xA426DC00,  //  0007  IMPORT	R9	K110
       0x6028000C,  //  0008  GETGBL	R10	G12
       0x5C2C0200,  //  0009  MOVE	R11	R1
       0x7C280200,  //  000A  CALL	R10	1
-      0x1C281506,  //  000B  EQ	R10	R10	K6
+      0x1C281507,  //  000B  EQ	R10	R10	K7
       0x782A0002,  //  000C  JMPF	R10	#0010
       0x50280000,  //  000D  LDBOOL	R10	0	0
       0xA0000000,  //  000E  CLOSE	R0
       0x80041400,  //  000F  RET	1	R10
-      0x8C281183,  //  0010  GETMET	R10	R8	K131
+      0x8C28116F,  //  0010  GETMET	R10	R8	K111
       0x5C300200,  //  0011  MOVE	R12	R1
-      0x5834004F,  //  0012  LDCONST	R13	K79
+      0x58340051,  //  0012  LDCONST	R13	K81
       0x7C280600,  //  0013  CALL	R10	3
       0x742A0000,  //  0014  JMPT	R10	#0016
-      0x00069E01,  //  0015  ADD	R1	K79	R1
-      0x8C28111E,  //  0016  GETMET	R10	R8	K30
+      0x0006A201,  //  0015  ADD	R1	K81	R1
+      0x8C281132,  //  0016  GETMET	R10	R8	K50
       0x5C300200,  //  0017  MOVE	R12	R1
-      0x58340084,  //  0018  LDCONST	R13	K132
+      0x58340070,  //  0018  LDCONST	R13	K112
       0x7C280600,  //  0019  CALL	R10	3
-      0x242C1506,  //  001A  GT	R11	R10	K6
+      0x242C1507,  //  001A  GT	R11	R10	K7
       0x782E0003,  //  001B  JMPF	R11	#0020
-      0x0430150A,  //  001C  SUB	R12	R10	K10
-      0x40320C0C,  //  001D  CONNECT	R12	K6	R12
+      0x0430150C,  //  001C  SUB	R12	R10	K12
+      0x40320E0C,  //  001D  CONNECT	R12	K7	R12
       0x9430020C,  //  001E  GETIDX	R12	R1	R12
       0x70020000,  //  001F  JMP		#0021
       0x5C300200,  //  0020  MOVE	R12	R1
       0x782E0003,  //  0021  JMPF	R11	#0026
-      0x0034150A,  //  0022  ADD	R13	R10	K10
-      0x40341B81,  //  0023  CONNECT	R13	R13	K129
+      0x0034150C,  //  0022  ADD	R13	R10	K12
+      0x40341B71,  //  0023  CONNECT	R13	R13	K113
       0x9434020D,  //  0024  GETIDX	R13	R1	R13
       0x70020000,  //  0025  JMP		#0027
       0x5C340200,  //  0026  MOVE	R13	R1
-      0x8C38111E,  //  0027  GETMET	R14	R8	K30
+      0x8C381132,  //  0027  GETMET	R14	R8	K50
       0x5C401A00,  //  0028  MOVE	R16	R13
-      0x58440085,  //  0029  LDCONST	R17	K133
+      0x58440072,  //  0029  LDCONST	R17	K114
       0x7C380600,  //  002A  CALL	R14	3
-      0x14381D06,  //  002B  LT	R14	R14	K6
+      0x14381D07,  //  002B  LT	R14	R14	K7
       0x783A0001,  //  002C  JMPF	R14	#002F
-      0x00040386,  //  002D  ADD	R1	R1	K134
-      0x00341B86,  //  002E  ADD	R13	R13	K134
-      0x8C381187,  //  002F  GETMET	R14	R8	K135
+      0x00040373,  //  002D  ADD	R1	R1	K115
+      0x00341B73,  //  002E  ADD	R13	R13	K115
+      0x8C381174,  //  002F  GETMET	R14	R8	K116
       0x5C401A00,  //  0030  MOVE	R16	R13
-      0x58440086,  //  0031  LDCONST	R17	K134
+      0x58440073,  //  0031  LDCONST	R17	K115
       0x7C380600,  //  0032  CALL	R14	3
-      0x8C3C1187,  //  0033  GETMET	R15	R8	K135
+      0x8C3C1174,  //  0033  GETMET	R15	R8	K116
       0x5C441A00,  //  0034  MOVE	R17	R13
-      0x58480088,  //  0035  LDCONST	R18	K136
+      0x58480075,  //  0035  LDCONST	R18	K117
       0x7C3C0600,  //  0036  CALL	R15	3
       0x783E0001,  //  0037  JMPF	R15	#003A
       0x5C400200,  //  0038  MOVE	R16	R1
       0x70020000,  //  0039  JMP		#003B
-      0x00400389,  //  003A  ADD	R16	R1	K137
+      0x00400376,  //  003A  ADD	R16	R1	K118
       0x5C441C00,  //  003B  MOVE	R17	R14
       0x74460007,  //  003C  JMPT	R17	#0045
       0x5C441E00,  //  003D  MOVE	R17	R15
       0x74460005,  //  003E  JMPT	R17	#0045
       0x60440001,  //  003F  GETGBL	R17	G1
-      0x5848008A,  //  0040  LDCONST	R18	K138
+      0x58480077,  //  0040  LDCONST	R18	K119
       0x7C440200,  //  0041  CALL	R17	1
       0x50440000,  //  0042  LDBOOL	R17	0	0
       0xA0000000,  //  0043  CLOSE	R0
       0x80042200,  //  0044  RET	1	R17
       0x50440000,  //  0045  LDBOOL	R17	0	0
       0x783E0008,  //  0046  JMPF	R15	#0050
-      0x8C48138B,  //  0047  GETMET	R18	R9	K139
+      0x8C481378,  //  0047  GETMET	R18	R9	K120
       0x5C502000,  //  0048  MOVE	R20	R16
       0x7C480400,  //  0049  CALL	R18	2
       0x744A0002,  //  004A  JMPT	R18	#004E
@@ -2368,11 +2137,11 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x80042400,  //  004D  RET	1	R18
       0x50440200,  //  004E  LDBOOL	R17	1	0
       0x70020014,  //  004F  JMP		#0065
-      0x8C48138B,  //  0050  GETMET	R18	R9	K139
+      0x8C481378,  //  0050  GETMET	R18	R9	K120
       0x5C500200,  //  0051  MOVE	R20	R1
       0x7C480400,  //  0052  CALL	R18	2
       0x784A0007,  //  0053  JMPF	R18	#005C
-      0x8C48138B,  //  0054  GETMET	R18	R9	K139
+      0x8C481378,  //  0054  GETMET	R18	R9	K120
       0x5C502000,  //  0055  MOVE	R20	R16
       0x7C480400,  //  0056  CALL	R18	2
       0x784A0002,  //  0057  JMPF	R18	#005B
@@ -2380,7 +2149,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x5C4C2000,  //  0059  MOVE	R19	R16
       0x7C480200,  //  005A  CALL	R18	1
       0x70020008,  //  005B  JMP		#0065
-      0x8C48138B,  //  005C  GETMET	R18	R9	K139
+      0x8C481378,  //  005C  GETMET	R18	R9	K120
       0x5C502000,  //  005D  MOVE	R20	R16
       0x7C480400,  //  005E  CALL	R18	2
       0x784A0001,  //  005F  JMPF	R18	#0062
@@ -2390,13 +2159,13 @@ be_local_closure(class_Tasmota_load,   /* name */
       0xA0000000,  //  0063  CLOSE	R0
       0x80042400,  //  0064  RET	1	R18
       0x782E0005,  //  0065  JMPF	R11	#006C
-      0x00481984,  //  0066  ADD	R18	R12	K132
-      0x90028A12,  //  0067  SETMBR	R0	K69	R18
+      0x00481970,  //  0066  ADD	R18	R12	K112
+      0x90029212,  //  0067  SETMBR	R0	K73	R18
       0x5C480400,  //  0068  MOVE	R18	R2
-      0x884C0145,  //  0069  GETMBR	R19	R0	K69
+      0x884C0149,  //  0069  GETMBR	R19	R0	K73
       0x7C480200,  //  006A  CALL	R18	1
       0x70020000,  //  006B  JMP		#006D
-      0x90028B46,  //  006C  SETMBR	R0	K69	K70
+      0x9002934A,  //  006C  SETMBR	R0	K73	K74
       0x4C480000,  //  006D  LDNIL	R18
       0x78460025,  //  006E  JMPF	R17	#0095
       0x5C4C0800,  //  006F  MOVE	R19	R4
@@ -2408,7 +2177,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x78560007,  //  0075  JMPF	R21	#007E
       0x60540001,  //  0076  GETGBL	R21	G1
       0x60580018,  //  0077  GETGBL	R22	G24
-      0x585C008C,  //  0078  LDCONST	R23	K140
+      0x585C0079,  //  0078  LDCONST	R23	K121
       0x5C602000,  //  0079  MOVE	R24	R16
       0x7C580400,  //  007A  CALL	R22	2
       0x7C540200,  //  007B  CALL	R21	1
@@ -2419,7 +2188,7 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x78560007,  //  0080  JMPF	R21	#0089
       0x60540001,  //  0081  GETGBL	R21	G1
       0x60580018,  //  0082  GETGBL	R22	G24
-      0x585C008D,  //  0083  LDCONST	R23	K141
+      0x585C007A,  //  0083  LDCONST	R23	K122
       0x5C602000,  //  0084  MOVE	R24	R16
       0x5C642600,  //  0085  MOVE	R25	R19
       0x7C580600,  //  0086  CALL	R22	3
@@ -2448,10 +2217,419 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x7C4C0200,  //  009D  CALL	R19	1
       0x782E0002,  //  009E  JMPF	R11	#00A2
       0x5C500600,  //  009F  MOVE	R20	R3
-      0x00541984,  //  00A0  ADD	R21	R12	K132
+      0x00541970,  //  00A0  ADD	R21	R12	K112
       0x7C500200,  //  00A1  CALL	R20	1
       0xA0000000,  //  00A2  CLOSE	R0
       0x80042600,  //  00A3  RET	1	R19
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: exec_rules
+********************************************************************/
+be_local_closure(class_Tasmota_exec_rules,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_exec_rules,
+    &be_const_str_solidified,
+    ( &(const binstruction[60]) {  /* code */
+      0x880C012B,  //  0000  GETMBR	R3	R0	K43
+      0x88100106,  //  0001  GETMBR	R4	R0	K6
+      0x74120002,  //  0002  JMPT	R4	#0006
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120033,  //  0005  JMPF	R4	#003A
+      0xA4123E00,  //  0006  IMPORT	R4	K31
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90025605,  //  0008  SETMBR	R0	K43	R5
+      0x50140000,  //  0009  LDBOOL	R5	0	0
+      0x8C180920,  //  000A  GETMET	R6	R4	K32
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x7C180400,  //  000C  CALL	R6	2
+      0x4C1C0000,  //  000D  LDNIL	R7
+      0x1C1C0C07,  //  000E  EQ	R7	R6	R7
+      0x781E0004,  //  000F  JMPF	R7	#0015
+      0x8C1C015C,  //  0010  GETMET	R7	R0	K92
+      0x0026C801,  //  0011  ADD	R9	K100	R1
+      0x5828001B,  //  0012  LDCONST	R10	K27
+      0x7C1C0600,  //  0013  CALL	R7	3
+      0x5C180200,  //  0014  MOVE	R6	R1
+      0x780A001E,  //  0015  JMPF	R2	#0035
+      0x881C0106,  //  0016  GETMBR	R7	R0	K6
+      0x781E001C,  //  0017  JMPF	R7	#0035
+      0x581C0007,  //  0018  LDCONST	R7	K7
+      0x6020000C,  //  0019  GETGBL	R8	G12
+      0x88240106,  //  001A  GETMBR	R9	R0	K6
+      0x7C200200,  //  001B  CALL	R8	1
+      0x14200E08,  //  001C  LT	R8	R7	R8
+      0x78220016,  //  001D  JMPF	R8	#0035
+      0x88200106,  //  001E  GETMBR	R8	R0	K6
+      0x94201007,  //  001F  GETIDX	R8	R8	R7
+      0x8C240166,  //  0020  GETMET	R9	R0	K102
+      0x5C2C0C00,  //  0021  MOVE	R11	R6
+      0x88301108,  //  0022  GETMBR	R12	R8	K8
+      0x88341140,  //  0023  GETMBR	R13	R8	K64
+      0x7C240800,  //  0024  CALL	R9	4
+      0x74160001,  //  0025  JMPT	R5	#0028
+      0x74260000,  //  0026  JMPT	R9	#0028
+      0x50140001,  //  0027  LDBOOL	R5	0	1
+      0x50140200,  //  0028  LDBOOL	R5	1	0
+      0x78260008,  //  0029  JMPF	R9	#0033
+      0x8828117B,  //  002A  GETMBR	R10	R8	K123
+      0x502C0200,  //  002B  LDBOOL	R11	1	0
+      0x1C28140B,  //  002C  EQ	R10	R10	R11
+      0x782A0004,  //  002D  JMPF	R10	#0033
+      0x88280106,  //  002E  GETMBR	R10	R0	K6
+      0x8C28150B,  //  002F  GETMET	R10	R10	K11
+      0x5C300E00,  //  0030  MOVE	R12	R7
+      0x7C280400,  //  0031  CALL	R10	2
+      0x70020000,  //  0032  JMP		#0034
+      0x001C0F0C,  //  0033  ADD	R7	R7	K12
+      0x7001FFE3,  //  0034  JMP		#0019
+      0x4C1C0000,  //  0035  LDNIL	R7
+      0x201C0607,  //  0036  NE	R7	R3	R7
+      0x781E0000,  //  0037  JMPF	R7	#0039
+      0x90025606,  //  0038  SETMBR	R0	K43	R6
+      0x80040A00,  //  0039  RET	1	R5
+      0x50100000,  //  003A  LDBOOL	R4	0	0
+      0x80040800,  //  003B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_driver
+********************************************************************/
+be_local_closure(class_Tasmota_remove_driver,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_remove_driver,
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88080131,  //  0000  GETMBR	R2	R0	K49
+      0x780A000A,  //  0001  JMPF	R2	#000D
+      0x88080131,  //  0002  GETMBR	R2	R0	K49
+      0x8C080532,  //  0003  GETMET	R2	R2	K50
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x200C0403,  //  0007  NE	R3	R2	R3
+      0x780E0003,  //  0008  JMPF	R3	#000D
+      0x880C0131,  //  0009  GETMBR	R3	R0	K49
+      0x8C0C0752,  //  000A  GETMET	R3	R3	K82
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: gen_cb
+********************************************************************/
+be_local_closure(class_Tasmota_gen_cb,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_gen_cb,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xA40AF800,  //  0000  IMPORT	R2	K124
+      0x8C0C057D,  //  0001  GETMET	R3	R2	K125
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x80040600,  //  0004  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event
+********************************************************************/
+be_local_closure(class_Tasmota_event,   /* name */
+  be_nested_proto(
+    19,                          /* nstack */
+    6,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_event,
+    &be_const_str_solidified,
+    ( &(const binstruction[112]) {  /* code */
+      0xA41A1A00,  //  0000  IMPORT	R6	K13
+      0x1C1C037E,  //  0001  EQ	R7	R1	K126
+      0x781E0005,  //  0002  JMPF	R7	#0009
+      0x881C0126,  //  0003  GETMBR	R7	R0	K38
+      0x781E0001,  //  0004  JMPF	R7	#0007
+      0x8C1C017F,  //  0005  GETMET	R7	R0	K127
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x8C1C0180,  //  0007  GETMET	R7	R0	K128
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x1C1C0381,  //  0009  EQ	R7	R1	K129
+      0x781E0001,  //  000A  JMPF	R7	#000D
+      0x8C1C0182,  //  000B  GETMET	R7	R0	K130
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x501C0000,  //  000D  LDBOOL	R7	0	0
+      0x50200000,  //  000E  LDBOOL	R8	0	0
+      0x1C240383,  //  000F  EQ	R9	R1	K131
+      0x78260000,  //  0010  JMPF	R9	#0012
+      0x50200200,  //  0011  LDBOOL	R8	1	0
+      0x1C240384,  //  0012  EQ	R9	R1	K132
+      0x78260006,  //  0013  JMPF	R9	#001B
+      0x8C240185,  //  0014  GETMET	R9	R0	K133
+      0x5C2C0400,  //  0015  MOVE	R11	R2
+      0x5C300600,  //  0016  MOVE	R12	R3
+      0x5C340800,  //  0017  MOVE	R13	R4
+      0x7C240800,  //  0018  CALL	R9	4
+      0x80041200,  //  0019  RET	1	R9
+      0x7002004E,  //  001A  JMP		#006A
+      0x1C240386,  //  001B  EQ	R9	R1	K134
+      0x78260004,  //  001C  JMPF	R9	#0022
+      0x8C240187,  //  001D  GETMET	R9	R0	K135
+      0x5C2C0800,  //  001E  MOVE	R11	R4
+      0x7C240400,  //  001F  CALL	R9	2
+      0x80041200,  //  0020  RET	1	R9
+      0x70020047,  //  0021  JMP		#006A
+      0x1C240309,  //  0022  EQ	R9	R1	K9
+      0x78260007,  //  0023  JMPF	R9	#002C
+      0x8C240188,  //  0024  GETMET	R9	R0	K136
+      0x5C2C0800,  //  0025  MOVE	R11	R4
+      0x60300017,  //  0026  GETGBL	R12	G23
+      0x5C340600,  //  0027  MOVE	R13	R3
+      0x7C300200,  //  0028  CALL	R12	1
+      0x7C240600,  //  0029  CALL	R9	3
+      0x80041200,  //  002A  RET	1	R9
+      0x7002003D,  //  002B  JMP		#006A
+      0x1C240333,  //  002C  EQ	R9	R1	K51
+      0x78260003,  //  002D  JMPF	R9	#0032
+      0x8C240133,  //  002E  GETMET	R9	R0	K51
+      0x7C240200,  //  002F  CALL	R9	1
+      0x80041200,  //  0030  RET	1	R9
+      0x70020037,  //  0031  JMP		#006A
+      0x88240131,  //  0032  GETMBR	R9	R0	K49
+      0x78260035,  //  0033  JMPF	R9	#006A
+      0x58240007,  //  0034  LDCONST	R9	K7
+      0x6028000C,  //  0035  GETGBL	R10	G12
+      0x882C0131,  //  0036  GETMBR	R11	R0	K49
+      0x7C280200,  //  0037  CALL	R10	1
+      0x1428120A,  //  0038  LT	R10	R9	R10
+      0x782A002F,  //  0039  JMPF	R10	#006A
+      0x88280131,  //  003A  GETMBR	R10	R0	K49
+      0x94281409,  //  003B  GETIDX	R10	R10	R9
+      0x8C2C0D45,  //  003C  GETMET	R11	R6	K69
+      0x5C341400,  //  003D  MOVE	R13	R10
+      0x5C380200,  //  003E  MOVE	R14	R1
+      0x7C2C0600,  //  003F  CALL	R11	3
+      0x60300004,  //  0040  GETGBL	R12	G4
+      0x5C341600,  //  0041  MOVE	R13	R11
+      0x7C300200,  //  0042  CALL	R12	1
+      0x1C30190E,  //  0043  EQ	R12	R12	K14
+      0x78320022,  //  0044  JMPF	R12	#0068
+      0xA8020011,  //  0045  EXBLK	0	#0058
+      0x5C301600,  //  0046  MOVE	R12	R11
+      0x5C341400,  //  0047  MOVE	R13	R10
+      0x5C380400,  //  0048  MOVE	R14	R2
+      0x5C3C0600,  //  0049  MOVE	R15	R3
+      0x5C400800,  //  004A  MOVE	R16	R4
+      0x5C440A00,  //  004B  MOVE	R17	R5
+      0x7C300A00,  //  004C  CALL	R12	5
+      0x74320001,  //  004D  JMPT	R12	#0050
+      0x741E0000,  //  004E  JMPT	R7	#0050
+      0x501C0001,  //  004F  LDBOOL	R7	0	1
+      0x501C0200,  //  0050  LDBOOL	R7	1	0
+      0x781E0003,  //  0051  JMPF	R7	#0056
+      0x5C301000,  //  0052  MOVE	R12	R8
+      0x74320001,  //  0053  JMPT	R12	#0056
+      0xA8040001,  //  0054  EXBLK	1	1
+      0x70020013,  //  0055  JMP		#006A
+      0xA8040001,  //  0056  EXBLK	1	1
+      0x7002000F,  //  0057  JMP		#0068
+      0xAC300002,  //  0058  CATCH	R12	0	2
+      0x7002000C,  //  0059  JMP		#0067
+      0x60380001,  //  005A  GETGBL	R14	G1
+      0x603C0018,  //  005B  GETGBL	R15	G24
+      0x58400089,  //  005C  LDCONST	R16	K137
+      0x5C441800,  //  005D  MOVE	R17	R12
+      0x5C481A00,  //  005E  MOVE	R18	R13
+      0x7C3C0600,  //  005F  CALL	R15	3
+      0x7C380200,  //  0060  CALL	R14	1
+      0x8838014B,  //  0061  GETMBR	R14	R0	K75
+      0x783A0002,  //  0062  JMPF	R14	#0066
+      0xA43A9A00,  //  0063  IMPORT	R14	K77
+      0x8C3C1D8A,  //  0064  GETMET	R15	R14	K138
+      0x7C3C0200,  //  0065  CALL	R15	1
+      0x70020000,  //  0066  JMP		#0068
+      0xB0080000,  //  0067  RAISE	2	R0	R0
+      0x0024130C,  //  0068  ADD	R9	R9	K12
+      0x7001FFCA,  //  0069  JMP		#0035
+      0x1C24038B,  //  006A  EQ	R9	R1	K139
+      0x78260002,  //  006B  JMPF	R9	#006F
+      0xA4271800,  //  006C  IMPORT	R9	K140
+      0x8C28138D,  //  006D  GETMET	R10	R9	K141
+      0x7C280200,  //  006E  CALL	R10	1
+      0x80040E00,  //  006F  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: run_network_up
+********************************************************************/
+be_local_closure(class_Tasmota_run_network_up,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_run_network_up,
+    &be_const_str_solidified,
+    ( &(const binstruction[49]) {  /* code */
+      0x88040126,  //  0000  GETMBR	R1	R0	K38
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8063000,  //  0005  GETNGBL	R1	K24
+      0x8C040323,  //  0006  GETMET	R1	R1	K35
+      0x7C040200,  //  0007  CALL	R1	1
+      0x94040324,  //  0008  GETIDX	R1	R1	K36
+      0x74060005,  //  0009  JMPT	R1	#0010
+      0xB8063000,  //  000A  GETNGBL	R1	K24
+      0x8C040325,  //  000B  GETMET	R1	R1	K37
+      0x7C040200,  //  000C  CALL	R1	1
+      0x94040324,  //  000D  GETIDX	R1	R1	K36
+      0x74060000,  //  000E  JMPT	R1	#0010
+      0x50040001,  //  000F  LDBOOL	R1	0	1
+      0x50040200,  //  0010  LDBOOL	R1	1	0
+      0x7806001D,  //  0011  JMPF	R1	#0030
+      0x6008000C,  //  0012  GETGBL	R2	G12
+      0x880C0126,  //  0013  GETMBR	R3	R0	K38
+      0x7C080200,  //  0014  CALL	R2	1
+      0x24080507,  //  0015  GT	R2	R2	K7
+      0x780A0016,  //  0016  JMPF	R2	#002E
+      0x88080126,  //  0017  GETMBR	R2	R0	K38
+      0x94080507,  //  0018  GETIDX	R2	R2	K7
+      0x880C0126,  //  0019  GETMBR	R3	R0	K38
+      0x8C0C070B,  //  001A  GETMET	R3	R3	K11
+      0x58140007,  //  001B  LDCONST	R5	K7
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0xA8020003,  //  001D  EXBLK	0	#0022
+      0x5C0C0400,  //  001E  MOVE	R3	R2
+      0x7C0C0000,  //  001F  CALL	R3	0
+      0xA8040001,  //  0020  EXBLK	1	1
+      0x7002000A,  //  0021  JMP		#002D
+      0xAC0C0002,  //  0022  CATCH	R3	0	2
+      0x70020007,  //  0023  JMP		#002C
+      0x60140001,  //  0024  GETGBL	R5	G1
+      0x60180018,  //  0025  GETGBL	R6	G24
+      0x581C008E,  //  0026  LDCONST	R7	K142
+      0x5C200600,  //  0027  MOVE	R8	R3
+      0x5C240800,  //  0028  MOVE	R9	R4
+      0x7C180600,  //  0029  CALL	R6	3
+      0x7C140200,  //  002A  CALL	R5	1
+      0x70020000,  //  002B  JMP		#002D
+      0xB0080000,  //  002C  RAISE	2	R0	R0
+      0x7001FFE3,  //  002D  JMP		#0012
+      0x4C080000,  //  002E  LDNIL	R2
+      0x90024C02,  //  002F  SETMBR	R0	K38	R2
+      0x80000000,  //  0030  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_op
+********************************************************************/
+be_local_closure(class_Tasmota_find_op,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_find_op,
+    &be_const_str_solidified,
+    ( &(const binstruction[31]) {  /* code */
+      0x8C08018F,  //  0000  GETMET	R2	R0	K143
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x280C0507,  //  0003  GE	R3	R2	K7
+      0x780E0011,  //  0004  JMPF	R3	#0017
+      0x540E7FFE,  //  0005  LDINT	R3	32767
+      0x2C0C0403,  //  0006  AND	R3	R2	R3
+      0x5412000F,  //  0007  LDINT	R4	16
+      0x3C100404,  //  0008  SHR	R4	R2	R4
+      0x60140012,  //  0009  GETGBL	R5	G18
+      0x7C140000,  //  000A  CALL	R5	0
+      0x0418070C,  //  000B  SUB	R6	R3	K12
+      0x401A0E06,  //  000C  CONNECT	R6	K7	R6
+      0x94180206,  //  000D  GETIDX	R6	R1	R6
+      0x40180A06,  //  000E  CONNECT	R6	R5	R6
+      0x0418090C,  //  000F  SUB	R6	R4	K12
+      0x40180606,  //  0010  CONNECT	R6	R3	R6
+      0x94180206,  //  0011  GETIDX	R6	R1	R6
+      0x40180A06,  //  0012  CONNECT	R6	R5	R6
+      0x40180971,  //  0013  CONNECT	R6	R4	K113
+      0x94180206,  //  0014  GETIDX	R6	R1	R6
+      0x40180A06,  //  0015  CONNECT	R6	R5	R6
+      0x80040A00,  //  0016  RET	1	R5
+      0x600C0012,  //  0017  GETGBL	R3	G18
+      0x7C0C0000,  //  0018  CALL	R3	0
+      0x40100601,  //  0019  CONNECT	R4	R3	R1
+      0x4C100000,  //  001A  LDNIL	R4
+      0x40100604,  //  001B  CONNECT	R4	R3	R4
+      0x4C100000,  //  001C  LDNIL	R4
+      0x40100604,  //  001D  CONNECT	R4	R3	R4
+      0x80040600,  //  001E  RET	1	R3
     })
   )
 );
@@ -2475,29 +2653,29 @@ be_local_closure(class_Tasmota_compile,   /* name */
     &be_const_str_compile,
     &be_const_str_solidified,
     ( &(const binstruction[84]) {  /* code */
-      0xA40A2200,  //  0000  IMPORT	R2	K17
-      0x8C0C0587,  //  0001  GETMET	R3	R2	K135
+      0xA40A7800,  //  0000  IMPORT	R2	K60
+      0x8C0C0574,  //  0001  GETMET	R3	R2	K116
       0x5C140200,  //  0002  MOVE	R5	R1
-      0x58180086,  //  0003  LDCONST	R6	K134
+      0x58180073,  //  0003  LDCONST	R6	K115
       0x7C0C0600,  //  0004  CALL	R3	3
       0x740E0007,  //  0005  JMPT	R3	#000E
       0x600C0001,  //  0006  GETGBL	R3	G1
       0x60100018,  //  0007  GETGBL	R4	G24
-      0x5814008E,  //  0008  LDCONST	R5	K142
+      0x58140090,  //  0008  LDCONST	R5	K144
       0x5C180200,  //  0009  MOVE	R6	R1
       0x7C100400,  //  000A  CALL	R4	2
       0x7C0C0200,  //  000B  CALL	R3	1
       0x500C0000,  //  000C  LDBOOL	R3	0	0
       0x80040600,  //  000D  RET	1	R3
-      0x8C0C051E,  //  000E  GETMET	R3	R2	K30
+      0x8C0C0532,  //  000E  GETMET	R3	R2	K50
       0x5C140200,  //  000F  MOVE	R5	R1
-      0x58180084,  //  0010  LDCONST	R6	K132
+      0x58180070,  //  0010  LDCONST	R6	K112
       0x7C0C0600,  //  0011  CALL	R3	3
-      0x240C0706,  //  0012  GT	R3	R3	K6
+      0x240C0707,  //  0012  GT	R3	R3	K7
       0x780E0006,  //  0013  JMPF	R3	#001B
       0x600C0001,  //  0014  GETGBL	R3	G1
       0x60100018,  //  0015  GETGBL	R4	G24
-      0x5814008F,  //  0016  LDCONST	R5	K143
+      0x58140091,  //  0016  LDCONST	R5	K145
       0x7C100200,  //  0017  CALL	R4	1
       0x7C0C0200,  //  0018  CALL	R3	1
       0x500C0000,  //  0019  LDBOOL	R3	0	0
@@ -2506,7 +2684,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0xA8020011,  //  001C  EXBLK	0	#002F
       0x6010000D,  //  001D  GETGBL	R4	G13
       0x5C140200,  //  001E  MOVE	R5	R1
-      0x58180090,  //  001F  LDCONST	R6	K144
+      0x58180092,  //  001F  LDCONST	R6	K146
       0x7C100400,  //  0020  CALL	R4	2
       0x5C0C0800,  //  0021  MOVE	R3	R4
       0x4C100000,  //  0022  LDNIL	R4
@@ -2514,7 +2692,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x78120007,  //  0024  JMPF	R4	#002D
       0x60100001,  //  0025  GETGBL	R4	G1
       0x60140018,  //  0026  GETGBL	R5	G24
-      0x58180091,  //  0027  LDCONST	R6	K145
+      0x58180093,  //  0027  LDCONST	R6	K147
       0x7C140200,  //  0028  CALL	R5	1
       0x7C100200,  //  0029  CALL	R4	1
       0x50100000,  //  002A  LDBOOL	R4	0	0
@@ -2526,7 +2704,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x7002000A,  //  0030  JMP		#003C
       0x60180001,  //  0031  GETGBL	R6	G1
       0x601C0018,  //  0032  GETGBL	R7	G24
-      0x58200092,  //  0033  LDCONST	R8	K146
+      0x58200094,  //  0033  LDCONST	R8	K148
       0x5C240200,  //  0034  MOVE	R9	R1
       0x5C280800,  //  0035  MOVE	R10	R4
       0x5C2C0A00,  //  0036  MOVE	R11	R5
@@ -2536,9 +2714,9 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x80040C00,  //  003A  RET	1	R6
       0x70020000,  //  003B  JMP		#003D
       0xB0080000,  //  003C  RAISE	2	R0	R0
-      0x00100389,  //  003D  ADD	R4	R1	K137
+      0x00100376,  //  003D  ADD	R4	R1	K118
       0xA8020005,  //  003E  EXBLK	0	#0045
-      0x8C140172,  //  003F  GETMET	R5	R0	K114
+      0x8C14018D,  //  003F  GETMET	R5	R0	K141
       0x5C1C0800,  //  0040  MOVE	R7	R4
       0x5C200600,  //  0041  MOVE	R8	R3
       0x7C140600,  //  0042  CALL	R5	3
@@ -2548,7 +2726,7 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0x70020009,  //  0046  JMP		#0051
       0x60180001,  //  0047  GETGBL	R6	G1
       0x601C0018,  //  0048  GETGBL	R7	G24
-      0x58200093,  //  0049  LDCONST	R8	K147
+      0x58200095,  //  0049  LDCONST	R8	K149
       0x5C240800,  //  004A  MOVE	R9	R4
       0x5C280A00,  //  004B  MOVE	R10	R5
       0x7C1C0600,  //  004C  CALL	R7	3
@@ -2559,6 +2737,81 @@ be_local_closure(class_Tasmota_compile,   /* name */
       0xB0080000,  //  0051  RAISE	2	R0	R0
       0x50140200,  //  0052  LDBOOL	R5	1	0
       0x80040A00,  //  0053  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_light
+********************************************************************/
+be_local_closure(class_Tasmota_get_light,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_get_light,
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080001,  //  0000  GETGBL	R2	G1
+      0x580C0096,  //  0001  LDCONST	R3	K150
+      0x7C080200,  //  0002  CALL	R2	1
+      0xA40B2E00,  //  0003  IMPORT	R2	K151
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x200C0203,  //  0005  NE	R3	R1	R3
+      0x780E0004,  //  0006  JMPF	R3	#000C
+      0x8C0C0545,  //  0007  GETMET	R3	R2	K69
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80040600,  //  000A  RET	1	R3
+      0x70020002,  //  000B  JMP		#000F
+      0x8C0C0545,  //  000C  GETMET	R3	R2	K69
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x80040600,  //  000E  RET	1	R3
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: time_str
+********************************************************************/
+be_local_closure(class_Tasmota_time_str,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tasmota,     /* shared constants */
+    &be_const_str_time_str,
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8C080198,  //  0000  GETMET	R2	R0	K152
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x600C0018,  //  0003  GETGBL	R3	G24
+      0x58100099,  //  0004  LDCONST	R4	K153
+      0x9414059A,  //  0005  GETIDX	R5	R2	K154
+      0x9418059B,  //  0006  GETIDX	R6	R2	K155
+      0x941C059C,  //  0007  GETIDX	R7	R2	K156
+      0x9420059D,  //  0008  GETIDX	R8	R2	K157
+      0x9424059E,  //  0009  GETIDX	R9	R2	K158
+      0x9428059F,  //  000A  GETIDX	R10	R2	K159
+      0x7C0C0E00,  //  000B  CALL	R3	7
+      0x80040600,  //  000C  RET	1	R3
     })
   )
 );
@@ -2583,19 +2836,19 @@ be_local_closure(class_Tasmota_set_light,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0x600C0001,  //  0000  GETGBL	R3	G1
-      0x58100094,  //  0001  LDCONST	R4	K148
+      0x581000A0,  //  0001  LDCONST	R4	K160
       0x7C0C0200,  //  0002  CALL	R3	1
-      0xA40EEE00,  //  0003  IMPORT	R3	K119
+      0xA40F2E00,  //  0003  IMPORT	R3	K151
       0x4C100000,  //  0004  LDNIL	R4
       0x20100404,  //  0005  NE	R4	R2	R4
       0x78120005,  //  0006  JMPF	R4	#000D
-      0x8C100795,  //  0007  GETMET	R4	R3	K149
+      0x8C1007A1,  //  0007  GETMET	R4	R3	K161
       0x5C180200,  //  0008  MOVE	R6	R1
       0x5C1C0400,  //  0009  MOVE	R7	R2
       0x7C100600,  //  000A  CALL	R4	3
       0x80040800,  //  000B  RET	1	R4
       0x70020003,  //  000C  JMP		#0011
-      0x8C100795,  //  000D  GETMET	R4	R3	K149
+      0x8C1007A1,  //  000D  GETMET	R4	R3	K161
       0x5C180200,  //  000E  MOVE	R6	R1
       0x7C100400,  //  000F  CALL	R4	2
       0x80040800,  //  0010  RET	1	R4
@@ -2607,12 +2860,12 @@ be_local_closure(class_Tasmota_set_light,   /* name */
 
 
 /********************************************************************
-** Solidified function: gen_cb
+** Solidified function: try_rule
 ********************************************************************/
-be_local_closure(class_Tasmota_gen_cb,   /* name */
+be_local_closure(class_Tasmota_try_rule,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2620,142 +2873,27 @@ be_local_closure(class_Tasmota_gen_cb,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_gen_cb,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xA40B2C00,  //  0000  IMPORT	R2	K150
-      0x8C0C0597,  //  0001  GETMET	R3	R2	K151
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x80040600,  //  0004  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: urlfetch_cmd
-********************************************************************/
-be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_urlfetch_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0xA4162200,  //  0000  IMPORT	R5	K17
-      0x8C180B1E,  //  0001  GETMET	R6	R5	K30
-      0x5C200600,  //  0002  MOVE	R8	R3
-      0x58240098,  //  0003  LDCONST	R9	K152
-      0x7C180600,  //  0004  CALL	R6	3
-      0x20180D06,  //  0005  NE	R6	R6	K6
-      0x781A0003,  //  0006  JMPF	R6	#000B
-      0x8C180199,  //  0007  GETMET	R6	R0	K153
-      0x5820009A,  //  0008  LDCONST	R8	K154
-      0x7C180400,  //  0009  CALL	R6	2
-      0x80000C00,  //  000A  RET	0
-      0xA802000A,  //  000B  EXBLK	0	#0017
-      0x8C18019B,  //  000C  GETMET	R6	R0	K155
-      0x5C200600,  //  000D  MOVE	R8	R3
-      0x7C180400,  //  000E  CALL	R6	2
-      0x141C0D06,  //  000F  LT	R7	R6	K6
-      0x781E0003,  //  0010  JMPF	R7	#0015
-      0x8C1C019C,  //  0011  GETMET	R7	R0	K156
-      0x7C1C0200,  //  0012  CALL	R7	1
-      0xA8040001,  //  0013  EXBLK	1	1
-      0x80000E00,  //  0014  RET	0
-      0xA8040001,  //  0015  EXBLK	1	1
-      0x70020006,  //  0016  JMP		#001E
-      0xAC180002,  //  0017  CATCH	R6	0	2
-      0x70020003,  //  0018  JMP		#001D
-      0x8C20019C,  //  0019  GETMET	R8	R0	K156
-      0x7C200200,  //  001A  CALL	R8	1
-      0x80001000,  //  001B  RET	0
-      0x70020000,  //  001C  JMP		#001E
-      0xB0080000,  //  001D  RAISE	2	R0	R0
-      0xB81A5E00,  //  001E  GETNGBL	R6	K47
-      0x8C180D9D,  //  001F  GETMET	R6	R6	K157
-      0x7C180200,  //  0020  CALL	R6	1
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_cmd
-********************************************************************/
-be_local_closure(class_Tasmota_remove_cmd,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_remove_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8808017D,  //  0000  GETMBR	R2	R0	K125
-      0x780A0003,  //  0001  JMPF	R2	#0006
-      0x8808017D,  //  0002  GETMBR	R2	R0	K125
-      0x8C080535,  //  0003  GETMET	R2	R2	K53
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_timer
-********************************************************************/
-be_local_closure(class_Tasmota_remove_timer,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Tasmota,     /* shared constants */
-    &be_const_str_remove_timer,
+    &be_const_str_try_rule,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x8808014C,  //  0000  GETMBR	R2	R0	K76
-      0x780A000E,  //  0001  JMPF	R2	#0011
-      0x580C0006,  //  0002  LDCONST	R3	K6
-      0x8C100507,  //  0003  GETMET	R4	R2	K7
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120009,  //  0006  JMPF	R4	#0011
-      0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100908,  //  0008  GETMBR	R4	R4	K8
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120003,  //  000A  JMPF	R4	#000F
-      0x8C100535,  //  000B  GETMET	R4	R2	K53
-      0x5C180600,  //  000C  MOVE	R6	R3
-      0x7C100400,  //  000D  CALL	R4	2
-      0x70020000,  //  000E  JMP		#0010
-      0x000C070A,  //  000F  ADD	R3	R3	K10
-      0x7001FFF1,  //  0010  JMP		#0003
-      0x80000000,  //  0011  RET	0
+      0x8C1005A2,  //  0000  GETMET	R4	R2	K162
+      0x5C180200,  //  0001  MOVE	R6	R1
+      0x7C100400,  //  0002  CALL	R4	2
+      0x4C140000,  //  0003  LDNIL	R5
+      0x20140805,  //  0004  NE	R5	R4	R5
+      0x78160009,  //  0005  JMPF	R5	#0010
+      0x4C140000,  //  0006  LDNIL	R5
+      0x20140605,  //  0007  NE	R5	R3	R5
+      0x78160004,  //  0008  JMPF	R5	#000E
+      0x5C140600,  //  0009  MOVE	R5	R3
+      0x5C180800,  //  000A  MOVE	R6	R4
+      0x881C05A3,  //  000B  GETMBR	R7	R2	K163
+      0x5C200200,  //  000C  MOVE	R8	R1
+      0x7C140600,  //  000D  CALL	R5	3
+      0x50140200,  //  000E  LDBOOL	R5	1	0
+      0x80040A00,  //  000F  RET	1	R5
+      0x50140000,  //  0010  LDBOOL	R5	0	0
+      0x80040A00,  //  0011  RET	1	R5
     })
   )
 );
@@ -2766,66 +2904,69 @@ be_local_closure(class_Tasmota_remove_timer,   /* name */
 ** Solidified class: Tasmota
 ********************************************************************/
 be_local_class(Tasmota,
-    14,
+    15,
     NULL,
-    be_nested_map(56,
+    be_nested_map(59,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(wire_scan, 29), be_const_closure(class_Tasmota_wire_scan_closure) },
-        { be_const_key(next_cron, -1), be_const_closure(class_Tasmota_next_cron_closure) },
-        { be_const_key(remove_timer, -1), be_const_closure(class_Tasmota_remove_timer_closure) },
-        { be_const_key(find_list_i, -1), be_const_closure(class_Tasmota_find_list_i_closure) },
-        { be_const_key(time_str, 40), be_const_closure(class_Tasmota_time_str_closure) },
-        { be_const_key(remove_cmd, 41), be_const_closure(class_Tasmota_remove_cmd_closure) },
-        { be_const_key(wd, 12), be_const_var(12) },
-        { be_const_key(urlfetch_cmd, 52), be_const_closure(class_Tasmota_urlfetch_cmd_closure) },
-        { be_const_key(remove_driver, -1), be_const_closure(class_Tasmota_remove_driver_closure) },
-        { be_const_key(exec_tele, -1), be_const_closure(class_Tasmota_exec_tele_closure) },
-        { be_const_key(run_cron, -1), be_const_closure(class_Tasmota_run_cron_closure) },
-        { be_const_key(set_light, -1), be_const_closure(class_Tasmota_set_light_closure) },
-        { be_const_key(compile, -1), be_const_closure(class_Tasmota_compile_closure) },
-        { be_const_key(hs2rgb, 16), be_const_closure(class_Tasmota_hs2rgb_closure) },
-        { be_const_key(exec_rules, -1), be_const_closure(class_Tasmota_exec_rules_closure) },
-        { be_const_key(add_rule, -1), be_const_closure(class_Tasmota_add_rule_closure) },
-        { be_const_key(_ccmd, -1), be_const_var(5) },
-        { be_const_key(_rules, -1), be_const_var(1) },
-        { be_const_key(int, -1), be_const_static_closure(class_Tasmota_int_closure) },
-        { be_const_key(init, 53), be_const_closure(class_Tasmota_init_closure) },
-        { be_const_key(exec_cmd, 46), be_const_closure(class_Tasmota_exec_cmd_closure) },
-        { be_const_key(add_cron, 7), be_const_closure(class_Tasmota_add_cron_closure) },
-        { be_const_key(_defer, -1), be_const_var(3) },
-        { be_const_key(run_timers, -1), be_const_closure(class_Tasmota_run_timers_closure) },
-        { be_const_key(remove_rule, -1), be_const_closure(class_Tasmota_remove_rule_closure) },
-        { be_const_key(_drivers, -1), be_const_var(6) },
-        { be_const_key(urlfetch, 51), be_const_closure(class_Tasmota_urlfetch_closure) },
-        { be_const_key(_crons, 50), be_const_var(4) },
-        { be_const_key(_timers, 14), be_const_var(2) },
-        { be_const_key(settings, -1), be_const_var(11) },
-        { be_const_key(global, 18), be_const_var(10) },
-        { be_const_key(check_not_method, 20), be_const_closure(class_Tasmota_check_not_method_closure) },
-        { be_const_key(run_deferred, 11), be_const_closure(class_Tasmota_run_deferred_closure) },
-        { be_const_key(add_rule_once, -1), be_const_closure(class_Tasmota_add_rule_once_closure) },
-        { be_const_key(remove_cron, -1), be_const_closure(class_Tasmota_remove_cron_closure) },
-        { be_const_key(defer, 10), be_const_closure(class_Tasmota_defer_closure) },
-        { be_const_key(event, -1), be_const_closure(class_Tasmota_event_closure) },
-        { be_const_key(_debug_present, -1), be_const_var(13) },
-        { be_const_key(wire2, -1), be_const_var(8) },
-        { be_const_key(remove_fast_loop, 36), be_const_closure(class_Tasmota_remove_fast_loop_closure) },
-        { be_const_key(get_light, -1), be_const_closure(class_Tasmota_get_light_closure) },
-        { be_const_key(find_key_i, -1), be_const_closure(class_Tasmota_find_key_i_closure) },
-        { be_const_key(add_fast_loop, -1), be_const_closure(class_Tasmota_add_fast_loop_closure) },
+        { be_const_key(add_cron, 2), be_const_closure(class_Tasmota_add_cron_closure) },
+        { be_const_key(remove_rule, 7), be_const_closure(class_Tasmota_remove_rule_closure) },
+        { be_const_key(global, -1), be_const_var(11) },
+        { be_const_key(add_rule, 43), be_const_closure(class_Tasmota_add_rule_closure) },
+        { be_const_key(hs2rgb, 23), be_const_closure(class_Tasmota_hs2rgb_closure) },
+        { be_const_key(_crons, -1), be_const_var(4) },
+        { be_const_key(cmd_res, -1), be_const_var(10) },
+        { be_const_key(_fl, 45), be_const_var(0) },
+        { be_const_key(exec_cmd, 20), be_const_closure(class_Tasmota_exec_cmd_closure) },
+        { be_const_key(when_network_up, 52), be_const_closure(class_Tasmota_when_network_up_closure) },
+        { be_const_key(_debug_present, -1), be_const_var(14) },
+        { be_const_key(run_deferred, 15), be_const_closure(class_Tasmota_run_deferred_closure) },
+        { be_const_key(settings, -1), be_const_var(12) },
+        { be_const_key(fast_loop, -1), be_const_closure(class_Tasmota_fast_loop_closure) },
         { be_const_key(cmd, -1), be_const_closure(class_Tasmota_cmd_closure) },
-        { be_const_key(_fl, -1), be_const_var(0) },
-        { be_const_key(try_rule, 23), be_const_closure(class_Tasmota_try_rule_closure) },
+        { be_const_key(set_light, -1), be_const_closure(class_Tasmota_set_light_closure) },
         { be_const_key(gc, -1), be_const_closure(class_Tasmota_gc_closure) },
+        { be_const_key(defer, -1), be_const_closure(class_Tasmota_defer_closure) },
+        { be_const_key(_drivers, 37), be_const_var(6) },
+        { be_const_key(remove_timer, -1), be_const_closure(class_Tasmota_remove_timer_closure) },
+        { be_const_key(remove_fast_loop, -1), be_const_closure(class_Tasmota_remove_fast_loop_closure) },
+        { be_const_key(int, -1), be_const_static_closure(class_Tasmota_int_closure) },
+        { be_const_key(wire_scan, -1), be_const_closure(class_Tasmota_wire_scan_closure) },
+        { be_const_key(compile, -1), be_const_closure(class_Tasmota_compile_closure) },
+        { be_const_key(wire1, -1), be_const_var(8) },
+        { be_const_key(remove_cmd, -1), be_const_closure(class_Tasmota_remove_cmd_closure) },
+        { be_const_key(find_list_i, -1), be_const_closure(class_Tasmota_find_list_i_closure) },
+        { be_const_key(remove_cron, 30), be_const_closure(class_Tasmota_remove_cron_closure) },
+        { be_const_key(find_op, 50), be_const_closure(class_Tasmota_find_op_closure) },
+        { be_const_key(_rules, -1), be_const_var(1) },
+        { be_const_key(_defer, -1), be_const_var(3) },
+        { be_const_key(init, -1), be_const_closure(class_Tasmota_init_closure) },
+        { be_const_key(_ccmd, -1), be_const_var(5) },
         { be_const_key(add_cmd, -1), be_const_closure(class_Tasmota_add_cmd_closure) },
-        { be_const_key(find_op, -1), be_const_closure(class_Tasmota_find_op_closure) },
-        { be_const_key(load, -1), be_const_closure(class_Tasmota_load_closure) },
-        { be_const_key(add_driver, 35), be_const_closure(class_Tasmota_add_driver_closure) },
-        { be_const_key(cmd_res, -1), be_const_var(9) },
-        { be_const_key(set_timer, -1), be_const_closure(class_Tasmota_set_timer_closure) },
-        { be_const_key(wire1, -1), be_const_var(7) },
-        { be_const_key(fast_loop, 5), be_const_closure(class_Tasmota_fast_loop_closure) },
-        { be_const_key(gen_cb, 2), be_const_closure(class_Tasmota_gen_cb_closure) },
+        { be_const_key(urlfetch, -1), be_const_closure(class_Tasmota_urlfetch_closure) },
+        { be_const_key(urlfetch_cmd, 28), be_const_closure(class_Tasmota_urlfetch_cmd_closure) },
+        { be_const_key(run_network_up, -1), be_const_closure(class_Tasmota_run_network_up_closure) },
+        { be_const_key(event, 48), be_const_closure(class_Tasmota_event_closure) },
+        { be_const_key(add_fast_loop, -1), be_const_closure(class_Tasmota_add_fast_loop_closure) },
+        { be_const_key(set_timer, 42), be_const_closure(class_Tasmota_set_timer_closure) },
+        { be_const_key(run_cron, -1), be_const_closure(class_Tasmota_run_cron_closure) },
+        { be_const_key(wd, -1), be_const_var(13) },
+        { be_const_key(_wnu, 38), be_const_var(7) },
+        { be_const_key(find_key_i, 51), be_const_closure(class_Tasmota_find_key_i_closure) },
+        { be_const_key(exec_rules, -1), be_const_closure(class_Tasmota_exec_rules_closure) },
+        { be_const_key(load, 16), be_const_closure(class_Tasmota_load_closure) },
+        { be_const_key(remove_driver, -1), be_const_closure(class_Tasmota_remove_driver_closure) },
+        { be_const_key(gen_cb, -1), be_const_closure(class_Tasmota_gen_cb_closure) },
+        { be_const_key(add_rule_once, 55), be_const_closure(class_Tasmota_add_rule_once_closure) },
+        { be_const_key(wire2, 36), be_const_var(9) },
+        { be_const_key(exec_tele, -1), be_const_closure(class_Tasmota_exec_tele_closure) },
+        { be_const_key(_timers, -1), be_const_var(2) },
+        { be_const_key(run_timers, 56), be_const_closure(class_Tasmota_run_timers_closure) },
+        { be_const_key(get_light, -1), be_const_closure(class_Tasmota_get_light_closure) },
+        { be_const_key(time_str, -1), be_const_closure(class_Tasmota_time_str_closure) },
+        { be_const_key(add_driver, -1), be_const_closure(class_Tasmota_add_driver_closure) },
+        { be_const_key(next_cron, -1), be_const_closure(class_Tasmota_next_cron_closure) },
+        { be_const_key(check_not_method, 6), be_const_closure(class_Tasmota_check_not_method_closure) },
+        { be_const_key(try_rule, -1), be_const_closure(class_Tasmota_try_rule_closure) },
     })),
     (bstring*) &be_const_str_Tasmota
 );


### PR DESCRIPTION
## Description:

Add `tasmota.when_network_up(function) -> nil` when you need to call network functions that would crash if the network stack has not yet started.

Simplified Matter code to use this function, and run even when Rules are not enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
