### PR TITLE
Update uDisplay.h with pink not being same as magenta

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -97,7 +97,7 @@ enum uColorType { uCOLOR_BW, uCOLOR_COLOR };
 #define UDISP_WHITE       0xFFFF      /* 255, 255, 255 */
 #define UDISP_ORANGE      0xFD20      /* 255, 165,   0 */
 #define UDISP_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
-#define UDISP_PINK        0xF81F
+#define UDISP_PINK        0xFc18      /* 255, 128, 192 */
 
 #ifdef ESP8266
 #define PIN_OUT_SET 0x60000304


### PR DESCRIPTION
RGB565 value for pink was same as magenta. This is obviously wrong, hence correcting to the "pink" value from the docs.

While I'm far from certain about the "right" shading of color nuances, the correction does look "reasonably pink" in my eyes (on a ST7789), and assuming that the value from the docs was sourced from something relevant to the small displays used with Tasmota, I consider the change to be at least a move in the right direction.

Still, the corrected value (FF80C0 in RGB888) does have the name "tea rose" when using HTML color codes as a reference, but "some people" may have more interest in long discussions like what pink "really" is.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
