### PR TITLE
NeoPool fix reset to default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - OpenTherm library from v0.9.0 to v1.1.5 (#23704)
 
 ### Fixed
+- NeoPool fix reset to default settings
 
 ### Removed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -815,14 +815,14 @@ typedef union {
 } NeoPoolBitfield;;
 
 // Global structure containing sensor saved variables
-struct {
+typedef struct {
   uint32_t  crc32;
   uint16_t  version;
   NeoPoolBitfield flags;
   uint8_t   result;
   uint16_t  npteleperiod;
-} NeoPoolSettings;
-
+} TNeoPoolSettings;
+TNeoPoolSettings NeoPoolSettings;
 
 #define D_NEOPOOL_NAME "NeoPool"
 
@@ -3381,6 +3381,9 @@ void NeoPoolSettingsLoad(bool erase) {
   NeoPoolSettings.flags.conn_stat = 1;
   NeoPoolSettings.result = NEOPOOL_DEFAULT_RESULT;
   NeoPoolSettings.npteleperiod = NEOPOOL_DEFAULT_NPTELEPERIOD;
+  TNeoPoolSettings NeoPoolSettingsDefaults;
+  memcpy(&NeoPoolSettingsDefaults, &NeoPoolSettings, sizeof(NeoPoolSettingsDefaults));
+
 
 #ifdef USE_UFILESYS
   snprintf_P(filename, sizeof(filename), PSTR(TASM_FILE_SENSOR), XSNS_83);
@@ -3391,6 +3394,10 @@ void NeoPoolSettingsLoad(bool erase) {
 #ifdef DEBUG_TASMOTA_SENSOR
     AddLog(LOG_LEVEL_DEBUG, PSTR("NEO: Settings loaded from file '%s'"), filename);
 #endif  // DEBUG_TASMOTA_SENSOR
+    if (NeoPoolSettings.crc32 != GetCfgCrc32((uint8_t*)&NeoPoolSettings +4, sizeof(NeoPoolSettings) -4)) {
+      AddLog(LOG_LEVEL_INFO, PSTR("NEO: Settings CRC error, reset to defaults"));
+      memcpy(&NeoPoolSettings, &NeoPoolSettingsDefaults, sizeof(NeoPoolSettings));
+    }
   }
   else {
 #ifdef DEBUG_TASMOTA_SENSOR


### PR DESCRIPTION
## Description:

Resetting NeoPool settings to defaults on inconsistency or settings struct changes
(reported in [HA NeoPool MQTT: integration of Tasmota NeoPool (for Sugar Valley, Hayward/Aquarite, Bayrol devices) #434](https://community.home-assistant.io/t/ha-neopool-mqtt-integration-of-tasmota-neopool-for-sugar-valley-hayward-aquarite-bayrol-devices/632517/438))

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
