### PR TITLE
WebUI heap status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Wireguard VPN (#23347)
 - Optional Wifi strength indicator in WebUI status line (#23352)
 - WebUI status line left and renamed events `FUNC_WEB_STATUS_LEFT` and `FUNC_WEB_STATUS_RIGHT` (#23354)
+- WebUI heap status
 
 ### Breaking Changed
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -509,6 +509,7 @@
   #define USE_ENHANCED_GUI_WIFI_SCAN             // Enable Wi-Fi scan output with BSSID (+0k5 code)
   #define USE_WEB_STATUS_LINE                      // Enable upper status line in web UI (+0k5 code)
 //    #define USE_WEB_STATUS_LINE_WIFI               // Enable upper left wifi indicator in main page (+0k5 code)
+//    #define USE_WEB_STATUS_LINE_HEAP               // Enable upper left display of free heap memory (+0k1 code)
 //  #define USE_ALPINEJS                           // Enable AlpineJS v2.8.2 (+8k8 code)
 //  #define USE_WEBSEND_RESPONSE                   // Enable command WebSend response message (+1k code)
 //  #define USE_WEBGETCONFIG                       // Enable restoring config from external webserver (+0k6)

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1931,6 +1931,9 @@ bool HandleRootStatusRefresh(void) {
                           rssi >= -85 ? "active" : "");
   }
 #endif // USE_WEB_STATUS_LINE_WIFI
+#ifdef USE_WEB_STATUS_LINE_HEAP
+  WSContentSend_P("<span>&nbsp;%ik</span>", ESP_getFreeHeap() / 1024);
+#endif // USE_WEB_STATUS_LINE_HEAP
   // display here anything that goes on the left side
   XsnsXdrvCall(FUNC_WEB_STATUS_LEFT);
   WSContentSend_P(PSTR("</div>"));


### PR DESCRIPTION
## Description:

Add a `C` version of the free heap memory display in status line. This is not included in pre-compiled binaries. It is provided as `C` code for ESP8266. For ESP32, please favor Berry scripts that I will provide separately.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
