### PR TITLE
Berry 'introspect.solidified()' to know if a Berry object is solidified in Flash or in RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - LVGL experimental mirroring of display on Web UI (#23041)
 - Allow acl in mqtt when client certificate is in use with `#define USE_MQTT_CLIENT_CERT` (#22998)
 - Berry `tasmota.when_network_up()` and simplified Matter using it
+- Berry `introspect.isconst()` to know if a Berry object is solidified or in RAM
 
 ### Breaking Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - LVGL experimental mirroring of display on Web UI (#23041)
 - Allow acl in mqtt when client certificate is in use with `#define USE_MQTT_CLIENT_CERT` (#22998)
 - Berry `tasmota.when_network_up()` and simplified Matter using it
-- Berry `introspect.isconst()` to know if a Berry object is solidified or in RAM
+- Berry `introspect.solidified()` to know if a Berry object is solidified or in RAM
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -137,6 +137,20 @@ static int m_toptr(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_isconst(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
+            bbool isconst = gc_isconst((bgcobject*)var_toobj(v));
+            be_pushbool(vm, isconst);
+            be_return(vm);
+        }
+    }
+    be_return_nil(vm);
+}
+
 static int m_fromptr(bvm *vm)
 {
     int top = be_top(vm);
@@ -245,6 +259,7 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
+    be_native_module_function("isconst", m_isconst),
 
     be_native_module_function("name", m_name),
 
@@ -266,6 +281,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)
+    isconst, func(m_isconst)
 
     name, func(m_name)
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -137,7 +137,7 @@ static int m_toptr(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_isconst(bvm *vm)
+static int m_solidified(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -259,7 +259,7 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
-    be_native_module_function("isconst", m_isconst),
+    be_native_module_function("solidified", m_solidified),
 
     be_native_module_function("name", m_name),
 
@@ -281,7 +281,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)
-    isconst, func(m_isconst)
+    soldified, func(m_solidified)
 
     name, func(m_name)
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -281,7 +281,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)
-    soldified, func(m_solidified)
+    solidified, func(m_solidified)
 
     name, func(m_name)
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -107,7 +107,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     init, closure(class_Tasmota_init_closure)
 
     get_free_heap, func(l_getFreeHeap)
-    arch, func(l_arch)
+    arch, static_func(l_arch)
     publish, func(be_mqtt_publish)
     publish_result, func(l_publish_result)
     publish_rule, func(l_publish_rule)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -982,7 +982,7 @@ extern "C" {
     be_return(vm);
   }
 
-  // Berry: `arvh() -> string`
+  // Berry: `arch() -> string`
   // ESP object
   int32_t l_arch(bvm *vm);
   int32_t l_arch(bvm *vm) {


### PR DESCRIPTION
## Description:

Berry, add `introspect.solidified(any) -> bool or nil`. Returns `true` if the object constant, i.e. is solidified in Flash, which also means that the object will not be removed by the garbage collector (hence removing any reference will not save space). Returns `false` if the object is in RAM and could be removed by the garbage collector if no reference points to it. Returns `nil` if it's irrelevant to this type (ex: int).

```berry
import introspect
import math

print(introspect.solidified(math))
# true

class A end
print(introspect.solidified(A))
# false

print(introspect.solidified("math"))
# true - the string "math" is part of the string pool in Flash

print(introspect.solidified("arandomsentencethatislikelynotinflash"))
# false - this string was allocated in RAM

print(introspect.solidified(2))
# nil - irrelevant for numbers
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
