### PR TITLE
WebUI status line left and renamed events 'FUNC_WEB_STATUS_LEFT' and 'FUNC_WEB_STATUS_RIGHT'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - WebUI status line for MQTT and TLS, added `FUNC_WEB_STATUS` event (#23326)
 - Wireguard VPN (#23347)
 - Optional Wifi strength indicator in WebUI status line
+- WebUI status line left and renamed events `FUNC_WEB_STATUS_left` and `FUNC_WEB_STATUS_RIGHT`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -27,6 +27,7 @@ extern int w_webserver_content_flush(bvm *vm);
 extern int w_webserver_content_stop(bvm *vm);
 extern int w_webserver_content_close(bvm *vm);
 extern int w_webserver_content_button(bvm *vm);
+extern int w_webserver_content_status_sticker(bvm *vm);
 
 extern int w_webserver_html_escape(bvm *vm);
 
@@ -156,6 +157,8 @@ module webserver (scope: global) {
     content_stop, func(w_webserver_content_stop)
     content_close, func(w_webserver_content_close)
     content_button, func(w_webserver_content_button)
+
+    content_status_sticker, func(w_webserver_content_status_sticker)
 
     html_escape, func(w_webserver_html_escape)
 

--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -442,7 +442,7 @@ enum XsnsFunctions { FUNC_SETTINGS_OVERRIDE, FUNC_SETUP_RING1, FUNC_SETUP_RING2,
                      FUNC_WEB_GET_ARG, FUNC_WEB_ADD_HANDLER, FUNC_SET_SCHEME, FUNC_HOTPLUG_SCAN, FUNC_TIME_SYNCED,
                      FUNC_DEVICE_GROUP_ITEM,
                      FUNC_NETWORK_UP, FUNC_NETWORK_DOWN,
-                     FUNC_WEB_STATUS,
+                     FUNC_WEB_STATUS_LEFT, FUNC_WEB_STATUS_RIGHT,
                      FUNC_return_result = 200,  // Insert function WITHOUT return results before here. Following functions return results
                      FUNC_PIN_STATE, FUNC_MODULE_INIT, FUNC_ADD_BUTTON, FUNC_ADD_SWITCH, FUNC_BUTTON_PRESSED, FUNC_BUTTON_MULTI_PRESSED,
                      FUNC_SET_DEVICE_POWER,

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1175,26 +1175,12 @@ void WSContentStop(void) {
 //
 // Convert seconds to a string representing days, hours or minutes.
 // The string will contain the most coarse time only, rounded down (61m == 01h, 01h37m == 01h).
-void WSContentStatusSticker(const char *msg, int32_t seconds)
+void WSContentStatusSticker(const char *msg, const char *attr = NULL);
+void WSContentStatusSticker(const char *msg, const char *attr)
 {
-  char title_attr[64] = "";
-
-  if (seconds > 0) {
-    static const uint32_t conversions[4] = {24 * 3600, 3600, 60, 1};
-    static const char     units[4] = { 'd', 'h', 'm', 's'};   // day, hour, minute
-
-    char unit;
-    int32_t time_unit = seconds;
-    for(uint32_t i = 0; i < 4; ++i) {
-      unit = units[i];
-      if (time_unit >= conversions[i]) {    // always pass even if 00m
-        time_unit = seconds / conversions[i];
-        break;
-      }
-    }
-    ext_snprintf_P(title_attr, sizeof(title_attr), PSTR(" title='Connected for %i%c'"), time_unit, unit);
-  }
-  WSContentSend_P(HTTP_STATUS_STICKER, 0xAAAAAA, title_attr, msg);
+  if (msg == NULL) { return; }
+  if (attr == NULL) { attr = ""; }
+  WSContentSend_P(HTTP_STATUS_STICKER, 0xAAAAAA, attr, msg);
 }
 #endif // USE_WEB_STATUS_LINE
 
@@ -1932,25 +1918,26 @@ bool HandleRootStatusRefresh(void) {
   }
 
 #ifdef USE_WEB_STATUS_LINE
-#ifdef USE_WEB_STATUS_LINE_WIFI
   // create a first DIV for the upper left status bar, positioned left-justified
   // we use the same string literal for both lines to reduce Flash
   WSContentSend_P(PSTR("<div style='font-size:9px;font-weight:bold;text-align:%s;position:absolute;top:0;%s:0;display:inline-flex;'>"), PSTR("left"), PSTR("left"));
+#ifdef USE_WEB_STATUS_LINE_WIFI
   if (Settings->flag4.network_wifi) {
     int32_t rssi = WiFi.RSSI();
-    WSContentSend_P(PSTR("<div class='wifi' title='" D_RSSI " %d%%, %d dBm'><div class='arc a3 %s'></div><div class='arc a2 %s'></div><div class='arc a1 %s'></div><div class='arc a0 active'></div></div>"),
+    WSContentSend_P(PSTR("<div class='wifi' title='" D_RSSI " %d%%, %d dBm' style='padding:0 2px 0 2px;'><div class='arc a3 %s'></div><div class='arc a2 %s'></div><div class='arc a1 %s'></div><div class='arc a0 active'></div></div>"),
                           WifiGetRssiAsQuality(rssi), rssi,
                           rssi >= -55 ? "active" : "",
                           rssi >= -70 ? "active" : "",
                           rssi >= -85 ? "active" : "");
   }
-  // display here anything that goes on the left side
-  WSContentSend_P(PSTR("</div>"));
 #endif // USE_WEB_STATUS_LINE_WIFI
+  // display here anything that goes on the left side
+  XsnsXdrvCall(FUNC_WEB_STATUS_LEFT);
+  WSContentSend_P(PSTR("</div>"));
 
   // create a second DIV for the upper right status bar, positioned right-justified
   WSContentSend_P(PSTR("<div style='font-size:9px;font-weight:bold;text-align:%s;position:absolute;top:0;%s:0;display:inline-flex;'>"), PSTR("right"), PSTR("right"));
-  XsnsXdrvCall(FUNC_WEB_STATUS);
+  XsnsXdrvCall(FUNC_WEB_STATUS_RIGHT);
   WSContentSend_P(PSTR("</div>"));
 #endif // USE_WEB_STATUS_LINE
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -2117,13 +2117,12 @@ bool Xdrv02(uint32_t function)
         WebServer_on(PSTR("/" WEB_HANDLE_MQTT), HandleMqttConfiguration);
         break;
 #ifdef USE_WEB_STATUS_LINE
-      case FUNC_WEB_STATUS:
-        // MqttConnectCount(), mqtt_tls
+      case FUNC_WEB_STATUS_RIGHT:
         if (MqttIsConnected()) {
           if (MqttTLSEnabled()) {
-            WSContentStatusSticker(PSTR("MQTT TLS"), -1);
+            WSContentStatusSticker(PSTR("MQTT TLS"));
           } else {
-            WSContentStatusSticker(PSTR("MQTT"), -1);
+            WSContentStatusSticker(PSTR("MQTT"));
           }
         }
         break;

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -366,6 +366,21 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: `webserver.content_status_sticker(msg:string) -> nil`
+  //
+  int32_t w_webserver_content_status_sticker(struct bvm *vm) {
+  #ifdef USE_WEB_STATUS_LINE
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * msg = be_tostring(vm, 1);
+      WSContentStatusSticker(msg);
+      be_return_nil(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+#else
+  be_return_nil(vm);
+#endif // USE_WEB_STATUS_LINE
 }
 
 #endif // USE_WEBSERVER

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -1062,8 +1062,11 @@ bool Xdrv52(uint32_t function)
       WebServer_on("/tapp", HandleBerryBECLoader, HTTP_GET);
       break;
 #ifdef USE_WEB_STATUS_LINE
-      case FUNC_WEB_STATUS:
-        callBerryEventDispatcher(PSTR("web_status_line"), nullptr, 0, nullptr);
+      case FUNC_WEB_STATUS_LEFT:
+        callBerryEventDispatcher(PSTR("web_status_line_left"), nullptr, 0, nullptr);
+        break;
+      case FUNC_WEB_STATUS_RIGHT:
+        callBerryEventDispatcher(PSTR("web_status_line_right"), nullptr, 0, nullptr);
         break;
 #endif  // USE_WEB_STATUS_LINE
 #endif // USE_WEBSERVER


### PR DESCRIPTION
## Description:

Some improvements in WebUI status line:
- improved vertical alignment of Wifi strength indicator (not included in pre-compiled binaries)
- event `FUNC_WEB_STATUS` renamed `FUNC_WEB_STATUS_RIGHT`
- added event `FUNC_WEB_STATUS_LEFT`
- added berry events `web_status_line_left` and `web_status_line_right`
- added Berry helper `webserver.content_status_sticker(msg:string) -> nil` to show a small text sticker

Example:
```berry
class StickerTest
   def init()
     tasmota.add_driver(self)
   end
   def web_status_line_left()
     import webserver
     webserver.content_status_sticker("LEFT")
   end
   def web_status_line_right()
     import webserver
     webserver.content_status_sticker("RIGHT")
   end
end
StickerTest()
```

Displays:
![image](https://github.com/user-attachments/assets/c27e7c2b-a757-4c3c-a974-a6a2337316a0)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
