### PR TITLE
Update flasher for Sonoff ZBBridge Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Platform from 2025.02.30 to 2025.03.30, Framework (Arduino Core) from v3.1.1.250203 to v3.1.3.250302 and IDF from v5.3.2.250120 to 5.3.2.250228 (#23088)
 - ESP32 enable webcam version 2 (#18732)
 - ESP8266 enable FTP for >= 4MB variants (#23120)
+- Update flasher for Sonoff ZBBridge Pro
 
 ### Fixed
 - Berry prevent `import` from hiding a solidified class (#23112)

--- a/tasmota/berry/zigbee/cc2652_flasher.be
+++ b/tasmota/berry/zigbee/cc2652_flasher.be
@@ -107,7 +107,6 @@ class cc2652_flasher
 
   # restart the MCU in BSL mode and establish communication
   def start(debug)
-    if debug == nil    debug = false end
     self.debug = bool(debug)
     self.reset_bsl()
     #
@@ -134,9 +133,9 @@ class cc2652_flasher
 
     self.ser.write(bytes("5555"))          # trigger auto baudrate detector
     var ret = self.recv_raw(100)
-    if self.debug print("ret=", ret) end
-    if ret != bytes('CC')
-      raise "protocol_error"
+    if self.debug print(f"reset_bsl ret='{ret}'") end
+    if ret[-1] != 0xCC
+      raise "protocol_error", f"received '{ret}'"
     end
   end
 
@@ -218,7 +217,7 @@ class cc2652_flasher
     if self.debug print("sending:", payload) end
     self.ser.write(payload)
     var ret = self.recv_raw(500)
-    if self.debug print("ret=", ret) end
+    if self.debug print(f"ret={ret}") end
     if no_response == true
       #ignore
       self.decode_ack(ret)

--- a/tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
+++ b/tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
@@ -70,7 +70,7 @@ class sonoff_zb_pro_flasher
     except .. as e, m
       self.file_checked = false
       self.file_validated = false
-      raise e, m
+      print(f"FLH: Exception raised '{e}' - '{m}'")
     end
   end
 


### PR DESCRIPTION
## Description:

Make flasher for Zigbee CC2652P more tolerant to changes in BSL mode.

**Related issue (if applicable):** fixes #23074

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
