### PR TITLE
enable wifi sleep for c3

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -185,9 +185,9 @@ void WiFiSetSleepMode(void)
   }
 */
   bool wifi_no_sleep = Settings->flag5.wifi_no_sleep;
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-  wifi_no_sleep = true;                         // Temporary patch for IDF4.4, wifi sleeping may cause wifi drops
-#endif
+//#ifdef CONFIG_IDF_TARGET_ESP32C3
+//  wifi_no_sleep = true;                         // Temporary patch for IDF4.4, wifi sleeping may cause wifi drops
+//#endif
   if (0 == TasmotaGlobal.sleep || wifi_no_sleep) {
     if (!TasmotaGlobal.wifi_stay_asleep) {
       WiFiHelper::setSleepMode(WIFI_NONE_SLEEP);       // Disable sleep


### PR DESCRIPTION
## Description:

reduces power consumption by enabling WiFi sleep. The current used workaround should not be needed anymore. Using IDF 5.x.x. A lot of changes/fixes has been done in IDF since this bug in IDF 4.4.x (Bug fixed https://github.com/espressif/esp-idf/issues/9059#issuecomment-118971454)
As discussed in https://github.com/arendst/Tasmota/discussions/23096

If needed the sleep can be disabled with `SetOption127 1`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
