### PR TITLE
Added V9240 energy metering chip driver

### DIFF
--- a/tasmota/berry/include/be_gpio_defines.h
+++ b/tasmota/berry/include/be_gpio_defines.h
@@ -360,7 +360,7 @@ const be_const_member_t lv_gpio_constants[] = {
     { "ZEROCROSS", (int32_t) GPIO_ZEROCROSS },
     { "ZIGBEE_RST", (int32_t) GPIO_ZIGBEE_RST },
     { "ZIGBEE_RX", (int32_t) GPIO_ZIGBEE_RX },
-    { "ZIGBEE_TX", (int32_t) GPIO_ZIGBEE_TX },    
+    { "ZIGBEE_TX", (int32_t) GPIO_ZIGBEE_TX },
 
 };
 

--- a/tasmota/berry/include/be_gpio_defines.h
+++ b/tasmota/berry/include/be_gpio_defines.h
@@ -333,6 +333,8 @@ const be_const_member_t lv_gpio_constants[] = {
     { "TUYA_TX", (int32_t) GPIO_TUYA_TX },
     { "TX2X_TXD_BLACK", (int32_t) GPIO_TX2X_TXD_BLACK },
     { "TXD", (int32_t) GPIO_TXD },
+    { "V9240_RX", (int32_t) GPIO_V9240_RX },
+    { "V9240_TX", (int32_t) GPIO_V9240_TX },
     { "VINDRIKTNING_RX", (int32_t) GPIO_VINDRIKTNING_RX },
     { "VL53LXX_XSHUT1", (int32_t) GPIO_VL53LXX_XSHUT1 },
     { "WE517_RX", (int32_t) GPIO_WE517_RX },
@@ -359,9 +361,6 @@ const be_const_member_t lv_gpio_constants[] = {
     { "ZIGBEE_RST", (int32_t) GPIO_ZIGBEE_RST },
     { "ZIGBEE_RX", (int32_t) GPIO_ZIGBEE_RX },
     { "ZIGBEE_TX", (int32_t) GPIO_ZIGBEE_TX },    
-    { "V9240_RX", (int32_t) GPIO_V9240_RX },
-    { "V9240_TX", (int32_t) GPIO_V9240_TX },
-
 
 };
 

--- a/tasmota/berry/include/be_gpio_defines.h
+++ b/tasmota/berry/include/be_gpio_defines.h
@@ -358,7 +358,10 @@ const be_const_member_t lv_gpio_constants[] = {
     { "ZEROCROSS", (int32_t) GPIO_ZEROCROSS },
     { "ZIGBEE_RST", (int32_t) GPIO_ZIGBEE_RST },
     { "ZIGBEE_RX", (int32_t) GPIO_ZIGBEE_RX },
-    { "ZIGBEE_TX", (int32_t) GPIO_ZIGBEE_TX },
+    { "ZIGBEE_TX", (int32_t) GPIO_ZIGBEE_TX },    
+    { "V9240_RX", (int32_t) GPIO_V9240_RX },
+    { "V9240_TX", (int32_t) GPIO_V9240_TX },
+
 
 };
 

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -230,6 +230,7 @@ enum UserSelectablePins {
   GPIO_TM1640CLK, GPIO_TM1640DIN,       // TM1640 (16 x seven-segment LED controler)
   GPIO_TWAI_TX, GPIO_TWAI_RX, GPIO_TWAI_BO, GPIO_TWAI_CLK,  // ESP32 TWAI serial interface
   GPIO_C8_CO2_5K_TX, GPIO_C8_CO2_5K_RX, // C8-CO2-5K CO2 Sensor
+  GPIO_V9240_TX, GPIO_V9240_RX, // V9240 serial interface
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -507,6 +508,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_TM1640_CLK "|" D_SENSOR_TM1640_DIN "|"
   D_SENSOR_TWAI_TX "|" D_SENSOR_TWAI_RX "|" D_SENSOR_TWAI_BO "|" D_SENSOR_TWAI_CLK "|"
   D_SENSOR_C8_CO2_5K_TX "|" D_SENSOR_C8_CO2_5K_RX
+  D_SENSOR_TWAI_TX "|" D_SENSOR_TWAI_RX "|" D_SENSOR_TWAI_BO "|" D_SENSOR_TWAI_CLK
+        "|" D_SENSOR_V9240_TX "|" D_SENSOR_V9240_RX
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -1007,6 +1010,11 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_BL6523_TX),                         // BL6523 based Watt meter Serial interface
   AGPIO(GPIO_BL6523_RX),                         // BL6523 based Watt meter Serial interface
 #endif
+#ifdef USE_V9240
+  AGPIO(GPIO_V9240_RX),                          // V9240 Serial interface
+  AGPIO(GPIO_V9240_TX),                          // V9240 Serial interface
+#endif
+
 #endif  // USE_ENERGY_SENSOR
 
 /*-------------------------------------------------------------------------------------------*\

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -230,7 +230,7 @@ enum UserSelectablePins {
   GPIO_TM1640CLK, GPIO_TM1640DIN,       // TM1640 (16 x seven-segment LED controler)
   GPIO_TWAI_TX, GPIO_TWAI_RX, GPIO_TWAI_BO, GPIO_TWAI_CLK,  // ESP32 TWAI serial interface
   GPIO_C8_CO2_5K_TX, GPIO_C8_CO2_5K_RX, // C8-CO2-5K CO2 Sensor
-  GPIO_V9240_TX, GPIO_V9240_RX, // V9240 serial interface
+  GPIO_V9240_TX, GPIO_V9240_RX,         //  V9240 serial interface
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -507,9 +507,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_I2C_SER_TX "|" D_SENSOR_I2C_SER_RX "|"
   D_SENSOR_TM1640_CLK "|" D_SENSOR_TM1640_DIN "|"
   D_SENSOR_TWAI_TX "|" D_SENSOR_TWAI_RX "|" D_SENSOR_TWAI_BO "|" D_SENSOR_TWAI_CLK "|"
-  D_SENSOR_C8_CO2_5K_TX "|" D_SENSOR_C8_CO2_5K_RX
-  D_SENSOR_TWAI_TX "|" D_SENSOR_TWAI_RX "|" D_SENSOR_TWAI_BO "|" D_SENSOR_TWAI_CLK
-        "|" D_SENSOR_V9240_TX "|" D_SENSOR_V9240_RX
+  D_SENSOR_C8_CO2_5K_TX "|" D_SENSOR_C8_CO2_5K_RX "|"
+  D_SENSOR_V9240_TX "|" D_SENSOR_V9240_RX
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -1011,10 +1010,9 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_BL6523_RX),                         // BL6523 based Watt meter Serial interface
 #endif
 #ifdef USE_V9240
-  AGPIO(GPIO_V9240_RX),                          // V9240 Serial interface
-  AGPIO(GPIO_V9240_TX),                          // V9240 Serial interface
+    AGPIO(GPIO_V9240_RX),                          //  Serial V9240 interface
+    AGPIO(GPIO_V9240_TX),                          //  Serial V9240 interface
 #endif
-
 #endif  // USE_ENERGY_SENSOR
 
 /*-------------------------------------------------------------------------------------------*\

--- a/tasmota/include/tasmota_template_legacy.h
+++ b/tasmota/include/tasmota_template_legacy.h
@@ -471,7 +471,10 @@ const uint16_t kGpioConvert[] PROGMEM = {
   AGPIO(GPIO_IEM3000_TX),     // IEM3000 Serial interface
   AGPIO(GPIO_IEM3000_RX),     // IEM3000 Serial interface
   AGPIO(GPIO_ZIGBEE_RST),     // Zigbee reset
-  AGPIO(GPIO_DYP_RX)
+  AGPIO(GPIO_DYP_RX),
+  AGPIO(GPIO_V9240_TX),     // V9240 Serial interface
+  AGPIO(GPIO_V9240_RX)      // V9240 Serial interface
+
 };
 
 /********************************************************************************************/

--- a/tasmota/include/tasmota_template_legacy.h
+++ b/tasmota/include/tasmota_template_legacy.h
@@ -471,10 +471,7 @@ const uint16_t kGpioConvert[] PROGMEM = {
   AGPIO(GPIO_IEM3000_TX),     // IEM3000 Serial interface
   AGPIO(GPIO_IEM3000_RX),     // IEM3000 Serial interface
   AGPIO(GPIO_ZIGBEE_RST),     // Zigbee reset
-  AGPIO(GPIO_DYP_RX),
-  AGPIO(GPIO_V9240_TX),     // V9240 Serial interface
-  AGPIO(GPIO_V9240_RX)      // V9240 Serial interface
-
+  AGPIO(GPIO_DYP_RX)
 };
 
 /********************************************************************************************/

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_AF_AF_H_

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -1314,7 +1314,10 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-#define D_SENSOR_V9240_TX "V9240_TX"
-#define D_SENSOR_V9240_RX "V9240_RX"
+
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 
 #endif  // _LANGUAGE_BG_BG_H_

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -1315,7 +1315,7 @@
 #define D_CAPACITY                        "Capacity"
 
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -1314,4 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+#define D_SENSOR_V9240_TX "V9240_TX"
+#define D_SENSOR_V9240_RX "V9240_RX"
+
 #endif  // _LANGUAGE_BG_BG_H_

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_CA_AD_H_

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_CS_CZ_H_

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Aufladen"
 #define D_CAPACITY                        "Kapazität"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Aufladen"
 #define D_CAPACITY                        "Kapazität"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_DE_DE_H_

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_EL_GR_H_

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -1315,7 +1315,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -1315,7 +1315,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-#define D_SENSOR_V9240_TX "V9240_TX"
-#define D_SENSOR_V9240_RX "V9240_RX"
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
 
 #endif  // _LANGUAGE_EN_GB_H_

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -1315,4 +1315,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+#define D_SENSOR_V9240_TX "V9240_TX"
+#define D_SENSOR_V9240_RX "V9240_RX"
+
 #endif  // _LANGUAGE_EN_GB_H_

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Cargando"
 #define D_CAPACITY                        "Capacidad"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_ES_ES_H_

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Cargando"
 #define D_CAPACITY                        "Capacidad"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -1315,7 +1315,7 @@
 #define D_CHARGING                        "En charge"
 #define D_CAPACITY                        "Capacité"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -1315,4 +1315,8 @@
 #define D_CHARGING                        "En charge"
 #define D_CAPACITY                        "Capacité"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_FR_FR_H_

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_FY_NL_H_

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_HE_HE_H_

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -1321,4 +1321,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_HU_HU_H_

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -1321,7 +1321,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -1315,7 +1315,7 @@
 #define D_CHARGING                        "In carica"
 #define D_CAPACITY                        "Capacità"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -1315,4 +1315,8 @@
 #define D_CHARGING                        "In carica"
 #define D_CAPACITY                        "Capacità"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_IT_IT_H_

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_KO_KO_H_

--- a/tasmota/language/lt_LT.h
+++ b/tasmota/language/lt_LT.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Kraunasi"
 #define D_CAPACITY                        "Talpa"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_LT_LT_H_

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_NL_NL_H_

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Ładowanie"
 #define D_CAPACITY                        "Pojemność"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_PL_PL_D_H_

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Ładowanie"
 #define D_CAPACITY                        "Pojemność"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_PT_BR_H_

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_PT_PT_H_

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_RO_RO_H_

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -1315,7 +1315,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -1315,4 +1315,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_RU_RU_H_

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_SK_SK_H_

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_SV_SE_H_

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_TR_TR_H_

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -1315,7 +1315,7 @@
 #define D_CAPACITY                        "Capacity"
 
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -1314,7 +1314,9 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-#define D_SENSOR_V9240_TX "V9240_TX"
-#define D_SENSOR_V9240_RX "V9240_RX"
+
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
 
 #endif // _LANGUAGE_UK_UA_H_

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -1314,4 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+#define D_SENSOR_V9240_TX "V9240_TX"
+#define D_SENSOR_V9240_RX "V9240_RX"
+
 #endif // _LANGUAGE_UK_UA_H_

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_VI_VN_H_

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_ZH_CN_H_

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -1314,4 +1314,8 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
+// xnrg_34_v9240.ino
+#define D_SENSOR_V9240_TX "V9240 TX"
+#define D_SENSOR_V9240_RX "V9240 RX"
+
 #endif  // _LANGUAGE_ZH_TW_H_

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -1314,7 +1314,7 @@
 #define D_CHARGING                        "Charging"
 #define D_CAPACITY                        "Capacity"
 
-// xnrg_34_v9240.ino
+// xnrg_25_v9240.ino
 #define D_SENSOR_V9240_TX "V9240 TX"
 #define D_SENSOR_V9240_RX "V9240 RX"
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -950,6 +950,7 @@
 //  #define IEM3000_IEM3155                        // Compatibility fix for Iem3155 (changes Power and Energy total readout)
 //#define USE_WE517                                // Add support for Orno WE517-Modbus energy monitor (+1k code)
 //#define USE_MODBUS_ENERGY                        // Add support for generic modbus energy monitor using a user file in rule space (+5k)
+//#define USE_V9240                         // Add support for v9240
 
 // -- Low level interface devices -----------------
 #define USE_DHT                                  // Add support for DHT11, AM2301 (DHT21, DHT22, AM2302, AM2321) and SI7021 Temperature and Humidity sensor (1k6 code)

--- a/tasmota/tasmota_support/support_features.ino
+++ b/tasmota/tasmota_support/support_features.ino
@@ -943,6 +943,10 @@ constexpr uint32_t feature[] = {
 #ifdef USE_WIZMOTE
   0x00002000 |  // xdrv_77_wizmote.ino
 #endif
+#if defined(USE_ENERGY_SENSOR) && defined(USE_V9240)
+    0x00004000 |  // xnrg_34_v9240.ino
+#endif
+//  0x00002000 |  //
 //  0x00004000 |  // 
 //  0x00008000 |  // 
 //  0x00010000 |  // 

--- a/tasmota/tasmota_support/support_features.ino
+++ b/tasmota/tasmota_support/support_features.ino
@@ -944,7 +944,7 @@ constexpr uint32_t feature[] = {
   0x00002000 |  // xdrv_77_wizmote.ino
 #endif
 #if defined(USE_ENERGY_SENSOR) && defined(USE_V9240)
-    0x00004000 |  // xnrg_34_v9240.ino
+    0x00004000 |  // xnrg_25_v9240.ino
 #endif 
 //  0x00008000 |  // 
 //  0x00010000 |  // 

--- a/tasmota/tasmota_support/support_features.ino
+++ b/tasmota/tasmota_support/support_features.ino
@@ -945,9 +945,7 @@ constexpr uint32_t feature[] = {
 #endif
 #if defined(USE_ENERGY_SENSOR) && defined(USE_V9240)
     0x00004000 |  // xnrg_34_v9240.ino
-#endif
-//  0x00002000 |  //
-//  0x00004000 |  // 
+#endif 
 //  0x00008000 |  // 
 //  0x00010000 |  // 
 //  0x00020000 |  // 

--- a/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
@@ -45,7 +45,7 @@
 #define D_CMND_MODULEADDRESS "ModuleAddress"
 
 enum EnergyCalibration {
-  ENERGY_POWER_CALIBRATION, ENERGY_VOLTAGE_CALIBRATION, ENERGY_CURRENT_CALIBRATION, ENERGY_FREQUENCY_CALIBRATION };
+  ENERGY_POWER_CALIBRATION, ENERGY_VOLTAGE_CALIBRATION, ENERGY_CURRENT_CALIBRATION, ENERGY_FREQUENCY_CALIBRATION,ENERGY_REACTIVE_CALIBRATION };
 
 enum EnergyCommands {
   CMND_POWERCAL, CMND_VOLTAGECAL, CMND_CURRENTCAL, CMND_FREQUENCYCAL,
@@ -924,6 +924,8 @@ uint32_t EnergyGetCalibration(uint32_t cal_type, uint32_t chan = 0) {
       case ENERGY_POWER_CALIBRATION: return Settings->energy_power_calibration;
       case ENERGY_VOLTAGE_CALIBRATION: return Settings->energy_voltage_calibration;
       case ENERGY_CURRENT_CALIBRATION: return Settings->energy_current_calibration;
+      case ENERGY_REACTIVE_CALIBRATION: return Settings->energy_power_calibration2;
+
     }
   }
   return Settings->energy_frequency_calibration;
@@ -944,6 +946,7 @@ void EnergySetCalibration(uint32_t cal_type, uint32_t value, uint32_t chan = 0) 
       case ENERGY_VOLTAGE_CALIBRATION: Settings->energy_voltage_calibration = value; return;
       case ENERGY_CURRENT_CALIBRATION: Settings->energy_current_calibration = value; return;
       case ENERGY_FREQUENCY_CALIBRATION: Settings->energy_frequency_calibration = value; return;
+      case ENERGY_REACTIVE_CALIBRATION: Settings->energy_power_calibration2 = value; return;
     }
   }
 }
@@ -1300,7 +1303,6 @@ void EnergyShow(bool json) {
         else if (0 == Energy->current[i]) {
           reactive_power[i] = 0;
         }
-
       }
     }
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
@@ -45,7 +45,7 @@
 #define D_CMND_MODULEADDRESS "ModuleAddress"
 
 enum EnergyCalibration {
-  ENERGY_POWER_CALIBRATION, ENERGY_VOLTAGE_CALIBRATION, ENERGY_CURRENT_CALIBRATION, ENERGY_FREQUENCY_CALIBRATION,ENERGY_REACTIVE_CALIBRATION };
+  ENERGY_POWER_CALIBRATION, ENERGY_VOLTAGE_CALIBRATION, ENERGY_CURRENT_CALIBRATION, ENERGY_FREQUENCY_CALIBRATION };
 
 enum EnergyCommands {
   CMND_POWERCAL, CMND_VOLTAGECAL, CMND_CURRENTCAL, CMND_FREQUENCYCAL,
@@ -924,7 +924,6 @@ uint32_t EnergyGetCalibration(uint32_t cal_type, uint32_t chan = 0) {
       case ENERGY_POWER_CALIBRATION: return Settings->energy_power_calibration;
       case ENERGY_VOLTAGE_CALIBRATION: return Settings->energy_voltage_calibration;
       case ENERGY_CURRENT_CALIBRATION: return Settings->energy_current_calibration;
-      case ENERGY_REACTIVE_CALIBRATION: return Settings->energy_power_calibration2;
 
     }
   }
@@ -946,7 +945,6 @@ void EnergySetCalibration(uint32_t cal_type, uint32_t value, uint32_t chan = 0) 
       case ENERGY_VOLTAGE_CALIBRATION: Settings->energy_voltage_calibration = value; return;
       case ENERGY_CURRENT_CALIBRATION: Settings->energy_current_calibration = value; return;
       case ENERGY_FREQUENCY_CALIBRATION: Settings->energy_frequency_calibration = value; return;
-      case ENERGY_REACTIVE_CALIBRATION: Settings->energy_power_calibration2 = value; return;
     }
   }
 }

--- a/tasmota/tasmota_xnrg_energy/xnrg_25_v9240.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_25_v9240.ino
@@ -64,9 +64,7 @@ namespace Address
 } ;
 
 
-static const int32_t header = 0x7d;
-static const int32_t ctrl_read = 0x1;
-static const int32_t ctrl_write = 0x2;
+
 
 
 // register structures
@@ -177,6 +175,10 @@ private:
     static constexpr size_t rw_len = 23;
     static constexpr size_t ro_len = 22;
     static constexpr size_t buffer_size = 128; // max response + max query
+
+    static constexpr int32_t header = 0x7d;
+    static constexpr int32_t ctrl_read = 0x1;
+    static constexpr int32_t ctrl_write = 0x2;
 
     explicit V9240();
     ~V9240();
@@ -546,7 +548,6 @@ void V9240::close()
     if(port != nullptr)
     {
         port->end();
-        Serial.end();
         delete port;
         port = nullptr;
     }

--- a/tasmota/tasmota_xnrg_energy/xnrg_25_v9240.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_25_v9240.ino
@@ -1,5 +1,5 @@
 /*
-  xnrg_34_v9240.ino - v9240 energy sensor support for Tasmota
+  xnrg_25_v9240.ino - v9240 energy sensor support for Tasmota
 
 */
 
@@ -13,7 +13,7 @@
 #ifdef USE_ENERGY_SENSOR
 #ifdef USE_V9240
 
-#define XNRG_34             34
+#define XNRG_25             25
 
 #ifdef USE_UFILESYS
 #define  V9240_FILENAME "./v9240_param"
@@ -748,7 +748,7 @@ void Xnrg34PreInit()
 {
     if (PinUsed(GPIO_V9240_RX) && PinUsed(GPIO_V9240_TX))
     {
-      TasmotaGlobal.energy_driver = XNRG_34;
+      TasmotaGlobal.energy_driver = XNRG_25;
       V9240::instance().open("");
       V9240::instance().reset();
     }
@@ -757,7 +757,7 @@ void Xnrg34PreInit()
 
 
 
-bool Xnrg34(uint32_t function) {
+bool Xnrg25(uint32_t function) {
     bool result = false;
 
     switch (function) {

--- a/tasmota/tasmota_xnrg_energy/xnrg_34_v9240.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_34_v9240.ino
@@ -1,0 +1,652 @@
+/*
+  xnrg_34_v9240.ino - v9240 energy sensor support for Tasmota
+
+*/
+
+#ifdef USE_ENERGY_SENSOR
+#ifdef USE_V9240
+
+#define XNRG_34             34
+
+#include <TasmotaSerial.h>
+#include <algorithm>
+
+
+namespace Address
+{
+    static const uint16_t SysCtrl   = 0x0180;
+    static const uint16_t AnaCtrl0  = 0x0182;
+    static const uint16_t AnaCtrl1  = 0x0183;
+
+
+    static const uint16_t PAC       = 0x00F6;
+    static const uint16_t PHC       = 0x00F7;
+    static const uint16_t PADCC     = 0x00F8;
+    static const uint16_t QAC       = 0x00F9;
+    static const uint16_t QADCC     = 0x00FB;
+    static const uint16_t IAC       = 0x00FD;
+    static const uint16_t IADCC     = 0x00FE;
+    static const uint16_t UC        = 0x00FF;
+    static const uint16_t IAADCC    = 0x0104;
+    static const uint16_t UADCC     = 0x0106;
+    static const uint16_t BPFPARA   = 0x0107;
+    static const uint16_t UDCC      = 0x0108;
+    static const uint16_t CKSUM     = 0x0109;
+
+    static const uint16_t RW_START  = PAC;
+
+    static const uint16_t SysStsClr = 0x019D;
+    static const uint16_t SFTRST    = 0x01BF;
+
+    static const uint16_t SysSts    = 0x00CA;
+    static const uint16_t FREQINST  = 0x00CB;
+    static const uint16_t PAINST    = 0x00CC;
+    static const uint16_t QINST     = 0x00CD;
+    static const uint16_t IAINST    = 0x00CE;
+    static const uint16_t UINST     = 0x00CF;
+    static const uint16_t PAAVG     = 0x00D0;
+    static const uint16_t QAVG      = 0x00D1;
+    static const uint16_t FREQAVG   = 0x00D2;
+    static const uint16_t IAAVG     = 0x00D3;
+    static const uint16_t UAVG      = 0x00D4;
+    static const uint16_t UDCINST   = 0x00D9;
+    static const uint16_t IADCINST  = 0x00DA;
+    static const uint16_t ZXDATREG  = 0x00DC;
+    static const uint16_t ZXDAT     = 0x00DD;
+    static const uint16_t PHDAT     = 0x00DE;
+
+    static const uint16_t T8BAUD     = 0x00E0;
+
+    static const uint16_t RO_START    = SysSts;
+} ;
+
+
+static const int32_t header = 0x7d;
+static const int32_t ctrl_read = 0x1;
+static const int32_t ctrl_write = 0x2;
+
+
+// register structures
+
+union SysSts // 0x0CA
+{
+    int32_t reg;
+    struct __attribute__ ((packed))
+    {
+        uint32_t ref:1;       // 0
+        uint32_t phsdone:1;   // 1
+        uint32_t chkerr:1;    // 2
+        uint32_t rstsrc:3;    // 3:5
+        uint32_t pdn_r:1;     // 6
+        uint32_t pdn:1;       // 7
+        uint32_t bisterr:1;   // 8
+        uint32_t phsdone_r:1; // 9
+        uint32_t Resered1:1;  // 10
+        uint32_t usign:1;     // 11
+    };
+} ;
+
+union SysCtrl // 0x0180
+{
+    int32_t reg;
+    struct __attribute__ ((packed))
+    {
+        uint32_t Reserved0:1;    // 0
+        uint32_t pgau:1;         // 1
+        uint32_t bphpf:1;        // 2
+        uint32_t iesul:1;        // 3
+        uint32_t iepdn:1;        // 4
+        uint32_t iehse:1;        // 5
+        uint32_t rcx12:1;        // 6
+        uint32_t rctrim:5;       // 7:11
+        uint32_t shorti:1;       // 12
+        uint32_t shortu:1;       // 13
+        uint32_t restl:2;        // 14:15
+        uint32_t rest:3;         // 16:18
+        uint32_t meaclksel:1;    // 19
+        uint32_t adcclksel:2;    // 20:21
+        uint32_t gai:2;          // 22:23
+        uint32_t Reserved1:2;    // 24:25
+        uint32_t gu:1;           // 26
+        uint32_t adciapdn:1;     // 27
+        uint32_t Reserved2:1;    // 28
+        uint32_t adcupdn:1;      // 29
+        uint32_t Reserved3:2;    // 30:31
+    };
+};
+
+
+union AnaCtrl0 // 0x0182
+{
+    int32_t reg;
+    struct __attribute__ ((packed))
+    {
+        uint32_t Reserved1:8; // 0:7
+        uint32_t IT:2;        // 8:9
+        uint32_t Reserved2:22;  // 10:31
+    };
+};
+
+union AnaCtrl1 // 0x0183
+{
+    int32_t reg;
+    struct __attribute__ ((packed))
+    {
+        uint32_t Reserved1:28;  // 0:27
+        uint32_t CSEL:2;        // 28:29
+        uint32_t Reserved2:2;   // 30:31
+    };
+};
+
+union SysStsClr // 0x019D
+{
+    int32_t reg;
+    struct __attribute__ ((packed))
+    {
+        uint32_t Reserved1:6;  // 0:5
+        uint32_t pdn_clr:1;    // 6
+        uint32_t Reserved2:2;  // 7:8
+        uint32_t phsdone_clr:1;// 9
+        uint32_t Reserved3:22; // 10:31
+    };
+};
+
+// communication structures
+union packet
+{
+    struct __attribute__ ((packed)) {
+        uint8_t header;
+        uint16_t ctrl:4;
+        uint16_t addr_h:4;
+        uint16_t addr_l:8;
+        uint32_t data;
+        uint8_t check;
+    } ;
+    char buff[8];
+} ;
+
+
+
+
+class V9240
+{
+private:
+    static constexpr size_t rw_len = 23;
+    static constexpr size_t ro_len = 22;
+    static constexpr size_t buffer_size = 256; // max response + max query
+
+    explicit V9240();
+    ~V9240();
+
+public:
+    enum parameter{
+        Voltage = 0,
+        Amperage,
+        Frequency,
+        Power,
+        Reactive
+    };
+
+    static V9240& instance();
+
+    bool open(char const*);
+    void close();
+    void start();
+    bool reset();
+    inline void loop() {read_data_from_port();};
+
+    float value(const parameter p) const;
+    inline float operator [] (const parameter p) const {return  value(p);};
+private:
+    bool read(int32_t *ptr,uint16_t address, size_t n);
+    bool write(int16_t address, int32_t data);
+    void set_checksum();
+    inline  char calc_check(char *buff,size_t len);
+
+private :
+    void read_data_from_port();
+    void send_next();
+
+private:
+    TasmotaSerial *port;
+
+    size_t step = 0;
+
+    size_t next_read_len =  0;
+    size_t byte_readed = 0;
+    char serial_buff[buffer_size];
+    int32_t *ptr_read = nullptr;
+
+    // chip memory
+    int32_t rw_mem[rw_len];
+    int32_t ro_mem[ro_len];
+
+    // RW Control & Calibration registers
+    volatile SysCtrl &SYSCTRL; // rw_mem[0];
+    volatile AnaCtrl0 &ANACTRL0;
+    volatile AnaCtrl1 &ANACTRL1;
+
+    volatile int32_t &UADCC;
+    volatile int32_t &IAADCC ;
+    volatile int32_t &PAC  ;   // = 1;
+    volatile int32_t &PADCC;   // = 0;
+    volatile int32_t &PHC;     // = 0;
+    volatile int32_t &QAC;     // = 1;
+    volatile int32_t &QADCC;   // = 0;
+    volatile int32_t &IAC;     // = 0;
+    volatile int32_t &IADCC;   // = 0;
+    volatile int32_t &UC;      // = -1103500000;
+    volatile int32_t &UDCC;    // = 1196289;
+    volatile int32_t &BPFPARA; // = 0x806764B6;
+    volatile int32_t &CKSUM;   // = 0;
+
+    // RO Meterin control register
+    volatile const SysSts  &SYSSTS;
+    volatile const int32_t &FREQINST;
+    volatile const int32_t &PAINST;
+    volatile const int32_t &QINST;
+    volatile const int32_t &IAINST;
+    volatile const int32_t &UINST;
+    volatile const int32_t &PAAVG;
+    volatile const int32_t &QAVG;
+    volatile const int32_t &FREQAVG;
+    volatile const int32_t &IAAVG;
+    volatile const int32_t &UAVG;
+    volatile const int32_t &UDCINST;
+    volatile const int32_t &IADCINST;
+    volatile const int32_t &ZXDATREG;
+    volatile const int32_t &ZXDAT;
+    volatile const int32_t &PHDAT;
+    volatile const int32_t &T8BAUD;
+
+};
+
+V9240& V9240::instance()
+{
+    static V9240 chip;
+    return chip;
+}
+
+
+V9240::V9240() :   port(nullptr)
+// mapping registers to arrays
+  , SYSCTRL (*reinterpret_cast<SysCtrl*>(rw_mem + 0))
+  , ANACTRL0(*reinterpret_cast<AnaCtrl0*>(rw_mem + 1))
+  , ANACTRL1(*reinterpret_cast<AnaCtrl1*>(rw_mem + 2))
+  , UADCC  (*(rw_mem+3+ (Address::UADCC    - Address::RW_START )))
+  , IAADCC (*(rw_mem+3+ (Address::IAADCC   - Address::RW_START )))
+  , PAC    (*(rw_mem+3+ (Address::PAC      - Address::RW_START )))
+  , PADCC  (*(rw_mem+3+ (Address::PADCC    - Address::RW_START )))
+  , PHC    (*(rw_mem+3+ (Address::PHC      - Address::RW_START )))
+  , QAC    (*(rw_mem+3+ (Address::QAC      - Address::RW_START )))
+  , QADCC  (*(rw_mem+3+ (Address::QADCC    - Address::RW_START )))
+  , IAC    (*(rw_mem+3+ (Address::IAC      - Address::RW_START )))
+  , IADCC  (*(rw_mem+3+ (Address::IADCC    - Address::RW_START )))
+  , UC     (*(rw_mem+3+ (Address::UC       - Address::RW_START )))
+  , UDCC   (*(rw_mem+3+ (Address::UDCC     - Address::RW_START )))
+  , BPFPARA(*(rw_mem+3+ (Address::BPFPARA  - Address::RW_START )))
+  , CKSUM  (*(rw_mem+3+ (Address::CKSUM    - Address::RW_START )))
+
+  , SYSSTS  (*reinterpret_cast<SysSts*>(ro_mem + (Address::SysSts - Address::RO_START)))
+  , FREQINST(*(ro_mem + (Address::FREQINST - Address::RO_START )))
+  , PAINST  (*(ro_mem + (Address::PAINST   - Address::RO_START )))
+  , QINST   (*(ro_mem + (Address::QINST    - Address::RO_START )))
+  , IAINST  (*(ro_mem + (Address::IAINST   - Address::RO_START )))
+  , UINST   (*(ro_mem + (Address::UINST    - Address::RO_START )))
+  , PAAVG   (*(ro_mem + (Address::PAAVG    - Address::RO_START )))
+  , QAVG    (*(ro_mem + (Address::QAVG     - Address::RO_START )))
+  , FREQAVG (*(ro_mem + (Address::FREQAVG  - Address::RO_START )))
+  , IAAVG   (*(ro_mem + (Address::IAAVG    - Address::RO_START )))
+  , UAVG    (*(ro_mem + (Address::UAVG     - Address::RO_START )))
+  , UDCINST (*(ro_mem + (Address::UDCINST  - Address::RO_START )))
+  , IADCINST(*(ro_mem + (Address::IADCINST - Address::RO_START )))
+  , ZXDATREG(*(ro_mem + (Address::ZXDATREG - Address::RO_START )))
+  , ZXDAT   (*(ro_mem + (Address::ZXDAT    - Address::RO_START )))
+  , PHDAT   (*(ro_mem + (Address::PHDAT    - Address::RO_START )))
+  , T8BAUD  (*(ro_mem + (Address::T8BAUD   - Address::RO_START - 1 )))
+{
+    memset(rw_mem,0,sizeof (rw_mem));
+    memset(ro_mem,0,sizeof (ro_mem));
+
+    // its calibration coeficients for my chip
+    PAC      = 0;
+    PADCC    = 0;
+    PHC      = 0;
+    QAC      = 0;
+    QADCC    = 0;
+    IAC      = 0;
+    IADCC    = 16758789;
+
+    UC       = -1103500000;
+    UDCC     = 1196289;
+
+    BPFPARA  = 0x806764B6;
+}
+
+V9240::~V9240()
+{
+    close();
+}
+
+void V9240::start()
+{
+    if(port != nullptr)
+    {
+        step = 0;
+        read(ro_mem,Address::SysSts,1);
+    }
+}
+
+float V9240::value(const V9240::parameter p) const
+{
+    float v = 0;
+    switch (p) {
+    case Voltage:
+        v = float(UAVG)*1e-6;
+        break;
+    case Amperage:
+        v = float(IAAVG)*1e-6;
+        break;
+    case Frequency:
+        v = 0.00390625*19200.0*T8BAUD/float(FREQAVG);
+        break;
+    case Power:
+        v = float(PAAVG)*1e-6;
+        break;
+    case Reactive:
+        v = float(QAVG)*1e-6;
+        break;
+    default:
+        break;
+    }
+    return v;
+}
+
+
+void V9240::set_checksum()
+{
+    CKSUM = UINT32_MAX - std::accumulate(rw_mem,rw_mem+rw_len-1 ,0);
+    write(Address::CKSUM,CKSUM);
+}
+
+char V9240::calc_check(char *buff, size_t len)
+{
+    return ~std::accumulate(buff,buff+len,0)+0x33;
+}
+
+
+void V9240::send_next()
+{
+    switch (step++) {
+    case 0:
+        read(rw_mem,Address::SysCtrl,1);
+        break;
+    case 1:
+        write(Address::AnaCtrl0,ANACTRL0.reg);
+        break;
+    case 2:
+        // Configure CSEL (
+        ANACTRL1.CSEL  = 1;
+        write(Address::AnaCtrl1,ANACTRL1.reg);
+        break;
+    case 3:
+        // Enable ADC
+        SYSCTRL.adcupdn  = 1;
+        SYSCTRL.adciapdn = 1;
+        write(Address::SysCtrl,SYSCTRL.reg);
+        break;
+    case 4:
+        // DC calibratio. Paragraph 7.4 page 33
+        SYSCTRL.shortu = 1 ;
+        SYSCTRL.shorti = 1 ;
+        write(Address::SysCtrl,SYSCTRL.reg);
+        break;
+    case 5:
+        read(ro_mem, Address::RO_START,ro_len);
+        break;
+    case 6:
+        UADCC  = UDCINST;
+        IAADCC = IADCINST;
+
+        SYSCTRL.shortu = 0 ;
+        SYSCTRL.shorti = 0 ;
+        write(Address::SysCtrl,SYSCTRL.reg);
+        break;
+    case 7:
+        // Write calibration parameter
+        write(Address::UADCC   ,UADCC);
+        break;
+    case 8:
+        write(Address::IAADCC  ,IAADCC);
+        break;
+    case 9:
+        write(Address::PAC     ,PAC);
+        break;
+    case 10:
+        write(Address::PADCC   ,PADCC);
+        break;
+    case 11:
+        write(Address::QAC     ,QAC);
+        break;
+    case 12:
+        write(Address::QADCC   ,QADCC);
+        break;
+    case 13:
+        write(Address::PHC     ,PHC);
+        break;
+    case 14:
+        write(Address::IAC     ,IAC);
+        break;
+    case 15:
+        write(Address::IADCC   ,IADCC);
+        break;
+    case 16:
+        write(Address::UC      ,UC);
+        break;
+    case 17:
+        write(Address::UDCC    ,UDCC);
+        break;
+    case 18:
+        write(Address::BPFPARA ,BPFPARA);
+        break;
+    case 19:
+        set_checksum();
+        break;
+    case 20:
+        read(&ro_mem[ro_len-1],Address::T8BAUD,1);
+        break;
+    default:
+        read(ro_mem,Address::RO_START,ro_len-1);
+        step = 20;
+    }
+}
+
+// next methods is platfrm-specific (serial port & Qt signals)
+void V9240::read_data_from_port()
+{
+    auto bytes = port->available();
+
+    if(byte_readed + bytes > buffer_size)
+        bytes = buffer_size - byte_readed;
+
+    port->read(serial_buff + byte_readed,bytes);
+
+    byte_readed += bytes;
+
+    if(byte_readed == buffer_size)
+        byte_readed = 0;
+
+    if(byte_readed == next_read_len)
+    {
+        char checksum =  calc_check(serial_buff+sizeof(packet),next_read_len-sizeof(packet)-1);
+        if(checksum == serial_buff[next_read_len-1])
+        {
+            packet &recv = *reinterpret_cast<packet*>( serial_buff + sizeof (packet) );
+            if(recv.ctrl == ctrl_read)
+            {
+                int32_t *data = (int32_t*)(serial_buff + sizeof (packet) + 3);
+                memcpy(ptr_read,data,sizeof (int32_t) * (recv.addr_l==0 ? 1 : recv.addr_l));
+            }
+
+        }
+        next_read_len = 0;
+        byte_readed = 0;
+        ptr_read = nullptr;
+//        QTimer::singleShot(25,this,&V9240::send_next);
+    }
+}
+
+
+bool V9240::open(char const *portName)
+{
+    if(port != nullptr)
+        return false;
+
+    port = new TasmotaSerial(Pin(GPIO_V9240_RX),Pin(GPIO_V9240_TX),1);
+    port->begin(19200,SERIAL_8O1);
+
+    return true;
+}
+
+void V9240::close()
+{
+    if(port != nullptr)
+    {
+        port->end();
+        delete port;
+        port = nullptr;
+    }
+}
+
+bool V9240::reset()
+{
+#if 0
+    if(port != nullptr && port->isOpen())
+    {
+        port->blockSignals(true);
+        port->setBaudRate(102);
+        port->write("\0",1);
+        port->flush();
+        port->waitForReadyRead(1000);
+        port->read(1);
+        port->setBaudRate(QSerialPort::Baud19200);
+        port->blockSignals(false);
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+#else
+    return true;
+#endif
+}
+
+
+bool V9240::read(int32_t *ptr, uint16_t address, size_t n)
+{
+    packet p;
+    p.header = header;
+    p.ctrl = ctrl_read;
+    p.addr_h = (address&0x0F00)>>8;
+    p.addr_l = address&0x00FF;
+    p.data = n;
+    p.check = calc_check(p.buff,sizeof(p)-1);
+
+    next_read_len = sizeof (p) + 4 + sizeof (int32_t)*n;
+    byte_readed = 0;
+    ptr_read = ptr;
+
+    port->write(p.buff,sizeof (p));
+
+    return true;
+}
+
+bool V9240::write(int16_t address, int32_t data)
+{
+    packet p;
+    p.header = header;
+    p.ctrl = ctrl_write;
+    p.addr_h = (address&0x0F00)>>8;
+    p.addr_l = address&0x00FF;
+    p.data = data;
+    p.check = calc_check(p.buff,sizeof(p)-1);
+
+    next_read_len = sizeof (p) + 4;
+    byte_readed = 0;
+
+    port->write(p.buff,sizeof (p));
+
+    return true;
+}
+
+
+
+
+
+
+void Xnrg34Init()
+{
+    Energy->phase_count = 1;
+    Energy->voltage_common = true;    // Phase voltage = false, Common voltage = true
+    Energy->frequency_common = true;  // Phase frequency = false, Common frequency = true
+    Energy->type_dc = false;          // AC = false, DC = true;
+    Energy->use_overtemp = true;      // Use global temperature for overtemp detection
+
+    V9240::instance().start();
+}
+
+void Xnrg34Second()
+{
+    static int32_t last_power = 0;
+
+    if (Energy->power_on) {
+    Energy->data_valid[0] = 0;
+    Energy->frequency[0] = 50;
+    Energy->voltage[0] = 200.0;
+    Energy->current[0] = 5.0;
+    Energy->active_power[0] = 1000.0;
+    Energy->kWhtoday_delta[0] += (Energy->active_power[0]+last_power) * 500.0 / 36.0; // trapezoid integration
+    last_power = Energy->active_power[0];
+    EnergyUpdateTotal();
+    }
+}
+
+void Xnrg34PreInit()
+{
+    if (PinUsed(GPIO_V9240_RX) && PinUsed(GPIO_V9240_TX))
+    {
+      TasmotaGlobal.energy_driver = XNRG_34;
+      V9240::instance().open("");
+    }
+
+}
+
+bool Xnrg34(uint32_t function) {
+    bool result = false;
+
+    switch (function) {
+    case FUNC_LOOP:
+        V9240::instance().loop();
+        break;
+    case FUNC_ENERGY_EVERY_SECOND:
+        Xnrg34Second();
+        break;
+    case FUNC_EVERY_250_MSECOND:
+        break;
+    case FUNC_COMMAND:
+        result = true;
+        break;
+    case FUNC_INIT:
+        Xnrg34Init();
+        break;
+    case FUNC_PRE_INIT:
+        Xnrg34PreInit();
+        break;
+    }
+    return result;
+}
+
+#endif  // USE_ENERGY_V9240
+#endif  // USE_ENERGY_SENSOR

--- a/tasmota/tasmota_xnrg_energy/xnrg_34_v9240.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_34_v9240.ino
@@ -8,6 +8,7 @@
 
 #define XNRG_34             34
 
+#if 0
 #include <TasmotaSerial.h>
 #include <algorithm>
 
@@ -647,6 +648,12 @@ bool Xnrg34(uint32_t function) {
     }
     return result;
 }
+#else
+bool Xnrg34(uint32_t function) {
+    bool result = false;
+    return result;
+}
+#endif
 
 #endif  // USE_ENERGY_V9240
 #endif  // USE_ENERGY_SENSOR

--- a/tasmota/tasmota_xx2c_global/xnrg_interface.ino
+++ b/tasmota/tasmota_xx2c_global/xnrg_interface.ino
@@ -154,11 +154,7 @@ bool (* const xnrg_func_ptr[])(uint32_t) = {   // Energy driver Function Pointer
 #endif
 
 #ifdef XNRG_33  // Reserved for use by xsns_02_analog.ino
-  &Xnrg33,
-#endif
-
-#ifdef XNRG_25
-  &Xnrg25
+  &Xnrg33
 #endif
 };
 

--- a/tasmota/tasmota_xx2c_global/xnrg_interface.ino
+++ b/tasmota/tasmota_xx2c_global/xnrg_interface.ino
@@ -154,7 +154,11 @@ bool (* const xnrg_func_ptr[])(uint32_t) = {   // Energy driver Function Pointer
 #endif
 
 #ifdef XNRG_33  // Reserved for use by xsns_02_analog.ino
-  &Xnrg33
+  &Xnrg33,
+#endif
+
+#ifdef XNRG_34
+  &Xnrg34
 #endif
 };
 

--- a/tasmota/tasmota_xx2c_global/xnrg_interface.ino
+++ b/tasmota/tasmota_xx2c_global/xnrg_interface.ino
@@ -157,8 +157,8 @@ bool (* const xnrg_func_ptr[])(uint32_t) = {   // Energy driver Function Pointer
   &Xnrg33,
 #endif
 
-#ifdef XNRG_34
-  &Xnrg34
+#ifdef XNRG_25
+  &Xnrg25
 #endif
 };
 


### PR DESCRIPTION
Added V9240 energy metering chip driver

**Related issue (if applicable):** fixes # 22868

## Checklist:
  - [*] The pull request is done against the latest development branch
  - [*] Only relevant files were touched
  - [*] Only one feature/fix was added per PR and the code change compiles without warnings
  - [*] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [-] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [*] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
  
[Datasheet](https://www.vangotech.com/uploadpic/163903940488.pdf)
There is a certain discrepancy in the calibration commands of this chip. I tried to do it according to the description of these commands, but then I could not calibrate accurately. Now the readings in the tasmota ui  correspond to the commercial metering device I have.
