### PR TITLE
fix DIMMER ! to use correct dim value

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2060,11 +2060,19 @@ uint16_t fadeGammaReverse(uint32_t channel, uint16_t vg) {
   }
 }
 
+uint16_t fadeEndGammaReverse(uint32_t channel, uint16_t vg) {
+  if (isChannelGammaCorrected(channel)) {
+    return ledGammaReverse(vg);
+  } else {
+    return vg;
+  }
+}
+
 uint8_t LightGetCurFadeBri(void) {
   uint8_t max_bri = 0;
   uint8_t bri_i = 0;
   for (uint8_t i = 0; i < LST_MAX; i++) {
-    bri_i = changeUIntScale(fadeGammaReverse(i, Light.fade_cur_10[i]), 4, 1023, 1, 100);
+    bri_i = changeUIntScale(fadeEndGammaReverse(i, Light.fade_cur_10[i]), 4, 1023, 1, 100);
     if (bri_i > max_bri) max_bri = bri_i ;
   }
   return max_bri;


### PR DESCRIPTION
## Description:

if https://github.com/arendst/Tasmota/pull/23195 is not implemented (or via setoption) this is necessary.

Otherwise DIMMER ! will stop on a wrong value.

Example:
Dimming from 0 to 100 is stopped via DIMMER !
The internal value is 100 (1 to 1023)
This is converted by this Method to a dim % of 20% using the fast gamma table.
In the real gamma table 100 corresponds to about 50%
Now DIMMER 20 is executed to get the state correct but that now changes the brightness to a much lower value.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
