### PR TITLE
Berry remove imports from globals

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
@@ -32,7 +32,7 @@ const char be_berry_init_code[] =
   "import global "
 #ifdef USE_BERRY_PYTHON_COMPAT
   // enable python syntax compatibility mode
-  "import python_compat "
+  "do import python_compat end "      // don't keep 'python_compat' in global namespace
 #endif
   "import cb "
 
@@ -55,7 +55,7 @@ const char be_berry_init_code[] =
 
 #ifdef USE_AUTOCONF
   // autoconf
-  "import autoconf "
+  "do import autoconf end "
 #endif // USE_AUTOCONF
 
 #ifdef USE_LVGL
@@ -80,11 +80,7 @@ const char be_berry_init_code[] =
   "import light "
 #endif // USE_LIGHT
 
-#if defined(USE_EMULATION) && defined(USE_EMULATION_HUE)
-  "import hue_bridge "
-#endif
-
-  "import tapp "
+  "do import tapp end "     // we don't need to keep `tapp` in the global namespace
 
 #ifdef USE_BERRY_DEBUG
   "import debug "


### PR DESCRIPTION
## Description:

Berry, rearrange some imports so that they don't create an unused global object anymore: `python_compat`, `autoconf`, `tapp`. Also remove `import hue_bridge` that will be needed only when actually used.

No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
