### PR TITLE
Fix typo of be_set_ctype_func_hanlder

### DIFF
--- a/lib/libesp32/berry/default/berry.c
+++ b/lib/libesp32/berry/default/berry.c
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
 {
     int res;
     bvm *vm = be_vm_new(); /* create a virtual machine instance */
-    be_set_ctype_func_hanlder(vm, be_call_ctype_func);
+    be_set_ctype_func_handler(vm, be_call_ctype_func);
     res = analysis_args(vm, argc, argv);
     be_vm_delete(vm); /* free all objects and vm */
     return res;

--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -1408,7 +1408,7 @@ BERRY_API void be_set_obs_micros(bvm *vm, bmicrosfnct micros)
     vm->microsfnct = micros;
 }
 
-BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler)
+BERRY_API void be_set_ctype_func_handler(bvm *vm, bctypefunc handler)
 {
     vm->ctypefunc = handler;
 }

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -2168,14 +2168,14 @@ BERRY_API void be_set_obs_micros(bvm *vm, bmicrosfnct micros);
 
 
 /**
- * @fn void be_set_ctype_func_hanlder(bvm*, bctypefunc)
+ * @fn void be_set_ctype_func_handler(bvm*, bctypefunc)
  * @note Observability hook
  * @brief (???)
  *
  * @param vm virtual machine instance
  * @param handler
  */
-BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler);
+BERRY_API void be_set_ctype_func_handler(bvm *vm, bctypefunc handler);
 
 /**
  * @fn bctypefunc be_get_ctype_func_hanlder(bvm*)

--- a/lib/libesp32/berry_mapping/README.md
+++ b/lib/libesp32/berry_mapping/README.md
@@ -171,7 +171,7 @@ You need to register the ctype function handler at the launch of the Berry VM:
 void berry_launch(boid)
 {
     bvm *vm = be_vm_new();      /* Construct a VM */
-    be_set_ctype_func_hanlder(berry.vm, be_call_ctype_func);  /* register the ctype function handler */
+    be_set_ctype_func_handler(berry.vm, be_call_ctype_func);  /* register the ctype function handler */
 }
 ```
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -364,7 +364,7 @@ void BerryInit(void) {
     be_set_obs_micros(berry.vm, (bmicrosfnct)&micros);
     comp_set_named_gbl(berry.vm);  /* Enable named globals in Berry compiler */
     comp_set_strict(berry.vm);  /* Enable strict mode in Berry compiler, equivalent of `import strict` */
-    be_set_ctype_func_hanlder(berry.vm, be_call_ctype_func);
+    be_set_ctype_func_handler(berry.vm, be_call_ctype_func);
 
     if (UsePSRAM()) {     // if PSRAM is available, raise the max size to 512kb
       berry.vm->bytesmaxsize = 512 * 1024;


### PR DESCRIPTION
## Description:

Fix typo.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
