### PR TITLE
use SDK config information about BLE capabilities

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -50,7 +50,7 @@
 */
 #ifndef USE_BLE_ESP32
 #ifdef ESP32                       // ESP32 only. Use define USE_HM10 for ESP8266 support
-#if defined CONFIG_IDF_TARGET_ESP32 || defined CONFIG_IDF_TARGET_ESP32C3 || defined CONFIG_IDF_TARGET_ESP32C2 || defined CONFIG_IDF_TARGET_ESP32C6 || defined CONFIG_IDF_TARGET_ESP32S3
+#ifdef CONFIG_BT_NIMBLE_ENABLED
 
 #ifdef USE_MI_ESP32
 
@@ -3003,6 +3003,6 @@ bool Xsns62(uint32_t function)
   return result;
 }
 #endif  // USE_MI_ESP32
-#endif  // CONFIG_IDF_TARGET_ESP32 or CONFIG_IDF_TARGET_ESP32C3
+#endif  // CONFIG_BT_NIMBLE_ENABLED
 #endif  // ESP32
 #endif  // USE_BLE_ESP32


### PR DESCRIPTION
## Description:

The information from the framework makes it easier to read, what will be conditionally compiled based on SOC capabilities and/or activated features.
No functional changes, except that this would allow compilation on upcoming SOC's like the ESP32P4 without adding it explicitly.
There are more places in Tasmota that could be refactored that way.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
