### PR TITLE
Prepare use of esptool v5.0.0

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -85,6 +85,17 @@ if not variants_dir:
     variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
     env.BoardConfig().update("build.variants_dir", variants_dir)
 
+def esptool_call(cmd):
+    try:
+        esptool.main(cmd)
+    except SystemExit as e:
+        # Fetch sys.exit() without leaving the script
+        if e.code == 0:
+            return True
+        else:
+            print(f"❌ esptool failed with exit code: {e.code}")
+            return False
+
 def esp32_detect_flashsize():
     uploader = env.subst("$UPLOADER")
     if not "upload" in COMMAND_LINE_TARGETS:
@@ -339,7 +350,7 @@ def esp32_create_combined_bin(source, target, env):
                 sys.stdout = devnull
                 sys.stderr = devnull
                 try:
-                    esptool.main(cmd)
+                    esptool_call(cmd)
                 finally:
                     sys.stdout = old_stdout
                     sys.stderr = old_stderr


### PR DESCRIPTION
## Description:

esptool v5 explicit exists, fetch the exit when calling esptool to prevent leaving the running pio script.
The change is backwards compatible. No change with current used esptool.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
