### PR TITLE
Berry prevent 'import' from hiding a solidified class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 enable webcam version 2 (#18732)
 
 ### Fixed
+- Berry prevent `import` from hiding a solidified class
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -488,7 +488,10 @@ static void new_var(bparser *parser, bstring *name, bexpdesc *var)
         var->v.idx = new_localvar(parser, name); /* if local, contains the index in current local var list */
     } else {
         init_exp(var, ETGLOBAL, 0);
-        var->v.idx = be_global_new(parser->vm, name);
+        var->v.idx = be_global_find(parser->vm, name);
+        if (var->v.idx < 0) {
+            var->v.idx = be_global_new(parser->vm, name);
+        }
         if (var->v.idx > (int)IBx_MASK) {
             push_error(parser,
                 "too many global variables (in '%s')", str(name));


### PR DESCRIPTION
## Description:

Berry has a mechanism to have solidified classes than are added as global names at first invocation, hence avoiding to pollute the global namespace with names you don't use.

Because of a nasty side effect, command `import <name>` on the name of a solidified class would actually hide it completely.

Before:
```berry
import serial
# BRY: Exception> 'import_error' - module 'serial' not found
# stack traceback:
# 	:1: in function `main`

print(serial)
# nil
```

After:
```berry
import serial
# BRY: Exception> 'import_error' - module 'serial' not found
# stack traceback:
# 	:1: in function `main`

print(serial)
# <class: serial>
```

No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
