### PR TITLE
Switch off not needed waiting for FS up and download

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -81,7 +81,7 @@ extra_scripts               = pre:pio-tools/pre_source_dir.py
 extra_scripts               = post:pio-tools/name-firmware.py
                               post:pio-tools/gzip-firmware.py
                               post:pio-tools/metrics-firmware.py
-                              post:pio-tools/custom_target.py
+                              pre:pio-tools/custom_target.py
 ;                              post:pio-tools/obj-dump.py
                               ${scripts_defaults.extra_scripts}
 ; *** remove undesired all warnings


### PR DESCRIPTION
## Description:

- change in pio script custom_targets.py to switch of the unnecessary step of LDF scan for Filesystem up and downloads. 
- changed syntax from commands for esptool v5.0
- no changes in Tasmota source code nor in resulting firmwares
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
