### PR TITLE
Use Alias in MI32/TRV

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -1910,6 +1910,10 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
   int newstate = GEN_STATE_STARTED;
   op->state = GEN_STATE_STARTED;
 
+  char addrstr[13];
+  const uint8_t* m_address = op->addr.getNative();
+  snprintf(addrstr, sizeof(addrstr), "%02X%02X%02X%02X%02X%02X", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
+
 #ifdef BLE_ESP32_DEBUG
   if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
 #endif
@@ -2120,21 +2124,21 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
     switch (rc){
       case (0x0200+BLE_ERR_CONN_LIMIT ):
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Hit connection limit? - restarting NimBLE"));
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: %s: Hit connection limit? - restarting NimBLE"), addrstr);
         BLERestartNimBLE = 1;
         BLERestartBLEReason = BLE_RESTART_BLE_REASON_CONN_LIMIT;
         break;
       case (0x0200+BLE_ERR_ACL_CONN_EXISTS):
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Connection exists? - restarting NimBLE"));
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: %s: Connection exists? - restarting NimBLE"), addrstr);
         BLERestartNimBLE = 1;
         BLERestartBLEReason = BLE_RESTART_BLE_REASON_CONN_EXISTS;
         break;
     }
     if (rc){
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed to connect to device low level rc 0x%x"), rc);
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLE: %s: Failed to connect to device low level rc 0x%X"), addrstr, rc);
     }
     // failed to connect
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed to connect to device"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: %s: Failed to connect to device"), addrstr);
   }
   op->state = newstate;
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -989,12 +989,12 @@ int EQ3SendResult(char *requested, const char *result){
 }
 
 #ifdef USE_WEBSERVER
-const char HTTP_EQ3_ALIAS[]        PROGMEM = "{s}EQ3 %d Alias{m}%s{e}";
-const char HTTP_EQ3_MAC[]          PROGMEM = "{s}EQ3 %d " D_MAC_ADDRESS "{m}%s{e}";
-const char HTTP_EQ3_RSSI[]         PROGMEM = "{s}EQ3 %d " D_RSSI "{m}%d dBm{e}";
-const char HTTP_EQ3_TEMPERATURE[]  PROGMEM = "{s}EQ3 %d %s{m}%*_f " D_UNIT_DEGREE "%c{e}";
-const char HTTP_EQ3_DUTY_CYCLE[]   PROGMEM = "{s}EQ3 %d " D_THERMOSTAT_VALVE_POSITION "{m}%d " D_UNIT_PERCENT "{e}";
-const char HTTP_EQ3_BATTERY[]      PROGMEM = "{s}EQ3 %d " D_BATTERY "{m}%s{e}";
+const char HTTP_EQ3_TYPE[]         PROGMEM = "{s}%s " D_NEOPOOL_TYPE "{m}EQ3{e}";
+const char HTTP_EQ3_MAC[]          PROGMEM = "{s}%s " D_MAC_ADDRESS "{m}%s{e}";
+const char HTTP_EQ3_RSSI[]         PROGMEM = "{s}%s " D_RSSI "{m}%d dBm{e}";
+const char HTTP_EQ3_TEMPERATURE[]  PROGMEM = "{s}%s " D_THERMOSTAT_SET_POINT "{m}%*_f " D_UNIT_DEGREE "%c{e}";
+const char HTTP_EQ3_DUTY_CYCLE[]   PROGMEM = "{s}%s " D_THERMOSTAT_VALVE_POSITION "{m}%d " D_UNIT_PERCENT "{e}";
+const char HTTP_EQ3_BATTERY[]      PROGMEM = "{s}%s " D_BATTERY "{m}%s{e}";
 
 void EQ3Show(void)
 {
@@ -1005,15 +1005,21 @@ void EQ3Show(void)
     if (EQ3Devices[i].timeoutTime) {
       if (FirstSensorShown) WSContentSend_P(HTTP_SNS_HR_THIN);
       FirstSensorShown = true;
+      const char *label;
       const char *alias = BLE_ESP32::getAlias(EQ3Devices[i].addr);
       if (alias && *alias){
-        WSContentSend_P(HTTP_EQ3_ALIAS, i + 1, alias);
+        label = alias;
+        WSContentSend_P(HTTP_EQ3_TYPE, label);
+      } else {
+        char tlabel[8];
+        snprintf(tlabel, sizeof(tlabel), "EQ3-%d", i + 1);
+        label = tlabel;
       }
-      WSContentSend_P(HTTP_EQ3_MAC, i + 1, addrStr(EQ3Devices[i].addr));
-      WSContentSend_PD(HTTP_EQ3_RSSI, i + 1, EQ3Devices[i].RSSI);
-      WSContentSend_PD(HTTP_EQ3_TEMPERATURE, i + 1, D_THERMOSTAT_SET_POINT, Settings->flag2.temperature_resolution, &EQ3Devices[i].TargetTemp, c_unit);
-      WSContentSend_P(HTTP_EQ3_DUTY_CYCLE, i + 1, EQ3Devices[i].DutyCycle);
-      WSContentSend_P(HTTP_EQ3_BATTERY, i + 1, EQ3Devices[i].Battery ? D_NEOPOOL_LOW : D_OK);
+      WSContentSend_P(HTTP_EQ3_MAC, label, addrStr(EQ3Devices[i].addr));
+      WSContentSend_PD(HTTP_EQ3_RSSI, label, EQ3Devices[i].RSSI);
+      WSContentSend_PD(HTTP_EQ3_TEMPERATURE, label, Settings->flag2.temperature_resolution, &EQ3Devices[i].TargetTemp, c_unit);
+      WSContentSend_P(HTTP_EQ3_DUTY_CYCLE, label, EQ3Devices[i].DutyCycle);
+      WSContentSend_P(HTTP_EQ3_BATTERY, label, EQ3Devices[i].Battery ? D_NEOPOOL_LOW : D_OK);
     }
   }
 }

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -20,13 +20,15 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#define MI32_VERSION "V0.9.2.5"
+#define MI32_VERSION "V0.9.2.6"
 /*
   --------------------------------------------------------------------------------------------
   Version yyyymmdd  Action    Description
   --------------------------------------------------------------------------------------------
+  0.9.2.6 20250503  changed - display alias instead of type, when present
+  -------
   0.9.2.5 20250319  changed - added support for MI LYWSD02MMC with different device ID
-
+  -------
   0.9.2.4 20240111  changed - Enhancement of debug log output                              
   -------
   0.9.2.3 20240101  changed - added initial support for MI LYWSD02MMC                              
@@ -2745,7 +2747,7 @@ void CmndMi32Keys(void){
 \*********************************************************************************************/
 
 const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 " MI32_VERSION "{m}%u%s / %u{e}";
-const char HTTP_MI32_ALIAS[] PROGMEM = "{s}%s Alias{m}%s{e}";
+const char HTTP_MI32_TYPE[] PROGMEM = "{s}%s " D_SENSOR"{m}%s{e}";
 const char HTTP_MI32_MAC[] PROGMEM = "{s}%s " D_MAC_ADDRESS "{m}%s{e}";
 const char HTTP_MI32_RSSI[] PROGMEM = "{s}%s " D_RSSI "{m}%d dBm{e}";
 const char HTTP_MI32_BATTERY[] PROGMEM = "{s}%s " D_BATTERY "{m}%u %%{e}";
@@ -3545,32 +3547,36 @@ void MI32Show(bool json)
       mi_sensor_t *p;
       p = &MIBLEsensors[i];
 
+      const char *label;
       const char *typeName = kMI32DeviceType[p->type-1];
       const char *alias = BLE_ESP32::getAlias(p->MAC);
       if (alias && *alias){
-        WSContentSend_P(HTTP_MI32_ALIAS, typeName, alias);
+        label = alias;
+        WSContentSend_P(HTTP_MI32_TYPE, label, typeName);
+      } else {
+        label = typeName;
       }
       char _MAC[18];
       ToHex_P(p->MAC,6,_MAC,18);//,':');
-      WSContentSend_P(HTTP_MI32_MAC, typeName, _MAC);
-      WSContentSend_PD(HTTP_MI32_RSSI, typeName, p->RSSI);
+      WSContentSend_P(HTTP_MI32_MAC, label, _MAC);
+      WSContentSend_PD(HTTP_MI32_RSSI, label, p->RSSI);
 
       // for some reason, display flora differently
       switch(p->type){
         case MI_FLORA:{
           if (!isnan(p->temp)) {
-            WSContentSend_Temp(typeName, ConvertTempToFahrenheit(p->temp));  // convert if SO8 on
+            WSContentSend_Temp(label, ConvertTempToFahrenheit(p->temp));  // convert if SO8 on
           }
           if (p->moisture!=0xff) {
-            WSContentSend_PD(HTTP_SNS_MOISTURE, typeName, p->moisture);
+            WSContentSend_PD(HTTP_SNS_MOISTURE, label, p->moisture);
           }
           if (p->fertility!=0xffff) {
-            WSContentSend_PD(HTTP_MI32_FLORA_DATA, typeName, p->fertility);
+            WSContentSend_PD(HTTP_MI32_FLORA_DATA, label, p->fertility);
           }
         } break;
         default:{
           if (!isnan(p->hum) && !isnan(p->temp)) {
-            WSContentSend_THD(typeName, ConvertTempToFahrenheit(p->temp), p->hum);  // convert if SO8 on
+            WSContentSend_THD(label, ConvertTempToFahrenheit(p->temp), p->hum);  // convert if SO8 on
           }
         }
       }
@@ -3611,52 +3617,52 @@ void MI32Show(bool json)
       // (future work)
       if (showkey){
         BLE_ESP32::dump(_MAC, 13, p->MAC, 6);
-        WSContentSend_P(HTTP_NEEDKEY, typeName, _MAC, IPGetListeningAddressStr().c_str(), tmp);
+        WSContentSend_P(HTTP_NEEDKEY, label, _MAC, IPGetListeningAddressStr().c_str(), tmp);
       }
 
 #endif //USE_MI_DECRYPTION
 
       if (p->feature.events){
-        WSContentSend_PD(HTTP_MI32_EVENTS, typeName, p->events);
+        WSContentSend_PD(HTTP_MI32_EVENTS, label, p->events);
       }
       if (p->feature.NMT){
         // no motion time
-        if(p->NMT>0) WSContentSend_PD(HTTP_MI32_NMT, typeName, p->NMT);
+        if(p->NMT>0) WSContentSend_PD(HTTP_MI32_NMT, label, p->NMT);
       }
 
       if (p->feature.lux){
         if (p->lux!=0x00ffffff) { // this is the error code -> no valid value
-          WSContentSend_PD(HTTP_SNS_ILLUMINANCE, typeName, p->lux);
+          WSContentSend_PD(HTTP_SNS_ILLUMINANCE, label, p->lux);
         }
       }
       if (p->feature.light){
-        WSContentSend_PD(HTTP_MI32_LIGHT, typeName, p->light);
+        WSContentSend_PD(HTTP_MI32_LIGHT, label, p->light);
       }
       if (p->feature.scale){
-        WSContentSend_PD(HTTP_MISCALE_WEIGHT, typeName, Settings->flag2.weight_resolution, &p->weight, p->weight_unit);
+        WSContentSend_PD(HTTP_MISCALE_WEIGHT, label, Settings->flag2.weight_resolution, &p->weight, p->weight_unit);
         if (MI32.option.directBridgeMode) {
-          WSContentSend_PD(HTTP_MISCALE_WEIGHT_REMOVED, typeName, p->weight_removed? PSTR("yes") : PSTR("no"));
-          WSContentSend_PD(HTTP_MISCALE_WEIGHT_STABILIZED, typeName, p->weight_stabilized ? PSTR("yes") : PSTR("no"));
+          WSContentSend_PD(HTTP_MISCALE_WEIGHT_REMOVED, label, p->weight_removed? PSTR("yes") : PSTR("no"));
+          WSContentSend_PD(HTTP_MISCALE_WEIGHT_STABILIZED, label, p->weight_stabilized ? PSTR("yes") : PSTR("no"));
         }
         if (p->feature.impedance) {
-          WSContentSend_PD(HTTP_MISCALE_IMPEDANCE, typeName, p->impedance);
+          WSContentSend_PD(HTTP_MISCALE_IMPEDANCE, label, p->impedance);
           if (MI32.option.directBridgeMode) {
-            WSContentSend_PD(HTTP_MISCALE_IMPEDANCE_STABILIZED, typeName, p->impedance_stabilized? PSTR("yes") : PSTR("no"));
+            WSContentSend_PD(HTTP_MISCALE_IMPEDANCE_STABILIZED, label, p->impedance_stabilized? PSTR("yes") : PSTR("no"));
           }
         }
       }
       if(p->bat!=0x00){
-          WSContentSend_PD(HTTP_MI32_BATTERY, typeName, p->bat);
+          WSContentSend_PD(HTTP_MI32_BATTERY, label, p->bat);
       }
       if (p->feature.Btn){
-        WSContentSend_PD(HTTP_MI32_LASTBUTTON, typeName, p->Btn);
+        WSContentSend_PD(HTTP_MI32_LASTBUTTON, label, p->Btn);
       }
       if (p->feature.flooding)
       {
-        WSContentSend_PD(HTTP_SJWS01LM_FLOODING, typeName, p->flooding);
+        WSContentSend_PD(HTTP_SJWS01LM_FLOODING, label, p->flooding);
       }
       if (p->pairing){
-        WSContentSend_PD(HTTP_PAIRING, typeName);
+        WSContentSend_PD(HTTP_PAIRING, label);
       }
     }
     _counter++;


### PR DESCRIPTION
## Description:
- Display Alias in MI32/TRV instead of type, when present
- Show device MAC in BLE log messages
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).