### PR TITLE
add i2s to some demo environments

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -184,6 +184,8 @@ extends                     = env:tasmota32_base
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
+                              -DUSE_BERRY_ULP
+                              -DUSE_I2S_ALL
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
@@ -195,6 +197,7 @@ board                       = esp32c3
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
+                              -DUSE_I2S_ALL
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
@@ -206,6 +209,8 @@ board                       = esp32s3-qio_qspi
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
+                              -DUSE_BERRY_ULP
+                              -DUSE_I2S_ALL
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
@@ -217,6 +222,8 @@ board                       = esp32c6
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
+                              -DUSE_BERRY_ULP
+                              -DUSE_I2S_ALL
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 


### PR DESCRIPTION
## Description:

Add some more features to some environments, which can be used for testing Tasmotas audio features in some unofficial builds in the future.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
