### PR TITLE
use gcc optimize settings sections

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -16,6 +16,9 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wno-switch-unreachable
                               -Wno-stringop-overflow
                               -fno-exceptions
+                              -ffunction-sections
+                              -fdata-sections
+                              -Wl,--gc-sections
                               -DBUFFER_LENGTH=128
                               -DHTTP_UPLOAD_BUFLEN=2048
                               -DMQTT_MAX_PACKET_SIZE=1200


### PR DESCRIPTION
## Description:

The compiler and linker optimization settings can save flash space. It differes and depends on used IDF. The savings are between 1k and 10k

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
