### PR TITLE
add esp32-p4 to GH Actions

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -98,6 +98,8 @@ jobs:
           - tasmota32s3ser-safeboot
           - tasmota32c6-safeboot
           - tasmota32c6ser-safeboot
+          - tasmota32p4-safeboot
+          - tasmota32p4ser-safeboot
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,6 +197,7 @@ jobs:
           - tasmota32c2
           - tasmota32c3
           - tasmota32c6
+          - tasmota32p4
           - tasmota32s2
           - tasmota32s2cdc
           - tasmota32s3

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -32,6 +32,8 @@ jobs:
           - tasmota32s3ser-safeboot
           - tasmota32c6-safeboot
           - tasmota32c6ser-safeboot
+          - tasmota32p4-safeboot
+          - tasmota32p4ser-safeboot
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,6 +124,7 @@ jobs:
           - tasmota32c2
           - tasmota32c3
           - tasmota32c6
+          - tasmota32p4
           - tasmota32s2
           - tasmota32s2cdc
           - tasmota32s3

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -95,6 +95,7 @@ jobs:
           - tasmota32c2
           - tasmota32c3
           - tasmota32c6
+          - tasmota32p4
           - tasmota32s2
           - tasmota32s2cdc
           - tasmota32s3
@@ -112,6 +113,7 @@ jobs:
           - tasmota32c2-safeboot
           - tasmota32c3-safeboot
           - tasmota32c6-safeboot
+          - tasmota32p4-safeboot
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/boards/esp32p4.json
+++ b/boards/esp32p4.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_TASMOTA -DESP32P4 -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE"
+    ],
+    "f_cpu": "360000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32p4",
+    "variant": "esp32p4",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "openthread",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32p4.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif Generic ESP32-P4 >= 4M Flash, Tasmota 2880k Code/OTA, >= 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32p4-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 768000,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 1500000
+  },
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "vendor": "Espressif"
+}

--- a/boards/esp32p4ser.json
+++ b/boards/esp32p4ser.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_TASMOTA -DESP32P4 -DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "360000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32p4",
+    "variant": "esp32p4",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "openthread",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32p4.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif Generic ESP32-P4 >= 4M Flash, Tasmota 2880k Code/OTA, >= 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32p4-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 768000,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 1500000
+  },
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html",
+  "vendor": "Espressif"
+}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -162,11 +162,21 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4-safeboot]
 extends                 = env:tasmota32_base
-board                   = esp32p4_ev
+board                   = esp32p4
 board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4-safeboot.bin"'
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32p4ser-safeboot]
+extends                 = env:tasmota32_base
+board                   = esp32p4ser
+board_build.app_partition_name = safeboot
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
@@ -246,7 +256,7 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 
 [env:tasmota32p4]
 extends                 = env:tasmota32_base
-board                   = esp32p4_ev
+board                   = esp32p4
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4.bin"'


### PR DESCRIPTION
## Description:

to build precompiled binary for the esp32-p4. 
Added standard p4 boards which aligns to Tasmota boards convention and changed the p4 env to use generic p4 board

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250707
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
