### PR TITLE
Fix TwoWire signature change

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_76_serial_i2c.ino
@@ -116,8 +116,8 @@ public:
   }
 
   // unused function, but override to NOP just in case
-  void onReceive(void (*)(int)) override {};
-  void onRequest(void (*)(void)) override {};
+  void onReceive(const std::function<void(int)> &) override {};
+  void onRequest(const std::function<void()> &) override {};
 
   void beginTransmission(uint8_t address) override {
     non_stop = false;


### PR DESCRIPTION
## Description:

Fix compilation error in `xdrv_76_serial_i2c.ino` due to change in `TwoWire` signature of methods.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
