### PR TITLE
fixes for ina226 driver

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_54_ina226.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_54_ina226.ino
@@ -78,7 +78,11 @@
 
 #define INA226_REG_CONFIG                       (0x00)    // Config register
 #define INA226_RES_CONFIG                       (0x4127)  // Config register at reset
-#define INA226_DEF_CONFIG                       (0x42FF)  // Our default configuration
+// 0x4B27 = 0100 101 (256 - averages) 100 (1.1 ms - vbusct) 100 (1.1 ms - vshct) 111 (continuous - mode)
+// driver will sample 256 * (1.1 ms + 1.1 ms) = 563.2 ms of data per second
+#ifndef INA226_DEF_CONFIG
+#define INA226_DEF_CONFIG                       (0x4B27)  // Our default configuration
+#endif
 #define INA226_CONFIG_RESET                     (0x8000)  // Config register reset bit
 
 #define INA226_REG_SHUNTVOLTAGE                 (0x01)
@@ -460,7 +464,7 @@ bool Ina226CommandSensor()
     // Full scale vbus is volatile (saved in RAM)
     dtostrfd((Ina226Info[device].vbus_lsb*32768.0), 2, fs_vbus_str);
     // Send json response
-    Response_P(PSTR("{\"Sensor54-device-settings-%d\":{\"SHUNT_R\":%s,\"FS_I\":%s\"FS_V\":%s}}"),
+    Response_P(PSTR("{\"Sensor54-device-settings-%d\":{\"SHUNT_R\":%s,\"FS_I\":%s,\"FS_V\":%s}}"),
       device + 1, shunt_r_str, fs_i_str, fs_vbus_str);
   }
 


### PR DESCRIPTION
## Description:

adjust current/voltage timing to be consistent
fix missing comma in json display

I discuss the timing issue in [discussion](https://github.com/arendst/Tasmota/discussions/23189). The short version is that the current INA226 config has the driver getting only the last 2.352 ms of voltage and 32.976 ms of current data for every second. The time spans don't match and most of the data from the last second is ignored.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
