### PR TITLE
permit battery already expressed in percent

### DIFF
--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -98,6 +98,13 @@ class lwdecode_cls
       batt_percent /= 7                                       # 1..14px showing battery load
       msg += format("<td><i class=\"bt\" title=\"%.3fV (%s)\" style=\"--bl:%dpx;color:%s\"></i></td>",
                    battery, self.dhm(battery_last_seen), batt_percent, color_text)
+    elif battery >= 100000 && battery <= 100100               # battery already expressed in %
+      battery -= 100000
+      var batt_percent = battery
+      if batt_percent > 98 batt_percent = 98 end              # 98% / 14px = 7
+      batt_percent /= 7                                       # 1..14px showing battery load
+      msg += format("<td><i class=\"bt\" title=\"%d%% (%s)\" style=\"--bl:%dpx;color:%s\"></i></td>",
+                   battery, self.dhm(battery_last_seen), batt_percent, color_text)
     else
       msg += "<td>&nbsp;</td>"
     end
@@ -174,9 +181,6 @@ class webPageLoRaWAN : Driver
      cmdArg = webserver.arg('an')
      if !cmdArg cmdArg='"' end
      tasmota.cmd('LoRaWanName'+inode+' '+cmdArg,true)
-     cmdArg = webserver.arg('ce')
-     if !cmdArg cmdArg='0' else cmdArg='1' end
-     tasmota.cmd('LoRaWanNode'+inode+' '+cmdArg,true)
     end
 
     webserver.content_start("LoRaWAN")           #- title of the web page -#
@@ -207,7 +211,7 @@ class webPageLoRaWAN : Driver
      "window.onload = function(){selNode("+str(inode)+");};"
      "</script>")
 
-    var arg, appKey, decoder, name, enables, enabled
+    var arg, appKey, decoder, name
     var hintAK='32 character Application Key'
     var hintDecoder='Decoder file, ending in .be'
     var hintAN='Device name for MQTT messages'
@@ -221,14 +225,7 @@ class webPageLoRaWAN : Driver
     end
     webserver.content_send(
     f"</div><br><br><br><br>")                   #- Terminate indent and add space -#
-
-    arg='LoRaWanNode'
-    enables=string.split(tasmota.cmd(arg,true).find(arg), ',') # [1,!2,!3,!4,5,6,7,8,9,10,11,12,13,14,15,16]
     for node:1..16
-     enabled=""
-     if enables[node-1][0] != '!'
-       enabled=' checked'
-     end
      arg='LoRaWanAppKey' + str(node)
      appKey=tasmota.cmd(arg,true).find(arg)
      arg='LoRaWanName' + str(node)
@@ -238,7 +235,6 @@ class webPageLoRaWAN : Driver
      webserver.content_send(
      f"<div id='nd{node}' style='display:none'>"
       "<form action='' method='post'>"
-       "<p><label><input id='ce' name='ce' type='checkbox'{enabled}><b>Enabled</b></label></p>"
        "<p><b>Application Key</b>"
         "<input title='{hintAK}' pattern='[A-Fa-f0-9]{{32}}' id='ak' minlength='32' maxlength='32' required='' placeholder='{hintAK}' value='{appKey}' name='ak' style='font-size:smaller'>"
        "</p>"

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -99,12 +99,12 @@ class lwdecode_cls
       msg += format("<td><i class=\"bt\" title=\"%.3fV (%s)\" style=\"--bl:%dpx;color:%s\"></i></td>",
                    battery, self.dhm(battery_last_seen), batt_percent, color_text)
     elif battery >= 100000 && battery <= 100100               # battery already expressed in %
-      battery -= 100000
-      var batt_percent = battery
+      var pbatt = battery - 100000
+      var batt_percent = pbatt
       if batt_percent > 98 batt_percent = 98 end              # 98% / 14px = 7
       batt_percent /= 7                                       # 1..14px showing battery load
       msg += format("<td><i class=\"bt\" title=\"%d%% (%s)\" style=\"--bl:%dpx;color:%s\"></i></td>",
-                   battery, self.dhm(battery_last_seen), batt_percent, color_text)
+                   pbatt, self.dhm(battery_last_seen), batt_percent, color_text)
     else
       msg += "<td>&nbsp;</td>"
     end

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -181,6 +181,9 @@ class webPageLoRaWAN : Driver
      cmdArg = webserver.arg('an')
      if !cmdArg cmdArg='"' end
      tasmota.cmd('LoRaWanName'+inode+' '+cmdArg,true)
+     cmdArg = webserver.arg('ce')
+     if !cmdArg cmdArg='0' else cmdArg='1' end
+     tasmota.cmd('LoRaWanNode'+inode+' '+cmdArg,true)
     end
 
     webserver.content_start("LoRaWAN")           #- title of the web page -#
@@ -211,7 +214,7 @@ class webPageLoRaWAN : Driver
      "window.onload = function(){selNode("+str(inode)+");};"
      "</script>")
 
-    var arg, appKey, decoder, name
+    var arg, appKey, decoder, name, enables, enabled
     var hintAK='32 character Application Key'
     var hintDecoder='Decoder file, ending in .be'
     var hintAN='Device name for MQTT messages'
@@ -225,7 +228,14 @@ class webPageLoRaWAN : Driver
     end
     webserver.content_send(
     f"</div><br><br><br><br>")                   #- Terminate indent and add space -#
+
+    arg='LoRaWanNode'
+    enables=string.split(tasmota.cmd(arg,true).find(arg), ',') # [1,!2,!3,!4,5,6,7,8,9,10,11,12,13,14,15,16]
     for node:1..16
+     enabled=""
+     if enables[node-1][0] != '!'
+       enabled=' checked'
+     end
      arg='LoRaWanAppKey' + str(node)
      appKey=tasmota.cmd(arg,true).find(arg)
      arg='LoRaWanName' + str(node)
@@ -235,6 +245,7 @@ class webPageLoRaWAN : Driver
      webserver.content_send(
      f"<div id='nd{node}' style='display:none'>"
       "<form action='' method='post'>"
+       "<p><label><input id='ce' name='ce' type='checkbox'{enabled}><b>Enabled</b></label></p>"
        "<p><b>Application Key</b>"
         "<input title='{hintAK}' pattern='[A-Fa-f0-9]{{32}}' id='ak' minlength='32' maxlength='32' required='' placeholder='{hintAK}' value='{appKey}' name='ak' style='font-size:smaller'>"
        "</p>"


### PR DESCRIPTION
## Description:

In preparation of the Milesight vendor, that rappresent the battery in %, a little tricky fix for header() function to handle it.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
