### PR TITLE
Berry `introspect.module()` failed to load modules in files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Berry `display.touch_update` wrongly applies resistive calibration (#23363)
 - NimBLE log_level definition conflict (#23366)
 - Matter and mDNS can be enabled at the same time (#23373)
+- Berry `introspect.module()` failed to load modules in files
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -132,10 +132,10 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
     if (var_isclosure(func)) {
         base = str(cl->proto->source); /* get the source file path */
     } else {
-        base = "/";
+        base = "";
     }
 #else
-    base = "/";
+    base = "";
 #endif
     split = be_splitpath(base);
     *size = split - base + (size_t)str_len(path) + SUFFIX_LEN;
@@ -183,11 +183,14 @@ static int open_libfile(bvm *vm, char *path, size_t size)
         strcpy(path + size - SUFFIX_LEN, sfxs[idx]);
         res = open_script(vm, path);
     } while (idx++ < 2 && res == BE_IO_ERROR);
-    if (res == BE_IO_ERROR) {
 #if BE_USE_SHARED_LIB
+    if (res == BE_IO_ERROR) {
         strcpy(path + size - SUFFIX_LEN, DLL_SUFFIX);
         res = open_dllib(vm, path);
+    }
 #endif
+    if (res == BE_EXCEPTION) {
+        be_dumpexcept(vm);
     }
     be_free(vm, path, size);
     return res;


### PR DESCRIPTION
## Description:

As seen on Discord, fix `introspect.module()` that would fail at loading modules in `.be` files.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
