### PR TITLE
Berry minor fixes to tapp handling

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
@@ -114,6 +114,11 @@ class sortedmap
   def iter()
     return self._data.iter()
   end
+
+  # Get by index number
+  def get_by_index(idx)
+    return self._data[self._keys[idx]]
+  end
   
   # Clear all key-value pairs
   def clear()

--- a/lib/libesp32/berry_tasmota/src/embedded/tapp.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tapp.be
@@ -20,7 +20,7 @@ tapp_module.init = def (m)
       for d: path.listdir(dir_name)
         if string.endswith(d, ".tapp")
           log(f"TAP: Loaded Tasmota App '{dir_name}{d}'", 2)
-          tasmota.load(dir_name + d + "#autoexec.be")
+          tasmota.load(dir_name + d)
         end
       end
     end

--- a/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
@@ -503,6 +503,7 @@ class Tasmota
   #    load("autoexec.be")        -- loads file from .be or .bec if .be is not here, remove .bec if .be exists
   #    load("autoexec")           -- same as above
   #    load("autoexec.bec")       -- load only .bec file and ignore .be
+  #    load("app.tapp")           -- loads app, internally adds "#autoexec.be"
   #    load("app.tapp#module.be") -- loads from tapp arhive
   #
   # Returns 'true' if succesful of 'false' if file is not found or corrupt
@@ -597,6 +598,12 @@ class Tasmota
     if !string.startswith(f_name, '/')   f_name = '/' + f_name   end
     # Ex: f_name = '/app.zip#autoexec'
 
+    # if ends with ".tapp", add "#autoexec"
+    # there's a trick here, since actual prefix may be ".tapp" or "._tapp" (the later for no-autp-run)
+    if string.endswith(f_name, 'tapp')
+      f_name += "#autoexec"
+    end
+
     var f_find_hash = string.find(f_name, '#')
     var f_archive = (f_find_hash > 0)                     # is the file in an archive
     var f_prefix = f_archive ? f_name[0..f_find_hash - 1] : f_name
@@ -685,6 +692,7 @@ class Tasmota
     # remove path prefix
     if f_archive
       pop_path(f_prefix + "#")
+      self.wd = ""
     end
 
     return run_ok

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_sortedmap.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_sortedmap.h
@@ -3,41 +3,41 @@
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
-// compact class 'sortedmap' ktab size: 22, total: 54 (saved 256 bytes)
+// compact class 'sortedmap' ktab size: 22, total: 56 (saved 272 bytes)
 static const bvalue be_ktab_class_sortedmap[22] = {
   /* K0   */  be_nested_str(_data),
-  /* K1   */  be_nested_str(_keys),
-  /* K2   */  be_nested_str(insert),
-  /* K3   */  be_nested_str(string),
-  /* K4   */  be_nested_str(_X7B),
-  /* K5   */  be_const_int(0),
-  /* K6   */  be_nested_str(size),
-  /* K7   */  be_const_int(1),
-  /* K8   */  be_nested_str(_X2C_X20),
-  /* K9   */  be_nested_str(format),
-  /* K10  */  be_nested_str(_X27_X25s_X27_X3A_X20),
-  /* K11  */  be_nested_str(_X25s_X3A_X20),
-  /* K12  */  be_nested_str(_X27_X25s_X27),
-  /* K13  */  be_nested_str(stop_iteration),
-  /* K14  */  be_nested_str(_X7D),
-  /* K15  */  be_const_int(2),
-  /* K16  */  be_nested_str(push),
-  /* K17  */  be_nested_str(remove),
-  /* K18  */  be_nested_str(find),
-  /* K19  */  be_nested_str(contains),
-  /* K20  */  be_nested_str(_find_insert_position),
-  /* K21  */  be_nested_str(iter),
+  /* K1   */  be_nested_str(size),
+  /* K2   */  be_nested_str(iter),
+  /* K3   */  be_nested_str(_keys),
+  /* K4   */  be_nested_str(contains),
+  /* K5   */  be_nested_str(remove),
+  /* K6   */  be_nested_str(find),
+  /* K7   */  be_nested_str(string),
+  /* K8   */  be_nested_str(_X7B),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_const_int(1),
+  /* K11  */  be_nested_str(_X2C_X20),
+  /* K12  */  be_nested_str(format),
+  /* K13  */  be_nested_str(_X27_X25s_X27_X3A_X20),
+  /* K14  */  be_nested_str(_X25s_X3A_X20),
+  /* K15  */  be_nested_str(_X27_X25s_X27),
+  /* K16  */  be_nested_str(stop_iteration),
+  /* K17  */  be_nested_str(_X7D),
+  /* K18  */  be_nested_str(_find_insert_position),
+  /* K19  */  be_nested_str(insert),
+  /* K20  */  be_const_int(2),
+  /* K21  */  be_nested_str(push),
 };
 
 
 extern const bclass be_class_sortedmap;
 
 /********************************************************************
-** Solidified function: clear
+** Solidified function: size
 ********************************************************************/
-be_local_closure(class_sortedmap_clear,   /* name */
+be_local_closure(class_sortedmap_size,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -46,16 +46,13 @@ be_local_closure(class_sortedmap_clear,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_clear,
+    &be_const_str_size,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x60040012,  //  0003  GETGBL	R1	G18
-      0x7C040000,  //  0004  CALL	R1	0
-      0x90020201,  //  0005  SETMBR	R0	K1	R1
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -63,12 +60,12 @@ be_local_closure(class_sortedmap_clear,   /* name */
 
 
 /********************************************************************
-** Solidified function: setitem
+** Solidified function: iter
 ********************************************************************/
-be_local_closure(class_sortedmap_setitem,   /* name */
+be_local_closure(class_sortedmap_iter,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
+    3,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -76,14 +73,143 @@ be_local_closure(class_sortedmap_setitem,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_setitem,
+    &be_const_str_iter,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_by_index
+********************************************************************/
+be_local_closure(class_sortedmap_get_by_index,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_get_by_index,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C0C0102,  //  0000  GETMET	R3	R0	K2
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x5C180400,  //  0002  MOVE	R6	R2
-      0x7C0C0600,  //  0003  CALL	R3	3
-      0x80040600,  //  0004  RET	1	R3
+      0x88080103,  //  0000  GETMBR	R2	R0	K3
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x94080401,  //  0002  GETIDX	R2	R2	R1
+      0x94080602,  //  0003  GETIDX	R2	R3	R2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove
+********************************************************************/
+be_local_closure(class_sortedmap_remove,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_remove,
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080504,  //  0001  GETMET	R2	R2	K4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0010,  //  0004  JMPF	R2	#0016
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x8C080505,  //  0006  GETMET	R2	R2	K5
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x7C080400,  //  000C  CALL	R2	2
+      0x4C0C0000,  //  000D  LDNIL	R3
+      0x200C0403,  //  000E  NE	R3	R2	R3
+      0x780E0003,  //  000F  JMPF	R3	#0014
+      0x880C0103,  //  0010  GETMBR	R3	R0	K3
+      0x8C0C0705,  //  0011  GETMET	R3	R3	K5
+      0x5C140400,  //  0012  MOVE	R5	R2
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x500C0200,  //  0014  LDBOOL	R3	1	0
+      0x80040600,  //  0015  RET	1	R3
+      0x50080000,  //  0016  LDBOOL	R2	0	0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: contains
+********************************************************************/
+be_local_closure(class_sortedmap_contains,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_contains,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080504,  //  0001  GETMET	R2	R2	K4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: keys
+********************************************************************/
+be_local_closure(class_sortedmap_keys,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_keys,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -107,40 +233,40 @@ be_local_closure(class_sortedmap_tostring,   /* name */
     &be_const_str_tostring,
     &be_const_str_solidified,
     ( &(const binstruction[60]) {  /* code */
-      0xA4060600,  //  0000  IMPORT	R1	K3
-      0x58080004,  //  0001  LDCONST	R2	K4
+      0xA4060E00,  //  0000  IMPORT	R1	K7
+      0x58080008,  //  0001  LDCONST	R2	K8
       0x500C0200,  //  0002  LDBOOL	R3	1	0
       0x60100010,  //  0003  GETGBL	R4	G16
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
-      0x8C140B06,  //  0005  GETMET	R5	R5	K6
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
       0x7C140200,  //  0006  CALL	R5	1
-      0x04140B07,  //  0007  SUB	R5	R5	K7
-      0x40160A05,  //  0008  CONNECT	R5	K5	R5
+      0x04140B0A,  //  0007  SUB	R5	R5	K10
+      0x40161205,  //  0008  CONNECT	R5	K9	R5
       0x7C100200,  //  0009  CALL	R4	1
       0xA802002B,  //  000A  EXBLK	0	#0037
       0x5C140800,  //  000B  MOVE	R5	R4
       0x7C140000,  //  000C  CALL	R5	0
-      0x88180101,  //  000D  GETMBR	R6	R0	K1
+      0x88180103,  //  000D  GETMBR	R6	R0	K3
       0x94180C05,  //  000E  GETIDX	R6	R6	R5
       0x881C0100,  //  000F  GETMBR	R7	R0	K0
       0x941C0E06,  //  0010  GETIDX	R7	R7	R6
       0x5C200600,  //  0011  MOVE	R8	R3
       0x74220000,  //  0012  JMPT	R8	#0014
-      0x00080508,  //  0013  ADD	R2	R2	K8
+      0x0008050B,  //  0013  ADD	R2	R2	K11
       0x500C0000,  //  0014  LDBOOL	R3	0	0
       0x60200004,  //  0015  GETGBL	R8	G4
       0x5C240C00,  //  0016  MOVE	R9	R6
       0x7C200200,  //  0017  CALL	R8	1
-      0x1C201103,  //  0018  EQ	R8	R8	K3
+      0x1C201107,  //  0018  EQ	R8	R8	K7
       0x78220005,  //  0019  JMPF	R8	#0020
-      0x8C200309,  //  001A  GETMET	R8	R1	K9
-      0x5828000A,  //  001B  LDCONST	R10	K10
+      0x8C20030C,  //  001A  GETMET	R8	R1	K12
+      0x5828000D,  //  001B  LDCONST	R10	K13
       0x5C2C0C00,  //  001C  MOVE	R11	R6
       0x7C200600,  //  001D  CALL	R8	3
       0x00080408,  //  001E  ADD	R2	R2	R8
       0x70020006,  //  001F  JMP		#0027
-      0x8C200309,  //  0020  GETMET	R8	R1	K9
-      0x5828000B,  //  0021  LDCONST	R10	K11
+      0x8C20030C,  //  0020  GETMET	R8	R1	K12
+      0x5828000E,  //  0021  LDCONST	R10	K14
       0x602C0008,  //  0022  GETGBL	R11	G8
       0x5C300C00,  //  0023  MOVE	R12	R6
       0x7C2C0200,  //  0024  CALL	R11	1
@@ -149,10 +275,10 @@ be_local_closure(class_sortedmap_tostring,   /* name */
       0x60200004,  //  0027  GETGBL	R8	G4
       0x5C240E00,  //  0028  MOVE	R9	R7
       0x7C200200,  //  0029  CALL	R8	1
-      0x1C201103,  //  002A  EQ	R8	R8	K3
+      0x1C201107,  //  002A  EQ	R8	R8	K7
       0x78220005,  //  002B  JMPF	R8	#0032
-      0x8C200309,  //  002C  GETMET	R8	R1	K9
-      0x5828000C,  //  002D  LDCONST	R10	K12
+      0x8C20030C,  //  002C  GETMET	R8	R1	K12
+      0x5828000F,  //  002D  LDCONST	R10	K15
       0x5C2C0E00,  //  002E  MOVE	R11	R7
       0x7C200600,  //  002F  CALL	R8	3
       0x00080408,  //  0030  ADD	R2	R2	R8
@@ -162,11 +288,145 @@ be_local_closure(class_sortedmap_tostring,   /* name */
       0x7C200200,  //  0034  CALL	R8	1
       0x00080408,  //  0035  ADD	R2	R2	R8
       0x7001FFD3,  //  0036  JMP		#000B
-      0x5810000D,  //  0037  LDCONST	R4	K13
+      0x58100010,  //  0037  LDCONST	R4	K16
       0xAC100200,  //  0038  CATCH	R4	1	0
       0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x0008050E,  //  003A  ADD	R2	R2	K14
+      0x00080511,  //  003A  ADD	R2	R2	K17
       0x80040400,  //  003B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: insert
+********************************************************************/
+be_local_closure(class_sortedmap_insert,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_insert,
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0704,  //  0001  GETMET	R3	R3	K4
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0000,  //  0004  JMPF	R3	#0006
+      0x500C0001,  //  0005  LDBOOL	R3	0	1
+      0x500C0200,  //  0006  LDBOOL	R3	1	0
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x98100202,  //  0008  SETIDX	R4	R1	R2
+      0x780E0009,  //  0009  JMPF	R3	#0014
+      0x8C100112,  //  000A  GETMET	R4	R0	K18
+      0x5C180200,  //  000B  MOVE	R6	R1
+      0x7C100400,  //  000C  CALL	R4	2
+      0x88140103,  //  000D  GETMBR	R5	R0	K3
+      0x8C140B13,  //  000E  GETMET	R5	R5	K19
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x5C200200,  //  0010  MOVE	R8	R1
+      0x7C140600,  //  0011  CALL	R5	3
+      0x50140200,  //  0012  LDBOOL	R5	1	0
+      0x80040A00,  //  0013  RET	1	R5
+      0x50100000,  //  0014  LDBOOL	R4	0	0
+      0x80040800,  //  0015  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _find_insert_position
+********************************************************************/
+be_local_closure(class_sortedmap__find_insert_position,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str__find_insert_position,
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x58080009,  //  0000  LDCONST	R2	K9
+      0x880C0103,  //  0001  GETMBR	R3	R0	K3
+      0x8C0C0701,  //  0002  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x040C070A,  //  0004  SUB	R3	R3	K10
+      0x18100403,  //  0005  LE	R4	R2	R3
+      0x78120020,  //  0006  JMPF	R4	#0028
+      0x60100009,  //  0007  GETGBL	R4	G9
+      0x00140403,  //  0008  ADD	R5	R2	R3
+      0x0C140B14,  //  0009  DIV	R5	R5	K20
+      0x7C100200,  //  000A  CALL	R4	1
+      0x88140103,  //  000B  GETMBR	R5	R0	K3
+      0x94140A04,  //  000C  GETIDX	R5	R5	R4
+      0x4C180000,  //  000D  LDNIL	R6
+      0x601C0004,  //  000E  GETGBL	R7	G4
+      0x5C200200,  //  000F  MOVE	R8	R1
+      0x7C1C0200,  //  0010  CALL	R7	1
+      0x60200004,  //  0011  GETGBL	R8	G4
+      0x5C240A00,  //  0012  MOVE	R9	R5
+      0x7C200200,  //  0013  CALL	R8	1
+      0x1C1C0E08,  //  0014  EQ	R7	R7	R8
+      0x781E0002,  //  0015  JMPF	R7	#0019
+      0x241C0205,  //  0016  GT	R7	R1	R5
+      0x5C180E00,  //  0017  MOVE	R6	R7
+      0x70020007,  //  0018  JMP		#0021
+      0x601C0008,  //  0019  GETGBL	R7	G8
+      0x5C200200,  //  001A  MOVE	R8	R1
+      0x7C1C0200,  //  001B  CALL	R7	1
+      0x60200008,  //  001C  GETGBL	R8	G8
+      0x5C240A00,  //  001D  MOVE	R9	R5
+      0x7C200200,  //  001E  CALL	R8	1
+      0x241C0E08,  //  001F  GT	R7	R7	R8
+      0x5C180E00,  //  0020  MOVE	R6	R7
+      0x781A0002,  //  0021  JMPF	R6	#0025
+      0x001C090A,  //  0022  ADD	R7	R4	K10
+      0x5C080E00,  //  0023  MOVE	R2	R7
+      0x70020001,  //  0024  JMP		#0027
+      0x041C090A,  //  0025  SUB	R7	R4	K10
+      0x5C0C0E00,  //  0026  MOVE	R3	R7
+      0x7001FFDC,  //  0027  JMP		#0005
+      0x80040400,  //  0028  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_keys
+********************************************************************/
+be_local_closure(class_sortedmap_get_keys,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_get_keys,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -200,12 +460,12 @@ be_local_closure(class_sortedmap_item,   /* name */
 
 
 /********************************************************************
-** Solidified function: _find_insert_position
+** Solidified function: setitem
 ********************************************************************/
-be_local_closure(class_sortedmap__find_insert_position,   /* name */
+be_local_closure(class_sortedmap_setitem,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -213,50 +473,14 @@ be_local_closure(class_sortedmap__find_insert_position,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str__find_insert_position,
+    &be_const_str_setitem,
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x58080005,  //  0000  LDCONST	R2	K5
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x8C0C0706,  //  0002  GETMET	R3	R3	K6
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x040C0707,  //  0004  SUB	R3	R3	K7
-      0x18100403,  //  0005  LE	R4	R2	R3
-      0x78120020,  //  0006  JMPF	R4	#0028
-      0x60100009,  //  0007  GETGBL	R4	G9
-      0x00140403,  //  0008  ADD	R5	R2	R3
-      0x0C140B0F,  //  0009  DIV	R5	R5	K15
-      0x7C100200,  //  000A  CALL	R4	1
-      0x88140101,  //  000B  GETMBR	R5	R0	K1
-      0x94140A04,  //  000C  GETIDX	R5	R5	R4
-      0x4C180000,  //  000D  LDNIL	R6
-      0x601C0004,  //  000E  GETGBL	R7	G4
-      0x5C200200,  //  000F  MOVE	R8	R1
-      0x7C1C0200,  //  0010  CALL	R7	1
-      0x60200004,  //  0011  GETGBL	R8	G4
-      0x5C240A00,  //  0012  MOVE	R9	R5
-      0x7C200200,  //  0013  CALL	R8	1
-      0x1C1C0E08,  //  0014  EQ	R7	R7	R8
-      0x781E0002,  //  0015  JMPF	R7	#0019
-      0x241C0205,  //  0016  GT	R7	R1	R5
-      0x5C180E00,  //  0017  MOVE	R6	R7
-      0x70020007,  //  0018  JMP		#0021
-      0x601C0008,  //  0019  GETGBL	R7	G8
-      0x5C200200,  //  001A  MOVE	R8	R1
-      0x7C1C0200,  //  001B  CALL	R7	1
-      0x60200008,  //  001C  GETGBL	R8	G8
-      0x5C240A00,  //  001D  MOVE	R9	R5
-      0x7C200200,  //  001E  CALL	R8	1
-      0x241C0E08,  //  001F  GT	R7	R7	R8
-      0x5C180E00,  //  0020  MOVE	R6	R7
-      0x781A0002,  //  0021  JMPF	R6	#0025
-      0x001C0907,  //  0022  ADD	R7	R4	K7
-      0x5C080E00,  //  0023  MOVE	R2	R7
-      0x70020001,  //  0024  JMP		#0027
-      0x041C0907,  //  0025  SUB	R7	R4	K7
-      0x5C0C0E00,  //  0026  MOVE	R3	R7
-      0x7001FFDC,  //  0027  JMP		#0005
-      0x80040400,  //  0028  RET	1	R2
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C0C0113,  //  0000  GETMET	R3	R0	K19
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x5C180400,  //  0002  MOVE	R6	R2
+      0x7C0C0600,  //  0003  CALL	R3	3
+      0x80040600,  //  0004  RET	1	R3
     })
   )
 );
@@ -283,41 +507,41 @@ be_local_closure(class_sortedmap_remove_by_value,   /* name */
       0x60080012,  //  0000  GETGBL	R2	G18
       0x7C080000,  //  0001  CALL	R2	0
       0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
-      0x8C100906,  //  0004  GETMET	R4	R4	K6
+      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0x8C100901,  //  0004  GETMET	R4	R4	K1
       0x7C100200,  //  0005  CALL	R4	1
-      0x04100907,  //  0006  SUB	R4	R4	K7
-      0x40120A04,  //  0007  CONNECT	R4	K5	R4
+      0x0410090A,  //  0006  SUB	R4	R4	K10
+      0x40121204,  //  0007  CONNECT	R4	K9	R4
       0x7C0C0200,  //  0008  CALL	R3	1
       0xA802000B,  //  0009  EXBLK	0	#0016
       0x5C100600,  //  000A  MOVE	R4	R3
       0x7C100000,  //  000B  CALL	R4	0
-      0x88140101,  //  000C  GETMBR	R5	R0	K1
+      0x88140103,  //  000C  GETMBR	R5	R0	K3
       0x94140A04,  //  000D  GETIDX	R5	R5	R4
       0x88180100,  //  000E  GETMBR	R6	R0	K0
       0x94180C05,  //  000F  GETIDX	R6	R6	R5
       0x1C180C01,  //  0010  EQ	R6	R6	R1
       0x781A0002,  //  0011  JMPF	R6	#0015
-      0x8C180510,  //  0012  GETMET	R6	R2	K16
+      0x8C180515,  //  0012  GETMET	R6	R2	K21
       0x5C200A00,  //  0013  MOVE	R8	R5
       0x7C180400,  //  0014  CALL	R6	2
       0x7001FFF3,  //  0015  JMP		#000A
-      0x580C000D,  //  0016  LDCONST	R3	K13
+      0x580C0010,  //  0016  LDCONST	R3	K16
       0xAC0C0200,  //  0017  CATCH	R3	1	0
       0xB0080000,  //  0018  RAISE	2	R0	R0
-      0x580C0005,  //  0019  LDCONST	R3	K5
+      0x580C0009,  //  0019  LDCONST	R3	K9
       0x60100010,  //  001A  GETGBL	R4	G16
       0x5C140400,  //  001B  MOVE	R5	R2
       0x7C100200,  //  001C  CALL	R4	1
       0xA8020006,  //  001D  EXBLK	0	#0025
       0x5C140800,  //  001E  MOVE	R5	R4
       0x7C140000,  //  001F  CALL	R5	0
-      0x8C180111,  //  0020  GETMET	R6	R0	K17
+      0x8C180105,  //  0020  GETMET	R6	R0	K5
       0x5C200A00,  //  0021  MOVE	R8	R5
       0x7C180400,  //  0022  CALL	R6	2
-      0x000C0707,  //  0023  ADD	R3	R3	K7
+      0x000C070A,  //  0023  ADD	R3	R3	K10
       0x7001FFF8,  //  0024  JMP		#001E
-      0x5810000D,  //  0025  LDCONST	R4	K13
+      0x58100010,  //  0025  LDCONST	R4	K16
       0xAC100200,  //  0026  CATCH	R4	1	0
       0xB0080000,  //  0027  RAISE	2	R0	R0
       0x80040600,  //  0028  RET	1	R3
@@ -328,83 +552,9 @@ be_local_closure(class_sortedmap_remove_by_value,   /* name */
 
 
 /********************************************************************
-** Solidified function: find
+** Solidified function: clear
 ********************************************************************/
-be_local_closure(class_sortedmap_find,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_find,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0712,  //  0001  GETMET	R3	R3	K18
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x5C180400,  //  0003  MOVE	R6	R2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x80040600,  //  0005  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: insert
-********************************************************************/
-be_local_closure(class_sortedmap_insert,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_insert,
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0713,  //  0001  GETMET	R3	R3	K19
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0000,  //  0004  JMPF	R3	#0006
-      0x500C0001,  //  0005  LDBOOL	R3	0	1
-      0x500C0200,  //  0006  LDBOOL	R3	1	0
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x98100202,  //  0008  SETIDX	R4	R1	R2
-      0x780E0009,  //  0009  JMPF	R3	#0014
-      0x8C100114,  //  000A  GETMET	R4	R0	K20
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x7C100400,  //  000C  CALL	R4	2
-      0x88140101,  //  000D  GETMBR	R5	R0	K1
-      0x8C140B02,  //  000E  GETMET	R5	R5	K2
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x5C200200,  //  0010  MOVE	R8	R1
-      0x7C140600,  //  0011  CALL	R5	3
-      0x50140200,  //  0012  LDBOOL	R5	1	0
-      0x80040A00,  //  0013  RET	1	R5
-      0x50100000,  //  0014  LDBOOL	R4	0	0
-      0x80040800,  //  0015  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_keys
-********************************************************************/
-be_local_closure(class_sortedmap_get_keys,   /* name */
+be_local_closure(class_sortedmap_clear,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -415,167 +565,16 @@ be_local_closure(class_sortedmap_get_keys,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_get_keys,
+    &be_const_str_clear,
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: keys
-********************************************************************/
-be_local_closure(class_sortedmap_keys,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_keys,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x8C040315,  //  0001  GETMET	R1	R1	K21
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove
-********************************************************************/
-be_local_closure(class_sortedmap_remove,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_remove,
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080513,  //  0001  GETMET	R2	R2	K19
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0010,  //  0004  JMPF	R2	#0016
-      0x88080100,  //  0005  GETMBR	R2	R0	K0
-      0x8C080511,  //  0006  GETMET	R2	R2	K17
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x8C080512,  //  000A  GETMET	R2	R2	K18
-      0x5C100200,  //  000B  MOVE	R4	R1
-      0x7C080400,  //  000C  CALL	R2	2
-      0x4C0C0000,  //  000D  LDNIL	R3
-      0x200C0403,  //  000E  NE	R3	R2	R3
-      0x780E0003,  //  000F  JMPF	R3	#0014
-      0x880C0101,  //  0010  GETMBR	R3	R0	K1
-      0x8C0C0711,  //  0011  GETMET	R3	R3	K17
-      0x5C140400,  //  0012  MOVE	R5	R2
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x500C0200,  //  0014  LDBOOL	R3	1	0
-      0x80040600,  //  0015  RET	1	R3
-      0x50080000,  //  0016  LDBOOL	R2	0	0
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: size
-********************************************************************/
-be_local_closure(class_sortedmap_size,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_size,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040306,  //  0001  GETMET	R1	R1	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: contains
-********************************************************************/
-be_local_closure(class_sortedmap_contains,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_contains,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080513,  //  0001  GETMET	R2	R2	K19
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: iter
-********************************************************************/
-be_local_closure(class_sortedmap_iter,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_sortedmap,     /* shared constants */
-    &be_const_str_iter,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040315,  //  0001  GETMET	R1	R1	K21
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[ 7]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x60040012,  //  0003  GETGBL	R1	G18
+      0x7C040000,  //  0004  CALL	R1	0
+      0x90020601,  //  0005  SETMBR	R0	K3	R1
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -604,8 +603,37 @@ be_local_closure(class_sortedmap_init,   /* name */
       0x90020001,  //  0002  SETMBR	R0	K0	R1
       0x60040012,  //  0003  GETGBL	R1	G18
       0x7C040000,  //  0004  CALL	R1	0
-      0x90020201,  //  0005  SETMBR	R0	K1	R1
+      0x90020601,  //  0005  SETMBR	R0	K3	R1
       0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find
+********************************************************************/
+be_local_closure(class_sortedmap_find,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_sortedmap,     /* shared constants */
+    &be_const_str_find,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0706,  //  0001  GETMET	R3	R3	K6
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x80040600,  //  0005  RET	1	R3
     })
   )
 );
@@ -618,25 +646,26 @@ be_local_closure(class_sortedmap_init,   /* name */
 be_local_class(sortedmap,
     2,
     NULL,
-    be_nested_map(17,
+    be_nested_map(18,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key(size, 1), be_const_closure(class_sortedmap_size_closure) },
         { be_const_key(_data, -1), be_const_var(0) },
-        { be_const_key(remove, -1), be_const_closure(class_sortedmap_remove_closure) },
-        { be_const_key(tostring, -1), be_const_closure(class_sortedmap_tostring_closure) },
         { be_const_key(item, -1), be_const_closure(class_sortedmap_item_closure) },
-        { be_const_key(_find_insert_position, -1), be_const_closure(class_sortedmap__find_insert_position_closure) },
-        { be_const_key(remove_by_value, -1), be_const_closure(class_sortedmap_remove_by_value_closure) },
-        { be_const_key(find, -1), be_const_closure(class_sortedmap_find_closure) },
+        { be_const_key(remove, -1), be_const_closure(class_sortedmap_remove_closure) },
+        { be_const_key(contains, 2), be_const_closure(class_sortedmap_contains_closure) },
+        { be_const_key(keys, -1), be_const_closure(class_sortedmap_keys_closure) },
+        { be_const_key(get_by_index, 17), be_const_closure(class_sortedmap_get_by_index_closure) },
+        { be_const_key(tostring, -1), be_const_closure(class_sortedmap_tostring_closure) },
         { be_const_key(insert, -1), be_const_closure(class_sortedmap_insert_closure) },
+        { be_const_key(_find_insert_position, -1), be_const_closure(class_sortedmap__find_insert_position_closure) },
         { be_const_key(get_keys, -1), be_const_closure(class_sortedmap_get_keys_closure) },
-        { be_const_key(keys, 13), be_const_closure(class_sortedmap_keys_closure) },
-        { be_const_key(setitem, 1), be_const_closure(class_sortedmap_setitem_closure) },
-        { be_const_key(size, -1), be_const_closure(class_sortedmap_size_closure) },
-        { be_const_key(contains, -1), be_const_closure(class_sortedmap_contains_closure) },
-        { be_const_key(_keys, -1), be_const_var(1) },
-        { be_const_key(iter, -1), be_const_closure(class_sortedmap_iter_closure) },
+        { be_const_key(remove_by_value, -1), be_const_closure(class_sortedmap_remove_by_value_closure) },
+        { be_const_key(clear, -1), be_const_closure(class_sortedmap_clear_closure) },
+        { be_const_key(iter, 11), be_const_closure(class_sortedmap_iter_closure) },
+        { be_const_key(setitem, 12), be_const_closure(class_sortedmap_setitem_closure) },
         { be_const_key(init, -1), be_const_closure(class_sortedmap_init_closure) },
-        { be_const_key(clear, 0), be_const_closure(class_sortedmap_clear_closure) },
+        { be_const_key(find, -1), be_const_closure(class_sortedmap_find_closure) },
+        { be_const_key(_keys, -1), be_const_var(1) },
     })),
     (bstring*) &be_const_str_sortedmap
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tapp.h
@@ -4,8 +4,8 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Tapp;
-// compact class 'Tapp' ktab size: 17, total: 18 (saved 8 bytes)
-static const bvalue be_ktab_class_Tapp[17] = {
+// compact class 'Tapp' ktab size: 16, total: 17 (saved 8 bytes)
+static const bvalue be_ktab_class_Tapp[16] = {
   /* K0   */  be_nested_str(tasmota),
   /* K1   */  be_nested_str(add_driver),
   /* K2   */  be_nested_str(autoexec_dir),
@@ -21,8 +21,7 @@ static const bvalue be_ktab_class_Tapp[17] = {
   /* K12  */  be_nested_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X25s_X27),
   /* K13  */  be_const_int(2),
   /* K14  */  be_nested_str(load),
-  /* K15  */  be_nested_str(_X23autoexec_X2Ebe),
-  /* K16  */  be_nested_str(stop_iteration),
+  /* K15  */  be_nested_str(stop_iteration),
 };
 
 
@@ -102,7 +101,7 @@ be_local_closure(class_Tapp_autoexec_dir,   /* name */
     &be_ktab_class_Tapp,     /* shared constants */
     &be_const_str_autoexec_dir,
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
+    ( &(const binstruction[33]) {  /* code */
       0x58040005,  //  0000  LDCONST	R1	K5
       0xA40A0C00,  //  0001  IMPORT	R2	K6
       0xA40E0E00,  //  0002  IMPORT	R3	K7
@@ -111,14 +110,14 @@ be_local_closure(class_Tapp_autoexec_dir,   /* name */
       0x5C1C0000,  //  0005  MOVE	R7	R0
       0x7C140400,  //  0006  CALL	R5	2
       0x7C100200,  //  0007  CALL	R4	1
-      0xA8020014,  //  0008  EXBLK	0	#001E
+      0xA8020013,  //  0008  EXBLK	0	#001D
       0x5C140800,  //  0009  MOVE	R5	R4
       0x7C140000,  //  000A  CALL	R5	0
       0x8C180709,  //  000B  GETMET	R6	R3	K9
       0x5C200A00,  //  000C  MOVE	R8	R5
       0x5824000A,  //  000D  LDCONST	R9	K10
       0x7C180600,  //  000E  CALL	R6	3
-      0x781A000C,  //  000F  JMPF	R6	#001D
+      0x781A000B,  //  000F  JMPF	R6	#001C
       0xB81A1600,  //  0010  GETNGBL	R6	K11
       0x601C0018,  //  0011  GETGBL	R7	G24
       0x5820000C,  //  0012  LDCONST	R8	K12
@@ -130,13 +129,12 @@ be_local_closure(class_Tapp_autoexec_dir,   /* name */
       0xB81A0000,  //  0018  GETNGBL	R6	K0
       0x8C180D0E,  //  0019  GETMET	R6	R6	K14
       0x00200005,  //  001A  ADD	R8	R0	R5
-      0x0020110F,  //  001B  ADD	R8	R8	K15
-      0x7C180400,  //  001C  CALL	R6	2
-      0x7001FFEA,  //  001D  JMP		#0009
-      0x58100010,  //  001E  LDCONST	R4	K16
-      0xAC100200,  //  001F  CATCH	R4	1	0
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0x80000000,  //  0021  RET	0
+      0x7C180400,  //  001B  CALL	R6	2
+      0x7001FFEB,  //  001C  JMP		#0009
+      0x5810000F,  //  001D  LDCONST	R4	K15
+      0xAC100200,  //  001E  CATCH	R4	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0x80000000,  //  0020  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -4,8 +4,8 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Tasmota;
-// compact class 'Tasmota' ktab size: 165, total: 319 (saved 1232 bytes)
-static const bvalue be_ktab_class_Tasmota[165] = {
+// compact class 'Tasmota' ktab size: 167, total: 321 (saved 1232 bytes)
+static const bvalue be_ktab_class_Tasmota[167] = {
   /* K0   */  be_nested_str(_crons),
   /* K1   */  be_const_int(0),
   /* K2   */  be_nested_str(size),
@@ -145,32 +145,34 @@ static const bvalue be_ktab_class_Tasmota[165] = {
   /* K136 */  be_nested_str(path),
   /* K137 */  be_nested_str(startswith),
   /* K138 */  be_nested_str(_X2F),
-  /* K139 */  be_nested_str(_X2E),
-  /* K140 */  be_nested_str(_X2Ebec),
-  /* K141 */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
-  /* K142 */  be_nested_str(exists),
-  /* K143 */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
-  /* K144 */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
-  /* K145 */  be_nested_str(split),
-  /* K146 */  be_nested_str(index_X2Ehtml),
-  /* K147 */  be_nested_str(webclient),
-  /* K148 */  be_nested_str(set_follow_redirects),
-  /* K149 */  be_nested_str(begin),
-  /* K150 */  be_nested_str(GET),
-  /* K151 */  be_nested_str(status_X3A_X20),
-  /* K152 */  be_nested_str(connection_error),
-  /* K153 */  be_nested_str(write_file),
-  /* K154 */  be_nested_str(close),
-  /* K155 */  be_nested_str(BRY_X3A_X20Fetched_X20),
-  /* K156 */  be_nested_str(cb),
-  /* K157 */  be_nested_str(gen_cb),
-  /* K158 */  be_nested_str(BRY_X3A_X20Exception_X3E_X20run_network_up_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-  /* K159 */  be_nested_str(http),
-  /* K160 */  be_nested_str(resp_cmnd_str),
-  /* K161 */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
-  /* K162 */  be_nested_str(urlfetch),
-  /* K163 */  be_nested_str(resp_cmnd_failed),
-  /* K164 */  be_nested_str(resp_cmnd_done),
+  /* K139 */  be_nested_str(tapp),
+  /* K140 */  be_nested_str(_X23autoexec),
+  /* K141 */  be_nested_str(_X2E),
+  /* K142 */  be_nested_str(_X2Ebec),
+  /* K143 */  be_nested_str(BRY_X3A_X20file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20nor_X20_X27_X2Ebec_X27),
+  /* K144 */  be_nested_str(exists),
+  /* K145 */  be_nested_str(BRY_X3A_X20corrupt_X20bytecode_X20_X27_X25s_X27),
+  /* K146 */  be_nested_str(BRY_X3A_X20bytecode_X20has_X20wrong_X20version_X20_X27_X25s_X27_X20_X28_X25s_X29),
+  /* K147 */  be_nested_str(split),
+  /* K148 */  be_nested_str(index_X2Ehtml),
+  /* K149 */  be_nested_str(webclient),
+  /* K150 */  be_nested_str(set_follow_redirects),
+  /* K151 */  be_nested_str(begin),
+  /* K152 */  be_nested_str(GET),
+  /* K153 */  be_nested_str(status_X3A_X20),
+  /* K154 */  be_nested_str(connection_error),
+  /* K155 */  be_nested_str(write_file),
+  /* K156 */  be_nested_str(close),
+  /* K157 */  be_nested_str(BRY_X3A_X20Fetched_X20),
+  /* K158 */  be_nested_str(cb),
+  /* K159 */  be_nested_str(gen_cb),
+  /* K160 */  be_nested_str(BRY_X3A_X20Exception_X3E_X20run_network_up_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K161 */  be_nested_str(http),
+  /* K162 */  be_nested_str(resp_cmnd_str),
+  /* K163 */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
+  /* K164 */  be_nested_str(urlfetch),
+  /* K165 */  be_nested_str(resp_cmnd_failed),
+  /* K166 */  be_nested_str(resp_cmnd_done),
 };
 
 
@@ -2346,7 +2348,7 @@ be_local_closure(class_Tasmota_load,   /* name */
     &be_ktab_class_Tasmota,     /* shared constants */
     &be_const_str_load,
     &be_const_str_solidified,
-    ( &(const binstruction[164]) {  /* code */
+    ( &(const binstruction[171]) {  /* code */
       0x84080000,  //  0000  CLOSURE	R2	P0
       0x840C0001,  //  0001  CLOSURE	R3	P1
       0x84100002,  //  0002  CLOSURE	R4	P2
@@ -2369,148 +2371,155 @@ be_local_closure(class_Tasmota_load,   /* name */
       0x7C280600,  //  0013  CALL	R10	3
       0x742A0000,  //  0014  JMPT	R10	#0016
       0x00071401,  //  0015  ADD	R1	K138	R1
-      0x8C28111E,  //  0016  GETMET	R10	R8	K30
+      0x8C28113C,  //  0016  GETMET	R10	R8	K60
       0x5C300200,  //  0017  MOVE	R12	R1
-      0x5834003F,  //  0018  LDCONST	R13	K63
+      0x5834008B,  //  0018  LDCONST	R13	K139
       0x7C280600,  //  0019  CALL	R10	3
-      0x242C1501,  //  001A  GT	R11	R10	K1
-      0x782E0003,  //  001B  JMPF	R11	#0020
-      0x04301505,  //  001C  SUB	R12	R10	K5
-      0x4032020C,  //  001D  CONNECT	R12	K1	R12
-      0x9430020C,  //  001E  GETIDX	R12	R1	R12
-      0x70020000,  //  001F  JMP		#0021
-      0x5C300200,  //  0020  MOVE	R12	R1
+      0x782A0000,  //  001A  JMPF	R10	#001C
+      0x0004038C,  //  001B  ADD	R1	R1	K140
+      0x8C28111E,  //  001C  GETMET	R10	R8	K30
+      0x5C300200,  //  001D  MOVE	R12	R1
+      0x5834003F,  //  001E  LDCONST	R13	K63
+      0x7C280600,  //  001F  CALL	R10	3
+      0x242C1501,  //  0020  GT	R11	R10	K1
       0x782E0003,  //  0021  JMPF	R11	#0026
-      0x00341505,  //  0022  ADD	R13	R10	K5
-      0x40341B87,  //  0023  CONNECT	R13	R13	K135
-      0x9434020D,  //  0024  GETIDX	R13	R1	R13
+      0x04301505,  //  0022  SUB	R12	R10	K5
+      0x4032020C,  //  0023  CONNECT	R12	K1	R12
+      0x9430020C,  //  0024  GETIDX	R12	R1	R12
       0x70020000,  //  0025  JMP		#0027
-      0x5C340200,  //  0026  MOVE	R13	R1
-      0x8C38111E,  //  0027  GETMET	R14	R8	K30
-      0x5C401A00,  //  0028  MOVE	R16	R13
-      0x5844008B,  //  0029  LDCONST	R17	K139
-      0x7C380600,  //  002A  CALL	R14	3
-      0x14381D01,  //  002B  LT	R14	R14	K1
-      0x783A0001,  //  002C  JMPF	R14	#002F
-      0x0004033D,  //  002D  ADD	R1	R1	K61
-      0x00341B3D,  //  002E  ADD	R13	R13	K61
-      0x8C38113C,  //  002F  GETMET	R14	R8	K60
-      0x5C401A00,  //  0030  MOVE	R16	R13
-      0x5844003D,  //  0031  LDCONST	R17	K61
-      0x7C380600,  //  0032  CALL	R14	3
-      0x8C3C113C,  //  0033  GETMET	R15	R8	K60
-      0x5C441A00,  //  0034  MOVE	R17	R13
-      0x5848008C,  //  0035  LDCONST	R18	K140
-      0x7C3C0600,  //  0036  CALL	R15	3
-      0x783E0001,  //  0037  JMPF	R15	#003A
-      0x5C400200,  //  0038  MOVE	R16	R1
-      0x70020000,  //  0039  JMP		#003B
-      0x00400344,  //  003A  ADD	R16	R1	K68
-      0x5C441C00,  //  003B  MOVE	R17	R14
-      0x74460007,  //  003C  JMPT	R17	#0045
-      0x5C441E00,  //  003D  MOVE	R17	R15
-      0x74460005,  //  003E  JMPT	R17	#0045
-      0x60440001,  //  003F  GETGBL	R17	G1
-      0x5848008D,  //  0040  LDCONST	R18	K141
-      0x7C440200,  //  0041  CALL	R17	1
-      0x50440000,  //  0042  LDBOOL	R17	0	0
-      0xA0000000,  //  0043  CLOSE	R0
-      0x80042200,  //  0044  RET	1	R17
-      0x50440000,  //  0045  LDBOOL	R17	0	0
-      0x783E0008,  //  0046  JMPF	R15	#0050
-      0x8C48138E,  //  0047  GETMET	R18	R9	K142
-      0x5C502000,  //  0048  MOVE	R20	R16
-      0x7C480400,  //  0049  CALL	R18	2
-      0x744A0002,  //  004A  JMPT	R18	#004E
-      0x50480000,  //  004B  LDBOOL	R18	0	0
-      0xA0000000,  //  004C  CLOSE	R0
-      0x80042400,  //  004D  RET	1	R18
-      0x50440200,  //  004E  LDBOOL	R17	1	0
-      0x70020014,  //  004F  JMP		#0065
-      0x8C48138E,  //  0050  GETMET	R18	R9	K142
-      0x5C500200,  //  0051  MOVE	R20	R1
-      0x7C480400,  //  0052  CALL	R18	2
-      0x784A0007,  //  0053  JMPF	R18	#005C
-      0x8C48138E,  //  0054  GETMET	R18	R9	K142
-      0x5C502000,  //  0055  MOVE	R20	R16
-      0x7C480400,  //  0056  CALL	R18	2
-      0x784A0002,  //  0057  JMPF	R18	#005B
-      0x5C480A00,  //  0058  MOVE	R18	R5
-      0x5C4C2000,  //  0059  MOVE	R19	R16
-      0x7C480200,  //  005A  CALL	R18	1
-      0x70020008,  //  005B  JMP		#0065
-      0x8C48138E,  //  005C  GETMET	R18	R9	K142
-      0x5C502000,  //  005D  MOVE	R20	R16
-      0x7C480400,  //  005E  CALL	R18	2
-      0x784A0001,  //  005F  JMPF	R18	#0062
-      0x50440200,  //  0060  LDBOOL	R17	1	0
-      0x70020002,  //  0061  JMP		#0065
-      0x50480000,  //  0062  LDBOOL	R18	0	0
-      0xA0000000,  //  0063  CLOSE	R0
-      0x80042400,  //  0064  RET	1	R18
-      0x782E0005,  //  0065  JMPF	R11	#006C
-      0x0048193F,  //  0066  ADD	R18	R12	K63
-      0x90026612,  //  0067  SETMBR	R0	K51	R18
-      0x5C480400,  //  0068  MOVE	R18	R2
-      0x884C0133,  //  0069  GETMBR	R19	R0	K51
-      0x7C480200,  //  006A  CALL	R18	1
-      0x70020000,  //  006B  JMP		#006D
-      0x90026734,  //  006C  SETMBR	R0	K51	K52
-      0x4C480000,  //  006D  LDNIL	R18
-      0x78460025,  //  006E  JMPF	R17	#0095
-      0x5C4C0800,  //  006F  MOVE	R19	R4
-      0x5C502000,  //  0070  MOVE	R20	R16
-      0x7C4C0200,  //  0071  CALL	R19	1
-      0x50500200,  //  0072  LDBOOL	R20	1	0
-      0x4C540000,  //  0073  LDNIL	R21
-      0x1C542615,  //  0074  EQ	R21	R19	R21
-      0x78560007,  //  0075  JMPF	R21	#007E
-      0x60540001,  //  0076  GETGBL	R21	G1
-      0x60580018,  //  0077  GETGBL	R22	G24
-      0x585C008F,  //  0078  LDCONST	R23	K143
-      0x5C602000,  //  0079  MOVE	R24	R16
-      0x7C580400,  //  007A  CALL	R22	2
-      0x7C540200,  //  007B  CALL	R21	1
-      0x50500000,  //  007C  LDBOOL	R20	0	0
-      0x7002000A,  //  007D  JMP		#0089
-      0x54560003,  //  007E  LDINT	R21	4
-      0x20542615,  //  007F  NE	R21	R19	R21
-      0x78560007,  //  0080  JMPF	R21	#0089
-      0x60540001,  //  0081  GETGBL	R21	G1
-      0x60580018,  //  0082  GETGBL	R22	G24
-      0x585C0090,  //  0083  LDCONST	R23	K144
-      0x5C602000,  //  0084  MOVE	R24	R16
-      0x5C642600,  //  0085  MOVE	R25	R19
-      0x7C580600,  //  0086  CALL	R22	3
-      0x7C540200,  //  0087  CALL	R21	1
-      0x50500000,  //  0088  LDBOOL	R20	0	0
-      0x78520003,  //  0089  JMPF	R20	#008E
-      0x5C540C00,  //  008A  MOVE	R21	R6
-      0x5C582000,  //  008B  MOVE	R22	R16
-      0x7C540200,  //  008C  CALL	R21	1
-      0x5C482A00,  //  008D  MOVE	R18	R21
-      0x4C540000,  //  008E  LDNIL	R21
-      0x1C542415,  //  008F  EQ	R21	R18	R21
-      0x78560003,  //  0090  JMPF	R21	#0095
-      0x5C540A00,  //  0091  MOVE	R21	R5
-      0x5C582000,  //  0092  MOVE	R22	R16
-      0x7C540200,  //  0093  CALL	R21	1
-      0x50440000,  //  0094  LDBOOL	R17	0	0
-      0x5C4C2200,  //  0095  MOVE	R19	R17
-      0x744E0003,  //  0096  JMPT	R19	#009B
-      0x5C4C0C00,  //  0097  MOVE	R19	R6
-      0x5C500200,  //  0098  MOVE	R20	R1
-      0x7C4C0200,  //  0099  CALL	R19	1
-      0x5C482600,  //  009A  MOVE	R18	R19
-      0x5C4C0E00,  //  009B  MOVE	R19	R7
-      0x5C502400,  //  009C  MOVE	R20	R18
-      0x7C4C0200,  //  009D  CALL	R19	1
-      0x782E0002,  //  009E  JMPF	R11	#00A2
-      0x5C500600,  //  009F  MOVE	R20	R3
-      0x0054193F,  //  00A0  ADD	R21	R12	K63
-      0x7C500200,  //  00A1  CALL	R20	1
-      0xA0000000,  //  00A2  CLOSE	R0
-      0x80042600,  //  00A3  RET	1	R19
+      0x5C300200,  //  0026  MOVE	R12	R1
+      0x782E0003,  //  0027  JMPF	R11	#002C
+      0x00341505,  //  0028  ADD	R13	R10	K5
+      0x40341B87,  //  0029  CONNECT	R13	R13	K135
+      0x9434020D,  //  002A  GETIDX	R13	R1	R13
+      0x70020000,  //  002B  JMP		#002D
+      0x5C340200,  //  002C  MOVE	R13	R1
+      0x8C38111E,  //  002D  GETMET	R14	R8	K30
+      0x5C401A00,  //  002E  MOVE	R16	R13
+      0x5844008D,  //  002F  LDCONST	R17	K141
+      0x7C380600,  //  0030  CALL	R14	3
+      0x14381D01,  //  0031  LT	R14	R14	K1
+      0x783A0001,  //  0032  JMPF	R14	#0035
+      0x0004033D,  //  0033  ADD	R1	R1	K61
+      0x00341B3D,  //  0034  ADD	R13	R13	K61
+      0x8C38113C,  //  0035  GETMET	R14	R8	K60
+      0x5C401A00,  //  0036  MOVE	R16	R13
+      0x5844003D,  //  0037  LDCONST	R17	K61
+      0x7C380600,  //  0038  CALL	R14	3
+      0x8C3C113C,  //  0039  GETMET	R15	R8	K60
+      0x5C441A00,  //  003A  MOVE	R17	R13
+      0x5848008E,  //  003B  LDCONST	R18	K142
+      0x7C3C0600,  //  003C  CALL	R15	3
+      0x783E0001,  //  003D  JMPF	R15	#0040
+      0x5C400200,  //  003E  MOVE	R16	R1
+      0x70020000,  //  003F  JMP		#0041
+      0x00400344,  //  0040  ADD	R16	R1	K68
+      0x5C441C00,  //  0041  MOVE	R17	R14
+      0x74460007,  //  0042  JMPT	R17	#004B
+      0x5C441E00,  //  0043  MOVE	R17	R15
+      0x74460005,  //  0044  JMPT	R17	#004B
+      0x60440001,  //  0045  GETGBL	R17	G1
+      0x5848008F,  //  0046  LDCONST	R18	K143
+      0x7C440200,  //  0047  CALL	R17	1
+      0x50440000,  //  0048  LDBOOL	R17	0	0
+      0xA0000000,  //  0049  CLOSE	R0
+      0x80042200,  //  004A  RET	1	R17
+      0x50440000,  //  004B  LDBOOL	R17	0	0
+      0x783E0008,  //  004C  JMPF	R15	#0056
+      0x8C481390,  //  004D  GETMET	R18	R9	K144
+      0x5C502000,  //  004E  MOVE	R20	R16
+      0x7C480400,  //  004F  CALL	R18	2
+      0x744A0002,  //  0050  JMPT	R18	#0054
+      0x50480000,  //  0051  LDBOOL	R18	0	0
+      0xA0000000,  //  0052  CLOSE	R0
+      0x80042400,  //  0053  RET	1	R18
+      0x50440200,  //  0054  LDBOOL	R17	1	0
+      0x70020014,  //  0055  JMP		#006B
+      0x8C481390,  //  0056  GETMET	R18	R9	K144
+      0x5C500200,  //  0057  MOVE	R20	R1
+      0x7C480400,  //  0058  CALL	R18	2
+      0x784A0007,  //  0059  JMPF	R18	#0062
+      0x8C481390,  //  005A  GETMET	R18	R9	K144
+      0x5C502000,  //  005B  MOVE	R20	R16
+      0x7C480400,  //  005C  CALL	R18	2
+      0x784A0002,  //  005D  JMPF	R18	#0061
+      0x5C480A00,  //  005E  MOVE	R18	R5
+      0x5C4C2000,  //  005F  MOVE	R19	R16
+      0x7C480200,  //  0060  CALL	R18	1
+      0x70020008,  //  0061  JMP		#006B
+      0x8C481390,  //  0062  GETMET	R18	R9	K144
+      0x5C502000,  //  0063  MOVE	R20	R16
+      0x7C480400,  //  0064  CALL	R18	2
+      0x784A0001,  //  0065  JMPF	R18	#0068
+      0x50440200,  //  0066  LDBOOL	R17	1	0
+      0x70020002,  //  0067  JMP		#006B
+      0x50480000,  //  0068  LDBOOL	R18	0	0
+      0xA0000000,  //  0069  CLOSE	R0
+      0x80042400,  //  006A  RET	1	R18
+      0x782E0005,  //  006B  JMPF	R11	#0072
+      0x0048193F,  //  006C  ADD	R18	R12	K63
+      0x90026612,  //  006D  SETMBR	R0	K51	R18
+      0x5C480400,  //  006E  MOVE	R18	R2
+      0x884C0133,  //  006F  GETMBR	R19	R0	K51
+      0x7C480200,  //  0070  CALL	R18	1
+      0x70020000,  //  0071  JMP		#0073
+      0x90026734,  //  0072  SETMBR	R0	K51	K52
+      0x4C480000,  //  0073  LDNIL	R18
+      0x78460025,  //  0074  JMPF	R17	#009B
+      0x5C4C0800,  //  0075  MOVE	R19	R4
+      0x5C502000,  //  0076  MOVE	R20	R16
+      0x7C4C0200,  //  0077  CALL	R19	1
+      0x50500200,  //  0078  LDBOOL	R20	1	0
+      0x4C540000,  //  0079  LDNIL	R21
+      0x1C542615,  //  007A  EQ	R21	R19	R21
+      0x78560007,  //  007B  JMPF	R21	#0084
+      0x60540001,  //  007C  GETGBL	R21	G1
+      0x60580018,  //  007D  GETGBL	R22	G24
+      0x585C0091,  //  007E  LDCONST	R23	K145
+      0x5C602000,  //  007F  MOVE	R24	R16
+      0x7C580400,  //  0080  CALL	R22	2
+      0x7C540200,  //  0081  CALL	R21	1
+      0x50500000,  //  0082  LDBOOL	R20	0	0
+      0x7002000A,  //  0083  JMP		#008F
+      0x54560003,  //  0084  LDINT	R21	4
+      0x20542615,  //  0085  NE	R21	R19	R21
+      0x78560007,  //  0086  JMPF	R21	#008F
+      0x60540001,  //  0087  GETGBL	R21	G1
+      0x60580018,  //  0088  GETGBL	R22	G24
+      0x585C0092,  //  0089  LDCONST	R23	K146
+      0x5C602000,  //  008A  MOVE	R24	R16
+      0x5C642600,  //  008B  MOVE	R25	R19
+      0x7C580600,  //  008C  CALL	R22	3
+      0x7C540200,  //  008D  CALL	R21	1
+      0x50500000,  //  008E  LDBOOL	R20	0	0
+      0x78520003,  //  008F  JMPF	R20	#0094
+      0x5C540C00,  //  0090  MOVE	R21	R6
+      0x5C582000,  //  0091  MOVE	R22	R16
+      0x7C540200,  //  0092  CALL	R21	1
+      0x5C482A00,  //  0093  MOVE	R18	R21
+      0x4C540000,  //  0094  LDNIL	R21
+      0x1C542415,  //  0095  EQ	R21	R18	R21
+      0x78560003,  //  0096  JMPF	R21	#009B
+      0x5C540A00,  //  0097  MOVE	R21	R5
+      0x5C582000,  //  0098  MOVE	R22	R16
+      0x7C540200,  //  0099  CALL	R21	1
+      0x50440000,  //  009A  LDBOOL	R17	0	0
+      0x5C4C2200,  //  009B  MOVE	R19	R17
+      0x744E0003,  //  009C  JMPT	R19	#00A1
+      0x5C4C0C00,  //  009D  MOVE	R19	R6
+      0x5C500200,  //  009E  MOVE	R20	R1
+      0x7C4C0200,  //  009F  CALL	R19	1
+      0x5C482600,  //  00A0  MOVE	R18	R19
+      0x5C4C0E00,  //  00A1  MOVE	R19	R7
+      0x5C502400,  //  00A2  MOVE	R20	R18
+      0x7C4C0200,  //  00A3  CALL	R19	1
+      0x782E0003,  //  00A4  JMPF	R11	#00A9
+      0x5C500600,  //  00A5  MOVE	R20	R3
+      0x0054193F,  //  00A6  ADD	R21	R12	K63
+      0x7C500200,  //  00A7  CALL	R20	1
+      0x90026734,  //  00A8  SETMBR	R0	K51	K52
+      0xA0000000,  //  00A9  CLOSE	R0
+      0x80042600,  //  00AA  RET	1	R19
     })
   )
 );
@@ -2538,7 +2547,7 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E000D,  //  0002  JMPF	R3	#0011
       0xA40E7600,  //  0003  IMPORT	R3	K59
-      0x8C100791,  //  0004  GETMET	R4	R3	K145
+      0x8C100793,  //  0004  GETMET	R4	R3	K147
       0x5C180200,  //  0005  MOVE	R6	R1
       0x581C008A,  //  0006  LDCONST	R7	K138
       0x7C100600,  //  0007  CALL	R4	3
@@ -2550,16 +2559,16 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
       0x7C100200,  //  000D  CALL	R4	1
       0x1C100901,  //  000E  EQ	R4	R4	K1
       0x78120000,  //  000F  JMPF	R4	#0011
-      0x58080092,  //  0010  LDCONST	R2	K146
-      0xB80F2600,  //  0011  GETNGBL	R3	K147
+      0x58080094,  //  0010  LDCONST	R2	K148
+      0xB80F2A00,  //  0011  GETNGBL	R3	K149
       0x7C0C0000,  //  0012  CALL	R3	0
-      0x8C100794,  //  0013  GETMET	R4	R3	K148
+      0x8C100796,  //  0013  GETMET	R4	R3	K150
       0x50180200,  //  0014  LDBOOL	R6	1	0
       0x7C100400,  //  0015  CALL	R4	2
-      0x8C100795,  //  0016  GETMET	R4	R3	K149
+      0x8C100797,  //  0016  GETMET	R4	R3	K151
       0x5C180200,  //  0017  MOVE	R6	R1
       0x7C100400,  //  0018  CALL	R4	2
-      0x8C100796,  //  0019  GETMET	R4	R3	K150
+      0x8C100798,  //  0019  GETMET	R4	R3	K152
       0x7C100200,  //  001A  CALL	R4	1
       0x541600C7,  //  001B  LDINT	R5	200
       0x20140805,  //  001C  NE	R5	R4	R5
@@ -2567,18 +2576,18 @@ be_local_closure(class_Tasmota_urlfetch,   /* name */
       0x60140008,  //  001E  GETGBL	R5	G8
       0x5C180800,  //  001F  MOVE	R6	R4
       0x7C140200,  //  0020  CALL	R5	1
-      0x00172E05,  //  0021  ADD	R5	K151	R5
-      0xB0073005,  //  0022  RAISE	1	K152	R5
-      0x8C140799,  //  0023  GETMET	R5	R3	K153
+      0x00173205,  //  0021  ADD	R5	K153	R5
+      0xB0073405,  //  0022  RAISE	1	K154	R5
+      0x8C14079B,  //  0023  GETMET	R5	R3	K155
       0x5C1C0400,  //  0024  MOVE	R7	R2
       0x7C140400,  //  0025  CALL	R5	2
-      0x8C18079A,  //  0026  GETMET	R6	R3	K154
+      0x8C18079C,  //  0026  GETMET	R6	R3	K156
       0x7C180200,  //  0027  CALL	R6	1
       0x8C180122,  //  0028  GETMET	R6	R0	K34
       0x60200008,  //  0029  GETGBL	R8	G8
       0x5C240A00,  //  002A  MOVE	R9	R5
       0x7C200200,  //  002B  CALL	R8	1
-      0x00233608,  //  002C  ADD	R8	K155	R8
+      0x00233A08,  //  002C  ADD	R8	K157	R8
       0x58240019,  //  002D  LDCONST	R9	K25
       0x7C180600,  //  002E  CALL	R6	3
       0x80040800,  //  002F  RET	1	R4
@@ -2605,8 +2614,8 @@ be_local_closure(class_Tasmota_gen_cb,   /* name */
     &be_const_str_gen_cb,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xA40B3800,  //  0000  IMPORT	R2	K156
-      0x8C0C059D,  //  0001  GETMET	R3	R2	K157
+      0xA40B3C00,  //  0000  IMPORT	R2	K158
+      0x8C0C059F,  //  0001  GETMET	R3	R2	K159
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x80040600,  //  0004  RET	1	R3
@@ -2661,7 +2670,7 @@ be_local_closure(class_Tasmota_run_network_up,   /* name */
       0x70020007,  //  0019  JMP		#0022
       0x60100001,  //  001A  GETGBL	R4	G1
       0x60140018,  //  001B  GETGBL	R5	G24
-      0x5818009E,  //  001C  LDCONST	R6	K158
+      0x581800A0,  //  001C  LDCONST	R6	K160
       0x5C1C0400,  //  001D  MOVE	R7	R2
       0x5C200600,  //  001E  MOVE	R8	R3
       0x7C140600,  //  001F  CALL	R5	3
@@ -2698,21 +2707,21 @@ be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
       0xA4167600,  //  0000  IMPORT	R5	K59
       0x8C180B1E,  //  0001  GETMET	R6	R5	K30
       0x5C200600,  //  0002  MOVE	R8	R3
-      0x5824009F,  //  0003  LDCONST	R9	K159
+      0x582400A1,  //  0003  LDCONST	R9	K161
       0x7C180600,  //  0004  CALL	R6	3
       0x20180D01,  //  0005  NE	R6	R6	K1
       0x781A0003,  //  0006  JMPF	R6	#000B
-      0x8C1801A0,  //  0007  GETMET	R6	R0	K160
-      0x582000A1,  //  0008  LDCONST	R8	K161
+      0x8C1801A2,  //  0007  GETMET	R6	R0	K162
+      0x582000A3,  //  0008  LDCONST	R8	K163
       0x7C180400,  //  0009  CALL	R6	2
       0x80000C00,  //  000A  RET	0
       0xA802000A,  //  000B  EXBLK	0	#0017
-      0x8C1801A2,  //  000C  GETMET	R6	R0	K162
+      0x8C1801A4,  //  000C  GETMET	R6	R0	K164
       0x5C200600,  //  000D  MOVE	R8	R3
       0x7C180400,  //  000E  CALL	R6	2
       0x141C0D01,  //  000F  LT	R7	R6	K1
       0x781E0003,  //  0010  JMPF	R7	#0015
-      0x8C1C01A3,  //  0011  GETMET	R7	R0	K163
+      0x8C1C01A5,  //  0011  GETMET	R7	R0	K165
       0x7C1C0200,  //  0012  CALL	R7	1
       0xA8040001,  //  0013  EXBLK	1	1
       0x80000E00,  //  0014  RET	0
@@ -2720,13 +2729,13 @@ be_local_closure(class_Tasmota_urlfetch_cmd,   /* name */
       0x70020006,  //  0016  JMP		#001E
       0xAC180002,  //  0017  CATCH	R6	0	2
       0x70020003,  //  0018  JMP		#001D
-      0x8C2001A3,  //  0019  GETMET	R8	R0	K163
+      0x8C2001A5,  //  0019  GETMET	R8	R0	K165
       0x7C200200,  //  001A  CALL	R8	1
       0x80001000,  //  001B  RET	0
       0x70020000,  //  001C  JMP		#001E
       0xB0080000,  //  001D  RAISE	2	R0	R0
       0xB81A1400,  //  001E  GETNGBL	R6	K10
-      0x8C180DA4,  //  001F  GETMET	R6	R6	K164
+      0x8C180DA6,  //  001F  GETMET	R6	R6	K166
       0x7C180200,  //  0020  CALL	R6	1
       0x80000000,  //  0021  RET	0
     })


### PR DESCRIPTION
## Description:

Berry minor fixes to tapp handling:
- add `sortedmap` method `get_by_index()` to retrieve in sorted order
- `tasmota.load()` now accepts a tapp fil name and automatically calls "#autoexec.be" in the tapp file
- changes in `Tapp` class accordingly
- fix bug of not reseting `tasmota.wd` after loading a file

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
