### PR TITLE
RV3028 RTC Chip support

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -131,5 +131,6 @@ Index | Define              | Driver   | Device   | Address(es) | Bus2 | Descrip
   91  | USE_MS5837          | xsns_116 | MS5837    | 0x76       |      | Pressure and temperature sensor
   92  | USE_PCF85063        | xdrv_56  | PCF85063  | 0x51       |      | PCF85063 Real time clock
   93  | USE_AS33772S        | xdrv_119 | AS33772S  | 0x52       | Yes  | AS33772S USB PD Sink Controller
+  94  | USE_RV3028          | xdrv_56  | RV3028    | 0x52       | Yes  | RV-3028-C7 RTC Controller
 
   NOTE: Bus2 supported on ESP32 only.

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -791,6 +791,7 @@
 //  #define USE_AP33772S                           // [I2cDriver93] Enable AP33772S USB PD Sink Controller (I2C addresses 0x52) (+3k1 code)
 
 //  #define USE_RTC_CHIPS                          // Enable RTC chip support and NTP server - Select only one
+//    #define USE_RV3028                           // [I2cDriver94] Enable RV3028 RTC chip support (I2C address 0x52)
 //    #define USE_DS3231                           // [I2cDriver26] Enable DS3231 RTC - used by Ulanzi TC001 (I2C address 0x68) (+1k2 code)
 //    #define DS3231_ENABLE_TEMP                   //   In DS3231 driver, enable the internal temperature sensor
 //    #define USE_BM8563                           // [I2cDriver59] Enable BM8563 RTC - used by M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)


### PR DESCRIPTION
## Description:

Added support for relative new RTC Chip from Micro Crystal Switzerland - RV-3028-C7 RTC Chip. Fully tested with ESP32 S3 on both I2C buses. The init-procedure to activate Direct Switching Mode is included also (necessary when using RTC backup battery connected to VBACKUP pin on chip). Personally using this chip in my MSB Master G1 development board.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
