### PR TITLE
Add support for Hyundai WS Senzor 77(TH)

### DIFF
--- a/lib/lib_rf/rc-switch/src/RCSwitch.cpp
+++ b/lib/lib_rf/rc-switch/src/RCSwitch.cpp
@@ -154,6 +154,7 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 250,  0, { 0, 0 }, 1, {  18,  6 }, { 1,  3 }, { 3, 1 }, false,  0 },  // 36 Dooya remote DC2700AC for Dooya DT82TV curtains motor
   { 200,  0, { 0, 0 }, 0, {   0,  0 }, { 1,  3 }, { 3, 1 }, false, 20 },	// 37 DEWENWILS Power Strip
   { 500,  0, { 0, 0 }, 1, {   7,  1 }, { 2,  1 }, { 4, 1 }, true,   0 },  // 38 temperature and humidity sensor, various brands, nexus protocol, 36 bits + start impulse  
+  { 560,  0, { 0, 0 }, 1, {   15, 1 }, { 3,  1 }, { 7, 1 }, true,   0 }   // 39 Hyundai WS Senzor 77/77TH, 36 bits (requires disabled protocol 38: 'RfProtocol38 0')
 };
 
 enum {


### PR DESCRIPTION
## Description:

Add support for Hyundai WS Senzor 77/77TH wireless outdoor unit to rc-switch library. This device is a weather sensor communicating on radio frequency 433.92 MHz.
Device has first available protocol number assigned (39). However traffic is frequently intercepted by preceding one (38 - which is more generic). Therefore it is recommended to disable protocol 38 when this weather sensor is in use. Alternatively this new one should get 38 and existing one should be moved to 39 (solution not backward-compatible though).

Please refer here if you want to decode payload: https://github.com/realmicu/RFLink32/blob/main/RFLink/Plugins/Plugin_051.c

Example output when enabled:
`18:12:03.699 MQT: tele/radiotest/RESULT = {"Time":"2025-07-11T18:12:03","RfReceived":{"Data":"0xFB0230AB7","Bits":36,"Protocol":39,"Pulse":588}}`

(Above value 0xFB0230AB7 means : Channel 2, Battery OK, Temperature +19.6 Celsius, Humidity 57%)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
