### PR TITLE
enable FTP for all esp8266 >= 4MB (not only for 4MB variant)

### DIFF
--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -1057,7 +1057,6 @@
     #define USE_UFILESYS
       #define GUI_TRASH_FILE
       #define GUI_EDIT_FILE
-    #ifdef ESP8266_4M
       #ifndef USE_FTP
         #define USE_FTP
       #endif
@@ -1067,7 +1066,6 @@
       #ifndef PW_FTP
         #define PW_FTP "pass"
       #endif
-    #endif // ESP8266_4M
     #define USE_SPI
     #define USE_SDCARD
     #define USE_PING

--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -1057,6 +1057,7 @@
     #define USE_UFILESYS
       #define GUI_TRASH_FILE
       #define GUI_EDIT_FILE
+    #ifdef ESP8266
       #ifndef USE_FTP
         #define USE_FTP
       #endif
@@ -1066,6 +1067,7 @@
       #ifndef PW_FTP
         #define PW_FTP "pass"
       #endif
+    #endif // ESP8266
     #define USE_SPI
     #define USE_SDCARD
     #define USE_PING


### PR DESCRIPTION
## Description:

currently the FTP is only activated for the 4MB esp8266

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
