### PR TITLE
Berry minor fixes to remove warnings

### DIFF
--- a/lib/libesp32/berry_int64/src/be_int64_class.c
+++ b/lib/libesp32/berry_int64/src/be_int64_class.c
@@ -11,25 +11,25 @@
 #include "be_mem.h"
 
 static void int64_toa(int64_t num, uint8_t* str) {
-	uint64_t sum = num;
+  uint64_t sum = num;
   if (num < 0) {
     sum = -num;
     str[0] = '-';
     str++;
   }
-	int len = 0;
-	do {
+  int len = 0;
+  do {
     str[len++] = '0' + sum % 10LL;
-		sum /= 10LL;
-	} while (sum);
-	str[len] = '\0';
+    sum /= 10LL;
+  } while (sum);
+  str[len] = '\0';
   /* strrev */
   int i, j;
-	for (i = 0, j = len - 1; i < j; i++, j--){
-		uint8_t a = str[i];
-		str[i] = str[j];
-		str[j] = a;
-	}
+  for (i = 0, j = len - 1; i < j; i++, j--){
+    uint8_t a = str[i];
+    str[i] = str[j];
+    str[j] = a;
+  }
 }
 
 /* constructor*/
@@ -320,15 +320,15 @@ be_local_closure(toint64,   /* name */
     &be_const_str_toint64,
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x1C040001,  //  0001  EQ	R1	R0	R1
-      0x78060001,  //  0002  JMPF	R1	#0005
-      0x4C040000,  //  0003  LDNIL	R1
-      0x80040200,  //  0004  RET	1	R1
-      0xB8060000,  //  0005  GETNGBL	R1	K0
-      0x5C080000,  //  0006  MOVE	R2	R0
-      0x7C040200,  //  0007  CALL	R1	1
-      0x80040200,  //  0008  RET	1	R1
+      0x4C040000,  //  0000  LDNIL  R1
+      0x1C040001,  //  0001  EQ  R1  R0  R1
+      0x78060001,  //  0002  JMPF  R1  #0005
+      0x4C040000,  //  0003  LDNIL  R1
+      0x80040200,  //  0004  RET  1  R1
+      0xB8060000,  //  0005  GETNGBL  R1  K0
+      0x5C080000,  //  0006  MOVE  R2  R0
+      0x7C040200,  //  0007  CALL  R1  1
+      0x80040200,  //  0008  RET  1  R1
     })
   )
 );

--- a/lib/libesp32/berry_mapping/src/be_cb_module.c
+++ b/lib/libesp32/berry_mapping/src/be_cb_module.c
@@ -27,26 +27,26 @@ static int call_berry_cb(int num, int v0, int v1, int v2, int v3, int v4);
 
 #define BERRY_CB(n) int berry_cb_##n(int v0, int v1, int v2, int v3, int v4) { return call_berry_cb(n, v0, v1, v2, v3, v4); }
 // list the callbacks
-BERRY_CB(0);
-BERRY_CB(1);
-BERRY_CB(2);
-BERRY_CB(3);
-BERRY_CB(4);
-BERRY_CB(5);
-BERRY_CB(6);
-BERRY_CB(7);
-BERRY_CB(8);
-BERRY_CB(9);
-BERRY_CB(10);
-BERRY_CB(11);
-BERRY_CB(12);
-BERRY_CB(13);
-BERRY_CB(14);
-BERRY_CB(15);
-BERRY_CB(16);
-BERRY_CB(17);
-BERRY_CB(18);
-BERRY_CB(19);
+BERRY_CB(0)
+BERRY_CB(1)
+BERRY_CB(2)
+BERRY_CB(3)
+BERRY_CB(4)
+BERRY_CB(5)
+BERRY_CB(6)
+BERRY_CB(7)
+BERRY_CB(8)
+BERRY_CB(9)
+BERRY_CB(10)
+BERRY_CB(11)
+BERRY_CB(12)
+BERRY_CB(13)
+BERRY_CB(14)
+BERRY_CB(15)
+BERRY_CB(16)
+BERRY_CB(17)
+BERRY_CB(18)
+BERRY_CB(19)
 
 // array of callbacks
 static const berry_callback_t berry_callback_array[BE_MAX_CB] = {


### PR DESCRIPTION
## Description:

Berry: remove tab characters in C file, and remove superfluous `;` to avoid compiler warnings.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
