### PR TITLE
Show network interface priority in 'Status 5' debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - AlpineJS 2.8.2 - optional for now (#23259)
 - Support for XMODEM over serial and telnet if enabled with `#define USE_XYZMODEM`
 - PZEM_AC device address in JSON and GUI (#23268)
+- Show network interface priority in `Status 5` debug logging
 
 ### Breaking Changed
 - HASPmota added `y2_min` and `y2_max` to control the second series of `chart` (#23287)

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -648,15 +648,18 @@ String DNSGetIPStr(uint32_t idx)
 
 //
 #include "lwip/dns.h"
+#include "esp_netif_net_stack.h"
 void WifiDumpAddressesIPv6(void)
 {
   for (netif* intf = netif_list; intf != nullptr; intf = intf->next) {
-    if (!ip_addr_isany_val(intf->ip_addr)) AddLog(LOG_LEVEL_DEBUG, "WIF: '%c%c%i' IPv4 %s", intf->name[0], intf->name[1], intf->num, IPAddress(&intf->ip_addr).toString(true).c_str());
+    esp_netif_t *esp_netif = esp_netif_get_handle_from_netif_impl(intf);
+    int32_t route_prio = esp_netif ? esp_netif_get_route_prio(esp_netif) : -1;
+    if (!ip_addr_isany_val(intf->ip_addr)) AddLog(LOG_LEVEL_DEBUG, "WIF: '%c%c%i' IPv4 %s (%i)", intf->name[0], intf->name[1], intf->num, IPAddress(&intf->ip_addr).toString(true).c_str(), route_prio);
     for (uint32_t i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
       if (!ip_addr_isany_val(intf->ip6_addr[i]))
-        AddLog(LOG_LEVEL_DEBUG, "IP : '%c%c%i' IPv6 %s %s", intf->name[0], intf->name[1], intf->num,
+        AddLog(LOG_LEVEL_DEBUG, "IP : '%c%c%i' IPv6 %s %s (%i)", intf->name[0], intf->name[1], intf->num,
                                 IPAddress(&intf->ip6_addr[i]).toString(true).c_str(),
-                                ip_addr_islinklocal(&intf->ip6_addr[i]) ? "local" : "");
+                                ip_addr_islinklocal(&intf->ip6_addr[i]) ? "local" : "", route_prio);
     }
   }
   AddLog(LOG_LEVEL_DEBUG, "IP : DNS: %s %s", IPAddress(dns_getserver(0)).toString().c_str(),  IPAddress(dns_getserver(1)).toString(true).c_str());


### PR DESCRIPTION
## Description:

When debug logging (level 3) is enabled, `Status 5` now shows priority of each network interface:

```
12:22:47.047 WIF: 'st2' IPv4 192.168.2.138 (100)
12:22:47.048 IP : 'st2' IPv6 fe80::96b9:7eff:fe8b:e030%st2 local (100)
12:22:47.059 WIF: 'en1' IPv4 192.168.2.41 (50)
12:22:47.059 IP : 'en1' IPv6 fe80::94b9:7eff:fe8b:e030%en1 local (50)
12:22:47.070 IP : 'en1' IPv6 fd8d:f23a:f3f6:8f2b:94b9:7eff:fe8b:e030  (50)
12:22:47.071 WIF: 'lo0' IPv4 127.0.0.1 (-1)
12:22:47.082 IP : 'lo0' IPv6 ::1  (-1)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
