### PR TITLE
fix: AHT30 sensor start with null values

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_63_aht1x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_63_aht1x.ino
@@ -83,7 +83,7 @@ struct {
   bool write_ok = false;
   uint8_t addresses[2] = { AHT1X_ADDR1, AHT1X_ADDR2 };
   uint8_t count  = 0;
-  uint8_t Pcount = 0;
+  uint8_t Pcount = 9;
 } aht1x;
 
 struct {


### PR DESCRIPTION
## Description:

The ATH driver's null-value output during startup prevents proper MQTT data acquisition when Deep Sleep is enabled.

### BEFORE
```
HDW: ESP8266EX
...
I2C: AHT3X found at 0x38
...
MQT: tele/tasmota_xxxxxx/SENSOR = {"Time":"2025-06-30T05:12:07","AHT3X":{"Temperature":null,"Humidity":null,"DewPoint":null},"TempUnit":"C"}
DSL: Countdown: 3
DSL: Countdown: 2
DSL: Countdown: 1
MQT: tele/tasmota_xxxxxx/DEEPSLEEP = {"DeepSleep":{"Time":"2025-06-30T05:13:30","DeepSleep":1751260329,"Wakeup":1751260410}} (retained)
...
```

### AFTER
```
HDW: ESP8266EX
...
I2C: AHT3X found at 0x38
...
MQT: tele/tasmota_xxxxxx/SENSOR = {"Time":"2025-06-30T07:31:36","AHT3X":{"Temperature":29.7,"Humidity":52.1,"DewPoint":18.8},"TempUnit":"C"}
DSL: Countdown: 3
...
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
