### PR TITLE
Berry: 'webserver.content_status_sticker' attribute parameter added

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -403,7 +403,7 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // Berry: `webserver.content_status_sticker(msg:string,attr:string) -> nil`
+  // Berry: `webserver.content_status_sticker(msg:string [,attr:string]) -> nil`
   //
   int32_t w_webserver_content_status_sticker(struct bvm *vm) {
   #ifdef USE_WEB_STATUS_LINE

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -403,14 +403,18 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // Berry: `webserver.content_status_sticker(msg:string) -> nil`
+  // Berry: `webserver.content_status_sticker(msg:string,attr:string) -> nil`
   //
   int32_t w_webserver_content_status_sticker(struct bvm *vm) {
   #ifdef USE_WEB_STATUS_LINE
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 1 && be_isstring(vm, 1)) {
       const char * msg = be_tostring(vm, 1);
-      WSContentStatusSticker(msg);
+      const char * attr = nullptr;
+      if (argc >= 2 && be_isstring(vm, 2)) {
+        attr = be_tostring(vm, 2);
+      }
+      WSContentStatusSticker(msg, attr);
       be_return_nil(vm);
     }
     be_raise(vm, kTypeError, nullptr);


### PR DESCRIPTION
## Description:

Berry added attribute management (like tooltip) on 'webserver.content_status_sticker':

Sample usage:

```
	def web_status_line_left()
		var ni =  tasmota.eth()
		if ni.has('ip')
			webserver.content_status_sticker("Eth",' title="'+ ni['ip'] +'"')
		end
	end
```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
