### PR TITLE
Berry 'bytes().asstring()' now truncates a string if buffer contains NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Berry `bytes().asstring()` now truncates a string if buffer contains NULL
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -806,7 +806,8 @@ static int m_asstring(bvm *vm)
 {
     buf_impl attr = bytes_check_data(vm, 0);
     check_ptr(vm, &attr);
-    be_pushnstring(vm, (const char*) attr.bufptr, attr.len);
+    size_t safe_len = strnlen((const char*) attr.bufptr, attr.len);
+    be_pushnstring(vm, (const char*) attr.bufptr, safe_len);
     be_return(vm);
 }
 

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -354,3 +354,9 @@ assert(b.appendb64(c, 2) == bytes("AABBCC49673D3D"))
 b = bytes("AABBCC")
 assert(bytes().fromstring(bytes("11").tob64()) == bytes('45513D3D'))
 assert(b.appendb64(c, 1, 1) == bytes("AABBCC45513D3D"))
+
+#- asstring truncates if NULL is present -#
+s=bytes("414243").asstring()
+assert(size(s) == 3)
+s=bytes("410000").asstring()
+assert(size(s) == 1)


### PR DESCRIPTION
## Description:

Berry 'bytes().asstring()' now truncates the string if the buffer contains a NULL character - as discussed on Discord.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
