### PR TITLE
LVGL restore `lv_chart.set_range` removed in LVGL 9.3.0 in favor of `lv_chart.set_axis_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Library names (#23560)
 
 ### Fixed
-- LVGL restore `lv_chart.set_range` remove in LVGL 9.3.0 in favor of `lv_chart.set_axis_range`
+- LVGL restore `lv_chart.set_range` removed in LVGL 9.3.0 in favor of `lv_chart.set_axis_range`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Library names (#23560)
 
 ### Fixed
-- LVGL restore `lv_chart.set_range` remove in LVGL 8.3.0 in favor of `lv_chart.set_axis_range`
+- LVGL restore `lv_chart.set_range` remove in LVGL 9.3.0 in favor of `lv_chart.set_axis_range`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Library names (#23560)
 
 ### Fixed
+- LVGL restore `lv_chart.set_range` remove in LVGL 8.3.0 in favor of `lv_chart.set_axis_range`
 
 ### Removed
 

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
@@ -1470,6 +1470,7 @@ set_div_line_count|int, int||[lv_chart_set_div_line_count](https://docs.lvgl.io/
 set_next_value|lv.chart_series, int||[lv_chart_set_next_value](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_next_value)
 set_next_value2|lv.chart_series, int, int||[lv_chart_set_next_value2](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_next_value2)
 set_point_count|int||[lv_chart_set_point_count](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_point_count)
+set_range|int, int, int||[lv_chart_set_axis_range](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_axis_range)
 set_series_color|lv.chart_series, lv.color||[lv_chart_set_series_color](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_series_color)
 set_series_ext_x_array|lv.chart_series, lv.int_arr||[lv_chart_set_series_ext_x_array](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_series_ext_x_array)
 set_series_ext_y_array|lv.chart_series, lv.int_arr||[lv_chart_set_series_ext_y_array](https://docs.lvgl.io/9.0/search.html?q=lv_chart_set_series_ext_y_array)

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
@@ -1026,6 +1026,7 @@ const be_ntv_func_def_t lv_chart_func[] = {
   { "set_next_value", { (const void*) &lv_chart_set_next_value, "", "(lv.obj)(lv.chart_series)i" } },
   { "set_next_value2", { (const void*) &lv_chart_set_next_value2, "", "(lv.obj)(lv.chart_series)ii" } },
   { "set_point_count", { (const void*) &lv_chart_set_point_count, "", "(lv.obj)i" } },
+  { "set_range", { (const void*) &lv_chart_set_axis_range, "", "(lv.obj)iii" } },
   { "set_series_color", { (const void*) &lv_chart_set_series_color, "", "(lv.obj)(lv.chart_series)(lv.color)" } },
   { "set_series_ext_x_array", { (const void*) &lv_chart_set_series_ext_x_array, "", "(lv.obj)(lv.chart_series)(lv.int_arr)" } },
   { "set_series_ext_y_array", { (const void*) &lv_chart_set_series_ext_y_array, "", "(lv.obj)(lv.chart_series)(lv.int_arr)" } },

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
@@ -226,6 +226,8 @@ synonym_functions = {
   "set_transform_zoom": "set_transform_scale",
 
   "scr_load_anim": "screen_load_anim",
+
+  "set_range": "set_axis_range",
 }
 
 def get_synonyms(name):


### PR DESCRIPTION
## Description:

LVGL 9.3.0 renamed `lv_chart.set_range` to `lv_chart.set_axis_range` breaking `lv_wifi_chart` widget. This patch restores a synonym for backwards compatibility.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
