### PR TITLE
Berry remove global 'b'

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/python_compat.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/python_compat.be
@@ -8,6 +8,5 @@ python_compat.init = def (m)
     global.True = true
     global.False = false
     global.None = nil
-    global.b = bytes
     return m
 end


### PR DESCRIPTION
## Description:

Berry `python_compat` tried to introduce the `b` global to mimic `b"0011"` python notation. However this construct without parenthesis does not work anymore in Berry.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
