### PR TITLE
Berry 'global.undef()' to undefine a global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Allow acl in mqtt when client certificate is in use with `#define USE_MQTT_CLIENT_CERT` (#22998)
 - Berry `tasmota.when_network_up()` and simplified Matter using it (#23057)
 - Berry `introspect.solidified()` to know if a Berry object is solidified or in RAM (#23063)
+- Berry `global.undef()` to undefine a global variable
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -82,8 +82,8 @@ BERRY_API void be_regfunc(bvm *vm, const char *name, bntvfunc f)
     bstring *s = be_newstr(vm, name);
 #if !BE_USE_PRECOMPILED_OBJECT
     int idx = be_builtin_find(vm, s);
-    be_assert(idx == -1);
-    if (idx == -1) { /* new function */
+    be_assert(idx < 0);
+    if (idx < 0) { /* new function */
         idx = be_builtin_new(vm, s);
 #else
     int idx = be_global_find(vm, s);
@@ -102,8 +102,8 @@ BERRY_API void be_regclass(bvm *vm, const char *name, const bnfuncinfo *lib)
     bstring *s = be_newstr(vm, name);
 #if !BE_USE_PRECOMPILED_OBJECT
     int idx = be_builtin_find(vm, s);
-    be_assert(idx == -1);
-    if (idx == -1) { /* new function */
+    be_assert(idx < 0);
+    if (idx < 0) { /* new function */
         idx = be_builtin_new(vm, s);
 #else
     int idx = be_global_find(vm, s);
@@ -599,7 +599,7 @@ BERRY_API bbool be_getglobal(bvm *vm, const char *name)
 {
     int idx = be_global_find(vm, be_newstr(vm, name));
     bvalue *top = be_incrtop(vm);
-    if (idx > -1) {
+    if (idx >= 0) {
         *top = *be_global_var(vm, idx);
         return btrue;
     }

--- a/lib/libesp32/berry/src/be_var.h
+++ b/lib/libesp32/berry/src/be_var.h
@@ -20,6 +20,7 @@ void be_globalvar_init(bvm *vm);
 void be_globalvar_deinit(bvm *vm);
 int be_global_find(bvm *vm, bstring *name);
 int be_global_new(bvm *vm, bstring *name);
+bbool be_global_undef(bvm *vm, bstring *name);
 bvalue* be_global_var(bvm *vm, int index);
 void be_global_release_space(bvm *vm);
 int be_builtin_find(bvm *vm, bstring *name);

--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -591,7 +591,7 @@ newframe: /* a new call frame */
             if (var_isstr(b)) {
                 bstring *name = var_tostr(b);
                 int idx = be_global_find(vm, name);
-                if (idx > -1) {
+                if (idx >= 0) {
                     *v = *be_global_var(vm, idx);
                 } else {
                     vm_error(vm, "attribute_error", "'%s' undeclared", str(name));


### PR DESCRIPTION
## Description:

Berry experimental feature. Add `global.undef(name: string) -> nil` to undefine any global variable. Its content is not referenced by the global variable, so it may be garbage collected (if there isn't any other reference to it) and the name disappears from global scope. Solidified imports and classes are automatically reinserted to the global scope when needed.

```berry
A = 10
print(global.contains("A"))
# true

print(A)
# 10

global.undef("A")
print(A)
# BRY: Exception> 'attribute_error' - 'A' undeclared
# stack traceback:
# 	:9: in function `main`
# - this happens because the compiler knows that "A" exists at compile time, but the global does not exist at runtime

print(global.contains("A"))
# false

print(global.A)
# nil - nil is returned if the global does not exist
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
