### PR TITLE
Command lookup table in support_command.ino broken for ESP32

### DIFF
--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -54,11 +54,11 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #endif  // USE_UFILESYS
 
 #ifdef ESP32
-  "|Info|"
+  "Info|"
 #if defined(SOC_TOUCH_VERSION_1) || defined(SOC_TOUCH_VERSION_2)
   D_CMND_TOUCH_CAL "|" D_CMND_TOUCH_THRES "|"
 #endif  // ESP32 SOC_TOUCH_VERSION_1 or SOC_TOUCH_VERSION_2
-  D_CMND_CPU_FREQUENCY
+  D_CMND_CPU_FREQUENCY "|"
 #endif  // ESP32
 
   D_CMND_SETSENSOR "|" D_CMND_SENSOR "|" D_CMND_DRIVER "|" D_CMND_JSON "|" D_CMND_JSON_PP


### PR DESCRIPTION
I observed that the definition of command names became mangled with commit https://github.com/arendst/Tasmota/commit/2bc5f682b04ab8fb0a7975763c1a4c2f4a8d54b5 due to vertical bar not being placed where it should. With no bar after `D_CMND_CPU_FREQUENCY`, the command name became concatenated with the next `D_CMND_SETSENSOR` with the "funny" effect that command name `CpuFrequencySetSensor` got matched with `&CmndSetSensor`

The reason for it not being matched with `&CmndCpuFrequency` is that there is a bar too many before the `Info` command name, as previous command name lines all finish with `"|"`. Hence an extra command table entry was created, meaning that the mismatch "only" affected command names `Info`, `TouchCal`, `TouchThres`, `CpuFrequency` and `SetSensor`.

Issue is only for ESP32, as both mishaps happened in a block conditional on `#ifdef ESP32`.

Arguably, it could make sense to have all the lines with command names start with `"|"` as a consistent way of formatting the lines without the special case of ending `"|"` to be omitted for the very last command name line, but I wanted to only make minimal changes

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
