### PR TITLE
Autoconf failing when last line has no trailing LF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Berry avoid json parsing for unmatched commands (#23494)
 - Berry integer and real parser to handle overflows (#23495)
 - Berry potential pointer underflow with `string.endswith` (#23496)
+- Autoconf failing when last line has no trailing LF
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -319,7 +319,7 @@ char* be_fgets(void *hfile, void *buffer, int size)
         // Serial.printf("be_fgets size=%d ret=%d\n", size, ret);
         if (ret >= 0) {
             buf[ret] = 0;           // add string terminator
-            if (ret < size - 1) {
+            if ((ret != 0) && (ret < size - 1)) {
                 buf[ret] = '\n';
                 buf[ret+1] = 0;
             }


### PR DESCRIPTION
## Description:

Fix autoconf parsing failing when the last line does not end with `LF`. This regression was indirectly introduced in #23276

**Related issue (if applicable):** fixes #23536

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
