### PR TITLE
Group "MQTT TLS" in a single sticker

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -2120,9 +2120,10 @@ bool Xdrv02(uint32_t function)
       case FUNC_WEB_STATUS:
         // MqttConnectCount(), mqtt_tls
         if (MqttIsConnected()) {
-          WSContentStatusSticker(PSTR("MQTT"), -1);
           if (MqttTLSEnabled()) {
-            WSContentStatusSticker(PSTR("TLS"), -1);
+            WSContentStatusSticker(PSTR("MQTT TLS"), -1);
+          } else {
+            WSContentStatusSticker(PSTR("MQTT"), -1);
           }
         }
         break;


### PR DESCRIPTION
## Description:

Group "MQTT TLS" in a single sticker, instead of two sticker "MQTT" and "TLS"

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
