### PR TITLE
Berry change number parser for json to reuse same parser as lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Platform from 2025.05.40 to 2025.05.30, Framework (Arduino Core) from v3.2.0.250504 to v3.1.3.250504 and IDF from v5.4.1.250501 to v5.3.3.250501 (#23404)
 - ESP8266 platform update from 2024.09.00 to 2025.05.00 (#23448)
 - Increase number of supported LoRaWan nodes from 4 to 16
+- Berry change number parser for json to reuse same parser as lexer
 
 ### Fixed
 - Haspmota `haspmota.parse()` page parsing (#23403)


### PR DESCRIPTION
## Description:

Berry, second part of fixing the number parser. Now `json.load` uses the same parser as the Berry lexer, but adds a layer to enforce JSON syntax. Ex: `+42`, `.45`, `0x12` are valid numbers in Berry but not valid JSON numbers.

JSON checker done with the help of claude.ai

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
