### PR TITLE
NimBLE: remove Bluedroid reference to Arduino core

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
@@ -50,10 +50,6 @@
 #  include "nimble/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h"
 #endif
 
-#if defined(ESP_PLATFORM) && defined(CONFIG_ENABLE_ARDUINO_DEPENDS)
-#  include "esp32-hal-bt.h"
-#endif
-
 #include "NimBLELog.h"
 
 static const char* LOG_TAG = "NimBLEDevice";
@@ -867,11 +863,6 @@ void NimBLEDevice::init(const std::string &deviceName) {
         int rc=0;
 #ifdef ESP_PLATFORM
         esp_err_t errRc = ESP_OK;
-
-#ifdef CONFIG_ENABLE_ARDUINO_DEPENDS
-        // make sure the linker includes esp32-hal-bt.c so Arduino init doesn't release BLE memory.
-        btStarted();
-#endif
 
         errRc = nvs_flash_init();
 


### PR DESCRIPTION
## Description:

fix compile error with upcoming new Arduino core. Fix is backward compatible

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
