### PR TITLE
Berry increase web hooks from 16 to 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - ESP8266 platform update from 2024.09.00 to 2025.05.00 (#23448)
 - Increase number of supported LoRaWan nodes from 4 to 16
 - Berry change number parser for json to reuse same parser as lexer
+- Berry increase web hooks from 16 to 32
 
 ### Fixed
 - Haspmota `haspmota.parse()` page parsing (#23403)

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -43,7 +43,7 @@ extern int w_webserver_header(bvm *vm);
 // model from Arduino framework.
 // We use our own list of callbacks
 
-#define WEBSERVER_REQ_HANDLER_HOOK_MAX       16      // max number of callbacks, each callback requires a distinct address
+#define WEBSERVER_REQ_HANDLER_HOOK_MAX       32      // max number of callbacks, each callback requires a distinct address
 typedef struct be_webserver_callback_hook_t {
   bvm *vm;                // make sure we are using the same VM
   bvalue f;               // the Berry function to call
@@ -71,6 +71,22 @@ WEBSERVER_HOOK_CB(12);
 WEBSERVER_HOOK_CB(13);
 WEBSERVER_HOOK_CB(14);
 WEBSERVER_HOOK_CB(15);
+WEBSERVER_HOOK_CB(16);
+WEBSERVER_HOOK_CB(17);
+WEBSERVER_HOOK_CB(18);
+WEBSERVER_HOOK_CB(19);
+WEBSERVER_HOOK_CB(20);
+WEBSERVER_HOOK_CB(21);
+WEBSERVER_HOOK_CB(22);
+WEBSERVER_HOOK_CB(23);
+WEBSERVER_HOOK_CB(24);
+WEBSERVER_HOOK_CB(25);
+WEBSERVER_HOOK_CB(26);
+WEBSERVER_HOOK_CB(27);
+WEBSERVER_HOOK_CB(28);
+WEBSERVER_HOOK_CB(29);
+WEBSERVER_HOOK_CB(30);
+WEBSERVER_HOOK_CB(31);
 
 // array of callbacks
 static const berry_webserver_cb_t berry_callback_array[WEBSERVER_REQ_HANDLER_HOOK_MAX] = {
@@ -90,6 +106,22 @@ static const berry_webserver_cb_t berry_callback_array[WEBSERVER_REQ_HANDLER_HOO
   berry_webserver_cb_13,
   berry_webserver_cb_14,
   berry_webserver_cb_15,
+  berry_webserver_cb_16,
+  berry_webserver_cb_17,
+  berry_webserver_cb_18,
+  berry_webserver_cb_19,
+  berry_webserver_cb_20,
+  berry_webserver_cb_21,
+  berry_webserver_cb_22,
+  berry_webserver_cb_23,
+  berry_webserver_cb_24,
+  berry_webserver_cb_25,
+  berry_webserver_cb_26,
+  berry_webserver_cb_27,
+  berry_webserver_cb_28,
+  berry_webserver_cb_29,
+  berry_webserver_cb_30,
+  berry_webserver_cb_31,
 };
 
 // Return slot number


### PR DESCRIPTION
## Description:

Berry, due to the increase of features, the number of available web hooks is increased from 16 to 32 slots. Flash increase 250 bytes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
