### PR TITLE
support_wifi.ino: Check if WiFi is connected before getting localIP

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -508,6 +508,9 @@ bool WifiGetIP(IPAddress *ip, bool exclude_ap = false);
 // Returns only IPv6 global address (no loopback and no link-local)
 bool WifiGetIPv4(IPAddress *ip)
 {
+  if (WiFi.status() != WL_CONNECTED) {
+    return false;
+  }
   uint32_t wifi_uint = (uint32_t) WiFi.localIP();
   if (ip != nullptr) { *ip = wifi_uint; }
   return wifi_uint != 0;


### PR DESCRIPTION
 
## Description:
I'm using a ZB-GW03-V1.2 device ([https://templates.blakadder.com/ewelink_ZB-GW03](https://templates.blakadder.com/ewelink_ZB-GW03)). With the following scenario:

* Device connected via Ethernet (unsure yet if happens without Ethernet connected)
* At least one SSID configured, **SSIDs configured must not be able to be connected to**

Results in a panic after failing to connect to the WiFi for 1-2 minute aprox. The device then reboots.

This is the error shown via Serial:

```
[15:08:45]00:02:20.938 WIF: Connect failed as AP cannot be reached [15:08:45]Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled. [15:08:45]
[15:08:45]Core  1 register dump:
[15:08:45]PC      : 0x4016dc6a  PS      : 0x00060c30  A0      : 0x80142249  A1      : 0x3ffbc220  
[15:08:45]A2      : 0x3ffd73f0  A3      : 0x3ffbc240  A4      : 0x80090b1a  A5      : 0x3ffb1a30  
[15:08:45]A6      : 0x00000003  A7      : 0x00060023  A8      : 0x801c9456  A9      : 0x00000000  
[15:08:45]A10     : 0x3ffbc240  A11     : 0x00000000  A12     : 0x80000020  A13     : 0x80000000  
[15:08:45]A14     : 0x00000005  A15     : 0x00000001  SAR     : 0x00000015  EXCCAUSE: 0x0000001c  
[15:08:45]EXCVADDR: 0x801c9539  LBEG    : 0x4008b4e8  LEND    : 0x4008b4fe  LCOUNT  : 0xffffffff  
[15:08:45]
[15:08:45]
[15:08:45]Backtrace: 0x4016dc67:0x3ffbc220 0x40142246:0x3ffbc240 0x4013c189:0x3ffbc270 0x40119906:0x3ffbc2b0 0x400e2ee8:0x3ffbc2f0 0x401109cb:0x3ffbc340
```

Checking it with xtensa-esp32-elf-addr2line:

```
_ZNK16NetworkInterface7localIPEv$isra$0
/home/gitpod/.platformio/packages/framework-arduinoespressif32/libraries/Network/src/NetworkInterface.cpp:660 _ZN12WiFiSTAClass7localIPEv
/home/gitpod/.platformio/packages/framework-arduinoespressif32/libraries/WiFi/src/WiFiSTA.cpp:282 _Z11WifiHasIPv4v
/workspace/Tasmota-build/tasmota/tasmota_support/support_wifi.ino:517 _Z10WifiEventsP15arduino_event_t
/workspace/Tasmota-build/tasmota/tasmota_support/support_wifi.ino:1492 _ZN13NetworkEvents14_checkForEventEv
/home/gitpod/.platformio/packages/framework-arduinoespressif32/libraries/Network/src/NetworkEvents.cpp:137

```
Points to support_wifi.ino having a problem handling the ip pointer when the WiFi is not connected. The proposed patch checks if the WiFi is connected prior to getting the IP.

I don't know if this is a bug from Tasmota or in the ESP32 libraries themselves, but with this change the panic is gone.


**Related issue (if applicable):** No related issue

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
