### PR TITLE
esptool v5.0.0 changes for post pio esp32 script

### DIFF
--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -1,22 +1,11 @@
 Import("env")
 
 import os
-import tasmotapiolib
 from os.path import join
-import subprocess
 
 def firm_metrics(source, target, env):
     print()
-    if env["PIOPLATFORM"] == "espressif32":
-        try:
-            import tasmota_metrics
-            map_file = str(tasmotapiolib.get_source_map_path(env).resolve())
-            subprocess.run([
-                env.subst("$PYTHONEXE"), "-m", "tasmota_metrics", map_file
-            ], check=False)
-        except:
-            pass
-    elif env["PIOPLATFORM"] == "espressif8266":
+    if env["PIOPLATFORM"] == "espressif8266":
         map_file = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
         with open(map_file,'r', encoding='utf-8') as f:
             phrase = "_text_end = ABSOLUTE (.)"

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -335,7 +335,7 @@ def esp32_create_combined_bin(source, target, env):
                 "--flash-freq", "${__get_board_f_flash(__env__)}",
                 "--flash-size", flash_size
                 ],
-                UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS ' + " ".join(cmd[7:])
+                UPLOADCMD='"$UPLOADER" $UPLOADERFLAGS ' + " ".join(cmd[7:])
                 )
                 print(Fore.GREEN + "Will use custom upload command for flashing operation to add file system defined for this build target.")
                 print()

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -36,7 +36,8 @@ from colorama import Fore, Back, Style
 from SCons.Script import COMMAND_LINE_TARGETS
 from platformio.project.config import ProjectConfig
 
-esptoolpy = [env.subst("$OBJCOPY")]
+esptoolpy = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tool-esptoolpy")
+sys.path.append(esptoolpy)
 import esptool
 
 config = env.GetProjectConfig()

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -103,7 +103,7 @@ def esp32_detect_flashsize():
     if not "esptool" in uploader:
         return "4MB",False
     else:
-        esptoolpy_flags = ["flash_id"]
+        esptoolpy_flags = ["flash-id"]
         esptoolpy_cmd = [env["PYTHONEXE"], esptoolpy] + esptoolpy_flags
         try:
             output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
@@ -282,14 +282,14 @@ def esp32_create_combined_bin(source, target, env):
         cmd = [
             "--chip",
             chip,
-            "merge_bin",
+            "merge-bin",
             "-o",
             new_file_name,
-            "--flash_mode",
+            "--flash-mode",
             flash_mode,
-            "--flash_freq",
+            "--flash-freq",
             flash_freq,
-            "--flash_size",
+            "--flash-size",
             flash_size,
         ]
         # platformio estimates the flash space used to store the firmware.
@@ -320,8 +320,8 @@ def esp32_create_combined_bin(source, target, env):
         if(upload_protocol == "esptool") and (fs_offset != -1):
             fs_bin = join(env.subst("$BUILD_DIR"),"littlefs.bin")
             if exists(fs_bin):
-                before_reset = env.BoardConfig().get("upload.before_reset", "default_reset")
-                after_reset = env.BoardConfig().get("upload.after_reset", "hard_reset")
+                before_reset = env.BoardConfig().get("upload.before_reset", "default-reset")
+                after_reset = env.BoardConfig().get("upload.after_reset", "hard-reset")
                 print(f" -  {hex(fs_offset).ljust(8)} | {fs_bin}")
                 print()
                 cmd += [hex(fs_offset), fs_bin]
@@ -332,10 +332,10 @@ def esp32_create_combined_bin(source, target, env):
                 "--baud", "$UPLOAD_SPEED",
                 "--before", before_reset,
                 "--after", after_reset,
-                "write_flash", "-z",
-                "--flash_mode", "${__get_board_flash_mode(__env__)}",
-                "--flash_freq", "${__get_board_f_flash(__env__)}",
-                "--flash_size", flash_size
+                "write-flash", "-z",
+                "--flash-mode", "${__get_board_flash_mode(__env__)}",
+                "--flash-freq", "${__get_board_f_flash(__env__)}",
+                "--flash-size", flash_size
                 ],
                 UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS ' + " ".join(cmd[7:])
                 )

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -36,9 +36,7 @@ from colorama import Fore, Back, Style
 from SCons.Script import COMMAND_LINE_TARGETS
 from platformio.project.config import ProjectConfig
 
-esptoolpy = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tool-esptoolpy")
-sys.path.append(esptoolpy)
-
+esptoolpy = [env.subst("$OBJCOPY")]
 import esptool
 
 config = env.GetProjectConfig()
@@ -104,7 +102,7 @@ def esp32_detect_flashsize():
         return "4MB",False
     else:
         esptoolpy_flags = ["flash-id"]
-        esptoolpy_cmd = [env["PYTHONEXE"], esptoolpy] + esptoolpy_flags
+        esptoolpy_cmd = esptoolpy + esptoolpy_flags
         try:
             output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
             for l in output:


### PR DESCRIPTION
## Description:

updates for post_esp32.py to fix deprecated warnings

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
