### PR TITLE
Berry load  files in '/.extensions/' then in '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.5.0.2] 
 ### Added
+- Berry load `.tapp` files in `/.extensions/` then in `/`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/tapp.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tapp.be
@@ -8,29 +8,34 @@ tapp_module.init = def (m)
 
   class Tapp
 
+    # we make sure the instance is registered as a driver to receive the "autoexec" event
     def init()
       tasmota.add_driver(self)
     end
 
-    def autoexec()
+    # Takes a list of files, and run any tapp file's autoexec.be
+    static def autoexec_dir(dir_name)
       import path
       import string
-
-      var dir = path.listdir("/")
-
-      for d: dir
-        if string.find(d, ".tapp") > 0
-          tasmota.log(format("TAP: Loaded Tasmota App '%s'", d), 2)
-          tasmota.load(d + "#autoexec.be")
+      for d: path.listdir(dir_name)
+        if string.endswith(d, ".tapp")
+          log(f"TAP: Loaded Tasmota App '{dir_name}{d}'", 2)
+          tasmota.load(dir_name + d + "#autoexec.be")
         end
       end
+    end
+
+    # react to the "autoexec" event that is triggered at first tick when Berry starts
+    # Note: this is alled before the file "/autoexec.be" is loaded
+    #
+    # We run all `*.tapp` that are located in "/.extensions/" and in "/" in this order
+    def autoexec()
+      self.autoexec_dir("/.extensions/")
+      self.autoexec_dir("/")
     end
   end
 
   return Tapp()    # return an instance of this class
 end
 
-# aa = autoconf_module.init(autoconf_module)
-# import webserver
-# webserver.on('/ac2', / -> aa.page_autoconf_mgr(), webserver.HTTP_GET)
 return tapp_module

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
@@ -3,23 +3,26 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'Tapp' ktab size: 15, total: 16 (saved 8 bytes)
-static const bvalue be_ktab_class_Tapp[15] = {
+extern const bclass be_class_Tapp;
+// compact class 'Tapp' ktab size: 17, total: 18 (saved 8 bytes)
+static const bvalue be_ktab_class_Tapp[17] = {
   /* K0   */  be_nested_str(tasmota),
   /* K1   */  be_nested_str(add_driver),
-  /* K2   */  be_nested_str(path),
-  /* K3   */  be_nested_str(string),
-  /* K4   */  be_nested_str(listdir),
-  /* K5   */  be_nested_str(_X2F),
-  /* K6   */  be_nested_str(find),
-  /* K7   */  be_nested_str(_X2Etapp),
-  /* K8   */  be_const_int(0),
-  /* K9   */  be_nested_str(log),
-  /* K10  */  be_nested_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27),
-  /* K11  */  be_const_int(2),
-  /* K12  */  be_nested_str(load),
-  /* K13  */  be_nested_str(_X23autoexec_X2Ebe),
-  /* K14  */  be_nested_str(stop_iteration),
+  /* K2   */  be_nested_str(autoexec_dir),
+  /* K3   */  be_nested_str(_X2F_X2Eextensions_X2F),
+  /* K4   */  be_nested_str(_X2F),
+  /* K5   */  be_const_class(be_class_Tapp),
+  /* K6   */  be_nested_str(path),
+  /* K7   */  be_nested_str(string),
+  /* K8   */  be_nested_str(listdir),
+  /* K9   */  be_nested_str(endswith),
+  /* K10  */  be_nested_str(_X2Etapp),
+  /* K11  */  be_nested_str(log),
+  /* K12  */  be_nested_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X25s_X27),
+  /* K13  */  be_const_int(2),
+  /* K14  */  be_nested_str(load),
+  /* K15  */  be_nested_str(_X23autoexec_X2Ebe),
+  /* K16  */  be_nested_str(stop_iteration),
 };
 
 
@@ -58,7 +61,7 @@ be_local_closure(class_Tapp_init,   /* name */
 ********************************************************************/
 be_local_closure(class_Tapp_autoexec,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -69,38 +72,68 @@ be_local_closure(class_Tapp_autoexec,   /* name */
     &be_ktab_class_Tapp,     /* shared constants */
     &be_const_str_autoexec,
     &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C040102,  //  0000  GETMET	R1	R0	K2
+      0x580C0003,  //  0001  LDCONST	R3	K3
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x580C0004,  //  0004  LDCONST	R3	K4
+      0x7C040400,  //  0005  CALL	R1	2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoexec_dir
+********************************************************************/
+be_local_closure(class_Tapp_autoexec_dir,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Tapp,     /* shared constants */
+    &be_const_str_autoexec_dir,
+    &be_const_str_solidified,
     ( &(const binstruction[34]) {  /* code */
-      0xA4060400,  //  0000  IMPORT	R1	K2
-      0xA40A0600,  //  0001  IMPORT	R2	K3
-      0x8C0C0304,  //  0002  GETMET	R3	R1	K4
-      0x58140005,  //  0003  LDCONST	R5	K5
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x60100010,  //  0005  GETGBL	R4	G16
-      0x5C140600,  //  0006  MOVE	R5	R3
+      0x58040005,  //  0000  LDCONST	R1	K5
+      0xA40A0C00,  //  0001  IMPORT	R2	K6
+      0xA40E0E00,  //  0002  IMPORT	R3	K7
+      0x60100010,  //  0003  GETGBL	R4	G16
+      0x8C140508,  //  0004  GETMET	R5	R2	K8
+      0x5C1C0000,  //  0005  MOVE	R7	R0
+      0x7C140400,  //  0006  CALL	R5	2
       0x7C100200,  //  0007  CALL	R4	1
       0xA8020014,  //  0008  EXBLK	0	#001E
       0x5C140800,  //  0009  MOVE	R5	R4
       0x7C140000,  //  000A  CALL	R5	0
-      0x8C180506,  //  000B  GETMET	R6	R2	K6
+      0x8C180709,  //  000B  GETMET	R6	R3	K9
       0x5C200A00,  //  000C  MOVE	R8	R5
-      0x58240007,  //  000D  LDCONST	R9	K7
+      0x5824000A,  //  000D  LDCONST	R9	K10
       0x7C180600,  //  000E  CALL	R6	3
-      0x24180D08,  //  000F  GT	R6	R6	K8
-      0x781A000B,  //  0010  JMPF	R6	#001D
-      0xB81A0000,  //  0011  GETNGBL	R6	K0
-      0x8C180D09,  //  0012  GETMET	R6	R6	K9
-      0x60200018,  //  0013  GETGBL	R8	G24
-      0x5824000A,  //  0014  LDCONST	R9	K10
-      0x5C280A00,  //  0015  MOVE	R10	R5
-      0x7C200400,  //  0016  CALL	R8	2
-      0x5824000B,  //  0017  LDCONST	R9	K11
-      0x7C180600,  //  0018  CALL	R6	3
-      0xB81A0000,  //  0019  GETNGBL	R6	K0
-      0x8C180D0C,  //  001A  GETMET	R6	R6	K12
-      0x00200B0D,  //  001B  ADD	R8	R5	K13
+      0x781A000C,  //  000F  JMPF	R6	#001D
+      0xB81A1600,  //  0010  GETNGBL	R6	K11
+      0x601C0018,  //  0011  GETGBL	R7	G24
+      0x5820000C,  //  0012  LDCONST	R8	K12
+      0x5C240000,  //  0013  MOVE	R9	R0
+      0x5C280A00,  //  0014  MOVE	R10	R5
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x5820000D,  //  0016  LDCONST	R8	K13
+      0x7C180400,  //  0017  CALL	R6	2
+      0xB81A0000,  //  0018  GETNGBL	R6	K0
+      0x8C180D0E,  //  0019  GETMET	R6	R6	K14
+      0x00200005,  //  001A  ADD	R8	R0	R5
+      0x0020110F,  //  001B  ADD	R8	R8	K15
       0x7C180400,  //  001C  CALL	R6	2
       0x7001FFEA,  //  001D  JMP		#0009
-      0x5810000E,  //  001E  LDCONST	R4	K14
+      0x58100010,  //  001E  LDCONST	R4	K16
       0xAC100200,  //  001F  CATCH	R4	1	0
       0xB0080000,  //  0020  RAISE	2	R0	R0
       0x80000000,  //  0021  RET	0
@@ -116,10 +149,11 @@ be_local_closure(class_Tapp_autoexec,   /* name */
 be_local_class(Tapp,
     0,
     NULL,
-    be_nested_map(2,
+    be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(init, -1), be_const_closure(class_Tapp_init_closure) },
         { be_const_key(autoexec, -1), be_const_closure(class_Tapp_autoexec_closure) },
-        { be_const_key(init, 0), be_const_closure(class_Tapp_init_closure) },
+        { be_const_key(autoexec_dir, -1), be_const_static_closure(class_Tapp_autoexec_dir_closure) },
     })),
     (bstring*) &be_const_str_Tapp
 );


### PR DESCRIPTION
## Description:

Berry, load all `*.tapp` files located in `/.extensions/` hidden directory, then from the root directory `/`, then finally load `autoexec.be`.

This is in preparation for an extensions manager.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
