### PR TITLE
Berry avoid bootloop when Berry is disabled

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -906,6 +906,7 @@ extern "C" bbool BerryBECLoader(const char * url) {
 bool Xdrv52(uint32_t function)
 {
   bool result = false;
+  if (berry.vm == NULL) { return result; }
 
   switch (function) {
     case FUNC_SLEEP_LOOP:
@@ -1029,7 +1030,7 @@ bool Xdrv52(uint32_t function)
     case FUNC_WEB_ADD_CONSOLE_BUTTON:
       if (XdrvMailbox.index) {
         XdrvMailbox.index++;
-      } else if (berry.vm != NULL) {
+      } else {
         WSContentSend_P(HTTP_BTN_BERRY_CONSOLE);
         HandleBerryBECLoaderButton();               // display buttons to load BEC files
         callBerryEventDispatcher(PSTR("web_add_button"), nullptr, 0, nullptr);


### PR DESCRIPTION
## Description:

Fix bug introduced in #23181 that would cause an infinite bootloop when Berry is disabled because of a first bootloop.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
