### PR TITLE
Fix solidification of float on macos

### DIFF
--- a/lib/libesp32/berry/Makefile
+++ b/lib/libesp32/berry/Makefile
@@ -1,4 +1,4 @@
-CFLAGS      = -Wall -Wextra -std=c99 -O2 -Wno-zero-length-array -Wno-empty-translation-unit -DUSE_BERRY_INT64
+CFLAGS      = -Wall -Wextra -std=c99 -O2 -Wno-zero-length-array -Wno-empty-translation-unit -ffp-contract=off -DUSE_BERRY_INT64
 DEBUG_FLAGS = -O0 -g -DBE_DEBUG
 TEST_FLAGS  = $(DEBUG_FLAGS) --coverage -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined
 LIBS        = -lm


### PR DESCRIPTION
## Description:

Change compilation option so the `C` value `0.00055f` always solidifies to `0x3A102DE0`. However on macos it solidifies to `3A102DE1`. Although the difference is insignificant, it triggers unwanted staged files. Now it solidifies the same way on Linux and macos. (Thanks claude.ai for providing the solution)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
