### PR TITLE
TLS increase timeout and fix crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - INA226 driver fixes (#23197)
+- TLS increase timeout and fix crash
 
 ### Removed
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -303,7 +303,9 @@ int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port, int32_t timeout
     setLastError(ERR_TCP_CONNECT);
     return 0;
   }
-  return _connectSSL(_domain.isEmpty() ? nullptr : _domain.c_str());
+  bool success = _connectSSL(_domain.isEmpty() ? nullptr : _domain.c_str());
+  if (!success) { stop(); }
+  return success;
 }
 #else // ESP32
 int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port) {
@@ -313,7 +315,9 @@ int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port) {
     setLastError(ERR_TCP_CONNECT);
     return 0;
   }
-  return _connectSSL(_domain.isEmpty() ? nullptr : _domain.c_str());
+  bool success = _connectSSL(_domain.isEmpty() ? nullptr : _domain.c_str());
+  if (!success) { stop(); }
+  return success;
 }
 #endif
 
@@ -570,6 +574,7 @@ int WiFiClientSecure_light::_run_until(unsigned target, bool blocking) {
     
     if (((int32_t)(millis() - (t + this->_loopTimeout)) >= 0)){
       DEBUG_BSSL("_run_until: Timeout\n");
+      setLastError(ERR_TLS_TIMEOUT);
       return -1;
     }
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -137,7 +137,7 @@ class WiFiClientSecure_light : public WiFiClient {
     }
 
   private:
-    uint32_t _loopTimeout=5000;
+    uint32_t _loopTimeout=10000;
     void _clear();
     bool _ctx_present;
     std::shared_ptr<br_ssl_client_context> _sc;
@@ -192,7 +192,8 @@ class WiFiClientSecure_light : public WiFiClient {
 #define ERR_CANT_RESOLVE_IP -1001
 #define ERR_TCP_CONNECT     -1002
 // #define ERR_MISSING_EC_KEY  -1003   // deprecated, AWS IoT is not called if the private key is not present
-#define ERR_MISSING_CA      -1004
+// #define ERR_MISSING_CA      -1004   // deprecated
+#define ERR_TLS_TIMEOUT     -1005
 
 // For reference, BearSSL error codes:
 // #define BR_ERR_OK                      0


### PR DESCRIPTION
## Description:

Fix TLS issue with HiveMQ:
- increase time-out for handshake from 5s to 10s
- avoid crash when timeout occurs
- add new error code `-1005` to indicate a timeout

**Related issue (if applicable):** fixes #23217

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
