### PR TITLE
Berry 'display.touch_update' wrongly applies resistive calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Berry `bytes().asstring()` now truncates a string if buffer contains NULL (#23311)
 - Berry string literals containing NULL are truncated (#23312)
+- Berry `display.touch_update` wrongly applies resistive calibration
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_display.ino
@@ -75,7 +75,7 @@ extern "C" {
 
   void be_ntv_display_touch_update(int32_t touches, int32_t raw_x, int32_t raw_y, int32_t gesture) {
   #if defined(USE_UNIVERSAL_TOUCH) || defined(USE_FT5206) || defined(USE_XPT2046) || defined(USE_GT911) || defined(USE_LILYGO47) || defined(USE_TOUCH_BUTTONS)
-    Touch_SetStatus(touches, raw_x, raw_y, gesture);
+    Touch_SetStatus(touches, raw_x, raw_y, gesture,true /*don't convert*/);
   #endif
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_55_touch.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_55_touch.ino
@@ -82,14 +82,16 @@ bool utouch_found = false;
 VButton *buttons[MAX_TOUCH_BUTTONS];
 #endif
 
-void Touch_SetStatus(uint8_t touches, uint16_t raw_x, uint16_t raw_y, uint8_t gesture) {
+void Touch_SetStatus(uint8_t touches, uint16_t raw_x, uint16_t raw_y, uint8_t gesture, bool force_no_convert) {
   TSGlobal.external_ts = true;
   TSGlobal.gesture = gesture;
   TSGlobal.touches = touches;
   TSGlobal.touched = (TSGlobal.touches > 0);
   TSGlobal.touch_xp = TSGlobal.raw_touch_xp = raw_x;
   TSGlobal.touch_yp = TSGlobal.raw_touch_yp = raw_y;
-  TS_RotConvert(&TSGlobal.touch_xp, &TSGlobal.touch_yp);
+  if (!force_no_convert) {
+    TS_RotConvert(&TSGlobal.touch_xp, &TSGlobal.touch_yp);
+  }
 }
 
 // return true if succesful, false if not configured


### PR DESCRIPTION
## Description:

Fix bug in Berry `display.touch_update` that would wrongly apply resistive touch calibration, and breaks the LVGL mirroring feature.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
