### PR TITLE
Unishox show compressed size

### DIFF
--- a/tasmota/html_compressed/HTTP_HEADER1_ES6.h
+++ b/tasmota/html_compressed/HTTP_HEADER1_ES6.h
@@ -3,7 +3,7 @@
 // input sha256: 3417a3f0d32f6537d82e4638a9cd462098b9da4f641160355e0c8d9334aed1d4
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEADER1_SIZE = 683;
+const size_t HTTP_HEADER1_SIZE = 683;    // compressed size 502 bytes
 const char HTTP_HEADER1_COMPRESSED[] PROGMEM = "\x3D\x0F\xE1\x10\x98\x1D\x19\x0C\x64\x85\x50\xD0\x8F\xC3\xD0\x55\x0D\x09\x05\x7C"
                              "\x3C\x7C\x3D\x87\xD7\x8F\x62\x0C\x2B\xF7\x8F\x87\xB0\xF6\x1F\x87\xA0\xA7\x62\x1F"
                              "\x87\xA0\xD7\x56\x83\x15\x7F\xF3\xA3\xE1\xF6\x2E\x8C\x1D\x67\x3E\x7D\x90\x21\x52"

--- a/tasmota/html_compressed/HTTP_HEAD_LAST_SCRIPT.h
+++ b/tasmota/html_compressed/HTTP_HEAD_LAST_SCRIPT.h
@@ -3,7 +3,7 @@
 // input sha256: e0fcb684eb9f29a5fd0f678262046d9d05d055466b1752a58a35da2648ecd0e7
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEAD_LAST_SCRIPT_SIZE = 355;
+const size_t HTTP_HEAD_LAST_SCRIPT_SIZE = 355;    // compressed size 221 bytes
 const char HTTP_HEAD_LAST_SCRIPT_COMPRESSED[] PROGMEM = "\x30\x2F\x83\xAD\xCE\x46\xB1\x0E\xE9\xDE\x3D\xA6\x77\xF5\x47\xC3\x8C\xEA\x2D\x3E"
                              "\x09\x81\x8B\x1A\xFA\x8E\x86\xA1\x6F\xE6\x45\xE6\x13\x0E\xB3\xE5\x61\x04\x77\x4F"
                              "\xBD\xE1\x82\xE8\xEA\x1C\x2E\xAB\x38\xEA\xA6\x6C\xAB\xFB\xB3\xAB\xCC\x26\x1D\x1F"

--- a/tasmota/html_compressed/HTTP_HEAD_LAST_SCRIPT32.h
+++ b/tasmota/html_compressed/HTTP_HEAD_LAST_SCRIPT32.h
@@ -3,7 +3,7 @@
 // input sha256: 996873eafc91c9d084e3f68b60d32a37a27e91dd1acd0863fc1096119d8de6a2
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEAD_LAST_SCRIPT32_SIZE = 1013;
+const size_t HTTP_HEAD_LAST_SCRIPT32_SIZE = 1013;    // compressed size 663 bytes
 const char HTTP_HEAD_LAST_SCRIPT32_COMPRESSED[] PROGMEM = "\x30\x2F\x83\xAD\xCE\x46\xB1\x0E\xE9\xDE\x3D\xA6\x77\xF5\x47\xC3\x8C\xEA\x2D\x3E"
                              "\x09\x81\x8B\x1A\xFA\x8E\x86\xA1\x6F\xE6\x45\xE6\x13\x0E\xB3\xE5\x61\x04\x77\x4F"
                              "\xBD\xE1\x82\xE8\xEA\x1C\x2E\xAB\x38\xEA\xA6\x6C\xAB\xFB\xB3\xAB\xCC\x26\x1D\x1F"

--- a/tasmota/html_compressed/HTTP_HEAD_STYLE1.h
+++ b/tasmota/html_compressed/HTTP_HEAD_STYLE1.h
@@ -3,7 +3,7 @@
 // input sha256: 8c22c19284fa41f8eb66b1f50cb94cc3fe14369f900031e791107fe56d583c2f
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEAD_STYLE1_SIZE = 591;
+const size_t HTTP_HEAD_STYLE1_SIZE = 591;    // compressed size 330 bytes
 const char HTTP_HEAD_STYLE1_COMPRESSED[] PROGMEM = "\x3D\x3D\x46\x41\x33\xF0\x4D\x33\x3A\x8C\x6B\x08\x4F\x3A\x3A\xB7\x86\x0B\xA3\xAB"
                              "\xCC\x26\x1D\x1E\xD1\x96\x20\x9B\xC3\xC7\x99\xCD\x21\x86\xC3\xC1\x8C\xEA\x3A\xFD"
                              "\xA6\xD6\x79\x9C\x84\xC6\x9E\x0F\x70\x21\xE1\xA7\xB4\x75\x86\x68\x3D\xFC\x17\xC2"

--- a/tasmota/html_compressed/HTTP_HEAD_STYLE2.h
+++ b/tasmota/html_compressed/HTTP_HEAD_STYLE2.h
@@ -3,7 +3,7 @@
 // input sha256: cff4350b756f01fb7866cbbffa2d169d4fe9eaca6ba45634f368ca1d714cd582
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEAD_STYLE2_SIZE = 496;
+const size_t HTTP_HEAD_STYLE2_SIZE = 496;    // compressed size 262 bytes
 const char HTTP_HEAD_STYLE2_COMPRESSED[] PROGMEM = "\x1C\x2E\xAB\x38\xF6\x8E\xCF\x88\xFE\x79\x9C\x67\x82\x04\x18\xA7\x5F\xEC\x4D\x17"
                              "\xE3\xCC\xE3\x3A\x59\x7D\x8D\x3C\x0E\xB0\xCD\x07\xBF\x82\xF8\x43\xCC\xF2\x3E\x8E"
                              "\x3E\x23\x61\xE0\x3C\x0B\x3E\x08\x52\x02\xDE\x67\x58\xA7\xA3\xC2\xA8\xF3\x39\x47"

--- a/tasmota/html_compressed/HTTP_HEAD_STYLE_ZIGBEE.h
+++ b/tasmota/html_compressed/HTTP_HEAD_STYLE_ZIGBEE.h
@@ -3,7 +3,7 @@
 // input sha256: ee7e68972559c2ad3df6a6594445bfdfeb14a0a37dec2389ec20a197c26c9311
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_HEAD_STYLE_ZIGBEE_SIZE = 363;
+const size_t HTTP_HEAD_STYLE_ZIGBEE_SIZE = 363;    // compressed size 240 bytes
 const char HTTP_HEAD_STYLE_ZIGBEE_COMPRESSED[] PROGMEM = "\x3A\x0E\xA3\xDA\x3B\x0D\x87\x5F\xB4\xDB\xBC\x3C\x79\x8E\xCF\x88\xFE\x75\x8E\xC3"
                              "\x61\xE0\x66\x7B\x6B\x73\x8F\x3F\xB0\xAE\xB4\xCD\x9E\x04\xDF\x0C\x0A\xCC\x8F\x3D"
                              "\xE0\xB7\x99\xD6\x38\x2C\x0C\xD0\xF0\x3F\xA2\x50\xA3\xCC\xE5\x32\x18\x6C\x3C\x0A"

--- a/tasmota/html_compressed/HTTP_SCRIPT_CONSOL.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_CONSOL.h
@@ -3,7 +3,7 @@
 // input sha256: 960fbc2354bc4029cbc93953e54edc74024a46ca58902af175f5ecf8839eb0a8
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_CONSOL_SIZE = 985;
+const size_t HTTP_SCRIPT_CONSOL_SIZE = 985;    // compressed size 724 bytes
 const char HTTP_SCRIPT_CONSOL_COMPRESSED[] PROGMEM = "\x33\xBF\xAF\x71\xF0\xE3\x3A\x8B\x44\x3E\x1C\x67\x51\x18\xA3\xA8\x2A\x2B\x1A\x7C"
                              "\x3E\x84\x3C\x18\x17\xC1\xD6\xE7\x20\x8E\xE8\xC3\xBC\x7B\x4C\xEF\xE8\x33\xAB\x0F"
                              "\x87\xD9\xF6\x78\x0C\x27\x7F\x2A\x2B\xD1\xAF\x05\xD1\xDD\x0A\x8E\xF0\x24\xCD\x31"

--- a/tasmota/html_compressed/HTTP_SCRIPT_MODULE_TEMPLATE.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_MODULE_TEMPLATE.h
@@ -3,7 +3,7 @@
 // input sha256: 92e33b521e56657da8f50887c7e1431219de0a8f19048247211f3b6d4c9b68ba
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_MODULE_TEMPLATE_SIZE = 589;
+const size_t HTTP_SCRIPT_MODULE_TEMPLATE_SIZE = 589;    // compressed size 441 bytes
 const char HTTP_SCRIPT_MODULE_TEMPLATE_COMPRESSED[] PROGMEM = "\x33\xBF\xAC\xF1\xD4\x2B\xC7\x83\x02\xF8\x3A\xDC\xE4\x1B\x3B\xBA\x75\x1A\x8E\xF1"
                              "\xED\x33\xBF\xAC\x3E\x09\x81\x8B\x1A\xFA\x8E\x81\xFD\xDD\x32\x61\x31\xAF\xA8\xEE"
                              "\x9F\x78\x32\xB7\x38\xFB\x3B\xC7\x8C\x3A\x53\x36\x51\x07\x9D\x4F\xA8\xF9\xA7\x83"

--- a/tasmota/html_compressed/HTTP_SCRIPT_ROOT_NO_WEB_DISPLAY.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_ROOT_NO_WEB_DISPLAY.h
@@ -3,7 +3,7 @@
 // input sha256: 6e369f0e06cba0656d3c7187ac833b999a54f84edfd9385b4cf44ba8643e01d8
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_ROOT_SIZE = 499;
+const size_t HTTP_SCRIPT_ROOT_SIZE = 499;    // compressed size 343 bytes
 const char HTTP_SCRIPT_ROOT_COMPRESSED[] PROGMEM = "\x33\xBF\xA3\x14\x78\x30\x2F\x83\xAD\xCE\x41\x59\xDD\x18\x77\x8F\x6D\x9F\x06\x1F"
                              "\xE3\xFC\x7D\x9F\x67\x80\xC2\x77\xF2\xAD\x1A\xF0\x5D\x1D\xD3\x14\x77\x81\x26\x68"
                              "\x54\x77\x8F\x1A\x60\xEE\x9B\x0F\xE1\xF3\x85\x84\x11\xDE\x3D\xA6\xC3\xA5\x8E\xCF"

--- a/tasmota/html_compressed/HTTP_SCRIPT_ROOT_PART2.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_ROOT_PART2.h
@@ -3,7 +3,7 @@
 // input sha256: c85b76468eb793a235944c16a2d986bce127bd4fc1b0690499b3b5b88ab4f70f
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_ROOT_PART2_SIZE = 222;
+const size_t HTTP_SCRIPT_ROOT_PART2_SIZE = 222;    // compressed size 192 bytes
 const char HTTP_SCRIPT_ROOT_PART2_COMPRESSED[] PROGMEM = "\x30\x2F\x83\xAD\xCE\x41\x06\x77\x4C\xCE\xAD\x3A\x86\x1D\xE3\xDB\xA6\x0E\xEB\x1C"
                              "\x77\x4F\xBF\x1F\x67\x78\xEF\x1E\xDD\x30\x77\x4C\xCF\x87\xC3\xEC\x51\xF6\x7F\x8F"
                              "\xF1\x99\xF0\xF8\x7D\x88\x7D\x9D\xE3\xDA\x67\x7F\x5E\x08\xF8\xC7\x1D\xD3\xEF\xC1"

--- a/tasmota/html_compressed/HTTP_SCRIPT_ROOT_SSE_NO_WEB_DISPLAY.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_ROOT_SSE_NO_WEB_DISPLAY.h
@@ -3,7 +3,7 @@
 // input sha256: b42b87eb23e656d5ae799709721147c847ae381f0d1f0cb9f86bd55e9509bf51
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_ROOT_SIZE = 434;
+const size_t HTTP_SCRIPT_ROOT_SIZE = 434;    // compressed size 325 bytes
 const char HTTP_SCRIPT_ROOT_COMPRESSED[] PROGMEM = "\x30\x2F\x83\xAD\xCE\x41\x59\xDD\x18\x77\x8F\x6E\x98\x3B\xB4\x64\x31\xE1\x83\xBA"
                              "\x4C\xCD\xF5\x17\xB0\x5F\xC3\x67\x78\xFE\x1F\x0F\x87\xB0\x5F\x08\xCC\x6F\x31\x0F"
                              "\x61\xDE\x3D\xA6\x77\xF4\xCF\x9C\xC7\xD0\x23\x60\x47\x74\xFB\x3B\x43\x4F\x87\x21"

--- a/tasmota/html_compressed/HTTP_SCRIPT_ROOT_WEB_DISPLAY.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_ROOT_WEB_DISPLAY.h
@@ -3,7 +3,7 @@
 // input sha256: c137f990d750da7e1e51a6ec80baad5445853da492c12c4dad87c95724c50441
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_ROOT_SIZE = 872;
+const size_t HTTP_SCRIPT_ROOT_SIZE = 872;    // compressed size 493 bytes
 const char HTTP_SCRIPT_ROOT_COMPRESSED[] PROGMEM = "\x33\xBF\xAF\x98\xF0\xA3\xE1\xC8\x75\x11\x8A\x3C\x18\x17\xC1\xD6\xE7\x20\xAC\xEE"
                              "\x8C\x3B\xC7\xB6\xCF\x83\x0F\xF1\xFE\x3E\xCF\xB3\xC0\x61\x3B\xF9\x56\x8D\x78\x2E"
                              "\x8E\xE9\x8A\x3B\xC0\x93\x34\x2A\x2B\x3B\xC7\x8D\x30\x77\x4D\x87\xF0\xF9\xC2\xC2"

--- a/tasmota/html_compressed/HTTP_SCRIPT_TEMPLATE.h
+++ b/tasmota/html_compressed/HTTP_SCRIPT_TEMPLATE.h
@@ -3,7 +3,7 @@
 // input sha256: 464453a8f35b349965adc050d3e4f968239a974f171cfa64efc665bafe3ba3f4
 /////////////////////////////////////////////////////////////////////
 
-const size_t HTTP_SCRIPT_TEMPLATE_SIZE = 288;
+const size_t HTTP_SCRIPT_TEMPLATE_SIZE = 288;    // compressed size 237 bytes
 const char HTTP_SCRIPT_TEMPLATE_COMPRESSED[] PROGMEM = "\x30\x2F\x83\xAD\xCE\x41\x08\x77\x45\x9D\x46\x0E\xF1\xED\x33\xBF\xA3\x61\xF3\x98"
                              "\xFA\x23\x61\x0D\x20\x88\x55\x50\xC2\xFB\x35\x0B\x7E\xA3\xBA\x77\x8F\x06\xC3\xA6"
                              "\x77\xDD\x88\x65\xEA\xBA\x61\x8A\xBE\x1E\x67\xC3\xBA\x77\x8F\x87\xE1\xED\xD3\x07"

--- a/tools/unishox/compress-html-uncompressed.py
+++ b/tools/unishox/compress-html-uncompressed.py
@@ -169,7 +169,7 @@ def compress_html(source, target, argv=None, verbose=False):
 
   lines_raw = [ "\"\\x" + "\\x".join( [ '{:02X}'.format(b) for b in chunk ] ) + "\"" for chunk in chunks ]
   line_complete = f"const char {const_name}_COMPRESSED[] PROGMEM = " + ("\n" + " "*29).join(lines_raw) + ";"
-  lines = f"\nconst size_t {const_name}_SIZE = {in_len};\n{line_complete}\n\n"
+  lines = f"\nconst size_t {const_name}_SIZE = {in_len};    // compressed size {out_len} bytes\n{line_complete}\n\n"
 
   #print('####### Final output:')
   #print(lines)


### PR DESCRIPTION
## Description:

Cosmetic minor change: now shows compressed size in pre-compressed Unishox files

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
