### PR TITLE
fix wrong comment in xdrv_79_esp32_ble.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -2711,10 +2711,10 @@ void CmndBLEAddrFilter(void){
 
 //////////////////////////////////////////////////////////////
 // Scan options
-// BLEScan0 -> do a scan now if BLEMode == BLEModeScanByCommand
-// BLEScan0 <timesec> -> do a scan now if BLEMode == BLEModeScanByCommand for timesec seconds
-// BLEScan1 0 -> Scans are passive
-// BLEScan1 1 -> Scans are active
+// BLEScan0 0 -> Scans are passive
+// BLEScan0 1 -> Scans are active
+// BLEScan1 -> do a scan now if BLEMode == BLEModeScanByCommand
+// BLEScan1 <timesec> -> do a scan now if BLEMode == BLEModeScanByCommand for timesec seconds
 // more options could be added...
 void CmndBLEScan(void){
   switch(XdrvMailbox.index){


### PR DESCRIPTION
## Description:

The comment was opposite to all other documentation and actual functionality

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
