### PR TITLE
Sml update

### DIFF
--- a/lib/lib_div/ams/han_Parser.h
+++ b/lib/lib_div/ams/han_Parser.h
@@ -6,7 +6,7 @@
 #include "DataParsers.h"
 #include "DataParser.h"
 #include "Cosem.h"
-#include "ntohll.h"
+#include "ntohll_ams.h"
 
 #define BUF_SIZE_HAN (1280)
 

--- a/lib/lib_div/ams/ntohll_ams.cpp
+++ b/lib/lib_div/ams/ntohll_ams.cpp
@@ -1,5 +1,5 @@
-#include "ntohll.h"
+#include "ntohll_ams.h"
 
-uint64_t ntohll(uint64_t x) {
+uint64_t ntohll_ams(uint64_t x) {
     return (((uint64_t)ntohl((uint32_t)x)) << 32) + ntohl(x >> 32);
 }

--- a/lib/lib_div/ams/ntohll_ams.h
+++ b/lib/lib_div/ams/ntohll_ams.h
@@ -3,6 +3,6 @@
 
 #include "lwip/def.h"
 
-uint64_t ntohll(uint64_t x);
+uint64_t ntohll_ams(uint64_t x);
 
 #endif


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #23266

rename nthll (64 bit version)
compile SML_CRC always on ESP32


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
