### PR TITLE
DNS setting with 'IPAddress4/5' not persisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Haspmota `haspmota.parse()` page parsing (#23403)
 - ESP32-S3 display stability regression from #23397 (#23404)
+- DNS setting with `IPAddress4/5` not persisted
 
 ### Removed
 

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -244,6 +244,7 @@ void WifiBegin(uint8_t flag, uint8_t channel) {
     Settings->sta_active ^= 1;  // Skip empty SSID
   }
   if (Settings->ipv4_address[0]) {
+    // AddLog(LOG_LEVEL_INFO, ">>>1: Wifi Config DNS %_I %_I", Settings->ipv4_address[3], Settings->ipv4_address[4]);
     WiFi.config(Settings->ipv4_address[0], Settings->ipv4_address[1], Settings->ipv4_address[2], Settings->ipv4_address[3], Settings->ipv4_address[4]);  // Set static IP
   }
   WiFi.hostname(TasmotaGlobal.hostname);  // ESP8266 needs this here (after WiFi.mode)
@@ -842,10 +843,12 @@ void WifiCheckIp(void) {
     if (Wifi.status != WL_CONNECTED) {
       AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CONNECTED));
 //      AddLog(LOG_LEVEL_INFO, PSTR("Wifi: Set IP addresses"));
+      // AddLog(LOG_LEVEL_INFO, ">>>1: Before DNS %_I %_I", Settings->ipv4_address[3], Settings->ipv4_address[4]);
       Settings->ipv4_address[1] = (uint32_t)WiFi.gatewayIP();
       Settings->ipv4_address[2] = (uint32_t)WiFi.subnetMask();
       Settings->ipv4_address[3] = (uint32_t)WiFi.dnsIP();
       Settings->ipv4_address[4] = (uint32_t)WiFi.dnsIP(1);
+      // AddLog(LOG_LEVEL_INFO, ">>>1: After DNS %_I %_I", Settings->ipv4_address[3], Settings->ipv4_address[4]);
 
       // Save current AP parameters for quick reconnect
       Settings->wifi_channel = WiFi.channel();


### PR DESCRIPTION
## Description:

Fix DNS selection and persistance when using `IPAddress4/5`, also improve support for dual IPv4/IPv6 DNS.

**Related issue (if applicable):** fixes #23353

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
