### PR TITLE
Berry 'introspect.module' option to not cache module entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota auto-dimming when no touch (#23425)
 - Provide serial upload port from VSC to PIO (#23436)
 - Berry support for `sortedmap` (#23441)
+- Berry `introspect.module` option to not cache module entry
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -182,7 +182,11 @@ static int m_getmodule(bvm *vm)
     if (top >= 1) {
         bvalue *v = be_indexof(vm, 1);
         if (var_isstr(v)) {
-            int ret = be_module_load(vm, var_tostr(v));
+            bbool no_cache = bfalse;
+            if (top >= 2) {
+                no_cache = be_tobool(vm, 2);
+            }
+            int ret = be_module_load_nocache(vm, var_tostr(v), no_cache);
             if (ret == BE_OK) {
                 be_return(vm);
             }

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -278,8 +278,8 @@ static void module_init(bvm *vm) {
     }
 }
 
-/* load module to vm->top */
-int be_module_load(bvm *vm, bstring *path)
+/* load module to vm->top, option to cache or not */
+int be_module_load_nocache(bvm *vm, bstring *path, bbool nocache)
 {
     int res = BE_OK;
     if (!load_cached(vm, path)) {
@@ -287,12 +287,20 @@ int be_module_load(bvm *vm, bstring *path)
         if (res == BE_IO_ERROR)
             res = load_package(vm, path);
         if (res == BE_OK) {
-            /* on first load of the module, try running the '()' function */
+            /* on first load of the module, try running the 'init' function */
             module_init(vm);
-            be_cache_module(vm, path);
+            if (!nocache) { /* cache the module if it is loaded successfully */
+                be_cache_module(vm, path);
+            }
         }
     }
     return res;
+}
+
+/* load module to vm->top */
+int be_module_load(bvm *vm, bstring *path)
+{
+    return be_module_load_nocache(vm, path, btrue);
 }
 
 BERRY_API bbool be_getmodule(bvm *vm, const char *k)

--- a/lib/libesp32/berry/src/be_module.h
+++ b/lib/libesp32/berry/src/be_module.h
@@ -34,6 +34,7 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
+int be_module_load_nocache(bvm *vm, bstring *path, bbool cache);
 void be_cache_module(bvm *vm, bstring *name);
 int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
 bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);


### PR DESCRIPTION
## Description:

Berry, add ability to load a module (`import`) without caching the entry in the global table, which makes it possible to completely unload it later:
- `introspect.module(name:string [, noload:bool]) -> any` : new `noload` optional boolean, if `true` do not cache entry
- add internal api `be_module_load_nocache`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
