### PR TITLE
Wireguard default values

### DIFF
--- a/lib/lib_ssl/IniFile-Tasmota/src/IniFile.cpp
+++ b/lib/lib_ssl/IniFile-Tasmota/src/IniFile.cpp
@@ -257,13 +257,17 @@ bool IniFile::getCIDR(const char* section, const char* key, ip_addr_t *ip, ip_ad
 	return parseCIDR(cidr, ip, mask);
 }
 
-bool IniFile::getDomainPort(const char* section, const char* key, String &domain, uint16_t &port)
+bool IniFile::getDomainPort(const char* section, const char* key, String &domain, uint16_t &port, uint16_t default_port)
 {
 	if (!getValueString(section, key, domain)) return false; // error
 	int32_t colon = domain.indexOf(':');
-	if (colon < 0) { return false; }
-	port = domain.substring(colon + 1).toInt();
-	domain = domain.substring(0, colon);
+	if (colon == 0) { return false; }			// having an empty domain is wrong
+	if (colon > 0) {
+		port = domain.substring(colon + 1).toInt();
+		domain = domain.substring(0, colon);
+	} else {
+		port = default_port;
+	}
 	return true;
 }
 

--- a/lib/lib_ssl/IniFile-Tasmota/src/IniFile.h
+++ b/lib/lib_ssl/IniFile-Tasmota/src/IniFile.h
@@ -68,7 +68,7 @@ public:
 	static bool parseCIDR(String& str, ip_addr_t *ip, ip_addr_t *mask);
 	bool getCIDR(const char* section, const char* key, ip_addr_t *ip, ip_addr_t *mask);
 
-	bool getDomainPort(const char* section, const char* key, String &domain, uint16_t &port);
+	bool getDomainPort(const char* section, const char* key, String &domain, uint16_t &port, uint16_t default_port);
 
 	// From the file location saved in 'state' look for the next section and read its name.
 	// The name will be in the buffer. Returns false if no section found. 


### PR DESCRIPTION
## Description:

Improve Wireguard support:
- default port `51820` if not specified in `Endpoint`
- default `0.0.0.0/0.0.0.0` added if `AllowedIPs` is not specified

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
