### PR TITLE
Matter prepare for ICD cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Berry load `.tapp` files in `/.extensions/` then in `/` (#23113)
 - Support Vango Technologies V924x ultralow power, single-phase, power measurement (#23127)
 - Support for HLK-LD2402 24GHz smart wave motion sensor (#23133)
+- Matter prepare for ICD cluster
 
 ### Breaking Changed
 - Berry remove `Leds.create_matrix` from the standard library waiting for reimplementation (#23114)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_0_Inspect.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_0_Inspect.be
@@ -87,9 +87,18 @@ matter.inspect = inspect
 #
 # Build a consolidated map of all the `CLUSTERS` static vars
 # from the inheritance hierarchy
+#
+# `cl` can be a the class to get the superclass, or a `map`
 #@ solidify:matter.consolidate_clusters,weak
 def consolidate_clusters(cl, m)
-  var cl_parent = (super(cl) != nil) ? super(cl).CLUSTERS : {}
+  var cl_parent
+  if cl == nil
+    cl_parent = {}
+  elif type(cl) == 'class'
+    cl_parent = (super(cl) != nil) ? super(cl).CLUSTERS : {}
+  elif type(cl) == 'instance'
+    cl_parent = cl
+  end
   var ret = {}
   # clone cl_parent
   for k: cl_parent.keys()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -48,6 +48,7 @@ class Matter_Plugin
   # `FEATURE_MAPS` contains any non-zero value per cluster, if not present default to `0`
   static var FEATURE_MAPS = {               # feature map per cluster
     0x0031: 0x04,                           # Put Eth for now which should work for any on-network
+    # 0x0046: 0x04,                           # LITS: LongIdleTimeSupport
     0x0102: 1 + 4,                          # Lift + PA_LF
     0x0202: 2,                              # Fan: Auto
   }
@@ -77,6 +78,7 @@ class Matter_Plugin
     # 0x0040: 1,                            # Initial Release
     # 0x0041: 1,                            # Initial Release
     # 0x0042: 1,                            # Initial Release
+    # 0x0046: 3,                              # ICD v3
     # 0x005B: 1,                            # Initial Release
     # 0x005C: 1,                            # Initial Release
     0x0101: 7,                              # Added support for European door locks (unbolt feature)
@@ -283,20 +285,20 @@ matter_device.events.dump()
     return self.endpoint
   end
   def get_cluster_list_sorted()
-    return self.device.k2l(self.CLUSTERS)
+    return self.device.k2l(self.get_clusters())
   end
   def contains_cluster(cluster)
-    return self.CLUSTERS.contains(cluster)
+    return self.get_clusters().contains(cluster)
   end
   # def get_attribute_list(cluster)
   #   return self.clusters.find(cluster, [])
   # end
   # returns as a constant bytes of 16-bit ints, big endian
   def get_attribute_list_bytes(cluster)
-    return self.CLUSTERS.find(cluster, nil)
+    return self.get_clusters().find(cluster, nil)
   end
   def contains_attribute(cluster, attribute)
-    var attr_list = self.CLUSTERS.find(cluster)
+    var attr_list = self.get_clusters().find(cluster)
     # log(f"MTR: contains_attribute {cluster=} {attribute=} {attr_list=}")
     if attr_list != nil
       var idx = 0

--- a/lib/libesp32/berry_matter/src/embedded/Matter_z_Autoconf.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_z_Autoconf.be
@@ -40,7 +40,7 @@ class Matter_Autoconf
     var plugins = self.device.plugins
 
     # start with mandatory endpoint 0 for root node
-    plugins.push(matter.Plugin_Root(self.device, 0, {}))
+    plugins.push(matter.Plugin_Root(self.device, 0, config.find("0", {})))
     log("MTR: Configuring endpoints", 2)
     log(format("MTR:   endpoint = %5i type:%s%s", 0, 'root', ''), 2)
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -732,11 +732,7 @@ class Matter_Device
     var keys = []
     for k: self.plugins_config.keys()   keys.push(int(k))    end
     for ep: keys
-      if ep == 0
-        log("MTR: invalid entry with ep '0'", 2)
-        self.plugins_config.remove(str(ep))
-        dirty = true
-      elif ep == matter.AGGREGATOR_ENDPOINT
+      if ep == matter.AGGREGATOR_ENDPOINT
         dirty = true
         log(f"MTR: endpoint {ep} collides wit aggregator, relocating to {self.next_ep}", 2)
         self.plugins_config[str(self.next_ep)] = self.plugins_config[str(ep)]

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_0_Inspect.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_0_Inspect.h
@@ -257,204 +257,227 @@ be_local_closure(module_matter_consolidate_clusters,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(CLUSTERS),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    /* K8   */  be_nested_str_weak(contains),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(sort),
-    /* K12  */  be_nested_str_weak(add),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(class),
+    /* K1   */  be_nested_str_weak(CLUSTERS),
+    /* K2   */  be_nested_str_weak(instance),
+    /* K3   */  be_nested_str_weak(keys),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(get),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(stop_iteration),
+    /* K10  */  be_nested_str_weak(contains),
+    /* K11  */  be_nested_str_weak(find),
+    /* K12  */  be_nested_str_weak(matter),
+    /* K13  */  be_nested_str_weak(sort),
+    /* K14  */  be_nested_str_weak(add),
     }),
     be_str_weak(consolidate_clusters),
     &be_const_str_solidified,
-    ( &(const binstruction[180]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0004,  //  0005  JMPF	R2	#000B
-      0x60080003,  //  0006  GETGBL	R2	G3
-      0x5C0C0000,  //  0007  MOVE	R3	R0
-      0x7C080200,  //  0008  CALL	R2	1
-      0x88080500,  //  0009  GETMBR	R2	R2	K0
-      0x70020001,  //  000A  JMP		#000D
-      0x60080013,  //  000B  GETGBL	R2	G19
-      0x7C080000,  //  000C  CALL	R2	0
-      0x600C0013,  //  000D  GETGBL	R3	G19
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x60100010,  //  000F  GETGBL	R4	G16
-      0x8C140501,  //  0010  GETMET	R5	R2	K1
-      0x7C140200,  //  0011  CALL	R5	1
-      0x7C100200,  //  0012  CALL	R4	1
-      0xA802001A,  //  0013  EXBLK	0	#002F
-      0x5C140800,  //  0014  MOVE	R5	R4
-      0x7C140000,  //  0015  CALL	R5	0
-      0x60180012,  //  0016  GETGBL	R6	G18
-      0x7C180000,  //  0017  CALL	R6	0
-      0x941C0405,  //  0018  GETIDX	R7	R2	R5
-      0x4C200000,  //  0019  LDNIL	R8
-      0x20200E08,  //  001A  NE	R8	R7	R8
-      0x78220004,  //  001B  JMPF	R8	#0021
-      0x6020000C,  //  001C  GETGBL	R8	G12
-      0x5C240E00,  //  001D  MOVE	R9	R7
-      0x7C200200,  //  001E  CALL	R8	1
-      0x0C201102,  //  001F  DIV	R8	R8	K2
-      0x70020000,  //  0020  JMP		#0022
-      0x58200003,  //  0021  LDCONST	R8	K3
-      0x58240003,  //  0022  LDCONST	R9	K3
-      0x14281208,  //  0023  LT	R10	R9	R8
-      0x782A0007,  //  0024  JMPF	R10	#002D
-      0x8C280D04,  //  0025  GETMET	R10	R6	K4
-      0x8C300F05,  //  0026  GETMET	R12	R7	K5
-      0x08381302,  //  0027  MUL	R14	R9	K2
-      0x543DFFFD,  //  0028  LDINT	R15	-2
-      0x7C300600,  //  0029  CALL	R12	3
-      0x7C280400,  //  002A  CALL	R10	2
-      0x00241306,  //  002B  ADD	R9	R9	K6
-      0x7001FFF5,  //  002C  JMP		#0023
-      0x980C0A06,  //  002D  SETIDX	R3	R5	R6
-      0x7001FFE4,  //  002E  JMP		#0014
-      0x58100007,  //  002F  LDCONST	R4	K7
-      0xAC100200,  //  0030  CATCH	R4	1	0
-      0xB0080000,  //  0031  RAISE	2	R0	R0
-      0x60100010,  //  0032  GETGBL	R4	G16
-      0x8C140301,  //  0033  GETMET	R5	R1	K1
-      0x7C140200,  //  0034  CALL	R5	1
-      0x7C100200,  //  0035  CALL	R4	1
-      0xA802001E,  //  0036  EXBLK	0	#0056
-      0x5C140800,  //  0037  MOVE	R5	R4
-      0x7C140000,  //  0038  CALL	R5	0
-      0x8C180708,  //  0039  GETMET	R6	R3	K8
-      0x5C200A00,  //  003A  MOVE	R8	R5
-      0x7C180400,  //  003B  CALL	R6	2
-      0x741A0002,  //  003C  JMPT	R6	#0040
-      0x60180012,  //  003D  GETGBL	R6	G18
-      0x7C180000,  //  003E  CALL	R6	0
-      0x980C0A06,  //  003F  SETIDX	R3	R5	R6
-      0x60180010,  //  0040  GETGBL	R6	G16
-      0x941C0205,  //  0041  GETIDX	R7	R1	R5
-      0x7C180200,  //  0042  CALL	R6	1
-      0xA802000D,  //  0043  EXBLK	0	#0052
-      0x5C1C0C00,  //  0044  MOVE	R7	R6
-      0x7C1C0000,  //  0045  CALL	R7	0
-      0x94200605,  //  0046  GETIDX	R8	R3	R5
-      0x8C201109,  //  0047  GETMET	R8	R8	K9
-      0x5C280E00,  //  0048  MOVE	R10	R7
-      0x7C200400,  //  0049  CALL	R8	2
-      0x4C240000,  //  004A  LDNIL	R9
-      0x1C201009,  //  004B  EQ	R8	R8	R9
-      0x78220003,  //  004C  JMPF	R8	#0051
-      0x94200605,  //  004D  GETIDX	R8	R3	R5
-      0x8C201104,  //  004E  GETMET	R8	R8	K4
-      0x5C280E00,  //  004F  MOVE	R10	R7
-      0x7C200400,  //  0050  CALL	R8	2
-      0x7001FFF1,  //  0051  JMP		#0044
-      0x58180007,  //  0052  LDCONST	R6	K7
-      0xAC180200,  //  0053  CATCH	R6	1	0
-      0xB0080000,  //  0054  RAISE	2	R0	R0
-      0x7001FFE0,  //  0055  JMP		#0037
-      0x58100007,  //  0056  LDCONST	R4	K7
-      0xAC100200,  //  0057  CATCH	R4	1	0
-      0xB0080000,  //  0058  RAISE	2	R0	R0
-      0x60100012,  //  0059  GETGBL	R4	G18
-      0x7C100000,  //  005A  CALL	R4	0
-      0x5416FFF7,  //  005B  LDINT	R5	65528
-      0x40140805,  //  005C  CONNECT	R5	R4	R5
-      0x5416FFF8,  //  005D  LDINT	R5	65529
-      0x40140805,  //  005E  CONNECT	R5	R4	R5
-      0x5416FFF9,  //  005F  LDINT	R5	65530
-      0x40140805,  //  0060  CONNECT	R5	R4	R5
-      0x5416FFFA,  //  0061  LDINT	R5	65531
-      0x40140805,  //  0062  CONNECT	R5	R4	R5
-      0x5416FFFB,  //  0063  LDINT	R5	65532
-      0x40140805,  //  0064  CONNECT	R5	R4	R5
-      0x5416FFFC,  //  0065  LDINT	R5	65533
-      0x40140805,  //  0066  CONNECT	R5	R4	R5
-      0x60140010,  //  0067  GETGBL	R5	G16
-      0x8C180301,  //  0068  GETMET	R6	R1	K1
-      0x7C180200,  //  0069  CALL	R6	1
-      0x7C140200,  //  006A  CALL	R5	1
-      0xA8020017,  //  006B  EXBLK	0	#0084
-      0x5C180A00,  //  006C  MOVE	R6	R5
-      0x7C180000,  //  006D  CALL	R6	0
-      0x601C0010,  //  006E  GETGBL	R7	G16
-      0x5C200800,  //  006F  MOVE	R8	R4
-      0x7C1C0200,  //  0070  CALL	R7	1
-      0xA802000D,  //  0071  EXBLK	0	#0080
-      0x5C200E00,  //  0072  MOVE	R8	R7
-      0x7C200000,  //  0073  CALL	R8	0
-      0x94240606,  //  0074  GETIDX	R9	R3	R6
-      0x8C241309,  //  0075  GETMET	R9	R9	K9
-      0x5C2C1000,  //  0076  MOVE	R11	R8
-      0x7C240400,  //  0077  CALL	R9	2
-      0x4C280000,  //  0078  LDNIL	R10
-      0x1C24120A,  //  0079  EQ	R9	R9	R10
-      0x78260003,  //  007A  JMPF	R9	#007F
-      0x94240606,  //  007B  GETIDX	R9	R3	R6
-      0x8C241304,  //  007C  GETMET	R9	R9	K4
-      0x5C2C1000,  //  007D  MOVE	R11	R8
-      0x7C240400,  //  007E  CALL	R9	2
-      0x7001FFF1,  //  007F  JMP		#0072
-      0x581C0007,  //  0080  LDCONST	R7	K7
-      0xAC1C0200,  //  0081  CATCH	R7	1	0
-      0xB0080000,  //  0082  RAISE	2	R0	R0
-      0x7001FFE7,  //  0083  JMP		#006C
-      0x58140007,  //  0084  LDCONST	R5	K7
-      0xAC140200,  //  0085  CATCH	R5	1	0
-      0xB0080000,  //  0086  RAISE	2	R0	R0
-      0x60140010,  //  0087  GETGBL	R5	G16
-      0x8C180701,  //  0088  GETMET	R6	R3	K1
-      0x7C180200,  //  0089  CALL	R6	1
-      0x7C140200,  //  008A  CALL	R5	1
-      0xA8020008,  //  008B  EXBLK	0	#0095
-      0x5C180A00,  //  008C  MOVE	R6	R5
-      0x7C180000,  //  008D  CALL	R6	0
-      0x941C0606,  //  008E  GETIDX	R7	R3	R6
-      0xB8221400,  //  008F  GETNGBL	R8	K10
-      0x8C20110B,  //  0090  GETMET	R8	R8	K11
-      0x5C280E00,  //  0091  MOVE	R10	R7
-      0x7C200400,  //  0092  CALL	R8	2
-      0x980C0C08,  //  0093  SETIDX	R3	R6	R8
-      0x7001FFF6,  //  0094  JMP		#008C
-      0x58140007,  //  0095  LDCONST	R5	K7
-      0xAC140200,  //  0096  CATCH	R5	1	0
+    ( &(const binstruction[201]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0003,  //  0002  EQ	R3	R0	R3
+      0x780E0003,  //  0003  JMPF	R3	#0008
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x5C080600,  //  0006  MOVE	R2	R3
+      0x70020019,  //  0007  JMP		#0022
+      0x600C0004,  //  0008  GETGBL	R3	G4
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x1C0C0700,  //  000B  EQ	R3	R3	K0
+      0x780E000E,  //  000C  JMPF	R3	#001C
+      0x600C0003,  //  000D  GETGBL	R3	G3
+      0x5C100000,  //  000E  MOVE	R4	R0
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x4C100000,  //  0010  LDNIL	R4
+      0x200C0604,  //  0011  NE	R3	R3	R4
+      0x780E0004,  //  0012  JMPF	R3	#0018
+      0x600C0003,  //  0013  GETGBL	R3	G3
+      0x5C100000,  //  0014  MOVE	R4	R0
+      0x7C0C0200,  //  0015  CALL	R3	1
+      0x880C0701,  //  0016  GETMBR	R3	R3	K1
+      0x70020001,  //  0017  JMP		#001A
+      0x600C0013,  //  0018  GETGBL	R3	G19
+      0x7C0C0000,  //  0019  CALL	R3	0
+      0x5C080600,  //  001A  MOVE	R2	R3
+      0x70020005,  //  001B  JMP		#0022
+      0x600C0004,  //  001C  GETGBL	R3	G4
+      0x5C100000,  //  001D  MOVE	R4	R0
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x1C0C0702,  //  001F  EQ	R3	R3	K2
+      0x780E0000,  //  0020  JMPF	R3	#0022
+      0x5C080000,  //  0021  MOVE	R2	R0
+      0x600C0013,  //  0022  GETGBL	R3	G19
+      0x7C0C0000,  //  0023  CALL	R3	0
+      0x60100010,  //  0024  GETGBL	R4	G16
+      0x8C140503,  //  0025  GETMET	R5	R2	K3
+      0x7C140200,  //  0026  CALL	R5	1
+      0x7C100200,  //  0027  CALL	R4	1
+      0xA802001A,  //  0028  EXBLK	0	#0044
+      0x5C140800,  //  0029  MOVE	R5	R4
+      0x7C140000,  //  002A  CALL	R5	0
+      0x60180012,  //  002B  GETGBL	R6	G18
+      0x7C180000,  //  002C  CALL	R6	0
+      0x941C0405,  //  002D  GETIDX	R7	R2	R5
+      0x4C200000,  //  002E  LDNIL	R8
+      0x20200E08,  //  002F  NE	R8	R7	R8
+      0x78220004,  //  0030  JMPF	R8	#0036
+      0x6020000C,  //  0031  GETGBL	R8	G12
+      0x5C240E00,  //  0032  MOVE	R9	R7
+      0x7C200200,  //  0033  CALL	R8	1
+      0x0C201104,  //  0034  DIV	R8	R8	K4
+      0x70020000,  //  0035  JMP		#0037
+      0x58200005,  //  0036  LDCONST	R8	K5
+      0x58240005,  //  0037  LDCONST	R9	K5
+      0x14281208,  //  0038  LT	R10	R9	R8
+      0x782A0007,  //  0039  JMPF	R10	#0042
+      0x8C280D06,  //  003A  GETMET	R10	R6	K6
+      0x8C300F07,  //  003B  GETMET	R12	R7	K7
+      0x08381304,  //  003C  MUL	R14	R9	K4
+      0x543DFFFD,  //  003D  LDINT	R15	-2
+      0x7C300600,  //  003E  CALL	R12	3
+      0x7C280400,  //  003F  CALL	R10	2
+      0x00241308,  //  0040  ADD	R9	R9	K8
+      0x7001FFF5,  //  0041  JMP		#0038
+      0x980C0A06,  //  0042  SETIDX	R3	R5	R6
+      0x7001FFE4,  //  0043  JMP		#0029
+      0x58100009,  //  0044  LDCONST	R4	K9
+      0xAC100200,  //  0045  CATCH	R4	1	0
+      0xB0080000,  //  0046  RAISE	2	R0	R0
+      0x60100010,  //  0047  GETGBL	R4	G16
+      0x8C140303,  //  0048  GETMET	R5	R1	K3
+      0x7C140200,  //  0049  CALL	R5	1
+      0x7C100200,  //  004A  CALL	R4	1
+      0xA802001E,  //  004B  EXBLK	0	#006B
+      0x5C140800,  //  004C  MOVE	R5	R4
+      0x7C140000,  //  004D  CALL	R5	0
+      0x8C18070A,  //  004E  GETMET	R6	R3	K10
+      0x5C200A00,  //  004F  MOVE	R8	R5
+      0x7C180400,  //  0050  CALL	R6	2
+      0x741A0002,  //  0051  JMPT	R6	#0055
+      0x60180012,  //  0052  GETGBL	R6	G18
+      0x7C180000,  //  0053  CALL	R6	0
+      0x980C0A06,  //  0054  SETIDX	R3	R5	R6
+      0x60180010,  //  0055  GETGBL	R6	G16
+      0x941C0205,  //  0056  GETIDX	R7	R1	R5
+      0x7C180200,  //  0057  CALL	R6	1
+      0xA802000D,  //  0058  EXBLK	0	#0067
+      0x5C1C0C00,  //  0059  MOVE	R7	R6
+      0x7C1C0000,  //  005A  CALL	R7	0
+      0x94200605,  //  005B  GETIDX	R8	R3	R5
+      0x8C20110B,  //  005C  GETMET	R8	R8	K11
+      0x5C280E00,  //  005D  MOVE	R10	R7
+      0x7C200400,  //  005E  CALL	R8	2
+      0x4C240000,  //  005F  LDNIL	R9
+      0x1C201009,  //  0060  EQ	R8	R8	R9
+      0x78220003,  //  0061  JMPF	R8	#0066
+      0x94200605,  //  0062  GETIDX	R8	R3	R5
+      0x8C201106,  //  0063  GETMET	R8	R8	K6
+      0x5C280E00,  //  0064  MOVE	R10	R7
+      0x7C200400,  //  0065  CALL	R8	2
+      0x7001FFF1,  //  0066  JMP		#0059
+      0x58180009,  //  0067  LDCONST	R6	K9
+      0xAC180200,  //  0068  CATCH	R6	1	0
+      0xB0080000,  //  0069  RAISE	2	R0	R0
+      0x7001FFE0,  //  006A  JMP		#004C
+      0x58100009,  //  006B  LDCONST	R4	K9
+      0xAC100200,  //  006C  CATCH	R4	1	0
+      0xB0080000,  //  006D  RAISE	2	R0	R0
+      0x60100012,  //  006E  GETGBL	R4	G18
+      0x7C100000,  //  006F  CALL	R4	0
+      0x5416FFF7,  //  0070  LDINT	R5	65528
+      0x40140805,  //  0071  CONNECT	R5	R4	R5
+      0x5416FFF8,  //  0072  LDINT	R5	65529
+      0x40140805,  //  0073  CONNECT	R5	R4	R5
+      0x5416FFF9,  //  0074  LDINT	R5	65530
+      0x40140805,  //  0075  CONNECT	R5	R4	R5
+      0x5416FFFA,  //  0076  LDINT	R5	65531
+      0x40140805,  //  0077  CONNECT	R5	R4	R5
+      0x5416FFFB,  //  0078  LDINT	R5	65532
+      0x40140805,  //  0079  CONNECT	R5	R4	R5
+      0x5416FFFC,  //  007A  LDINT	R5	65533
+      0x40140805,  //  007B  CONNECT	R5	R4	R5
+      0x60140010,  //  007C  GETGBL	R5	G16
+      0x8C180303,  //  007D  GETMET	R6	R1	K3
+      0x7C180200,  //  007E  CALL	R6	1
+      0x7C140200,  //  007F  CALL	R5	1
+      0xA8020017,  //  0080  EXBLK	0	#0099
+      0x5C180A00,  //  0081  MOVE	R6	R5
+      0x7C180000,  //  0082  CALL	R6	0
+      0x601C0010,  //  0083  GETGBL	R7	G16
+      0x5C200800,  //  0084  MOVE	R8	R4
+      0x7C1C0200,  //  0085  CALL	R7	1
+      0xA802000D,  //  0086  EXBLK	0	#0095
+      0x5C200E00,  //  0087  MOVE	R8	R7
+      0x7C200000,  //  0088  CALL	R8	0
+      0x94240606,  //  0089  GETIDX	R9	R3	R6
+      0x8C24130B,  //  008A  GETMET	R9	R9	K11
+      0x5C2C1000,  //  008B  MOVE	R11	R8
+      0x7C240400,  //  008C  CALL	R9	2
+      0x4C280000,  //  008D  LDNIL	R10
+      0x1C24120A,  //  008E  EQ	R9	R9	R10
+      0x78260003,  //  008F  JMPF	R9	#0094
+      0x94240606,  //  0090  GETIDX	R9	R3	R6
+      0x8C241306,  //  0091  GETMET	R9	R9	K6
+      0x5C2C1000,  //  0092  MOVE	R11	R8
+      0x7C240400,  //  0093  CALL	R9	2
+      0x7001FFF1,  //  0094  JMP		#0087
+      0x581C0009,  //  0095  LDCONST	R7	K9
+      0xAC1C0200,  //  0096  CATCH	R7	1	0
       0xB0080000,  //  0097  RAISE	2	R0	R0
-      0x60140010,  //  0098  GETGBL	R5	G16
-      0x8C180701,  //  0099  GETMET	R6	R3	K1
-      0x7C180200,  //  009A  CALL	R6	1
-      0x7C140200,  //  009B  CALL	R5	1
-      0xA8020012,  //  009C  EXBLK	0	#00B0
-      0x5C180A00,  //  009D  MOVE	R6	R5
-      0x7C180000,  //  009E  CALL	R6	0
-      0x941C0606,  //  009F  GETIDX	R7	R3	R6
-      0x60200015,  //  00A0  GETGBL	R8	G21
-      0x7C200000,  //  00A1  CALL	R8	0
-      0x58240003,  //  00A2  LDCONST	R9	K3
-      0x6028000C,  //  00A3  GETGBL	R10	G12
-      0x5C2C0E00,  //  00A4  MOVE	R11	R7
-      0x7C280200,  //  00A5  CALL	R10	1
-      0x1428120A,  //  00A6  LT	R10	R9	R10
-      0x782A0005,  //  00A7  JMPF	R10	#00AE
-      0x8C28110C,  //  00A8  GETMET	R10	R8	K12
-      0x94300E09,  //  00A9  GETIDX	R12	R7	R9
-      0x5435FFFD,  //  00AA  LDINT	R13	-2
-      0x7C280600,  //  00AB  CALL	R10	3
-      0x00241306,  //  00AC  ADD	R9	R9	K6
-      0x7001FFF4,  //  00AD  JMP		#00A3
-      0x980C0C08,  //  00AE  SETIDX	R3	R6	R8
-      0x7001FFEC,  //  00AF  JMP		#009D
-      0x58140007,  //  00B0  LDCONST	R5	K7
-      0xAC140200,  //  00B1  CATCH	R5	1	0
-      0xB0080000,  //  00B2  RAISE	2	R0	R0
-      0x80040600,  //  00B3  RET	1	R3
+      0x7001FFE7,  //  0098  JMP		#0081
+      0x58140009,  //  0099  LDCONST	R5	K9
+      0xAC140200,  //  009A  CATCH	R5	1	0
+      0xB0080000,  //  009B  RAISE	2	R0	R0
+      0x60140010,  //  009C  GETGBL	R5	G16
+      0x8C180703,  //  009D  GETMET	R6	R3	K3
+      0x7C180200,  //  009E  CALL	R6	1
+      0x7C140200,  //  009F  CALL	R5	1
+      0xA8020008,  //  00A0  EXBLK	0	#00AA
+      0x5C180A00,  //  00A1  MOVE	R6	R5
+      0x7C180000,  //  00A2  CALL	R6	0
+      0x941C0606,  //  00A3  GETIDX	R7	R3	R6
+      0xB8221800,  //  00A4  GETNGBL	R8	K12
+      0x8C20110D,  //  00A5  GETMET	R8	R8	K13
+      0x5C280E00,  //  00A6  MOVE	R10	R7
+      0x7C200400,  //  00A7  CALL	R8	2
+      0x980C0C08,  //  00A8  SETIDX	R3	R6	R8
+      0x7001FFF6,  //  00A9  JMP		#00A1
+      0x58140009,  //  00AA  LDCONST	R5	K9
+      0xAC140200,  //  00AB  CATCH	R5	1	0
+      0xB0080000,  //  00AC  RAISE	2	R0	R0
+      0x60140010,  //  00AD  GETGBL	R5	G16
+      0x8C180703,  //  00AE  GETMET	R6	R3	K3
+      0x7C180200,  //  00AF  CALL	R6	1
+      0x7C140200,  //  00B0  CALL	R5	1
+      0xA8020012,  //  00B1  EXBLK	0	#00C5
+      0x5C180A00,  //  00B2  MOVE	R6	R5
+      0x7C180000,  //  00B3  CALL	R6	0
+      0x941C0606,  //  00B4  GETIDX	R7	R3	R6
+      0x60200015,  //  00B5  GETGBL	R8	G21
+      0x7C200000,  //  00B6  CALL	R8	0
+      0x58240005,  //  00B7  LDCONST	R9	K5
+      0x6028000C,  //  00B8  GETGBL	R10	G12
+      0x5C2C0E00,  //  00B9  MOVE	R11	R7
+      0x7C280200,  //  00BA  CALL	R10	1
+      0x1428120A,  //  00BB  LT	R10	R9	R10
+      0x782A0005,  //  00BC  JMPF	R10	#00C3
+      0x8C28110E,  //  00BD  GETMET	R10	R8	K14
+      0x94300E09,  //  00BE  GETIDX	R12	R7	R9
+      0x5435FFFD,  //  00BF  LDINT	R13	-2
+      0x7C280600,  //  00C0  CALL	R10	3
+      0x00241308,  //  00C1  ADD	R9	R9	K8
+      0x7001FFF4,  //  00C2  JMP		#00B8
+      0x980C0C08,  //  00C3  SETIDX	R3	R6	R8
+      0x7001FFEC,  //  00C4  JMP		#00B2
+      0x58140009,  //  00C5  LDCONST	R5	K9
+      0xAC140200,  //  00C6  CATCH	R5	1	0
+      0xB0080000,  //  00C7  RAISE	2	R0	R0
+      0x80040600,  //  00C8  RET	1	R3
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -4,8 +4,8 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_Plugin;
-// compact class 'Matter_Plugin' ktab size: 65, total: 108 (saved 344 bytes)
-static const bvalue be_ktab_class_Matter_Plugin[65] = {
+// compact class 'Matter_Plugin' ktab size: 66, total: 108 (saved 336 bytes)
+static const bvalue be_ktab_class_Matter_Plugin[66] = {
   /* K0   */  be_nested_str_weak(json),
   /* K1   */  be_nested_str_weak(node_label),
   /* K2   */  be_nested_str_weak(_X2C_X22Name_X22_X3A_X25s),
@@ -21,7 +21,7 @@ static const bvalue be_ktab_class_Matter_Plugin[65] = {
   /* K12  */  be_nested_str_weak(message_handler),
   /* K13  */  be_nested_str_weak(im),
   /* K14  */  be_nested_str_weak(send_ack_now),
-  /* K15  */  be_nested_str_weak(CLUSTERS),
+  /* K15  */  be_nested_str_weak(get_clusters),
   /* K16  */  be_nested_str_weak(find),
   /* K17  */  be_nested_str_weak(attribute_updated),
   /* K18  */  be_nested_str_weak(update_next),
@@ -53,24 +53,25 @@ static const bvalue be_ktab_class_Matter_Plugin[65] = {
   /* K44  */  be_nested_str_weak(_X25s_X2C_X25s_X3A_X25s),
   /* K45  */  be_nested_str_weak(publish_command),
   /* K46  */  be_nested_str_weak(MtrReceived),
-  /* K47  */  be_nested_str_weak(contains),
-  /* K48  */  be_nested_str_weak(TLV),
-  /* K49  */  be_nested_str_weak(cluster),
-  /* K50  */  be_nested_str_weak(attribute),
-  /* K51  */  be_nested_str_weak(Matter_TLV_array),
-  /* K52  */  be_nested_str_weak(TYPES),
-  /* K53  */  be_nested_str_weak(keys),
-  /* K54  */  be_nested_str_weak(add_struct),
-  /* K55  */  be_nested_str_weak(add_TLV),
-  /* K56  */  be_nested_str_weak(U2),
-  /* K57  */  be_nested_str_weak(stop_iteration),
-  /* K58  */  be_nested_str_weak(get_cluster_list_sorted),
-  /* K59  */  be_nested_str_weak(U4),
-  /* K60  */  be_const_int(3),
-  /* K61  */  be_nested_str_weak(set),
-  /* K62  */  be_nested_str_weak(get_attribute_list_bytes),
-  /* K63  */  be_nested_str_weak(FEATURE_MAPS),
-  /* K64  */  be_nested_str_weak(CLUSTER_REVISIONS),
+  /* K47  */  be_nested_str_weak(CLUSTERS),
+  /* K48  */  be_nested_str_weak(contains),
+  /* K49  */  be_nested_str_weak(TLV),
+  /* K50  */  be_nested_str_weak(cluster),
+  /* K51  */  be_nested_str_weak(attribute),
+  /* K52  */  be_nested_str_weak(Matter_TLV_array),
+  /* K53  */  be_nested_str_weak(TYPES),
+  /* K54  */  be_nested_str_weak(keys),
+  /* K55  */  be_nested_str_weak(add_struct),
+  /* K56  */  be_nested_str_weak(add_TLV),
+  /* K57  */  be_nested_str_weak(U2),
+  /* K58  */  be_nested_str_weak(stop_iteration),
+  /* K59  */  be_nested_str_weak(get_cluster_list_sorted),
+  /* K60  */  be_nested_str_weak(U4),
+  /* K61  */  be_const_int(3),
+  /* K62  */  be_nested_str_weak(set),
+  /* K63  */  be_nested_str_weak(get_attribute_list_bytes),
+  /* K64  */  be_nested_str_weak(FEATURE_MAPS),
+  /* K65  */  be_nested_str_weak(CLUSTER_REVISIONS),
 };
 
 
@@ -210,13 +211,14 @@ be_local_closure(class_Matter_Plugin_get_attribute_list_bytes,   /* name */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_attribute_list_bytes),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8808010F,  //  0000  GETMBR	R2	R0	K15
-      0x8C080510,  //  0001  GETMET	R2	R2	K16
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x4C140000,  //  0003  LDNIL	R5
-      0x7C080600,  //  0004  CALL	R2	3
-      0x80040400,  //  0005  RET	1	R2
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C08010F,  //  0000  GETMET	R2	R0	K15
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C080510,  //  0002  GETMET	R2	R2	K16
+      0x5C100200,  //  0003  MOVE	R4	R1
+      0x4C140000,  //  0004  LDNIL	R5
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
     })
   )
 );
@@ -612,7 +614,7 @@ be_local_closure(class_Matter_Plugin_consolidate_update_commands,   /* name */
 ********************************************************************/
 be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -623,12 +625,13 @@ be_local_closure(class_Matter_Plugin_get_cluster_list_sorted,   /* name */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(get_cluster_list_sorted),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[ 6]) {  /* code */
       0x88040109,  //  0000  GETMBR	R1	R0	K9
       0x8C040320,  //  0001  GETMET	R1	R1	K32
-      0x880C010F,  //  0002  GETMBR	R3	R0	K15
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
+      0x8C0C010F,  //  0002  GETMET	R3	R0	K15
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -820,33 +823,34 @@ be_local_closure(class_Matter_Plugin_contains_attribute,   /* name */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(contains_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x880C010F,  //  0000  GETMBR	R3	R0	K15
-      0x8C0C0710,  //  0001  GETMET	R3	R3	K16
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x78120010,  //  0006  JMPF	R4	#0018
-      0x58100023,  //  0007  LDCONST	R4	K35
-      0x6014000C,  //  0008  GETGBL	R5	G12
-      0x5C180600,  //  0009  MOVE	R6	R3
-      0x7C140200,  //  000A  CALL	R5	1
-      0x0C140B24,  //  000B  DIV	R5	R5	K36
-      0x14180805,  //  000C  LT	R6	R4	R5
-      0x781A0009,  //  000D  JMPF	R6	#0018
-      0x8C180725,  //  000E  GETMET	R6	R3	K37
-      0x08200924,  //  000F  MUL	R8	R4	K36
-      0x5425FFFD,  //  0010  LDINT	R9	-2
-      0x7C180600,  //  0011  CALL	R6	3
-      0x1C180C02,  //  0012  EQ	R6	R6	R2
-      0x781A0001,  //  0013  JMPF	R6	#0016
-      0x50180200,  //  0014  LDBOOL	R6	1	0
-      0x80040C00,  //  0015  RET	1	R6
-      0x00100926,  //  0016  ADD	R4	R4	K38
-      0x7001FFF3,  //  0017  JMP		#000C
-      0x50100000,  //  0018  LDBOOL	R4	0	0
-      0x80040800,  //  0019  RET	1	R4
+    ( &(const binstruction[27]) {  /* code */
+      0x8C0C010F,  //  0000  GETMET	R3	R0	K15
+      0x7C0C0200,  //  0001  CALL	R3	1
+      0x8C0C0710,  //  0002  GETMET	R3	R3	K16
+      0x5C140200,  //  0003  MOVE	R5	R1
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x4C100000,  //  0005  LDNIL	R4
+      0x20100604,  //  0006  NE	R4	R3	R4
+      0x78120010,  //  0007  JMPF	R4	#0019
+      0x58100023,  //  0008  LDCONST	R4	K35
+      0x6014000C,  //  0009  GETGBL	R5	G12
+      0x5C180600,  //  000A  MOVE	R6	R3
+      0x7C140200,  //  000B  CALL	R5	1
+      0x0C140B24,  //  000C  DIV	R5	R5	K36
+      0x14180805,  //  000D  LT	R6	R4	R5
+      0x781A0009,  //  000E  JMPF	R6	#0019
+      0x8C180725,  //  000F  GETMET	R6	R3	K37
+      0x08200924,  //  0010  MUL	R8	R4	K36
+      0x5425FFFD,  //  0011  LDINT	R9	-2
+      0x7C180600,  //  0012  CALL	R6	3
+      0x1C180C02,  //  0013  EQ	R6	R6	R2
+      0x781A0001,  //  0014  JMPF	R6	#0017
+      0x50180200,  //  0015  LDBOOL	R6	1	0
+      0x80040C00,  //  0016  RET	1	R6
+      0x00100926,  //  0017  ADD	R4	R4	K38
+      0x7001FFF3,  //  0018  JMP		#000D
+      0x50100000,  //  0019  LDBOOL	R4	0	0
+      0x80040800,  //  001A  RET	1	R4
     })
   )
 );
@@ -1086,7 +1090,7 @@ be_local_closure(class_Matter_Plugin_get_clusters,   /* name */
     be_str_weak(get_clusters),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x8804010F,  //  0000  GETMBR	R1	R0	K15
+      0x8804012F,  //  0000  GETMBR	R1	R0	K47
       0x80040200,  //  0001  RET	1	R1
     })
   )
@@ -1110,12 +1114,13 @@ be_local_closure(class_Matter_Plugin_contains_cluster,   /* name */
     &be_ktab_class_Matter_Plugin,     /* shared constants */
     be_str_weak(contains_cluster),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808010F,  //  0000  GETMBR	R2	R0	K15
-      0x8C08052F,  //  0001  GETMET	R2	R2	K47
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C08010F,  //  0000  GETMET	R2	R0	K15
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C080530,  //  0002  GETMET	R2	R2	K48
+      0x5C100200,  //  0003  MOVE	R4	R1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
@@ -1140,81 +1145,81 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[169]) {  /* code */
       0xB8122600,  //  0000  GETNGBL	R4	K19
-      0x88100930,  //  0001  GETMBR	R4	R4	K48
-      0x88140531,  //  0002  GETMBR	R5	R2	K49
-      0x88180532,  //  0003  GETMBR	R6	R2	K50
+      0x88100931,  //  0001  GETMBR	R4	R4	K49
+      0x88140532,  //  0002  GETMBR	R5	R2	K50
+      0x88180533,  //  0003  GETMBR	R6	R2	K51
       0x541E001C,  //  0004  LDINT	R7	29
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
       0x781E0050,  //  0006  JMPF	R7	#0058
       0x1C1C0D23,  //  0007  EQ	R7	R6	K35
       0x781E001B,  //  0008  JMPF	R7	#0025
-      0x8C1C0933,  //  0009  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0009  GETMET	R7	R4	K52
       0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200134,  //  000B  GETMBR	R8	R0	K52
+      0x88200135,  //  000B  GETMBR	R8	R0	K53
       0x60240010,  //  000C  GETGBL	R9	G16
-      0x8C281135,  //  000D  GETMET	R10	R8	K53
+      0x8C281136,  //  000D  GETMET	R10	R8	K54
       0x7C280200,  //  000E  CALL	R10	1
       0x7C240200,  //  000F  CALL	R9	1
       0xA802000E,  //  0010  EXBLK	0	#0020
       0x5C281200,  //  0011  MOVE	R10	R9
       0x7C280000,  //  0012  CALL	R10	0
-      0x8C2C0F36,  //  0013  GETMET	R11	R7	K54
+      0x8C2C0F37,  //  0013  GETMET	R11	R7	K55
       0x7C2C0200,  //  0014  CALL	R11	1
-      0x8C301737,  //  0015  GETMET	R12	R11	K55
+      0x8C301738,  //  0015  GETMET	R12	R11	K56
       0x58380023,  //  0016  LDCONST	R14	K35
-      0x883C0938,  //  0017  GETMBR	R15	R4	K56
+      0x883C0939,  //  0017  GETMBR	R15	R4	K57
       0x5C401400,  //  0018  MOVE	R16	R10
       0x7C300800,  //  0019  CALL	R12	4
-      0x8C301737,  //  001A  GETMET	R12	R11	K55
+      0x8C301738,  //  001A  GETMET	R12	R11	K56
       0x58380026,  //  001B  LDCONST	R14	K38
-      0x883C0938,  //  001C  GETMBR	R15	R4	K56
+      0x883C0939,  //  001C  GETMBR	R15	R4	K57
       0x9440100A,  //  001D  GETIDX	R16	R8	R10
       0x7C300800,  //  001E  CALL	R12	4
       0x7001FFF0,  //  001F  JMP		#0011
-      0x58240039,  //  0020  LDCONST	R9	K57
+      0x5824003A,  //  0020  LDCONST	R9	K58
       0xAC240200,  //  0021  CATCH	R9	1	0
       0xB0080000,  //  0022  RAISE	2	R0	R0
       0x80040E00,  //  0023  RET	1	R7
       0x70020032,  //  0024  JMP		#0058
       0x1C1C0D26,  //  0025  EQ	R7	R6	K38
       0x781E0013,  //  0026  JMPF	R7	#003B
-      0x8C1C0933,  //  0027  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0027  GETMET	R7	R4	K52
       0x7C1C0200,  //  0028  CALL	R7	1
       0x60200010,  //  0029  GETGBL	R8	G16
-      0x8C24013A,  //  002A  GETMET	R9	R0	K58
+      0x8C24013B,  //  002A  GETMET	R9	R0	K59
       0x7C240200,  //  002B  CALL	R9	1
       0x7C200200,  //  002C  CALL	R8	1
       0xA8020007,  //  002D  EXBLK	0	#0036
       0x5C241000,  //  002E  MOVE	R9	R8
       0x7C240000,  //  002F  CALL	R9	0
-      0x8C280F37,  //  0030  GETMET	R10	R7	K55
+      0x8C280F38,  //  0030  GETMET	R10	R7	K56
       0x4C300000,  //  0031  LDNIL	R12
-      0x8834093B,  //  0032  GETMBR	R13	R4	K59
+      0x8834093C,  //  0032  GETMBR	R13	R4	K60
       0x5C381200,  //  0033  MOVE	R14	R9
       0x7C280800,  //  0034  CALL	R10	4
       0x7001FFF7,  //  0035  JMP		#002E
-      0x58200039,  //  0036  LDCONST	R8	K57
+      0x5820003A,  //  0036  LDCONST	R8	K58
       0xAC200200,  //  0037  CATCH	R8	1	0
       0xB0080000,  //  0038  RAISE	2	R0	R0
       0x80040E00,  //  0039  RET	1	R7
       0x7002001C,  //  003A  JMP		#0058
       0x1C1C0D24,  //  003B  EQ	R7	R6	K36
       0x781E0003,  //  003C  JMPF	R7	#0041
-      0x8C1C0933,  //  003D  GETMET	R7	R4	K51
+      0x8C1C0934,  //  003D  GETMET	R7	R4	K52
       0x7C1C0200,  //  003E  CALL	R7	1
       0x80040E00,  //  003F  RET	1	R7
       0x70020016,  //  0040  JMP		#0058
-      0x1C1C0D3C,  //  0041  EQ	R7	R6	K60
+      0x1C1C0D3D,  //  0041  EQ	R7	R6	K61
       0x781E0003,  //  0042  JMPF	R7	#0047
-      0x8C1C0933,  //  0043  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0043  GETMET	R7	R4	K52
       0x7C1C0200,  //  0044  CALL	R7	1
       0x80040E00,  //  0045  RET	1	R7
       0x70020010,  //  0046  JMP		#0058
       0x541EFFFB,  //  0047  LDINT	R7	65532
       0x1C1C0C07,  //  0048  EQ	R7	R6	R7
       0x781E0005,  //  0049  JMPF	R7	#0050
-      0x8C1C073D,  //  004A  GETMET	R7	R3	K61
-      0x8824093B,  //  004B  GETMBR	R9	R4	K59
+      0x8C1C073E,  //  004A  GETMET	R7	R3	K62
+      0x8824093C,  //  004B  GETMBR	R9	R4	K60
       0x58280023,  //  004C  LDCONST	R10	K35
       0x7C1C0600,  //  004D  CALL	R7	3
       0x80040E00,  //  004E  RET	1	R7
@@ -1222,24 +1227,24 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x541EFFFC,  //  0050  LDINT	R7	65533
       0x1C1C0C07,  //  0051  EQ	R7	R6	R7
       0x781E0004,  //  0052  JMPF	R7	#0058
-      0x8C1C073D,  //  0053  GETMET	R7	R3	K61
-      0x8824093B,  //  0054  GETMBR	R9	R4	K59
+      0x8C1C073E,  //  0053  GETMET	R7	R3	K62
+      0x8824093C,  //  0054  GETMBR	R9	R4	K60
       0x58280026,  //  0055  LDCONST	R10	K38
       0x7C1C0600,  //  0056  CALL	R7	3
       0x80040E00,  //  0057  RET	1	R7
       0x541EFFF7,  //  0058  LDINT	R7	65528
       0x1C1C0C07,  //  0059  EQ	R7	R6	R7
       0x781E0003,  //  005A  JMPF	R7	#005F
-      0x8C1C0933,  //  005B  GETMET	R7	R4	K51
+      0x8C1C0934,  //  005B  GETMET	R7	R4	K52
       0x7C1C0200,  //  005C  CALL	R7	1
       0x80040E00,  //  005D  RET	1	R7
       0x70020047,  //  005E  JMP		#00A7
       0x541EFFFA,  //  005F  LDINT	R7	65531
       0x1C1C0C07,  //  0060  EQ	R7	R6	R7
       0x781E001B,  //  0061  JMPF	R7	#007E
-      0x8C1C0933,  //  0062  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0062  GETMET	R7	R4	K52
       0x7C1C0200,  //  0063  CALL	R7	1
-      0x8C20013E,  //  0064  GETMET	R8	R0	K62
+      0x8C20013F,  //  0064  GETMET	R8	R0	K63
       0x5C280A00,  //  0065  MOVE	R10	R5
       0x7C200400,  //  0066  CALL	R8	2
       0x4C240000,  //  0067  LDNIL	R9
@@ -1253,9 +1258,9 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x58280023,  //  006F  LDCONST	R10	K35
       0x142C1409,  //  0070  LT	R11	R10	R9
       0x782E0009,  //  0071  JMPF	R11	#007C
-      0x8C2C0F37,  //  0072  GETMET	R11	R7	K55
+      0x8C2C0F38,  //  0072  GETMET	R11	R7	K56
       0x4C340000,  //  0073  LDNIL	R13
-      0x88380938,  //  0074  GETMBR	R14	R4	K56
+      0x88380939,  //  0074  GETMBR	R14	R4	K57
       0x8C3C1125,  //  0075  GETMET	R15	R8	K37
       0x08441524,  //  0076  MUL	R17	R10	K36
       0x5449FFFD,  //  0077  LDINT	R18	-2
@@ -1268,27 +1273,27 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x541EFFF9,  //  007E  LDINT	R7	65530
       0x1C1C0C07,  //  007F  EQ	R7	R6	R7
       0x781E0003,  //  0080  JMPF	R7	#0085
-      0x8C1C0933,  //  0081  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0081  GETMET	R7	R4	K52
       0x7C1C0200,  //  0082  CALL	R7	1
       0x80040E00,  //  0083  RET	1	R7
       0x70020021,  //  0084  JMP		#00A7
       0x541EFFF8,  //  0085  LDINT	R7	65529
       0x1C1C0C07,  //  0086  EQ	R7	R6	R7
       0x781E0003,  //  0087  JMPF	R7	#008C
-      0x8C1C0933,  //  0088  GETMET	R7	R4	K51
+      0x8C1C0934,  //  0088  GETMET	R7	R4	K52
       0x7C1C0200,  //  0089  CALL	R7	1
       0x80040E00,  //  008A  RET	1	R7
       0x7002001A,  //  008B  JMP		#00A7
       0x541EFFFB,  //  008C  LDINT	R7	65532
       0x1C1C0C07,  //  008D  EQ	R7	R6	R7
       0x781E000A,  //  008E  JMPF	R7	#009A
-      0x881C013F,  //  008F  GETMBR	R7	R0	K63
+      0x881C0140,  //  008F  GETMBR	R7	R0	K64
       0x8C1C0F10,  //  0090  GETMET	R7	R7	K16
       0x5C240A00,  //  0091  MOVE	R9	R5
       0x58280023,  //  0092  LDCONST	R10	K35
       0x7C1C0600,  //  0093  CALL	R7	3
-      0x8C20073D,  //  0094  GETMET	R8	R3	K61
-      0x8828093B,  //  0095  GETMBR	R10	R4	K59
+      0x8C20073E,  //  0094  GETMET	R8	R3	K62
+      0x8828093C,  //  0095  GETMBR	R10	R4	K60
       0x5C2C0E00,  //  0096  MOVE	R11	R7
       0x7C200600,  //  0097  CALL	R8	3
       0x80041000,  //  0098  RET	1	R8
@@ -1296,13 +1301,13 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x541EFFFC,  //  009A  LDINT	R7	65533
       0x1C1C0C07,  //  009B  EQ	R7	R6	R7
       0x781E0009,  //  009C  JMPF	R7	#00A7
-      0x881C0140,  //  009D  GETMBR	R7	R0	K64
+      0x881C0141,  //  009D  GETMBR	R7	R0	K65
       0x8C1C0F10,  //  009E  GETMET	R7	R7	K16
       0x5C240A00,  //  009F  MOVE	R9	R5
       0x58280026,  //  00A0  LDCONST	R10	K38
       0x7C1C0600,  //  00A1  CALL	R7	3
-      0x8C20073D,  //  00A2  GETMET	R8	R3	K61
-      0x8828093B,  //  00A3  GETMBR	R10	R4	K59
+      0x8C20073E,  //  00A2  GETMET	R8	R3	K62
+      0x8828093C,  //  00A3  GETMBR	R10	R4	K60
       0x5C2C0E00,  //  00A4  MOVE	R11	R7
       0x7C200600,  //  00A5  CALL	R8	3
       0x80041000,  //  00A6  RET	1	R8

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Autoconf.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_z_Autoconf.h
@@ -3,8 +3,8 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'Matter_Autoconf' ktab size: 73, total: 90 (saved 136 bytes)
-static const bvalue be_ktab_class_Matter_Autoconf[73] = {
+// compact class 'Matter_Autoconf' ktab size: 74, total: 91 (saved 136 bytes)
+static const bvalue be_ktab_class_Matter_Autoconf[74] = {
   /* K0   */  be_nested_str_weak(device),
   /* K1   */  be_nested_str_weak(k2l_num),
   /* K2   */  be_nested_str_weak(plugins),
@@ -12,72 +12,73 @@ static const bvalue be_ktab_class_Matter_Autoconf[73] = {
   /* K4   */  be_nested_str_weak(matter),
   /* K5   */  be_nested_str_weak(Plugin_Root),
   /* K6   */  be_const_int(0),
-  /* K7   */  be_nested_str_weak(log),
-  /* K8   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
-  /* K9   */  be_const_int(2),
-  /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
-  /* K11  */  be_nested_str_weak(root),
-  /* K12  */  be_nested_str_weak(),
-  /* K13  */  be_nested_str_weak(Plugin_Aggregator),
-  /* K14  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-  /* K15  */  be_nested_str_weak(aggregator),
-  /* K16  */  be_nested_str_weak(find),
-  /* K17  */  be_nested_str_weak(type),
-  /* K18  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-  /* K19  */  be_const_int(3),
-  /* K20  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-  /* K21  */  be_nested_str_weak(plugins_classes),
-  /* K22  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-  /* K23  */  be_nested_str_weak(_X27_X20skipping),
-  /* K24  */  be_nested_str_weak(conf_to_log),
-  /* K25  */  be_nested_str_weak(MTR_X3A_X20Exception),
-  /* K26  */  be_nested_str_weak(_X7C),
-  /* K27  */  be_nested_str_weak(stop_iteration),
-  /* K28  */  be_nested_str_weak(tasmota),
-  /* K29  */  be_nested_str_weak(publish_result),
-  /* K30  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-  /* K31  */  be_nested_str_weak(Matter),
-  /* K32  */  be_nested_str_weak(json),
-  /* K33  */  be_nested_str_weak(START_ENDPOINT),
-  /* K34  */  be_nested_str_weak(light),
-  /* K35  */  be_nested_str_weak(get),
-  /* K36  */  be_nested_str_weak(channels),
-  /* K37  */  be_const_int(1),
-  /* K38  */  be_nested_str_weak(light1),
-  /* K39  */  be_nested_str_weak(light2),
-  /* K40  */  be_nested_str_weak(light3),
-  /* K41  */  be_nested_str_weak(cmd),
-  /* K42  */  be_nested_str_weak(Status_X2013),
-  /* K43  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
-  /* K44  */  be_nested_str_weak(contains),
-  /* K45  */  be_nested_str_weak(StatusSHT),
-  /* K46  */  be_nested_str_weak(SHT),
-  /* K47  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
-  /* K48  */  be_nested_str_weak(Relay1),
-  /* K49  */  be_nested_str_weak(Relay2),
-  /* K50  */  be_nested_str_weak(MTR_X3A_X20relay1_X3D_X25s_X20relay2_X3D_X25s),
-  /* K51  */  be_nested_str_weak(TiltConfig),
-  /* K52  */  be_nested_str_weak(shutter_X2Btilt),
-  /* K53  */  be_nested_str_weak(shutter),
-  /* K54  */  be_nested_str_weak(get_power),
-  /* K55  */  be_nested_str_weak(relay),
-  /* K56  */  be_nested_str_weak(load),
-  /* K57  */  be_nested_str_weak(read_sensors),
-  /* K58  */  be_nested_str_weak(autoconf_sensors_list),
-  /* K59  */  be_nested_str_weak(k2l),
-  /* K60  */  be_nested_str_weak(Temperature),
-  /* K61  */  be_nested_str_weak(_X23Temperature),
-  /* K62  */  be_nested_str_weak(temperature),
-  /* K63  */  be_nested_str_weak(filter),
-  /* K64  */  be_nested_str_weak(Pressure),
-  /* K65  */  be_nested_str_weak(_X23Pressure),
-  /* K66  */  be_nested_str_weak(pressure),
-  /* K67  */  be_nested_str_weak(Illuminance),
-  /* K68  */  be_nested_str_weak(_X23Illuminance),
-  /* K69  */  be_nested_str_weak(illuminance),
-  /* K70  */  be_nested_str_weak(Humidity),
-  /* K71  */  be_nested_str_weak(_X23Humidity),
-  /* K72  */  be_nested_str_weak(humidity),
+  /* K7   */  be_nested_str_weak(find),
+  /* K8   */  be_nested_str_weak(0),
+  /* K9   */  be_nested_str_weak(log),
+  /* K10  */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
+  /* K13  */  be_nested_str_weak(root),
+  /* K14  */  be_nested_str_weak(),
+  /* K15  */  be_nested_str_weak(Plugin_Aggregator),
+  /* K16  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K17  */  be_nested_str_weak(aggregator),
+  /* K18  */  be_nested_str_weak(type),
+  /* K19  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+  /* K20  */  be_const_int(3),
+  /* K21  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+  /* K22  */  be_nested_str_weak(plugins_classes),
+  /* K23  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+  /* K24  */  be_nested_str_weak(_X27_X20skipping),
+  /* K25  */  be_nested_str_weak(conf_to_log),
+  /* K26  */  be_nested_str_weak(MTR_X3A_X20Exception),
+  /* K27  */  be_nested_str_weak(_X7C),
+  /* K28  */  be_nested_str_weak(stop_iteration),
+  /* K29  */  be_nested_str_weak(tasmota),
+  /* K30  */  be_nested_str_weak(publish_result),
+  /* K31  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+  /* K32  */  be_nested_str_weak(Matter),
+  /* K33  */  be_nested_str_weak(json),
+  /* K34  */  be_nested_str_weak(START_ENDPOINT),
+  /* K35  */  be_nested_str_weak(light),
+  /* K36  */  be_nested_str_weak(get),
+  /* K37  */  be_nested_str_weak(channels),
+  /* K38  */  be_const_int(1),
+  /* K39  */  be_nested_str_weak(light1),
+  /* K40  */  be_nested_str_weak(light2),
+  /* K41  */  be_nested_str_weak(light3),
+  /* K42  */  be_nested_str_weak(cmd),
+  /* K43  */  be_nested_str_weak(Status_X2013),
+  /* K44  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
+  /* K45  */  be_nested_str_weak(contains),
+  /* K46  */  be_nested_str_weak(StatusSHT),
+  /* K47  */  be_nested_str_weak(SHT),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
+  /* K49  */  be_nested_str_weak(Relay1),
+  /* K50  */  be_nested_str_weak(Relay2),
+  /* K51  */  be_nested_str_weak(MTR_X3A_X20relay1_X3D_X25s_X20relay2_X3D_X25s),
+  /* K52  */  be_nested_str_weak(TiltConfig),
+  /* K53  */  be_nested_str_weak(shutter_X2Btilt),
+  /* K54  */  be_nested_str_weak(shutter),
+  /* K55  */  be_nested_str_weak(get_power),
+  /* K56  */  be_nested_str_weak(relay),
+  /* K57  */  be_nested_str_weak(load),
+  /* K58  */  be_nested_str_weak(read_sensors),
+  /* K59  */  be_nested_str_weak(autoconf_sensors_list),
+  /* K60  */  be_nested_str_weak(k2l),
+  /* K61  */  be_nested_str_weak(Temperature),
+  /* K62  */  be_nested_str_weak(_X23Temperature),
+  /* K63  */  be_nested_str_weak(temperature),
+  /* K64  */  be_nested_str_weak(filter),
+  /* K65  */  be_nested_str_weak(Pressure),
+  /* K66  */  be_nested_str_weak(_X23Pressure),
+  /* K67  */  be_nested_str_weak(pressure),
+  /* K68  */  be_nested_str_weak(Illuminance),
+  /* K69  */  be_nested_str_weak(_X23Illuminance),
+  /* K70  */  be_nested_str_weak(illuminance),
+  /* K71  */  be_nested_str_weak(Humidity),
+  /* K72  */  be_nested_str_weak(_X23Humidity),
+  /* K73  */  be_nested_str_weak(humidity),
 };
 
 
@@ -99,7 +100,7 @@ be_local_closure(class_Matter_Autoconf_instantiate_plugins_from_config,   /* nam
     &be_ktab_class_Matter_Autoconf,     /* shared constants */
     be_str_weak(instantiate_plugins_from_config),
     &be_const_str_solidified,
-    ( &(const binstruction[148]) {  /* code */
+    ( &(const binstruction[151]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x5C100200,  //  0002  MOVE	R4	R1
@@ -111,143 +112,146 @@ be_local_closure(class_Matter_Autoconf_instantiate_plugins_from_config,   /* nam
       0x8C180D05,  //  0008  GETMET	R6	R6	K5
       0x88200100,  //  0009  GETMBR	R8	R0	K0
       0x58240006,  //  000A  LDCONST	R9	K6
-      0x60280013,  //  000B  GETGBL	R10	G19
-      0x7C280000,  //  000C  CALL	R10	0
-      0x7C180800,  //  000D  CALL	R6	4
-      0x7C100400,  //  000E  CALL	R4	2
-      0xB8120E00,  //  000F  GETNGBL	R4	K7
-      0x58140008,  //  0010  LDCONST	R5	K8
-      0x58180009,  //  0011  LDCONST	R6	K9
-      0x7C100400,  //  0012  CALL	R4	2
-      0xB8120E00,  //  0013  GETNGBL	R4	K7
-      0x60140018,  //  0014  GETGBL	R5	G24
-      0x5818000A,  //  0015  LDCONST	R6	K10
-      0x581C0006,  //  0016  LDCONST	R7	K6
-      0x5820000B,  //  0017  LDCONST	R8	K11
-      0x5824000C,  //  0018  LDCONST	R9	K12
-      0x7C140800,  //  0019  CALL	R5	4
-      0x58180009,  //  001A  LDCONST	R6	K9
-      0x7C100400,  //  001B  CALL	R4	2
-      0x8C100703,  //  001C  GETMET	R4	R3	K3
-      0xB81A0800,  //  001D  GETNGBL	R6	K4
-      0x8C180D0D,  //  001E  GETMET	R6	R6	K13
-      0x88200100,  //  001F  GETMBR	R8	R0	K0
-      0xB8260800,  //  0020  GETNGBL	R9	K4
-      0x8824130E,  //  0021  GETMBR	R9	R9	K14
-      0x60280013,  //  0022  GETGBL	R10	G19
-      0x7C280000,  //  0023  CALL	R10	0
-      0x7C180800,  //  0024  CALL	R6	4
-      0x7C100400,  //  0025  CALL	R4	2
-      0xB8120E00,  //  0026  GETNGBL	R4	K7
-      0x60140018,  //  0027  GETGBL	R5	G24
-      0x5818000A,  //  0028  LDCONST	R6	K10
-      0xB81E0800,  //  0029  GETNGBL	R7	K4
-      0x881C0F0E,  //  002A  GETMBR	R7	R7	K14
-      0x5820000F,  //  002B  LDCONST	R8	K15
-      0x5824000C,  //  002C  LDCONST	R9	K12
-      0x7C140800,  //  002D  CALL	R5	4
-      0x58180009,  //  002E  LDCONST	R6	K9
-      0x7C100400,  //  002F  CALL	R4	2
-      0x60100010,  //  0030  GETGBL	R4	G16
-      0x5C140400,  //  0031  MOVE	R5	R2
-      0x7C100200,  //  0032  CALL	R4	1
-      0xA8020056,  //  0033  EXBLK	0	#008B
-      0x5C140800,  //  0034  MOVE	R5	R4
-      0x7C140000,  //  0035  CALL	R5	0
-      0x1C180B06,  //  0036  EQ	R6	R5	K6
-      0x781A0000,  //  0037  JMPF	R6	#0039
-      0x7001FFFA,  //  0038  JMP		#0034
-      0xA802003F,  //  0039  EXBLK	0	#007A
-      0x60180008,  //  003A  GETGBL	R6	G8
-      0x5C1C0A00,  //  003B  MOVE	R7	R5
-      0x7C180200,  //  003C  CALL	R6	1
-      0x94180206,  //  003D  GETIDX	R6	R1	R6
-      0x8C1C0D10,  //  003E  GETMET	R7	R6	K16
-      0x58240011,  //  003F  LDCONST	R9	K17
-      0x7C1C0400,  //  0040  CALL	R7	2
-      0x4C200000,  //  0041  LDNIL	R8
-      0x1C200E08,  //  0042  EQ	R8	R7	R8
-      0x78220005,  //  0043  JMPF	R8	#004A
-      0xB8220E00,  //  0044  GETNGBL	R8	K7
-      0x58240012,  //  0045  LDCONST	R9	K18
-      0x58280013,  //  0046  LDCONST	R10	K19
-      0x7C200400,  //  0047  CALL	R8	2
-      0xA8040001,  //  0048  EXBLK	1	1
-      0x7001FFE9,  //  0049  JMP		#0034
-      0x1C200F0B,  //  004A  EQ	R8	R7	K11
-      0x78220005,  //  004B  JMPF	R8	#0052
-      0xB8220E00,  //  004C  GETNGBL	R8	K7
-      0x58240014,  //  004D  LDCONST	R9	K20
-      0x58280013,  //  004E  LDCONST	R10	K19
-      0x7C200400,  //  004F  CALL	R8	2
-      0xA8040001,  //  0050  EXBLK	1	1
-      0x7001FFE1,  //  0051  JMP		#0034
-      0x88200100,  //  0052  GETMBR	R8	R0	K0
-      0x88201115,  //  0053  GETMBR	R8	R8	K21
-      0x8C201110,  //  0054  GETMET	R8	R8	K16
-      0x5C280E00,  //  0055  MOVE	R10	R7
-      0x7C200400,  //  0056  CALL	R8	2
-      0x4C240000,  //  0057  LDNIL	R9
-      0x1C241009,  //  0058  EQ	R9	R8	R9
-      0x78260009,  //  0059  JMPF	R9	#0064
-      0xB8260E00,  //  005A  GETNGBL	R9	K7
-      0x60280008,  //  005B  GETGBL	R10	G8
-      0x5C2C0E00,  //  005C  MOVE	R11	R7
-      0x7C280200,  //  005D  CALL	R10	1
-      0x002A2C0A,  //  005E  ADD	R10	K22	R10
-      0x00281517,  //  005F  ADD	R10	R10	K23
-      0x582C0009,  //  0060  LDCONST	R11	K9
-      0x7C240400,  //  0061  CALL	R9	2
-      0xA8040001,  //  0062  EXBLK	1	1
-      0x7001FFCF,  //  0063  JMP		#0034
-      0x5C241000,  //  0064  MOVE	R9	R8
-      0x88280100,  //  0065  GETMBR	R10	R0	K0
-      0x5C2C0A00,  //  0066  MOVE	R11	R5
-      0x5C300C00,  //  0067  MOVE	R12	R6
-      0x7C240600,  //  0068  CALL	R9	3
-      0x8C280703,  //  0069  GETMET	R10	R3	K3
-      0x5C301200,  //  006A  MOVE	R12	R9
-      0x7C280400,  //  006B  CALL	R10	2
-      0xB82A0E00,  //  006C  GETNGBL	R10	K7
-      0x602C0018,  //  006D  GETGBL	R11	G24
-      0x5830000A,  //  006E  LDCONST	R12	K10
-      0x5C340A00,  //  006F  MOVE	R13	R5
-      0x5C380E00,  //  0070  MOVE	R14	R7
-      0x883C0100,  //  0071  GETMBR	R15	R0	K0
-      0x8C3C1F18,  //  0072  GETMET	R15	R15	K24
-      0x5C440C00,  //  0073  MOVE	R17	R6
-      0x7C3C0400,  //  0074  CALL	R15	2
-      0x7C2C0800,  //  0075  CALL	R11	4
-      0x58300009,  //  0076  LDCONST	R12	K9
-      0x7C280400,  //  0077  CALL	R10	2
-      0xA8040001,  //  0078  EXBLK	1	1
-      0x7002000F,  //  0079  JMP		#008A
-      0xAC180002,  //  007A  CATCH	R6	0	2
-      0x7002000C,  //  007B  JMP		#0089
-      0xB8220E00,  //  007C  GETNGBL	R8	K7
-      0x60240008,  //  007D  GETGBL	R9	G8
-      0x5C280C00,  //  007E  MOVE	R10	R6
-      0x7C240200,  //  007F  CALL	R9	1
-      0x00263209,  //  0080  ADD	R9	K25	R9
-      0x0024131A,  //  0081  ADD	R9	R9	K26
-      0x60280008,  //  0082  GETGBL	R10	G8
-      0x5C2C0E00,  //  0083  MOVE	R11	R7
-      0x7C280200,  //  0084  CALL	R10	1
-      0x0024120A,  //  0085  ADD	R9	R9	R10
-      0x58280009,  //  0086  LDCONST	R10	K9
-      0x7C200400,  //  0087  CALL	R8	2
-      0x70020000,  //  0088  JMP		#008A
-      0xB0080000,  //  0089  RAISE	2	R0	R0
-      0x7001FFA8,  //  008A  JMP		#0034
-      0x5810001B,  //  008B  LDCONST	R4	K27
-      0xAC100200,  //  008C  CATCH	R4	1	0
-      0xB0080000,  //  008D  RAISE	2	R0	R0
-      0xB8123800,  //  008E  GETNGBL	R4	K28
-      0x8C10091D,  //  008F  GETMET	R4	R4	K29
-      0x5818001E,  //  0090  LDCONST	R6	K30
-      0x581C001F,  //  0091  LDCONST	R7	K31
-      0x7C100600,  //  0092  CALL	R4	3
-      0x80000000,  //  0093  RET	0
+      0x8C280307,  //  000B  GETMET	R10	R1	K7
+      0x58300008,  //  000C  LDCONST	R12	K8
+      0x60340013,  //  000D  GETGBL	R13	G19
+      0x7C340000,  //  000E  CALL	R13	0
+      0x7C280600,  //  000F  CALL	R10	3
+      0x7C180800,  //  0010  CALL	R6	4
+      0x7C100400,  //  0011  CALL	R4	2
+      0xB8121200,  //  0012  GETNGBL	R4	K9
+      0x5814000A,  //  0013  LDCONST	R5	K10
+      0x5818000B,  //  0014  LDCONST	R6	K11
+      0x7C100400,  //  0015  CALL	R4	2
+      0xB8121200,  //  0016  GETNGBL	R4	K9
+      0x60140018,  //  0017  GETGBL	R5	G24
+      0x5818000C,  //  0018  LDCONST	R6	K12
+      0x581C0006,  //  0019  LDCONST	R7	K6
+      0x5820000D,  //  001A  LDCONST	R8	K13
+      0x5824000E,  //  001B  LDCONST	R9	K14
+      0x7C140800,  //  001C  CALL	R5	4
+      0x5818000B,  //  001D  LDCONST	R6	K11
+      0x7C100400,  //  001E  CALL	R4	2
+      0x8C100703,  //  001F  GETMET	R4	R3	K3
+      0xB81A0800,  //  0020  GETNGBL	R6	K4
+      0x8C180D0F,  //  0021  GETMET	R6	R6	K15
+      0x88200100,  //  0022  GETMBR	R8	R0	K0
+      0xB8260800,  //  0023  GETNGBL	R9	K4
+      0x88241310,  //  0024  GETMBR	R9	R9	K16
+      0x60280013,  //  0025  GETGBL	R10	G19
+      0x7C280000,  //  0026  CALL	R10	0
+      0x7C180800,  //  0027  CALL	R6	4
+      0x7C100400,  //  0028  CALL	R4	2
+      0xB8121200,  //  0029  GETNGBL	R4	K9
+      0x60140018,  //  002A  GETGBL	R5	G24
+      0x5818000C,  //  002B  LDCONST	R6	K12
+      0xB81E0800,  //  002C  GETNGBL	R7	K4
+      0x881C0F10,  //  002D  GETMBR	R7	R7	K16
+      0x58200011,  //  002E  LDCONST	R8	K17
+      0x5824000E,  //  002F  LDCONST	R9	K14
+      0x7C140800,  //  0030  CALL	R5	4
+      0x5818000B,  //  0031  LDCONST	R6	K11
+      0x7C100400,  //  0032  CALL	R4	2
+      0x60100010,  //  0033  GETGBL	R4	G16
+      0x5C140400,  //  0034  MOVE	R5	R2
+      0x7C100200,  //  0035  CALL	R4	1
+      0xA8020056,  //  0036  EXBLK	0	#008E
+      0x5C140800,  //  0037  MOVE	R5	R4
+      0x7C140000,  //  0038  CALL	R5	0
+      0x1C180B06,  //  0039  EQ	R6	R5	K6
+      0x781A0000,  //  003A  JMPF	R6	#003C
+      0x7001FFFA,  //  003B  JMP		#0037
+      0xA802003F,  //  003C  EXBLK	0	#007D
+      0x60180008,  //  003D  GETGBL	R6	G8
+      0x5C1C0A00,  //  003E  MOVE	R7	R5
+      0x7C180200,  //  003F  CALL	R6	1
+      0x94180206,  //  0040  GETIDX	R6	R1	R6
+      0x8C1C0D07,  //  0041  GETMET	R7	R6	K7
+      0x58240012,  //  0042  LDCONST	R9	K18
+      0x7C1C0400,  //  0043  CALL	R7	2
+      0x4C200000,  //  0044  LDNIL	R8
+      0x1C200E08,  //  0045  EQ	R8	R7	R8
+      0x78220005,  //  0046  JMPF	R8	#004D
+      0xB8221200,  //  0047  GETNGBL	R8	K9
+      0x58240013,  //  0048  LDCONST	R9	K19
+      0x58280014,  //  0049  LDCONST	R10	K20
+      0x7C200400,  //  004A  CALL	R8	2
+      0xA8040001,  //  004B  EXBLK	1	1
+      0x7001FFE9,  //  004C  JMP		#0037
+      0x1C200F0D,  //  004D  EQ	R8	R7	K13
+      0x78220005,  //  004E  JMPF	R8	#0055
+      0xB8221200,  //  004F  GETNGBL	R8	K9
+      0x58240015,  //  0050  LDCONST	R9	K21
+      0x58280014,  //  0051  LDCONST	R10	K20
+      0x7C200400,  //  0052  CALL	R8	2
+      0xA8040001,  //  0053  EXBLK	1	1
+      0x7001FFE1,  //  0054  JMP		#0037
+      0x88200100,  //  0055  GETMBR	R8	R0	K0
+      0x88201116,  //  0056  GETMBR	R8	R8	K22
+      0x8C201107,  //  0057  GETMET	R8	R8	K7
+      0x5C280E00,  //  0058  MOVE	R10	R7
+      0x7C200400,  //  0059  CALL	R8	2
+      0x4C240000,  //  005A  LDNIL	R9
+      0x1C241009,  //  005B  EQ	R9	R8	R9
+      0x78260009,  //  005C  JMPF	R9	#0067
+      0xB8261200,  //  005D  GETNGBL	R9	K9
+      0x60280008,  //  005E  GETGBL	R10	G8
+      0x5C2C0E00,  //  005F  MOVE	R11	R7
+      0x7C280200,  //  0060  CALL	R10	1
+      0x002A2E0A,  //  0061  ADD	R10	K23	R10
+      0x00281518,  //  0062  ADD	R10	R10	K24
+      0x582C000B,  //  0063  LDCONST	R11	K11
+      0x7C240400,  //  0064  CALL	R9	2
+      0xA8040001,  //  0065  EXBLK	1	1
+      0x7001FFCF,  //  0066  JMP		#0037
+      0x5C241000,  //  0067  MOVE	R9	R8
+      0x88280100,  //  0068  GETMBR	R10	R0	K0
+      0x5C2C0A00,  //  0069  MOVE	R11	R5
+      0x5C300C00,  //  006A  MOVE	R12	R6
+      0x7C240600,  //  006B  CALL	R9	3
+      0x8C280703,  //  006C  GETMET	R10	R3	K3
+      0x5C301200,  //  006D  MOVE	R12	R9
+      0x7C280400,  //  006E  CALL	R10	2
+      0xB82A1200,  //  006F  GETNGBL	R10	K9
+      0x602C0018,  //  0070  GETGBL	R11	G24
+      0x5830000C,  //  0071  LDCONST	R12	K12
+      0x5C340A00,  //  0072  MOVE	R13	R5
+      0x5C380E00,  //  0073  MOVE	R14	R7
+      0x883C0100,  //  0074  GETMBR	R15	R0	K0
+      0x8C3C1F19,  //  0075  GETMET	R15	R15	K25
+      0x5C440C00,  //  0076  MOVE	R17	R6
+      0x7C3C0400,  //  0077  CALL	R15	2
+      0x7C2C0800,  //  0078  CALL	R11	4
+      0x5830000B,  //  0079  LDCONST	R12	K11
+      0x7C280400,  //  007A  CALL	R10	2
+      0xA8040001,  //  007B  EXBLK	1	1
+      0x7002000F,  //  007C  JMP		#008D
+      0xAC180002,  //  007D  CATCH	R6	0	2
+      0x7002000C,  //  007E  JMP		#008C
+      0xB8221200,  //  007F  GETNGBL	R8	K9
+      0x60240008,  //  0080  GETGBL	R9	G8
+      0x5C280C00,  //  0081  MOVE	R10	R6
+      0x7C240200,  //  0082  CALL	R9	1
+      0x00263409,  //  0083  ADD	R9	K26	R9
+      0x0024131B,  //  0084  ADD	R9	R9	K27
+      0x60280008,  //  0085  GETGBL	R10	G8
+      0x5C2C0E00,  //  0086  MOVE	R11	R7
+      0x7C280200,  //  0087  CALL	R10	1
+      0x0024120A,  //  0088  ADD	R9	R9	R10
+      0x5828000B,  //  0089  LDCONST	R10	K11
+      0x7C200400,  //  008A  CALL	R8	2
+      0x70020000,  //  008B  JMP		#008D
+      0xB0080000,  //  008C  RAISE	2	R0	R0
+      0x7001FFA8,  //  008D  JMP		#0037
+      0x5810001C,  //  008E  LDCONST	R4	K28
+      0xAC100200,  //  008F  CATCH	R4	1	0
+      0xB0080000,  //  0090  RAISE	2	R0	R0
+      0xB8123A00,  //  0091  GETNGBL	R4	K29
+      0x8C10091E,  //  0092  GETMET	R4	R4	K30
+      0x5818001F,  //  0093  LDCONST	R6	K31
+      0x581C0020,  //  0094  LDCONST	R7	K32
+      0x7C100600,  //  0095  CALL	R4	3
+      0x80000000,  //  0096  RET	0
     })
   )
 );
@@ -271,41 +275,41 @@ be_local_closure(class_Matter_Autoconf_autoconf_device_map,   /* name */
     be_str_weak(autoconf_device_map),
     &be_const_str_solidified,
     ( &(const binstruction[262]) {  /* code */
-      0xA4064000,  //  0000  IMPORT	R1	K32
+      0xA4064200,  //  0000  IMPORT	R1	K33
       0x60080013,  //  0001  GETGBL	R2	G19
       0x7C080000,  //  0002  CALL	R2	0
       0xB80E0800,  //  0003  GETNGBL	R3	K4
-      0x880C0721,  //  0004  GETMBR	R3	R3	K33
+      0x880C0722,  //  0004  GETMBR	R3	R3	K34
       0x58100006,  //  0005  LDCONST	R4	K6
-      0xA4164400,  //  0006  IMPORT	R5	K34
-      0x8C180B23,  //  0007  GETMET	R6	R5	K35
+      0xA4164600,  //  0006  IMPORT	R5	K35
+      0x8C180B24,  //  0007  GETMET	R6	R5	K36
       0x58200006,  //  0008  LDCONST	R8	K6
       0x7C180400,  //  0009  CALL	R6	2
       0x4C1C0000,  //  000A  LDNIL	R7
       0x201C0C07,  //  000B  NE	R7	R6	R7
       0x781E0066,  //  000C  JMPF	R7	#0074
       0x601C000C,  //  000D  GETGBL	R7	G12
-      0x8C200D10,  //  000E  GETMET	R8	R6	K16
-      0x58280024,  //  000F  LDCONST	R10	K36
-      0x582C000C,  //  0010  LDCONST	R11	K12
+      0x8C200D07,  //  000E  GETMET	R8	R6	K7
+      0x58280025,  //  000F  LDCONST	R10	K37
+      0x582C000E,  //  0010  LDCONST	R11	K14
       0x7C200600,  //  0011  CALL	R8	3
       0x7C1C0200,  //  0012  CALL	R7	1
-      0x58100025,  //  0013  LDCONST	R4	K37
+      0x58100026,  //  0013  LDCONST	R4	K38
       0x24200F06,  //  0014  GT	R8	R7	K6
       0x7822005D,  //  0015  JMPF	R8	#0074
-      0x1C200F25,  //  0016  EQ	R8	R7	K37
+      0x1C200F26,  //  0016  EQ	R8	R7	K38
       0x7822001E,  //  0017  JMPF	R8	#0037
       0x60200008,  //  0018  GETGBL	R8	G8
       0x5C240600,  //  0019  MOVE	R9	R3
       0x7C200200,  //  001A  CALL	R8	1
       0x60240013,  //  001B  GETGBL	R9	G19
       0x7C240000,  //  001C  CALL	R9	0
-      0x98262326,  //  001D  SETIDX	R9	K17	K38
+      0x98262527,  //  001D  SETIDX	R9	K18	K39
       0x98081009,  //  001E  SETIDX	R2	R8	R9
-      0x000C0725,  //  001F  ADD	R3	R3	K37
-      0x58200025,  //  0020  LDCONST	R8	K37
+      0x000C0726,  //  001F  ADD	R3	R3	K38
+      0x58200026,  //  0020  LDCONST	R8	K38
       0x4C240000,  //  0021  LDNIL	R9
-      0x8C280B23,  //  0022  GETMET	R10	R5	K35
+      0x8C280B24,  //  0022  GETMET	R10	R5	K36
       0x5C301000,  //  0023  MOVE	R12	R8
       0x7C280400,  //  0024  CALL	R10	2
       0x5C241400,  //  0025  MOVE	R9	R10
@@ -317,152 +321,152 @@ be_local_closure(class_Matter_Autoconf_autoconf_device_map,   /* name */
       0x7C280200,  //  002B  CALL	R10	1
       0x602C0013,  //  002C  GETGBL	R11	G19
       0x7C2C0000,  //  002D  CALL	R11	0
-      0x982E2326,  //  002E  SETIDX	R11	K17	K38
-      0x00301125,  //  002F  ADD	R12	R8	K37
-      0x982E440C,  //  0030  SETIDX	R11	K34	R12
+      0x982E2527,  //  002E  SETIDX	R11	K18	K39
+      0x00301126,  //  002F  ADD	R12	R8	K38
+      0x982E460C,  //  0030  SETIDX	R11	K35	R12
       0x9808140B,  //  0031  SETIDX	R2	R10	R11
-      0x000C0725,  //  0032  ADD	R3	R3	K37
-      0x00100925,  //  0033  ADD	R4	R4	K37
-      0x00201125,  //  0034  ADD	R8	R8	K37
+      0x000C0726,  //  0032  ADD	R3	R3	K38
+      0x00100926,  //  0033  ADD	R4	R4	K38
+      0x00201126,  //  0034  ADD	R8	R8	K38
       0x7001FFEB,  //  0035  JMP		#0022
       0x7002003C,  //  0036  JMP		#0074
-      0x1C200F09,  //  0037  EQ	R8	R7	K9
+      0x1C200F0B,  //  0037  EQ	R8	R7	K11
       0x78220008,  //  0038  JMPF	R8	#0042
       0x60200008,  //  0039  GETGBL	R8	G8
       0x5C240600,  //  003A  MOVE	R9	R3
       0x7C200200,  //  003B  CALL	R8	1
       0x60240013,  //  003C  GETGBL	R9	G19
       0x7C240000,  //  003D  CALL	R9	0
-      0x98262327,  //  003E  SETIDX	R9	K17	K39
+      0x98262528,  //  003E  SETIDX	R9	K18	K40
       0x98081009,  //  003F  SETIDX	R2	R8	R9
-      0x000C0725,  //  0040  ADD	R3	R3	K37
+      0x000C0726,  //  0040  ADD	R3	R3	K38
       0x70020031,  //  0041  JMP		#0074
-      0x1C200F13,  //  0042  EQ	R8	R7	K19
+      0x1C200F14,  //  0042  EQ	R8	R7	K20
       0x7822002B,  //  0043  JMPF	R8	#0070
       0x60200008,  //  0044  GETGBL	R8	G8
       0x5C240600,  //  0045  MOVE	R9	R3
       0x7C200200,  //  0046  CALL	R8	1
       0x60240013,  //  0047  GETGBL	R9	G19
       0x7C240000,  //  0048  CALL	R9	0
-      0x98262328,  //  0049  SETIDX	R9	K17	K40
+      0x98262529,  //  0049  SETIDX	R9	K18	K41
       0x98081009,  //  004A  SETIDX	R2	R8	R9
-      0x000C0725,  //  004B  ADD	R3	R3	K37
-      0x8C200B23,  //  004C  GETMET	R8	R5	K35
-      0x58280025,  //  004D  LDCONST	R10	K37
+      0x000C0726,  //  004B  ADD	R3	R3	K38
+      0x8C200B24,  //  004C  GETMET	R8	R5	K36
+      0x58280026,  //  004D  LDCONST	R10	K38
       0x7C200400,  //  004E  CALL	R8	2
       0x4C240000,  //  004F  LDNIL	R9
       0x20241009,  //  0050  NE	R9	R8	R9
       0x7826001C,  //  0051  JMPF	R9	#006F
       0x6024000C,  //  0052  GETGBL	R9	G12
-      0x8C281110,  //  0053  GETMET	R10	R8	K16
-      0x58300024,  //  0054  LDCONST	R12	K36
-      0x5834000C,  //  0055  LDCONST	R13	K12
+      0x8C281107,  //  0053  GETMET	R10	R8	K7
+      0x58300025,  //  0054  LDCONST	R12	K37
+      0x5834000E,  //  0055  LDCONST	R13	K14
       0x7C280600,  //  0056  CALL	R10	3
       0x7C240200,  //  0057  CALL	R9	1
-      0x1C281325,  //  0058  EQ	R10	R9	K37
+      0x1C281326,  //  0058  EQ	R10	R9	K38
       0x782A0009,  //  0059  JMPF	R10	#0064
       0x60280008,  //  005A  GETGBL	R10	G8
       0x5C2C0600,  //  005B  MOVE	R11	R3
       0x7C280200,  //  005C  CALL	R10	1
       0x602C0013,  //  005D  GETGBL	R11	G19
       0x7C2C0000,  //  005E  CALL	R11	0
-      0x982E2326,  //  005F  SETIDX	R11	K17	K38
+      0x982E2527,  //  005F  SETIDX	R11	K18	K39
       0x9808140B,  //  0060  SETIDX	R2	R10	R11
-      0x000C0725,  //  0061  ADD	R3	R3	K37
-      0x00100925,  //  0062  ADD	R4	R4	K37
+      0x000C0726,  //  0061  ADD	R3	R3	K38
+      0x00100926,  //  0062  ADD	R4	R4	K38
       0x7002000A,  //  0063  JMP		#006F
-      0x1C281309,  //  0064  EQ	R10	R9	K9
+      0x1C28130B,  //  0064  EQ	R10	R9	K11
       0x782A0008,  //  0065  JMPF	R10	#006F
       0x60280008,  //  0066  GETGBL	R10	G8
       0x5C2C0600,  //  0067  MOVE	R11	R3
       0x7C280200,  //  0068  CALL	R10	1
       0x602C0013,  //  0069  GETGBL	R11	G19
       0x7C2C0000,  //  006A  CALL	R11	0
-      0x982E2327,  //  006B  SETIDX	R11	K17	K39
+      0x982E2528,  //  006B  SETIDX	R11	K18	K40
       0x9808140B,  //  006C  SETIDX	R2	R10	R11
-      0x000C0725,  //  006D  ADD	R3	R3	K37
-      0x00100925,  //  006E  ADD	R4	R4	K37
+      0x000C0726,  //  006D  ADD	R3	R3	K38
+      0x00100926,  //  006E  ADD	R4	R4	K38
       0x70020003,  //  006F  JMP		#0074
       0x54220003,  //  0070  LDINT	R8	4
       0x1C200E08,  //  0071  EQ	R8	R7	R8
       0x78220000,  //  0072  JMPF	R8	#0074
       0x7001FFFF,  //  0073  JMP		#0074
-      0xB81E3800,  //  0074  GETNGBL	R7	K28
-      0x8C1C0F29,  //  0075  GETMET	R7	R7	K41
-      0x5824002A,  //  0076  LDCONST	R9	K42
+      0xB81E3A00,  //  0074  GETNGBL	R7	K29
+      0x8C1C0F2A,  //  0075  GETMET	R7	R7	K42
+      0x5824002B,  //  0076  LDCONST	R9	K43
       0x50280200,  //  0077  LDBOOL	R10	1	0
       0x7C1C0600,  //  0078  CALL	R7	3
       0x60200012,  //  0079  GETGBL	R8	G18
       0x7C200000,  //  007A  CALL	R8	0
-      0xB8260E00,  //  007B  GETNGBL	R9	K7
+      0xB8261200,  //  007B  GETNGBL	R9	K9
       0x60280008,  //  007C  GETGBL	R10	G8
       0x5C2C0E00,  //  007D  MOVE	R11	R7
       0x7C280200,  //  007E  CALL	R10	1
-      0x002A560A,  //  007F  ADD	R10	K43	R10
-      0x582C0013,  //  0080  LDCONST	R11	K19
+      0x002A580A,  //  007F  ADD	R10	K44	R10
+      0x582C0014,  //  0080  LDCONST	R11	K20
       0x7C240400,  //  0081  CALL	R9	2
       0x4C240000,  //  0082  LDNIL	R9
       0x20240E09,  //  0083  NE	R9	R7	R9
       0x7826004D,  //  0084  JMPF	R9	#00D3
-      0x8C240F2C,  //  0085  GETMET	R9	R7	K44
-      0x582C002D,  //  0086  LDCONST	R11	K45
+      0x8C240F2D,  //  0085  GETMET	R9	R7	K45
+      0x582C002E,  //  0086  LDCONST	R11	K46
       0x7C240400,  //  0087  CALL	R9	2
       0x78260049,  //  0088  JMPF	R9	#00D3
-      0x941C0F2D,  //  0089  GETIDX	R7	R7	K45
+      0x941C0F2E,  //  0089  GETIDX	R7	R7	K46
       0x58240006,  //  008A  LDCONST	R9	K6
       0x50280200,  //  008B  LDBOOL	R10	1	0
       0x782A0045,  //  008C  JMPF	R10	#00D3
       0x60280008,  //  008D  GETGBL	R10	G8
       0x5C2C1200,  //  008E  MOVE	R11	R9
       0x7C280200,  //  008F  CALL	R10	1
-      0x002A5C0A,  //  0090  ADD	R10	K46	R10
-      0x8C2C0F2C,  //  0091  GETMET	R11	R7	K44
+      0x002A5E0A,  //  0090  ADD	R10	K47	R10
+      0x8C2C0F2D,  //  0091  GETMET	R11	R7	K45
       0x5C341400,  //  0092  MOVE	R13	R10
       0x7C2C0400,  //  0093  CALL	R11	2
       0x742E0000,  //  0094  JMPT	R11	#0096
       0x7002003C,  //  0095  JMP		#00D3
       0x942C0E0A,  //  0096  GETIDX	R11	R7	R10
-      0xB8320E00,  //  0097  GETNGBL	R12	K7
+      0xB8321200,  //  0097  GETNGBL	R12	K9
       0x60340018,  //  0098  GETGBL	R13	G24
-      0x5838002F,  //  0099  LDCONST	R14	K47
+      0x58380030,  //  0099  LDCONST	R14	K48
       0x5C3C1400,  //  009A  MOVE	R15	R10
       0x60400008,  //  009B  GETGBL	R16	G8
       0x5C441600,  //  009C  MOVE	R17	R11
       0x7C400200,  //  009D  CALL	R16	1
       0x7C340600,  //  009E  CALL	R13	3
-      0x58380013,  //  009F  LDCONST	R14	K19
+      0x58380014,  //  009F  LDCONST	R14	K20
       0x7C300400,  //  00A0  CALL	R12	2
-      0x8C301710,  //  00A1  GETMET	R12	R11	K16
-      0x58380030,  //  00A2  LDCONST	R14	K48
+      0x8C301707,  //  00A1  GETMET	R12	R11	K7
+      0x58380031,  //  00A2  LDCONST	R14	K49
       0x543DFFFE,  //  00A3  LDINT	R15	-1
       0x7C300600,  //  00A4  CALL	R12	3
-      0x8C341710,  //  00A5  GETMET	R13	R11	K16
-      0x583C0031,  //  00A6  LDCONST	R15	K49
+      0x8C341707,  //  00A5  GETMET	R13	R11	K7
+      0x583C0032,  //  00A6  LDCONST	R15	K50
       0x5441FFFE,  //  00A7  LDINT	R16	-1
       0x7C340600,  //  00A8  CALL	R13	3
       0x24381906,  //  00A9  GT	R14	R12	K6
       0x783A0002,  //  00AA  JMPF	R14	#00AE
       0x8C381103,  //  00AB  GETMET	R14	R8	K3
-      0x04401925,  //  00AC  SUB	R16	R12	K37
+      0x04401926,  //  00AC  SUB	R16	R12	K38
       0x7C380400,  //  00AD  CALL	R14	2
       0x24381B06,  //  00AE  GT	R14	R13	K6
       0x783A0002,  //  00AF  JMPF	R14	#00B3
       0x8C381103,  //  00B0  GETMET	R14	R8	K3
-      0x04401B25,  //  00B1  SUB	R16	R13	K37
+      0x04401B26,  //  00B1  SUB	R16	R13	K38
       0x7C380400,  //  00B2  CALL	R14	2
-      0xB83A0E00,  //  00B3  GETNGBL	R14	K7
+      0xB83A1200,  //  00B3  GETNGBL	R14	K9
       0x603C0018,  //  00B4  GETGBL	R15	G24
-      0x58400032,  //  00B5  LDCONST	R16	K50
+      0x58400033,  //  00B5  LDCONST	R16	K51
       0x5C441800,  //  00B6  MOVE	R17	R12
       0x5C481A00,  //  00B7  MOVE	R18	R13
       0x7C3C0600,  //  00B8  CALL	R15	3
-      0x58400013,  //  00B9  LDCONST	R16	K19
+      0x58400014,  //  00B9  LDCONST	R16	K20
       0x7C380400,  //  00BA  CALL	R14	2
-      0x8C381710,  //  00BB  GETMET	R14	R11	K16
-      0x58400033,  //  00BC  LDCONST	R16	K51
+      0x8C381707,  //  00BB  GETMET	R14	R11	K7
+      0x58400034,  //  00BC  LDCONST	R16	K52
       0x7C380400,  //  00BD  CALL	R14	2
       0x783A0002,  //  00BE  JMPF	R14	#00C2
-      0x943C1D09,  //  00BF  GETIDX	R15	R14	K9
+      0x943C1D0B,  //  00BF  GETIDX	R15	R14	K11
       0x243C1F06,  //  00C0  GT	R15	R15	K6
       0x743E0000,  //  00C1  JMPT	R15	#00C3
       0x503C0001,  //  00C2  LDBOOL	R15	0	1
@@ -473,25 +477,25 @@ be_local_closure(class_Matter_Autoconf_autoconf_device_map,   /* name */
       0x60440013,  //  00C7  GETGBL	R17	G19
       0x7C440000,  //  00C8  CALL	R17	0
       0x783E0001,  //  00C9  JMPF	R15	#00CC
-      0x58480034,  //  00CA  LDCONST	R18	K52
+      0x58480035,  //  00CA  LDCONST	R18	K53
       0x70020000,  //  00CB  JMP		#00CD
-      0x58480035,  //  00CC  LDCONST	R18	K53
-      0x98462212,  //  00CD  SETIDX	R17	K17	R18
-      0x98466A09,  //  00CE  SETIDX	R17	K53	R9
+      0x58480036,  //  00CC  LDCONST	R18	K54
+      0x98462412,  //  00CD  SETIDX	R17	K18	R18
+      0x98466C09,  //  00CE  SETIDX	R17	K54	R9
       0x98082011,  //  00CF  SETIDX	R2	R16	R17
-      0x000C0725,  //  00D0  ADD	R3	R3	K37
-      0x00241325,  //  00D1  ADD	R9	R9	K37
+      0x000C0726,  //  00D0  ADD	R3	R3	K38
+      0x00241326,  //  00D1  ADD	R9	R9	K38
       0x7001FFB7,  //  00D2  JMP		#008B
       0x6024000C,  //  00D3  GETGBL	R9	G12
-      0xB82A3800,  //  00D4  GETNGBL	R10	K28
-      0x8C281536,  //  00D5  GETMET	R10	R10	K54
+      0xB82A3A00,  //  00D4  GETNGBL	R10	K29
+      0x8C281537,  //  00D5  GETMET	R10	R10	K55
       0x7C280200,  //  00D6  CALL	R10	1
       0x7C240200,  //  00D7  CALL	R9	1
       0x58280006,  //  00D8  LDCONST	R10	K6
       0x04241204,  //  00D9  SUB	R9	R9	R4
       0x142C1409,  //  00DA  LT	R11	R10	R9
       0x782E0011,  //  00DB  JMPF	R11	#00EE
-      0x8C2C1110,  //  00DC  GETMET	R11	R8	K16
+      0x8C2C1107,  //  00DC  GETMET	R11	R8	K7
       0x5C341400,  //  00DD  MOVE	R13	R10
       0x7C2C0400,  //  00DE  CALL	R11	2
       0x4C300000,  //  00DF  LDNIL	R12
@@ -502,19 +506,19 @@ be_local_closure(class_Matter_Autoconf_autoconf_device_map,   /* name */
       0x7C2C0200,  //  00E4  CALL	R11	1
       0x60300013,  //  00E5  GETGBL	R12	G19
       0x7C300000,  //  00E6  CALL	R12	0
-      0x98322337,  //  00E7  SETIDX	R12	K17	K55
-      0x00341525,  //  00E8  ADD	R13	R10	K37
-      0x98326E0D,  //  00E9  SETIDX	R12	K55	R13
+      0x98322538,  //  00E7  SETIDX	R12	K18	K56
+      0x00341526,  //  00E8  ADD	R13	R10	K38
+      0x9832700D,  //  00E9  SETIDX	R12	K56	R13
       0x9808160C,  //  00EA  SETIDX	R2	R11	R12
-      0x000C0725,  //  00EB  ADD	R3	R3	K37
-      0x00281525,  //  00EC  ADD	R10	R10	K37
+      0x000C0726,  //  00EB  ADD	R3	R3	K38
+      0x00281526,  //  00EC  ADD	R10	R10	K38
       0x7001FFEB,  //  00ED  JMP		#00DA
-      0x8C2C0338,  //  00EE  GETMET	R11	R1	K56
-      0xB8363800,  //  00EF  GETNGBL	R13	K28
-      0x8C341B39,  //  00F0  GETMET	R13	R13	K57
+      0x8C2C0339,  //  00EE  GETMET	R11	R1	K57
+      0xB8363A00,  //  00EF  GETNGBL	R13	K29
+      0x8C341B3A,  //  00F0  GETMET	R13	R13	K58
       0x7C340200,  //  00F1  CALL	R13	1
       0x7C2C0400,  //  00F2  CALL	R11	2
-      0x8C30013A,  //  00F3  GETMET	R12	R0	K58
+      0x8C30013B,  //  00F3  GETMET	R12	R0	K59
       0x5C381600,  //  00F4  MOVE	R14	R11
       0x7C300400,  //  00F5  CALL	R12	2
       0x60340010,  //  00F6  GETGBL	R13	G16
@@ -527,9 +531,9 @@ be_local_closure(class_Matter_Autoconf_autoconf_device_map,   /* name */
       0x5C400600,  //  00FD  MOVE	R16	R3
       0x7C3C0200,  //  00FE  CALL	R15	1
       0x98081E0E,  //  00FF  SETIDX	R2	R15	R14
-      0x000C0725,  //  0100  ADD	R3	R3	K37
+      0x000C0726,  //  0100  ADD	R3	R3	K38
       0x7001FFF7,  //  0101  JMP		#00FA
-      0x5834001B,  //  0102  LDCONST	R13	K27
+      0x5834001C,  //  0102  LDCONST	R13	K28
       0xAC340200,  //  0103  CATCH	R13	1	0
       0xB0080000,  //  0104  RAISE	2	R0	R0
       0x80040400,  //  0105  RET	1	R2
@@ -582,7 +586,7 @@ be_local_closure(class_Matter_Autoconf_autoconf_sensors_list,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[121]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8808053B,  //  0001  GETMBR	R2	R2	K59
+      0x8808053C,  //  0001  GETMBR	R2	R2	K60
       0x600C0012,  //  0002  GETGBL	R3	G18
       0x7C0C0000,  //  0003  CALL	R3	0
       0x60100010,  //  0004  GETGBL	R4	G16
@@ -599,19 +603,19 @@ be_local_closure(class_Matter_Autoconf_autoconf_sensors_list,   /* name */
       0x60240013,  //  000F  GETGBL	R9	G19
       0x7C1C0400,  //  0010  CALL	R7	2
       0x781E000A,  //  0011  JMPF	R7	#001D
-      0x8C1C0D2C,  //  0012  GETMET	R7	R6	K44
-      0x5824003C,  //  0013  LDCONST	R9	K60
+      0x8C1C0D2D,  //  0012  GETMET	R7	R6	K45
+      0x5824003D,  //  0013  LDCONST	R9	K61
       0x7C1C0400,  //  0014  CALL	R7	2
       0x781E0006,  //  0015  JMPF	R7	#001D
-      0x001C0B3D,  //  0016  ADD	R7	R5	K61
+      0x001C0B3E,  //  0016  ADD	R7	R5	K62
       0x8C200703,  //  0017  GETMET	R8	R3	K3
       0x60280013,  //  0018  GETGBL	R10	G19
       0x7C280000,  //  0019  CALL	R10	0
-      0x982A233E,  //  001A  SETIDX	R10	K17	K62
-      0x982A7E07,  //  001B  SETIDX	R10	K63	R7
+      0x982A253F,  //  001A  SETIDX	R10	K18	K63
+      0x982A8007,  //  001B  SETIDX	R10	K64	R7
       0x7C200400,  //  001C  CALL	R8	2
       0x7001FFEB,  //  001D  JMP		#000A
-      0x5810001B,  //  001E  LDCONST	R4	K27
+      0x5810001C,  //  001E  LDCONST	R4	K28
       0xAC100200,  //  001F  CATCH	R4	1	0
       0xB0080000,  //  0020  RAISE	2	R0	R0
       0x60100010,  //  0021  GETGBL	R4	G16
@@ -628,19 +632,19 @@ be_local_closure(class_Matter_Autoconf_autoconf_sensors_list,   /* name */
       0x60240013,  //  002C  GETGBL	R9	G19
       0x7C1C0400,  //  002D  CALL	R7	2
       0x781E000A,  //  002E  JMPF	R7	#003A
-      0x8C1C0D2C,  //  002F  GETMET	R7	R6	K44
-      0x58240040,  //  0030  LDCONST	R9	K64
+      0x8C1C0D2D,  //  002F  GETMET	R7	R6	K45
+      0x58240041,  //  0030  LDCONST	R9	K65
       0x7C1C0400,  //  0031  CALL	R7	2
       0x781E0006,  //  0032  JMPF	R7	#003A
-      0x001C0B41,  //  0033  ADD	R7	R5	K65
+      0x001C0B42,  //  0033  ADD	R7	R5	K66
       0x8C200703,  //  0034  GETMET	R8	R3	K3
       0x60280013,  //  0035  GETGBL	R10	G19
       0x7C280000,  //  0036  CALL	R10	0
-      0x982A2342,  //  0037  SETIDX	R10	K17	K66
-      0x982A7E07,  //  0038  SETIDX	R10	K63	R7
+      0x982A2543,  //  0037  SETIDX	R10	K18	K67
+      0x982A8007,  //  0038  SETIDX	R10	K64	R7
       0x7C200400,  //  0039  CALL	R8	2
       0x7001FFEB,  //  003A  JMP		#0027
-      0x5810001B,  //  003B  LDCONST	R4	K27
+      0x5810001C,  //  003B  LDCONST	R4	K28
       0xAC100200,  //  003C  CATCH	R4	1	0
       0xB0080000,  //  003D  RAISE	2	R0	R0
       0x60100010,  //  003E  GETGBL	R4	G16
@@ -657,19 +661,19 @@ be_local_closure(class_Matter_Autoconf_autoconf_sensors_list,   /* name */
       0x60240013,  //  0049  GETGBL	R9	G19
       0x7C1C0400,  //  004A  CALL	R7	2
       0x781E000A,  //  004B  JMPF	R7	#0057
-      0x8C1C0D2C,  //  004C  GETMET	R7	R6	K44
-      0x58240043,  //  004D  LDCONST	R9	K67
+      0x8C1C0D2D,  //  004C  GETMET	R7	R6	K45
+      0x58240044,  //  004D  LDCONST	R9	K68
       0x7C1C0400,  //  004E  CALL	R7	2
       0x781E0006,  //  004F  JMPF	R7	#0057
-      0x001C0B44,  //  0050  ADD	R7	R5	K68
+      0x001C0B45,  //  0050  ADD	R7	R5	K69
       0x8C200703,  //  0051  GETMET	R8	R3	K3
       0x60280013,  //  0052  GETGBL	R10	G19
       0x7C280000,  //  0053  CALL	R10	0
-      0x982A2345,  //  0054  SETIDX	R10	K17	K69
-      0x982A7E07,  //  0055  SETIDX	R10	K63	R7
+      0x982A2546,  //  0054  SETIDX	R10	K18	K70
+      0x982A8007,  //  0055  SETIDX	R10	K64	R7
       0x7C200400,  //  0056  CALL	R8	2
       0x7001FFEB,  //  0057  JMP		#0044
-      0x5810001B,  //  0058  LDCONST	R4	K27
+      0x5810001C,  //  0058  LDCONST	R4	K28
       0xAC100200,  //  0059  CATCH	R4	1	0
       0xB0080000,  //  005A  RAISE	2	R0	R0
       0x60100010,  //  005B  GETGBL	R4	G16
@@ -686,19 +690,19 @@ be_local_closure(class_Matter_Autoconf_autoconf_sensors_list,   /* name */
       0x60240013,  //  0066  GETGBL	R9	G19
       0x7C1C0400,  //  0067  CALL	R7	2
       0x781E000A,  //  0068  JMPF	R7	#0074
-      0x8C1C0D2C,  //  0069  GETMET	R7	R6	K44
-      0x58240046,  //  006A  LDCONST	R9	K70
+      0x8C1C0D2D,  //  0069  GETMET	R7	R6	K45
+      0x58240047,  //  006A  LDCONST	R9	K71
       0x7C1C0400,  //  006B  CALL	R7	2
       0x781E0006,  //  006C  JMPF	R7	#0074
-      0x001C0B47,  //  006D  ADD	R7	R5	K71
+      0x001C0B48,  //  006D  ADD	R7	R5	K72
       0x8C200703,  //  006E  GETMET	R8	R3	K3
       0x60280013,  //  006F  GETGBL	R10	G19
       0x7C280000,  //  0070  CALL	R10	0
-      0x982A2348,  //  0071  SETIDX	R10	K17	K72
-      0x982A7E07,  //  0072  SETIDX	R10	K63	R7
+      0x982A2549,  //  0071  SETIDX	R10	K18	K73
+      0x982A8007,  //  0072  SETIDX	R10	K64	R7
       0x7C200400,  //  0073  CALL	R8	2
       0x7001FFEB,  //  0074  JMP		#0061
-      0x5810001B,  //  0075  LDCONST	R4	K27
+      0x5810001C,  //  0075  LDCONST	R4	K28
       0xAC100200,  //  0076  CATCH	R4	1	0
       0xB0080000,  //  0077  RAISE	2	R0	R0
       0x80040600,  //  0078  RET	1	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -4,8 +4,8 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_Device;
-// compact class 'Matter_Device' ktab size: 212, total: 455 (saved 1944 bytes)
-static const bvalue be_ktab_class_Matter_Device[212] = {
+// compact class 'Matter_Device' ktab size: 211, total: 453 (saved 1936 bytes)
+static const bvalue be_ktab_class_Matter_Device[211] = {
   /* K0   */  be_nested_str_weak(json),
   /* K1   */  be_nested_str_weak(tasmota),
   /* K2   */  be_nested_str_weak(read_sensors),
@@ -29,195 +29,194 @@ static const bvalue be_ktab_class_Matter_Device[212] = {
   /* K20  */  be_nested_str_weak(keys),
   /* K21  */  be_nested_str_weak(push),
   /* K22  */  be_nested_str_weak(stop_iteration),
-  /* K23  */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
-  /* K24  */  be_const_int(2),
-  /* K25  */  be_nested_str_weak(remove),
-  /* K26  */  be_nested_str_weak(matter),
-  /* K27  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-  /* K28  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
-  /* K29  */  be_nested_str_weak(next_ep),
-  /* K30  */  be_nested_str_weak(endpoint),
-  /* K31  */  be_nested_str_weak(invoke_request),
-  /* K32  */  be_nested_str_weak(status),
-  /* K33  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-  /* K34  */  be_nested_str_weak(attribute_updated),
-  /* K35  */  be_nested_str_weak(crypto),
-  /* K36  */  be_nested_str_weak(FILENAME),
-  /* K37  */  be_nested_str_weak(read),
-  /* K38  */  be_nested_str_weak(close),
-  /* K39  */  be_nested_str_weak(root_discriminator),
-  /* K40  */  be_nested_str_weak(find),
-  /* K41  */  be_nested_str_weak(distinguish),
-  /* K42  */  be_nested_str_weak(root_passcode),
-  /* K43  */  be_nested_str_weak(passcode),
-  /* K44  */  be_nested_str_weak(ipv4only),
-  /* K45  */  be_nested_str_weak(disable_bridge_mode),
-  /* K46  */  be_nested_str_weak(nextep),
-  /* K47  */  be_nested_str_weak(config),
-  /* K48  */  be_nested_str_weak(debug),
-  /* K49  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
-  /* K50  */  be_nested_str_weak(adjust_next_ep),
-  /* K51  */  be_nested_str_weak(check_config_ep),
-  /* K52  */  be_nested_str_weak(plugins_persist),
-  /* K53  */  be_nested_str_weak(plugins_config_remotes),
-  /* K54  */  be_nested_str_weak(remotes),
-  /* K55  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-  /* K56  */  be_nested_str_weak(io_error),
-  /* K57  */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
-  /* K58  */  be_nested_str_weak(_X7C),
-  /* K59  */  be_nested_str_weak(random),
-  /* K60  */  be_nested_str_weak(get),
-  /* K61  */  be_nested_str_weak(commissioning),
-  /* K62  */  be_nested_str_weak(generate_random_passcode),
-  /* K63  */  be_nested_str_weak(save_param),
-  /* K64  */  be_const_class(be_class_Matter_Device),
-  /* K65  */  be_nested_str_weak(),
-  /* K66  */  be_nested_str_weak(k2l),
-  /* K67  */  be_nested_str_weak(type),
-  /* K68  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-  /* K69  */  be_nested_str_weak(introspect),
-  /* K70  */  be_nested_str_weak(module),
-  /* K71  */  be_nested_str_weak(matter_zigbee),
-  /* K72  */  be_nested_str_weak(remove_driver),
-  /* K73  */  be_nested_str_weak(udp_server),
-  /* K74  */  be_nested_str_weak(stop),
-  /* K75  */  be_nested_str_weak(get_name),
-  /* K76  */  be_nested_str_weak(start_root_basic_commissioning),
-  /* K77  */  be_nested_str_weak(stop_basic_commissioning),
-  /* K78  */  be_nested_str_weak(resp_cmnd_done),
-  /* K79  */  be_nested_str_weak(MtrInfo_one),
-  /* K80  */  be_nested_str_weak(int),
-  /* K81  */  be_nested_str_weak(find_plugin_by_friendly_name),
-  /* K82  */  be_nested_str_weak(find_plugin_by_endpoint),
-  /* K83  */  be_nested_str_weak(state_json),
-  /* K84  */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
-  /* K85  */  be_nested_str_weak(publish_result),
-  /* K86  */  be_nested_str_weak(cluster),
-  /* K87  */  be_nested_str_weak(attribute),
-  /* K88  */  be_nested_str_weak(contains_cluster),
-  /* K89  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-  /* K90  */  be_nested_str_weak(contains_attribute),
-  /* K91  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-  /* K92  */  be_nested_str_weak(sessions),
-  /* K93  */  be_nested_str_weak(every_second),
-  /* K94  */  be_nested_str_weak(message_handler),
-  /* K95  */  be_nested_str_weak(events),
-  /* K96  */  be_nested_str_weak(plugins_classes),
-  /* K97  */  be_nested_str_weak(DISPLAY_NAME),
-  /* K98  */  be_nested_str_weak(ARG),
-  /* K99  */  be_nested_str_weak(PathGenerator),
-  /* K100 */  be_nested_str_weak(start),
-  /* K101 */  be_nested_str_weak(is_direct),
-  /* K102 */  be_nested_str_weak(next_attribute),
-  /* K103 */  be_nested_str_weak(get_pi),
-  /* K104 */  be_nested_str_weak(get_endpoint),
-  /* K105 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-  /* K106 */  be_nested_str_weak(get_fabric_id),
-  /* K107 */  be_nested_str_weak(copy),
-  /* K108 */  be_nested_str_weak(reverse),
-  /* K109 */  be_nested_str_weak(tohex),
-  /* K110 */  be_nested_str_weak(im),
-  /* K111 */  be_nested_str_weak(subs_shop),
-  /* K112 */  be_nested_str_weak(remove_by_fabric),
-  /* K113 */  be_nested_str_weak(mdns_remove_op_discovery),
-  /* K114 */  be_nested_str_weak(remove_fabric),
-  /* K115 */  be_nested_str_weak(save_fabrics),
-  /* K116 */  be_nested_str_weak(Path),
-  /* K117 */  be_nested_str_weak(attribute_updated_ctx),
-  /* K118 */  be_nested_str_weak(add_cmd),
-  /* K119 */  be_nested_str_weak(MtrJoin),
-  /* K120 */  be_nested_str_weak(MtrUpdate),
-  /* K121 */  be_nested_str_weak(MtrInfo),
-  /* K122 */  be_nested_str_weak(update_remotes_info),
-  /* K123 */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-  /* K124 */  be_nested_str_weak(true),
-  /* K125 */  be_nested_str_weak(false),
-  /* K126 */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
-  /* K127 */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
-  /* K128 */  be_nested_str_weak(dump),
-  /* K129 */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
-  /* K130 */  be_nested_str_weak(_X7D),
-  /* K131 */  be_nested_str_weak(w),
-  /* K132 */  be_nested_str_weak(write),
-  /* K133 */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-  /* K134 */  be_nested_str_weak(_X20and_X20configuration),
-  /* K135 */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-  /* K136 */  be_nested_str_weak(http_remotes),
-  /* K137 */  be_nested_str_weak(http_remote),
-  /* K138 */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-  /* K139 */  be_nested_str_weak(addr),
-  /* K140 */  be_nested_str_weak(contains),
-  /* K141 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-  /* K142 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-  /* K143 */  be_nested_str_weak(clean_remotes),
-  /* K144 */  be_nested_str_weak(signal_endpoints_changed),
-  /* K145 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-  /* K146 */  be_nested_str_weak(UDPServer),
-  /* K147 */  be_nested_str_weak(count_active_fabrics),
-  /* K148 */  be_nested_str_weak(get_option),
-  /* K149 */  be_nested_str_weak(MATTER_OPTION),
-  /* K150 */  be_nested_str_weak(ui),
-  /* K151 */  be_nested_str_weak(UI),
-  /* K152 */  be_nested_str_weak(profiler),
-  /* K153 */  be_nested_str_weak(Profiler),
-  /* K154 */  be_nested_str_weak(tick),
-  /* K155 */  be_nested_str_weak(EP),
-  /* K156 */  be_nested_str_weak(Commissioning),
-  /* K157 */  be_nested_str_weak(load_param),
-  /* K158 */  be_nested_str_weak(Session_Store),
-  /* K159 */  be_nested_str_weak(load_fabrics),
-  /* K160 */  be_nested_str_weak(MessageHandler),
-  /* K161 */  be_nested_str_weak(EventHandler),
-  /* K162 */  be_nested_str_weak(zigbee),
-  /* K163 */  be_nested_str_weak(init_zigbee),
-  /* K164 */  be_nested_str_weak(when_network_up),
-  /* K165 */  be_nested_str_weak(init_basic_commissioning),
-  /* K166 */  be_nested_str_weak(add_driver),
-  /* K167 */  be_nested_str_weak(register_commands),
-  /* K168 */  be_nested_str_weak(received_ack),
-  /* K169 */  be_nested_str_weak(read_sensors_scheduler),
-  /* K170 */  be_nested_str_weak(every_250ms),
-  /* K171 */  be_nested_str_weak(send_UDP),
-  /* K172 */  be_nested_str_weak(autoconf_device),
-  /* K173 */  be_nested_str_weak(_start_udp),
-  /* K174 */  be_nested_str_weak(UDP_PORT),
-  /* K175 */  be_nested_str_weak(start_mdns_announce_hostnames),
-  /* K176 */  be_nested_str_weak(get_info),
-  /* K177 */  be_nested_str_weak(every_50ms),
-  /* K178 */  be_nested_str_weak(get_timeout),
-  /* K179 */  be_nested_str_weak(set_timeout),
-  /* K180 */  be_nested_str_weak(HTTP_remote),
-  /* K181 */  be_nested_str_weak(set_info),
-  /* K182 */  be_nested_str_weak(msg_received),
-  /* K183 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-  /* K184 */  be_nested_str_weak(_X27_X20skipping),
-  /* K185 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-  /* K186 */  be_nested_str_weak(conf_to_log),
-  /* K187 */  be_nested_str_weak(autoconf),
-  /* K188 */  be_nested_str_weak(Autoconf),
-  /* K189 */  be_nested_str_weak(autoconf_device_map),
-  /* K190 */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-  /* K191 */  be_nested_str_weak(instantiate_plugins_from_config),
-  /* K192 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-  /* K193 */  be_nested_str_weak(resp_cmnd_str),
-  /* K194 */  be_nested_str_weak(Invalid_X20JSON),
-  /* K195 */  be_nested_str_weak(find_key_i),
-  /* K196 */  be_nested_str_weak(Ep),
-  /* K197 */  be_nested_str_weak(Name),
-  /* K198 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
-  /* K199 */  be_nested_str_weak(Invalid_X20Device),
-  /* K200 */  be_nested_str_weak(VIRTUAL),
-  /* K201 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
-  /* K202 */  be_nested_str_weak(consolidate_update_commands),
-  /* K203 */  be_nested_str_weak(find_list_i),
-  /* K204 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
-  /* K205 */  be_nested_str_weak(update_virtual),
-  /* K206 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
-  /* K207 */  be_nested_str_weak(resp_cmnd),
-  /* K208 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
-  /* K209 */  be_nested_str_weak(Matter_Zigbee_Mapper),
-  /* K210 */  be_nested_str_weak(is_zigbee_present),
-  /* K211 */  be_nested_str_weak(jitter),
+  /* K23  */  be_nested_str_weak(matter),
+  /* K24  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+  /* K25  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
+  /* K26  */  be_nested_str_weak(next_ep),
+  /* K27  */  be_const_int(2),
+  /* K28  */  be_nested_str_weak(remove),
+  /* K29  */  be_nested_str_weak(endpoint),
+  /* K30  */  be_nested_str_weak(invoke_request),
+  /* K31  */  be_nested_str_weak(status),
+  /* K32  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+  /* K33  */  be_nested_str_weak(attribute_updated),
+  /* K34  */  be_nested_str_weak(crypto),
+  /* K35  */  be_nested_str_weak(FILENAME),
+  /* K36  */  be_nested_str_weak(read),
+  /* K37  */  be_nested_str_weak(close),
+  /* K38  */  be_nested_str_weak(root_discriminator),
+  /* K39  */  be_nested_str_weak(find),
+  /* K40  */  be_nested_str_weak(distinguish),
+  /* K41  */  be_nested_str_weak(root_passcode),
+  /* K42  */  be_nested_str_weak(passcode),
+  /* K43  */  be_nested_str_weak(ipv4only),
+  /* K44  */  be_nested_str_weak(disable_bridge_mode),
+  /* K45  */  be_nested_str_weak(nextep),
+  /* K46  */  be_nested_str_weak(config),
+  /* K47  */  be_nested_str_weak(debug),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
+  /* K49  */  be_nested_str_weak(adjust_next_ep),
+  /* K50  */  be_nested_str_weak(check_config_ep),
+  /* K51  */  be_nested_str_weak(plugins_persist),
+  /* K52  */  be_nested_str_weak(plugins_config_remotes),
+  /* K53  */  be_nested_str_weak(remotes),
+  /* K54  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+  /* K55  */  be_nested_str_weak(io_error),
+  /* K56  */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
+  /* K57  */  be_nested_str_weak(_X7C),
+  /* K58  */  be_nested_str_weak(random),
+  /* K59  */  be_nested_str_weak(get),
+  /* K60  */  be_nested_str_weak(commissioning),
+  /* K61  */  be_nested_str_weak(generate_random_passcode),
+  /* K62  */  be_nested_str_weak(save_param),
+  /* K63  */  be_const_class(be_class_Matter_Device),
+  /* K64  */  be_nested_str_weak(),
+  /* K65  */  be_nested_str_weak(k2l),
+  /* K66  */  be_nested_str_weak(type),
+  /* K67  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+  /* K68  */  be_nested_str_weak(introspect),
+  /* K69  */  be_nested_str_weak(module),
+  /* K70  */  be_nested_str_weak(matter_zigbee),
+  /* K71  */  be_nested_str_weak(remove_driver),
+  /* K72  */  be_nested_str_weak(udp_server),
+  /* K73  */  be_nested_str_weak(stop),
+  /* K74  */  be_nested_str_weak(get_name),
+  /* K75  */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K76  */  be_nested_str_weak(stop_basic_commissioning),
+  /* K77  */  be_nested_str_weak(resp_cmnd_done),
+  /* K78  */  be_nested_str_weak(MtrInfo_one),
+  /* K79  */  be_nested_str_weak(int),
+  /* K80  */  be_nested_str_weak(find_plugin_by_friendly_name),
+  /* K81  */  be_nested_str_weak(find_plugin_by_endpoint),
+  /* K82  */  be_nested_str_weak(state_json),
+  /* K83  */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
+  /* K84  */  be_nested_str_weak(publish_result),
+  /* K85  */  be_nested_str_weak(cluster),
+  /* K86  */  be_nested_str_weak(attribute),
+  /* K87  */  be_nested_str_weak(contains_cluster),
+  /* K88  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+  /* K89  */  be_nested_str_weak(contains_attribute),
+  /* K90  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+  /* K91  */  be_nested_str_weak(sessions),
+  /* K92  */  be_nested_str_weak(every_second),
+  /* K93  */  be_nested_str_weak(message_handler),
+  /* K94  */  be_nested_str_weak(events),
+  /* K95  */  be_nested_str_weak(plugins_classes),
+  /* K96  */  be_nested_str_weak(DISPLAY_NAME),
+  /* K97  */  be_nested_str_weak(ARG),
+  /* K98  */  be_nested_str_weak(PathGenerator),
+  /* K99  */  be_nested_str_weak(start),
+  /* K100 */  be_nested_str_weak(is_direct),
+  /* K101 */  be_nested_str_weak(next_attribute),
+  /* K102 */  be_nested_str_weak(get_pi),
+  /* K103 */  be_nested_str_weak(get_endpoint),
+  /* K104 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+  /* K105 */  be_nested_str_weak(get_fabric_id),
+  /* K106 */  be_nested_str_weak(copy),
+  /* K107 */  be_nested_str_weak(reverse),
+  /* K108 */  be_nested_str_weak(tohex),
+  /* K109 */  be_nested_str_weak(im),
+  /* K110 */  be_nested_str_weak(subs_shop),
+  /* K111 */  be_nested_str_weak(remove_by_fabric),
+  /* K112 */  be_nested_str_weak(mdns_remove_op_discovery),
+  /* K113 */  be_nested_str_weak(remove_fabric),
+  /* K114 */  be_nested_str_weak(save_fabrics),
+  /* K115 */  be_nested_str_weak(Path),
+  /* K116 */  be_nested_str_weak(attribute_updated_ctx),
+  /* K117 */  be_nested_str_weak(add_cmd),
+  /* K118 */  be_nested_str_weak(MtrJoin),
+  /* K119 */  be_nested_str_weak(MtrUpdate),
+  /* K120 */  be_nested_str_weak(MtrInfo),
+  /* K121 */  be_nested_str_weak(update_remotes_info),
+  /* K122 */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+  /* K123 */  be_nested_str_weak(true),
+  /* K124 */  be_nested_str_weak(false),
+  /* K125 */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
+  /* K126 */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
+  /* K127 */  be_nested_str_weak(dump),
+  /* K128 */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
+  /* K129 */  be_nested_str_weak(_X7D),
+  /* K130 */  be_nested_str_weak(w),
+  /* K131 */  be_nested_str_weak(write),
+  /* K132 */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+  /* K133 */  be_nested_str_weak(_X20and_X20configuration),
+  /* K134 */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+  /* K135 */  be_nested_str_weak(http_remotes),
+  /* K136 */  be_nested_str_weak(http_remote),
+  /* K137 */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+  /* K138 */  be_nested_str_weak(addr),
+  /* K139 */  be_nested_str_weak(contains),
+  /* K140 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+  /* K141 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+  /* K142 */  be_nested_str_weak(clean_remotes),
+  /* K143 */  be_nested_str_weak(signal_endpoints_changed),
+  /* K144 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+  /* K145 */  be_nested_str_weak(UDPServer),
+  /* K146 */  be_nested_str_weak(count_active_fabrics),
+  /* K147 */  be_nested_str_weak(get_option),
+  /* K148 */  be_nested_str_weak(MATTER_OPTION),
+  /* K149 */  be_nested_str_weak(ui),
+  /* K150 */  be_nested_str_weak(UI),
+  /* K151 */  be_nested_str_weak(profiler),
+  /* K152 */  be_nested_str_weak(Profiler),
+  /* K153 */  be_nested_str_weak(tick),
+  /* K154 */  be_nested_str_weak(EP),
+  /* K155 */  be_nested_str_weak(Commissioning),
+  /* K156 */  be_nested_str_weak(load_param),
+  /* K157 */  be_nested_str_weak(Session_Store),
+  /* K158 */  be_nested_str_weak(load_fabrics),
+  /* K159 */  be_nested_str_weak(MessageHandler),
+  /* K160 */  be_nested_str_weak(EventHandler),
+  /* K161 */  be_nested_str_weak(zigbee),
+  /* K162 */  be_nested_str_weak(init_zigbee),
+  /* K163 */  be_nested_str_weak(when_network_up),
+  /* K164 */  be_nested_str_weak(init_basic_commissioning),
+  /* K165 */  be_nested_str_weak(add_driver),
+  /* K166 */  be_nested_str_weak(register_commands),
+  /* K167 */  be_nested_str_weak(received_ack),
+  /* K168 */  be_nested_str_weak(read_sensors_scheduler),
+  /* K169 */  be_nested_str_weak(every_250ms),
+  /* K170 */  be_nested_str_weak(send_UDP),
+  /* K171 */  be_nested_str_weak(autoconf_device),
+  /* K172 */  be_nested_str_weak(_start_udp),
+  /* K173 */  be_nested_str_weak(UDP_PORT),
+  /* K174 */  be_nested_str_weak(start_mdns_announce_hostnames),
+  /* K175 */  be_nested_str_weak(get_info),
+  /* K176 */  be_nested_str_weak(every_50ms),
+  /* K177 */  be_nested_str_weak(get_timeout),
+  /* K178 */  be_nested_str_weak(set_timeout),
+  /* K179 */  be_nested_str_weak(HTTP_remote),
+  /* K180 */  be_nested_str_weak(set_info),
+  /* K181 */  be_nested_str_weak(msg_received),
+  /* K182 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+  /* K183 */  be_nested_str_weak(_X27_X20skipping),
+  /* K184 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+  /* K185 */  be_nested_str_weak(conf_to_log),
+  /* K186 */  be_nested_str_weak(autoconf),
+  /* K187 */  be_nested_str_weak(Autoconf),
+  /* K188 */  be_nested_str_weak(autoconf_device_map),
+  /* K189 */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+  /* K190 */  be_nested_str_weak(instantiate_plugins_from_config),
+  /* K191 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+  /* K192 */  be_nested_str_weak(resp_cmnd_str),
+  /* K193 */  be_nested_str_weak(Invalid_X20JSON),
+  /* K194 */  be_nested_str_weak(find_key_i),
+  /* K195 */  be_nested_str_weak(Ep),
+  /* K196 */  be_nested_str_weak(Name),
+  /* K197 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
+  /* K198 */  be_nested_str_weak(Invalid_X20Device),
+  /* K199 */  be_nested_str_weak(VIRTUAL),
+  /* K200 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
+  /* K201 */  be_nested_str_weak(consolidate_update_commands),
+  /* K202 */  be_nested_str_weak(find_list_i),
+  /* K203 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
+  /* K204 */  be_nested_str_weak(update_virtual),
+  /* K205 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
+  /* K206 */  be_nested_str_weak(resp_cmnd),
+  /* K207 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
+  /* K208 */  be_nested_str_weak(Matter_Zigbee_Mapper),
+  /* K209 */  be_nested_str_weak(is_zigbee_present),
+  /* K210 */  be_nested_str_weak(jitter),
 };
 
 
@@ -405,7 +404,7 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
     &be_ktab_class_Matter_Device,     /* shared constants */
     be_str_weak(check_config_ep),
     &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
+    ( &(const binstruction[63]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
@@ -429,60 +428,46 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
       0x600C0010,  //  0014  GETGBL	R3	G16
       0x5C100400,  //  0015  MOVE	R4	R2
       0x7C0C0200,  //  0016  CALL	R3	1
-      0xA8020030,  //  0017  EXBLK	0	#0049
+      0xA8020022,  //  0017  EXBLK	0	#003B
       0x5C100600,  //  0018  MOVE	R4	R3
       0x7C100000,  //  0019  CALL	R4	0
-      0x1C140908,  //  001A  EQ	R5	R4	K8
-      0x7816000B,  //  001B  JMPF	R5	#0028
-      0xB8160A00,  //  001C  GETNGBL	R5	K5
-      0x58180017,  //  001D  LDCONST	R6	K23
-      0x581C0018,  //  001E  LDCONST	R7	K24
-      0x7C140400,  //  001F  CALL	R5	2
-      0x88140113,  //  0020  GETMBR	R5	R0	K19
-      0x8C140B19,  //  0021  GETMET	R5	R5	K25
-      0x601C0008,  //  0022  GETGBL	R7	G8
-      0x5C200800,  //  0023  MOVE	R8	R4
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x7C140400,  //  0025  CALL	R5	2
-      0x50040200,  //  0026  LDBOOL	R1	1	0
-      0x7002001F,  //  0027  JMP		#0048
-      0xB8163400,  //  0028  GETNGBL	R5	K26
-      0x88140B1B,  //  0029  GETMBR	R5	R5	K27
-      0x1C140805,  //  002A  EQ	R5	R4	R5
-      0x7816001B,  //  002B  JMPF	R5	#0048
-      0x50040200,  //  002C  LDBOOL	R1	1	0
-      0xB8160A00,  //  002D  GETNGBL	R5	K5
-      0x60180018,  //  002E  GETGBL	R6	G24
-      0x581C001C,  //  002F  LDCONST	R7	K28
-      0x5C200800,  //  0030  MOVE	R8	R4
-      0x8824011D,  //  0031  GETMBR	R9	R0	K29
-      0x7C180600,  //  0032  CALL	R6	3
-      0x581C0018,  //  0033  LDCONST	R7	K24
-      0x7C140400,  //  0034  CALL	R5	2
-      0x60140008,  //  0035  GETGBL	R5	G8
-      0x8818011D,  //  0036  GETMBR	R6	R0	K29
-      0x7C140200,  //  0037  CALL	R5	1
-      0x88180113,  //  0038  GETMBR	R6	R0	K19
-      0x601C0008,  //  0039  GETGBL	R7	G8
-      0x5C200800,  //  003A  MOVE	R8	R4
-      0x7C1C0200,  //  003B  CALL	R7	1
-      0x88200113,  //  003C  GETMBR	R8	R0	K19
-      0x941C1007,  //  003D  GETIDX	R7	R8	R7
-      0x98180A07,  //  003E  SETIDX	R6	R5	R7
-      0x88140113,  //  003F  GETMBR	R5	R0	K19
-      0x8C140B19,  //  0040  GETMET	R5	R5	K25
-      0x601C0008,  //  0041  GETGBL	R7	G8
-      0x5C200800,  //  0042  MOVE	R8	R4
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x7C140400,  //  0044  CALL	R5	2
-      0x8814011D,  //  0045  GETMBR	R5	R0	K29
-      0x00140B0B,  //  0046  ADD	R5	R5	K11
-      0x90023A05,  //  0047  SETMBR	R0	K29	R5
-      0x7001FFCE,  //  0048  JMP		#0018
-      0x580C0016,  //  0049  LDCONST	R3	K22
-      0xAC0C0200,  //  004A  CATCH	R3	1	0
-      0xB0080000,  //  004B  RAISE	2	R0	R0
-      0x80040200,  //  004C  RET	1	R1
+      0xB8162E00,  //  001A  GETNGBL	R5	K23
+      0x88140B18,  //  001B  GETMBR	R5	R5	K24
+      0x1C140805,  //  001C  EQ	R5	R4	R5
+      0x7816001B,  //  001D  JMPF	R5	#003A
+      0x50040200,  //  001E  LDBOOL	R1	1	0
+      0xB8160A00,  //  001F  GETNGBL	R5	K5
+      0x60180018,  //  0020  GETGBL	R6	G24
+      0x581C0019,  //  0021  LDCONST	R7	K25
+      0x5C200800,  //  0022  MOVE	R8	R4
+      0x8824011A,  //  0023  GETMBR	R9	R0	K26
+      0x7C180600,  //  0024  CALL	R6	3
+      0x581C001B,  //  0025  LDCONST	R7	K27
+      0x7C140400,  //  0026  CALL	R5	2
+      0x60140008,  //  0027  GETGBL	R5	G8
+      0x8818011A,  //  0028  GETMBR	R6	R0	K26
+      0x7C140200,  //  0029  CALL	R5	1
+      0x88180113,  //  002A  GETMBR	R6	R0	K19
+      0x601C0008,  //  002B  GETGBL	R7	G8
+      0x5C200800,  //  002C  MOVE	R8	R4
+      0x7C1C0200,  //  002D  CALL	R7	1
+      0x88200113,  //  002E  GETMBR	R8	R0	K19
+      0x941C1007,  //  002F  GETIDX	R7	R8	R7
+      0x98180A07,  //  0030  SETIDX	R6	R5	R7
+      0x88140113,  //  0031  GETMBR	R5	R0	K19
+      0x8C140B1C,  //  0032  GETMET	R5	R5	K28
+      0x601C0008,  //  0033  GETGBL	R7	G8
+      0x5C200800,  //  0034  MOVE	R8	R4
+      0x7C1C0200,  //  0035  CALL	R7	1
+      0x7C140400,  //  0036  CALL	R5	2
+      0x8814011A,  //  0037  GETMBR	R5	R0	K26
+      0x00140B0B,  //  0038  ADD	R5	R5	K11
+      0x90023405,  //  0039  SETMBR	R0	K26	R5
+      0x7001FFDC,  //  003A  JMP		#0018
+      0x580C0016,  //  003B  LDCONST	R3	K22
+      0xAC0C0200,  //  003C  CATCH	R3	1	0
+      0xB0080000,  //  003D  RAISE	2	R0	R0
+      0x80040200,  //  003E  RET	1	R1
     })
   )
 );
@@ -507,7 +492,7 @@ be_local_closure(class_Matter_Device_invoke_request,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
       0x58100008,  //  0000  LDCONST	R4	K8
-      0x8814071E,  //  0001  GETMBR	R5	R3	K30
+      0x8814071D,  //  0001  GETMBR	R5	R3	K29
       0x6018000C,  //  0002  GETGBL	R6	G12
       0x881C0109,  //  0003  GETMBR	R7	R0	K9
       0x7C180200,  //  0004  CALL	R6	1
@@ -515,10 +500,10 @@ be_local_closure(class_Matter_Device_invoke_request,   /* name */
       0x781A000C,  //  0006  JMPF	R6	#0014
       0x88180109,  //  0007  GETMBR	R6	R0	K9
       0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D1E,  //  0009  GETMBR	R7	R6	K30
+      0x881C0D1D,  //  0009  GETMBR	R7	R6	K29
       0x1C1C0E05,  //  000A  EQ	R7	R7	R5
       0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D1F,  //  000C  GETMET	R7	R6	K31
+      0x8C1C0D1E,  //  000C  GETMET	R7	R6	K30
       0x5C240200,  //  000D  MOVE	R9	R1
       0x5C280400,  //  000E  MOVE	R10	R2
       0x5C2C0600,  //  000F  MOVE	R11	R3
@@ -526,9 +511,9 @@ be_local_closure(class_Matter_Device_invoke_request,   /* name */
       0x80040E00,  //  0011  RET	1	R7
       0x0010090B,  //  0012  ADD	R4	R4	K11
       0x7001FFED,  //  0013  JMP		#0002
-      0xB81A3400,  //  0014  GETNGBL	R6	K26
-      0x88180D21,  //  0015  GETMBR	R6	R6	K33
-      0x900E4006,  //  0016  SETMBR	R3	K32	R6
+      0xB81A2E00,  //  0014  GETNGBL	R6	K23
+      0x88180D20,  //  0015  GETMBR	R6	R6	K32
+      0x900E3E06,  //  0016  SETMBR	R3	K31	R6
       0x80000000,  //  0017  RET	0
     })
   )
@@ -553,15 +538,15 @@ be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
     be_str_weak(signal_endpoints_changed),
     &be_const_str_solidified,
     ( &(const binstruction[14]) {  /* code */
-      0x8C040122,  //  0000  GETMET	R1	R0	K34
+      0x8C040121,  //  0000  GETMET	R1	R0	K33
       0x580C0008,  //  0001  LDCONST	R3	K8
       0x5412001C,  //  0002  LDINT	R4	29
       0x58140004,  //  0003  LDCONST	R5	K4
       0x50180000,  //  0004  LDBOOL	R6	0	0
       0x7C040A00,  //  0005  CALL	R1	5
-      0x8C040122,  //  0006  GETMET	R1	R0	K34
-      0xB80E3400,  //  0007  GETNGBL	R3	K26
-      0x880C071B,  //  0008  GETMBR	R3	R3	K27
+      0x8C040121,  //  0006  GETMET	R1	R0	K33
+      0xB80E2E00,  //  0007  GETNGBL	R3	K23
+      0x880C0718,  //  0008  GETMBR	R3	R3	K24
       0x5412001C,  //  0009  LDINT	R4	29
       0x58140004,  //  000A  LDCONST	R5	K4
       0x50180000,  //  000B  LDBOOL	R6	0	0
@@ -590,140 +575,140 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
     be_str_weak(load_param),
     &be_const_str_solidified,
     ( &(const binstruction[136]) {  /* code */
-      0xA4064600,  //  0000  IMPORT	R1	K35
+      0xA4064400,  //  0000  IMPORT	R1	K34
       0x50080000,  //  0001  LDBOOL	R2	0	0
       0xA8020056,  //  0002  EXBLK	0	#005A
       0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100124,  //  0004  GETMBR	R4	R0	K36
+      0x88100123,  //  0004  GETMBR	R4	R0	K35
       0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100725,  //  0006  GETMET	R4	R3	K37
+      0x8C100724,  //  0006  GETMET	R4	R3	K36
       0x7C100200,  //  0007  CALL	R4	1
-      0x8C140726,  //  0008  GETMET	R5	R3	K38
+      0x8C140725,  //  0008  GETMET	R5	R3	K37
       0x7C140200,  //  0009  CALL	R5	1
       0xA4160000,  //  000A  IMPORT	R5	K0
       0x8C180B07,  //  000B  GETMET	R6	R5	K7
       0x5C200800,  //  000C  MOVE	R8	R4
       0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D28,  //  000E  GETMET	R7	R6	K40
-      0x58240029,  //  000F  LDCONST	R9	K41
-      0x88280127,  //  0010  GETMBR	R10	R0	K39
+      0x8C1C0D27,  //  000E  GETMET	R7	R6	K39
+      0x58240028,  //  000F  LDCONST	R9	K40
+      0x88280126,  //  0010  GETMBR	R10	R0	K38
       0x7C1C0600,  //  0011  CALL	R7	3
-      0x90024E07,  //  0012  SETMBR	R0	K39	R7
-      0x8C1C0D28,  //  0013  GETMET	R7	R6	K40
-      0x5824002B,  //  0014  LDCONST	R9	K43
-      0x8828012A,  //  0015  GETMBR	R10	R0	K42
+      0x90024C07,  //  0012  SETMBR	R0	K38	R7
+      0x8C1C0D27,  //  0013  GETMET	R7	R6	K39
+      0x5824002A,  //  0014  LDCONST	R9	K42
+      0x88280129,  //  0015  GETMBR	R10	R0	K41
       0x7C1C0600,  //  0016  CALL	R7	3
-      0x90025407,  //  0017  SETMBR	R0	K42	R7
+      0x90025207,  //  0017  SETMBR	R0	K41	R7
       0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D28,  //  0019  GETMET	R8	R6	K40
-      0x5828002C,  //  001A  LDCONST	R10	K44
+      0x8C200D27,  //  0019  GETMET	R8	R6	K39
+      0x5828002B,  //  001A  LDCONST	R10	K43
       0x502C0000,  //  001B  LDBOOL	R11	0	0
       0x7C200600,  //  001C  CALL	R8	3
       0x7C1C0200,  //  001D  CALL	R7	1
-      0x90025807,  //  001E  SETMBR	R0	K44	R7
+      0x90025607,  //  001E  SETMBR	R0	K43	R7
       0x601C0017,  //  001F  GETGBL	R7	G23
-      0x8C200D28,  //  0020  GETMET	R8	R6	K40
-      0x5828002D,  //  0021  LDCONST	R10	K45
+      0x8C200D27,  //  0020  GETMET	R8	R6	K39
+      0x5828002C,  //  0021  LDCONST	R10	K44
       0x502C0000,  //  0022  LDBOOL	R11	0	0
       0x7C200600,  //  0023  CALL	R8	3
       0x7C1C0200,  //  0024  CALL	R7	1
-      0x90025A07,  //  0025  SETMBR	R0	K45	R7
-      0x8C1C0D28,  //  0026  GETMET	R7	R6	K40
-      0x5824002E,  //  0027  LDCONST	R9	K46
-      0x8828011D,  //  0028  GETMBR	R10	R0	K29
+      0x90025807,  //  0025  SETMBR	R0	K44	R7
+      0x8C1C0D27,  //  0026  GETMET	R7	R6	K39
+      0x5824002D,  //  0027  LDCONST	R9	K45
+      0x8828011A,  //  0028  GETMBR	R10	R0	K26
       0x7C1C0600,  //  0029  CALL	R7	3
-      0x90023A07,  //  002A  SETMBR	R0	K29	R7
-      0x8C1C0D28,  //  002B  GETMET	R7	R6	K40
-      0x5824002F,  //  002C  LDCONST	R9	K47
+      0x90023407,  //  002A  SETMBR	R0	K26	R7
+      0x8C1C0D27,  //  002B  GETMET	R7	R6	K39
+      0x5824002E,  //  002C  LDCONST	R9	K46
       0x60280013,  //  002D  GETGBL	R10	G19
       0x7C280000,  //  002E  CALL	R10	0
       0x7C1C0600,  //  002F  CALL	R7	3
       0x90022607,  //  0030  SETMBR	R0	K19	R7
       0x601C0017,  //  0031  GETGBL	R7	G23
-      0x8C200D28,  //  0032  GETMET	R8	R6	K40
-      0x58280030,  //  0033  LDCONST	R10	K48
+      0x8C200D27,  //  0032  GETMET	R8	R6	K39
+      0x5828002F,  //  0033  LDCONST	R10	K47
       0x7C200400,  //  0034  CALL	R8	2
       0x7C1C0200,  //  0035  CALL	R7	1
-      0x90026007,  //  0036  SETMBR	R0	K48	R7
+      0x90025E07,  //  0036  SETMBR	R0	K47	R7
       0x881C0113,  //  0037  GETMBR	R7	R0	K19
       0x4C200000,  //  0038  LDNIL	R8
       0x201C0E08,  //  0039  NE	R7	R7	R8
       0x781E000D,  //  003A  JMPF	R7	#0049
       0xB81E0A00,  //  003B  GETNGBL	R7	K5
       0x60200018,  //  003C  GETGBL	R8	G24
-      0x58240031,  //  003D  LDCONST	R9	K49
+      0x58240030,  //  003D  LDCONST	R9	K48
       0x88280113,  //  003E  GETMBR	R10	R0	K19
       0x7C200400,  //  003F  CALL	R8	2
       0x58240004,  //  0040  LDCONST	R9	K4
       0x7C1C0400,  //  0041  CALL	R7	2
-      0x8C1C0132,  //  0042  GETMET	R7	R0	K50
+      0x8C1C0131,  //  0042  GETMET	R7	R0	K49
       0x7C1C0200,  //  0043  CALL	R7	1
-      0x8C1C0133,  //  0044  GETMET	R7	R0	K51
+      0x8C1C0132,  //  0044  GETMET	R7	R0	K50
       0x7C1C0200,  //  0045  CALL	R7	1
       0x5C080E00,  //  0046  MOVE	R2	R7
       0x501C0200,  //  0047  LDBOOL	R7	1	0
-      0x90026807,  //  0048  SETMBR	R0	K52	R7
-      0x8C1C0D28,  //  0049  GETMET	R7	R6	K40
-      0x58240036,  //  004A  LDCONST	R9	K54
+      0x90026607,  //  0048  SETMBR	R0	K51	R7
+      0x8C1C0D27,  //  0049  GETMET	R7	R6	K39
+      0x58240035,  //  004A  LDCONST	R9	K53
       0x60280013,  //  004B  GETGBL	R10	G19
       0x7C280000,  //  004C  CALL	R10	0
       0x7C1C0600,  //  004D  CALL	R7	3
-      0x90026A07,  //  004E  SETMBR	R0	K53	R7
-      0x881C0135,  //  004F  GETMBR	R7	R0	K53
+      0x90026807,  //  004E  SETMBR	R0	K52	R7
+      0x881C0134,  //  004F  GETMBR	R7	R0	K52
       0x781E0006,  //  0050  JMPF	R7	#0058
       0xB81E0A00,  //  0051  GETNGBL	R7	K5
       0x60200008,  //  0052  GETGBL	R8	G8
-      0x88240135,  //  0053  GETMBR	R9	R0	K53
+      0x88240134,  //  0053  GETMBR	R9	R0	K52
       0x7C200200,  //  0054  CALL	R8	1
-      0x00226E08,  //  0055  ADD	R8	K55	R8
+      0x00226C08,  //  0055  ADD	R8	K54	R8
       0x58240004,  //  0056  LDCONST	R9	K4
       0x7C1C0400,  //  0057  CALL	R7	2
       0xA8040001,  //  0058  EXBLK	1	1
       0x70020011,  //  0059  JMP		#006C
       0xAC0C0002,  //  005A  CATCH	R3	0	2
       0x7002000E,  //  005B  JMP		#006B
-      0x20140738,  //  005C  NE	R5	R3	K56
+      0x20140737,  //  005C  NE	R5	R3	K55
       0x7816000B,  //  005D  JMPF	R5	#006A
       0xB8160A00,  //  005E  GETNGBL	R5	K5
       0x60180008,  //  005F  GETGBL	R6	G8
       0x5C1C0600,  //  0060  MOVE	R7	R3
       0x7C180200,  //  0061  CALL	R6	1
-      0x001A7206,  //  0062  ADD	R6	K57	R6
-      0x00180D3A,  //  0063  ADD	R6	R6	K58
+      0x001A7006,  //  0062  ADD	R6	K56	R6
+      0x00180D39,  //  0063  ADD	R6	R6	K57
       0x601C0008,  //  0064  GETGBL	R7	G8
       0x5C200800,  //  0065  MOVE	R8	R4
       0x7C1C0200,  //  0066  CALL	R7	1
       0x00180C07,  //  0067  ADD	R6	R6	R7
-      0x581C0018,  //  0068  LDCONST	R7	K24
+      0x581C001B,  //  0068  LDCONST	R7	K27
       0x7C140400,  //  0069  CALL	R5	2
       0x70020000,  //  006A  JMP		#006C
       0xB0080000,  //  006B  RAISE	2	R0	R0
-      0x880C0127,  //  006C  GETMBR	R3	R0	K39
+      0x880C0126,  //  006C  GETMBR	R3	R0	K38
       0x4C100000,  //  006D  LDNIL	R4
       0x1C0C0604,  //  006E  EQ	R3	R3	R4
       0x780E000A,  //  006F  JMPF	R3	#007B
-      0x8C0C033B,  //  0070  GETMET	R3	R1	K59
-      0x58140018,  //  0071  LDCONST	R5	K24
+      0x8C0C033A,  //  0070  GETMET	R3	R1	K58
+      0x5814001B,  //  0071  LDCONST	R5	K27
       0x7C0C0400,  //  0072  CALL	R3	2
-      0x8C0C073C,  //  0073  GETMET	R3	R3	K60
+      0x8C0C073B,  //  0073  GETMET	R3	R3	K59
       0x58140008,  //  0074  LDCONST	R5	K8
-      0x58180018,  //  0075  LDCONST	R6	K24
+      0x5818001B,  //  0075  LDCONST	R6	K27
       0x7C0C0600,  //  0076  CALL	R3	3
       0x54120FFE,  //  0077  LDINT	R4	4095
       0x2C0C0604,  //  0078  AND	R3	R3	R4
-      0x90024E03,  //  0079  SETMBR	R0	K39	R3
+      0x90024C03,  //  0079  SETMBR	R0	K38	R3
       0x50080200,  //  007A  LDBOOL	R2	1	0
-      0x880C012A,  //  007B  GETMBR	R3	R0	K42
+      0x880C0129,  //  007B  GETMBR	R3	R0	K41
       0x4C100000,  //  007C  LDNIL	R4
       0x1C0C0604,  //  007D  EQ	R3	R3	R4
       0x780E0004,  //  007E  JMPF	R3	#0084
-      0x880C013D,  //  007F  GETMBR	R3	R0	K61
-      0x8C0C073E,  //  0080  GETMET	R3	R3	K62
+      0x880C013C,  //  007F  GETMBR	R3	R0	K60
+      0x8C0C073D,  //  0080  GETMET	R3	R3	K61
       0x7C0C0200,  //  0081  CALL	R3	1
-      0x90025403,  //  0082  SETMBR	R0	K42	R3
+      0x90025203,  //  0082  SETMBR	R0	K41	R3
       0x50080200,  //  0083  LDBOOL	R2	1	0
       0x780A0001,  //  0084  JMPF	R2	#0087
-      0x8C0C013F,  //  0085  GETMET	R3	R0	K63
+      0x8C0C013E,  //  0085  GETMET	R3	R0	K62
       0x7C0C0200,  //  0086  CALL	R3	1
       0x80000000,  //  0087  RET	0
     })
@@ -749,21 +734,21 @@ be_local_closure(class_Matter_Device_conf_to_log,   /* name */
     be_str_weak(conf_to_log),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x58040040,  //  0000  LDCONST	R1	K64
-      0x58080041,  //  0001  LDCONST	R2	K65
+      0x5804003F,  //  0000  LDCONST	R1	K63
+      0x58080040,  //  0001  LDCONST	R2	K64
       0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100342,  //  0003  GETMET	R4	R1	K66
+      0x8C100341,  //  0003  GETMET	R4	R1	K65
       0x5C180000,  //  0004  MOVE	R6	R0
       0x7C100400,  //  0005  CALL	R4	2
       0x7C0C0200,  //  0006  CALL	R3	1
       0xA802000B,  //  0007  EXBLK	0	#0014
       0x5C100600,  //  0008  MOVE	R4	R3
       0x7C100000,  //  0009  CALL	R4	0
-      0x1C140943,  //  000A  EQ	R5	R4	K67
+      0x1C140942,  //  000A  EQ	R5	R4	K66
       0x78160000,  //  000B  JMPF	R5	#000D
       0x7001FFFA,  //  000C  JMP		#0008
       0x60140018,  //  000D  GETGBL	R5	G24
-      0x58180044,  //  000E  LDCONST	R6	K68
+      0x58180043,  //  000E  LDCONST	R6	K67
       0x5C1C0800,  //  000F  MOVE	R7	R4
       0x94200004,  //  0010  GETIDX	R8	R0	R4
       0x7C140600,  //  0011  CALL	R5	3
@@ -796,9 +781,9 @@ be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
     be_str_weak(is_zigbee_present),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0xA4068A00,  //  0000  IMPORT	R1	K69
-      0x8C080346,  //  0001  GETMET	R2	R1	K70
-      0x58100047,  //  0002  LDCONST	R4	K71
+      0xA4068800,  //  0000  IMPORT	R1	K68
+      0x8C080345,  //  0001  GETMET	R2	R1	K69
+      0x58100046,  //  0002  LDCONST	R4	K70
       0x7C080400,  //  0003  CALL	R2	2
       0x4C0C0000,  //  0004  LDNIL	R3
       0x20080403,  //  0005  NE	R2	R2	R3
@@ -826,7 +811,7 @@ be_local_closure(class_Matter_Device_k2l,   /* name */
     be_str_weak(k2l),
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0x58040040,  //  0000  LDCONST	R1	K64
+      0x5804003F,  //  0000  LDCONST	R1	K63
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -900,13 +885,13 @@ be_local_closure(class_Matter_Device_stop,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
       0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040348,  //  0001  GETMET	R1	R1	K72
+      0x8C040347,  //  0001  GETMET	R1	R1	K71
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x88040149,  //  0004  GETMBR	R1	R0	K73
+      0x88040148,  //  0004  GETMBR	R1	R0	K72
       0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040149,  //  0006  GETMBR	R1	R0	K73
-      0x8C04034A,  //  0007  GETMET	R1	R1	K74
+      0x88040148,  //  0006  GETMBR	R1	R0	K72
+      0x8C040349,  //  0007  GETMET	R1	R1	K73
       0x7C040200,  //  0008  CALL	R1	1
       0x80000000,  //  0009  RET	0
     })
@@ -950,7 +935,7 @@ be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
       0x780E0010,  //  000F  JMPF	R3	#0021
       0x880C0109,  //  0010  GETMBR	R3	R0	K9
       0x940C0602,  //  0011  GETIDX	R3	R3	R2
-      0x8C10074B,  //  0012  GETMET	R4	R3	K75
+      0x8C10074A,  //  0012  GETMET	R4	R3	K74
       0x7C100200,  //  0013  CALL	R4	1
       0x4C140000,  //  0014  LDNIL	R5
       0x20140805,  //  0015  NE	R5	R4	R5
@@ -994,15 +979,15 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
       0x5C180600,  //  0001  MOVE	R6	R3
       0x7C140200,  //  0002  CALL	R5	1
       0x78160003,  //  0003  JMPF	R5	#0008
-      0x8818013D,  //  0004  GETMBR	R6	R0	K61
-      0x8C180D4C,  //  0005  GETMET	R6	R6	K76
+      0x8818013C,  //  0004  GETMBR	R6	R0	K60
+      0x8C180D4B,  //  0005  GETMET	R6	R6	K75
       0x7C180200,  //  0006  CALL	R6	1
       0x70020002,  //  0007  JMP		#000B
-      0x8818013D,  //  0008  GETMBR	R6	R0	K61
-      0x8C180D4D,  //  0009  GETMET	R6	R6	K77
+      0x8818013C,  //  0008  GETMBR	R6	R0	K60
+      0x8C180D4C,  //  0009  GETMET	R6	R6	K76
       0x7C180200,  //  000A  CALL	R6	1
       0xB81A0200,  //  000B  GETNGBL	R6	K1
-      0x8C180D4E,  //  000C  GETMET	R6	R6	K78
+      0x8C180D4D,  //  000C  GETMET	R6	R6	K77
       0x7C180200,  //  000D  CALL	R6	1
       0x80000000,  //  000E  RET	0
     })
@@ -1028,8 +1013,8 @@ be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
     be_str_weak(get_plugin_remote_info),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88080135,  //  0000  GETMBR	R2	R0	K53
-      0x8C080528,  //  0001  GETMET	R2	R2	K40
+      0x88080134,  //  0000  GETMBR	R2	R0	K52
+      0x8C080527,  //  0001  GETMET	R2	R2	K39
       0x5C100200,  //  0002  MOVE	R4	R1
       0x60140013,  //  0003  GETGBL	R5	G19
       0x7C140000,  //  0004  CALL	R5	0
@@ -1058,9 +1043,9 @@ be_local_closure(class_Matter_Device_MtrInfo,   /* name */
     be_str_weak(MtrInfo),
     &be_const_str_solidified,
     ( &(const binstruction[40]) {  /* code */
-      0x1C140741,  //  0000  EQ	R5	R3	K65
+      0x1C140740,  //  0000  EQ	R5	R3	K64
       0x7815FFFF,  //  0001  JMPF	R5	#0002
-      0x1C140741,  //  0002  EQ	R5	R3	K65
+      0x1C140740,  //  0002  EQ	R5	R3	K64
       0x7816000D,  //  0003  JMPF	R5	#0012
       0x60140010,  //  0004  GETGBL	R5	G16
       0x88180109,  //  0005  GETMBR	R6	R0	K9
@@ -1068,8 +1053,8 @@ be_local_closure(class_Matter_Device_MtrInfo,   /* name */
       0xA8020005,  //  0007  EXBLK	0	#000E
       0x5C180A00,  //  0008  MOVE	R6	R5
       0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C014F,  //  000A  GETMET	R7	R0	K79
-      0x88240D1E,  //  000B  GETMBR	R9	R6	K30
+      0x8C1C014E,  //  000A  GETMET	R7	R0	K78
+      0x88240D1D,  //  000B  GETMBR	R9	R6	K29
       0x7C1C0400,  //  000C  CALL	R7	2
       0x7001FFF9,  //  000D  JMP		#0008
       0x58140016,  //  000E  LDCONST	R5	K22
@@ -1079,23 +1064,23 @@ be_local_closure(class_Matter_Device_MtrInfo,   /* name */
       0x60140004,  //  0012  GETGBL	R5	G4
       0x5C180800,  //  0013  MOVE	R6	R4
       0x7C140200,  //  0014  CALL	R5	1
-      0x1C140B50,  //  0015  EQ	R5	R5	K80
+      0x1C140B4F,  //  0015  EQ	R5	R5	K79
       0x78160003,  //  0016  JMPF	R5	#001B
-      0x8C14014F,  //  0017  GETMET	R5	R0	K79
+      0x8C14014E,  //  0017  GETMET	R5	R0	K78
       0x5C1C0800,  //  0018  MOVE	R7	R4
       0x7C140400,  //  0019  CALL	R5	2
       0x70020008,  //  001A  JMP		#0024
-      0x8C140151,  //  001B  GETMET	R5	R0	K81
+      0x8C140150,  //  001B  GETMET	R5	R0	K80
       0x5C1C0600,  //  001C  MOVE	R7	R3
       0x7C140400,  //  001D  CALL	R5	2
       0x4C180000,  //  001E  LDNIL	R6
       0x20180A06,  //  001F  NE	R6	R5	R6
       0x781A0002,  //  0020  JMPF	R6	#0024
-      0x8C18014F,  //  0021  GETMET	R6	R0	K79
-      0x88200B1E,  //  0022  GETMBR	R8	R5	K30
+      0x8C18014E,  //  0021  GETMET	R6	R0	K78
+      0x88200B1D,  //  0022  GETMBR	R8	R5	K29
       0x7C180400,  //  0023  CALL	R6	2
       0xB8160200,  //  0024  GETNGBL	R5	K1
-      0x8C140B4E,  //  0025  GETMET	R5	R5	K78
+      0x8C140B4D,  //  0025  GETMET	R5	R5	K77
       0x7C140200,  //  0026  CALL	R5	1
       0x80000000,  //  0027  RET	0
     })
@@ -1121,24 +1106,24 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
     be_str_weak(MtrInfo_one),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x8C080152,  //  0000  GETMET	R2	R0	K82
+      0x8C080151,  //  0000  GETMET	R2	R0	K81
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C0C0403,  //  0004  EQ	R3	R2	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x80000600,  //  0006  RET	0
-      0x8C0C0553,  //  0007  GETMET	R3	R2	K83
+      0x8C0C0552,  //  0007  GETMET	R3	R2	K82
       0x7C0C0200,  //  0008  CALL	R3	1
       0x780E0008,  //  0009  JMPF	R3	#0013
       0x60100018,  //  000A  GETGBL	R4	G24
-      0x58140054,  //  000B  LDCONST	R5	K84
+      0x58140053,  //  000B  LDCONST	R5	K83
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
       0xB8160200,  //  000E  GETNGBL	R5	K1
-      0x8C140B55,  //  000F  GETMET	R5	R5	K85
+      0x8C140B54,  //  000F  GETMET	R5	R5	K84
       0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x58200041,  //  0011  LDCONST	R8	K65
+      0x58200040,  //  0011  LDCONST	R8	K64
       0x7C140600,  //  0012  CALL	R5	3
       0x80000000,  //  0013  RET	0
     })
@@ -1164,9 +1149,9 @@ be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
     be_str_weak(resolve_attribute_read_solo),
     &be_const_str_solidified,
     ( &(const binstruction[47]) {  /* code */
-      0x8808031E,  //  0000  GETMBR	R2	R1	K30
-      0x880C0356,  //  0001  GETMBR	R3	R1	K86
-      0x88100357,  //  0002  GETMBR	R4	R1	K87
+      0x8808031D,  //  0000  GETMBR	R2	R1	K29
+      0x880C0355,  //  0001  GETMBR	R3	R1	K85
+      0x88100356,  //  0002  GETMBR	R4	R1	K86
       0x4C140000,  //  0003  LDNIL	R5
       0x1C140405,  //  0004  EQ	R5	R2	R5
       0x74160005,  //  0005  JMPT	R5	#000C
@@ -1178,36 +1163,36 @@ be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
       0x78160001,  //  000B  JMPF	R5	#000E
       0x4C140000,  //  000C  LDNIL	R5
       0x80040A00,  //  000D  RET	1	R5
-      0x8C140152,  //  000E  GETMET	R5	R0	K82
+      0x8C140151,  //  000E  GETMET	R5	R0	K81
       0x5C1C0400,  //  000F  MOVE	R7	R2
       0x7C140400,  //  0010  CALL	R5	2
       0x4C180000,  //  0011  LDNIL	R6
       0x1C180A06,  //  0012  EQ	R6	R5	R6
       0x781A0005,  //  0013  JMPF	R6	#001A
-      0xB81A3400,  //  0014  GETNGBL	R6	K26
-      0x88180D21,  //  0015  GETMBR	R6	R6	K33
-      0x90064006,  //  0016  SETMBR	R1	K32	R6
+      0xB81A2E00,  //  0014  GETNGBL	R6	K23
+      0x88180D20,  //  0015  GETMBR	R6	R6	K32
+      0x90063E06,  //  0016  SETMBR	R1	K31	R6
       0x4C180000,  //  0017  LDNIL	R6
       0x80040C00,  //  0018  RET	1	R6
       0x70020013,  //  0019  JMP		#002E
-      0x8C180B58,  //  001A  GETMET	R6	R5	K88
+      0x8C180B57,  //  001A  GETMET	R6	R5	K87
       0x5C200600,  //  001B  MOVE	R8	R3
       0x7C180400,  //  001C  CALL	R6	2
       0x741A0005,  //  001D  JMPT	R6	#0024
-      0xB81A3400,  //  001E  GETNGBL	R6	K26
-      0x88180D59,  //  001F  GETMBR	R6	R6	K89
-      0x90064006,  //  0020  SETMBR	R1	K32	R6
+      0xB81A2E00,  //  001E  GETNGBL	R6	K23
+      0x88180D58,  //  001F  GETMBR	R6	R6	K88
+      0x90063E06,  //  0020  SETMBR	R1	K31	R6
       0x4C180000,  //  0021  LDNIL	R6
       0x80040C00,  //  0022  RET	1	R6
       0x70020009,  //  0023  JMP		#002E
-      0x8C180B5A,  //  0024  GETMET	R6	R5	K90
+      0x8C180B59,  //  0024  GETMET	R6	R5	K89
       0x5C200600,  //  0025  MOVE	R8	R3
       0x5C240800,  //  0026  MOVE	R9	R4
       0x7C180600,  //  0027  CALL	R6	3
       0x741A0004,  //  0028  JMPT	R6	#002E
-      0xB81A3400,  //  0029  GETNGBL	R6	K26
-      0x88180D5B,  //  002A  GETMBR	R6	R6	K91
-      0x90064006,  //  002B  SETMBR	R1	K32	R6
+      0xB81A2E00,  //  0029  GETNGBL	R6	K23
+      0x88180D5A,  //  002A  GETMBR	R6	R6	K90
+      0x90063E06,  //  002B  SETMBR	R1	K31	R6
       0x4C180000,  //  002C  LDNIL	R6
       0x80040C00,  //  002D  RET	1	R6
       0x80040A00,  //  002E  RET	1	R5
@@ -1234,17 +1219,17 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
     be_str_weak(every_second),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x8804015C,  //  0000  GETMBR	R1	R0	K92
-      0x8C04035D,  //  0001  GETMET	R1	R1	K93
+      0x8804015B,  //  0000  GETMBR	R1	R0	K91
+      0x8C04035C,  //  0001  GETMET	R1	R1	K92
       0x7C040200,  //  0002  CALL	R1	1
-      0x8804015E,  //  0003  GETMBR	R1	R0	K94
-      0x8C04035D,  //  0004  GETMET	R1	R1	K93
+      0x8804015D,  //  0003  GETMBR	R1	R0	K93
+      0x8C04035C,  //  0004  GETMET	R1	R1	K92
       0x7C040200,  //  0005  CALL	R1	1
-      0x8804015F,  //  0006  GETMBR	R1	R0	K95
-      0x8C04035D,  //  0007  GETMET	R1	R1	K93
+      0x8804015E,  //  0006  GETMBR	R1	R0	K94
+      0x8C04035C,  //  0007  GETMET	R1	R1	K92
       0x7C040200,  //  0008  CALL	R1	1
-      0x8804013D,  //  0009  GETMBR	R1	R0	K61
-      0x8C04035D,  //  000A  GETMET	R1	R1	K93
+      0x8804013C,  //  0009  GETMBR	R1	R0	K60
+      0x8C04035C,  //  000A  GETMET	R1	R1	K92
       0x7C040200,  //  000B  CALL	R1	1
       0x80000000,  //  000C  RET	0
     })
@@ -1270,7 +1255,7 @@ be_local_closure(class_Matter_Device_sort_distinct,   /* name */
     be_str_weak(sort_distinct),
     &be_const_str_solidified,
     ( &(const binstruction[53]) {  /* code */
-      0x58040040,  //  0000  LDCONST	R1	K64
+      0x5804003F,  //  0000  LDCONST	R1	K63
       0x60080010,  //  0001  GETGBL	R2	G16
       0x600C000C,  //  0002  GETGBL	R3	G12
       0x5C100000,  //  0003  MOVE	R4	R0
@@ -1315,7 +1300,7 @@ be_local_closure(class_Matter_Device_sort_distinct,   /* name */
       0x94100002,  //  002A  GETIDX	R4	R0	R2
       0x1C100803,  //  002B  EQ	R4	R4	R3
       0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100119,  //  002D  GETMET	R4	R0	K25
+      0x8C10011C,  //  002D  GETMET	R4	R0	K28
       0x5C180400,  //  002E  MOVE	R6	R2
       0x7C100400,  //  002F  CALL	R4	2
       0x70020001,  //  0030  JMP		#0033
@@ -1346,14 +1331,14 @@ be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
     be_str_weak(get_plugin_class_displayname),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080160,  //  0000  GETMBR	R2	R0	K96
-      0x8C080528,  //  0001  GETMET	R2	R2	K40
+      0x8808015F,  //  0000  GETMBR	R2	R0	K95
+      0x8C080527,  //  0001  GETMET	R2	R2	K39
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0561,  //  0005  GETMBR	R3	R2	K97
+      0x880C0560,  //  0005  GETMBR	R3	R2	K96
       0x70020000,  //  0006  JMP		#0008
-      0x580C0041,  //  0007  LDCONST	R3	K65
+      0x580C0040,  //  0007  LDCONST	R3	K64
       0x80040600,  //  0008  RET	1	R3
     })
   )
@@ -1378,14 +1363,14 @@ be_local_closure(class_Matter_Device_get_plugin_class_arg,   /* name */
     be_str_weak(get_plugin_class_arg),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x88080160,  //  0000  GETMBR	R2	R0	K96
-      0x8C080528,  //  0001  GETMET	R2	R2	K40
+      0x8808015F,  //  0000  GETMBR	R2	R0	K95
+      0x8C080527,  //  0001  GETMET	R2	R2	K39
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0562,  //  0005  GETMBR	R3	R2	K98
+      0x880C0561,  //  0005  GETMBR	R3	R2	K97
       0x70020000,  //  0006  JMP		#0008
-      0x580C0041,  //  0007  LDCONST	R3	K65
+      0x580C0040,  //  0007  LDCONST	R3	K64
       0x80040600,  //  0008  RET	1	R3
     })
   )
@@ -1410,29 +1395,29 @@ be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
     be_str_weak(process_attribute_expansion),
     &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x880C031E,  //  0000  GETMBR	R3	R1	K30
-      0x88100356,  //  0001  GETMBR	R4	R1	K86
-      0x88140357,  //  0002  GETMBR	R5	R1	K87
-      0xB81A3400,  //  0003  GETNGBL	R6	K26
-      0x8C180D63,  //  0004  GETMET	R6	R6	K99
+      0x880C031D,  //  0000  GETMBR	R3	R1	K29
+      0x88100355,  //  0001  GETMBR	R4	R1	K85
+      0x88140356,  //  0002  GETMBR	R5	R1	K86
+      0xB81A2E00,  //  0003  GETNGBL	R6	K23
+      0x8C180D62,  //  0004  GETMET	R6	R6	K98
       0x5C200000,  //  0005  MOVE	R8	R0
       0x7C180400,  //  0006  CALL	R6	2
-      0x8C1C0D64,  //  0007  GETMET	R7	R6	K100
+      0x8C1C0D63,  //  0007  GETMET	R7	R6	K99
       0x5C240600,  //  0008  MOVE	R9	R3
       0x5C280800,  //  0009  MOVE	R10	R4
       0x5C2C0A00,  //  000A  MOVE	R11	R5
       0x7C1C0800,  //  000B  CALL	R7	4
-      0x8C1C0D65,  //  000C  GETMET	R7	R6	K101
+      0x8C1C0D64,  //  000C  GETMET	R7	R6	K100
       0x7C1C0200,  //  000D  CALL	R7	1
       0x4C200000,  //  000E  LDNIL	R8
-      0x8C240D66,  //  000F  GETMET	R9	R6	K102
+      0x8C240D65,  //  000F  GETMET	R9	R6	K101
       0x7C240200,  //  0010  CALL	R9	1
       0x5C201200,  //  0011  MOVE	R8	R9
       0x4C280000,  //  0012  LDNIL	R10
       0x2024120A,  //  0013  NE	R9	R9	R10
       0x78260005,  //  0014  JMPF	R9	#001B
       0x5C240400,  //  0015  MOVE	R9	R2
-      0x8C280D67,  //  0016  GETMET	R10	R6	K103
+      0x8C280D66,  //  0016  GETMET	R10	R6	K102
       0x7C280200,  //  0017  CALL	R10	1
       0x5C2C1000,  //  0018  MOVE	R11	R8
       0x7C240400,  //  0019  CALL	R9	2
@@ -1469,7 +1454,7 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
       0x780E0008,  //  0005  JMPF	R3	#000F
       0x880C0109,  //  0006  GETMBR	R3	R0	K9
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100768,  //  0008  GETMET	R4	R3	K104
+      0x8C100767,  //  0008  GETMET	R4	R3	K103
       0x7C100200,  //  0009  CALL	R4	1
       0x1C100801,  //  000A  EQ	R4	R4	R1
       0x78120000,  //  000B  JMPF	R4	#000D
@@ -1505,33 +1490,33 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0019,  //  0002  JMPF	R2	#001D
       0xB80A0A00,  //  0003  GETNGBL	R2	K5
-      0x8C0C036A,  //  0004  GETMET	R3	R1	K106
+      0x8C0C0369,  //  0004  GETMET	R3	R1	K105
       0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C076B,  //  0006  GETMET	R3	R3	K107
+      0x8C0C076A,  //  0006  GETMET	R3	R3	K106
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C076C,  //  0008  GETMET	R3	R3	K108
+      0x8C0C076B,  //  0008  GETMET	R3	R3	K107
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C0C076D,  //  000A  GETMET	R3	R3	K109
+      0x8C0C076C,  //  000A  GETMET	R3	R3	K108
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x000ED203,  //  000C  ADD	R3	K105	R3
-      0x58100018,  //  000D  LDCONST	R4	K24
+      0x000ED003,  //  000C  ADD	R3	K104	R3
+      0x5810001B,  //  000D  LDCONST	R4	K27
       0x7C080400,  //  000E  CALL	R2	2
-      0x8808015E,  //  000F  GETMBR	R2	R0	K94
-      0x8808056E,  //  0010  GETMBR	R2	R2	K110
-      0x8808056F,  //  0011  GETMBR	R2	R2	K111
-      0x8C080570,  //  0012  GETMET	R2	R2	K112
+      0x8808015D,  //  000F  GETMBR	R2	R0	K93
+      0x8808056D,  //  0010  GETMBR	R2	R2	K109
+      0x8808056E,  //  0011  GETMBR	R2	R2	K110
+      0x8C08056F,  //  0012  GETMET	R2	R2	K111
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
-      0x8808013D,  //  0015  GETMBR	R2	R0	K61
-      0x8C080571,  //  0016  GETMET	R2	R2	K113
+      0x8808013C,  //  0015  GETMBR	R2	R0	K60
+      0x8C080570,  //  0016  GETMET	R2	R2	K112
       0x5C100200,  //  0017  MOVE	R4	R1
       0x7C080400,  //  0018  CALL	R2	2
-      0x8808015C,  //  0019  GETMBR	R2	R0	K92
-      0x8C080572,  //  001A  GETMET	R2	R2	K114
+      0x8808015B,  //  0019  GETMBR	R2	R0	K91
+      0x8C080571,  //  001A  GETMET	R2	R2	K113
       0x5C100200,  //  001B  MOVE	R4	R1
       0x7C080400,  //  001C  CALL	R2	2
-      0x8808015C,  //  001D  GETMBR	R2	R0	K92
-      0x8C080573,  //  001E  GETMET	R2	R2	K115
+      0x8808015B,  //  001D  GETMBR	R2	R0	K91
+      0x8C080572,  //  001E  GETMET	R2	R2	K114
       0x7C080200,  //  001F  CALL	R2	1
       0x80000000,  //  0020  RET	0
     })
@@ -1561,16 +1546,16 @@ be_local_closure(class_Matter_Device_attribute_updated,   /* name */
       0x1C140805,  //  0001  EQ	R5	R4	R5
       0x78160000,  //  0002  JMPF	R5	#0004
       0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8163400,  //  0004  GETNGBL	R5	K26
-      0x8C140B74,  //  0005  GETMET	R5	R5	K116
+      0xB8162E00,  //  0004  GETNGBL	R5	K23
+      0x8C140B73,  //  0005  GETMET	R5	R5	K115
       0x7C140200,  //  0006  CALL	R5	1
-      0x90163C01,  //  0007  SETMBR	R5	K30	R1
-      0x9016AC02,  //  0008  SETMBR	R5	K86	R2
-      0x9016AE03,  //  0009  SETMBR	R5	K87	R3
-      0x8818015E,  //  000A  GETMBR	R6	R0	K94
-      0x88180D6E,  //  000B  GETMBR	R6	R6	K110
-      0x88180D6F,  //  000C  GETMBR	R6	R6	K111
-      0x8C180D75,  //  000D  GETMET	R6	R6	K117
+      0x90163A01,  //  0007  SETMBR	R5	K29	R1
+      0x9016AA02,  //  0008  SETMBR	R5	K85	R2
+      0x9016AC03,  //  0009  SETMBR	R5	K86	R3
+      0x8818015D,  //  000A  GETMBR	R6	R0	K93
+      0x88180D6D,  //  000B  GETMBR	R6	R6	K109
+      0x88180D6E,  //  000C  GETMBR	R6	R6	K110
+      0x8C180D74,  //  000D  GETMET	R6	R6	K116
       0x5C200A00,  //  000E  MOVE	R8	R5
       0x5C240800,  //  000F  MOVE	R9	R4
       0x7C180600,  //  0010  CALL	R6	3
@@ -1606,7 +1591,7 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
       0x2C100404,  //  0005  AND	R4	R2	R4
       0x8C140112,  //  0006  GETMET	R5	R0	K18
       0x001C090B,  //  0007  ADD	R7	R4	K11
-      0x58200018,  //  0008  LDCONST	R8	K24
+      0x5820001B,  //  0008  LDCONST	R8	K27
       0x58240008,  //  0009  LDCONST	R9	K8
       0x5C280600,  //  000A  MOVE	R10	R3
       0x7C140A00,  //  000B  CALL	R5	5
@@ -1717,18 +1702,18 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040376,  //  0001  GETMET	R1	R1	K118
-      0x580C0077,  //  0002  LDCONST	R3	K119
+      0x8C040375,  //  0001  GETMET	R1	R1	K117
+      0x580C0076,  //  0002  LDCONST	R3	K118
       0x84100000,  //  0003  CLOSURE	R4	P0
       0x7C040600,  //  0004  CALL	R1	3
       0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040376,  //  0006  GETMET	R1	R1	K118
-      0x580C0078,  //  0007  LDCONST	R3	K120
+      0x8C040375,  //  0006  GETMET	R1	R1	K117
+      0x580C0077,  //  0007  LDCONST	R3	K119
       0x84100001,  //  0008  CLOSURE	R4	P1
       0x7C040600,  //  0009  CALL	R1	3
       0xB8060200,  //  000A  GETNGBL	R1	K1
-      0x8C040376,  //  000B  GETMET	R1	R1	K118
-      0x580C0079,  //  000C  LDCONST	R3	K121
+      0x8C040375,  //  000B  GETMET	R1	R1	K117
+      0x580C0078,  //  000C  LDCONST	R3	K120
       0x84100002,  //  000D  CLOSURE	R4	P2
       0x7C040600,  //  000E  CALL	R1	3
       0xA0000000,  //  000F  CLOSE	R0
@@ -1757,65 +1742,65 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[83]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C08017A,  //  0001  GETMET	R2	R0	K122
+      0x8C080179,  //  0001  GETMET	R2	R0	K121
       0x7C080200,  //  0002  CALL	R2	1
       0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C007B,  //  0004  LDCONST	R3	K123
-      0x88100127,  //  0005  GETMBR	R4	R0	K39
-      0x8814012A,  //  0006  GETMBR	R5	R0	K42
-      0x8818012C,  //  0007  GETMBR	R6	R0	K44
+      0x580C007A,  //  0004  LDCONST	R3	K122
+      0x88100126,  //  0005  GETMBR	R4	R0	K38
+      0x88140129,  //  0006  GETMBR	R5	R0	K41
+      0x8818012B,  //  0007  GETMBR	R6	R0	K43
       0x781A0001,  //  0008  JMPF	R6	#000B
-      0x5818007C,  //  0009  LDCONST	R6	K124
+      0x5818007B,  //  0009  LDCONST	R6	K123
       0x70020000,  //  000A  JMP		#000C
-      0x5818007D,  //  000B  LDCONST	R6	K125
-      0x881C012D,  //  000C  GETMBR	R7	R0	K45
+      0x5818007C,  //  000B  LDCONST	R6	K124
+      0x881C012C,  //  000C  GETMBR	R7	R0	K44
       0x781E0001,  //  000D  JMPF	R7	#0010
-      0x581C007C,  //  000E  LDCONST	R7	K124
+      0x581C007B,  //  000E  LDCONST	R7	K123
       0x70020000,  //  000F  JMP		#0011
-      0x581C007D,  //  0010  LDCONST	R7	K125
-      0x8820011D,  //  0011  GETMBR	R8	R0	K29
+      0x581C007C,  //  0010  LDCONST	R7	K124
+      0x8820011A,  //  0011  GETMBR	R8	R0	K26
       0x7C080C00,  //  0012  CALL	R2	6
-      0x880C0130,  //  0013  GETMBR	R3	R0	K48
+      0x880C012F,  //  0013  GETMBR	R3	R0	K47
       0x780E0000,  //  0014  JMPF	R3	#0016
-      0x0008057E,  //  0015  ADD	R2	R2	K126
-      0x880C0134,  //  0016  GETMBR	R3	R0	K52
+      0x0008057D,  //  0015  ADD	R2	R2	K125
+      0x880C0133,  //  0016  GETMBR	R3	R0	K51
       0x780E000E,  //  0017  JMPF	R3	#0027
-      0x0008057F,  //  0018  ADD	R2	R2	K127
-      0x8C0C0380,  //  0019  GETMET	R3	R1	K128
+      0x0008057E,  //  0018  ADD	R2	R2	K126
+      0x8C0C037F,  //  0019  GETMET	R3	R1	K127
       0x88140113,  //  001A  GETMBR	R5	R0	K19
       0x7C0C0400,  //  001B  CALL	R3	2
       0x00080403,  //  001C  ADD	R2	R2	R3
       0x600C000C,  //  001D  GETGBL	R3	G12
-      0x88100135,  //  001E  GETMBR	R4	R0	K53
+      0x88100134,  //  001E  GETMBR	R4	R0	K52
       0x7C0C0200,  //  001F  CALL	R3	1
       0x240C0708,  //  0020  GT	R3	R3	K8
       0x780E0004,  //  0021  JMPF	R3	#0027
-      0x00080581,  //  0022  ADD	R2	R2	K129
-      0x8C0C0380,  //  0023  GETMET	R3	R1	K128
-      0x88140135,  //  0024  GETMBR	R5	R0	K53
+      0x00080580,  //  0022  ADD	R2	R2	K128
+      0x8C0C037F,  //  0023  GETMET	R3	R1	K127
+      0x88140134,  //  0024  GETMBR	R5	R0	K52
       0x7C0C0400,  //  0025  CALL	R3	2
       0x00080403,  //  0026  ADD	R2	R2	R3
-      0x00080582,  //  0027  ADD	R2	R2	K130
+      0x00080581,  //  0027  ADD	R2	R2	K129
       0xA8020017,  //  0028  EXBLK	0	#0041
       0x600C0011,  //  0029  GETGBL	R3	G17
-      0x88100124,  //  002A  GETMBR	R4	R0	K36
-      0x58140083,  //  002B  LDCONST	R5	K131
+      0x88100123,  //  002A  GETMBR	R4	R0	K35
+      0x58140082,  //  002B  LDCONST	R5	K130
       0x7C0C0400,  //  002C  CALL	R3	2
-      0x8C100784,  //  002D  GETMET	R4	R3	K132
+      0x8C100783,  //  002D  GETMET	R4	R3	K131
       0x5C180400,  //  002E  MOVE	R6	R2
       0x7C100400,  //  002F  CALL	R4	2
-      0x8C100726,  //  0030  GETMET	R4	R3	K38
+      0x8C100725,  //  0030  GETMET	R4	R3	K37
       0x7C100200,  //  0031  CALL	R4	1
       0xB8120A00,  //  0032  GETNGBL	R4	K5
       0x60140018,  //  0033  GETGBL	R5	G24
-      0x58180085,  //  0034  LDCONST	R6	K133
-      0x881C0134,  //  0035  GETMBR	R7	R0	K52
+      0x58180084,  //  0034  LDCONST	R6	K132
+      0x881C0133,  //  0035  GETMBR	R7	R0	K51
       0x781E0001,  //  0036  JMPF	R7	#0039
-      0x581C0086,  //  0037  LDCONST	R7	K134
+      0x581C0085,  //  0037  LDCONST	R7	K133
       0x70020000,  //  0038  JMP		#003A
-      0x581C0041,  //  0039  LDCONST	R7	K65
+      0x581C0040,  //  0039  LDCONST	R7	K64
       0x7C140400,  //  003A  CALL	R5	2
-      0x58180018,  //  003B  LDCONST	R6	K24
+      0x5818001B,  //  003B  LDCONST	R6	K27
       0x7C100400,  //  003C  CALL	R4	2
       0xA8040001,  //  003D  EXBLK	1	1
       0x80040400,  //  003E  RET	1	R2
@@ -1827,13 +1812,13 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
       0x60180008,  //  0044  GETGBL	R6	G8
       0x5C1C0600,  //  0045  MOVE	R7	R3
       0x7C180200,  //  0046  CALL	R6	1
-      0x001B0E06,  //  0047  ADD	R6	K135	R6
-      0x00180D3A,  //  0048  ADD	R6	R6	K58
+      0x001B0C06,  //  0047  ADD	R6	K134	R6
+      0x00180D39,  //  0048  ADD	R6	R6	K57
       0x601C0008,  //  0049  GETGBL	R7	G8
       0x5C200800,  //  004A  MOVE	R8	R4
       0x7C1C0200,  //  004B  CALL	R7	1
       0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0018,  //  004D  LDCONST	R7	K24
+      0x581C001B,  //  004D  LDCONST	R7	K27
       0x7C140400,  //  004E  CALL	R5	2
       0x80040400,  //  004F  RET	1	R2
       0x70020000,  //  0050  JMP		#0052
@@ -1862,13 +1847,13 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
     be_str_weak(clean_remotes),
     &be_const_str_solidified,
     ( &(const binstruction[80]) {  /* code */
-      0xA4068A00,  //  0000  IMPORT	R1	K69
-      0x88080188,  //  0001  GETMBR	R2	R0	K136
+      0xA4068800,  //  0000  IMPORT	R1	K68
+      0x88080187,  //  0001  GETMBR	R2	R0	K135
       0x780A004B,  //  0002  JMPF	R2	#004F
       0x60080013,  //  0003  GETGBL	R2	G19
       0x7C080000,  //  0004  CALL	R2	0
       0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100188,  //  0006  GETMBR	R4	R0	K136
+      0x88100187,  //  0006  GETMBR	R4	R0	K135
       0x7C0C0200,  //  0007  CALL	R3	1
       0xA8020003,  //  0008  EXBLK	0	#000D
       0x5C100600,  //  0009  MOVE	R4	R3
@@ -1884,14 +1869,14 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
       0xA802000F,  //  0013  EXBLK	0	#0024
       0x5C100600,  //  0014  MOVE	R4	R3
       0x7C100000,  //  0015  CALL	R4	0
-      0x8C14033C,  //  0016  GETMET	R5	R1	K60
+      0x8C14033B,  //  0016  GETMET	R5	R1	K59
       0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200089,  //  0018  LDCONST	R8	K137
+      0x58200088,  //  0018  LDCONST	R8	K136
       0x7C140600,  //  0019  CALL	R5	3
       0x4C180000,  //  001A  LDNIL	R6
       0x20180A06,  //  001B  NE	R6	R5	R6
       0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C180528,  //  001D  GETMET	R6	R2	K40
+      0x8C180527,  //  001D  GETMET	R6	R2	K39
       0x5C200A00,  //  001E  MOVE	R8	R5
       0x58240008,  //  001F  LDCONST	R9	K8
       0x7C180600,  //  0020  CALL	R6	3
@@ -1927,15 +1912,15 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
       0x5C140800,  //  003E  MOVE	R5	R4
       0x7C140000,  //  003F  CALL	R5	0
       0xB81A0A00,  //  0040  GETNGBL	R6	K5
-      0x881C0B8B,  //  0041  GETMBR	R7	R5	K139
-      0x001F1407,  //  0042  ADD	R7	K138	R7
+      0x881C0B8A,  //  0041  GETMBR	R7	R5	K138
+      0x001F1207,  //  0042  ADD	R7	K137	R7
       0x58200004,  //  0043  LDCONST	R8	K4
       0x7C180400,  //  0044  CALL	R6	2
-      0x8C180B26,  //  0045  GETMET	R6	R5	K38
+      0x8C180B25,  //  0045  GETMET	R6	R5	K37
       0x7C180200,  //  0046  CALL	R6	1
-      0x88180188,  //  0047  GETMBR	R6	R0	K136
-      0x8C180D19,  //  0048  GETMET	R6	R6	K25
-      0x88200B8B,  //  0049  GETMBR	R8	R5	K139
+      0x88180187,  //  0047  GETMBR	R6	R0	K135
+      0x8C180D1C,  //  0048  GETMET	R6	R6	K28
+      0x88200B8A,  //  0049  GETMBR	R8	R5	K138
       0x7C180400,  //  004A  CALL	R6	2
       0x7001FFF1,  //  004B  JMP		#003E
       0x58100016,  //  004C  LDCONST	R4	K22
@@ -1972,28 +1957,28 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
       0x4C100000,  //  0004  LDNIL	R4
       0x4C140000,  //  0005  LDNIL	R5
       0x88180113,  //  0006  GETMBR	R6	R0	K19
-      0x8C180D8C,  //  0007  GETMET	R6	R6	K140
+      0x8C180D8B,  //  0007  GETMET	R6	R6	K139
       0x5C200600,  //  0008  MOVE	R8	R3
       0x7C180400,  //  0009  CALL	R6	2
       0x741A0004,  //  000A  JMPT	R6	#0010
       0xB81A0A00,  //  000B  GETNGBL	R6	K5
-      0x001F1A03,  //  000C  ADD	R7	K141	R3
+      0x001F1803,  //  000C  ADD	R7	K140	R3
       0x58200004,  //  000D  LDCONST	R8	K4
       0x7C180400,  //  000E  CALL	R6	2
       0x80000C00,  //  000F  RET	0
       0xB81A0A00,  //  0010  GETNGBL	R6	K5
       0x601C0018,  //  0011  GETGBL	R7	G24
-      0x5820008E,  //  0012  LDCONST	R8	K142
+      0x5820008D,  //  0012  LDCONST	R8	K141
       0x5C240200,  //  0013  MOVE	R9	R1
       0x7C1C0400,  //  0014  CALL	R7	2
-      0x58200018,  //  0015  LDCONST	R8	K24
+      0x5820001B,  //  0015  LDCONST	R8	K27
       0x7C180400,  //  0016  CALL	R6	2
       0x88180113,  //  0017  GETMBR	R6	R0	K19
-      0x8C180D19,  //  0018  GETMET	R6	R6	K25
+      0x8C180D1C,  //  0018  GETMET	R6	R6	K28
       0x5C200600,  //  0019  MOVE	R8	R3
       0x7C180400,  //  001A  CALL	R6	2
       0x50180200,  //  001B  LDBOOL	R6	1	0
-      0x90026806,  //  001C  SETMBR	R0	K52	R6
+      0x90026606,  //  001C  SETMBR	R0	K51	R6
       0x58180008,  //  001D  LDCONST	R6	K8
       0x601C000C,  //  001E  GETGBL	R7	G12
       0x88200109,  //  001F  GETMBR	R8	R0	K9
@@ -2002,23 +1987,23 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
       0x781E000D,  //  0022  JMPF	R7	#0031
       0x881C0109,  //  0023  GETMBR	R7	R0	K9
       0x941C0E06,  //  0024  GETIDX	R7	R7	R6
-      0x8C1C0F68,  //  0025  GETMET	R7	R7	K104
+      0x8C1C0F67,  //  0025  GETMET	R7	R7	K103
       0x7C1C0200,  //  0026  CALL	R7	1
       0x1C1C0207,  //  0027  EQ	R7	R1	R7
       0x781E0005,  //  0028  JMPF	R7	#002F
       0x881C0109,  //  0029  GETMBR	R7	R0	K9
-      0x8C1C0F19,  //  002A  GETMET	R7	R7	K25
+      0x8C1C0F1C,  //  002A  GETMET	R7	R7	K28
       0x5C240C00,  //  002B  MOVE	R9	R6
       0x7C1C0400,  //  002C  CALL	R7	2
       0x70020002,  //  002D  JMP		#0031
       0x70020000,  //  002E  JMP		#0030
       0x00180D0B,  //  002F  ADD	R6	R6	K11
       0x7001FFEC,  //  0030  JMP		#001E
-      0x8C1C018F,  //  0031  GETMET	R7	R0	K143
+      0x8C1C018E,  //  0031  GETMET	R7	R0	K142
       0x7C1C0200,  //  0032  CALL	R7	1
-      0x8C1C013F,  //  0033  GETMET	R7	R0	K63
+      0x8C1C013E,  //  0033  GETMET	R7	R0	K62
       0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0190,  //  0035  GETMET	R7	R0	K144
+      0x8C1C018F,  //  0035  GETMET	R7	R0	K143
       0x7C1C0200,  //  0036  CALL	R7	1
       0x80000000,  //  0037  RET	0
     })
@@ -2071,7 +2056,7 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
     be_str_weak(_start_udp),
     &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x88080149,  //  0000  GETMBR	R2	R0	K73
+      0x88080148,  //  0000  GETMBR	R2	R0	K72
       0x780A0000,  //  0001  JMPF	R2	#0003
       0x80000400,  //  0002  RET	0
       0x4C080000,  //  0003  LDNIL	R2
@@ -2082,18 +2067,18 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
       0x600C0008,  //  0008  GETGBL	R3	G8
       0x5C100200,  //  0009  MOVE	R4	R1
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x000F2203,  //  000B  ADD	R3	K145	R3
-      0x58100018,  //  000C  LDCONST	R4	K24
+      0x000F2003,  //  000B  ADD	R3	K144	R3
+      0x5810001B,  //  000C  LDCONST	R4	K27
       0x7C080400,  //  000D  CALL	R2	2
-      0xB80A3400,  //  000E  GETNGBL	R2	K26
-      0x8C080592,  //  000F  GETMET	R2	R2	K146
+      0xB80A2E00,  //  000E  GETNGBL	R2	K23
+      0x8C080591,  //  000F  GETMET	R2	R2	K145
       0x5C100000,  //  0010  MOVE	R4	R0
-      0x58140041,  //  0011  LDCONST	R5	K65
+      0x58140040,  //  0011  LDCONST	R5	K64
       0x5C180200,  //  0012  MOVE	R6	R1
       0x7C080800,  //  0013  CALL	R2	4
-      0x90029202,  //  0014  SETMBR	R0	K73	R2
-      0x88080149,  //  0015  GETMBR	R2	R0	K73
-      0x8C080564,  //  0016  GETMET	R2	R2	K100
+      0x90029002,  //  0014  SETMBR	R0	K72	R2
+      0x88080148,  //  0015  GETMBR	R2	R0	K72
+      0x8C080563,  //  0016  GETMET	R2	R2	K99
       0x84100000,  //  0017  CLOSURE	R4	P0
       0x7C080400,  //  0018  CALL	R2	2
       0xA0000000,  //  0019  CLOSE	R0
@@ -2121,16 +2106,16 @@ be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
     be_str_weak(event_fabrics_saved),
     &be_const_str_solidified,
     ( &(const binstruction[12]) {  /* code */
-      0x8804015C,  //  0000  GETMBR	R1	R0	K92
-      0x8C040393,  //  0001  GETMET	R1	R1	K147
+      0x8804015B,  //  0000  GETMBR	R1	R0	K91
+      0x8C040392,  //  0001  GETMET	R1	R1	K146
       0x7C040200,  //  0002  CALL	R1	1
       0x24040308,  //  0003  GT	R1	R1	K8
       0x78060005,  //  0004  JMPF	R1	#000B
-      0x88040134,  //  0005  GETMBR	R1	R0	K52
+      0x88040133,  //  0005  GETMBR	R1	R0	K51
       0x74060003,  //  0006  JMPT	R1	#000B
       0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90026801,  //  0008  SETMBR	R0	K52	R1
-      0x8C04013F,  //  0009  GETMET	R1	R0	K63
+      0x90026601,  //  0008  SETMBR	R0	K51	R1
+      0x8C04013E,  //  0009  GETMET	R1	R0	K62
       0x7C040200,  //  000A  CALL	R1	1
       0x80000000,  //  000B  RET	0
     })
@@ -2180,86 +2165,86 @@ be_local_closure(class_Matter_Device_init,   /* name */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[83]) {  /* code */
-      0xA4064600,  //  0000  IMPORT	R1	K35
+      0xA4064400,  //  0000  IMPORT	R1	K34
       0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080594,  //  0002  GETMET	R2	R2	K148
-      0xB8123400,  //  0003  GETNGBL	R4	K26
-      0x88100995,  //  0004  GETMBR	R4	R4	K149
+      0x8C080593,  //  0002  GETMET	R2	R2	K147
+      0xB8122E00,  //  0003  GETNGBL	R4	K23
+      0x88100994,  //  0004  GETMBR	R4	R4	K148
       0x7C080400,  //  0005  CALL	R2	2
       0x740A0006,  //  0006  JMPT	R2	#000E
-      0xB80A3400,  //  0007  GETNGBL	R2	K26
-      0x8C080597,  //  0008  GETMET	R2	R2	K151
+      0xB80A2E00,  //  0007  GETNGBL	R2	K23
+      0x8C080596,  //  0008  GETMET	R2	R2	K150
       0x5C100000,  //  0009  MOVE	R4	R0
       0x50140000,  //  000A  LDBOOL	R5	0	0
       0x7C080600,  //  000B  CALL	R2	3
-      0x90032C02,  //  000C  SETMBR	R0	K150	R2
+      0x90032A02,  //  000C  SETMBR	R0	K149	R2
       0x80000400,  //  000D  RET	0
-      0xB80A3400,  //  000E  GETNGBL	R2	K26
-      0xB80E3400,  //  000F  GETNGBL	R3	K26
-      0x8C0C0799,  //  0010  GETMET	R3	R3	K153
+      0xB80A2E00,  //  000E  GETNGBL	R2	K23
+      0xB80E2E00,  //  000F  GETNGBL	R3	K23
+      0x8C0C0798,  //  0010  GETMET	R3	R3	K152
       0x7C0C0200,  //  0011  CALL	R3	1
-      0x900B3003,  //  0012  SETMBR	R2	K152	R3
-      0x90033508,  //  0013  SETMBR	R0	K154	K8
+      0x900B2E03,  //  0012  SETMBR	R2	K151	R3
+      0x90033308,  //  0013  SETMBR	R0	K153	K8
       0x60080012,  //  0014  GETGBL	R2	G18
       0x7C080000,  //  0015  CALL	R2	0
       0x90021202,  //  0016  SETMBR	R0	K9	R2
       0x50080000,  //  0017  LDBOOL	R2	0	0
-      0x90026802,  //  0018  SETMBR	R0	K52	R2
+      0x90026602,  //  0018  SETMBR	R0	K51	R2
       0x60080013,  //  0019  GETGBL	R2	G19
       0x7C080000,  //  001A  CALL	R2	0
-      0x90026A02,  //  001B  SETMBR	R0	K53	R2
-      0x8808019B,  //  001C  GETMBR	R2	R0	K155
-      0x90023A02,  //  001D  SETMBR	R0	K29	R2
+      0x90026802,  //  001B  SETMBR	R0	K52	R2
+      0x8808019A,  //  001C  GETMBR	R2	R0	K154
+      0x90023402,  //  001D  SETMBR	R0	K26	R2
       0x50080000,  //  001E  LDBOOL	R2	0	0
-      0x90025802,  //  001F  SETMBR	R0	K44	R2
+      0x90025602,  //  001F  SETMBR	R0	K43	R2
       0x50080000,  //  0020  LDBOOL	R2	0	0
-      0x90025A02,  //  0021  SETMBR	R0	K45	R2
-      0xB80A3400,  //  0022  GETNGBL	R2	K26
-      0x8C08059C,  //  0023  GETMET	R2	R2	K156
+      0x90025802,  //  0021  SETMBR	R0	K44	R2
+      0xB80A2E00,  //  0022  GETNGBL	R2	K23
+      0x8C08059B,  //  0023  GETMET	R2	R2	K155
       0x5C100000,  //  0024  MOVE	R4	R0
       0x7C080400,  //  0025  CALL	R2	2
-      0x90027A02,  //  0026  SETMBR	R0	K61	R2
-      0x8C08019D,  //  0027  GETMET	R2	R0	K157
+      0x90027802,  //  0026  SETMBR	R0	K60	R2
+      0x8C08019C,  //  0027  GETMET	R2	R0	K156
       0x7C080200,  //  0028  CALL	R2	1
-      0xB80A3400,  //  0029  GETNGBL	R2	K26
-      0x8C08059E,  //  002A  GETMET	R2	R2	K158
+      0xB80A2E00,  //  0029  GETNGBL	R2	K23
+      0x8C08059D,  //  002A  GETMET	R2	R2	K157
       0x5C100000,  //  002B  MOVE	R4	R0
       0x7C080400,  //  002C  CALL	R2	2
-      0x9002B802,  //  002D  SETMBR	R0	K92	R2
-      0x8808015C,  //  002E  GETMBR	R2	R0	K92
-      0x8C08059F,  //  002F  GETMET	R2	R2	K159
+      0x9002B602,  //  002D  SETMBR	R0	K91	R2
+      0x8808015B,  //  002E  GETMBR	R2	R0	K91
+      0x8C08059E,  //  002F  GETMET	R2	R2	K158
       0x7C080200,  //  0030  CALL	R2	1
-      0xB80A3400,  //  0031  GETNGBL	R2	K26
-      0x8C0805A0,  //  0032  GETMET	R2	R2	K160
+      0xB80A2E00,  //  0031  GETNGBL	R2	K23
+      0x8C08059F,  //  0032  GETMET	R2	R2	K159
       0x5C100000,  //  0033  MOVE	R4	R0
       0x7C080400,  //  0034  CALL	R2	2
-      0x9002BC02,  //  0035  SETMBR	R0	K94	R2
-      0xB80A3400,  //  0036  GETNGBL	R2	K26
-      0x8C0805A1,  //  0037  GETMET	R2	R2	K161
+      0x9002BA02,  //  0035  SETMBR	R0	K93	R2
+      0xB80A2E00,  //  0036  GETNGBL	R2	K23
+      0x8C0805A0,  //  0037  GETMET	R2	R2	K160
       0x5C100000,  //  0038  MOVE	R4	R0
       0x7C080400,  //  0039  CALL	R2	2
-      0x9002BE02,  //  003A  SETMBR	R0	K95	R2
-      0x8C0801A3,  //  003B  GETMET	R2	R0	K163
+      0x9002BC02,  //  003A  SETMBR	R0	K94	R2
+      0x8C0801A2,  //  003B  GETMET	R2	R0	K162
       0x7C080200,  //  003C  CALL	R2	1
-      0x90034402,  //  003D  SETMBR	R0	K162	R2
-      0xB80A3400,  //  003E  GETNGBL	R2	K26
-      0x8C080597,  //  003F  GETMET	R2	R2	K151
+      0x90034202,  //  003D  SETMBR	R0	K161	R2
+      0xB80A2E00,  //  003E  GETNGBL	R2	K23
+      0x8C080596,  //  003F  GETMET	R2	R2	K150
       0x5C100000,  //  0040  MOVE	R4	R0
       0x50140200,  //  0041  LDBOOL	R5	1	0
       0x7C080600,  //  0042  CALL	R2	3
-      0x90032C02,  //  0043  SETMBR	R0	K150	R2
+      0x90032A02,  //  0043  SETMBR	R0	K149	R2
       0xB80A0200,  //  0044  GETNGBL	R2	K1
-      0x8C0805A4,  //  0045  GETMET	R2	R2	K164
+      0x8C0805A3,  //  0045  GETMET	R2	R2	K163
       0x84100000,  //  0046  CLOSURE	R4	P0
       0x7C080400,  //  0047  CALL	R2	2
-      0x8808013D,  //  0048  GETMBR	R2	R0	K61
-      0x8C0805A5,  //  0049  GETMET	R2	R2	K165
+      0x8808013C,  //  0048  GETMBR	R2	R0	K60
+      0x8C0805A4,  //  0049  GETMET	R2	R2	K164
       0x7C080200,  //  004A  CALL	R2	1
       0xB80A0200,  //  004B  GETNGBL	R2	K1
-      0x8C0805A6,  //  004C  GETMET	R2	R2	K166
+      0x8C0805A5,  //  004C  GETMET	R2	R2	K165
       0x5C100000,  //  004D  MOVE	R4	R0
       0x7C080400,  //  004E  CALL	R2	2
-      0x8C0801A7,  //  004F  GETMET	R2	R0	K167
+      0x8C0801A6,  //  004F  GETMET	R2	R0	K166
       0x7C080200,  //  0050  CALL	R2	1
       0xA0000000,  //  0051  CLOSE	R0
       0x80000000,  //  0052  RET	0
@@ -2294,13 +2279,13 @@ be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
       0xA8020011,  //  0005  EXBLK	0	#0018
       0x5C100600,  //  0006  MOVE	R4	R3
       0x7C100000,  //  0007  CALL	R4	0
-      0x8C140968,  //  0008  GETMET	R5	R4	K104
+      0x8C140967,  //  0008  GETMET	R5	R4	K103
       0x7C140200,  //  0009  CALL	R5	1
       0x78060002,  //  000A  JMPF	R1	#000E
       0x1C180B08,  //  000B  EQ	R6	R5	K8
       0x781A0000,  //  000C  JMPF	R6	#000E
       0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180528,  //  000E  GETMET	R6	R2	K40
+      0x8C180527,  //  000E  GETMET	R6	R2	K39
       0x5C200A00,  //  000F  MOVE	R8	R5
       0x7C180400,  //  0010  CALL	R6	2
       0x4C1C0000,  //  0011  LDNIL	R7
@@ -2337,8 +2322,8 @@ be_local_closure(class_Matter_Device_received_ack,   /* name */
     be_str_weak(received_ack),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080149,  //  0000  GETMBR	R2	R0	K73
-      0x8C0805A8,  //  0001  GETMET	R2	R2	K168
+      0x88080148,  //  0000  GETMBR	R2	R0	K72
+      0x8C0805A7,  //  0001  GETMET	R2	R2	K167
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -2376,11 +2361,11 @@ be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
       0x600C0009,  //  0008  GETGBL	R3	G9
       0x5C100400,  //  0009  MOVE	R4	R2
       0x7C0C0200,  //  000A  CALL	R3	1
-      0x8810011D,  //  000B  GETMBR	R4	R0	K29
+      0x8810011A,  //  000B  GETMBR	R4	R0	K26
       0x28100604,  //  000C  GE	R4	R3	R4
       0x78120001,  //  000D  JMPF	R4	#0010
       0x0010070B,  //  000E  ADD	R4	R3	K11
-      0x90023A04,  //  000F  SETMBR	R0	K29	R4
+      0x90023404,  //  000F  SETMBR	R0	K26	R4
       0x7001FFF4,  //  0010  JMP		#0006
       0x58040016,  //  0011  LDCONST	R1	K22
       0xAC040200,  //  0012  CATCH	R1	1	0
@@ -2410,10 +2395,10 @@ be_local_closure(class_Matter_Device_reset_param,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90026801,  //  0001  SETMBR	R0	K52	R1
-      0x8804019B,  //  0002  GETMBR	R1	R0	K155
-      0x90023A01,  //  0003  SETMBR	R0	K29	R1
-      0x8C04013F,  //  0004  GETMET	R1	R0	K63
+      0x90026601,  //  0001  SETMBR	R0	K51	R1
+      0x8804019A,  //  0002  GETMBR	R1	R0	K154
+      0x90023401,  //  0003  SETMBR	R0	K26	R1
+      0x8C04013E,  //  0004  GETMET	R1	R0	K62
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -2439,7 +2424,7 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
     be_str_weak(every_250ms),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x8C0401A9,  //  0000  GETMET	R1	R0	K169
+      0x8C0401A8,  //  0000  GETMET	R1	R0	K168
       0x7C040200,  //  0001  CALL	R1	1
       0x58040008,  //  0002  LDCONST	R1	K8
       0x6008000C,  //  0003  GETGBL	R2	G12
@@ -2449,7 +2434,7 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
       0x780A0005,  //  0007  JMPF	R2	#000E
       0x88080109,  //  0008  GETMBR	R2	R0	K9
       0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C0805AA,  //  000A  GETMET	R2	R2	K170
+      0x8C0805A9,  //  000A  GETMET	R2	R2	K169
       0x7C080200,  //  000B  CALL	R2	1
       0x0004030B,  //  000C  ADD	R1	R1	K11
       0x7001FFF4,  //  000D  JMP		#0003
@@ -2478,7 +2463,7 @@ be_local_closure(class_Matter_Device_button_handler,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
       0x58140008,  //  0000  LDCONST	R5	K8
-      0xA41A8A00,  //  0001  IMPORT	R6	K69
+      0xA41A8800,  //  0001  IMPORT	R6	K68
       0x601C000C,  //  0002  GETGBL	R7	G12
       0x88200109,  //  0003  GETMBR	R8	R0	K9
       0x7C1C0200,  //  0004  CALL	R7	1
@@ -2486,7 +2471,7 @@ be_local_closure(class_Matter_Device_button_handler,   /* name */
       0x781E0010,  //  0006  JMPF	R7	#0018
       0x881C0109,  //  0007  GETMBR	R7	R0	K9
       0x941C0E05,  //  0008  GETIDX	R7	R7	R5
-      0x8C200D8C,  //  0009  GETMET	R8	R6	K140
+      0x8C200D8B,  //  0009  GETMET	R8	R6	K139
       0x5C280E00,  //  000A  MOVE	R10	R7
       0x582C0012,  //  000B  LDCONST	R11	K18
       0x7C200600,  //  000C  CALL	R8	3
@@ -2525,8 +2510,8 @@ be_local_closure(class_Matter_Device_msg_send,   /* name */
     be_str_weak(msg_send),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88080149,  //  0000  GETMBR	R2	R0	K73
-      0x8C0805AB,  //  0001  GETMET	R2	R2	K171
+      0x88080148,  //  0000  GETMBR	R2	R0	K72
+      0x8C0805AA,  //  0001  GETMET	R2	R2	K170
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
@@ -2553,13 +2538,13 @@ be_local_closure(class_Matter_Device_start,   /* name */
     be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C0401AC,  //  0000  GETMET	R1	R0	K172
+      0x8C0401AB,  //  0000  GETMET	R1	R0	K171
       0x7C040200,  //  0001  CALL	R1	1
-      0x8C0401AD,  //  0002  GETMET	R1	R0	K173
-      0x880C01AE,  //  0003  GETMBR	R3	R0	K174
+      0x8C0401AC,  //  0002  GETMET	R1	R0	K172
+      0x880C01AD,  //  0003  GETMBR	R3	R0	K173
       0x7C040400,  //  0004  CALL	R1	2
-      0x8804013D,  //  0005  GETMBR	R1	R0	K61
-      0x8C0403AF,  //  0006  GETMET	R1	R1	K175
+      0x8804013C,  //  0005  GETMBR	R1	R0	K60
+      0x8C0403AE,  //  0006  GETMET	R1	R1	K174
       0x7C040200,  //  0007  CALL	R1	1
       0x80000000,  //  0008  RET	0
     })
@@ -2587,21 +2572,21 @@ be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
     ( &(const binstruction[33]) {  /* code */
       0x60040013,  //  0000  GETGBL	R1	G19
       0x7C040000,  //  0001  CALL	R1	0
-      0x88080188,  //  0002  GETMBR	R2	R0	K136
+      0x88080187,  //  0002  GETMBR	R2	R0	K135
       0x4C0C0000,  //  0003  LDNIL	R3
       0x20080403,  //  0004  NE	R2	R2	R3
       0x780A0018,  //  0005  JMPF	R2	#001F
       0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C0188,  //  0007  GETMBR	R3	R0	K136
+      0x880C0187,  //  0007  GETMBR	R3	R0	K135
       0x8C0C0714,  //  0008  GETMET	R3	R3	K20
       0x7C0C0200,  //  0009  CALL	R3	1
       0x7C080200,  //  000A  CALL	R2	1
       0xA802000F,  //  000B  EXBLK	0	#001C
       0x5C0C0400,  //  000C  MOVE	R3	R2
       0x7C0C0000,  //  000D  CALL	R3	0
-      0x88100188,  //  000E  GETMBR	R4	R0	K136
+      0x88100187,  //  000E  GETMBR	R4	R0	K135
       0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C1009B0,  //  0010  GETMET	R4	R4	K176
+      0x8C1009AF,  //  0010  GETMET	R4	R4	K175
       0x7C100200,  //  0011  CALL	R4	1
       0x4C140000,  //  0012  LDNIL	R5
       0x20140805,  //  0013  NE	R5	R4	R5
@@ -2616,7 +2601,7 @@ be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
       0x58080016,  //  001C  LDCONST	R2	K22
       0xAC080200,  //  001D  CATCH	R2	1	0
       0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90026A01,  //  001F  SETMBR	R0	K53	R1
+      0x90026801,  //  001F  SETMBR	R0	K52	R1
       0x80040200,  //  0020  RET	1	R1
     })
   )
@@ -2641,11 +2626,11 @@ be_local_closure(class_Matter_Device_every_50ms,   /* name */
     be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8804019A,  //  0000  GETMBR	R1	R0	K154
+      0x88040199,  //  0000  GETMBR	R1	R0	K153
       0x0004030B,  //  0001  ADD	R1	R1	K11
-      0x90033401,  //  0002  SETMBR	R0	K154	R1
-      0x8804015E,  //  0003  GETMBR	R1	R0	K94
-      0x8C0403B1,  //  0004  GETMET	R1	R1	K177
+      0x90033201,  //  0002  SETMBR	R0	K153	R1
+      0x8804015D,  //  0003  GETMBR	R1	R0	K93
+      0x8C0403B0,  //  0004  GETMET	R1	R1	K176
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -2671,7 +2656,7 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
     be_str_weak(k2l_num),
     &be_const_str_solidified,
     ( &(const binstruction[52]) {  /* code */
-      0x58040040,  //  0000  LDCONST	R1	K64
+      0x5804003F,  //  0000  LDCONST	R1	K63
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -2746,46 +2731,46 @@ be_local_closure(class_Matter_Device_register_http_remote,   /* name */
     be_str_weak(register_http_remote),
     &be_const_str_solidified,
     ( &(const binstruction[42]) {  /* code */
-      0x880C0188,  //  0000  GETMBR	R3	R0	K136
+      0x880C0187,  //  0000  GETMBR	R3	R0	K135
       0x4C100000,  //  0001  LDNIL	R4
       0x1C0C0604,  //  0002  EQ	R3	R3	R4
       0x780E0002,  //  0003  JMPF	R3	#0007
       0x600C0013,  //  0004  GETGBL	R3	G19
       0x7C0C0000,  //  0005  CALL	R3	0
-      0x90031003,  //  0006  SETMBR	R0	K136	R3
+      0x90030E03,  //  0006  SETMBR	R0	K135	R3
       0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100188,  //  0008  GETMBR	R4	R0	K136
-      0x8C10098C,  //  0009  GETMET	R4	R4	K140
+      0x88100187,  //  0008  GETMBR	R4	R0	K135
+      0x8C10098B,  //  0009  GETMET	R4	R4	K139
       0x5C180200,  //  000A  MOVE	R6	R1
       0x7C100400,  //  000B  CALL	R4	2
       0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100188,  //  000D  GETMBR	R4	R0	K136
+      0x88100187,  //  000D  GETMBR	R4	R0	K135
       0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C1007B2,  //  000F  GETMET	R4	R3	K178
+      0x8C1007B1,  //  000F  GETMET	R4	R3	K177
       0x7C100200,  //  0010  CALL	R4	1
       0x14100404,  //  0011  LT	R4	R2	R4
       0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C1007B3,  //  0013  GETMET	R4	R3	K179
+      0x8C1007B2,  //  0013  GETMET	R4	R3	K178
       0x5C180400,  //  0014  MOVE	R6	R2
       0x7C100400,  //  0015  CALL	R4	2
       0x70020011,  //  0016  JMP		#0029
-      0xB8123400,  //  0017  GETNGBL	R4	K26
-      0x8C1009B4,  //  0018  GETMET	R4	R4	K180
+      0xB8122E00,  //  0017  GETNGBL	R4	K23
+      0x8C1009B3,  //  0018  GETMET	R4	R4	K179
       0x5C180000,  //  0019  MOVE	R6	R0
       0x5C1C0200,  //  001A  MOVE	R7	R1
       0x5C200400,  //  001B  MOVE	R8	R2
       0x7C100800,  //  001C  CALL	R4	4
       0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x88100135,  //  001E  GETMBR	R4	R0	K53
-      0x8C10098C,  //  001F  GETMET	R4	R4	K140
+      0x88100134,  //  001E  GETMBR	R4	R0	K52
+      0x8C10098B,  //  001F  GETMET	R4	R4	K139
       0x5C180200,  //  0020  MOVE	R6	R1
       0x7C100400,  //  0021  CALL	R4	2
       0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C1007B5,  //  0023  GETMET	R4	R3	K181
-      0x88180135,  //  0024  GETMBR	R6	R0	K53
+      0x8C1007B4,  //  0023  GETMET	R4	R3	K180
+      0x88180134,  //  0024  GETMBR	R6	R0	K52
       0x94180C01,  //  0025  GETIDX	R6	R6	R1
       0x7C100400,  //  0026  CALL	R4	2
-      0x88100188,  //  0027  GETMBR	R4	R0	K136
+      0x88100187,  //  0027  GETMBR	R4	R0	K135
       0x98100203,  //  0028  SETIDX	R4	R1	R3
       0x80040600,  //  0029  RET	1	R3
     })
@@ -2811,8 +2796,8 @@ be_local_closure(class_Matter_Device_msg_received,   /* name */
     be_str_weak(msg_received),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8810015E,  //  0000  GETMBR	R4	R0	K94
-      0x8C1009B6,  //  0001  GETMET	R4	R4	K182
+      0x8810015D,  //  0000  GETMBR	R4	R0	K93
+      0x8C1009B5,  //  0001  GETMET	R4	R4	K181
       0x5C180200,  //  0002  MOVE	R6	R1
       0x5C1C0400,  //  0003  MOVE	R7	R2
       0x5C200600,  //  0004  MOVE	R8	R3
@@ -2841,8 +2826,8 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
     be_str_weak(bridge_add_endpoint),
     &be_const_str_solidified,
     ( &(const binstruction[68]) {  /* code */
-      0x880C0160,  //  0000  GETMBR	R3	R0	K96
-      0x8C0C0728,  //  0001  GETMET	R3	R3	K40
+      0x880C015F,  //  0000  GETMBR	R3	R0	K95
+      0x8C0C0727,  //  0001  GETMET	R3	R3	K39
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x4C100000,  //  0004  LDNIL	R4
@@ -2852,12 +2837,12 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
       0x60140008,  //  0008  GETGBL	R5	G8
       0x5C180200,  //  0009  MOVE	R6	R1
       0x7C140200,  //  000A  CALL	R5	1
-      0x00176E05,  //  000B  ADD	R5	K183	R5
-      0x00140BB8,  //  000C  ADD	R5	R5	K184
+      0x00176C05,  //  000B  ADD	R5	K182	R5
+      0x00140BB7,  //  000C  ADD	R5	R5	K183
       0x58180004,  //  000D  LDCONST	R6	K4
       0x7C100400,  //  000E  CALL	R4	2
       0x80000800,  //  000F  RET	0
-      0x8810011D,  //  0010  GETMBR	R4	R0	K29
+      0x8810011A,  //  0010  GETMBR	R4	R0	K26
       0x60140008,  //  0011  GETGBL	R5	G8
       0x5C180800,  //  0012  MOVE	R6	R4
       0x7C140200,  //  0013  CALL	R5	1
@@ -2872,7 +2857,7 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
       0x7C1C0400,  //  001C  CALL	R7	2
       0x601C0013,  //  001D  GETGBL	R7	G19
       0x7C1C0000,  //  001E  CALL	R7	0
-      0x981E8601,  //  001F  SETIDX	R7	K67	R1
+      0x981E8401,  //  001F  SETIDX	R7	K66	R1
       0x60200010,  //  0020  GETGBL	R8	G16
       0x8C240514,  //  0021  GETMET	R9	R2	K20
       0x7C240200,  //  0022  CALL	R9	1
@@ -2888,25 +2873,25 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
       0xB0080000,  //  002C  RAISE	2	R0	R0
       0xB8220A00,  //  002D  GETNGBL	R8	K5
       0x60240018,  //  002E  GETGBL	R9	G24
-      0x582800B9,  //  002F  LDCONST	R10	K185
+      0x582800B8,  //  002F  LDCONST	R10	K184
       0x5C2C0800,  //  0030  MOVE	R11	R4
       0x5C300200,  //  0031  MOVE	R12	R1
-      0x8C3401BA,  //  0032  GETMET	R13	R0	K186
+      0x8C3401B9,  //  0032  GETMET	R13	R0	K185
       0x5C3C0400,  //  0033  MOVE	R15	R2
       0x7C340400,  //  0034  CALL	R13	2
       0x7C240800,  //  0035  CALL	R9	4
-      0x58280018,  //  0036  LDCONST	R10	K24
+      0x5828001B,  //  0036  LDCONST	R10	K27
       0x7C200400,  //  0037  CALL	R8	2
       0x88200113,  //  0038  GETMBR	R8	R0	K19
       0x98200A07,  //  0039  SETIDX	R8	R5	R7
       0x50200200,  //  003A  LDBOOL	R8	1	0
-      0x90026808,  //  003B  SETMBR	R0	K52	R8
-      0x8820011D,  //  003C  GETMBR	R8	R0	K29
+      0x90026608,  //  003B  SETMBR	R0	K51	R8
+      0x8820011A,  //  003C  GETMBR	R8	R0	K26
       0x0020110B,  //  003D  ADD	R8	R8	K11
-      0x90023A08,  //  003E  SETMBR	R0	K29	R8
-      0x8C20013F,  //  003F  GETMET	R8	R0	K63
+      0x90023408,  //  003E  SETMBR	R0	K26	R8
+      0x8C20013E,  //  003F  GETMET	R8	R0	K62
       0x7C200200,  //  0040  CALL	R8	1
-      0x8C200190,  //  0041  GETMET	R8	R0	K144
+      0x8C20018F,  //  0041  GETMET	R8	R0	K143
       0x7C200200,  //  0042  CALL	R8	1
       0x80040800,  //  0043  RET	1	R4
     })
@@ -2939,47 +2924,47 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
       0x24080508,  //  0004  GT	R2	R2	K8
       0x780A0000,  //  0005  JMPF	R2	#0007
       0x80000400,  //  0006  RET	0
-      0x880801BB,  //  0007  GETMBR	R2	R0	K187
+      0x880801BA,  //  0007  GETMBR	R2	R0	K186
       0x4C0C0000,  //  0008  LDNIL	R3
       0x1C080403,  //  0009  EQ	R2	R2	R3
       0x780A0004,  //  000A  JMPF	R2	#0010
-      0xB80A3400,  //  000B  GETNGBL	R2	K26
-      0x8C0805BC,  //  000C  GETMET	R2	R2	K188
+      0xB80A2E00,  //  000B  GETNGBL	R2	K23
+      0x8C0805BB,  //  000C  GETMET	R2	R2	K187
       0x5C100000,  //  000D  MOVE	R4	R0
       0x7C080400,  //  000E  CALL	R2	2
-      0x90037602,  //  000F  SETMBR	R0	K187	R2
-      0x88080134,  //  0010  GETMBR	R2	R0	K52
+      0x90037402,  //  000F  SETMBR	R0	K186	R2
+      0x88080133,  //  0010  GETMBR	R2	R0	K51
       0x740A000F,  //  0011  JMPT	R2	#0022
-      0x880801BB,  //  0012  GETMBR	R2	R0	K187
-      0x8C0805BD,  //  0013  GETMET	R2	R2	K189
+      0x880801BA,  //  0012  GETMBR	R2	R0	K186
+      0x8C0805BC,  //  0013  GETMET	R2	R2	K188
       0x7C080200,  //  0014  CALL	R2	1
       0x90022602,  //  0015  SETMBR	R0	K19	R2
       0x60080013,  //  0016  GETGBL	R2	G19
       0x7C080000,  //  0017  CALL	R2	0
-      0x90026A02,  //  0018  SETMBR	R0	K53	R2
-      0x8C080132,  //  0019  GETMET	R2	R0	K50
+      0x90026802,  //  0018  SETMBR	R0	K52	R2
+      0x8C080131,  //  0019  GETMET	R2	R0	K49
       0x7C080200,  //  001A  CALL	R2	1
       0xB80A0A00,  //  001B  GETNGBL	R2	K5
       0x600C0008,  //  001C  GETGBL	R3	G8
       0x88100113,  //  001D  GETMBR	R4	R0	K19
       0x7C0C0200,  //  001E  CALL	R3	1
-      0x000F7C03,  //  001F  ADD	R3	K190	R3
+      0x000F7A03,  //  001F  ADD	R3	K189	R3
       0x58100004,  //  0020  LDCONST	R4	K4
       0x7C080400,  //  0021  CALL	R2	2
-      0x880801BB,  //  0022  GETMBR	R2	R0	K187
-      0x8C0805BF,  //  0023  GETMET	R2	R2	K191
+      0x880801BA,  //  0022  GETMBR	R2	R0	K186
+      0x8C0805BE,  //  0023  GETMET	R2	R2	K190
       0x88100113,  //  0024  GETMBR	R4	R0	K19
       0x7C080400,  //  0025  CALL	R2	2
-      0x88080134,  //  0026  GETMBR	R2	R0	K52
+      0x88080133,  //  0026  GETMBR	R2	R0	K51
       0x740A0008,  //  0027  JMPT	R2	#0031
-      0x8808015C,  //  0028  GETMBR	R2	R0	K92
-      0x8C080593,  //  0029  GETMET	R2	R2	K147
+      0x8808015B,  //  0028  GETMBR	R2	R0	K91
+      0x8C080592,  //  0029  GETMET	R2	R2	K146
       0x7C080200,  //  002A  CALL	R2	1
       0x24080508,  //  002B  GT	R2	R2	K8
       0x780A0003,  //  002C  JMPF	R2	#0031
       0x50080200,  //  002D  LDBOOL	R2	1	0
-      0x90026802,  //  002E  SETMBR	R0	K52	R2
-      0x8C08013F,  //  002F  GETMET	R2	R0	K63
+      0x90026602,  //  002E  SETMBR	R0	K51	R2
+      0x8C08013E,  //  002F  GETMET	R2	R0	K62
       0x7C080200,  //  0030  CALL	R2	1
       0x80000000,  //  0031  RET	0
     })
@@ -3005,11 +2990,11 @@ be_local_closure(class_Matter_Device_save_before_restart,   /* name */
     be_str_weak(save_before_restart),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x8804013D,  //  0000  GETMBR	R1	R0	K61
-      0x8C04034D,  //  0001  GETMET	R1	R1	K77
+      0x8804013C,  //  0000  GETMBR	R1	R0	K60
+      0x8C04034C,  //  0001  GETMET	R1	R1	K76
       0x7C040200,  //  0002  CALL	R1	1
-      0x8804013D,  //  0003  GETMBR	R1	R0	K61
-      0x8C0403C0,  //  0004  GETMET	R1	R1	K192
+      0x8804013C,  //  0003  GETMBR	R1	R0	K60
+      0x8C0403BF,  //  0004  GETMET	R1	R1	K191
       0x7C040200,  //  0005  CALL	R1	1
       0x80000000,  //  0006  RET	0
     })
@@ -3039,19 +3024,19 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
       0x1C140805,  //  0001  EQ	R5	R4	R5
       0x78160004,  //  0002  JMPF	R5	#0008
       0xB8160200,  //  0003  GETNGBL	R5	K1
-      0x8C140BC1,  //  0004  GETMET	R5	R5	K193
-      0x581C00C2,  //  0005  LDCONST	R7	K194
+      0x8C140BC0,  //  0004  GETMET	R5	R5	K192
+      0x581C00C1,  //  0005  LDCONST	R7	K193
       0x7C140400,  //  0006  CALL	R5	2
       0x80040A00,  //  0007  RET	1	R5
       0xB8160200,  //  0008  GETNGBL	R5	K1
-      0x8C140BC3,  //  0009  GETMET	R5	R5	K195
+      0x8C140BC2,  //  0009  GETMET	R5	R5	K194
       0x5C1C0800,  //  000A  MOVE	R7	R4
-      0x582000C4,  //  000B  LDCONST	R8	K196
+      0x582000C3,  //  000B  LDCONST	R8	K195
       0x7C140600,  //  000C  CALL	R5	3
       0xB81A0200,  //  000D  GETNGBL	R6	K1
-      0x8C180DC3,  //  000E  GETMET	R6	R6	K195
+      0x8C180DC2,  //  000E  GETMET	R6	R6	K194
       0x5C200800,  //  000F  MOVE	R8	R4
-      0x582400C5,  //  0010  LDCONST	R9	K197
+      0x582400C4,  //  0010  LDCONST	R9	K196
       0x7C180600,  //  0011  CALL	R6	3
       0x74160000,  //  0012  JMPT	R5	#0014
       0x781A0064,  //  0013  JMPF	R6	#0079
@@ -3063,44 +3048,44 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
       0x18241108,  //  0019  LE	R9	R8	K8
       0x78260004,  //  001A  JMPF	R9	#0020
       0xB8260200,  //  001B  GETNGBL	R9	K1
-      0x8C2413C1,  //  001C  GETMET	R9	R9	K193
-      0x582C00C6,  //  001D  LDCONST	R11	K198
+      0x8C2413C0,  //  001C  GETMET	R9	R9	K192
+      0x582C00C5,  //  001D  LDCONST	R11	K197
       0x7C240400,  //  001E  CALL	R9	2
       0x80041200,  //  001F  RET	1	R9
-      0x8C240152,  //  0020  GETMET	R9	R0	K82
+      0x8C240151,  //  0020  GETMET	R9	R0	K81
       0x5C2C1000,  //  0021  MOVE	R11	R8
       0x7C240400,  //  0022  CALL	R9	2
       0x5C1C1200,  //  0023  MOVE	R7	R9
-      0x8C240919,  //  0024  GETMET	R9	R4	K25
+      0x8C24091C,  //  0024  GETMET	R9	R4	K28
       0x5C2C0A00,  //  0025  MOVE	R11	R5
       0x7C240400,  //  0026  CALL	R9	2
       0x781A0009,  //  0027  JMPF	R6	#0032
       0x4C200000,  //  0028  LDNIL	R8
       0x1C200E08,  //  0029  EQ	R8	R7	R8
       0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C200151,  //  002B  GETMET	R8	R0	K81
+      0x8C200150,  //  002B  GETMET	R8	R0	K80
       0x94280806,  //  002C  GETIDX	R10	R4	R6
       0x7C200400,  //  002D  CALL	R8	2
       0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x8C200919,  //  002F  GETMET	R8	R4	K25
+      0x8C20091C,  //  002F  GETMET	R8	R4	K28
       0x5C280C00,  //  0030  MOVE	R10	R6
       0x7C200400,  //  0031  CALL	R8	2
       0x4C200000,  //  0032  LDNIL	R8
       0x1C200E08,  //  0033  EQ	R8	R7	R8
       0x78220004,  //  0034  JMPF	R8	#003A
       0xB8220200,  //  0035  GETNGBL	R8	K1
-      0x8C2011C1,  //  0036  GETMET	R8	R8	K193
-      0x582800C7,  //  0037  LDCONST	R10	K199
+      0x8C2011C0,  //  0036  GETMET	R8	R8	K192
+      0x582800C6,  //  0037  LDCONST	R10	K198
       0x7C200400,  //  0038  CALL	R8	2
       0x80041000,  //  0039  RET	1	R8
-      0x88200FC8,  //  003A  GETMBR	R8	R7	K200
+      0x88200FC7,  //  003A  GETMBR	R8	R7	K199
       0x74220004,  //  003B  JMPT	R8	#0041
       0xB8220200,  //  003C  GETNGBL	R8	K1
-      0x8C2011C1,  //  003D  GETMET	R8	R8	K193
-      0x582800C9,  //  003E  LDCONST	R10	K201
+      0x8C2011C0,  //  003D  GETMET	R8	R8	K192
+      0x582800C8,  //  003E  LDCONST	R10	K200
       0x7C200400,  //  003F  CALL	R8	2
       0x80041000,  //  0040  RET	1	R8
-      0x8C200FCA,  //  0041  GETMET	R8	R7	K202
+      0x8C200FC9,  //  0041  GETMET	R8	R7	K201
       0x7C200200,  //  0042  CALL	R8	1
       0x60240013,  //  0043  GETGBL	R9	G19
       0x7C240000,  //  0044  CALL	R9	0
@@ -3112,7 +3097,7 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
       0x5C2C1400,  //  004A  MOVE	R11	R10
       0x7C2C0000,  //  004B  CALL	R11	0
       0xB8320200,  //  004C  GETNGBL	R12	K1
-      0x8C3019CB,  //  004D  GETMET	R12	R12	K203
+      0x8C3019CA,  //  004D  GETMET	R12	R12	K202
       0x5C381000,  //  004E  MOVE	R14	R8
       0x5C3C1600,  //  004F  MOVE	R15	R11
       0x7C300600,  //  0050  CALL	R12	3
@@ -3120,9 +3105,9 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
       0x1C34180D,  //  0052  EQ	R13	R12	R13
       0x78360008,  //  0053  JMPF	R13	#005D
       0xB8360200,  //  0054  GETNGBL	R13	K1
-      0x8C341BC1,  //  0055  GETMET	R13	R13	K193
+      0x8C341BC0,  //  0055  GETMET	R13	R13	K192
       0x603C0018,  //  0056  GETGBL	R15	G24
-      0x584000CC,  //  0057  LDCONST	R16	K204
+      0x584000CB,  //  0057  LDCONST	R16	K203
       0x5C441600,  //  0058  MOVE	R17	R11
       0x7C3C0400,  //  0059  CALL	R15	2
       0x7C340400,  //  005A  CALL	R13	2
@@ -3135,30 +3120,30 @@ be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
       0x58280016,  //  0061  LDCONST	R10	K22
       0xAC280200,  //  0062  CATCH	R10	1	0
       0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x8C280FCD,  //  0064  GETMET	R10	R7	K205
+      0x8C280FCC,  //  0064  GETMET	R10	R7	K204
       0x5C301200,  //  0065  MOVE	R12	R9
       0x7C280400,  //  0066  CALL	R10	2
-      0x8C280F53,  //  0067  GETMET	R10	R7	K83
+      0x8C280F52,  //  0067  GETMET	R10	R7	K82
       0x7C280200,  //  0068  CALL	R10	1
       0x782A000A,  //  0069  JMPF	R10	#0075
       0x602C0018,  //  006A  GETGBL	R11	G24
-      0x583000CE,  //  006B  LDCONST	R12	K206
+      0x583000CD,  //  006B  LDCONST	R12	K205
       0x5C340200,  //  006C  MOVE	R13	R1
       0x5C381400,  //  006D  MOVE	R14	R10
       0x7C2C0600,  //  006E  CALL	R11	3
       0xB8320200,  //  006F  GETNGBL	R12	K1
-      0x8C3019CF,  //  0070  GETMET	R12	R12	K207
+      0x8C3019CE,  //  0070  GETMET	R12	R12	K206
       0x5C381600,  //  0071  MOVE	R14	R11
       0x7C300400,  //  0072  CALL	R12	2
       0x80041800,  //  0073  RET	1	R12
       0x70020003,  //  0074  JMP		#0079
       0xB82E0200,  //  0075  GETNGBL	R11	K1
-      0x8C2C174E,  //  0076  GETMET	R11	R11	K78
+      0x8C2C174D,  //  0076  GETMET	R11	R11	K77
       0x7C2C0200,  //  0077  CALL	R11	1
       0x80041600,  //  0078  RET	1	R11
       0xB81E0200,  //  0079  GETNGBL	R7	K1
-      0x8C1C0FC1,  //  007A  GETMET	R7	R7	K193
-      0x582400D0,  //  007B  LDCONST	R9	K208
+      0x8C1C0FC0,  //  007A  GETMET	R7	R7	K192
+      0x582400CF,  //  007B  LDCONST	R9	K207
       0x7C1C0400,  //  007C  CALL	R7	2
       0x80000000,  //  007D  RET	0
     })
@@ -3184,10 +3169,10 @@ be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
     be_str_weak(create_zb_mapper),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x880801A2,  //  0000  GETMBR	R2	R0	K162
+      0x880801A1,  //  0000  GETMBR	R2	R0	K161
       0x780A0004,  //  0001  JMPF	R2	#0007
-      0x880801A2,  //  0002  GETMBR	R2	R0	K162
-      0x8C0805D1,  //  0003  GETMET	R2	R2	K209
+      0x880801A1,  //  0002  GETMBR	R2	R0	K161
+      0x8C0805D0,  //  0003  GETMET	R2	R2	K208
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x80040400,  //  0006  RET	1	R2
@@ -3215,10 +3200,10 @@ be_local_closure(class_Matter_Device_init_zigbee,   /* name */
     be_str_weak(init_zigbee),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C0401D2,  //  0000  GETMET	R1	R0	K210
+      0x8C0401D1,  //  0000  GETMET	R1	R0	K209
       0x7C040200,  //  0001  CALL	R1	1
       0x78060004,  //  0002  JMPF	R1	#0008
-      0xA4068E00,  //  0003  IMPORT	R1	K71
+      0xA4068C00,  //  0003  IMPORT	R1	K70
       0x5C080200,  //  0004  MOVE	R2	R1
       0x5C0C0000,  //  0005  MOVE	R3	R0
       0x7C080200,  //  0006  CALL	R2	1
@@ -3255,8 +3240,8 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
       0x24080401,  //  0005  GT	R2	R2	R1
       0x780A0005,  //  0006  JMPF	R2	#000D
       0x90021A01,  //  0007  SETMBR	R0	K13	R1
-      0xB80A3400,  //  0008  GETNGBL	R2	K26
-      0x8C0805D3,  //  0009  GETMET	R2	R2	K211
+      0xB80A2E00,  //  0008  GETNGBL	R2	K23
+      0x8C0805D2,  //  0009  GETMET	R2	R2	K210
       0x5C100200,  //  000A  MOVE	R4	R1
       0x7C080400,  //  000B  CALL	R2	2
       0x90021C02,  //  000C  SETMBR	R0	K14	R2


### PR DESCRIPTION
## Description:

Matter prepare for ICD Cluster (Intermittently Connected Device) which could be useful for devices in deepsleep. However preliminary tests with Apple Home does not seem to give any different result than without ICD.

Hence the feature is commented out for now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
