### PR TITLE
CI: use uv instead of pip

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -108,8 +108,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Add SHA to footer
         run: |
@@ -158,8 +158,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
       - name: Add SHA to footer
         run: |
           COMMIT_SHA_LONG=$(git rev-parse --short HEAD || echo "")
@@ -209,8 +209,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v4
@@ -256,8 +256,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v4

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -42,8 +42,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Add "release" to footer
         run: |
@@ -86,8 +86,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Add "release" to footer
         run: |
@@ -136,8 +136,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v4
@@ -181,8 +181,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   os-check-win:
-    runs-on: windows-2019
+    runs-on: windows-latest
     if: github.repository == 'arendst/Tasmota'
     strategy:
       fail-fast: true

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -34,8 +34,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
       - name: Run PlatformIO
         env:
           PYTHONIOENCODING: utf-8
@@ -62,8 +62,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
       - name: Run PlatformIO
         env:
           PYTHONIOENCODING: utf-8
@@ -120,8 +120,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Run PlatformIO
         env:
@@ -149,8 +149,8 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install wheel
-          pip install -U platformio
+          pip install uv
+          uv pip install --system platformio
       - name: Run PlatformIO
         env:
           PYTHONIOENCODING: utf-8


### PR DESCRIPTION
## Description:

uv is faster than pip in installing the needed Python dependencies. No functional changes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
