### PR TITLE
Berry provide details when solidifying fails because of upvals

### DIFF
--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -426,7 +426,8 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, 
     const char * func_name = str(pr->name);
 
     if (clo->nupvals > 0) {
-        logfmt("--> Unsupported upvals in closure in '%s' <---", str(clo->proto->name));
+        const char *name = str(clo->proto->name);
+        logfmt("--> Unsupported upvals in closure in '%s' <---", name ? name : "<unkown>");
         // be_raise(vm, "internal_error", "Unsupported upvals in closure");
     }
 

--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -426,7 +426,7 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, 
     const char * func_name = str(pr->name);
 
     if (clo->nupvals > 0) {
-        logfmt("--> Unsupported upvals in closure <---");
+        logfmt("--> Unsupported upvals in closure in '%s' <---", str(clo->proto->name));
         // be_raise(vm, "internal_error", "Unsupported upvals in closure");
     }
 


### PR DESCRIPTION
## Description:

Berry, when trying to solidify closures with upvals, the solidified code would produce `--> Unsupported upvals in closure <---` without details about where this happened. New logging adds the name of the function where the upval was initially created.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
