### PR TITLE
Add AU915 Support for LoRaWAN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,5 +70,11 @@
         "tooltip": "PlatformIO: Rebuild IntelliSense Index",
         "commands": "platformio-ide.rebuildProjectIndex"
       }
-    ]
+    ],
+    "files.associations": {
+      "cstdint": "cpp",
+      "array": "cpp",
+      "string": "cpp",
+      "string_view": "cpp"
+    }
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,6 +75,7 @@
       "cstdint": "cpp",
       "array": "cpp",
       "string": "cpp",
-      "string_view": "cpp"
+      "string_view": "cpp",
+      "functional": "cpp"
     }
   }

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -60,7 +60,7 @@
 #define D_JSON_COUNT "Count"
 #define D_JSON_COUNTER "Counter"
 #define D_JSON_CRC_BYTES "CrcBytes"
-#define D_JSON_LORA_BAND "Band"
+#define D_JSON_LORA_REGION "Region"
 #define D_JSON_CURRENT "Current"         // As in Voltage and Current
 #define D_JSON_CURRENT_LIMIT "CurrentLimit"
 #define D_JSON_CURRENT_NEUTRAL "CurrentNeutral"

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -60,6 +60,7 @@
 #define D_JSON_COUNT "Count"
 #define D_JSON_COUNTER "Counter"
 #define D_JSON_CRC_BYTES "CrcBytes"
+#define D_JSON_LORA_BAND "Band"
 #define D_JSON_CURRENT "Current"         // As in Voltage and Current
 #define D_JSON_CURRENT_LIMIT "CurrentLimit"
 #define D_JSON_CURRENT_NEUTRAL "CurrentNeutral"

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
@@ -53,16 +53,42 @@
 
 /*
 These are default AU915 values when waiting for JOIN REQUEST 
+AU915 has 2 sets up UPLINK channels
 */
-//#ifndef TAS_LORA_AU915_FREQUENCY 
-//#define TAS_LORA_AU915_FREQUENCY                915.2  // Allowed values range from 915.2 to  927.8 MHz
-//#endif
-//#ifndef TAS_LORA_AU915_BANDWIDTH
-//#define TAS_LORA_AU915_BANDWIDTH                125.0  // Allowed values are 125.0 and 500.0 kHz
-//#endif
-//#ifndef TAS_LORA_AU915_SPREADING_FACTOR
-//#define TAS_LORA_AU915_SPREADING_FACTOR          10    // Allowed values range from 7 to 12
-//#endif
+#ifndef TAS_LORA_AU915_FREQUENCY_UP1 
+#define TAS_LORA_AU915_FREQUENCY_UP1            915.2  // Channel 0. There are 64 125 MHz channels (0-63), spaced 0.2 MHz apart.
+#endif
+#ifndef TAS_LORA_AU915_FREQUENCY_UP2 
+#define TAS_LORA_AU915_FREQUENCY_UP2            915.9  // Channel 64. There are 8 500 MHz channels (64-71), spaced 1.6 MHz apart
+#endif
+
+#ifndef TAS_LORA_AU915_BANDWIDTH_UP1
+#define TAS_LORA_AU915_BANDWIDTH_UP1            125.0  // Allowed values are 125.0 and 500.0 kHz
+#endif
+#ifndef TAS_LORA_AU915_BANDWIDTH_UP2
+#define TAS_LORA_AU915_BANDWIDTH_UP2            500.0  // Allowed values are 125.0 and 500.0 kHz
+#endif
+
+#ifndef TAS_LORA_AU915_SPREADING_FACTOR_UP1
+#define TAS_LORA_AU915_SPREADING_FACTOR_UP1      10    // Allowed values range from 7 to 12
+#endif
+#ifndef TAS_LORA_AU915_SPREADING_FACTOR_UP2
+#define TAS_LORA_AU915_SPREADING_FACTOR_UP2      8     // Allowed values range from 7 to 12
+#endif
+
+#ifndef TAS_LORA_AU915_FREQUENCY_DN 
+#define TAS_LORA_AU915_FREQUENCY_DN             923.3  //Channel 0 down
+#endif
+
+#ifndef TAS_LORA_AU915_BANDWIDTH_DN             
+#define TAS_LORA_AU915_BANDWIDTH_DN             500    //DR8
+#endif
+
+#ifndef TAS_LORA_AU915_SPREADING_FACTOR_DN
+#define TAS_LORA_AU915_SPREADING_FACTOR_DN      12     //DR8
+#endif
+
+
 #ifndef TAS_LORA_AU915_CODING_RATE
 #define TAS_LORA_AU915_CODING_RATE                5    // Allowed values range from 5 to 8
 #endif
@@ -226,6 +252,7 @@ typedef struct Lora_t {
   bool (* Available)(void);
   int (* Receive)(char*);
   bool (* Send)(uint8_t*, uint32_t, bool);
+  bool (* Init)(void);
   LoraSettings_t settings;                       // Persistent settings
   volatile uint32_t receive_time;
   float rssi;

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
@@ -21,7 +21,7 @@
 #define XDRV_73_KEY                "drvset73"
 
 #ifndef TAS_LORA_FREQUENCY
-#define TAS_LORA_FREQUENCY                868.0  // Allowed values range from 150.0 to 960.0 MHz
+#define TAS_LORA_FREQUENCY                868.1  // Allowed values range from 150.0 to 960.0 MHz
 #endif
 #ifndef TAS_LORA_BANDWIDTH
 #define TAS_LORA_BANDWIDTH                125.0  // Allowed values are 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125.0, 250.0 and 500.0 kHz
@@ -50,6 +50,41 @@
 #ifndef TAS_LORA_CRC_BYTES
 #define TAS_LORA_CRC_BYTES                  2    // No (0) or Number (1 to 4) of CRC bytes
 #endif
+
+/*
+These are default AU915 values when waiting for JOIN REQUEST 
+*/
+//#ifndef TAS_LORA_AU915_FREQUENCY 
+//#define TAS_LORA_AU915_FREQUENCY                915.2  // Allowed values range from 915.2 to  927.8 MHz
+//#endif
+//#ifndef TAS_LORA_AU915_BANDWIDTH
+//#define TAS_LORA_AU915_BANDWIDTH                125.0  // Allowed values are 125.0 and 500.0 kHz
+//#endif
+//#ifndef TAS_LORA_AU915_SPREADING_FACTOR
+//#define TAS_LORA_AU915_SPREADING_FACTOR          10    // Allowed values range from 7 to 12
+//#endif
+#ifndef TAS_LORA_AU915_CODING_RATE
+#define TAS_LORA_AU915_CODING_RATE                5    // Allowed values range from 5 to 8
+#endif
+#ifndef TAS_LORA_AU915_SYNC_WORD
+#define TAS_LORA_AU915_SYNC_WORD               0x34    // Allowed values range from 1 to 255
+#endif
+#ifndef TAS_LORA_AU915_OUTPUT_POWER
+#define TAS_LORA_AU915_OUTPUT_POWER              10    // Allowed values range from 1 to 20
+#endif
+#ifndef TAS_LORA_AU915_PREAMBLE_LENGTH
+#define TAS_LORA_AU915_PREAMBLE_LENGTH            8    // Allowed values range from 1 to 65535
+#endif
+#ifndef TAS_LORA_AU915_CURRENT_LIMIT
+#define TAS_LORA_AU915_CURRENT_LIMIT             60.0  // Overcurrent Protection - OCP in mA
+#endif
+#ifndef TAS_LORA_AU915_HEADER
+#define TAS_LORA_AU915_HEADER                     0    // Explicit (0) or Implicit (1 to 4) Header
+#endif
+#ifndef TAS_LORA_AU915_CRC_BYTES
+#define TAS_LORA_AU915_CRC_BYTES                  2    // No (0) or Number (1 to 4) of CRC bytes
+#endif
+
 
 #ifndef TAS_LORAWAN_FREQUENCY
 #define TAS_LORAWAN_FREQUENCY             868.1  // Allowed values range from 150.0 to 960.0 MHz
@@ -180,6 +215,7 @@ typedef struct LoraSettings_t {
   uint8_t implicit_header;                       // 0
   uint8_t crc_bytes;                             // 2 bytes
   uint8_t flags;
+  uint8_t band;                                  // 0=Default, 1=AU915, ...
 #ifdef USE_LORAWAN_BRIDGE
   LoraEndNode_t end_node[TAS_LORAWAN_ENDNODES];  // End node parameters
 #endif  // USE_LORAWAN_BRIDGE

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_0_lora_struct.ino
@@ -80,12 +80,20 @@ AU915 has 2 sets up UPLINK channels
 #define TAS_LORA_AU915_FREQUENCY_DN             923.3  //Channel 0 down
 #endif
 
-#ifndef TAS_LORA_AU915_BANDWIDTH_DN             
-#define TAS_LORA_AU915_BANDWIDTH_DN             500    //DR8
+#ifndef TAS_LORA_AU915_BANDWIDTH_RX1             
+#define TAS_LORA_AU915_BANDWIDTH_RX1             500    //DR8
 #endif
 
-#ifndef TAS_LORA_AU915_SPREADING_FACTOR_DN
-#define TAS_LORA_AU915_SPREADING_FACTOR_DN      12     //DR8
+#ifndef TAS_LORA_AU915_SPREADING_FACTOR_RX1
+#define TAS_LORA_AU915_SPREADING_FACTOR_RX1      12     //DR8
+#endif
+
+#ifndef TAS_LORA_AU915_BANDWIDTH_RX2             
+#define TAS_LORA_AU915_BANDWIDTH_RX2             500    //DR8
+#endif
+
+#ifndef TAS_LORA_AU915_SPREADING_FACTOR_RX2
+#define TAS_LORA_AU915_SPREADING_FACTOR_RX2      12     //DR8
 #endif
 
 
@@ -241,7 +249,7 @@ typedef struct LoraSettings_t {
   uint8_t implicit_header;                       // 0
   uint8_t crc_bytes;                             // 2 bytes
   uint8_t flags;
-  uint8_t band;                                  // 0=Default, 1=AU915, ...
+  uint8_t region;                                // 0=Default, 1=AU915, ...
 #ifdef USE_LORAWAN_BRIDGE
   LoraEndNode_t end_node[TAS_LORAWAN_ENDNODES];  // End node parameters
 #endif  // USE_LORAWAN_BRIDGE
@@ -270,6 +278,19 @@ typedef struct Lora_t {
 #endif  // USE_LORAWAN_BRIDGE
 } Lora_t;
 Lora_t* Lora = nullptr;
+
+enum LoRaRegion_t {
+  TAS_LORA_REGION_EU868, 
+  TAS_LORA_REGION_AU915
+};
+
+//LoraBands: One for each enum above
+const char * const LoraRegions[] PROGMEM = {
+	"EU868",
+	"AU915"
+};
+
+
 
 #endif  // USE_SPI_LORA
 #endif  // USE_SPI

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
@@ -49,13 +49,11 @@ void LoraSx126xOnInterrupt(void) {
   if (!Lora->send_flag && !Lora->received_flag && !Lora->receive_time) {
     Lora->receive_time = millis();
   }
-  //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xOnInterrupt() Setting RXflag"));
   Lora->received_flag = true;              // we got a packet, set the flag
 }
 
 bool LoraSx126xAvailable(void) {
   if (Lora->send_flag) {
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xAvailable() SendFlag set. Re-setting RXflag (was %u)"),Lora->received_flag);
     Lora->received_flag = false;           // Reset receive flag as it was caused by send interrupt
 
     uint32_t time = millis();
@@ -75,9 +73,7 @@ bool LoraSx126xAvailable(void) {
 #endif  // USE_LORA_SX126X_DEBUG
 
     if (0 == (irq_stat & RADIOLIB_SX126X_IRQ_RX_DONE)) {
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xAvailable() irq RX: NOT set"));
       Lora->received_flag = false;         // Reset receive flag
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xAvailable() Re-setting RXflag as irq RX: NOT set"));
     }
 
   }
@@ -86,8 +82,6 @@ bool LoraSx126xAvailable(void) {
 
 int LoraSx126xReceive(char* data) {
   Lora->received_flag = false;             // Reset flag
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xReceive() Re-setting received_flag"));
-
   int packet_size = LoRaRadio.getPacketLength();
   int state = LoRaRadio.readData((uint8_t*)data, TAS_LORA_MAX_PACKET_LENGTH -1);
   // LoRaWan downlink frames are sent without CRC, which will raise error on SX126x. We can ignore that error
@@ -127,7 +121,6 @@ bool LoraSx126xSend(uint8_t* data, uint32_t len, bool invert) {
 }
 
 bool LoraSx126xConfig(void) {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xConfig() f|sf|bw = %1_f|%u|%1_f"),&Lora->settings.frequency,Lora->settings.spreading_factor,&Lora->settings.bandwidth);
   LoRaRadio.setCodingRate(Lora->settings.coding_rate);
   LoRaRadio.setSyncWord(Lora->settings.sync_word);
   LoRaRadio.setPreambleLength(Lora->settings.preamble_length);
@@ -147,10 +140,8 @@ bool LoraSx126xConfig(void) {
 }
 
 bool LoraSx126xInit(void) {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xInit() Start"));
   LoRaRadio = new Module(Pin(GPIO_LORA_CS), Pin(GPIO_LORA_DI1), Pin(GPIO_LORA_RST), Pin(GPIO_LORA_BUSY));
   if (RADIOLIB_ERR_NONE == LoRaRadio.begin(Lora->settings.frequency)) {
-    AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xInit() About to call LoraSx126xConfig()"));
     LoraSx126xConfig();
     LoRaRadio.setDio1Action(LoraSx126xOnInterrupt);
     if (RADIOLIB_ERR_NONE == LoRaRadio.startReceive()) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
@@ -127,7 +127,7 @@ bool LoraSx126xSend(uint8_t* data, uint32_t len, bool invert) {
 }
 
 bool LoraSx126xConfig(void) {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xConfig() f|sf|bw = %1_f|%u:|%1_f"),&Lora->settings.frequency,Lora->settings.spreading_factor,&Lora->settings.bandwidth);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xConfig() f|sf|bw = %1_f|%u|%1_f"),&Lora->settings.frequency,Lora->settings.spreading_factor,&Lora->settings.bandwidth);
   LoRaRadio.setCodingRate(Lora->settings.coding_rate);
   LoRaRadio.setSyncWord(Lora->settings.sync_word);
   LoRaRadio.setPreambleLength(Lora->settings.preamble_length);

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_3_lora_sx126x.ino
@@ -86,7 +86,7 @@ bool LoraSx126xAvailable(void) {
 
 int LoraSx126xReceive(char* data) {
   Lora->received_flag = false;             // Reset flag
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xReceive() Re-setting RXflag"));
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSx126xReceive() Re-setting received_flag"));
 
   int packet_size = LoRaRadio.getPacketLength();
   int state = LoRaRadio.readData((uint8_t*)data, TAS_LORA_MAX_PACKET_LENGTH -1);
@@ -127,7 +127,7 @@ bool LoraSx126xSend(uint8_t* data, uint32_t len, bool invert) {
 }
 
 bool LoraSx126xConfig(void) {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xConfig() f=%1_f sf:bw=%u:%1_f"),&Lora->settings.frequency,Lora->settings.spreading_factor,&Lora->settings.bandwidth);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraSx126xConfig() f|sf|bw = %1_f|%u:|%1_f"),&Lora->settings.frequency,Lora->settings.spreading_factor,&Lora->settings.bandwidth);
   LoRaRadio.setCodingRate(Lora->settings.coding_rate);
   LoRaRadio.setSyncWord(Lora->settings.sync_word);
   LoRaRadio.setPreambleLength(Lora->settings.preamble_length);

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
@@ -164,14 +164,14 @@ void LoraWanTickerSend(void) {
   } 
   
   //DBGROB: Not needed ?????????
-  else {
-    Lora->send_buffer_step = 0;                     //Nothing more to send
-   }
+  //else {
+  //  Lora->send_buffer_step = 0;                     //Nothing more to send
+  // }
 
   if (0 == Lora->send_buffer_step){
-    AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraWanTickerSend() SledgeHammer LoraSx126xInit() Start"));
-    Lora->Init();                                   //Necessary to re-init the SXxxxx chip in cases where TX/RX frequencies differ //LoraSx126xInit();
-    AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraWanTickerSend() SledgeHammer LoraSx126xInit() End"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraWanTickerSend() SledgeHammer LoraSx126xInit() Start "));
+    Lora->Init();                                   //Necessary to re-init the SXxxxx chip in cases where TX/RX frequencies differ
+    AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraWanTickerSend() SledgeHammer LoraSx126xInit() End "));
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_9_lora.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_9_lora.ino
@@ -207,13 +207,19 @@ uint8_t LoraChannel(void) {
 /*
  Sets LoRa values
 */
-void LoraDefaults(uint32_t uRegion=TAS_LORA_REGION_EU868, bool bUplink=true, uint32_t uChannel=0){
+//void LoraDefaults(uint32_t uRegion=TAS_LORA_REGION_EU868, bool bUplink=true, uint32_t uChannel=0){
+void LoraDefaults(uint32_t uRegion=TAS_LORA_REGION_EU868, LoRaRadioMode_t mode=TAS_LORA_RADIO_UPLINK, uint32_t uChannel=0){
+
   switch(uRegion){
     case TAS_LORA_REGION_AU915:
-     AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraDefaults(AU915) uRegion=%u bUplink=%u channel=%u"),uRegion, bUplink, uChannel);
+     AddLog(LOG_LEVEL_DEBUG, PSTR("DBGROB:LoraDefaults(AU915) uRegion=%u mode(0:UPL,1:RX1,2:RX2)=%u channel=%u"),uRegion, mode, uChannel);
+
+     //TO DO: Need 3 profiles: Uplink, RX1, RX2
+     // Works OK for now as RX2 always received by end device.
 
      LoRaRadioInfo_t RadioInfo;
-     LoraRadioInfo( (bUplink ? TAS_LORA_RADIO_UPLINK : TAS_LORA_RADIO_RX2), &RadioInfo, uChannel);   //Region specific
+     //LoraRadioInfo( (bUplink ? TAS_LORA_RADIO_UPLINK : TAS_LORA_RADIO_RX2), &RadioInfo, uChannel);   //Region specific
+     LoraRadioInfo( mode, &RadioInfo, uChannel);   //Region specific
 
      Lora->settings.frequency        = RadioInfo.frequency;       
      Lora->settings.bandwidth        = RadioInfo.bandwidth;     
@@ -417,8 +423,8 @@ bool LoraSend(uint8_t* data, uint32_t len, bool invert, bool bUseUplinkProfile =
   if (!bUseUplinkProfile) { 
     // Different TX/RX profiles allowed. (e.g. LoRaWAN)
     // For CmndLoraSend() ... do not allow changes. 
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSend() Changing to TX profile. Current Freq:%1_f  "),&Lora->settings.frequency);
-    LoraDefaults(Lora->settings.region, false);    //Set Downlink profile
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSend() Changing to TX profile"));
+    LoraDefaults(Lora->settings.region, TAS_LORA_RADIO_RX2);    //Set Downlink profile   TO DO: Support different RX1 & RX2 profiles
     Lora->Config();  
   }
 
@@ -428,7 +434,7 @@ bool LoraSend(uint8_t* data, uint32_t len, bool invert, bool bUseUplinkProfile =
     lora_time, len, data, invert, TimePassedSince(lora_time));
   
   if (!bUseUplinkProfile) {
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSend() Changing to RX profile Current Freq:%1_f  "),&Lora->settings.frequency);
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: LoraSend() Changing to RX profile"));
     Lora->settings = RXsettings;
     Lora->Config();
   }
@@ -713,7 +719,7 @@ void CmndLoraConfig(void) {
       uint8_t uRegionIdx = LoraRegionIdx(ConfigRegion(uData));
       String sRegion = ConfigRegion(uData);
       AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DBGROB: Command Region %s  uChannel:%u uBandIdx: %u sBand:%s"),uData.c_str(),uChannel, uRegionIdx, sRegion.c_str());
-      LoraDefaults(uRegionIdx, true, uChannel); //Set Uplink values
+      LoraDefaults(uRegionIdx, TAS_LORA_RADIO_UPLINK, uChannel); //Set Uplink values
       
       //DBGROB: does this work OK??
       Lora->Config();


### PR DESCRIPTION
## Description:
Added 
- AU915 region support to Tasmota LoRaWanBridge
- Channel Mask setting in JOIN ACCEPT message (to lock end device to one freq)
- ADRACKReq/ADRACKAns support: After typically 64 Uplinks (approx 24hr for a Dragino LHT52/65), the End Device requests an ADRACKAns reply, to make sure communication is still up. If no ADRACKAns sent, the End device will start a recovery process, which means it will change freq, and we loose comms.

Unchanged 
- Default Region = EU868

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

## COMMENTS
The default behaviour remains:  (single frequency) EU868

## NEW COMMANDS
```
LoRaConfig AU915           - Set default for AU915 region, channel 0
LoRaConfig AU915 0         - Set default for AU915 region, channel 0
LoRaConfig AU915 10        - Set default for AU915 region, channel 10 (e.g.)
```
## TESTING
EU868: 
 - Not tested as I do not have access to any EU868 gear.

AU915:
End Devices: Dragino LHT52, and LHT65
```

--------  From my Dragino LPS8v2  Gateway ----------------------------------------------------
Time            Message Type       Mod  Freq  Data Rate  CNT Content
-------------- ------------------- ---- ----- ---------- --- -------------------------------------------------   
05/04-13:11:24 Join Request        LoRa 915.4 SF10 BW125 0   DevEui: A840414E4F5CAE3D,AppEUI: A840410000000100
05/04-13:24:48 Join Request        LoRa 916.4 SF10 BW125 0   DevEui: A840414E4F5CAE3D,AppEUI: A840410000000100
05/04-13:29:52 Join Request        LoRa 915.2 SF10 BW125 0   DevEui: A840414E4F5CAE3D,AppEUI: A840410000000100
05/04-13:29:59 Data Unconfirmed Up LoRa 915.2 SF10 BW125 0   Dev Addr: 00539B70, Size: 21
05/04-13:30:02 Data Unconfirmed Up LoRa 915.2 SF10 BW125 1   Dev Addr: 00539B70, Size: 15
05/04-13:30:05 Data Unconfirmed Up LoRa 915.2 SF10 BW125 2   Dev Addr: 00539B70, Size: 24
05/04-13:49:59 Data Unconfirmed Up LoRa 915.2 SF10 BW125 3   Dev Addr: 00539B70, Size: 24

--------  From Tasmota Console ----------------------------------------------------
<earlier>    CMD: loraconfig AU915 0
             MQT: stat/tasmota_539B70/RESULT = {"LoRaConfig":
              {"Frequency":915.2,
               "Bandwidth":125.0,
               "SpreadingFactor":10,
               "CodingRate4":5,
               "SyncWord":52,
               "OutputPower":10,
               "PreambleLength":8,
               "CurrentLimit":60.0,
               "ImplicitHeader":0,
               "CrcBytes":2,
               "Region":"AU915"                   <----------- New
               }
              }

13:29:52.131 LOR: Rcvd (2462444) '0000010000004140A83DAE5C4F4E4140A866BC055B8ABA', RSSI -31.0, SNR 7.5
13:29:52.133 LOR: JoinEUI 00010000004140A8, DevEUIh A840414E, DevEUIl 4F5CAE3D, DevNonce BC66, MIC BA8A5B05
13:29:57.557 LOR: Send (2467451) '208002B7E53AA84EB65F630CA21B5DDCEC45A6695B79743106FB9A9C13972F6320', Invert 1, Time 420

13:29:59.423 LOR: Rcvd (2467870) '40709B53008100000D05F009F230880ADCC361BFA8', RSSI -30.0, SNR 7.5
13:29:59.430 MQT: tele/tasmota_539B70/SENSOR = {"LwReceived":{"0xAE3D":{"Node":1,"Device":"0xAE3D","RSSI":-30.0,"SNR":7.5,"DevEUIh":"A840414E","DevEUIl":"4F5CAE3D","FPort":5,"Payload":[9,1,32,4,0,11,64]}}}

13:30:02.514 LOR: Rcvd (2472827) '40709B53008101000D02F891DE41FF', RSSI -31.0, SNR 7.5
13:30:02.520 MQT: tele/tasmota_539B70/SENSOR = {"LwReceived":{"0xAE3D":{"Node":1,"Device":"0xAE3D","RSSI":-31.0,"SNR":7.5,"DevEUIh":"A840414E","DevEUIl":"4F5CAE3D","FPort":2,"Payload":[0]}}}
13:30:03.822 LOR: Send (2473832) '60709B53002601000DC9BD41550037C530A5', Invert 1, Time 314

13:30:05.347 LOR: Rcvd (2474145) '40709B530080020002A55BDB845697B566D2C653859A4BAD', RSSI -30.0, SNR 8.0
13:30:05.353 MQT: tele/tasmota_539B70/SENSOR = {"LwReceived":{"0xAE3D":{"Node":1,"Device":"0xAE3D","RSSI":-30.0,"SNR":8.0,"DevEUIh":"A840414E","DevEUIl":"4F5CAE3D","FPort":2,"Payload":[9,164,1,237,127,255,1,104,22,251,56]}}}


13:49:59.426 LOR: Rcvd (3669739) '40709B530080030002F87C4C4F1DE661425186D572B9F446', RSSI -31.0, SNR 8.0
13:49:59.432 MQT: tele/tasmota_539B70/SENSOR = {"LwReceived":{"0xAE3D":{"Node":1,"Device":"0xAE3D","RSSI":-31.0,"SNR":8.0,"DevEUIh":"A840414E","DevEUIl":"4F5CAE3D","FPort":2,"Payload":[9,165,1,236,127,255,1,104,22,255,226]}}}




```

