### PR TITLE
poc hack for AU spec demanding rx config being different from tx config

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
@@ -154,7 +154,23 @@ void LoraWanTickerSend(void) {
     LoraWan_Send.once_ms(TAS_LORAWAN_RECEIVE_DELAY2, LoraWanTickerSend);  // Retry after 1000 ms
   }
   if (Lora->rx) {                                   // If received in RX1 do not resend in RX2
+    // AU915-928 downlink config (for now ignoring sf12 for rx2)
+    const float f_tx = 923.3;  // do rx and tx frequency have a fixed relation or is a random pick ok? 
+    const float b_tx = 500.0;
+    // save uplink config
+    float f_rx = Lora->settings.frequency;
+    float b_rx = Lora->settings.bandwidth;
+    // set downlink config for sending
+    Lora->settings.frequency = f_tx;
+    Lora->settings.bandwidth = b_tx;
+    Lora->Config();
+
     LoraSend(Lora->send_buffer, Lora->send_buffer_len, true);
+    
+    // restore uplink config 
+    Lora->settings.frequency = f_rx;
+    Lora->settings.bandwidth = b_rx;
+    Lora->Config();
   }
 }
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** maybe partly fixes #23324

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
