### PR TITLE
Platform 2025.05.40 Tasmota Arduino Core 3.2.0.250504 based on IDF 5.4.1.250501

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250411
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.2.0.250504
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/boards/esp32-solo1.json
+++ b/boards/esp32-solo1.json
@@ -41,6 +41,11 @@
   "download": {
     "speed": 230400
   },
+  "espidf": {
+    "custom_sdkconfig": [
+      "CONFIG_FREERTOS_UNICORE=y" 
+    ]
+  },
   "url": "https://www.espressif.com/sites/default/files/documentation/esp32-solo-1_datasheet_en.pdf",
   "vendor": "Espressif"
 }

--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -39,6 +39,6 @@
     "download": {
       "speed": 230400
     },
-    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp8684/esp8684-devkitm-1/user_guide.html",
     "vendor": "Espressif"
   }

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -39,6 +39,6 @@
     "download": {
       "speed": 230400
     },
-    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
+    "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp8684/esp8684-devkitm-1/user_guide.html",
     "vendor": "Espressif"
   }

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.04.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.05.40/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -31,7 +31,6 @@ extends                 = env:tasmota32_base
 board                   = esp32-solo1
 board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFRAMEWORK_ARDUINO_SOLO1
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -264,13 +263,14 @@ board_build.partitions  = partitions/esp32_partition_app1856k_fs1344k.csv
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-zbbrdgpro.bin"'
                           -DFIRMWARE_ZBBRDGPRO
-                          -DFRAMEWORK_ARDUINO_ITEAD
 custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
                           tools/fw_SonoffZigbeeBridgePro_cc2652/Sonoff_ZBPro.autoconf
                           tasmota/berry/zigbee/cc2652_flasher.be
                           tasmota/berry/zigbee/intelhex.be
                           tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
                           tools/fw_SonoffZigbeeBridgePro_cc2652/SonoffZBPro_coord_20220219.hex
+custom_sdkconfig        = CONFIG_D0WD_PSRAM_CLK_IO=5
+                          CONFIG_D0WD_PSRAM_CS_IO=18
 lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
@@ -282,8 +282,9 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_NSPANEL
-                          -DFRAMEWORK_ARDUINO_ITEAD
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-nspanel.bin"'
+custom_sdkconfig        = CONFIG_D0WD_PSRAM_CLK_IO=5
+                          CONFIG_D0WD_PSRAM_CS_IO=18
 
 [env:tasmota32-AD]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
Changes:

- Tasmota Arduino Core 3.2.0.250504 based on IDF 5.4.1.250501
- new Installer, everything needed is now installed from Github repos
- no extra frameworks for solo1 and ITEAD 
- removed support for not used DFU uploader
- updated OpenOCD and GDB

Possible (one time issue) when migrating from older platforms:
After installing of some packages the compile run stops with errors. In this case do:
- close VSC
- naviagate in your user folder to the hidden folder `.platformio` change there in folder `packages` delete any files and folders but **not** the folder `pyenv`
- Start VSC
- Start compile of a Tasmota32 version
- Be happy