### PR TITLE
Berry 'webserver.remove_route' to revert 'webserver.on'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Provide serial upload port from VSC to PIO (#23436)
 - Berry support for `sortedmap` (#23441)
 - Berry `introspect.module` option to not cache module entry
+- Berry `webserver.remove_route` to revert `webserver.on`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -646,6 +646,13 @@ void WebServer_on(const char * prefix, void (*func)(void), uint8_t method = HTTP
 #endif  // ESP32
 }
 
+#ifdef ESP32
+void WebServer_removeRoute(const char * prefix, uint8_t method = HTTP_ANY) {
+  if (Webserver == nullptr) { return; }
+  Webserver->removeRoute(prefix, (HTTPMethod) method);
+}
+#endif  // ESP32
+
 /*- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -*/
 
 // Always listens to all interfaces, so we don't need an IP address anymore


### PR DESCRIPTION
## Description:

Berry add ability to revert `webserver.on` and make all objects removable by GC:
- `webserver.remove_route(prefix:string, [, method:int]) -> bool` to remove a previously defined route with `webserver.on()`
- internal function `WebServer_removeRoute` added (for ESP32 only)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
