### PR TITLE
LoRaWAN Sensor standard formatter

### DIFF
--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -4,47 +4,49 @@
 var LwRegions = ["EU868","US915","IN865","AU915","KZ865","RU864","AS923","AS923-1","AS923-2","AS923-3"]
 var LwDeco
 
-var LwSensorIcons = {
-  "High Voltage":     "&#x26A1;",   # High Voltage Icon
-  "Electric Plug":    "&#x1F50C;",  # Electric Plug Icon  
-  "Bar Chart":        "&#x1F4CA;",  # Bar Chart Icon
-  "Light Bulb":       "&#x1F4A1;",  # Light Bulb Icon
-  "Stopwatch":        "&#x23F1;",   # Stopwatch Icon
-  "Abacus":           "&#x1F9EE;",  # Abacus Icon
-  "Power ON":         "&#x23FD;",   # Button State ON Icon
-  "Power OFF":        "&#x2B58;",   # Button State OFF Icon
-  "Locked":           "&#x1F512;",  # Lock Close Icon
-  "Unlocked":         "&#x1F513;",  # Lock Open Icon
-  "Check Mark":       "&#x2705;",
-  "Crosscheck Mark":  "&#x274C;",
-  "Free":             "&#x1F193;",
-  "No Entry":         "&#x1F6AB;",
-  "Moon":             "&#x1F315;",
-  "Sun":              "&#x1F31E;",
-  "Radio Button":     "&#x1F518;"
-}
-
-var LwSensorFormatter = {
-  "string":           { "unit": nil,      "format": "%s",     "icon": nil             },
-  "volt":             { "unit": "V",      "format": "%.1f",   "icon": "High Voltage"  },
-  "milliamp":         { "unit": "mA",     "format": "%.0f",   "icon": "Electric Plug" },
-  "power_factor%":    { "unit": "%",      "format": "%.0f",   "icon": "Bar Chart"     },
-  "power":            { "unit": "W",      "format": "%.0f",   "icon": "Light Bulb"    },
-  "energy":           { "unit": "Wh",     "format": "%.0f",   "icon": "Abacus"        }
-}
-
 import mqtt 
 import string
 
 class LwSensorFormatter_cls
   var Msg
 
+  static Icons = {
+    "Sensor Line":      "9478",   # | <sensor1><sensor2>... 
+    "High Voltage":     "x26A1",   # High Voltage Icon
+    "Electric Plug":    "x1F50C",  # Electric Plug Icon  
+    "Bar Chart":        "x1F4CA",  # Bar Chart Icon
+    "Light Bulb":       "x1F4A1",  # Light Bulb Icon
+    "Stopwatch":        "x23F1",   # Stopwatch Icon
+    "Abacus":           "x1F9EE",  # Abacus Icon
+    "Power ON":         "x23FD",   # Button State ON Icon
+    "Power OFF":        "x2B58",   # Button State OFF Icon
+    "Locked":           "x1F512",  # Lock Close Icon
+    "Unlocked":         "x1F513",  # Lock Open Icon
+    "Check Mark":       "x2705",
+    "Crosscheck Mark":  "x274C",
+    "Free":             "x1F193",
+    "No Entry":         "x1F6AB",
+    "Moon":             "x1F315",
+    "Sun":              "x1F31E",
+    "Radio Button":     "x1F518"
+  }
+
+  static Formatter = {
+    "string":           { "u": nil,      "f": "%s",     "i": nil             },
+    "volt":             { "u": "V",      "f": "%.1f",   "i": "High Voltage"  },
+    "milliamp":         { "u": "mA",     "f": "%.0f",   "i": "Electric Plug" },
+    "power_factor%":    { "u": "%",      "f": "%.0f",   "i": "Bar Chart"     },
+    "power":            { "u": "W",      "f": "%.0f",   "i": "Light Bulb"    },
+    "energy":           { "u": "Wh",     "f": "%.0f",   "i": "Abacus"        },
+    "empty":            { "u": nil,      "f": nil,      "i": nil             }
+  }
+
   def init()
     self.Msg = ""
   end
   
   def start_line()
-    self.Msg += format("<tr class='htr'><td colspan='4'>&#9478;")  # | <sensor1><sensor2>...
+    self.Msg += format("<tr class='htr'><td colspan='4'>" + self.get_icon("Sensor Line") )  # | <sensor1><sensor2>...
     return self
   end
 
@@ -58,11 +60,11 @@ class LwSensorFormatter_cls
   end
 
   def get_icon(icon)
-    return LwSensorIcons.find(icon) ? LwSensorIcons[icon] : icon
+    return self.Icons.find(icon) ? "&#" + self.Icons[icon] + ";" : icon
   end
 
   def begin_tooltip(ttip)
-    self.Msg += string.format("&nbsp;<div title='%s' class='si'>", ttip)
+    self.Msg += format("&nbsp;<div title='%s' class='si'>", ttip)
     return self
   end
 
@@ -76,26 +78,26 @@ class LwSensorFormatter_cls
       self.begin_tooltip(tooltip)
     end
 
-    var fmt = LwSensorFormatter.find(formatter)
+    var fmt = self.Formatter.find(formatter)
 
     if alt_icon 
       self.Msg += format(" %s", self.get_icon(alt_icon) )  # Use alternative icon
-    elif fmt && fmt.find("icon") && fmt["icon"]
-      self.Msg += format(" %s", self.get_icon(fmt["icon"]) )  # Use icon from formatter
+    elif fmt && fmt.find("icon") && fmt["i"]
+      self.Msg += format(" %s", self.get_icon(fmt["i"]) )  # Use icon from formatter
     end
 
-    if fmt && fmt.find("format") && fmt["format"]
-      self.Msg += string.format(fmt["format"], value)
+    if fmt && fmt.find("f") && fmt["f"]
+      self.Msg += format(fmt["f"], value)
     else
       self.Msg += str(value)  # Default to string representation
     end
 
-    if fmt && fmt.find("unit") && fmt["unit"]
-      self.Msg += string.format("%s", fmt["unit"])  # Append unit if defined
+    if fmt && fmt.find("u") && fmt["u"]
+      self.Msg += format("%s", fmt["u"])  # Append unit if defined
     end
 
     if tooltip
-      self.end_tooltip()
+      return self.end_tooltip()
     end
 
     return self

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -82,7 +82,7 @@ class LwSensorFormatter_cls
 
     if alt_icon 
       self.Msg += format(" %s", self.get_icon(alt_icon) )  # Use alternative icon
-    elif fmt && fmt.find("icon") && fmt["i"]
+    elif fmt && fmt.find("i") && fmt["i"]
       self.Msg += format(" %s", self.get_icon(fmt["i"]) )  # Use icon from formatter
     end
 

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -12,7 +12,16 @@ var LwSensorIcons = {
   "Stopwatch":        "&#x23F1;",   # Stopwatch Icon
   "Abacus":           "&#x1F9EE;",  # Abacus Icon
   "Power ON":         "&#x23FD;",   # Button State ON Icon
-  "Power OFF":        "&#x2B58;"    # Button State OFF Icon
+  "Power OFF":        "&#x2B58;",   # Button State OFF Icon
+  "Locked":           "&#x1F512;",  # Lock Close Icon
+  "Unlocked":         "&#x1F513;",  # Lock Open Icon
+  "Check Mark":       "&#x2705;",
+  "Crosscheck Mark":  "&#x274C;",
+  "Free":             "&#x1F193;",
+  "No Entry":         "&#x1F6AB;",
+  "Moon":             "&#x1F315;",
+  "Sun":              "&#x1F31E;",
+  "Radio Button":     "&#x1F518;"
 }
 
 var LwSensorFormatter = {
@@ -173,6 +182,10 @@ class lwdecode_cls
       unit = "m"
     end
     return format("%02d%s", since, unit)
+  end
+
+  def dhm_tt(last_time)
+    return format( "Received %s ago", self.dhm(last_time) )
   end
 
   def header(name, name_tooltip, battery, battery_last_seen, rssi, last_seen)

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -4,8 +4,98 @@
 var LwRegions = ["EU868","US915","IN865","AU915","KZ865","RU864","AS923","AS923-1","AS923-2","AS923-3"]
 var LwDeco
 
+var LwSensorIcons = {
+  "High Voltage":     "&#x26A1;",   # High Voltage Icon
+  "Electric Plug":    "&#x1F50C;",  # Electric Plug Icon  
+  "Bar Chart":        "&#x1F4CA;",  # Bar Chart Icon
+  "Light Bulb":       "&#x1F4A1;",  # Light Bulb Icon
+  "Stopwatch":        "&#x23F1;",   # Stopwatch Icon
+  "Abacus":           "&#x1F9EE;",  # Abacus Icon
+  "Power ON":         "&#x23FD;",   # Button State ON Icon
+  "Power OFF":        "&#x2B58;"    # Button State OFF Icon
+}
+
+var LwSensorFormatter = {
+  "string":           { "unit": nil,      "format": "%s",     "icon": nil             },
+  "volt":             { "unit": "V",      "format": "%.1f",   "icon": "High Voltage"  },
+  "milliamp":         { "unit": "mA",     "format": "%.0f",   "icon": "Electric Plug" },
+  "power_factor%":    { "unit": "%",      "format": "%.0f",   "icon": "Bar Chart"     },
+  "power":            { "unit": "W",      "format": "%.0f",   "icon": "Light Bulb"    },
+  "energy":           { "unit": "Wh",     "format": "%.0f",   "icon": "Abacus"        }
+}
+
 import mqtt 
 import string
+
+class LwSensorFormatter_cls
+  var Msg
+
+  def init()
+    self.Msg = ""
+  end
+  
+  def start_line()
+    self.Msg += format("<tr class='htr'><td colspan='4'>&#9478;")  # | <sensor1><sensor2>...
+    return self
+  end
+
+  def end_line()
+    self.Msg += "{e}"  # End of line
+    return self
+  end
+
+  def next_line()
+    return self.end_line().start_line()  # End of current line and start new line
+  end
+
+  def get_icon(icon)
+    return LwSensorIcons.find(icon) ? LwSensorIcons[icon] : icon
+  end
+
+  def begin_tooltip(ttip)
+    self.Msg += string.format("&nbsp;<div title='%s' class='si'>", ttip)
+    return self
+  end
+
+  def end_tooltip()
+    self.Msg += "</div>"
+    return self
+  end
+
+  def add_sensor(formatter, value, tooltip, alt_icon)
+    if tooltip
+      self.begin_tooltip(tooltip)
+    end
+
+    var fmt = LwSensorFormatter.find(formatter)
+
+    if alt_icon 
+      self.Msg += format(" %s", self.get_icon(alt_icon) )  # Use alternative icon
+    elif fmt && fmt.find("icon") && fmt["icon"]
+      self.Msg += format(" %s", self.get_icon(fmt["icon"]) )  # Use icon from formatter
+    end
+
+    if fmt && fmt.find("format") && fmt["format"]
+      self.Msg += string.format(fmt["format"], value)
+    else
+      self.Msg += str(value)  # Default to string representation
+    end
+
+    if fmt && fmt.find("unit") && fmt["unit"]
+      self.Msg += string.format("%s", fmt["unit"])  # Append unit if defined
+    end
+
+    if tooltip
+      self.end_tooltip()
+    end
+
+    return self
+  end
+
+  def get_msg()
+    return self.Msg
+  end
+end
 
 class lwdecode_cls
   var LwDecoders

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -11,13 +11,14 @@ class LwSensorFormatter_cls
   var Msg
 
   static Formatter = {
-    "string":           { "u": nil,      "f": "%s",     "i": nil         },
-    "volt":             { "u": "V",      "f": "%.1f",   "i": "&#x26A1;"  }, # High Voltage    ⚡ 
-    "milliamp":         { "u": "mA",     "f": "%.0f",   "i": "&#x1F50C;" }, # Electric Plug   🔌
-    "power_factor%":    { "u": "%",      "f": "%.0f",   "i": "&#x1F4CA;" }, # Bar Chart       📊      
-    "power":            { "u": "W",      "f": "%.0f",   "i": "&#x1F4A1;" }, # Light Bulb      💡    
-    "energy":           { "u": "Wh",     "f": "%.0f",   "i": "&#x1F9EE;" }, # Abacus          🧮
-    "empty":            { "u": nil,      "f": nil,      "i": nil         }
+    "string":           { "u": nil,   "f": " %s",    "i": nil         },
+    "volt":             { "u": "V",   "f": " %.1f",  "i": "&#x26A1;"  }, # High Voltage    ⚡ 
+    "milliamp":         { "u": "mA",  "f": " %.0f",  "i": "&#x1F50C;" }, # Electric Plug   🔌
+    "power_factor%":    { "u": "%",   "f": " %.0f",  "i": "&#x1F4CA;" }, # Bar Chart       📊      
+    "power":            { "u": "W",   "f": " %.0f",  "i": "&#x1F4A1;" }, # Light Bulb      💡    
+    "energy":           { "u": "Wh",  "f": " %.0f",  "i": "&#x1F9EE;" }, # Abacus          🧮
+    "altitude":         { "u": "mt",  "f": " %d",    "i": "&#x26F0;"  }, # Moutain         ⛰
+    "empty":            { "u": nil,   "f": nil,     "i": nil         }
   }
 
   def init()
@@ -48,8 +49,8 @@ class LwSensorFormatter_cls
     return self
   end
 
-  def add_link(title, url)
-    self.Msg += " <a target=_maps href='" + url + "'>" + title + "</a>"
+  def add_link(title, url, target)
+    self.Msg += format( " <a target=%s href='%s'>%s</a>", ( target ? target : "_blank" ), url, title )
     return self
   end
 
@@ -105,6 +106,17 @@ class lwdecode_cls
     end
     tasmota.add_driver(global.lwdecode_driver := self)
     tasmota.add_rule("LwReceived", /value, trigger, payload -> self.LwDecode(payload))
+  end
+
+  def SendDownlink(nodes, cmd, idx, payload, ok_result)
+    if nodes.find(idx)
+      var sendcmd = 'LoRaWanSend'
+      var output = tasmota.cmd( f'{sendcmd}{idx} {payload}', true)
+      if output.find(sendcmd) == 'Done'
+        return tasmota.resp_cmnd(f'{{"{cmd}{idx}":"{ok_result}"}}')
+      end
+      return output
+    end
   end
 
   def LwDecode(data)

--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -10,35 +10,14 @@ import string
 class LwSensorFormatter_cls
   var Msg
 
-  static Icons = {
-    "Sensor Line":      "9478",   # | <sensor1><sensor2>... 
-    "High Voltage":     "x26A1",   # High Voltage Icon
-    "Electric Plug":    "x1F50C",  # Electric Plug Icon  
-    "Bar Chart":        "x1F4CA",  # Bar Chart Icon
-    "Light Bulb":       "x1F4A1",  # Light Bulb Icon
-    "Stopwatch":        "x23F1",   # Stopwatch Icon
-    "Abacus":           "x1F9EE",  # Abacus Icon
-    "Power ON":         "x23FD",   # Button State ON Icon
-    "Power OFF":        "x2B58",   # Button State OFF Icon
-    "Locked":           "x1F512",  # Lock Close Icon
-    "Unlocked":         "x1F513",  # Lock Open Icon
-    "Check Mark":       "x2705",
-    "Crosscheck Mark":  "x274C",
-    "Free":             "x1F193",
-    "No Entry":         "x1F6AB",
-    "Moon":             "x1F315",
-    "Sun":              "x1F31E",
-    "Radio Button":     "x1F518"
-  }
-
   static Formatter = {
-    "string":           { "u": nil,      "f": "%s",     "i": nil             },
-    "volt":             { "u": "V",      "f": "%.1f",   "i": "High Voltage"  },
-    "milliamp":         { "u": "mA",     "f": "%.0f",   "i": "Electric Plug" },
-    "power_factor%":    { "u": "%",      "f": "%.0f",   "i": "Bar Chart"     },
-    "power":            { "u": "W",      "f": "%.0f",   "i": "Light Bulb"    },
-    "energy":           { "u": "Wh",     "f": "%.0f",   "i": "Abacus"        },
-    "empty":            { "u": nil,      "f": nil,      "i": nil             }
+    "string":           { "u": nil,      "f": "%s",     "i": nil         },
+    "volt":             { "u": "V",      "f": "%.1f",   "i": "&#x26A1;"  }, # High Voltage    ⚡ 
+    "milliamp":         { "u": "mA",     "f": "%.0f",   "i": "&#x1F50C;" }, # Electric Plug   🔌
+    "power_factor%":    { "u": "%",      "f": "%.0f",   "i": "&#x1F4CA;" }, # Bar Chart       📊      
+    "power":            { "u": "W",      "f": "%.0f",   "i": "&#x1F4A1;" }, # Light Bulb      💡    
+    "energy":           { "u": "Wh",     "f": "%.0f",   "i": "&#x1F9EE;" }, # Abacus          🧮
+    "empty":            { "u": nil,      "f": nil,      "i": nil         }
   }
 
   def init()
@@ -46,7 +25,7 @@ class LwSensorFormatter_cls
   end
   
   def start_line()
-    self.Msg += format("<tr class='htr'><td colspan='4'>" + self.get_icon("Sensor Line") )  # | <sensor1><sensor2>...
+    self.Msg += format("<tr class='htr'><td colspan='4'>&#9478;" )  # | <sensor1><sensor2>...
     return self
   end
 
@@ -59,10 +38,6 @@ class LwSensorFormatter_cls
     return self.end_line().start_line()  # End of current line and start new line
   end
 
-  def get_icon(icon)
-    return self.Icons.find(icon) ? "&#" + self.Icons[icon] + ";" : icon
-  end
-
   def begin_tooltip(ttip)
     self.Msg += format("&nbsp;<div title='%s' class='si'>", ttip)
     return self
@@ -70,6 +45,11 @@ class LwSensorFormatter_cls
 
   def end_tooltip()
     self.Msg += "</div>"
+    return self
+  end
+
+  def add_link(title, url)
+    self.Msg += " <a target=_maps href='" + url + "'>" + title + "</a>"
     return self
   end
 
@@ -81,9 +61,9 @@ class LwSensorFormatter_cls
     var fmt = self.Formatter.find(formatter)
 
     if alt_icon 
-      self.Msg += format(" %s", self.get_icon(alt_icon) )  # Use alternative icon
+      self.Msg += format(" %s", alt_icon )  # Use alternative icon
     elif fmt && fmt.find("i") && fmt["i"]
-      self.Msg += format(" %s", self.get_icon(fmt["i"]) )  # Use icon from formatter
+      self.Msg += format(" %s", fmt["i"] )  # Use icon from formatter
     end
 
     if fmt && fmt.find("f") && fmt["f"]

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
@@ -94,13 +94,13 @@ class LwDecoWS202
       msg += lwdecode.header(name, name_tooltip, battery + 100000, battery_last_seen, rssi, last_seen)
 
       # Sensors
-      var pir = (sensor[6] == true ? "Busy" : "Free")
+      var pir = lwdecode.dhm(sensor[7])
       var pir_ls = lwdecode.dhm_tt(sensor[7])
-      var pir_alt = (sensor[6] == true ? "No Entry" : "Free")
+      var pir_alt = (sensor[6] == true ? "&#x1F6AB;" : "&#x1F193;") # No Entry 🚫 / Free 🆓
       
-      var light     = (sensor[8] == 0) ? "Dark" : "Light"
+      var light     = lwdecode.dhm(sensor[9])
       var light_ls  = lwdecode.dhm_tt(sensor[9])
-      var light_alt = (sensor[8] == 0) ? "Moon" : "Sun"
+      var light_alt = (sensor[8] == 0) ? "&#x1F315;" : "&#x1F31E;"  # Moon 🌕 / Sun 🌞
 
       var fmt = LwSensorFormatter_cls()
       msg += fmt.start_line()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
@@ -94,20 +94,19 @@ class LwDecoWS202
       msg += lwdecode.header(name, name_tooltip, battery + 100000, battery_last_seen, rssi, last_seen)
 
       # Sensors
-      var pir = sensor[6]
-      var pir_last_seen = sensor[7]
-      var light = sensor[8]
-      var light_last_seen = sensor[9]
+      var pir = (sensor[6] == true ? "Busy" : "Free")
+      var pir_ls = lwdecode.dhm_tt(sensor[7])
+      var pir_alt = (sensor[6] == true ? "No Entry" : "Free")
+      
+      var light     = (sensor[8] == 0) ? "Dark" : "Light"
+      var light_ls  = lwdecode.dhm_tt(sensor[9])
+      var light_alt = (sensor[8] == 0) ? "Moon" : "Sun"
 
-      msg += "<tr class='htr'><td colspan='4'>&#9478;"                  # |
-
-      msg += string.format(" %s %s", pir == true ? "&#x1F6AB" : "&#x1F193",   # PIR Free or Busy
-                                     lwdecode.dhm(pir_last_seen))
-
-      msg += string.format(" %s %s", light == 0 ? "&#x1F315" : "&#x1F31E",   # Light
-                                     lwdecode.dhm(light_last_seen))
-
-      msg += "{e}"                                                          # = </td></tr>
+      msg += fmt.start_line()
+        .add_sensor( "string", pir,   pir_ls,   pir_alt )
+        .add_sensor( "string", light, light_ls, light_alt )
+        .end_line()
+        .get_msg()
     end
     return msg
   end #add_web_sensor()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS202.be
@@ -102,6 +102,7 @@ class LwDecoWS202
       var light_ls  = lwdecode.dhm_tt(sensor[9])
       var light_alt = (sensor[8] == 0) ? "Moon" : "Sun"
 
+      var fmt = LwSensorFormatter_cls()
       msg += fmt.start_line()
         .add_sensor( "string", pir,   pir_ls,   pir_alt )
         .add_sensor( "string", light, light_ls, light_alt )

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
@@ -94,17 +94,18 @@ class LwDecoWS301
       msg += lwdecode.header(name, name_tooltip, battery + 100000, battery_last_seen, rssi, last_seen)
 
       # Sensors
-      var open = (sensor[6] == true ? "Open" : "close")
-      var open_ls = lwdecode.dhm_tt(sensor[7])
-      var open_alt = (sensor[6] == true) ? "Unlocked" : "Locked"
+      var dopen = (sensor[6] == true ? "Opened" : "Closed")
+      var dopen_ls = lwdecode.dhm_tt(sensor[7])
+      var dopen_alt = (sensor[6] == true) ? "Unlocked" : "Locked"
 
       var inst = (sensor[8] == true ? "Installed" : "Not Installed") 
       var inst_ls = lwdecode.dhm_tt(sensor[9])
       var inst_alt =  (sensor[8] == true) ? "Check Mark" : "Crosscheck Mark"
 
+      var fmt = LwSensorFormatter_cls()
       msg += fmt.start_line()
-        .add_sensor( "string", open, open_ls, open_alt )
-        .add_sensor( "string", inst, inst_ls, inst_alt )
+        .add_sensor( "string", dopen, dopen_ls, dopen_alt )
+        .add_sensor( "string", inst,  inst_ls,  inst_alt )
         .end_line()
         .get_msg()
     end

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
@@ -96,11 +96,11 @@ class LwDecoWS301
       # Sensors
       var dopen = lwdecode.dhm(sensor[7])
       var dopen_tt = nil
-      var dopen_alt = (sensor[6] == true) ? "Unlocked" : "Locked"
+      var dopen_alt = (sensor[6] == true) ? "&#x1F513;" : "&#x1F512;" # Open Lock 🔓 / Lock 🔒
 
       var inst = lwdecode.dhm(sensor[9])
       var inst_tt = nil
-      var inst_alt =  (sensor[8] == true) ? "Check Mark" : "Crosscheck Mark"
+      var inst_alt =  (sensor[8] == true) ? "&#x2705;" : "&#x274C;" # Heavy Check Mark ✅ / Cross Mark ❌
 
       var fmt = LwSensorFormatter_cls()
       msg += fmt.start_line()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
@@ -94,18 +94,18 @@ class LwDecoWS301
       msg += lwdecode.header(name, name_tooltip, battery + 100000, battery_last_seen, rssi, last_seen)
 
       # Sensors
-      var dopen = (sensor[6] == true ? "Opened" : "Closed")
-      var dopen_ls = lwdecode.dhm_tt(sensor[7])
+      var dopen = lwdecode.dhm(sensor[7])
+      var dopen_tt = nil
       var dopen_alt = (sensor[6] == true) ? "Unlocked" : "Locked"
 
-      var inst = (sensor[8] == true ? "Installed" : "Not Installed") 
-      var inst_ls = lwdecode.dhm_tt(sensor[9])
+      var inst = lwdecode.dhm(sensor[9])
+      var inst_tt = nil
       var inst_alt =  (sensor[8] == true) ? "Check Mark" : "Crosscheck Mark"
 
       var fmt = LwSensorFormatter_cls()
       msg += fmt.start_line()
-        .add_sensor( "string", dopen, dopen_ls, dopen_alt )
-        .add_sensor( "string", inst,  inst_ls,  inst_alt )
+        .add_sensor( "string", dopen, dopen_tt, dopen_alt )
+        .add_sensor( "string", inst,  inst_tt,  inst_alt )
         .end_line()
         .get_msg()
     end

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS301.be
@@ -94,19 +94,19 @@ class LwDecoWS301
       msg += lwdecode.header(name, name_tooltip, battery + 100000, battery_last_seen, rssi, last_seen)
 
       # Sensors
-      var door_open = sensor[6]
-      var door_open_last_seen = sensor[7]
-      var installed = sensor[8]
-      var installed_last_seen = sensor[9]
+      var open = (sensor[6] == true ? "Open" : "close")
+      var open_ls = lwdecode.dhm_tt(sensor[7])
+      var open_alt = (sensor[6] == true) ? "Unlocked" : "Locked"
 
-      msg += "<tr class='htr'><td colspan='4'>&#9478;"                      # |
-      msg += string.format(" %s %s", (door_open == true) ? "&#x1F513" : "&#x1F512", # Open or Closed lock - Door
-                                     lwdecode.dhm(door_open_last_seen))
+      var inst = (sensor[8] == true ? "Installed" : "Not Installed") 
+      var inst_ls = lwdecode.dhm_tt(sensor[9])
+      var inst_alt =  (sensor[8] == true) ? "Check Mark" : "Crosscheck Mark"
 
-      msg += string.format(" %s %s", (installed == true) ? "&#x2705" : "&#x274C",   # Installed
-                                     lwdecode.dhm(installed_last_seen))
-
-      msg += "{e}"                                                          # = </td></tr>
+      msg += fmt.start_line()
+        .add_sensor( "string", open, open_ls, open_alt )
+        .add_sensor( "string", inst, inst_ls, inst_alt )
+        .end_line()
+        .get_msg()
     end
     return msg
   end #add_web_sensor()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
@@ -246,24 +246,30 @@ class LwDecoWS522
       var power_factor = sensor[6]
       var energy_sum = sensor[7]
       var current = sensor[8]
-      var button_state = sensor[9] ? "&#x23FD;" : "&#x2B58;"
-      var voltage_ls = sensor[10]
-      var active_power_ls = sensor[11]
-      var power_factor_ls = sensor[12]
-      var energy_sum_ls = sensor[13]
-      var current_ls = sensor[14]
-      var button_state_ls = sensor[15]
+      var button_status = (sensor[9] ? "ON" : "OFF")
+      var button_state = "Power " + button_status
 
-      msg += "<tr class='htr'><td colspan='4'>&#9478;"                               # |
-      msg += string.format(" %s %.1fV", "&#x26A1;",  voltage)                        # High Voltage Icon
-      msg += string.format(" %s %dmA",  "&#x1F50C;", current)                        # Electric Plug Icon
-      msg += string.format(" %s %d%%",  "&#x1F4CA;", power_factor)                   # Bar Chart Icon
-      msg += string.format(" %s %dw",   "&#x1F4A1;", active_power)                   # Light Bulb Icon
-      msg += "{e}<tr class='htr'><td colspan='4'>&#9478;"                               # |
-      msg += string.format(" %s",       button_state)                                # Button Sate ON | OFF icon
-      msg += string.format(" %s %s",    "&#x23F1;",  lwdecode.dhm(button_state_ls))  # Stopwatch icon
-      msg += string.format(" %s %dWh",  "&#x1F9EE;", energy_sum)                     # Abacus Icon
-      msg += "{e}"                                                                   # = </td></tr>
+      var voltage_ls = lwdecode.dhm_tt(sensor[10])
+      var active_power_ls = lwdecode.dhm_tt(sensor[11])
+      var power_factor_ls = lwdecode.dhm_tt(sensor[12])
+      var energy_sum_ls = lwdecode.dhm_tt(sensor[13])
+      var current_ls = lwdecode.dhm_tt(sensor[14])
+      var button_state_ls = lwdecode.dhm_tt(sensor[15])
+
+      var fmt = LwSensorFormatter_cls()
+
+      #             Formatter         Value           Tooltip                          alternative icon
+      #             ================  ============    ===============================  ================
+      msg += fmt.start_line()
+        .add_sensor("volt",           voltage,        voltage_ls )
+        .add_sensor("milliamp",       current,        current_ls )
+        .add_sensor("power_factor%",  power_factor,   power_factor_ls )
+        .add_sensor("power",          active_power,   active_power_ls )
+        .next_line()
+        .add_sensor("string",         button_status,  button_state,                    button_state)
+        .add_sensor("energy",         energy_sum,     string.format("Total Power Usage (%s)",energy_sum_ls) )
+        .end_line()
+        .get_msg()
     end
     return msg
   end #add_web_sensor()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
@@ -119,6 +119,38 @@ class LwDecoWS522
         data.insert("Button_State", button_state ? "Open" : "Close" )
         i += 1
 
+      # FE02(ReportInterval) 3C00=>06
+      elif channel_id == 0xFE && channel_type == 0x02
+        data.insert("Period", ((Bytes[i+1] << 8) | Bytes[i]) )
+        i += 2
+
+      # FF01(ProtocolVersion) 01=>V1 
+      elif channel_id == 0xFF && channel_type == 0x01
+        data.insert("Protocol Version", Bytes[i] )
+        i += 1
+
+      # FF09(HardwareVersion) 0140=>V1.4 
+      elif channel_id == 0xFF && channel_type == 0x09
+        data.insert("Hardware Version",  format("v%02x.%02x", Bytes[i], Bytes[i+1]) )
+        i += 2
+
+      # FF0a(SoftwareVersion) 0114=>V1.14 
+      elif channel_id == 0xFF && channel_type == 0x0A
+        data.insert("Software Version",  format("v%02x.%02x", Bytes[i], Bytes[i+1]) )
+        i += 2
+
+      # FF0b(PowerOn) Deviceison
+      elif channel_id == 0xFF && channel_type == 0x0B
+        i += 1
+
+      # FF16(DeviceSN) 16digits
+      elif channel_id == 0xFF && channel_type == 0x16
+        i += 8
+
+      # FF0f(DeviceType) 00:ClassA,01:ClassB,02:ClassC
+      elif channel_id == 0xFF && channel_type == 0x0F
+        i += 1
+
       else
         log( string.format("WS522: something missing? id={%s} type={%s}", channel_id, channel_type), 1)
 
@@ -130,58 +162,42 @@ class LwDecoWS522
 
     if valid_values
       if !command_init
-          tasmota.add_cmd( "LoraWS522Power",
-              def (cmd, idx, payload)
-                  if global.ws522Nodes.find(idx)
-                      if payload == "1" || string.toupper(payload) == "ON"
-                          tasmota.cmd(string.format("LoraWanSend%d 080100FF",idx))  
-                      elif payload == "0" || string.toupper(payload) == "OFF"
-                          tasmota.cmd(string.format("LoraWanSend%d 080000FF",idx))  
-                      else
-                          # nothing else
-                      end
-                  end
+          tasmota.add_cmd( "LwWS522Power",
+            def (cmd, idx, payload)
+              if payload == "1" || string.toupper(payload) == "ON"
+                  return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, '080100FF', 'ON')
+              elif payload == "0" || string.toupper(payload) == "OFF"
+                  return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, '080000FF', 'OFF')
               end
+            end
           )
 
-          tasmota.add_cmd( "LoraWS522Period",
-              def (cmd, idx, payload)
-                  if global.ws522Nodes.find(idx)
-                      if number(payload) > 30  
-                          tasmota.cmd( string.format("LoraWanSend%d FF02%s", idx, uint16le(number(payload))) )
-                      end
-                  end
-              end
+          tasmota.add_cmd( "LwWS522Period",
+            def (cmd, idx, payload)
+                return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, format('FF02%s',uint16le(number(payload))), number(payload))
+            end
           )
 
-          tasmota.add_cmd( "LoraWS522Reboot",
-              def (cmd, idx, payload)
-                  if global.ws522Nodes.find(idx)
-                      tasmota.cmd( string.format("LoraWanSend%d FF10FF", idx) )
-                  end
-              end
+          tasmota.add_cmd( "LwWS522Reboot",
+            def (cmd, idx, payload)
+                return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, 'FF10FF', 'Done')
+            end
           )
 
-          tasmota.add_cmd( "LoraWS522ResetPowerUsage",
-              def (cmd, idx, payload)
-                  if global.ws522Nodes.find(idx)
-                      tasmota.cmd( string.format("LoraWanSend%d FF27FF", idx) )
-                  end
-              end
+          tasmota.add_cmd( "LwWS522ResetPowerUsage",
+            def (cmd, idx, payload)
+                return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, 'FF27FF', 'Done')
+            end
           )
 
-          tasmota.add_cmd( "LoraWS522PowerLock",
-              def (cmd, idx, payload)
-                  if global.ws522Nodes.find(idx)
-                      if payload == "1" || string.toupper(payload) == "ON"
-                          tasmota.cmd(string.format("LoraWanSend%d FF250080",idx))  
-                      elif payload == "0" || string.toupper(payload) == "OFF"
-                          tasmota.cmd(string.format("LoraWanSend%d FF250000",idx))  
-                      else
-                          # nothing else
-                      end
-                  end
+          tasmota.add_cmd( "LwWS522PowerLock", 
+            def (cmd, idx, payload)
+              if payload == "1" || string.toupper(payload) == "ON"
+                return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, 'FF250080', 'ON')
+              elif payload == "0" || string.toupper(payload) == "OFF"
+                return lwdecode.SendDownlink(global.ws522Nodes, cmd, idx, 'FF250080', 'OFF')
               end
+            end
           )
           command_init = true
       end
@@ -233,28 +249,25 @@ class LwDecoWS522
       
       msg += lwdecode.header(name, name_tooltip, 1000, last_seen, rssi, last_seen)
 
-      # IEC Power Symbols
-      #  Power	        &#x23FB; ⏻
-      #  Toggle Power	  &#x23FC; ⏼
-      #  Power On	      &#x23FD; ⏽
-      #  Power Off	    &#x2B58; ⭘
-      #  Sleep Mode	    &#x23FE; ⏾
-
       # Sensors
       var voltage = sensor[4]
-      var active_power = sensor[5]
-      var power_factor = sensor[6]
-      var energy_sum = sensor[7]
-      var current = sensor[8]
-      var button_status = lwdecode.dhm(sensor[15])
-      var button_icon = (sensor[9] ? "&#x23FD;" : "&#x2B58;")
+      var voltage_tt = lwdecode.dhm(sensor[10])
 
-      var voltage_tt = lwdecode.dhm_tt(sensor[10])
-      var active_power_tt = lwdecode.dhm_tt(sensor[11])
-      var power_factor_tt = lwdecode.dhm_tt(sensor[12])
-      var energy_sum_tt = string.format( "Total Power Usage (%s)", lwdecode.dhm_tt(sensor[13] )
-      var current_tt = lwdecode.dhm_tt(sensor[14])
-      var button_state_tt = lwdecode.dhm_tt(sensor[15])
+      var active_power = sensor[5]
+      var active_power_tt = lwdecode.dhm(sensor[11])
+
+      var power_factor = sensor[6]
+      var power_factor_tt = lwdecode.dhm(sensor[12])
+
+      var current = sensor[8]
+      var current_tt = lwdecode.dhm(sensor[14])
+
+      var button_state = lwdecode.dhm(sensor[15])
+      var button_state_tt = lwdecode.dhm(sensor[15])
+      var button_state_icon = (sensor[9] ? " &#x1F7E2; " : " &#x26AB; ") # Large Green Circle 🟢 | Medium Black Circle ⚫
+
+      var energy_sum = sensor[7]
+      var energy_sum_tt = lwdecode.dhm(sensor[13] )
 
       var fmt = LwSensorFormatter_cls()
 
@@ -266,7 +279,7 @@ class LwDecoWS522
         .add_sensor("power_factor%",  power_factor,   power_factor_tt )
         .add_sensor("power",          active_power,   active_power_tt )
         .next_line()
-        .add_sensor("string",         button_status,  button_state_tt,    button_icon )
+        .add_sensor("string",         button_state,   button_state_tt,    button_state_icon )
         .add_sensor("energy",         energy_sum,     energy_sum_tt )
         .end_line()
         .get_msg()

--- a/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
+++ b/tasmota/berry/lorawan/decoders/vendors/milesight/WS522.be
@@ -246,28 +246,28 @@ class LwDecoWS522
       var power_factor = sensor[6]
       var energy_sum = sensor[7]
       var current = sensor[8]
-      var button_status = (sensor[9] ? "ON" : "OFF")
-      var button_state = "Power " + button_status
+      var button_status = lwdecode.dhm(sensor[15])
+      var button_icon = (sensor[9] ? "&#x23FD;" : "&#x2B58;")
 
-      var voltage_ls = lwdecode.dhm_tt(sensor[10])
-      var active_power_ls = lwdecode.dhm_tt(sensor[11])
-      var power_factor_ls = lwdecode.dhm_tt(sensor[12])
-      var energy_sum_ls = lwdecode.dhm_tt(sensor[13])
-      var current_ls = lwdecode.dhm_tt(sensor[14])
-      var button_state_ls = lwdecode.dhm_tt(sensor[15])
+      var voltage_tt = lwdecode.dhm_tt(sensor[10])
+      var active_power_tt = lwdecode.dhm_tt(sensor[11])
+      var power_factor_tt = lwdecode.dhm_tt(sensor[12])
+      var energy_sum_tt = string.format( "Total Power Usage (%s)", lwdecode.dhm_tt(sensor[13] )
+      var current_tt = lwdecode.dhm_tt(sensor[14])
+      var button_state_tt = lwdecode.dhm_tt(sensor[15])
 
       var fmt = LwSensorFormatter_cls()
 
-      #             Formatter         Value           Tooltip                          alternative icon
-      #             ================  ============    ===============================  ================
+      #             Formatter         Value           Tooltip             alternative icon
+      #             ================  ============    ==================  ================
       msg += fmt.start_line()
-        .add_sensor("volt",           voltage,        voltage_ls )
-        .add_sensor("milliamp",       current,        current_ls )
-        .add_sensor("power_factor%",  power_factor,   power_factor_ls )
-        .add_sensor("power",          active_power,   active_power_ls )
+        .add_sensor("volt",           voltage,        voltage_tt )
+        .add_sensor("milliamp",       current,        current_tt )
+        .add_sensor("power_factor%",  power_factor,   power_factor_tt )
+        .add_sensor("power",          active_power,   active_power_tt )
         .next_line()
-        .add_sensor("string",         button_status,  button_state,                    button_state)
-        .add_sensor("energy",         energy_sum,     string.format("Total Power Usage (%s)",energy_sum_ls) )
+        .add_sensor("string",         button_status,  button_state_tt,    button_icon )
+        .add_sensor("energy",         energy_sum,     energy_sum_tt )
         .end_line()
         .get_msg()
     end


### PR DESCRIPTION
## Description:

The aim of this PR is to standardize the display of LoRaWAN sensors. A "formatter" class has been implemented, which standardizes the display of information and icons.

Every single sensor displayed can have an icon + value + tooltip.
 
we can also simple implement other kind of "sensor formatter"... like mini-button to send downlink to the sensor for example.
with the same approach we can redesign the Header Line generation more dinamically.

Personally, I'm not very comfortable with the webserver & UI css styles part... if someone wanted to take care of that part, something interesting could come out.

Sample result:

<img width="651" height="833" alt="Screenshot 2025-08-04 155616" src="https://github.com/user-attachments/assets/935b7eef-80b5-41f7-8cd0-f9857b019c2b" />

Some tooltip details:

<img width="616" height="178" alt="Screenshot 2025-08-04 155931" src="https://github.com/user-attachments/assets/18fe9038-d196-4356-9409-9b8689db5624" />

<img width="629" height="123" alt="Screenshot 2025-08-04 160015" src="https://github.com/user-attachments/assets/c9f7208e-347c-4a45-91d2-a10ee8921f56" />

Formatter sample usage:

```
      # Sensors WS522
      var voltage = sensor[4]
      var active_power = sensor[5]
      var power_factor = sensor[6]
      var energy_sum = sensor[7]
      var current = sensor[8]
      var button_status = (sensor[9] ? "ON" : "OFF")
      var button_state = "Power " + button_status

      var voltage_ls = lwdecode.dhm_tt(sensor[10])
      var active_power_ls = lwdecode.dhm_tt(sensor[11])
      var power_factor_ls = lwdecode.dhm_tt(sensor[12])
      var energy_sum_ls = lwdecode.dhm_tt(sensor[13])
      var current_ls = lwdecode.dhm_tt(sensor[14])
      var button_state_ls = lwdecode.dhm_tt(sensor[15])

      var fmt = LwSensorFormatter_cls()

      #             Formatter         Value           Tooltip                          alternative icon
      #             ================  ============    ===============================  ================
      msg += fmt.start_line()
        .add_sensor("volt",           voltage,        voltage_ls )
        .add_sensor("milliamp",       current,        current_ls )
        .add_sensor("power_factor%",  power_factor,   power_factor_ls )
        .add_sensor("power",          active_power,   active_power_ls )
        .next_line()
        .add_sensor("string",         button_status,  button_state,                    button_state)
        .add_sensor("energy",         energy_sum,     string.format("Total Power Usage (%s)",energy_sum_ls) )
        .end_line()
        .get_msg()
```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
