### PR TITLE
check compiled esp32x firmware real size against partition size

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -26,7 +26,7 @@ platform = env.PioPlatform()
 from genericpath import exists
 import os
 import sys
-from os.path import join
+from os.path import join, getsize
 import csv
 import requests
 import shutil
@@ -272,6 +272,13 @@ def esp32_create_combined_bin(source, target, env):
             "--flash_size",
             flash_size,
         ]
+        # platformio estimates the flash space used to store the firmware.
+        # the estimation is inaccurate. perform a final check on the firmware
+        # size by comparing it against the partition size.
+        max_size = env.BoardConfig().get("upload.maximum_size", 1)
+        fw_size = getsize(firmware_name)
+        if (fw_size > max_size):
+            raise Exception(Fore.RED + "firmware binary too large: %d > %d" % (fw_size, max_size))
 
         print("    Offset | File")
         for section in sections:


### PR DESCRIPTION
## Description:

Platformio estimates the flash space used to store the firmware. The estimation is inaccurate. Perform a final check on the firmware size by comparing it against the partition size.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
