### PR TITLE
Fix esp_idf_http to make strings 'weak'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Extend command `GPIO` with different display options and allowing updating of module GPIO's in one go
 - Berry `bytes.add()` now accepts 3-bytes values (#23200)
+- Berry expose `esp_http_server` for websockets
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_httpserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_httpserver_lib.c
@@ -828,7 +828,7 @@ bool httpserver_has_queue() {
 }
 
 /* @const_object_info_begin
-module httpserver (scope: global) {
+module httpserver (scope: global, strings: weak) {
     start, func(w_httpserver_start)
     on, func(w_httpserver_on)
     send, func(w_httpserver_send)

--- a/lib/libesp32/berry_tasmota/src/be_webfiles_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webfiles_lib.c
@@ -374,7 +374,7 @@ static int w_webfiles_serve_file(bvm *vm) {
 
 // Module definition
 /* @const_object_info_begin
-module webfiles (scope: global) {
+module webfiles (scope: global, strings: weak) {
     serve, func(w_webfiles_serve)
     serve_file, func(w_webfiles_serve_file)
     

--- a/lib/libesp32/berry_tasmota/src/be_wsserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_wsserver_lib.c
@@ -1299,7 +1299,7 @@ esp_err_t websocket_disconnect_handler(httpd_handle_t hd, int sockfd) {
 
 // Module definition
 /* @const_object_info_begin
-module wsserver (scope: global) {
+module wsserver (scope: global, strings: weak) {
     CONNECT, int(WSSERVER_EVENT_CONNECT)
     DISCONNECT, int(WSSERVER_EVENT_DISCONNECT)
     MESSAGE, int(WSSERVER_EVENT_MESSAGE)


### PR DESCRIPTION
## Description:

Fixes #23206:
- make berry strings as `weak` so they don't take Flash space when the feature is not enabled (avoids 500 bytes to be consumed for nothing)
- add Changelog

**Related issue (if applicable):** fixes #23206

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
