### PR TITLE
remove malformed clutter from webcam status0 JSON response

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -1577,6 +1577,7 @@ bool Xdrv81(uint32_t function) {
       WcUpdateStats();
     case FUNC_JSON_APPEND:
       WcSensorStats();
+      break;
     case FUNC_WEB_SENSOR:
       WcStatsShow();
       break;


### PR DESCRIPTION
A regression was added in commit 01154e949, which prepends clutter to the status0 JSON status message.

Example:
```
$ curl 'http://webcam/cm?cmnd=Status0' -u admin:password
{s}Webcam Frame rate{m}0 FPS{e}{"Status":{"Module":0,"DeviceName":"... (edited for brevity)
```

The response is not properly formatted JSON and breaks client software.

The problem occurs because a new case statement was added for the purpose of injecting webcam stats into the JSON status message, but a break statement is missing and execution falls through to the following case, which prepends garbage to the output buffer.

With this one-line fix in place, the output is properly formatted:
```
$ curl 'http://webcam/cm?cmnd=Status0' -u admin:password
{"Status":{"Module":0,"DeviceName":"... (edited for brevity)
```

Note that the prior case for FUNC_EVERY_SECOND is also missing a break statement. That looks wrong to me but it's unrelated to fixing this issue and I'm inclined to punt that concern to others who are more familiar with this code.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
