### PR TITLE
BLE: Fix log_level definition conflict

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLELog.h
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLELog.h
@@ -75,5 +75,28 @@
 
 #define NIMBLE_LOGC( tag, format, ... ) console_printf("CRIT %s: " format "\n", tag, ##__VA_ARGS__)
 
+// The LOG_LEVEL macros are used to set the log level for the NimBLE stack, but they pollute the global namespace and would override the loglevel enum of Tasmota.
+// So we undefine them here to avoid conflicts.
+
+#ifdef LOG_LEVEL_DEBUG
+#undef LOG_LEVEL_DEBUG
+#endif
+
+#ifdef LOG_LEVEL_DEBUG_MORE
+#undef LOG_LEVEL_DEBUG_MORE
+#endif
+
+#ifdef LOG_LEVEL_INFO
+#undef LOG_LEVEL_INFO
+#endif
+
+#ifdef LOG_LEVEL_NONE
+#undef LOG_LEVEL_NONE
+#endif
+
+#ifdef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_ERROR
+#endif
+
 #endif /* CONFIG_BT_ENABLED */
 #endif /* MAIN_NIMBLELOG_H_ */


### PR DESCRIPTION
## Description:

The nimble stack uses macro definitions for the log levels, that would override the log levels with the same name in the enum of Tasmota.
This is quite nasty as the compiler does not present a warning and happily changes the levels in a wrong way.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
