### PR TITLE
Platform 2025.07.30 Tasmota Arduino Core 3.1.3.250707 based on IDF 5.3.3.250702

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.05.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.07.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/tasmota/tasmota_support/support_jpeg.ino
+++ b/tasmota/tasmota_support/support_jpeg.ino
@@ -22,7 +22,7 @@
 #ifdef JPEG_PICTS
 
 #include "img_converters.h"
-#include "esp_jpg_decode.h"
+#include "jpeg_decoder.h"
 
 void rgb888_to_565(uint8_t *in, uint16_t *out, uint32_t len) {
 uint8_t red, grn, blu;

--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -2298,7 +2298,7 @@ char ppath[16];
 #ifdef ESP32
 #ifdef JPEG_PICTS
 #include "img_converters.h"
-#include "esp_jpg_decode.h"
+#include "jpeg_decoder.h"
 bool jpg2rgb888(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
 bool jpg2rgb565(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
 char get_jpeg_size(unsigned char* data, unsigned int data_size, unsigned short *width, unsigned short *height);

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -279,7 +279,7 @@ These will save or append a picture to a file.  The picture must have been first
 #include "sensor.h"
 #include "fb_gfx.h"
 #include "camera_pins.h"
-#include "esp_jpg_decode.h"
+#include "jpeg_decoder.h"
 //#include "img_converters.h"
 
 #ifdef USE_UFILESYS

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task_motion.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task_motion.ino
@@ -143,7 +143,7 @@ and/or
 #include "sensor.h"
 #include "fb_gfx.h"
 #include "camera_pins.h"
-#include "esp_jpg_decode.h"
+#include "jpeg_decoder.h"
 //#include "img_converters.h"
 
 extern SemaphoreHandle_t WebcamMutex;


### PR DESCRIPTION
## Description:

- Refactored Installer, removes old leftover packages to avoid install errors, smart path shorten for Windows
- Refactored SCons scripts main, arduino and espidf
- Moved most Hybrid Compile functions in new Scons Script component_manager
- Platform now uses uv as python package manager
- esptool v5.0.0 release with breaking changes, adopting Platform and framework for the changes
- Updated OpenOCD to v0.12.0-20250707
- Updated IDF 5.3.3.250702
- Updated Arduino 3.1.3, backported major improvements/fixes from Arduino version 3.2.1

Tasmota code change: Camera driver changes. Uses now jpeg decoder from IDF component esp_jpeg

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
