### PR TITLE
Berry report from upstream !BE_USE_PRECOMPILED_OBJECT

### DIFF
--- a/lib/libesp32/berry/src/be_debuglib.c
+++ b/lib/libesp32/berry/src/be_debuglib.c
@@ -255,7 +255,7 @@ be_native_module_attr_table(debug) {
     be_native_module_function("top", m_top),
 #if BE_DEBUG_VAR_INFO
     be_native_module_function("varname", m_varname),
-    be_native_module_function("upvname", m_upvname)
+    be_native_module_function("upvname", m_upvname),
 #endif
     be_native_module_function("caller", m_caller),
     be_native_module_function("gcdebug", m_gcdebug)

--- a/lib/libesp32/berry/src/be_listlib.c
+++ b/lib/libesp32/berry/src/be_listlib.c
@@ -515,7 +515,7 @@ void be_load_listlib(bvm *vm)
         { "reverse", m_reverse },
         { "copy", m_copy },
         { "keys", m_keys },
-        { "tobool", m_tobool }
+        { "tobool", m_tobool },
         { "..", m_connect },
         { "+", m_merge },
         { "==", m_equal },


### PR DESCRIPTION
## Description:

Applying https://github.com/berry-lang/berry/pull/473 from upstream.

This has no impact on Tasmota because we use BE_USE_PRECOMPILED_OBJECT mode.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
