### PR TITLE
Smoothen light gamma curve when using `Fade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Output of commands `GPIO` and `GPIOs` swapped
+- Smoothen light gamma curve when using `Fade`
 
 ### Fixed
 - INA226 driver fixes (#23197)

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
@@ -59,9 +59,13 @@ const gamma_table_t gamma_table[] = {   // don't put in PROGMEM for performance 
 
 // simplified Gamma table for Fade, cheating a little at low brightness
 const gamma_table_t gamma_table_fast[] = {
-  {   384,    192 },
-  {   768,    576 },
-  {  1023,   1023 },
+  {    1,      1 },
+  {  312,     58 },
+  {  457,    106 },
+  {  626,    261 },
+  {  762,    450 },
+  {  895,    703 },
+  { 1023,   1023 },
   { 0xFFFF, 0xFFFF }          // fail-safe if out of range
 };
 


### PR DESCRIPTION
## Description:

The Gamma curve used by Tasmota is much steeper when using `Fade` animations, due to a bug fixed in #23194

The new Gamma curve is smoothen and closer to the original Gamma curve, except for low brightness, to avoid the impression of freezing at low brightness.

This PR supersedes #23195

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
