### PR TITLE
Berry `call()` now works for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - ESP32-P4 command `HostedOta` (#23675)
 - Support for RV3028 RTC (#23672)
 - Berry preview of animation framework (#23740)
+- Berry `call()` now works for classes
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_baselib.c
+++ b/lib/libesp32/berry/src/be_baselib.c
@@ -319,7 +319,7 @@ int be_baselib_iterator(bvm *vm)
 static int l_call(bvm *vm)
 {
     int top = be_top(vm);
-    if (top >= 1 && be_isfunction(vm, 1)) {
+    if (top >= 1 && (be_isfunction(vm, 1) || be_isclass(vm, 1))) {
         size_t arg_count = top - 1;  /* we have at least 'top - 1' arguments */
         /* test if last argument is a list */
 
@@ -354,7 +354,7 @@ static int l_call(bvm *vm)
 
         be_return(vm);
     }
-    be_raise(vm, "value_error", "first argument must be a function");
+    be_raise(vm, "value_error", "first argument must be a function or a class");
     be_return_nil(vm);
 }
 


### PR DESCRIPTION
## Description:

Berry make `call()` work for classes in addition to functions. This allows to call class constructors with variable number of arguments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
