### PR TITLE
fix(zigbee): fix `convertTuyaSpecificCluster` datapoint parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ lib/libesp32/berry/berry
 *.bak
 *.code-workspace
 
+## IntelliJ ######
+.idea
+
 ## Python virtual environments for Platformio ##
 venv
 .venv


### PR DESCRIPTION
Add support for multiple tuya data points in the same payload.

## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/23241

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] ~The code change is tested and works with Tasmota core ESP8266 V.2.7.8~ -> does not apply, only zigbee is impacted
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
