### PR TITLE
Fix version for IniFile-Tasmota

### DIFF
--- a/lib/lib_ssl/IniFile-Tasmota/library.properties
+++ b/lib/lib_ssl/IniFile-Tasmota/library.properties
@@ -1,5 +1,5 @@
 name=IniFile
-version=modified by Tasmota, based on 1.3.0
+version=1.3.0+tasmota
 author=Steve Marple <stevemarple@googlemail.com>, Stephan Hadiger
 maintainer=Steve Marple <stevemarple@googlemail.com>, Stephan Hadiger
 sentence=Library to read and parse .ini files, adapted for Tasmota


### PR DESCRIPTION
Fixes the version string in lib/lib_ssl/IniFile-Tasmota/library.properties file to be semver compliant to avoid build error:
  ValueError: Invalid version string: '0.0.0+modified by Tasmota, based on 1.3.0':

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
