### PR TITLE
port VSC: take care of WSL use

### DIFF
--- a/pio-tools/port-vsc.py
+++ b/pio-tools/port-vsc.py
@@ -23,6 +23,15 @@ if os.environ.get("PLATFORMIO_CALLER") == "vscode":
     except KeyError:
         print("Unknown OS: " + os_name)
 
+    # If the database is not found, check if running in WSL
+    # and try to find the database in the Windows file system
+    if not os.path.exists(db_path) and os_name == "Linux":
+        try:
+            db_path = os.path.expanduser(os.path.expandvars(os_paths["Windows"]))
+            print("Windows running PIO in WSL")
+        except KeyError:
+            pass
+
     # Only when the database is found we can go on
     if os.path.exists(db_path):
         conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Description:

try to make script Vsc-port working when using WSL with Windows.
@arendst  can you test?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
