### PR TITLE
Compile lib NeopixelBus only for esp8266

### DIFF
--- a/lib/lib_basic/NeoPixelBus/library.json
+++ b/lib/lib_basic/NeoPixelBus/library.json
@@ -9,11 +9,7 @@
   },
   "version": "2.6.7",
   "frameworks": "arduino",
-  "platforms": "*",
-  "dependencies": [
-    {
-      "name": "SPI"
-    }
-  ]
+  "libCompatMode": "strict",
+  "platforms": ["espressif8266"]
 }
 

--- a/lib/lib_basic/TasmotaLED/library.json
+++ b/lib/lib_basic/TasmotaLED/library.json
@@ -11,6 +11,7 @@
         "url": "https://github.com/arendst/Tasmota/lib/lib_basic/TasmotaLED"
     },
     "frameworks": "arduino",
+    "libCompatMode": "strict",
     "platforms": [
       "espressif32"
     ]


### PR DESCRIPTION
## Description:

Stop unneeded compile of lib NeopixelBus (not used for esp32). No Tasmota code change

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.1.250203
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
