### PR TITLE
Berry string literals containing NULL are truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Berry `bytes().asstring()` now truncates a string if buffer contains NULL
+- Berry string literals containing NULL are truncated
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -284,7 +284,8 @@ static void tr_string(blexer *lexer)
             break;
         }
     }
-    lexer->buf.len = dst - lexbuf(lexer);
+    size_t len = dst - lexbuf(lexer);
+    lexer->buf.len = strnlen(lexbuf(lexer), len);
 }
 
 static int skip_newline(blexer *lexer)

--- a/lib/libesp32/berry/tests/lexer.be
+++ b/lib/libesp32/berry/tests/lexer.be
@@ -84,3 +84,6 @@ var malformed_numbers = [
 for i : malformed_numbers
     test_source(i, 'malformed number')
 end
+
+#- ensure that string literal with NULL character is truncated -#
+assert(size('aa\000bb\000cc') == 2)


### PR DESCRIPTION
## Description:

Berry string literals containing NULL are truncated.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
