### PR TITLE
ESP32P4: add hostedOTA and info messages

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -333,6 +333,7 @@
 #define D_CMND_UPGRADE "Upgrade"
   #define D_JSON_ONE_OR_GT "1 or >%s to upgrade"
 #define D_CMND_OTAURL "OtaUrl"
+#define D_CMND_HOSTEDOTA "HostedOta"
 #define D_CMND_SERIALLOG "SerialLog"
 #define D_CMND_SYSLOG "SysLog"
 #define D_CMND_FILELOG "FileLog"

--- a/tasmota/tasmota_support/support_hosted_mcu.ino
+++ b/tasmota/tasmota_support/support_hosted_mcu.ino
@@ -1,0 +1,57 @@
+/*
+  support_hosted_mcu.ino - eeprom support for Tasmota
+
+  Copyright (C) 2025  Theo Arends & Christian Baars
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+
+#ifdef CONFIG_ESP_WIFI_REMOTE_ENABLED
+
+#include "esp_hosted.h"
+#include "esp_hosted_api_types.h"
+#include "esp_hosted_ota.h"
+
+String GetHostedMCUFwVersion()
+{
+  if(!esp_hosted_is_config_valid()) {
+    return String("");
+  }
+  esp_hosted_coprocessor_fwver_t ver_info;
+  esp_err_t err = esp_hosted_get_coprocessor_fwversion(&ver_info);
+  if (err == ESP_OK) {
+    char data[40];
+    snprintf_P(data, sizeof(data), PSTR("%d.%d.%d"), ver_info.major1,ver_info.minor1,ver_info.patch1);
+    // AddLog(LOG_LEVEL_DEBUG, PSTR("Fw: %d.%d.%d"), ver_info.major1, ver_info.minor1, ver_info.patch1);
+    return String(data);
+  }
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Err: %d, version 0.0..6 or older"), err);
+  return String(PSTR("0.0.6")); // we can not know exactly, but API was added after 0.0.6
+}
+
+void OTAHostedMCU(const char* image_url) {
+  AddLog(LOG_LEVEL_INFO, PSTR("OTA: co-processor OTA update started from %s"), image_url);
+  esp_err_t ret = esp_hosted_slave_ota(image_url);
+  // next lines are questionable, because ATM the system will reboot immediately - maybe we would see the failure
+  if (ret == ESP_OK) {
+    AddLog(LOG_LEVEL_INFO, PSTR("OTA: co-processor OTA update successful !!"));
+  } else {
+    AddLog(LOG_LEVEL_INFO, PSTR("OTA: co-processor OTA update failed: %d"), ret);
+  }
+}
+
+
+#endif //  CONFIG_ESP_WIFI_REMOTE_ENABLED

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2977,6 +2977,11 @@ void HandleInformation(void) {
     WSContentSend_P(PSTR("}1" D_FRIENDLY_NAME " %d}2%s"), i +1, SettingsTextEscaped(SET_FRIENDLYNAME1 +i).c_str());
   }
   WSContentSeparatorIFat();
+#ifdef CONFIG_ESP_WIFI_REMOTE_ENABLED
+  WSContentSend_P(PSTR("}1 Hosted MCU }2 " CONFIG_ESP_HOSTED_IDF_SLAVE_TARGET ""));
+  WSContentSend_P(PSTR("}1 Hosted Remote Fw }2%s"), GetHostedMCUFwVersion().c_str());
+  WSContentSeparatorIFat();
+#endif //CONFIG_ESP_WIFI_REMOTE_ENABLED
   bool show_hr = false;
   if ((WiFi.getMode() >= WIFI_AP) && (static_cast<uint32_t>(WiFi.softAPIP()) != 0)) {
     WSContentSend_P(PSTR("}1" D_MAC_ADDRESS "}2%s"), WiFi.softAPmacAddress().c_str());


### PR DESCRIPTION
## Description:

Adds info messages to STATUS 2 in the form of:
`STATUS2 = {"StatusFWR":{"Version":"15.0.1.2(bluetooth)","BuildDateTime":"2025-07-12T08:53:48","Core":"3_1_3","SDK":"5.3.3.250702","CpuFrequency":360,"Hardware":"ESP32-P4 v1.0","HostedMCU":{"Hardware":"esp32c6","Version":"2.0.14"},"CR":"350/699"}}`

and a similar section to the web `Information` page.
Note: Every firmware older or equal to `0.0.6` will be reported as `0.0.6`, because there had been no API before that.

Adds new command `HostedOta`, which will update the coprocessor firmware. Can be used locally like that:
1. Go to the firmware folder
2. `python3 -m http.server` (will need Port 8000)
3. Find out IP of your computer, then in the Tasmota console:
4. `hostedota  http://<ip>:8000/<correct_firmware.bin>`
5. Then wait and do not interrupt the process
6. Device will reboot after success

Notes:
Basically we call one function of a very high level API here, without fine grained control or usable status messages.
With correct usage I did not have a single failure.
Failure may require wired fw upload to the coprocessor - USE AT YOUR OWN RISK!!
We already have begun to embed these firmwares into the framework package used by Tasmota, but this is a moving target and that's why I do not write down the file path here. It is not too hard to find (in release 3791) and I used exactly these binaries for testing.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
