### PR TITLE
Use normal gamma table for fading

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2047,14 +2047,14 @@ int32_t ChannelWhite_when_PWMCT(void) {
 // Calculate the Gamma correction, if any, for fading, using the fast Gamma curve (10 bits in+out)
 uint16_t fadeGamma(uint32_t channel, uint16_t v) {
   if (isChannelGammaCorrected(channel)) {
-    return ledGammaFast(v);
+    return ledGamma10_10(v);
   } else {
     return v;
   }
 }
 uint16_t fadeGammaReverse(uint32_t channel, uint16_t vg) {
   if (isChannelGammaCorrected(channel)) {
-    return leddGammaReverseFast(vg);
+    return ledGammaReverse(vg);
   } else {
     return vg;
   }


### PR DESCRIPTION
## Description:

Fading uses a modified gamma table that results in much higher values for low brightnesses.
According to @s-hadinger on Discord this was done to improve the appearance of turning on lights so that they do not take too long.
Im a not sure why that would be needed.
If I want my lights to be at the specified brightness faster I reduce "speed" 

More importantly, the existing code breaks (or hinders) DIMMER ! since it calculates wrong dimming values when stopping the fade. However this can be fixed separately. (https://github.com/arendst/Tasmota/pull/23196)

I also have a feeling this is why I could never get multiple DIMMER + look smooth for the lower half of the Brightness %.

Question is, if this should maybe be implemented as a "setoption"?

I am still trying to wrap my head around the visual implications of the current behavior.

I think it means that if doing (DIMMER=DIMMER+1) from 1 to 50 looks visually linear
Fading from 1 to 50 in the same amount of time looks different. And that is not what is intended is it?

I think I noticed that.

So I guess we are back to square one. Why was this needed in the first place?



## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
