### PR TITLE
Mitsubishi electric HVAC set temp should be reported as a float

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
@@ -899,7 +899,7 @@ miel_hvac_cmnd_settemp(void)
 		update->temp05 = miel_hvac_deg2temp(degc);
 	}
 
-	ResponseCmndNumber(degc);
+	ResponseCmndFloat(degc);
 }
 
 static void


### PR DESCRIPTION
## Description:

There's a description of the issue in the commit message, but the heart of it is that the set temp for mitsubishi electric HVAC systems is often a float, but is always reported on the RESULT topic as an int. I have not yet had a chance to try this on an ESP8266, and I do not have an ESP32 to try it with.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
