### PR TITLE
Berry f-strings now support ':' in expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [15.0.1.1]
 ### Added
 - I2S additions (#23543)
+- Berry f-strings now support ':' in expression
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -175,6 +175,13 @@ assert(f"S = {a}" == 'S = foobar{0}')
 assert(f"S = {a:i}" == 'S = 0')
 assert(f"{a=}" == 'a=foobar{0}')
 
+# new option for f-strings, '::' encodes for ':'
+assert(f"{true ? 1 :: 2}" == "1")
+assert(f"{false ? 1 :: 2}" == "2")
+assert(f"{false ? 1 :: 2 : i}" == " 2")
+assert(f"{false ? 1 :: 2:i}" == "2")
+assert(f"{false ? 1 :: 2:04i}" == "0002")
+
 # startswith case sensitive
 assert(string.startswith("", "") == true)
 assert(string.startswith("qwerty", "qw") == true)


### PR DESCRIPTION
## Description:

Berry, now f-strings supports ':' in expression, if double as '::'.

Example:
```berry
var is_on = true
var s = f"status = {is_on ? 'on' :: 'off'}"
# s is 'status = on'
```

`f"status = {is_on ? 'on' :: 'off'}"` is equivalent to `format("status = %s", is_on ? 'on' : 'off')`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
