### PR TITLE
Add internal function 'WSContentSendRaw_P'

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -890,8 +890,9 @@ void _WSContentSendBufferChunk(const char* content) {
   if (len >= CHUNKED_BUFFER_SIZE) {                // Either content or chunk buffer is oversize
     WSContentFlush();                              // Send chunk buffer before possible content oversize
   }
-  if (strlen_P(content) >= CHUNKED_BUFFER_SIZE) {    // Content is oversize
-    _WSContentSend(content);                       // Send content
+  len = strlen_P(content);
+  if (len >= CHUNKED_BUFFER_SIZE) {                // Content is oversize
+    _WSContentSend(content, len);                  // Send content
   }
 }
 
@@ -913,7 +914,7 @@ void WSContentSend(const char* content, size_t size) {
 /*-------------------------------------------------------------------------------------------*/
 
 void WSContentSendRaw_P(const char* content) {   // Content sent without formatting
-  if (NULL == content || pgm_read_byte(content) == '\0') { return; }
+  if (nullptr == content || !strlen_P(content)) { return; }
   WSContentSeparator(2);                           // Print separator on next WSContentSeparator(1)
   _WSContentSendBufferChunk(content);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -912,15 +912,19 @@ void WSContentSend(const char* content, size_t size) {
 
 /*-------------------------------------------------------------------------------------------*/
 
+void WSContentSendRaw_P(const char* content) {   // Content sent without formatting
+  if (NULL == content || content[0] == '\0') { return; }
+  WSContentSeparator(2);                           // Print separator on next WSContentSeparator(1)
+  _WSContentSendBufferChunk(content);
+}
+
+/*-------------------------------------------------------------------------------------------*/
+
 void _WSContentSendBuffer(bool decimal, const char * formatP, va_list arg) {
   char* content = ext_vsnprintf_malloc_P(formatP, arg);
   if (content == nullptr) { return; }              // Avoid crash
 
   int len = strlen(content);
-  if (0 == len) { return; }                        // No content
-
-  WSContentSeparator(2);                           // Print separator on next WSContentSeparator(1)
-
   if (decimal && (D_DECIMAL_SEPARATOR[0] != '.')) {
     for (uint32_t i = 0; i < len; i++) {
       if ('.' == content[i]) {
@@ -929,7 +933,7 @@ void _WSContentSendBuffer(bool decimal, const char * formatP, va_list arg) {
     }
   }
 
-  _WSContentSendBufferChunk(content);
+  WSContentSendRaw_P(content);
   free(content);
 }
 
@@ -1009,14 +1013,14 @@ void WSContentSendStyle_P(const char* formatP, ...) {
                   WebColor(COL_CONSOLE_TEXT)        // --c_csltxt
   );
 
-  WSContentSend_P(PSTR("%s"), HTTP_HEAD_STYLE1);
-  WSContentSend_P(PSTR("%s"), HTTP_HEAD_STYLE2);
+  WSContentSendRaw_P(HTTP_HEAD_STYLE1);
+  WSContentSendRaw_P(HTTP_HEAD_STYLE2);
   
 #ifdef USE_WEB_STATUS_LINE_WIFI
-  WSContentSend_P(PSTR("%s"), HTTP_HEAD_STYLE_WIFI);
+  WSContentSendRaw_P(HTTP_HEAD_STYLE_WIFI);
 #endif
 #if defined(USE_ZIGBEE) || defined(USE_LORAWAN_BRIDGE)
-  WSContentSend_P(HTTP_HEAD_STYLE_ZIGBEE);
+  WSContentSendRaw_P(HTTP_HEAD_STYLE_ZIGBEE);
 #endif // USE_ZIGBEE
   if (formatP != nullptr) {
     // This uses char strings. Be aware of sending %% if % is needed

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -882,7 +882,7 @@ void WSContentFlush(void) {
 /*-------------------------------------------------------------------------------------------*/
 
 void _WSContentSendBufferChunk(const char* content) {
-  int len = strlen(content);
+  int len = strlen_P(content);
   if (len < CHUNKED_BUFFER_SIZE) {                 // Append chunk buffer with small content
     Web.chunk_buffer += content;
     len = Web.chunk_buffer.length();
@@ -890,7 +890,7 @@ void _WSContentSendBufferChunk(const char* content) {
   if (len >= CHUNKED_BUFFER_SIZE) {                // Either content or chunk buffer is oversize
     WSContentFlush();                              // Send chunk buffer before possible content oversize
   }
-  if (strlen(content) >= CHUNKED_BUFFER_SIZE) {    // Content is oversize
+  if (strlen_P(content) >= CHUNKED_BUFFER_SIZE) {    // Content is oversize
     _WSContentSend(content);                       // Send content
   }
 }
@@ -913,7 +913,7 @@ void WSContentSend(const char* content, size_t size) {
 /*-------------------------------------------------------------------------------------------*/
 
 void WSContentSendRaw_P(const char* content) {   // Content sent without formatting
-  if (NULL == content || content[0] == '\0') { return; }
+  if (NULL == content || pgm_read_byte(content) == '\0') { return; }
   WSContentSeparator(2);                           // Print separator on next WSContentSeparator(1)
   _WSContentSendBufferChunk(content);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_5_map.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_5_map.ino
@@ -159,7 +159,7 @@ void Z_Mapper::dumpInternals(void) const {
 
     const char *fname = device.friendlyName;
     if (fname != nullptr) {
-      WSContentSend_P(PSTR("%s"), EscapeJSONString(fname).c_str());
+      WSContentSendRaw_P(EscapeJSONString(fname).c_str());
     } else {
       WSContentSend_P(PSTR("0x%04X"), device.shortaddr);
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -1773,7 +1773,7 @@ void UfsEditor(void) {
         AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_UFS "UfsEditor: read=%d"), l);
         if (l < 0) { break; }
         buf[l] = '\0';
-        WSContentSend_P(PSTR("%s"), HtmlEscape((char*)buf).c_str());
+        WSContentSendRaw_P(HtmlEscape((char*)buf).c_str());
         filelen -= l;
       }
       fp.close();

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -800,7 +800,7 @@ extern "C" {
       const char *msg = be_tostring(vm, 2);
       be_pop(vm, top);  // avoid Error be_top is non zero message
 #ifdef USE_WEBSERVER
-      WSContentSend_P(PSTR("%s"), msg);
+      WSContentSendRaw_P(msg);
 #endif  // USE_WEBSERVER
       be_return_nil(vm); // Return nil when something goes wrong
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -249,7 +249,7 @@ extern "C" {
       } else {
         html = (const char*) be_tocomptr(vm, 1);
       }
-      WSContentSend_P(PSTR("%s"), html);
+      WSContentSendRaw_P(html);
       be_return_nil(vm);
     }
     be_raise(vm, kTypeError, nullptr);


### PR DESCRIPTION
## Description:

`WSContentSendRaw_P` is a lower function compared to `WSContentSend_P` without any malloc/free not any formatting. Its main purpose it to output static content (can be in PROGMEM) like CSS, JS and SVG.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
