### PR TITLE
Platform 2025.08.30 Tasmota Arduino Core 3.1.3.250808 based on IDF 5.3.3.250801

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -84,7 +84,8 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.07.31/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.08.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+


### PR DESCRIPTION
## Description:

- updated IDF 5.3.3.250801
- updated Arduino core 3.1.3.250808 (based on espressif Arduino branch master thats why it shows 3.3.0!!)
- updated esptool v5.0.2
- updated Installer v5.3.0  (renamed to tool-esp_install), hopefully fixes install issues (mostly Mac´s)
- updated GCC toolchains to espressif gcc 13.2.0+20250707
- major refactoring in Platform (forces install of venv now)

@arendst sdkconfig files includes slave firmware version: `CONFIG_ESP_HOSTED_IDF_SLAVE_TARGET="2.2.1"`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250712
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
