### PR TITLE
Update xsns_102_ld2402.ino, command table broken

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_102_ld2402.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_102_ld2402.ino
@@ -588,7 +588,7 @@ void (* const Ld2402Command[])(void) PROGMEM = {
   &CmndLd2402Help, 
 #endif // LD2402_INCLUDE_HELP
 #ifdef LD2402_INCLUDE_FOLLOW
-  , &CmndLd2402Follow
+  &CmndLd2402Follow,
 #endif // LD2402_INCLUDE_FOLLOW
   &CmndLd2402Mode, &CmndLd2402AutoUpdate, &CmndLd2402AutoGain, &CmndLd2402Status, &CmndLd2402Common,
   &CmndLd2402Motion, &CmndLd2402Micro, &CmndLd2402Save, &CmndLd2402ReRead };


### PR DESCRIPTION
Command pointer table broken after refactoring https://github.com/arendst/Tasmota/commit/3a28938b9153d01e7ccef0a03d981251ced56123

The error with a comma before an entry instead of after, to match the other pointers, looks very obvious to me. Hence, I'm submitting this PR without having the hardware, and thus not able to do a runtime test.

For context, I'm playing with extracting available commands from the source code, doing simple parsing of the reasonably recognizable format of the command table entries, leading to me noticing such an anomaly.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
