### PR TITLE
xdrv_04_light: force light refresh every second

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -3460,6 +3460,10 @@ bool Xdrv04(uint32_t function)
       case FUNC_EVERY_50_MSECOND:
         LightAnimate();
         break;
+      case FUNC_EVERY_SECOND:
+        Light.update = true;
+        LightAnimate();
+        break;
 #ifdef USE_DEVICE_GROUPS
       case FUNC_DEVICE_GROUP_ITEM:
         LightHandleDevGroupItem();


### PR DESCRIPTION
## Description:

This PR triggers a period refresh of all lights every second. This fixes the issue of electric noise causing some WS2812 LEDs to turn on although they are turned off in Tasmota. By refreshing them every second, the WS2812 always reflect the current requested state.

See Discussion: https://github.com/arendst/Tasmota/discussions/23180

This is a direct fix/hack. I'm open for other approaches, e.g. adding a custom command which would refresh the lights from a Berry Script.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
