### PR TITLE
esp8266 Platform 2025.08.00

### DIFF
--- a/pio-tools/custom_target.py
+++ b/pio-tools/custom_target.py
@@ -21,13 +21,13 @@ import subprocess
 import shutil
 import json
 from colorama import Fore, Back, Style
+from platformio.compat import IS_WINDOWS
 from platformio.project.config import ProjectConfig
 
 Import("env")
-platform = env.PioPlatform()
+platform = env["PIOPLATFORM"]
 board = env.BoardConfig()
-mcu = board.get("build.mcu", "esp32")
-IS_WINDOWS = sys.platform.startswith("win")
+mcu = board.get("build.mcu", "esp32").lower()
 
 class FSType(Enum):
     LITTLEFS="littlefs"
@@ -185,7 +185,8 @@ def get_partition_table():
             "0x1000",
             fs_file
     ]
-    esptool_cmd = [env["PYTHONEXE"], env.subst("$OBJCOPY")] + esptool_flags
+    ESPTOOL_EXE = env.get("ERASETOOL") if platform == "espressif8266" else env.get("OBJCOPY")
+    esptool_cmd = [ESPTOOL_EXE] + esptool_flags
     try:
         returncode = subprocess.call(esptool_cmd, shell=False)
     except subprocess.CalledProcessError as exc:
@@ -195,7 +196,6 @@ def get_partition_table():
         parse_partition_table(content)
 
 def get_fs_type_start_and_length():
-    platform = env["PIOPLATFORM"]
     if platform == "espressif32":
         print(f"Retrieving filesystem info for {mcu}.")
         get_partition_table()
@@ -238,7 +238,8 @@ def download_fs(fs_info: FSInfo):
             hex(fs_info.length),
             fs_file
     ]
-    esptool_cmd = [env["PYTHONEXE"], env.subst("$OBJCOPY")] + esptool_flags
+    ESPTOOL_EXE = env.get("ERASETOOL") if platform == "espressif8266" else env.get("OBJCOPY")
+    esptool_cmd = [ESPTOOL_EXE] + esptool_flags
     print("Download filesystem image")
     try:
         returncode = subprocess.call(esptool_cmd, shell=False)
@@ -303,7 +304,8 @@ def upload_factory(*args, **kwargs):
                 "0x0",
                 target_firm
         ]
-        esptool_cmd = [env["PYTHONEXE"], env.subst("$OBJCOPY")] + esptool_flags
+        ESPTOOL_EXE = env.get("ERASETOOL") if platform == "espressif8266" else env.get("OBJCOPY")
+        esptool_cmd = [ESPTOOL_EXE] + esptool_flags
         print("Flash firmware at address 0x0")
         subprocess.call(esptool_cmd, shell=False)
 
@@ -363,7 +365,8 @@ def reset_target(*args, **kwargs):
         "--port", upload_port,
         "flash-id"
     ]
-    esptool_cmd = [env["PYTHONEXE"], env.subst("$OBJCOPY")] + esptool_flags
+    ESPTOOL_EXE = env.get("ERASETOOL") if platform == "espressif8266" else env.get("OBJCOPY")
+    esptool_cmd = [ESPTOOL_EXE] + esptool_flags
     print("Try to reset device")
     subprocess.call(esptool_cmd, shell=False)
 

--- a/pio-tools/custom_target.py
+++ b/pio-tools/custom_target.py
@@ -377,8 +377,8 @@ env.AddCustomTarget(
     actions=[
         reset_target
     ],
-    title="Reset ESP32 target",
-    description="This command resets ESP32x target via esptool",
+    title="Reset connected device",
+    description="This command resets the connected device via esptool",
 )
 
 env.AddCustomTarget(

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,10 +137,11 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.07.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.08.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
+


### PR DESCRIPTION
## Description:

- align esp8266 with esp32 Platform. Ported changes and fixes.
- esp8266 now uses esptool v5.0.2
- adopted pio script "custom target" to work (again) with both Platforms

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
