### PR TITLE
Matter and mDNS can be enabled at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Berry string literals containing NULL are truncated (#23312)
 - Berry `display.touch_update` wrongly applies resistive calibration (#23363)
 - NimBLE log_level definition conflict (#23366)
+- Matter and mDNS can be enabled at the same time
 
 ### Removed
 

--- a/tasmota/tasmota_support/support_network.ino
+++ b/tasmota/tasmota_support/support_network.ino
@@ -29,7 +29,9 @@ struct {
 void StartMdns(void) {
   if (Settings->flag3.mdns_enabled) {  // SetOption55 - Control mDNS service
     if (!Mdns.begun) {
+#ifdef ESP8266    // the following will break Matter support, MDNS.end() does not seem necessary for ESP32, but I prefer to keep it on ESP8266 because I can't test it (#23371)
       MDNS.end(); // close existing or MDNS.begin will fail
+#endif // ESP8266
       Mdns.begun = (uint8_t)MDNS.begin(TasmotaGlobal.hostname);
       AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MDNS "%s '%s.local'"), (Mdns.begun) ? PSTR(D_INITIALIZED) : PSTR(D_FAILED), TasmotaGlobal.hostname);
     }


### PR DESCRIPTION
## Description:

Enabling mDNS with `SetOption55 1` would remove all mDNS entries created by Matter, and would break discovery of devices.

The fix removes the call to `MDNS.end()` which should be unnecessary. As I can't test for ESP8266, I kept it for ESP8266 but not for ESP32.

**Related issue (if applicable):** fixes #23371

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
