### PR TITLE
Berry 're.dump()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Support Vango Technologies V924x ultralow power, single-phase, power measurement (#23127)
 - Support for HLK-LD2402 24GHz smart wave motion sensor (#23133)
 - Matter prepare for ICD cluster (#23158)
+- Berry `re.dump()`
 
 ### Breaking Changed
 - Berry remove `Leds.create_matrix` from the standard library waiting for reimplementation (#23114)

--- a/lib/libesp32/berry/default/be_re_lib.c
+++ b/lib/libesp32/berry/default/be_re_lib.c
@@ -231,6 +231,21 @@ int be_re_search_all(bvm *vm) {
   return be_re_match_search_all(vm, bfalse);
 }
 
+// Berry: `re.dump(b:bytes) -> nil``
+int be_re_dump(bvm *vm) {
+#ifdef USE_BERRY_DEBUG
+  int32_t argc = be_top(vm); // Get the number of arguments
+  if (argc >= 1 && be_isbytes(vm, 1)) {
+    ByteProg *code = (ByteProg*) be_tobytes(vm, 1, NULL);
+    re1_5_dumpcode(code);
+    be_return_nil(vm);
+  }
+  be_raise(vm, "type_error", NULL);
+#else // USE_BERRY_DEBUG
+  be_return_nil(vm);
+#endif
+}
+
 // Berry: `re_pattern.search(s:string [, offset:int]) -> list(string)`
 int re_pattern_search(bvm *vm) {
   int32_t argc = be_top(vm); // Get the number of arguments
@@ -415,6 +430,7 @@ module re (scope: global) {
   match2, func(be_re_match2)
   matchall, func(be_re_match_all)
   split, func(be_re_split)
+  dump, func(be_re_dump)
 }
 @const_object_info_end 
 

--- a/lib/libesp32/re1.5/dumpcode.c
+++ b/lib/libesp32/re1.5/dumpcode.c
@@ -4,62 +4,82 @@
 
 #include "re1.5.h"
 
+// TASMOTA SPECIFIC
+#ifndef INST_BUF_SIZE
+#define INST_BUF_SIZE   96
+#endif
+
+void be_writebuffer(const char *buffer, size_t length);
+
+#define be_writestring(s)       be_writebuffer((s), strlen(s))
+
+#define logbuf(...)     snprintf(__lbuf, sizeof(__lbuf), __VA_ARGS__)
+
+#define logfmt(...)                     \
+    do {                                \
+        char __lbuf[INST_BUF_SIZE];     \
+        logbuf(__VA_ARGS__);            \
+        be_writestring(__lbuf);         \
+    } while (0)
+
+// all `printf` replaced with `logfmt`
+
 void re1_5_dumpcode(ByteProg *prog)
 {
     int pc = 0;
     char *code = prog->insts;
     while (pc < prog->bytelen) {
-                printf("%2d: ", pc);
+                logfmt("%2d: ", pc);
                 switch(code[pc++]) {
                 default:
                         assert(0);
 //                        re1_5_fatal("printprog");
                 case Split:
-                        printf("split %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
+                        logfmt("split %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
                         pc++;
                         break;
                 case RSplit:
-                        printf("rsplit %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
+                        logfmt("rsplit %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
                         pc++;
                         break;
                 case Jmp:
-                        printf("jmp %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
+                        logfmt("jmp %d (%d)\n", pc + (signed char)code[pc] + 1, (signed char)code[pc]);
                         pc++;
                         break;
                 case Char:
-                        printf("char %c\n", code[pc++]);
+                        logfmt("char %c\n", code[pc++]);
                         break;
                 case Any:
-                        printf("any\n");
+                        logfmt("any\n");
                         break;
                 case Class:
                 case ClassNot: {
                         int num = code[pc];
-                        printf("class%s %d", (code[pc - 1] == ClassNot ? "not" : ""), num);
+                        logfmt("class%s %d", (code[pc - 1] == ClassNot ? "not" : ""), num);
                         pc++;
                         while (num--) {
-                            printf(" 0x%02x-0x%02x", code[pc], code[pc + 1]);
+                            logfmt(" 0x%02x-0x%02x", code[pc], code[pc + 1]);
                             pc += 2;
                         }
-                        printf("\n");
+                        logfmt("\n");
                         break;
                 }
                 case NamedClass:
-                        printf("namedclass %c\n", code[pc++]);
+                        logfmt("namedclass %c\n", code[pc++]);
                         break;
                 case Match:
-                        printf("match\n");
+                        logfmt("match\n");
                         break;
                 case Save:
-                        printf("save %d\n", (unsigned char)code[pc++]);
+                        logfmt("save %d\n", (unsigned char)code[pc++]);
                         break;
                 case Bol:
-                        printf("assert bol\n");
+                        logfmt("assert bol\n");
                         break;
                 case Eol:
-                        printf("assert eol\n");
+                        logfmt("assert eol\n");
                         break;
                 }
     }
-    printf("Bytes: %d, insts: %d\n", prog->bytelen, prog->len);
+    logfmt("Bytes: %d, insts: %d\n", prog->bytelen, prog->len);
 }


### PR DESCRIPTION
## Description:

Berry added `re.dump(pattern_compiled:bytes) -> nil`, print a dump of the compiled pattern into the state-machine used by regex engine. This is only available if compiled with `#define USE_BERRY_DEBUG`

Example:
```berry
> import re
> var rb = re.compilebytes("a.*?b(z+)")
> print(rb)
bytes('1B0000000F0000000100000062030260FB7E00016162030260FB01627E02017A...')

> re.dump(rb)
 0: rsplit 5 (3)
 2: any
 3: jmp 0 (-5)
 5: save 0
 7: char a
 9: rsplit 14 (3)
11: any
12: jmp 9 (-5)
14: char b
16: save 2
18: char z
20: rsplit 18 (-4)
22: save 3
24: save 1
26: match
Bytes: 27, insts: 15
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
