### PR TITLE
Allow temporary change of DisplayDimmer

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -2006,12 +2006,12 @@ void CmndDisplayMode(void) {
 }
 
 // Apply the current display dimmer
-void ApplyDisplayDimmer(void) {
+void ApplyDisplayDimmer(uint8_t dimmer) {
   disp_apply_display_dimmer_request = true;
   if ((disp_power < 0) || !disp_device) { return; }  // Not initialized yet
   disp_apply_display_dimmer_request = false;
 
-  uint8_t dimmer8 = changeUIntScale(GetDisplayDimmer(), 0, 100, 0, 255);
+  uint8_t dimmer8 = changeUIntScale(dimmer, 0, 100, 0, 255);
   uint16_t dimmer10_gamma = ledGamma10(dimmer8);
   if (dimmer8 && !(disp_power)) {
     ExecuteCommandPower(disp_device, POWER_ON, SRC_DISPLAY);
@@ -2035,7 +2035,7 @@ void CmndDisplayDimmer(void) {
   if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 100)) {
     uint8_t dimmer = XdrvMailbox.payload;
     SetDisplayDimmer(dimmer);
-    ApplyDisplayDimmer();
+    ApplyDisplayDimmer(dimmer);
   }
   ResponseCmndNumber(GetDisplayDimmer());
 }
@@ -2923,7 +2923,7 @@ bool Xdrv13(uint32_t function) {
         break;
       case FUNC_INIT:
         if (disp_apply_display_dimmer_request) {
-          ApplyDisplayDimmer();  // Allowed here.
+          ApplyDisplayDimmer(GetDisplayDimmer());  // Allowed here.
         }
         break;
       case FUNC_EVERY_50_MSECOND:

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_display.ino
@@ -61,13 +61,20 @@ extern "C" {
   int be_ntv_display_dimmer(struct bvm *vm) {
     int32_t argc = be_top(vm); // Get the number of arguments
     int32_t dimmer;
+    bool no_settings = false;   // by default change settings
     if (argc >= 1) {
       if (!be_isint(vm, 1)) { be_raise(vm, "type_error", "arg must be int"); }
       dimmer = be_toint(vm, 1);
+      if (argc >= 2) {
+        if (!be_isbool(vm, 2)) { be_raise(vm, "type_error", "arg2 must be bool"); }
+        no_settings = be_tobool(vm, 2);
+      }
       if ((dimmer < 0) || (dimmer > 100)) { be_raise(vm, "value_error", "value must be in range 0..100"); }
       be_pop(vm, argc);   // clear stack to avoid ripple errors in code called later
-      SetDisplayDimmer(dimmer);
-      ApplyDisplayDimmer();
+      if (!no_settings) {  // change settings
+        SetDisplayDimmer(dimmer);
+      }
+      ApplyDisplayDimmer(dimmer);
     }
     be_pushint(vm, GetDisplayDimmer());
     be_return(vm);

--- a/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
@@ -492,7 +492,7 @@ Renderer *Init_uDisplay(const char *desc) {
     }*/
     renderer->invertDisplay(iniinv);
 
-    ApplyDisplayDimmer();
+    ApplyDisplayDimmer(GetDisplayDimmer());
 
 #ifdef SHOW_SPLASH
     if (!Settings->flag5.display_no_splash) {  // SetOption135 - (Display & LVGL) force disabling default splash screen


### PR DESCRIPTION
## Description:

Prepare for auto-dimmer. Now `ApplyDisplayDimmer()` can take a temporary value that is not saved into settings.

No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.2.0.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
