### PR TITLE
Berry fix potential pointer underflow with `string.endswith`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - DNS setting with `IPAddress4/5` not persisted (#23426)
 - Berry avoid json parsing for unmatched commands
 - Berry fix integer and real parser to handle overflows
+- Berry fix potential pointer underflow with `string.endswith`
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -1074,14 +1074,17 @@ static int str_endswith(bvm *vm)
         bbool result = bfalse;
         const char *s = be_tostring(vm, 1);
         const char *p = be_tostring(vm, 2);
-        size_t len = (size_t)be_strlen(vm, 2);
-        if (case_insensitive) {
-            if (str_strncasecmp(s + (int)strlen(s) - (int)len, p, len) == 0) {
-                result = btrue;
-            }
-        } else {
-            if (strncmp(s + (int)strlen(s) - (int)len, p, len) == 0) {
-                result = btrue;
+        size_t len_s = (size_t)be_strlen(vm, 1);
+        size_t len_p = (size_t)be_strlen(vm, 2);
+        if (len_s >= len_p) {
+            if (case_insensitive) {
+                if (str_strncasecmp(s + (int)len_s - (int)len_p, p, len_p) == 0) {
+                    result = btrue;
+                }
+            } else {
+                if (strncmp(s + (int)len_s - (int)len_p, p, len_p) == 0) {
+                    result = btrue;
+                }
             }
         }
         be_pushbool(vm, result);


### PR DESCRIPTION
## Description:

Fix calling `strncmp` or `str_strncasecmp` with an invalid pointer due to a negative offset from the beginning of the string.

Found by claude.ai

```berry
import string
string.endswith("", "a_very_long_string_will_cause_a_pointer_underlow")
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
