### PR TITLE
i2s additions

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
@@ -22,7 +22,6 @@
 
 struct AUDIO_I2S_WEBRADIO_t {
   AudioFileSourceICYStream *ifile = NULL;
-  char wr_title[64];
 } Audio_webradio;
 
 void I2sMDCallback(void *cbData, const char *type, bool isUnicode, const char *str) {
@@ -30,9 +29,8 @@ void I2sMDCallback(void *cbData, const char *type, bool isUnicode, const char *s
   (void) isUnicode; // Punt this ball for now
   (void) ptr;
   if (strstr_P(type, PSTR("Title"))) {
-    strncpy(Audio_webradio.wr_title, str, sizeof(Audio_webradio.wr_title));
-    Audio_webradio.wr_title[sizeof(Audio_webradio.wr_title)-1] = 0;
-    //AddLog(LOG_LEVEL_INFO,PSTR("WR-Title: %s"),wr_title);
+    strncpy(audio_i2s_mp3.audio_title, str, sizeof(audio_i2s_mp3.audio_title));
+    audio_i2s_mp3.audio_title[sizeof(audio_i2s_mp3.audio_title)-1] = 0;
   } else {
     // Who knows what to do?  Not me!
   }
@@ -106,21 +104,6 @@ i2swr_fail:
     I2sWebRadioStopPlaying();
     return false;
 }
-
-#ifdef USE_WEBSERVER
-const char HTTP_WEBRADIO[] PROGMEM =
-   "{s}" "Webradio:" "{m}%s{e}";
-
-void I2sWrShow(bool json) {
-    if (audio_i2s_mp3.decoder) {
-      if (json) {
-        ResponseAppend_P(PSTR(",\"WebRadio\":{\"Title\":\"%s\"}"), Audio_webradio.wr_title);
-      } else {
-        WSContentSend_PD(HTTP_WEBRADIO,Audio_webradio.wr_title);
-      }
-    }
-}
-#endif  // USE_WEBSERVER
 
 void CmndI2SWebRadio(void) {
   if (I2SPrepareTx() != I2S_OK) return;


### PR DESCRIPTION
## Description:

Adds an event to be used with RULES when audio stream ends. This allows playing a list of audio files and more.
Usage:
`Rule1 ON event#i2splay=ended DO <something> ENDON`

`i2splay` will now initially respond with `Started` and not - as before - `Done`, IMHO this better reflects the function.
After finish we will receive `{"Event":{"I2SPlay":"Ended"}}`.

Cosmetic change to show a playing audio stream for files and web radio using the generic term `Audio` for web interface and console/mqtt. If the latter breaks some automation, please raise an issue and we can create a more granular solution.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
