### PR TITLE
fix: teleinfo standard mode crash

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
@@ -454,13 +454,13 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
             // Contract subscribed (standard is in clear text in value)
             else if (ilabel == LABEL_NGTF)
             {
-                if (strstr(me->value, TELEINFO_STD_CONTRACT_BASE)) {
+                if (strstr_P(me->value, TELEINFO_STD_CONTRACT_BASE)) {
                     contrat = CONTRAT_BAS;
-                } else if (strstr(me->value, TELEINFO_STD_CONTRACT_HCHP)) {
+                } else if (strstr_P(me->value, TELEINFO_STD_CONTRACT_HCHP)) {
                     contrat = CONTRAT_HC;
-                } else if (strstr(me->value, TELEINFO_STD_CONTRACT_BBR)) {
+                } else if (strstr_P(me->value, TELEINFO_STD_CONTRACT_BBR)) {
                     contrat = CONTRAT_BBR;
-                } else if (strstr(me->value, TELEINFO_STD_CONTRACT_EJP)) {
+                } else if (strstr_P(me->value, TELEINFO_STD_CONTRACT_EJP)) {
                     contrat = CONTRAT_EJP;
                 }
 


### PR DESCRIPTION
## Description:

Tasmota teleinfo crash and reset in standard mode.
This fix works fine, source: [http://community.ch2i.eu/post/5929](http://community.ch2i.eu/post/5929)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
