### PR TITLE
provide serial upoload port setting from VSC to PIO

### DIFF
--- a/pio-tools/port-vsc.py
+++ b/pio-tools/port-vsc.py
@@ -1,0 +1,40 @@
+env = DefaultEnvironment()
+
+import os
+
+if os.environ.get("PLATFORMIO_CALLER") == "vscode":
+    print("PIO called from VS Code extension")
+    import platform
+    import sqlite3
+    import json
+    from platformio.project.helpers import get_project_dir
+
+    os_name = platform.system()
+    print("OS Platform:", os_name)
+    os_paths = {
+        "Darwin": "~/Library/Application Support/Code/User/globalStorage/state.vscdb",
+        "Linux": "~/.config/Code/User/globalStorage/state.vscdb",
+        "Windows": r"%APPDATA%\Code\User\globalStorage\state.vscdb"
+    }
+    project_path = get_project_dir()
+
+    try:
+        db_path = os.path.expanduser(os.path.expandvars(os_paths[os_name]))
+    except KeyError:
+        raise RuntimeError("Unknown OS: " + os_name)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    for key in ['pioarduino.pioarduino-ide', 'platformio.platformio-ide']:
+        cursor.execute("SELECT value FROM ItemTable WHERE key = ?", (key,))
+        row = cursor.fetchone()
+        if row:
+            data = json.loads(row[0])
+            projects = data.get("projects", {})
+            project = projects.get(project_path)
+            if project and "customPort" in project:
+                print("USB port set in VSC:", project["customPort"])
+                env["UPLOAD_PORT"] = project["customPort"]
+                break
+    conn.close()

--- a/platformio.ini
+++ b/platformio.ini
@@ -74,6 +74,7 @@ extra_scripts               = pre:pio-tools/pre_source_dir.py
                               pre:pio-tools/set_partition_table.py
                               pre:pio-tools/override_copy.py
                               pre:pio-tools/compress-html.py
+                              pre:pio-tools/port-vsc.py
                               post:pio-tools/strip-flags.py
 
 [esp_defaults]


### PR DESCRIPTION
## Description:

The serial Port setting in VSC is **not** always used in Platformio. Only used when flashing the firmware. The provided Pio script in this PR reads the VSC database `state.vscdb` and searches for a port set and if found, it is populated to Platformio by setting the `env["UPLOAD_PORT"]`.  So it is ensured that no random serial port is used (caused by autodetection) for **any** command possible with Platformio.
No change of behaviour if no setting is done in VSC or VSC is not used at all.
 
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
