### PR TITLE
Berry 'readline' when a line is exactly 98 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - INA226 driver fixes (#23197)
 - TLS increase timeout and fix crash (#23249)
+- Berry `readline` when a line is exactly 98 characters
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -315,11 +315,11 @@ char* be_fgets(void *hfile, void *buffer, int size)
     uint8_t * buf = (uint8_t*) buffer;
     if (hfile != nullptr && buffer != nullptr && size > 0) {
         File * f_ptr = (File*) hfile;
-        int ret = f_ptr->readBytesUntil('\n', buf, size - 2);
-        // Serial.printf("be_fgets ret=%d\n", ret);
+        int ret = f_ptr->readBytesUntil('\n', buf, size - 1);
+        // Serial.printf("be_fgets size=%d ret=%d\n", size, ret);
         if (ret >= 0) {
             buf[ret] = 0;           // add string terminator
-            if (ret > 0 && ret < size - 2) {
+            if (ret < size - 1) {
                 buf[ret] = '\n';
                 buf[ret+1] = 0;
             }

--- a/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
+++ b/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
@@ -2970,7 +2970,8 @@ class HASPmota
     while f.tell() < f.size()                 # while we're not at the end of the file
       var line = f.readline()
 
-      if (size(line) == 0) || (line[0] == '#')    # skip empty lines and lines starting with '#'
+      # if size is '1', the line is considered as empty because it's a '\n' character
+      if (size(line) <= 1) || (line[0] == '#')    # skip empty lines and lines starting with '#'
         continue
       end
 

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -11947,7 +11947,7 @@ be_local_class(lvh_page,
     be_str_weak(lvh_page)
 );
 extern const bclass be_class_HASPmota;
-// compact class 'HASPmota' ktab size: 124, total: 197 (saved 584 bytes)
+// compact class 'HASPmota' ktab size: 124, total: 198 (saved 592 bytes)
 static const bvalue be_ktab_class_HASPmota[124] = {
   /* K0   */  be_nested_str_weak(global),
   /* K1   */  be_nested_str_weak(introspect),
@@ -12667,7 +12667,7 @@ be_local_closure(class_HASPmota__load,   /* name */
       0x6018000C,  //  000D  GETGBL	R6	G12
       0x5C1C0A00,  //  000E  MOVE	R7	R5
       0x7C180200,  //  000F  CALL	R6	1
-      0x1C180D06,  //  0010  EQ	R6	R6	K6
+      0x18180D20,  //  0010  LE	R6	R6	K32
       0x741A0002,  //  0011  JMPT	R6	#0015
       0x94180B06,  //  0012  GETIDX	R6	R5	K6
       0x1C180D39,  //  0013  EQ	R6	R6	K57


### PR DESCRIPTION
## Description:

Berry, fix a bug that would miss the end of line when using `file.readline()` if a line was exactly 98 bytes.

Fixed HASPmota as well, because now `readline()` return `"\n"` when reading an empty line (before is returned an empty string).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250302
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
