### PR TITLE
Berry animation add strip_length provider

### DIFF
--- a/lib/libesp32/berry_animation/docs/ANIMATION_CLASS_HIERARCHY.md
+++ b/lib/libesp32/berry_animation/docs/ANIMATION_CLASS_HIERARCHY.md
@@ -40,6 +40,7 @@ ParameterizedObject
 │   └── (other animation classes)
 └── ValueProvider
     ├── StaticValueProvider
+    ├── StripLengthProvider
     ├── OscillatorValueProvider
     └── ColorProvider
         ├── StaticColorProvider
@@ -102,6 +103,18 @@ Wraps static values to provide ValueProvider interface. Inherits from `ValueProv
 | `value` | any | nil | - | The static value to return |
 
 **Factory**: `animation.static_value(engine)`
+
+### StripLengthProvider
+
+Provides access to the LED strip length as a dynamic value. Inherits from `ValueProvider`.
+
+| Parameter | Type | Default | Constraints | Description |
+|-----------|------|---------|-------------|-------------|
+| *(none)* | - | - | - | No parameters - strip length obtained from engine |
+
+**Usage**: Returns the 1D length of the LED strip in pixels. Useful for animations that need to know the strip dimensions for positioning, scaling, or boundary calculations.
+
+**Factory**: `animation.strip_length(engine)`
 
 ### OscillatorValueProvider
 

--- a/lib/libesp32/berry_animation/docs/DSL_REFERENCE.md
+++ b/lib/libesp32/berry_animation/docs/DSL_REFERENCE.md
@@ -496,6 +496,7 @@ Value providers create dynamic values that change over time:
 | Function | Description |
 |----------|-------------|
 | `static_value` | Returns a constant value |
+| `strip_length` | Returns the LED strip length in pixels |
 | `oscillator_value` | Oscillates between min/max values with various waveforms |
 
 **Oscillator Aliases:**
@@ -530,6 +531,7 @@ bounce(min_value=0, max_value=255, period=2s)      # Bouncing ball effect
 set brightness_oscillator = smooth(min_value=50, max_value=255, period=3s)
 set position_sweep = triangle(min_value=0, max_value=29, period=5s)
 set elastic_movement = elastic(min_value=0, max_value=30, period=4s)
+set strip_len = strip_length()  # Get the current strip length
 ```
 
 ### Color Providers

--- a/lib/libesp32/berry_animation/src/animation.be
+++ b/lib/libesp32/berry_animation/src/animation.be
@@ -93,6 +93,8 @@ import "providers/static_value_provider.be" as static_value_provider
 register_to_animation(static_value_provider)
 import "providers/oscillator_value_provider.be" as oscillator_value_provider
 register_to_animation(oscillator_value_provider)
+import "providers/strip_length_provider.be" as strip_length_provider
+register_to_animation(strip_length_provider)
 
 # Import color providers
 import "providers/color_provider.be" as color_provider

--- a/lib/libesp32/berry_animation/src/providers/strip_length_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/strip_length_provider.be
@@ -1,0 +1,39 @@
+# StripLengthProvider for Berry Animation Framework
+#
+# This value provider returns the length of the LED strip from the animation engine.
+# It provides access to the strip length as a dynamic value that can be used by
+# animations that need to know the strip dimensions.
+#
+# The strip length is obtained from the engine's width property, which is cached
+# from the strip.length() method for performance.
+#
+# Follows the parameterized class specification:
+# - Constructor takes only 'engine' parameter
+# - No additional parameters needed since strip length is obtained from engine
+
+#@ solidify:StripLengthProvider,weak
+class StripLengthProvider : animation.value_provider
+  # Produce the strip length value
+  #
+  # @param name: string - Parameter name being requested (ignored)
+  # @param time_ms: int - Current time in milliseconds (ignored)
+  # @return int - The strip length in pixels
+  def produce_value(name, time_ms)
+    if self.engine == nil
+      return 0
+    end
+    return self.engine.width
+  end
+  
+  # String representation of the provider
+  def tostring()
+    try
+      var length = self.engine != nil ? self.engine.width : 0
+      return f"StripLengthProvider(length={length})"
+    except ..
+      return "StripLengthProvider(length=unknown)"
+    end
+  end
+end
+
+return {'strip_length': StripLengthProvider}

--- a/lib/libesp32/berry_animation/src/solidify/solidified_animation.h
+++ b/lib/libesp32/berry_animation/src/solidify/solidified_animation.h
@@ -344,6 +344,372 @@ be_local_closure(triangle,   /* name */
 );
 /*******************************************************************/
 
+// compact class 'PalettePatternAnimation' ktab size: 21, total: 40 (saved 152 bytes)
+static const bvalue be_ktab_class_PalettePatternAnimation[21] = {
+  /* K0   */  be_nested_str_weak(pattern_func),
+  /* K1   */  be_nested_str_weak(color_source),
+  /* K2   */  be_nested_str_weak(_initialize_value_buffer),
+  /* K3   */  be_nested_str_weak(is_running),
+  /* K4   */  be_nested_str_weak(engine),
+  /* K5   */  be_nested_str_weak(time_ms),
+  /* K6   */  be_nested_str_weak(start_time),
+  /* K7   */  be_nested_str_weak(get_strip_length),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(width),
+  /* K10  */  be_nested_str_weak(value_buffer),
+  /* K11  */  be_nested_str_weak(get_color_for_value),
+  /* K12  */  be_nested_str_weak(current_color),
+  /* K13  */  be_nested_str_weak(set_pixel_color),
+  /* K14  */  be_const_int(1),
+  /* K15  */  be_nested_str_weak(resize),
+  /* K16  */  be_nested_str_weak(init),
+  /* K17  */  be_nested_str_weak(PalettePatternAnimation_X28strip_length_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K18  */  be_nested_str_weak(priority),
+  /* K19  */  be_nested_str_weak(update),
+  /* K20  */  be_nested_str_weak(_update_value_buffer),
+};
+
+
+extern const bclass be_class_PalettePatternAnimation;
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x740E0001,  //  0001  JMPT	R3	#0004
+      0x1C0C0301,  //  0002  EQ	R3	R1	K1
+      0x780E0001,  //  0003  JMPF	R3	#0006
+      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation_render,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[51]) {  /* code */
+      0x880C0103,  //  0000  GETMBR	R3	R0	K3
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x1C0C0403,  //  0008  EQ	R3	R2	R3
+      0x780E0001,  //  0009  JMPF	R3	#000C
+      0x880C0104,  //  000A  GETMBR	R3	R0	K4
+      0x88080705,  //  000B  GETMBR	R2	R3	K5
+      0x880C0101,  //  000C  GETMBR	R3	R0	K1
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C100604,  //  000E  EQ	R4	R3	R4
+      0x78120001,  //  000F  JMPF	R4	#0012
+      0x50100000,  //  0010  LDBOOL	R4	0	0
+      0x80040800,  //  0011  RET	1	R4
+      0x88100106,  //  0012  GETMBR	R4	R0	K6
+      0x04100404,  //  0013  SUB	R4	R2	R4
+      0x88140104,  //  0014  GETMBR	R5	R0	K4
+      0x8C140B07,  //  0015  GETMET	R5	R5	K7
+      0x7C140200,  //  0016  CALL	R5	1
+      0x58180008,  //  0017  LDCONST	R6	K8
+      0x141C0C05,  //  0018  LT	R7	R6	R5
+      0x781E0016,  //  0019  JMPF	R7	#0031
+      0x881C0309,  //  001A  GETMBR	R7	R1	K9
+      0x141C0C07,  //  001B  LT	R7	R6	R7
+      0x781E0013,  //  001C  JMPF	R7	#0031
+      0x881C010A,  //  001D  GETMBR	R7	R0	K10
+      0x941C0E06,  //  001E  GETIDX	R7	R7	R6
+      0x4C200000,  //  001F  LDNIL	R8
+      0x8824070B,  //  0020  GETMBR	R9	R3	K11
+      0x4C280000,  //  0021  LDNIL	R10
+      0x2024120A,  //  0022  NE	R9	R9	R10
+      0x78260005,  //  0023  JMPF	R9	#002A
+      0x8C24070B,  //  0024  GETMET	R9	R3	K11
+      0x5C2C0E00,  //  0025  MOVE	R11	R7
+      0x5C300800,  //  0026  MOVE	R12	R4
+      0x7C240600,  //  0027  CALL	R9	3
+      0x5C201200,  //  0028  MOVE	R8	R9
+      0x70020000,  //  0029  JMP		#002B
+      0x8820070C,  //  002A  GETMBR	R8	R3	K12
+      0x8C24030D,  //  002B  GETMET	R9	R1	K13
+      0x5C2C0C00,  //  002C  MOVE	R11	R6
+      0x5C301000,  //  002D  MOVE	R12	R8
+      0x7C240600,  //  002E  CALL	R9	3
+      0x00180D0E,  //  002F  ADD	R6	R6	K14
+      0x7001FFE6,  //  0030  JMP		#0018
+      0x501C0200,  //  0031  LDBOOL	R7	1	0
+      0x80040E00,  //  0032  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_value_buffer
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation__update_value_buffer,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(_update_value_buffer),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0403,  //  0002  EQ	R3	R2	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80000600,  //  0004  RET	0
+      0x880C0104,  //  0005  GETMBR	R3	R0	K4
+      0x8C0C0707,  //  0006  GETMET	R3	R3	K7
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x6010000C,  //  0008  GETGBL	R4	G12
+      0x8814010A,  //  0009  GETMBR	R5	R0	K10
+      0x7C100200,  //  000A  CALL	R4	1
+      0x20100803,  //  000B  NE	R4	R4	R3
+      0x78120003,  //  000C  JMPF	R4	#0011
+      0x8810010A,  //  000D  GETMBR	R4	R0	K10
+      0x8C10090F,  //  000E  GETMET	R4	R4	K15
+      0x5C180600,  //  000F  MOVE	R6	R3
+      0x7C100400,  //  0010  CALL	R4	2
+      0x58100008,  //  0011  LDCONST	R4	K8
+      0x14140803,  //  0012  LT	R5	R4	R3
+      0x78160008,  //  0013  JMPF	R5	#001D
+      0x8814010A,  //  0014  GETMBR	R5	R0	K10
+      0x5C180400,  //  0015  MOVE	R6	R2
+      0x5C1C0800,  //  0016  MOVE	R7	R4
+      0x5C200200,  //  0017  MOVE	R8	R1
+      0x5C240000,  //  0018  MOVE	R9	R0
+      0x7C180600,  //  0019  CALL	R6	3
+      0x98140806,  //  001A  SETIDX	R5	R4	R6
+      0x0010090E,  //  001B  ADD	R4	R4	K14
+      0x7001FFF4,  //  001C  JMP		#0012
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _initialize_value_buffer
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation__initialize_value_buffer,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(_initialize_value_buffer),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8808010A,  //  0003  GETMBR	R2	R0	K10
+      0x8C08050F,  //  0004  GETMET	R2	R2	K15
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x58080008,  //  0007  LDCONST	R2	K8
+      0x140C0401,  //  0008  LT	R3	R2	R1
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x880C010A,  //  000A  GETMBR	R3	R0	K10
+      0x980C0508,  //  000B  SETIDX	R3	R2	K8
+      0x0008050E,  //  000C  ADD	R2	R2	K14
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080510,  //  0003  GETMET	R2	R2	K16
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90021402,  //  0008  SETMBR	R0	K10	R2
+      0x8C080102,  //  0009  GETMET	R2	R0	K2
+      0x7C080200,  //  000A  CALL	R2	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation_tostring,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x8C040307,  //  0001  GETMET	R1	R1	K7
+      0x7C040200,  //  0002  CALL	R1	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C0011,  //  0004  LDCONST	R3	K17
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x88140112,  //  0006  GETMBR	R5	R0	K18
+      0x88180103,  //  0007  GETMBR	R6	R0	K3
+      0x7C080800,  //  0008  CALL	R2	4
+      0x80040400,  //  0009  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_PalettePatternAnimation_update,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080513,  //  0003  GETMET	R2	R2	K19
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0001,  //  0006  JMPT	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x88080106,  //  0009  GETMBR	R2	R0	K6
+      0x04080202,  //  000A  SUB	R2	R1	R2
+      0x8C0C0114,  //  000B  GETMET	R3	R0	K20
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x500C0200,  //  000E  LDBOOL	R3	1	0
+      0x80040600,  //  000F  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: PalettePatternAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(PalettePatternAnimation,
+    1,
+    &be_class_Animation,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(update, 1), be_const_closure(class_PalettePatternAnimation_update_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_PalettePatternAnimation_tostring_closure) },
+        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PalettePatternAnimation__update_value_buffer_closure) },
+        { be_const_key_weak(_initialize_value_buffer, -1), be_const_closure(class_PalettePatternAnimation__initialize_value_buffer_closure) },
+        { be_const_key_weak(on_param_changed, 8), be_const_closure(class_PalettePatternAnimation_on_param_changed_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(color_source, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_nil() },
+        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
+    }))    ) } )) },
+        { be_const_key_weak(pattern_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_nil() },
+        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(init, 5), be_const_closure(class_PalettePatternAnimation_init_closure) },
+        { be_const_key_weak(render, 0), be_const_closure(class_PalettePatternAnimation_render_closure) },
+        { be_const_key_weak(value_buffer, -1), be_const_var(0) },
+    })),
+    be_str_weak(PalettePatternAnimation)
+);
 
 /********************************************************************
 ** Solidified function: set_event_active
@@ -444,216 +810,61 @@ be_local_closure(noise_rainbow,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'TwinkleAnimation' ktab size: 37, total: 67 (saved 240 bytes)
-static const bvalue be_ktab_class_TwinkleAnimation[37] = {
-  /* K0   */  be_nested_str_weak(twinkle_speed),
-  /* K1   */  be_const_int(1),
-  /* K2   */  be_nested_str_weak(set_param),
-  /* K3   */  be_nested_str_weak(fade_speed),
-  /* K4   */  be_nested_str_weak(density),
-  /* K5   */  be_nested_str_weak(min_brightness),
-  /* K6   */  be_nested_str_weak(max_brightness),
-  /* K7   */  be_nested_str_weak(color),
-  /* K8   */  be_nested_str_weak(engine),
-  /* K9   */  be_nested_str_weak(get_strip_length),
-  /* K10  */  be_nested_str_weak(twinkle_states),
-  /* K11  */  be_nested_str_weak(_initialize_arrays),
-  /* K12  */  be_const_int(0),
-  /* K13  */  be_nested_str_weak(current_colors),
-  /* K14  */  be_nested_str_weak(tasmota),
-  /* K15  */  be_nested_str_weak(scale_uint),
-  /* K16  */  be_const_int(16777215),
-  /* K17  */  be_nested_str_weak(_random_range),
-  /* K18  */  be_nested_str_weak(get_param),
-  /* K19  */  be_nested_str_weak(animation),
-  /* K20  */  be_nested_str_weak(is_value_provider),
-  /* K21  */  be_nested_str_weak(0x_X2508x),
-  /* K22  */  be_nested_str_weak(TwinkleAnimation_X28color_X3D_X25s_X2C_X20density_X3D_X25s_X2C_X20twinkle_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K23  */  be_nested_str_weak(priority),
-  /* K24  */  be_nested_str_weak(is_running),
-  /* K25  */  be_nested_str_weak(init),
-  /* K26  */  be_nested_str_weak(last_update),
-  /* K27  */  be_nested_str_weak(random_seed),
-  /* K28  */  be_nested_str_weak(time_ms),
-  /* K29  */  be_nested_str_weak(width),
-  /* K30  */  be_nested_str_weak(set_pixel_color),
-  /* K31  */  be_nested_str_weak(update),
-  /* K32  */  be_nested_str_weak(_update_twinkle_simulation),
-  /* K33  */  be_nested_str_weak(resize),
-  /* K34  */  be_const_int(1103515245),
-  /* K35  */  be_const_int(2147483647),
-  /* K36  */  be_nested_str_weak(_random),
+// compact class 'ScaleAnimation' ktab size: 42, total: 83 (saved 328 bytes)
+static const bvalue be_ktab_class_ScaleAnimation[42] = {
+  /* K0   */  be_nested_str_weak(scale_mode),
+  /* K1   */  be_nested_str_weak(scale_factor),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_nested_str_weak(_sine),
+  /* K5   */  be_nested_str_weak(scale_phase),
+  /* K6   */  be_nested_str_weak(tasmota),
+  /* K7   */  be_nested_str_weak(scale_uint),
+  /* K8   */  be_const_int(2),
+  /* K9   */  be_nested_str_weak(engine),
+  /* K10  */  be_nested_str_weak(get_strip_length),
+  /* K11  */  be_nested_str_weak(current_colors),
+  /* K12  */  be_nested_str_weak(_initialize_buffers),
+  /* K13  */  be_nested_str_weak(source_animation),
+  /* K14  */  be_nested_str_weak(scale_center),
+  /* K15  */  be_nested_str_weak(interpolation),
+  /* K16  */  be_nested_str_weak(source_frame),
+  /* K17  */  be_nested_str_weak(clear),
+  /* K18  */  be_nested_str_weak(render),
+  /* K19  */  be_nested_str_weak(_get_current_scale_factor),
+  /* K20  */  be_nested_str_weak(get_pixel_color),
+  /* K21  */  be_const_int(-16777216),
+  /* K22  */  be_nested_str_weak(_interpolate_colors),
+  /* K23  */  be_nested_str_weak(scale_speed),
+  /* K24  */  be_nested_str_weak(start_time),
+  /* K25  */  be_nested_str_weak(is_running),
+  /* K26  */  be_nested_str_weak(start),
+  /* K27  */  be_nested_str_weak(update),
+  /* K28  */  be_nested_str_weak(_calculate_scale),
+  /* K29  */  be_nested_str_weak(static),
+  /* K30  */  be_nested_str_weak(oscillate),
+  /* K31  */  be_nested_str_weak(grow),
+  /* K32  */  be_nested_str_weak(shrink),
+  /* K33  */  be_nested_str_weak(unknown),
+  /* K34  */  be_nested_str_weak(ScaleAnimation_X28_X25s_X2C_X20factor_X3D_X25s_X2C_X20speed_X3D_X25s_X29),
+  /* K35  */  be_nested_str_weak(init),
+  /* K36  */  be_nested_str_weak(time_ms),
+  /* K37  */  be_nested_str_weak(animation),
+  /* K38  */  be_nested_str_weak(frame_buffer),
+  /* K39  */  be_nested_str_weak(resize),
+  /* K40  */  be_nested_str_weak(width),
+  /* K41  */  be_nested_str_weak(set_pixel_color),
 };
 
 
-extern const bclass be_class_TwinkleAnimation;
+extern const bclass be_class_ScaleAnimation;
 
 /********************************************************************
-** Solidified function: on_param_changed
+** Solidified function: _get_current_scale_factor
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation_on_param_changed,   /* name */
+be_local_closure(class_ScaleAnimation__get_current_scale_factor,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
-      0x780E0010,  //  0001  JMPF	R3	#0013
-      0x540E0031,  //  0002  LDINT	R3	50
-      0x280C0403,  //  0003  GE	R3	R2	R3
-      0x780E000D,  //  0004  JMPF	R3	#0013
-      0x540E03E7,  //  0005  LDINT	R3	1000
-      0x0C0C0602,  //  0006  DIV	R3	R3	R2
-      0x14100701,  //  0007  LT	R4	R3	K1
-      0x78120001,  //  0008  JMPF	R4	#000B
-      0x580C0001,  //  0009  LDCONST	R3	K1
-      0x70020003,  //  000A  JMP		#000F
-      0x54120013,  //  000B  LDINT	R4	20
-      0x24100604,  //  000C  GT	R4	R3	R4
-      0x78120000,  //  000D  JMPF	R4	#000F
-      0x540E0013,  //  000E  LDINT	R3	20
-      0x8C100102,  //  000F  GETMET	R4	R0	K2
-      0x58180000,  //  0010  LDCONST	R6	K0
-      0x5C1C0600,  //  0011  MOVE	R7	R3
-      0x7C100600,  //  0012  CALL	R4	3
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_twinkle_simulation
-********************************************************************/
-be_local_closure(class_TwinkleAnimation__update_twinkle_simulation,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_update_twinkle_simulation),
-    &be_const_str_solidified,
-    ( &(const binstruction[94]) {  /* code */
-      0x88080103,  //  0000  GETMBR	R2	R0	K3
-      0x880C0104,  //  0001  GETMBR	R3	R0	K4
-      0x88100105,  //  0002  GETMBR	R4	R0	K5
-      0x88140106,  //  0003  GETMBR	R5	R0	K6
-      0x88180107,  //  0004  GETMBR	R6	R0	K7
-      0x881C0108,  //  0005  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  0006  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0x6020000C,  //  0008  GETGBL	R8	G12
-      0x8824010A,  //  0009  GETMBR	R9	R0	K10
-      0x7C200200,  //  000A  CALL	R8	1
-      0x20201007,  //  000B  NE	R8	R8	R7
-      0x78220001,  //  000C  JMPF	R8	#000F
-      0x8C20010B,  //  000D  GETMET	R8	R0	K11
-      0x7C200200,  //  000E  CALL	R8	1
-      0x5820000C,  //  000F  LDCONST	R8	K12
-      0x14241007,  //  0010  LT	R9	R8	R7
-      0x7826001F,  //  0011  JMPF	R9	#0032
-      0x8824010D,  //  0012  GETMBR	R9	R0	K13
-      0x94241208,  //  0013  GETIDX	R9	R9	R8
-      0x542A0017,  //  0014  LDINT	R10	24
-      0x3C28120A,  //  0015  SHR	R10	R9	R10
-      0x542E00FE,  //  0016  LDINT	R11	255
-      0x2C28140B,  //  0017  AND	R10	R10	R11
-      0x242C150C,  //  0018  GT	R11	R10	K12
-      0x782E0015,  //  0019  JMPF	R11	#0030
-      0xB82E1C00,  //  001A  GETNGBL	R11	K14
-      0x8C2C170F,  //  001B  GETMET	R11	R11	K15
-      0x5C340400,  //  001C  MOVE	R13	R2
-      0x5838000C,  //  001D  LDCONST	R14	K12
-      0x543E00FE,  //  001E  LDINT	R15	255
-      0x58400001,  //  001F  LDCONST	R16	K1
-      0x54460013,  //  0020  LDINT	R17	20
-      0x7C2C0C00,  //  0021  CALL	R11	6
-      0x1830140B,  //  0022  LE	R12	R10	R11
-      0x78320004,  //  0023  JMPF	R12	#0029
-      0x8830010A,  //  0024  GETMBR	R12	R0	K10
-      0x9830110C,  //  0025  SETIDX	R12	R8	K12
-      0x8830010D,  //  0026  GETMBR	R12	R0	K13
-      0x9830110C,  //  0027  SETIDX	R12	R8	K12
-      0x70020006,  //  0028  JMP		#0030
-      0x0430140B,  //  0029  SUB	R12	R10	R11
-      0x2C341310,  //  002A  AND	R13	R9	K16
-      0x8838010D,  //  002B  GETMBR	R14	R0	K13
-      0x543E0017,  //  002C  LDINT	R15	24
-      0x383C180F,  //  002D  SHL	R15	R12	R15
-      0x303C1E0D,  //  002E  OR	R15	R15	R13
-      0x9838100F,  //  002F  SETIDX	R14	R8	R15
-      0x00201101,  //  0030  ADD	R8	R8	K1
-      0x7001FFDD,  //  0031  JMP		#0010
-      0x5824000C,  //  0032  LDCONST	R9	K12
-      0x14281207,  //  0033  LT	R10	R9	R7
-      0x782A0027,  //  0034  JMPF	R10	#005D
-      0x8828010A,  //  0035  GETMBR	R10	R0	K10
-      0x94281409,  //  0036  GETIDX	R10	R10	R9
-      0x1C28150C,  //  0037  EQ	R10	R10	K12
-      0x782A0021,  //  0038  JMPF	R10	#005B
-      0x8C280111,  //  0039  GETMET	R10	R0	K17
-      0x543200FE,  //  003A  LDINT	R12	255
-      0x7C280400,  //  003B  CALL	R10	2
-      0x14281403,  //  003C  LT	R10	R10	R3
-      0x782A001C,  //  003D  JMPF	R10	#005B
-      0x8C280111,  //  003E  GETMET	R10	R0	K17
-      0x04300A04,  //  003F  SUB	R12	R5	R4
-      0x00301901,  //  0040  ADD	R12	R12	K1
-      0x7C280400,  //  0041  CALL	R10	2
-      0x0028080A,  //  0042  ADD	R10	R4	R10
-      0x5C2C0C00,  //  0043  MOVE	R11	R6
-      0x5432000F,  //  0044  LDINT	R12	16
-      0x3C30160C,  //  0045  SHR	R12	R11	R12
-      0x543600FE,  //  0046  LDINT	R13	255
-      0x2C30180D,  //  0047  AND	R12	R12	R13
-      0x54360007,  //  0048  LDINT	R13	8
-      0x3C34160D,  //  0049  SHR	R13	R11	R13
-      0x543A00FE,  //  004A  LDINT	R14	255
-      0x2C341A0E,  //  004B  AND	R13	R13	R14
-      0x543A00FE,  //  004C  LDINT	R14	255
-      0x2C38160E,  //  004D  AND	R14	R11	R14
-      0x883C010A,  //  004E  GETMBR	R15	R0	K10
-      0x983C1301,  //  004F  SETIDX	R15	R9	K1
-      0x883C010D,  //  0050  GETMBR	R15	R0	K13
-      0x54420017,  //  0051  LDINT	R16	24
-      0x38401410,  //  0052  SHL	R16	R10	R16
-      0x5446000F,  //  0053  LDINT	R17	16
-      0x38441811,  //  0054  SHL	R17	R12	R17
-      0x30402011,  //  0055  OR	R16	R16	R17
-      0x54460007,  //  0056  LDINT	R17	8
-      0x38441A11,  //  0057  SHL	R17	R13	R17
-      0x30402011,  //  0058  OR	R16	R16	R17
-      0x3040200E,  //  0059  OR	R16	R16	R14
-      0x983C1210,  //  005A  SETIDX	R15	R9	R16
-      0x00241301,  //  005B  ADD	R9	R9	K1
-      0x7001FFD5,  //  005C  JMP		#0033
-      0x80000000,  //  005D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_tostring,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -661,150 +872,188 @@ be_local_closure(class_TwinkleAnimation_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x8C080112,  //  0001  GETMET	R2	R0	K18
-      0x58100007,  //  0002  LDCONST	R4	K7
-      0x7C080400,  //  0003  CALL	R2	2
-      0xB80E2600,  //  0004  GETNGBL	R3	K19
-      0x8C0C0714,  //  0005  GETMET	R3	R3	K20
-      0x5C140400,  //  0006  MOVE	R5	R2
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x600C0008,  //  0009  GETGBL	R3	G8
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x5C040600,  //  000C  MOVE	R1	R3
-      0x70020004,  //  000D  JMP		#0013
-      0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100015,  //  000F  LDCONST	R4	K21
-      0x88140107,  //  0010  GETMBR	R5	R0	K7
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x5C040600,  //  0012  MOVE	R1	R3
-      0x600C0018,  //  0013  GETGBL	R3	G24
-      0x58100016,  //  0014  LDCONST	R4	K22
-      0x5C140200,  //  0015  MOVE	R5	R1
-      0x88180104,  //  0016  GETMBR	R6	R0	K4
-      0x881C0100,  //  0017  GETMBR	R7	R0	K0
-      0x88200117,  //  0018  GETMBR	R8	R0	K23
-      0x88240118,  //  0019  GETMBR	R9	R0	K24
-      0x7C0C0C00,  //  001A  CALL	R3	6
-      0x80040600,  //  001B  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080519,  //  0003  GETMET	R2	R2	K25
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90021402,  //  0008  SETMBR	R0	K10	R2
-      0x60080012,  //  0009  GETGBL	R2	G18
-      0x7C080000,  //  000A  CALL	R2	0
-      0x90021A02,  //  000B  SETMBR	R0	K13	R2
-      0x9002350C,  //  000C  SETMBR	R0	K26	K12
-      0x88080108,  //  000D  GETMBR	R2	R0	K8
-      0x8808051C,  //  000E  GETMBR	R2	R2	K28
-      0x540EFFFF,  //  000F  LDINT	R3	65536
-      0x10080403,  //  0010  MOD	R2	R2	R3
-      0x90023602,  //  0011  SETMBR	R0	K27	R2
-      0x8C08010B,  //  0012  GETMET	R2	R0	K11
-      0x7C080200,  //  0013  CALL	R2	1
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_render,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(render),
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(_get_current_scale_factor),
     &be_const_str_solidified,
     ( &(const binstruction[45]) {  /* code */
-      0x880C0118,  //  0000  GETMBR	R3	R0	K24
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x1C0C0403,  //  0008  EQ	R3	R2	R3
-      0x780E0001,  //  0009  JMPF	R3	#000C
-      0x880C0108,  //  000A  GETMBR	R3	R0	K8
-      0x8808071C,  //  000B  GETMBR	R2	R3	K28
-      0x880C0108,  //  000C  GETMBR	R3	R0	K8
-      0x8C0C0709,  //  000D  GETMET	R3	R3	K9
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x6010000C,  //  000F  GETGBL	R4	G12
-      0x8814010A,  //  0010  GETMBR	R5	R0	K10
-      0x7C100200,  //  0011  CALL	R4	1
-      0x20100803,  //  0012  NE	R4	R4	R3
-      0x78120001,  //  0013  JMPF	R4	#0016
-      0x8C10010B,  //  0014  GETMET	R4	R0	K11
-      0x7C100200,  //  0015  CALL	R4	1
-      0x50100000,  //  0016  LDBOOL	R4	0	0
-      0x5814000C,  //  0017  LDCONST	R5	K12
-      0x14180A03,  //  0018  LT	R6	R5	R3
-      0x781A0011,  //  0019  JMPF	R6	#002C
-      0x8818031D,  //  001A  GETMBR	R6	R1	K29
-      0x14180A06,  //  001B  LT	R6	R5	R6
-      0x781A000C,  //  001C  JMPF	R6	#002A
-      0x8818010D,  //  001D  GETMBR	R6	R0	K13
-      0x94180C05,  //  001E  GETIDX	R6	R6	R5
-      0x541E0017,  //  001F  LDINT	R7	24
-      0x3C1C0C07,  //  0020  SHR	R7	R6	R7
-      0x542200FE,  //  0021  LDINT	R8	255
-      0x2C1C0E08,  //  0022  AND	R7	R7	R8
-      0x241C0F0C,  //  0023  GT	R7	R7	K12
-      0x781E0004,  //  0024  JMPF	R7	#002A
-      0x8C1C031E,  //  0025  GETMET	R7	R1	K30
-      0x5C240A00,  //  0026  MOVE	R9	R5
-      0x5C280C00,  //  0027  MOVE	R10	R6
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x50100200,  //  0029  LDBOOL	R4	1	0
-      0x00140B01,  //  002A  ADD	R5	R5	K1
-      0x7001FFEB,  //  002B  JMP		#0018
-      0x80040800,  //  002C  RET	1	R4
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C0C0302,  //  0002  EQ	R3	R1	K2
+      0x780E0001,  //  0003  JMPF	R3	#0006
+      0x80040400,  //  0004  RET	1	R2
+      0x70020025,  //  0005  JMP		#002C
+      0x1C0C0303,  //  0006  EQ	R3	R1	K3
+      0x780E000C,  //  0007  JMPF	R3	#0015
+      0x8C0C0104,  //  0008  GETMET	R3	R0	K4
+      0x88140105,  //  0009  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0xB8120C00,  //  000B  GETNGBL	R4	K6
+      0x8C100907,  //  000C  GETMET	R4	R4	K7
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x581C0002,  //  000E  LDCONST	R7	K2
+      0x542200FE,  //  000F  LDINT	R8	255
+      0x5426003F,  //  0010  LDINT	R9	64
+      0x542A00FE,  //  0011  LDINT	R10	255
+      0x7C100C00,  //  0012  CALL	R4	6
+      0x80040800,  //  0013  RET	1	R4
+      0x70020016,  //  0014  JMP		#002C
+      0x1C0C0308,  //  0015  EQ	R3	R1	K8
+      0x780E0009,  //  0016  JMPF	R3	#0021
+      0xB80E0C00,  //  0017  GETNGBL	R3	K6
+      0x8C0C0707,  //  0018  GETMET	R3	R3	K7
+      0x88140105,  //  0019  GETMBR	R5	R0	K5
+      0x58180002,  //  001A  LDCONST	R6	K2
+      0x541E00FE,  //  001B  LDINT	R7	255
+      0x5422003F,  //  001C  LDINT	R8	64
+      0x542600FE,  //  001D  LDINT	R9	255
+      0x7C0C0C00,  //  001E  CALL	R3	6
+      0x80040600,  //  001F  RET	1	R3
+      0x7002000A,  //  0020  JMP		#002C
+      0xB80E0C00,  //  0021  GETNGBL	R3	K6
+      0x8C0C0707,  //  0022  GETMET	R3	R3	K7
+      0x541600FE,  //  0023  LDINT	R5	255
+      0x88180105,  //  0024  GETMBR	R6	R0	K5
+      0x04140A06,  //  0025  SUB	R5	R5	R6
+      0x58180002,  //  0026  LDCONST	R6	K2
+      0x541E00FE,  //  0027  LDINT	R7	255
+      0x5422003F,  //  0028  LDINT	R8	64
+      0x542600FE,  //  0029  LDINT	R9	255
+      0x7C0C0C00,  //  002A  CALL	R3	6
+      0x80040600,  //  002B  RET	1	R3
+      0x80000000,  //  002C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _calculate_scale
+********************************************************************/
+be_local_closure(class_ScaleAnimation__calculate_scale,   /* name */
+  be_nested_proto(
+    21,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(_calculate_scale),
+    &be_const_str_solidified,
+    ( &(const binstruction[110]) {  /* code */
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0001  GETMET	R1	R1	K10
+      0x7C040200,  //  0002  CALL	R1	1
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C010B,  //  0004  GETMBR	R3	R0	K11
+      0x7C080200,  //  0005  CALL	R2	1
+      0x20080401,  //  0006  NE	R2	R2	R1
+      0x780A0001,  //  0007  JMPF	R2	#000A
+      0x8C08010C,  //  0008  GETMET	R2	R0	K12
+      0x7C080200,  //  0009  CALL	R2	1
+      0x8808010D,  //  000A  GETMBR	R2	R0	K13
+      0x880C010E,  //  000B  GETMBR	R3	R0	K14
+      0x8810010F,  //  000C  GETMBR	R4	R0	K15
+      0x88140110,  //  000D  GETMBR	R5	R0	K16
+      0x8C140B11,  //  000E  GETMET	R5	R5	K17
+      0x7C140200,  //  000F  CALL	R5	1
+      0x4C140000,  //  0010  LDNIL	R5
+      0x20140405,  //  0011  NE	R5	R2	R5
+      0x78160003,  //  0012  JMPF	R5	#0017
+      0x8C140512,  //  0013  GETMET	R5	R2	K18
+      0x881C0110,  //  0014  GETMBR	R7	R0	K16
+      0x58200002,  //  0015  LDCONST	R8	K2
+      0x7C140600,  //  0016  CALL	R5	3
+      0x8C140113,  //  0017  GETMET	R5	R0	K19
+      0x7C140200,  //  0018  CALL	R5	1
+      0xB81A0C00,  //  0019  GETNGBL	R6	K6
+      0x8C180D07,  //  001A  GETMET	R6	R6	K7
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x58240002,  //  001C  LDCONST	R9	K2
+      0x542A00FE,  //  001D  LDINT	R10	255
+      0x582C0002,  //  001E  LDCONST	R11	K2
+      0x04300303,  //  001F  SUB	R12	R1	K3
+      0x7C180C00,  //  0020  CALL	R6	6
+      0x581C0002,  //  0021  LDCONST	R7	K2
+      0x14200E01,  //  0022  LT	R8	R7	R1
+      0x78220048,  //  0023  JMPF	R8	#006D
+      0x04200E06,  //  0024  SUB	R8	R7	R6
+      0xB8260C00,  //  0025  GETNGBL	R9	K6
+      0x8C241307,  //  0026  GETMET	R9	R9	K7
+      0x542E007F,  //  0027  LDINT	R11	128
+      0x082C100B,  //  0028  MUL	R11	R8	R11
+      0x58300002,  //  0029  LDCONST	R12	K2
+      0x5436007F,  //  002A  LDINT	R13	128
+      0x543A007F,  //  002B  LDINT	R14	128
+      0x08341A0E,  //  002C  MUL	R13	R13	R14
+      0x58380002,  //  002D  LDCONST	R14	K2
+      0x543E007F,  //  002E  LDINT	R15	128
+      0x083C0A0F,  //  002F  MUL	R15	R5	R15
+      0x7C240C00,  //  0030  CALL	R9	6
+      0x542A007F,  //  0031  LDINT	R10	128
+      0x0C24120A,  //  0032  DIV	R9	R9	R10
+      0x00280C09,  //  0033  ADD	R10	R6	R9
+      0x1C2C0902,  //  0034  EQ	R11	R4	K2
+      0x782E000D,  //  0035  JMPF	R11	#0044
+      0x282C1502,  //  0036  GE	R11	R10	K2
+      0x782E0008,  //  0037  JMPF	R11	#0041
+      0x142C1401,  //  0038  LT	R11	R10	R1
+      0x782E0006,  //  0039  JMPF	R11	#0041
+      0x882C010B,  //  003A  GETMBR	R11	R0	K11
+      0x88300110,  //  003B  GETMBR	R12	R0	K16
+      0x8C301914,  //  003C  GETMET	R12	R12	K20
+      0x5C381400,  //  003D  MOVE	R14	R10
+      0x7C300400,  //  003E  CALL	R12	2
+      0x982C0E0C,  //  003F  SETIDX	R11	R7	R12
+      0x70020001,  //  0040  JMP		#0043
+      0x882C010B,  //  0041  GETMBR	R11	R0	K11
+      0x982C0F15,  //  0042  SETIDX	R11	R7	K21
+      0x70020026,  //  0043  JMP		#006B
+      0x282C1502,  //  0044  GE	R11	R10	K2
+      0x782E0022,  //  0045  JMPF	R11	#0069
+      0x042C0303,  //  0046  SUB	R11	R1	K3
+      0x142C140B,  //  0047  LT	R11	R10	R11
+      0x782E001F,  //  0048  JMPF	R11	#0069
+      0x602C0009,  //  0049  GETGBL	R11	G9
+      0x5C301400,  //  004A  MOVE	R12	R10
+      0x7C2C0200,  //  004B  CALL	R11	1
+      0x60300009,  //  004C  GETGBL	R12	G9
+      0x0434140B,  //  004D  SUB	R13	R10	R11
+      0x543A00FF,  //  004E  LDINT	R14	256
+      0x08341A0E,  //  004F  MUL	R13	R13	R14
+      0x7C300200,  //  0050  CALL	R12	1
+      0x28341702,  //  0051  GE	R13	R11	K2
+      0x78360012,  //  0052  JMPF	R13	#0066
+      0x04340303,  //  0053  SUB	R13	R1	K3
+      0x1434160D,  //  0054  LT	R13	R11	R13
+      0x7836000F,  //  0055  JMPF	R13	#0066
+      0x88340110,  //  0056  GETMBR	R13	R0	K16
+      0x8C341B14,  //  0057  GETMET	R13	R13	K20
+      0x5C3C1600,  //  0058  MOVE	R15	R11
+      0x7C340400,  //  0059  CALL	R13	2
+      0x88380110,  //  005A  GETMBR	R14	R0	K16
+      0x8C381D14,  //  005B  GETMET	R14	R14	K20
+      0x00401703,  //  005C  ADD	R16	R11	K3
+      0x7C380400,  //  005D  CALL	R14	2
+      0x883C010B,  //  005E  GETMBR	R15	R0	K11
+      0x8C400116,  //  005F  GETMET	R16	R0	K22
+      0x5C481A00,  //  0060  MOVE	R18	R13
+      0x5C4C1C00,  //  0061  MOVE	R19	R14
+      0x5C501800,  //  0062  MOVE	R20	R12
+      0x7C400800,  //  0063  CALL	R16	4
+      0x983C0E10,  //  0064  SETIDX	R15	R7	R16
+      0x70020001,  //  0065  JMP		#0068
+      0x8834010B,  //  0066  GETMBR	R13	R0	K11
+      0x98340F15,  //  0067  SETIDX	R13	R7	K21
+      0x70020001,  //  0068  JMP		#006B
+      0x882C010B,  //  0069  GETMBR	R11	R0	K11
+      0x982C0F15,  //  006A  SETIDX	R11	R7	K21
+      0x001C0F03,  //  006B  ADD	R7	R7	K3
+      0x7001FFB4,  //  006C  JMP		#0022
+      0x80000000,  //  006D  RET	0
     })
   )
 );
@@ -814,9 +1063,9 @@ be_local_closure(class_TwinkleAnimation_render,   /* name */
 /********************************************************************
 ** Solidified function: update
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation_update,   /* name */
+be_local_closure(class_ScaleAnimation_update,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    13,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -824,37 +1073,50 @@ be_local_closure(class_TwinkleAnimation_update,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
     be_str_weak(update),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08051F,  //  0003  GETMET	R2	R2	K31
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0001,  //  0006  JMPT	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x4C080000,  //  0009  LDNIL	R2
-      0x1C080202,  //  000A  EQ	R2	R1	R2
-      0x780A0001,  //  000B  JMPF	R2	#000E
-      0x88080108,  //  000C  GETMBR	R2	R0	K8
-      0x8804051C,  //  000D  GETMBR	R1	R2	K28
-      0x88080100,  //  000E  GETMBR	R2	R0	K0
-      0x540E03E7,  //  000F  LDINT	R3	1000
-      0x0C0C0602,  //  0010  DIV	R3	R3	R2
-      0x8810011A,  //  0011  GETMBR	R4	R0	K26
-      0x04100204,  //  0012  SUB	R4	R1	R4
-      0x28100803,  //  0013  GE	R4	R4	R3
-      0x78120003,  //  0014  JMPF	R4	#0019
-      0x90023401,  //  0015  SETMBR	R0	K26	R1
-      0x8C100120,  //  0016  GETMET	R4	R0	K32
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x7C100400,  //  0018  CALL	R4	2
-      0x50100200,  //  0019  LDBOOL	R4	1	0
-      0x80040800,  //  001A  RET	1	R4
+    ( &(const binstruction[40]) {  /* code */
+      0x88080117,  //  0000  GETMBR	R2	R0	K23
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x8810010D,  //  0002  GETMBR	R4	R0	K13
+      0x24140502,  //  0003  GT	R5	R2	K2
+      0x78160013,  //  0004  JMPF	R5	#0019
+      0x24140702,  //  0005  GT	R5	R3	K2
+      0x78160011,  //  0006  JMPF	R5	#0019
+      0x88140118,  //  0007  GETMBR	R5	R0	K24
+      0x04140205,  //  0008  SUB	R5	R1	R5
+      0xB81A0C00,  //  0009  GETNGBL	R6	K6
+      0x8C180D07,  //  000A  GETMET	R6	R6	K7
+      0x5C200400,  //  000B  MOVE	R8	R2
+      0x58240002,  //  000C  LDCONST	R9	K2
+      0x542A00FE,  //  000D  LDINT	R10	255
+      0x582C0002,  //  000E  LDCONST	R11	K2
+      0x58300008,  //  000F  LDCONST	R12	K8
+      0x7C180C00,  //  0010  CALL	R6	6
+      0x241C0D02,  //  0011  GT	R7	R6	K2
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x081C0A06,  //  0013  MUL	R7	R5	R6
+      0x542203E7,  //  0014  LDINT	R8	1000
+      0x0C1C0E08,  //  0015  DIV	R7	R7	R8
+      0x542200FF,  //  0016  LDINT	R8	256
+      0x101C0E08,  //  0017  MOD	R7	R7	R8
+      0x90020A07,  //  0018  SETMBR	R0	K5	R7
+      0x4C140000,  //  0019  LDNIL	R5
+      0x20140805,  //  001A  NE	R5	R4	R5
+      0x78160007,  //  001B  JMPF	R5	#0024
+      0x88140919,  //  001C  GETMBR	R5	R4	K25
+      0x74160002,  //  001D  JMPT	R5	#0021
+      0x8C14091A,  //  001E  GETMET	R5	R4	K26
+      0x881C0118,  //  001F  GETMBR	R7	R0	K24
+      0x7C140400,  //  0020  CALL	R5	2
+      0x8C14091B,  //  0021  GETMET	R5	R4	K27
+      0x5C1C0200,  //  0022  MOVE	R7	R1
+      0x7C140400,  //  0023  CALL	R5	2
+      0x8C14011C,  //  0024  GETMET	R5	R0	K28
+      0x7C140200,  //  0025  CALL	R5	1
+      0x50140200,  //  0026  LDBOOL	R5	1	0
+      0x80040A00,  //  0027  RET	1	R5
     })
   )
 );
@@ -862,9 +1124,192 @@ be_local_closure(class_TwinkleAnimation_update,   /* name */
 
 
 /********************************************************************
-** Solidified function: _initialize_arrays
+** Solidified function: tostring
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
+be_local_closure(class_ScaleAnimation_tostring,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x4008031D,  //  0002  CONNECT	R2	R1	K29
+      0x4008031E,  //  0003  CONNECT	R2	R1	K30
+      0x4008031F,  //  0004  CONNECT	R2	R1	K31
+      0x40080320,  //  0005  CONNECT	R2	R1	K32
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
+      0x880C0101,  //  0007  GETMBR	R3	R0	K1
+      0x88100117,  //  0008  GETMBR	R4	R0	K23
+      0x94140202,  //  0009  GETIDX	R5	R1	R2
+      0x4C180000,  //  000A  LDNIL	R6
+      0x20140A06,  //  000B  NE	R5	R5	R6
+      0x78160001,  //  000C  JMPF	R5	#000F
+      0x94140202,  //  000D  GETIDX	R5	R1	R2
+      0x70020000,  //  000E  JMP		#0010
+      0x58140021,  //  000F  LDCONST	R5	K33
+      0x60180018,  //  0010  GETGBL	R6	G24
+      0x581C0022,  //  0011  LDCONST	R7	K34
+      0x5C200A00,  //  0012  MOVE	R8	R5
+      0x5C240600,  //  0013  MOVE	R9	R3
+      0x5C280800,  //  0014  MOVE	R10	R4
+      0x7C180800,  //  0015  CALL	R6	4
+      0x80040C00,  //  0016  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ScaleAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_ScaleAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080523,  //  0003  GETMET	R2	R2	K35
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020B02,  //  0006  SETMBR	R0	K5	K2
+      0x88080109,  //  0007  GETMBR	R2	R0	K9
+      0x88080524,  //  0008  GETMBR	R2	R2	K36
+      0x90023002,  //  0009  SETMBR	R0	K24	R2
+      0x8C08010C,  //  000A  GETMET	R2	R0	K12
+      0x7C080200,  //  000B  CALL	R2	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _sine
+********************************************************************/
+be_local_closure(class_ScaleAnimation__sine,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(_sine),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0x540A003F,  //  0000  LDINT	R2	64
+      0x10080202,  //  0001  MOD	R2	R1	R2
+      0x540E003F,  //  0002  LDINT	R3	64
+      0x140C0203,  //  0003  LT	R3	R1	R3
+      0x780E0009,  //  0004  JMPF	R3	#000F
+      0xB80E0C00,  //  0005  GETNGBL	R3	K6
+      0x8C0C0707,  //  0006  GETMET	R3	R3	K7
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x58180002,  //  0008  LDCONST	R6	K2
+      0x541E003F,  //  0009  LDINT	R7	64
+      0x5422007F,  //  000A  LDINT	R8	128
+      0x542600FE,  //  000B  LDINT	R9	255
+      0x7C0C0C00,  //  000C  CALL	R3	6
+      0x80040600,  //  000D  RET	1	R3
+      0x70020025,  //  000E  JMP		#0035
+      0x540E007F,  //  000F  LDINT	R3	128
+      0x140C0203,  //  0010  LT	R3	R1	R3
+      0x780E000A,  //  0011  JMPF	R3	#001D
+      0xB80E0C00,  //  0012  GETNGBL	R3	K6
+      0x8C0C0707,  //  0013  GETMET	R3	R3	K7
+      0x5416007F,  //  0014  LDINT	R5	128
+      0x04140A01,  //  0015  SUB	R5	R5	R1
+      0x58180002,  //  0016  LDCONST	R6	K2
+      0x541E003F,  //  0017  LDINT	R7	64
+      0x5422007F,  //  0018  LDINT	R8	128
+      0x542600FE,  //  0019  LDINT	R9	255
+      0x7C0C0C00,  //  001A  CALL	R3	6
+      0x80040600,  //  001B  RET	1	R3
+      0x70020017,  //  001C  JMP		#0035
+      0x540E00BF,  //  001D  LDINT	R3	192
+      0x140C0203,  //  001E  LT	R3	R1	R3
+      0x780E000A,  //  001F  JMPF	R3	#002B
+      0xB80E0C00,  //  0020  GETNGBL	R3	K6
+      0x8C0C0707,  //  0021  GETMET	R3	R3	K7
+      0x5416007F,  //  0022  LDINT	R5	128
+      0x04140205,  //  0023  SUB	R5	R1	R5
+      0x58180002,  //  0024  LDCONST	R6	K2
+      0x541E003F,  //  0025  LDINT	R7	64
+      0x5422007F,  //  0026  LDINT	R8	128
+      0x58240002,  //  0027  LDCONST	R9	K2
+      0x7C0C0C00,  //  0028  CALL	R3	6
+      0x80040600,  //  0029  RET	1	R3
+      0x70020009,  //  002A  JMP		#0035
+      0xB80E0C00,  //  002B  GETNGBL	R3	K6
+      0x8C0C0707,  //  002C  GETMET	R3	R3	K7
+      0x541600FF,  //  002D  LDINT	R5	256
+      0x04140A01,  //  002E  SUB	R5	R5	R1
+      0x58180002,  //  002F  LDCONST	R6	K2
+      0x541E003F,  //  0030  LDINT	R7	64
+      0x5422007F,  //  0031  LDINT	R8	128
+      0x58240002,  //  0032  LDCONST	R9	K2
+      0x7C0C0C00,  //  0033  CALL	R3	6
+      0x80040600,  //  0034  RET	1	R3
+      0x80000000,  //  0035  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _initialize_buffers
+********************************************************************/
+be_local_closure(class_ScaleAnimation__initialize_buffers,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
@@ -874,31 +1319,33 @@ be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_initialize_arrays),
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(_initialize_buffers),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040108,  //  0000  GETMBR	R1	R0	K8
-      0x8C040309,  //  0001  GETMET	R1	R1	K9
+    ( &(const binstruction[23]) {  /* code */
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0001  GETMET	R1	R1	K10
       0x7C040200,  //  0002  CALL	R1	1
-      0x8808010A,  //  0003  GETMBR	R2	R0	K10
-      0x8C080521,  //  0004  GETMET	R2	R2	K33
+      0xB80A4A00,  //  0003  GETNGBL	R2	K37
+      0x8C080526,  //  0004  GETMET	R2	R2	K38
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
-      0x8808010D,  //  0007  GETMBR	R2	R0	K13
-      0x8C080521,  //  0008  GETMET	R2	R2	K33
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0x5808000C,  //  000B  LDCONST	R2	K12
-      0x140C0401,  //  000C  LT	R3	R2	R1
-      0x780E0005,  //  000D  JMPF	R3	#0014
-      0x880C010A,  //  000E  GETMBR	R3	R0	K10
-      0x980C050C,  //  000F  SETIDX	R3	R2	K12
-      0x880C010D,  //  0010  GETMBR	R3	R0	K13
-      0x980C050C,  //  0011  SETIDX	R3	R2	K12
-      0x00080501,  //  0012  ADD	R2	R2	K1
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x80000000,  //  0014  RET	0
+      0x90022002,  //  0007  SETMBR	R0	K16	R2
+      0x60080012,  //  0008  GETGBL	R2	G18
+      0x7C080000,  //  0009  CALL	R2	0
+      0x90021602,  //  000A  SETMBR	R0	K11	R2
+      0x8808010B,  //  000B  GETMBR	R2	R0	K11
+      0x8C080527,  //  000C  GETMET	R2	R2	K39
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x7C080400,  //  000E  CALL	R2	2
+      0x58080002,  //  000F  LDCONST	R2	K2
+      0x140C0401,  //  0010  LT	R3	R2	R1
+      0x780E0003,  //  0011  JMPF	R3	#0016
+      0x880C010B,  //  0012  GETMBR	R3	R0	K11
+      0x980C0515,  //  0013  SETIDX	R3	R2	K21
+      0x00080503,  //  0014  ADD	R2	R2	K3
+      0x7001FFF9,  //  0015  JMP		#0010
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -906,30 +1353,45 @@ be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
 
 
 /********************************************************************
-** Solidified function: _random
+** Solidified function: render
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation__random,   /* name */
+be_local_closure(class_ScaleAnimation_render,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
+    9,                          /* nstack */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_random),
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(render),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8804011B,  //  0000  GETMBR	R1	R0	K27
-      0x08040322,  //  0001  MUL	R1	R1	K34
-      0x540A3038,  //  0002  LDINT	R2	12345
-      0x00040202,  //  0003  ADD	R1	R1	R2
-      0x2C040323,  //  0004  AND	R1	R1	K35
-      0x90023601,  //  0005  SETMBR	R0	K27	R1
-      0x8804011B,  //  0006  GETMBR	R1	R0	K27
-      0x80040200,  //  0007  RET	1	R1
+    ( &(const binstruction[23]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0203,  //  0001  EQ	R3	R1	R3
+      0x780E0001,  //  0002  JMPF	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x880C0109,  //  0005  GETMBR	R3	R0	K9
+      0x8C0C070A,  //  0006  GETMET	R3	R3	K10
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x58100002,  //  0008  LDCONST	R4	K2
+      0x14140803,  //  0009  LT	R5	R4	R3
+      0x78160009,  //  000A  JMPF	R5	#0015
+      0x88140328,  //  000B  GETMBR	R5	R1	K40
+      0x14140805,  //  000C  LT	R5	R4	R5
+      0x78160004,  //  000D  JMPF	R5	#0013
+      0x8C140329,  //  000E  GETMET	R5	R1	K41
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x8820010B,  //  0010  GETMBR	R8	R0	K11
+      0x94201004,  //  0011  GETIDX	R8	R8	R4
+      0x7C140600,  //  0012  CALL	R5	3
+      0x00100903,  //  0013  ADD	R4	R4	K3
+      0x7001FFF3,  //  0014  JMP		#0009
+      0x50140200,  //  0015  LDBOOL	R5	1	0
+      0x80040A00,  //  0016  RET	1	R5
     })
   )
 );
@@ -937,11 +1399,100 @@ be_local_closure(class_TwinkleAnimation__random,   /* name */
 
 
 /********************************************************************
-** Solidified function: _random_range
+** Solidified function: _interpolate_colors
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation__random_range,   /* name */
+be_local_closure(class_ScaleAnimation__interpolate_colors,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    18,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(_interpolate_colors),
+    &be_const_str_solidified,
+    ( &(const binstruction[66]) {  /* code */
+      0x18100702,  //  0000  LE	R4	R3	K2
+      0x78120001,  //  0001  JMPF	R4	#0004
+      0x80040200,  //  0002  RET	1	R1
+      0x70020003,  //  0003  JMP		#0008
+      0x541200FF,  //  0004  LDINT	R4	256
+      0x28100604,  //  0005  GE	R4	R3	R4
+      0x78120000,  //  0006  JMPF	R4	#0008
+      0x80040400,  //  0007  RET	1	R2
+      0x54120017,  //  0008  LDINT	R4	24
+      0x3C100204,  //  0009  SHR	R4	R1	R4
+      0x541600FE,  //  000A  LDINT	R5	255
+      0x2C100805,  //  000B  AND	R4	R4	R5
+      0x5416000F,  //  000C  LDINT	R5	16
+      0x3C140205,  //  000D  SHR	R5	R1	R5
+      0x541A00FE,  //  000E  LDINT	R6	255
+      0x2C140A06,  //  000F  AND	R5	R5	R6
+      0x541A0007,  //  0010  LDINT	R6	8
+      0x3C180206,  //  0011  SHR	R6	R1	R6
+      0x541E00FE,  //  0012  LDINT	R7	255
+      0x2C180C07,  //  0013  AND	R6	R6	R7
+      0x541E00FE,  //  0014  LDINT	R7	255
+      0x2C1C0207,  //  0015  AND	R7	R1	R7
+      0x54220017,  //  0016  LDINT	R8	24
+      0x3C200408,  //  0017  SHR	R8	R2	R8
+      0x542600FE,  //  0018  LDINT	R9	255
+      0x2C201009,  //  0019  AND	R8	R8	R9
+      0x5426000F,  //  001A  LDINT	R9	16
+      0x3C240409,  //  001B  SHR	R9	R2	R9
+      0x542A00FE,  //  001C  LDINT	R10	255
+      0x2C24120A,  //  001D  AND	R9	R9	R10
+      0x542A0007,  //  001E  LDINT	R10	8
+      0x3C28040A,  //  001F  SHR	R10	R2	R10
+      0x542E00FE,  //  0020  LDINT	R11	255
+      0x2C28140B,  //  0021  AND	R10	R10	R11
+      0x542E00FE,  //  0022  LDINT	R11	255
+      0x2C2C040B,  //  0023  AND	R11	R2	R11
+      0x04301004,  //  0024  SUB	R12	R8	R4
+      0x08301803,  //  0025  MUL	R12	R12	R3
+      0x543600FF,  //  0026  LDINT	R13	256
+      0x0C30180D,  //  0027  DIV	R12	R12	R13
+      0x0030080C,  //  0028  ADD	R12	R4	R12
+      0x04341205,  //  0029  SUB	R13	R9	R5
+      0x08341A03,  //  002A  MUL	R13	R13	R3
+      0x543A00FF,  //  002B  LDINT	R14	256
+      0x0C341A0E,  //  002C  DIV	R13	R13	R14
+      0x00340A0D,  //  002D  ADD	R13	R5	R13
+      0x04381406,  //  002E  SUB	R14	R10	R6
+      0x08381C03,  //  002F  MUL	R14	R14	R3
+      0x543E00FF,  //  0030  LDINT	R15	256
+      0x0C381C0F,  //  0031  DIV	R14	R14	R15
+      0x00380C0E,  //  0032  ADD	R14	R6	R14
+      0x043C1607,  //  0033  SUB	R15	R11	R7
+      0x083C1E03,  //  0034  MUL	R15	R15	R3
+      0x544200FF,  //  0035  LDINT	R16	256
+      0x0C3C1E10,  //  0036  DIV	R15	R15	R16
+      0x003C0E0F,  //  0037  ADD	R15	R7	R15
+      0x54420017,  //  0038  LDINT	R16	24
+      0x38401810,  //  0039  SHL	R16	R12	R16
+      0x5446000F,  //  003A  LDINT	R17	16
+      0x38441A11,  //  003B  SHL	R17	R13	R17
+      0x30402011,  //  003C  OR	R16	R16	R17
+      0x54460007,  //  003D  LDINT	R17	8
+      0x38441C11,  //  003E  SHL	R17	R14	R17
+      0x30402011,  //  003F  OR	R16	R16	R17
+      0x3040200F,  //  0040  OR	R16	R16	R15
+      0x80042000,  //  0041  RET	1	R16
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_ScaleAnimation_start,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -949,17 +1500,24 @@ be_local_closure(class_TwinkleAnimation__random_range,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_random_range),
+    &be_ktab_class_ScaleAnimation,     /* shared constants */
+    be_str_weak(start),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x1808030C,  //  0000  LE	R2	R1	K12
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80061800,  //  0002  RET	1	K12
-      0x8C080124,  //  0003  GETMET	R2	R0	K36
-      0x7C080200,  //  0004  CALL	R2	1
-      0x10080401,  //  0005  MOD	R2	R2	R1
-      0x80040400,  //  0006  RET	1	R2
+    ( &(const binstruction[14]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051A,  //  0003  GETMET	R2	R2	K26
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020B02,  //  0006  SETMBR	R0	K5	K2
+      0x4C080000,  //  0007  LDNIL	R2
+      0x1C080202,  //  0008  EQ	R2	R1	R2
+      0x780A0001,  //  0009  JMPF	R2	#000C
+      0x88080109,  //  000A  GETMBR	R2	R0	K9
+      0x88040524,  //  000B  GETMBR	R1	R2	K36
+      0x90023001,  //  000C  SETMBR	R0	K24	R1
+      0x80040000,  //  000D  RET	1	R0
     })
   )
 );
@@ -967,73 +1525,76 @@ be_local_closure(class_TwinkleAnimation__random_range,   /* name */
 
 
 /********************************************************************
-** Solidified class: TwinkleAnimation
+** Solidified class: ScaleAnimation
 ********************************************************************/
 extern const bclass be_class_Animation;
-be_local_class(TwinkleAnimation,
+be_local_class(ScaleAnimation,
     4,
     &be_class_Animation,
-    be_nested_map(14,
+    be_nested_map(16,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_random_range, -1), be_const_closure(class_TwinkleAnimation__random_range_closure) },
-        { be_const_key_weak(twinkle_states, -1), be_const_var(0) },
-        { be_const_key_weak(init, -1), be_const_closure(class_TwinkleAnimation_init_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_TwinkleAnimation_tostring_closure) },
-        { be_const_key_weak(random_seed, -1), be_const_var(3) },
-        { be_const_key_weak(PARAMS, 6), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(_calculate_scale, -1), be_const_closure(class_ScaleAnimation__calculate_scale_closure) },
+        { be_const_key_weak(scale_phase, -1), be_const_var(0) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_ScaleAnimation_tostring_closure) },
+        { be_const_key_weak(PARAMS, 10), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fade_speed, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(180) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(twinkle_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(6) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(5000) },
-    }))    ) } )) },
-        { be_const_key_weak(density, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(scale_center, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(default, -1), be_const_int(128) },
         { be_const_key_weak(min, -1), be_const_int(0) },
         { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
-        { be_const_key_weak(max_brightness, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(scale_speed, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
+        { be_const_key_weak(default, -1), be_const_int(0) },
         { be_const_key_weak(min, -1), be_const_int(0) },
         { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
+        { be_const_key_weak(source_animation, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
+        { be_const_key_weak(default, -1), be_const_nil() },
+        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
     }))    ) } )) },
-        { be_const_key_weak(min_brightness, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(scale_factor, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(32) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
         { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
+        { be_const_key_weak(scale_mode, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(3) },
     }))    ) } )) },
-        { be_const_key_weak(_random, 9), be_const_closure(class_TwinkleAnimation__random_closure) },
-        { be_const_key_weak(last_update, -1), be_const_var(2) },
-        { be_const_key_weak(update, -1), be_const_closure(class_TwinkleAnimation_update_closure) },
-        { be_const_key_weak(_initialize_arrays, 10), be_const_closure(class_TwinkleAnimation__initialize_arrays_closure) },
-        { be_const_key_weak(render, 2), be_const_closure(class_TwinkleAnimation_render_closure) },
-        { be_const_key_weak(current_colors, -1), be_const_var(1) },
-        { be_const_key_weak(_update_twinkle_simulation, 1), be_const_closure(class_TwinkleAnimation__update_twinkle_simulation_closure) },
-        { be_const_key_weak(on_param_changed, 0), be_const_closure(class_TwinkleAnimation_on_param_changed_closure) },
+        { be_const_key_weak(interpolation, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(1) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(1) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(update, -1), be_const_closure(class_ScaleAnimation_update_closure) },
+        { be_const_key_weak(_get_current_scale_factor, 2), be_const_closure(class_ScaleAnimation__get_current_scale_factor_closure) },
+        { be_const_key_weak(source_frame, -1), be_const_var(1) },
+        { be_const_key_weak(current_colors, -1), be_const_var(2) },
+        { be_const_key_weak(render, -1), be_const_closure(class_ScaleAnimation_render_closure) },
+        { be_const_key_weak(start_time, -1), be_const_var(3) },
+        { be_const_key_weak(init, 0), be_const_closure(class_ScaleAnimation_init_closure) },
+        { be_const_key_weak(_sine, -1), be_const_closure(class_ScaleAnimation__sine_closure) },
+        { be_const_key_weak(_initialize_buffers, -1), be_const_closure(class_ScaleAnimation__initialize_buffers_closure) },
+        { be_const_key_weak(on_param_changed, 8), be_const_closure(class_ScaleAnimation_on_param_changed_closure) },
+        { be_const_key_weak(_interpolate_colors, -1), be_const_closure(class_ScaleAnimation__interpolate_colors_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(class_ScaleAnimation_start_closure) },
     })),
-    be_str_weak(TwinkleAnimation)
+    be_str_weak(ScaleAnimation)
 );
 
 /********************************************************************
@@ -1096,43 +1657,6 @@ be_local_closure(create_play_step,   /* name */
       0x980A0400,  //  0003  SETIDX	R2	K2	R0
       0x980A0601,  //  0004  SETIDX	R2	K3	R1
       0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: scale_oscillate
-********************************************************************/
-be_local_closure(scale_oscillate,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(scale_animation),
-    /* K2   */  be_nested_str_weak(scale_mode),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(scale_speed),
-    }),
-    be_str_weak(scale_oscillate),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A007F,  //  0005  LDINT	R2	128
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
-      0x80040200,  //  0007  RET	1	R1
     })
   )
 );
@@ -1458,6 +1982,43 @@ be_local_class(RichPaletteAnimation,
 );
 
 /********************************************************************
+** Solidified function: jitter_brightness
+********************************************************************/
+be_local_closure(jitter_brightness,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(jitter_animation),
+    /* K2   */  be_nested_str_weak(jitter_type),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(brightness_range),
+    }),
+    be_str_weak(jitter_brightness),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A0027,  //  0005  LDINT	R2	40
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: twinkle_solid
 ********************************************************************/
 be_local_closure(twinkle_solid,   /* name */
@@ -1506,667 +2067,37 @@ be_local_closure(twinkle_solid,   /* name */
 /*******************************************************************/
 
 
+extern const bclass be_class_PaletteGradientAnimation;
+
 /********************************************************************
-** Solidified function: get_user_function
+** Solidified function: init
 ********************************************************************/
-be_local_closure(get_user_function,   /* name */
+be_local_closure(class_PaletteGradientAnimation_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_animation_user_functions),
-    /* K2   */  be_nested_str_weak(find),
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(name),
+    /* K2   */  be_nested_str_weak(palette_gradient),
     }),
-    be_str_weak(get_user_function),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080301,  //  0001  GETMBR	R2	R1	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'JitterAnimation' ktab size: 47, total: 93 (saved 368 bytes)
-static const bvalue be_ktab_class_JitterAnimation[47] = {
-  /* K0   */  be_nested_str_weak(jitter_type),
-  /* K1   */  be_nested_str_weak(color_range),
-  /* K2   */  be_nested_str_weak(brightness_range),
-  /* K3   */  be_const_int(1),
-  /* K4   */  be_const_int(3),
-  /* K5   */  be_nested_str_weak(tasmota),
-  /* K6   */  be_nested_str_weak(scale_uint),
-  /* K7   */  be_const_int(0),
-  /* K8   */  be_nested_str_weak(_random_range),
-  /* K9   */  be_const_int(2),
-  /* K10  */  be_nested_str_weak(position),
-  /* K11  */  be_nested_str_weak(color),
-  /* K12  */  be_nested_str_weak(brightness),
-  /* K13  */  be_nested_str_weak(all),
-  /* K14  */  be_nested_str_weak(unknown),
-  /* K15  */  be_nested_str_weak(JitterAnimation_X28_X25s_X2C_X20intensity_X3D_X25s_X2C_X20frequency_X3D_X25s_X29),
-  /* K16  */  be_nested_str_weak(jitter_intensity),
-  /* K17  */  be_nested_str_weak(jitter_frequency),
-  /* K18  */  be_nested_str_weak(_random),
-  /* K19  */  be_nested_str_weak(init),
-  /* K20  */  be_nested_str_weak(random_seed),
-  /* K21  */  be_nested_str_weak(engine),
-  /* K22  */  be_nested_str_weak(time_ms),
-  /* K23  */  be_nested_str_weak(last_jitter_time),
-  /* K24  */  be_nested_str_weak(_initialize_buffers),
-  /* K25  */  be_nested_str_weak(get_strip_length),
-  /* K26  */  be_nested_str_weak(jitter_offsets),
-  /* K27  */  be_nested_str_weak(source_animation),
-  /* K28  */  be_nested_str_weak(position_range),
-  /* K29  */  be_nested_str_weak(source_frame),
-  /* K30  */  be_nested_str_weak(clear),
-  /* K31  */  be_nested_str_weak(render),
-  /* K32  */  be_const_int(-16777216),
-  /* K33  */  be_nested_str_weak(get_pixel_color),
-  /* K34  */  be_nested_str_weak(_apply_color_jitter),
-  /* K35  */  be_nested_str_weak(current_colors),
-  /* K36  */  be_nested_str_weak(width),
-  /* K37  */  be_nested_str_weak(set_pixel_color),
-  /* K38  */  be_const_int(1103515245),
-  /* K39  */  be_const_int(2147483647),
-  /* K40  */  be_nested_str_weak(_update_jitter),
-  /* K41  */  be_nested_str_weak(update),
-  /* K42  */  be_nested_str_weak(_calculate_jitter),
-  /* K43  */  be_nested_str_weak(start),
-  /* K44  */  be_nested_str_weak(resize),
-  /* K45  */  be_nested_str_weak(animation),
-  /* K46  */  be_nested_str_weak(frame_buffer),
-};
-
-
-extern const bclass be_class_JitterAnimation;
-
-/********************************************************************
-** Solidified function: _apply_color_jitter
-********************************************************************/
-be_local_closure(class_JitterAnimation__apply_color_jitter,   /* name */
-  be_nested_proto(
-    19,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_apply_color_jitter),
-    &be_const_str_solidified,
-    ( &(const binstruction[127]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
-      0x541A0017,  //  0003  LDINT	R6	24
-      0x3C180206,  //  0004  SHR	R6	R1	R6
-      0x541E00FE,  //  0005  LDINT	R7	255
-      0x2C180C07,  //  0006  AND	R6	R6	R7
-      0x541E000F,  //  0007  LDINT	R7	16
-      0x3C1C0207,  //  0008  SHR	R7	R1	R7
-      0x542200FE,  //  0009  LDINT	R8	255
-      0x2C1C0E08,  //  000A  AND	R7	R7	R8
-      0x54220007,  //  000B  LDINT	R8	8
-      0x3C200208,  //  000C  SHR	R8	R1	R8
-      0x542600FE,  //  000D  LDINT	R9	255
-      0x2C201009,  //  000E  AND	R8	R8	R9
-      0x542600FE,  //  000F  LDINT	R9	255
-      0x2C240209,  //  0010  AND	R9	R1	R9
-      0x1C280703,  //  0011  EQ	R10	R3	K3
-      0x742A0001,  //  0012  JMPT	R10	#0015
-      0x1C280704,  //  0013  EQ	R10	R3	K4
-      0x782A0013,  //  0014  JMPF	R10	#0029
-      0xB82A0A00,  //  0015  GETNGBL	R10	K5
-      0x8C281506,  //  0016  GETMET	R10	R10	K6
-      0x5C300800,  //  0017  MOVE	R12	R4
-      0x58340007,  //  0018  LDCONST	R13	K7
-      0x543A00FE,  //  0019  LDINT	R14	255
-      0x583C0007,  //  001A  LDCONST	R15	K7
-      0x5442001D,  //  001B  LDINT	R16	30
-      0x7C280C00,  //  001C  CALL	R10	6
-      0x8C2C0108,  //  001D  GETMET	R11	R0	K8
-      0x5C341400,  //  001E  MOVE	R13	R10
-      0x7C2C0400,  //  001F  CALL	R11	2
-      0x001C0E0B,  //  0020  ADD	R7	R7	R11
-      0x8C2C0108,  //  0021  GETMET	R11	R0	K8
-      0x5C341400,  //  0022  MOVE	R13	R10
-      0x7C2C0400,  //  0023  CALL	R11	2
-      0x0020100B,  //  0024  ADD	R8	R8	R11
-      0x8C2C0108,  //  0025  GETMET	R11	R0	K8
-      0x5C341400,  //  0026  MOVE	R13	R10
-      0x7C2C0400,  //  0027  CALL	R11	2
-      0x0024120B,  //  0028  ADD	R9	R9	R11
-      0x1C280709,  //  0029  EQ	R10	R3	K9
-      0x742A0001,  //  002A  JMPT	R10	#002D
-      0x1C280704,  //  002B  EQ	R10	R3	K4
-      0x782A002F,  //  002C  JMPF	R10	#005D
-      0xB82A0A00,  //  002D  GETNGBL	R10	K5
-      0x8C281506,  //  002E  GETMET	R10	R10	K6
-      0x5C300A00,  //  002F  MOVE	R12	R5
-      0x58340007,  //  0030  LDCONST	R13	K7
-      0x543A00FE,  //  0031  LDINT	R14	255
-      0x583C0007,  //  0032  LDCONST	R15	K7
-      0x54420031,  //  0033  LDINT	R16	50
-      0x7C280C00,  //  0034  CALL	R10	6
-      0x542E007F,  //  0035  LDINT	R11	128
-      0x8C300108,  //  0036  GETMET	R12	R0	K8
-      0x5C381400,  //  0037  MOVE	R14	R10
-      0x7C300400,  //  0038  CALL	R12	2
-      0x002C160C,  //  0039  ADD	R11	R11	R12
-      0x14301707,  //  003A  LT	R12	R11	K7
-      0x78320001,  //  003B  JMPF	R12	#003E
-      0x582C0007,  //  003C  LDCONST	R11	K7
-      0x70020003,  //  003D  JMP		#0042
-      0x543200FE,  //  003E  LDINT	R12	255
-      0x2430160C,  //  003F  GT	R12	R11	R12
-      0x78320000,  //  0040  JMPF	R12	#0042
-      0x542E00FE,  //  0041  LDINT	R11	255
-      0xB8320A00,  //  0042  GETNGBL	R12	K5
-      0x8C301906,  //  0043  GETMET	R12	R12	K6
-      0x5C380E00,  //  0044  MOVE	R14	R7
-      0x583C0007,  //  0045  LDCONST	R15	K7
-      0x544200FE,  //  0046  LDINT	R16	255
-      0x58440007,  //  0047  LDCONST	R17	K7
-      0x5C481600,  //  0048  MOVE	R18	R11
-      0x7C300C00,  //  0049  CALL	R12	6
-      0x5C1C1800,  //  004A  MOVE	R7	R12
-      0xB8320A00,  //  004B  GETNGBL	R12	K5
-      0x8C301906,  //  004C  GETMET	R12	R12	K6
-      0x5C381000,  //  004D  MOVE	R14	R8
-      0x583C0007,  //  004E  LDCONST	R15	K7
-      0x544200FE,  //  004F  LDINT	R16	255
-      0x58440007,  //  0050  LDCONST	R17	K7
-      0x5C481600,  //  0051  MOVE	R18	R11
-      0x7C300C00,  //  0052  CALL	R12	6
-      0x5C201800,  //  0053  MOVE	R8	R12
-      0xB8320A00,  //  0054  GETNGBL	R12	K5
-      0x8C301906,  //  0055  GETMET	R12	R12	K6
-      0x5C381200,  //  0056  MOVE	R14	R9
-      0x583C0007,  //  0057  LDCONST	R15	K7
-      0x544200FE,  //  0058  LDINT	R16	255
-      0x58440007,  //  0059  LDCONST	R17	K7
-      0x5C481600,  //  005A  MOVE	R18	R11
-      0x7C300C00,  //  005B  CALL	R12	6
-      0x5C241800,  //  005C  MOVE	R9	R12
-      0x542A00FE,  //  005D  LDINT	R10	255
-      0x24280E0A,  //  005E  GT	R10	R7	R10
-      0x782A0001,  //  005F  JMPF	R10	#0062
-      0x541E00FE,  //  0060  LDINT	R7	255
-      0x70020002,  //  0061  JMP		#0065
-      0x14280F07,  //  0062  LT	R10	R7	K7
-      0x782A0000,  //  0063  JMPF	R10	#0065
-      0x581C0007,  //  0064  LDCONST	R7	K7
-      0x542A00FE,  //  0065  LDINT	R10	255
-      0x2428100A,  //  0066  GT	R10	R8	R10
-      0x782A0001,  //  0067  JMPF	R10	#006A
-      0x542200FE,  //  0068  LDINT	R8	255
-      0x70020002,  //  0069  JMP		#006D
-      0x14281107,  //  006A  LT	R10	R8	K7
-      0x782A0000,  //  006B  JMPF	R10	#006D
-      0x58200007,  //  006C  LDCONST	R8	K7
-      0x542A00FE,  //  006D  LDINT	R10	255
-      0x2428120A,  //  006E  GT	R10	R9	R10
-      0x782A0001,  //  006F  JMPF	R10	#0072
-      0x542600FE,  //  0070  LDINT	R9	255
-      0x70020002,  //  0071  JMP		#0075
-      0x14281307,  //  0072  LT	R10	R9	K7
-      0x782A0000,  //  0073  JMPF	R10	#0075
-      0x58240007,  //  0074  LDCONST	R9	K7
-      0x542A0017,  //  0075  LDINT	R10	24
-      0x38280C0A,  //  0076  SHL	R10	R6	R10
-      0x542E000F,  //  0077  LDINT	R11	16
-      0x382C0E0B,  //  0078  SHL	R11	R7	R11
-      0x3028140B,  //  0079  OR	R10	R10	R11
-      0x542E0007,  //  007A  LDINT	R11	8
-      0x382C100B,  //  007B  SHL	R11	R8	R11
-      0x3028140B,  //  007C  OR	R10	R10	R11
-      0x30281409,  //  007D  OR	R10	R10	R9
-      0x80041400,  //  007E  RET	1	R10
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_JitterAnimation_tostring,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x4008030A,  //  0002  CONNECT	R2	R1	K10
-      0x4008030B,  //  0003  CONNECT	R2	R1	K11
-      0x4008030C,  //  0004  CONNECT	R2	R1	K12
-      0x4008030D,  //  0005  CONNECT	R2	R1	K13
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x940C0202,  //  0007  GETIDX	R3	R1	R2
-      0x4C100000,  //  0008  LDNIL	R4
-      0x200C0604,  //  0009  NE	R3	R3	R4
-      0x780E0001,  //  000A  JMPF	R3	#000D
-      0x940C0202,  //  000B  GETIDX	R3	R1	R2
-      0x70020000,  //  000C  JMP		#000E
-      0x580C000E,  //  000D  LDCONST	R3	K14
-      0x60100018,  //  000E  GETGBL	R4	G24
-      0x5814000F,  //  000F  LDCONST	R5	K15
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x881C0110,  //  0011  GETMBR	R7	R0	K16
-      0x88200111,  //  0012  GETMBR	R8	R0	K17
-      0x7C100800,  //  0013  CALL	R4	4
-      0x80040800,  //  0014  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _random_range
-********************************************************************/
-be_local_closure(class_JitterAnimation__random_range,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_random_range),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x18080307,  //  0000  LE	R2	R1	K7
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80060E00,  //  0002  RET	1	K7
-      0x8C080112,  //  0003  GETMET	R2	R0	K18
-      0x7C080200,  //  0004  CALL	R2	1
-      0x080C0309,  //  0005  MUL	R3	R1	K9
-      0x000C0703,  //  0006  ADD	R3	R3	K3
-      0x10080403,  //  0007  MOD	R2	R2	R3
-      0x040C0401,  //  0008  SUB	R3	R2	R1
-      0x80040600,  //  0009  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_JitterAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080513,  //  0003  GETMET	R2	R2	K19
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x88080115,  //  0006  GETMBR	R2	R0	K21
-      0x88080516,  //  0007  GETMBR	R2	R2	K22
-      0x540EFFFF,  //  0008  LDINT	R3	65536
-      0x10080403,  //  0009  MOD	R2	R2	R3
-      0x90022802,  //  000A  SETMBR	R0	K20	R2
-      0x90022F07,  //  000B  SETMBR	R0	K23	K7
-      0x8C080118,  //  000C  GETMET	R2	R0	K24
-      0x7C080200,  //  000D  CALL	R2	1
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_jitter
-********************************************************************/
-be_local_closure(class_JitterAnimation__update_jitter,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_update_jitter),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
-      0x8C040319,  //  0001  GETMET	R1	R1	K25
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88080110,  //  0003  GETMBR	R2	R0	K16
-      0xB80E0A00,  //  0004  GETNGBL	R3	K5
-      0x8C0C0706,  //  0005  GETMET	R3	R3	K6
-      0x5C140400,  //  0006  MOVE	R5	R2
-      0x58180007,  //  0007  LDCONST	R6	K7
-      0x541E00FE,  //  0008  LDINT	R7	255
-      0x58200007,  //  0009  LDCONST	R8	K7
-      0x54260009,  //  000A  LDINT	R9	10
-      0x7C0C0C00,  //  000B  CALL	R3	6
-      0x58100007,  //  000C  LDCONST	R4	K7
-      0x14140801,  //  000D  LT	R5	R4	R1
-      0x78160006,  //  000E  JMPF	R5	#0016
-      0x8814011A,  //  000F  GETMBR	R5	R0	K26
-      0x8C180108,  //  0010  GETMET	R6	R0	K8
-      0x5C200600,  //  0011  MOVE	R8	R3
-      0x7C180400,  //  0012  CALL	R6	2
-      0x98140806,  //  0013  SETIDX	R5	R4	R6
-      0x00100903,  //  0014  ADD	R4	R4	K3
-      0x7001FFF6,  //  0015  JMP		#000D
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _calculate_jitter
-********************************************************************/
-be_local_closure(class_JitterAnimation__calculate_jitter,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_calculate_jitter),
-    &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
-      0x8C040319,  //  0001  GETMET	R1	R1	K25
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8808011B,  //  0003  GETMBR	R2	R0	K27
-      0x880C0100,  //  0004  GETMBR	R3	R0	K0
-      0x8810011C,  //  0005  GETMBR	R4	R0	K28
-      0x8814011D,  //  0006  GETMBR	R5	R0	K29
-      0x8C140B1E,  //  0007  GETMET	R5	R5	K30
-      0x7C140200,  //  0008  CALL	R5	1
-      0x4C140000,  //  0009  LDNIL	R5
-      0x20140405,  //  000A  NE	R5	R2	R5
-      0x78160003,  //  000B  JMPF	R5	#0010
-      0x8C14051F,  //  000C  GETMET	R5	R2	K31
-      0x881C011D,  //  000D  GETMBR	R7	R0	K29
-      0x58200007,  //  000E  LDCONST	R8	K7
-      0x7C140600,  //  000F  CALL	R5	3
-      0x58140007,  //  0010  LDCONST	R5	K7
-      0x14180A01,  //  0011  LT	R6	R5	R1
-      0x781A0033,  //  0012  JMPF	R6	#0047
-      0x58180020,  //  0013  LDCONST	R6	K32
-      0x1C1C0707,  //  0014  EQ	R7	R3	K7
-      0x741E0001,  //  0015  JMPT	R7	#0018
-      0x1C1C0704,  //  0016  EQ	R7	R3	K4
-      0x781E0018,  //  0017  JMPF	R7	#0031
-      0xB81E0A00,  //  0018  GETNGBL	R7	K5
-      0x8C1C0F06,  //  0019  GETMET	R7	R7	K6
-      0x8824011A,  //  001A  GETMBR	R9	R0	K26
-      0x94241205,  //  001B  GETIDX	R9	R9	R5
-      0x5429FFF5,  //  001C  LDINT	R10	-10
-      0x542E0009,  //  001D  LDINT	R11	10
-      0x44300800,  //  001E  NEG	R12	R4
-      0x54360009,  //  001F  LDINT	R13	10
-      0x0C30180D,  //  0020  DIV	R12	R12	R13
-      0x54360009,  //  0021  LDINT	R13	10
-      0x0C34080D,  //  0022  DIV	R13	R4	R13
-      0x7C1C0C00,  //  0023  CALL	R7	6
-      0x00200A07,  //  0024  ADD	R8	R5	R7
-      0x28241107,  //  0025  GE	R9	R8	K7
-      0x78260007,  //  0026  JMPF	R9	#002F
-      0x14241001,  //  0027  LT	R9	R8	R1
-      0x78260005,  //  0028  JMPF	R9	#002F
-      0x8824011D,  //  0029  GETMBR	R9	R0	K29
-      0x8C241321,  //  002A  GETMET	R9	R9	K33
-      0x5C2C1000,  //  002B  MOVE	R11	R8
-      0x7C240400,  //  002C  CALL	R9	2
-      0x5C181200,  //  002D  MOVE	R6	R9
-      0x70020000,  //  002E  JMP		#0030
-      0x58180020,  //  002F  LDCONST	R6	K32
-      0x70020004,  //  0030  JMP		#0036
-      0x881C011D,  //  0031  GETMBR	R7	R0	K29
-      0x8C1C0F21,  //  0032  GETMET	R7	R7	K33
-      0x5C240A00,  //  0033  MOVE	R9	R5
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x5C180E00,  //  0035  MOVE	R6	R7
-      0x1C1C0703,  //  0036  EQ	R7	R3	K3
-      0x741E0003,  //  0037  JMPT	R7	#003C
-      0x1C1C0709,  //  0038  EQ	R7	R3	K9
-      0x741E0001,  //  0039  JMPT	R7	#003C
-      0x1C1C0704,  //  003A  EQ	R7	R3	K4
-      0x781E0006,  //  003B  JMPF	R7	#0043
-      0x201C0D20,  //  003C  NE	R7	R6	K32
-      0x781E0004,  //  003D  JMPF	R7	#0043
-      0x8C1C0122,  //  003E  GETMET	R7	R0	K34
-      0x5C240C00,  //  003F  MOVE	R9	R6
-      0x5C280A00,  //  0040  MOVE	R10	R5
-      0x7C1C0600,  //  0041  CALL	R7	3
-      0x5C180E00,  //  0042  MOVE	R6	R7
-      0x881C0123,  //  0043  GETMBR	R7	R0	K35
-      0x981C0A06,  //  0044  SETIDX	R7	R5	R6
-      0x00140B03,  //  0045  ADD	R5	R5	K3
-      0x7001FFC9,  //  0046  JMP		#0011
-      0x80000000,  //  0047  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_JitterAnimation_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0203,  //  0001  EQ	R3	R1	R3
-      0x780E0001,  //  0002  JMPF	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x880C0115,  //  0005  GETMBR	R3	R0	K21
-      0x8C0C0719,  //  0006  GETMET	R3	R3	K25
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x58100007,  //  0008  LDCONST	R4	K7
-      0x14140803,  //  0009  LT	R5	R4	R3
-      0x78160009,  //  000A  JMPF	R5	#0015
-      0x88140324,  //  000B  GETMBR	R5	R1	K36
-      0x14140805,  //  000C  LT	R5	R4	R5
-      0x78160004,  //  000D  JMPF	R5	#0013
-      0x8C140325,  //  000E  GETMET	R5	R1	K37
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x88200123,  //  0010  GETMBR	R8	R0	K35
-      0x94201004,  //  0011  GETIDX	R8	R8	R4
-      0x7C140600,  //  0012  CALL	R5	3
-      0x00100903,  //  0013  ADD	R4	R4	K3
-      0x7001FFF3,  //  0014  JMP		#0009
-      0x50140200,  //  0015  LDBOOL	R5	1	0
-      0x80040A00,  //  0016  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _random
-********************************************************************/
-be_local_closure(class_JitterAnimation__random,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_random),
-    &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88040114,  //  0000  GETMBR	R1	R0	K20
-      0x08040326,  //  0001  MUL	R1	R1	K38
-      0x540A3038,  //  0002  LDINT	R2	12345
-      0x00040202,  //  0003  ADD	R1	R1	R2
-      0x2C040327,  //  0004  AND	R1	R1	K39
-      0x90022801,  //  0005  SETMBR	R0	K20	R1
-      0x88040114,  //  0006  GETMBR	R1	R0	K20
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_JitterAnimation_update,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x88080111,  //  0000  GETMBR	R2	R0	K17
-      0x880C011B,  //  0001  GETMBR	R3	R0	K27
-      0x24100507,  //  0002  GT	R4	R2	K7
-      0x78120014,  //  0003  JMPF	R4	#0019
-      0xB8120A00,  //  0004  GETNGBL	R4	K5
-      0x8C100906,  //  0005  GETMET	R4	R4	K6
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x581C0007,  //  0007  LDCONST	R7	K7
-      0x542200FE,  //  0008  LDINT	R8	255
-      0x58240007,  //  0009  LDCONST	R9	K7
-      0x542A001D,  //  000A  LDINT	R10	30
-      0x7C100C00,  //  000B  CALL	R4	6
-      0x24140907,  //  000C  GT	R5	R4	K7
-      0x78160002,  //  000D  JMPF	R5	#0011
-      0x541603E7,  //  000E  LDINT	R5	1000
-      0x0C140A04,  //  000F  DIV	R5	R5	R4
-      0x70020000,  //  0010  JMP		#0012
-      0x541603E7,  //  0011  LDINT	R5	1000
-      0x88180117,  //  0012  GETMBR	R6	R0	K23
-      0x04180206,  //  0013  SUB	R6	R1	R6
-      0x28180C05,  //  0014  GE	R6	R6	R5
-      0x781A0002,  //  0015  JMPF	R6	#0019
-      0x90022E01,  //  0016  SETMBR	R0	K23	R1
-      0x8C180128,  //  0017  GETMET	R6	R0	K40
-      0x7C180200,  //  0018  CALL	R6	1
-      0x4C100000,  //  0019  LDNIL	R4
-      0x20100604,  //  001A  NE	R4	R3	R4
-      0x78120002,  //  001B  JMPF	R4	#001F
-      0x8C100729,  //  001C  GETMET	R4	R3	K41
-      0x5C180200,  //  001D  MOVE	R6	R1
-      0x7C100400,  //  001E  CALL	R4	2
-      0x8C10012A,  //  001F  GETMET	R4	R0	K42
-      0x7C100200,  //  0020  CALL	R4	1
-      0x50100200,  //  0021  LDBOOL	R4	1	0
-      0x80040800,  //  0022  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_JitterAnimation_start,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C08052B,  //  0003  GETMET	R2	R2	K43
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x4C080000,  //  0006  LDNIL	R2
-      0x20080202,  //  0007  NE	R2	R1	R2
-      0x780A0001,  //  0008  JMPF	R2	#000B
-      0x5C080200,  //  0009  MOVE	R2	R1
-      0x70020001,  //  000A  JMP		#000D
-      0x88080115,  //  000B  GETMBR	R2	R0	K21
-      0x88080516,  //  000C  GETMBR	R2	R2	K22
-      0x90022E02,  //  000D  SETMBR	R0	K23	R2
-      0x8C080118,  //  000E  GETMET	R2	R0	K24
-      0x7C080200,  //  000F  CALL	R2	1
-      0x80040000,  //  0010  RET	1	R0
+      0x90020302,  //  0006  SETMBR	R0	K1	K2
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -2174,54 +2105,76 @@ be_local_closure(class_JitterAnimation_start,   /* name */
 
 
 /********************************************************************
-** Solidified function: _initialize_buffers
+** Solidified function: _update_value_buffer
 ********************************************************************/
-be_local_closure(class_JitterAnimation__initialize_buffers,   /* name */
+be_local_closure(class_PaletteGradientAnimation__update_value_buffer,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
+    16,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_JitterAnimation,     /* shared constants */
-    be_str_weak(_initialize_buffers),
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shift_period),
+    /* K1   */  be_nested_str_weak(engine),
+    /* K2   */  be_nested_str_weak(get_strip_length),
+    /* K3   */  be_nested_str_weak(value_buffer),
+    /* K4   */  be_nested_str_weak(resize),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(scale_uint),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_const_real_hex(0x447A0000),
+    /* K9   */  be_const_int(1),
+    }),
+    be_str_weak(_update_value_buffer),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x88040115,  //  0000  GETMBR	R1	R0	K21
-      0x8C040319,  //  0001  GETMET	R1	R1	K25
-      0x7C040200,  //  0002  CALL	R1	1
-      0x60080012,  //  0003  GETGBL	R2	G18
-      0x7C080000,  //  0004  CALL	R2	0
-      0x90023402,  //  0005  SETMBR	R0	K26	R2
-      0x8808011A,  //  0006  GETMBR	R2	R0	K26
-      0x8C08052C,  //  0007  GETMET	R2	R2	K44
-      0x5C100200,  //  0008  MOVE	R4	R1
-      0x7C080400,  //  0009  CALL	R2	2
-      0xB80A5A00,  //  000A  GETNGBL	R2	K45
-      0x8C08052E,  //  000B  GETMET	R2	R2	K46
-      0x5C100200,  //  000C  MOVE	R4	R1
-      0x7C080400,  //  000D  CALL	R2	2
-      0x90023A02,  //  000E  SETMBR	R0	K29	R2
-      0x60080012,  //  000F  GETGBL	R2	G18
-      0x7C080000,  //  0010  CALL	R2	0
-      0x90024602,  //  0011  SETMBR	R0	K35	R2
-      0x88080123,  //  0012  GETMBR	R2	R0	K35
-      0x8C08052C,  //  0013  GETMET	R2	R2	K44
-      0x5C100200,  //  0014  MOVE	R4	R1
-      0x7C080400,  //  0015  CALL	R2	2
-      0x58080007,  //  0016  LDCONST	R2	K7
-      0x140C0401,  //  0017  LT	R3	R2	R1
-      0x780E0005,  //  0018  JMPF	R3	#001F
-      0x880C011A,  //  0019  GETMBR	R3	R0	K26
-      0x980C0507,  //  001A  SETIDX	R3	R2	K7
-      0x880C0123,  //  001B  GETMBR	R3	R0	K35
-      0x980C0520,  //  001C  SETIDX	R3	R2	K32
-      0x00080503,  //  001D  ADD	R2	R2	K3
-      0x7001FFF7,  //  001E  JMP		#0017
-      0x80000000,  //  001F  RET	0
+    ( &(const binstruction[43]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x6010000C,  //  0004  GETGBL	R4	G12
+      0x88140103,  //  0005  GETMBR	R5	R0	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x20100803,  //  0007  NE	R4	R4	R3
+      0x78120003,  //  0008  JMPF	R4	#000D
+      0x88100103,  //  0009  GETMBR	R4	R0	K3
+      0x8C100904,  //  000A  GETMET	R4	R4	K4
+      0x5C180600,  //  000B  MOVE	R6	R3
+      0x7C100400,  //  000C  CALL	R4	2
+      0xB8120A00,  //  000D  GETNGBL	R4	K5
+      0x8C100906,  //  000E  GETMET	R4	R4	K6
+      0x10180202,  //  000F  MOD	R6	R1	R2
+      0x581C0007,  //  0010  LDCONST	R7	K7
+      0x5C200400,  //  0011  MOVE	R8	R2
+      0x58240007,  //  0012  LDCONST	R9	K7
+      0x542A03E7,  //  0013  LDINT	R10	1000
+      0x7C100C00,  //  0014  CALL	R4	6
+      0x0C100908,  //  0015  DIV	R4	R4	K8
+      0x60140009,  //  0016  GETGBL	R5	G9
+      0x08180803,  //  0017  MUL	R6	R4	R3
+      0x7C140200,  //  0018  CALL	R5	1
+      0x58180007,  //  0019  LDCONST	R6	K7
+      0x141C0C03,  //  001A  LT	R7	R6	R3
+      0x781E000D,  //  001B  JMPF	R7	#002A
+      0x001C0C05,  //  001C  ADD	R7	R6	R5
+      0x101C0E03,  //  001D  MOD	R7	R7	R3
+      0x88200103,  //  001E  GETMBR	R8	R0	K3
+      0xB8260A00,  //  001F  GETNGBL	R9	K5
+      0x8C241306,  //  0020  GETMET	R9	R9	K6
+      0x5C2C0E00,  //  0021  MOVE	R11	R7
+      0x58300007,  //  0022  LDCONST	R12	K7
+      0x04340709,  //  0023  SUB	R13	R3	K9
+      0x58380007,  //  0024  LDCONST	R14	K7
+      0x543E0063,  //  0025  LDINT	R15	100
+      0x7C240C00,  //  0026  CALL	R9	6
+      0x98200C09,  //  0027  SETIDX	R8	R6	R9
+      0x00180D09,  //  0028  ADD	R6	R6	K9
+      0x7001FFEF,  //  0029  JMP		#001A
+      0x80000000,  //  002A  RET	0
     })
   )
 );
@@ -2229,84 +2182,28 @@ be_local_closure(class_JitterAnimation__initialize_buffers,   /* name */
 
 
 /********************************************************************
-** Solidified class: JitterAnimation
+** Solidified class: PaletteGradientAnimation
 ********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(JitterAnimation,
-    5,
-    &be_class_Animation,
-    be_nested_map(17,
+extern const bclass be_class_PalettePatternAnimation;
+be_local_class(PaletteGradientAnimation,
+    0,
+    &be_class_PalettePatternAnimation,
+    be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_apply_color_jitter, 8), be_const_closure(class_JitterAnimation__apply_color_jitter_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_JitterAnimation_tostring_closure) },
-        { be_const_key_weak(jitter_offsets, 7), be_const_var(2) },
-        { be_const_key_weak(_initialize_buffers, 9), be_const_closure(class_JitterAnimation__initialize_buffers_closure) },
-        { be_const_key_weak(last_jitter_time, -1), be_const_var(1) },
-        { be_const_key_weak(start, -1), be_const_closure(class_JitterAnimation_start_closure) },
-        { be_const_key_weak(update, -1), be_const_closure(class_JitterAnimation_update_closure) },
-        { be_const_key_weak(_update_jitter, 1), be_const_closure(class_JitterAnimation__update_jitter_closure) },
-        { be_const_key_weak(_random, 11), be_const_closure(class_JitterAnimation__random_closure) },
-        { be_const_key_weak(source_frame, -1), be_const_var(3) },
-        { be_const_key_weak(render, -1), be_const_closure(class_JitterAnimation_render_closure) },
-        { be_const_key_weak(current_colors, -1), be_const_var(4) },
-        { be_const_key_weak(random_seed, -1), be_const_var(0) },
-        { be_const_key_weak(_random_range, 6), be_const_closure(class_JitterAnimation__random_range_closure) },
-        { be_const_key_weak(_calculate_jitter, 5), be_const_closure(class_JitterAnimation__calculate_jitter_closure) },
-        { be_const_key_weak(init, 3), be_const_closure(class_JitterAnimation_init_closure) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(7,
+        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(brightness_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(40) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(jitter_intensity, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(100) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(jitter_type, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(3) },
-    }))    ) } )) },
-        { be_const_key_weak(color_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(30) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(source_animation, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(shift_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-        { be_const_key_weak(position_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(jitter_frequency, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(60) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
+        { be_const_key_weak(default, -1), be_const_int(10000) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_PaletteGradientAnimation_init_closure) },
+        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteGradientAnimation__update_value_buffer_closure) },
     })),
-    be_str_weak(JitterAnimation)
+    be_str_weak(PaletteGradientAnimation)
 );
 
 /********************************************************************
@@ -4116,6 +4013,46 @@ be_local_closure(jitter_position,   /* name */
 
 
 /********************************************************************
+** Solidified function: shift_fast_scroll
+********************************************************************/
+be_local_closure(shift_fast_scroll,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(shift_animation),
+    /* K2   */  be_nested_str_weak(direction),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(shift_speed),
+    /* K5   */  be_nested_str_weak(wrap_around),
+    }),
+    be_str_weak(shift_fast_scroll),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A00C7,  //  0005  LDINT	R2	200
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
+      0x50080200,  //  0007  LDBOOL	R2	1	0
+      0x90060A02,  //  0008  SETMBR	R1	K5	R2
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: scale_grow
 ********************************************************************/
 be_local_closure(scale_grow,   /* name */
@@ -4151,172 +4088,204 @@ be_local_closure(scale_grow,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'ShiftAnimation' ktab size: 33, total: 62 (saved 232 bytes)
-static const bvalue be_ktab_class_ShiftAnimation[33] = {
-  /* K0   */  be_nested_str_weak(engine),
-  /* K1   */  be_nested_str_weak(get_strip_length),
-  /* K2   */  be_nested_str_weak(source_frame),
-  /* K3   */  be_nested_str_weak(animation),
-  /* K4   */  be_nested_str_weak(frame_buffer),
-  /* K5   */  be_nested_str_weak(current_colors),
-  /* K6   */  be_nested_str_weak(resize),
+// compact class 'JitterAnimation' ktab size: 47, total: 93 (saved 368 bytes)
+static const bvalue be_ktab_class_JitterAnimation[47] = {
+  /* K0   */  be_nested_str_weak(jitter_type),
+  /* K1   */  be_nested_str_weak(color_range),
+  /* K2   */  be_nested_str_weak(brightness_range),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_const_int(3),
+  /* K5   */  be_nested_str_weak(tasmota),
+  /* K6   */  be_nested_str_weak(scale_uint),
   /* K7   */  be_const_int(0),
-  /* K8   */  be_const_int(-16777216),
-  /* K9   */  be_const_int(1),
-  /* K10  */  be_nested_str_weak(update),
-  /* K11  */  be_nested_str_weak(shift_speed),
-  /* K12  */  be_nested_str_weak(direction),
-  /* K13  */  be_nested_str_weak(wrap_around),
-  /* K14  */  be_nested_str_weak(source_animation),
-  /* K15  */  be_nested_str_weak(start_time),
-  /* K16  */  be_nested_str_weak(tasmota),
-  /* K17  */  be_nested_str_weak(scale_uint),
-  /* K18  */  be_nested_str_weak(current_offset),
-  /* K19  */  be_nested_str_weak(is_running),
-  /* K20  */  be_nested_str_weak(start),
-  /* K21  */  be_nested_str_weak(_calculate_shift),
-  /* K22  */  be_nested_str_weak(priority),
-  /* K23  */  be_nested_str_weak(right),
-  /* K24  */  be_nested_str_weak(left),
-  /* K25  */  be_nested_str_weak(ShiftAnimation_X28_X25s_X2C_X20speed_X3D_X25s_X2C_X20wrap_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K26  */  be_nested_str_weak(width),
-  /* K27  */  be_nested_str_weak(set_pixel_color),
-  /* K28  */  be_nested_str_weak(_initialize_buffers),
-  /* K29  */  be_nested_str_weak(clear),
-  /* K30  */  be_nested_str_weak(render),
-  /* K31  */  be_nested_str_weak(get_pixel_color),
-  /* K32  */  be_nested_str_weak(init),
+  /* K8   */  be_nested_str_weak(_random_range),
+  /* K9   */  be_const_int(2),
+  /* K10  */  be_nested_str_weak(position),
+  /* K11  */  be_nested_str_weak(color),
+  /* K12  */  be_nested_str_weak(brightness),
+  /* K13  */  be_nested_str_weak(all),
+  /* K14  */  be_nested_str_weak(unknown),
+  /* K15  */  be_nested_str_weak(JitterAnimation_X28_X25s_X2C_X20intensity_X3D_X25s_X2C_X20frequency_X3D_X25s_X29),
+  /* K16  */  be_nested_str_weak(jitter_intensity),
+  /* K17  */  be_nested_str_weak(jitter_frequency),
+  /* K18  */  be_nested_str_weak(_random),
+  /* K19  */  be_nested_str_weak(init),
+  /* K20  */  be_nested_str_weak(random_seed),
+  /* K21  */  be_nested_str_weak(engine),
+  /* K22  */  be_nested_str_weak(time_ms),
+  /* K23  */  be_nested_str_weak(last_jitter_time),
+  /* K24  */  be_nested_str_weak(_initialize_buffers),
+  /* K25  */  be_nested_str_weak(get_strip_length),
+  /* K26  */  be_nested_str_weak(jitter_offsets),
+  /* K27  */  be_nested_str_weak(source_animation),
+  /* K28  */  be_nested_str_weak(position_range),
+  /* K29  */  be_nested_str_weak(source_frame),
+  /* K30  */  be_nested_str_weak(clear),
+  /* K31  */  be_nested_str_weak(render),
+  /* K32  */  be_const_int(-16777216),
+  /* K33  */  be_nested_str_weak(get_pixel_color),
+  /* K34  */  be_nested_str_weak(_apply_color_jitter),
+  /* K35  */  be_nested_str_weak(current_colors),
+  /* K36  */  be_nested_str_weak(width),
+  /* K37  */  be_nested_str_weak(set_pixel_color),
+  /* K38  */  be_const_int(1103515245),
+  /* K39  */  be_const_int(2147483647),
+  /* K40  */  be_nested_str_weak(_update_jitter),
+  /* K41  */  be_nested_str_weak(update),
+  /* K42  */  be_nested_str_weak(_calculate_jitter),
+  /* K43  */  be_nested_str_weak(start),
+  /* K44  */  be_nested_str_weak(resize),
+  /* K45  */  be_nested_str_weak(animation),
+  /* K46  */  be_nested_str_weak(frame_buffer),
 };
 
 
-extern const bclass be_class_ShiftAnimation;
+extern const bclass be_class_JitterAnimation;
 
 /********************************************************************
-** Solidified function: _initialize_buffers
+** Solidified function: _apply_color_jitter
 ********************************************************************/
-be_local_closure(class_ShiftAnimation__initialize_buffers,   /* name */
+be_local_closure(class_JitterAnimation__apply_color_jitter,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    19,                          /* nstack */
+    3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(_initialize_buffers),
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_apply_color_jitter),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0600,  //  0003  GETNGBL	R2	K3
-      0x8C080504,  //  0004  GETMET	R2	R2	K4
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x90020402,  //  0007  SETMBR	R0	K2	R2
-      0x60080012,  //  0008  GETGBL	R2	G18
-      0x7C080000,  //  0009  CALL	R2	0
-      0x90020A02,  //  000A  SETMBR	R0	K5	R2
-      0x88080105,  //  000B  GETMBR	R2	R0	K5
-      0x8C080506,  //  000C  GETMET	R2	R2	K6
-      0x5C100200,  //  000D  MOVE	R4	R1
-      0x7C080400,  //  000E  CALL	R2	2
-      0x58080007,  //  000F  LDCONST	R2	K7
-      0x140C0401,  //  0010  LT	R3	R2	R1
-      0x780E0003,  //  0011  JMPF	R3	#0016
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
-      0x980C0508,  //  0013  SETIDX	R3	R2	K8
-      0x00080509,  //  0014  ADD	R2	R2	K9
-      0x7001FFF9,  //  0015  JMP		#0010
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_ShiftAnimation_update,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[63]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08050A,  //  0003  GETMET	R2	R2	K10
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8808010B,  //  0006  GETMBR	R2	R0	K11
-      0x880C010C,  //  0007  GETMBR	R3	R0	K12
-      0x8810010D,  //  0008  GETMBR	R4	R0	K13
-      0x8814010E,  //  0009  GETMBR	R5	R0	K14
-      0x88180100,  //  000A  GETMBR	R6	R0	K0
-      0x8C180D01,  //  000B  GETMET	R6	R6	K1
-      0x7C180200,  //  000C  CALL	R6	1
-      0x241C0507,  //  000D  GT	R7	R2	K7
-      0x781E0020,  //  000E  JMPF	R7	#0030
-      0x881C010F,  //  000F  GETMBR	R7	R0	K15
-      0x041C0207,  //  0010  SUB	R7	R1	R7
-      0xB8222000,  //  0011  GETNGBL	R8	K16
-      0x8C201111,  //  0012  GETMET	R8	R8	K17
-      0x5C280400,  //  0013  MOVE	R10	R2
-      0x582C0007,  //  0014  LDCONST	R11	K7
-      0x543200FE,  //  0015  LDINT	R12	255
-      0x58340007,  //  0016  LDCONST	R13	K7
-      0x543A0009,  //  0017  LDINT	R14	10
-      0x543E00FF,  //  0018  LDINT	R15	256
-      0x08381C0F,  //  0019  MUL	R14	R14	R15
-      0x7C200C00,  //  001A  CALL	R8	6
-      0x24241107,  //  001B  GT	R9	R8	K7
-      0x78260012,  //  001C  JMPF	R9	#0030
-      0x08240E08,  //  001D  MUL	R9	R7	R8
-      0x542A03E7,  //  001E  LDINT	R10	1000
-      0x0C24120A,  //  001F  DIV	R9	R9	R10
-      0x08241203,  //  0020  MUL	R9	R9	R3
-      0x7812000C,  //  0021  JMPF	R4	#002F
-      0x542A00FF,  //  0022  LDINT	R10	256
-      0x08280C0A,  //  0023  MUL	R10	R6	R10
-      0x1028120A,  //  0024  MOD	R10	R9	R10
-      0x9002240A,  //  0025  SETMBR	R0	K18	R10
-      0x88280112,  //  0026  GETMBR	R10	R0	K18
-      0x14281507,  //  0027  LT	R10	R10	K7
-      0x782A0004,  //  0028  JMPF	R10	#002E
-      0x542E00FF,  //  0029  LDINT	R11	256
-      0x082C0C0B,  //  002A  MUL	R11	R6	R11
-      0x88280112,  //  002B  GETMBR	R10	R0	K18
-      0x0028140B,  //  002C  ADD	R10	R10	R11
-      0x9002240A,  //  002D  SETMBR	R0	K18	R10
-      0x70020000,  //  002E  JMP		#0030
-      0x90022409,  //  002F  SETMBR	R0	K18	R9
-      0x4C1C0000,  //  0030  LDNIL	R7
-      0x201C0A07,  //  0031  NE	R7	R5	R7
-      0x781E0007,  //  0032  JMPF	R7	#003B
-      0x881C0B13,  //  0033  GETMBR	R7	R5	K19
-      0x741E0002,  //  0034  JMPT	R7	#0038
-      0x8C1C0B14,  //  0035  GETMET	R7	R5	K20
-      0x8824010F,  //  0036  GETMBR	R9	R0	K15
-      0x7C1C0400,  //  0037  CALL	R7	2
-      0x8C1C0B0A,  //  0038  GETMET	R7	R5	K10
-      0x5C240200,  //  0039  MOVE	R9	R1
-      0x7C1C0400,  //  003A  CALL	R7	2
-      0x8C1C0115,  //  003B  GETMET	R7	R0	K21
-      0x7C1C0200,  //  003C  CALL	R7	1
-      0x501C0200,  //  003D  LDBOOL	R7	1	0
-      0x80040E00,  //  003E  RET	1	R7
+    ( &(const binstruction[127]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x541A0017,  //  0003  LDINT	R6	24
+      0x3C180206,  //  0004  SHR	R6	R1	R6
+      0x541E00FE,  //  0005  LDINT	R7	255
+      0x2C180C07,  //  0006  AND	R6	R6	R7
+      0x541E000F,  //  0007  LDINT	R7	16
+      0x3C1C0207,  //  0008  SHR	R7	R1	R7
+      0x542200FE,  //  0009  LDINT	R8	255
+      0x2C1C0E08,  //  000A  AND	R7	R7	R8
+      0x54220007,  //  000B  LDINT	R8	8
+      0x3C200208,  //  000C  SHR	R8	R1	R8
+      0x542600FE,  //  000D  LDINT	R9	255
+      0x2C201009,  //  000E  AND	R8	R8	R9
+      0x542600FE,  //  000F  LDINT	R9	255
+      0x2C240209,  //  0010  AND	R9	R1	R9
+      0x1C280703,  //  0011  EQ	R10	R3	K3
+      0x742A0001,  //  0012  JMPT	R10	#0015
+      0x1C280704,  //  0013  EQ	R10	R3	K4
+      0x782A0013,  //  0014  JMPF	R10	#0029
+      0xB82A0A00,  //  0015  GETNGBL	R10	K5
+      0x8C281506,  //  0016  GETMET	R10	R10	K6
+      0x5C300800,  //  0017  MOVE	R12	R4
+      0x58340007,  //  0018  LDCONST	R13	K7
+      0x543A00FE,  //  0019  LDINT	R14	255
+      0x583C0007,  //  001A  LDCONST	R15	K7
+      0x5442001D,  //  001B  LDINT	R16	30
+      0x7C280C00,  //  001C  CALL	R10	6
+      0x8C2C0108,  //  001D  GETMET	R11	R0	K8
+      0x5C341400,  //  001E  MOVE	R13	R10
+      0x7C2C0400,  //  001F  CALL	R11	2
+      0x001C0E0B,  //  0020  ADD	R7	R7	R11
+      0x8C2C0108,  //  0021  GETMET	R11	R0	K8
+      0x5C341400,  //  0022  MOVE	R13	R10
+      0x7C2C0400,  //  0023  CALL	R11	2
+      0x0020100B,  //  0024  ADD	R8	R8	R11
+      0x8C2C0108,  //  0025  GETMET	R11	R0	K8
+      0x5C341400,  //  0026  MOVE	R13	R10
+      0x7C2C0400,  //  0027  CALL	R11	2
+      0x0024120B,  //  0028  ADD	R9	R9	R11
+      0x1C280709,  //  0029  EQ	R10	R3	K9
+      0x742A0001,  //  002A  JMPT	R10	#002D
+      0x1C280704,  //  002B  EQ	R10	R3	K4
+      0x782A002F,  //  002C  JMPF	R10	#005D
+      0xB82A0A00,  //  002D  GETNGBL	R10	K5
+      0x8C281506,  //  002E  GETMET	R10	R10	K6
+      0x5C300A00,  //  002F  MOVE	R12	R5
+      0x58340007,  //  0030  LDCONST	R13	K7
+      0x543A00FE,  //  0031  LDINT	R14	255
+      0x583C0007,  //  0032  LDCONST	R15	K7
+      0x54420031,  //  0033  LDINT	R16	50
+      0x7C280C00,  //  0034  CALL	R10	6
+      0x542E007F,  //  0035  LDINT	R11	128
+      0x8C300108,  //  0036  GETMET	R12	R0	K8
+      0x5C381400,  //  0037  MOVE	R14	R10
+      0x7C300400,  //  0038  CALL	R12	2
+      0x002C160C,  //  0039  ADD	R11	R11	R12
+      0x14301707,  //  003A  LT	R12	R11	K7
+      0x78320001,  //  003B  JMPF	R12	#003E
+      0x582C0007,  //  003C  LDCONST	R11	K7
+      0x70020003,  //  003D  JMP		#0042
+      0x543200FE,  //  003E  LDINT	R12	255
+      0x2430160C,  //  003F  GT	R12	R11	R12
+      0x78320000,  //  0040  JMPF	R12	#0042
+      0x542E00FE,  //  0041  LDINT	R11	255
+      0xB8320A00,  //  0042  GETNGBL	R12	K5
+      0x8C301906,  //  0043  GETMET	R12	R12	K6
+      0x5C380E00,  //  0044  MOVE	R14	R7
+      0x583C0007,  //  0045  LDCONST	R15	K7
+      0x544200FE,  //  0046  LDINT	R16	255
+      0x58440007,  //  0047  LDCONST	R17	K7
+      0x5C481600,  //  0048  MOVE	R18	R11
+      0x7C300C00,  //  0049  CALL	R12	6
+      0x5C1C1800,  //  004A  MOVE	R7	R12
+      0xB8320A00,  //  004B  GETNGBL	R12	K5
+      0x8C301906,  //  004C  GETMET	R12	R12	K6
+      0x5C381000,  //  004D  MOVE	R14	R8
+      0x583C0007,  //  004E  LDCONST	R15	K7
+      0x544200FE,  //  004F  LDINT	R16	255
+      0x58440007,  //  0050  LDCONST	R17	K7
+      0x5C481600,  //  0051  MOVE	R18	R11
+      0x7C300C00,  //  0052  CALL	R12	6
+      0x5C201800,  //  0053  MOVE	R8	R12
+      0xB8320A00,  //  0054  GETNGBL	R12	K5
+      0x8C301906,  //  0055  GETMET	R12	R12	K6
+      0x5C381200,  //  0056  MOVE	R14	R9
+      0x583C0007,  //  0057  LDCONST	R15	K7
+      0x544200FE,  //  0058  LDINT	R16	255
+      0x58440007,  //  0059  LDCONST	R17	K7
+      0x5C481600,  //  005A  MOVE	R18	R11
+      0x7C300C00,  //  005B  CALL	R12	6
+      0x5C241800,  //  005C  MOVE	R9	R12
+      0x542A00FE,  //  005D  LDINT	R10	255
+      0x24280E0A,  //  005E  GT	R10	R7	R10
+      0x782A0001,  //  005F  JMPF	R10	#0062
+      0x541E00FE,  //  0060  LDINT	R7	255
+      0x70020002,  //  0061  JMP		#0065
+      0x14280F07,  //  0062  LT	R10	R7	K7
+      0x782A0000,  //  0063  JMPF	R10	#0065
+      0x581C0007,  //  0064  LDCONST	R7	K7
+      0x542A00FE,  //  0065  LDINT	R10	255
+      0x2428100A,  //  0066  GT	R10	R8	R10
+      0x782A0001,  //  0067  JMPF	R10	#006A
+      0x542200FE,  //  0068  LDINT	R8	255
+      0x70020002,  //  0069  JMP		#006D
+      0x14281107,  //  006A  LT	R10	R8	K7
+      0x782A0000,  //  006B  JMPF	R10	#006D
+      0x58200007,  //  006C  LDCONST	R8	K7
+      0x542A00FE,  //  006D  LDINT	R10	255
+      0x2428120A,  //  006E  GT	R10	R9	R10
+      0x782A0001,  //  006F  JMPF	R10	#0072
+      0x542600FE,  //  0070  LDINT	R9	255
+      0x70020002,  //  0071  JMP		#0075
+      0x14281307,  //  0072  LT	R10	R9	K7
+      0x782A0000,  //  0073  JMPF	R10	#0075
+      0x58240007,  //  0074  LDCONST	R9	K7
+      0x542A0017,  //  0075  LDINT	R10	24
+      0x38280C0A,  //  0076  SHL	R10	R6	R10
+      0x542E000F,  //  0077  LDINT	R11	16
+      0x382C0E0B,  //  0078  SHL	R11	R7	R11
+      0x3028140B,  //  0079  OR	R10	R10	R11
+      0x542E0007,  //  007A  LDINT	R11	8
+      0x382C100B,  //  007B  SHL	R11	R8	R11
+      0x3028140B,  //  007C  OR	R10	R10	R11
+      0x30281409,  //  007D  OR	R10	R10	R9
+      0x80041400,  //  007E  RET	1	R10
     })
   )
 );
@@ -4326,126 +4295,9 @@ be_local_closure(class_ShiftAnimation_update,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-be_local_closure(class_ShiftAnimation_tostring,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8804010C,  //  0000  GETMBR	R1	R0	K12
-      0x8808010B,  //  0001  GETMBR	R2	R0	K11
-      0x880C010D,  //  0002  GETMBR	R3	R0	K13
-      0x88100116,  //  0003  GETMBR	R4	R0	K22
-      0x24140307,  //  0004  GT	R5	R1	K7
-      0x78160001,  //  0005  JMPF	R5	#0008
-      0x58140017,  //  0006  LDCONST	R5	K23
-      0x70020000,  //  0007  JMP		#0009
-      0x58140018,  //  0008  LDCONST	R5	K24
-      0x60180018,  //  0009  GETGBL	R6	G24
-      0x581C0019,  //  000A  LDCONST	R7	K25
-      0x5C200A00,  //  000B  MOVE	R8	R5
-      0x5C240400,  //  000C  MOVE	R9	R2
-      0x5C280600,  //  000D  MOVE	R10	R3
-      0x5C2C0800,  //  000E  MOVE	R11	R4
-      0x88300113,  //  000F  GETMBR	R12	R0	K19
-      0x7C180C00,  //  0010  CALL	R6	6
-      0x80040C00,  //  0011  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_ShiftAnimation_render,   /* name */
+be_local_closure(class_JitterAnimation_tostring,   /* name */
   be_nested_proto(
     9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x880C0113,  //  0000  GETMBR	R3	R0	K19
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x58100007,  //  000A  LDCONST	R4	K7
-      0x14140803,  //  000B  LT	R5	R4	R3
-      0x78160009,  //  000C  JMPF	R5	#0017
-      0x8814031A,  //  000D  GETMBR	R5	R1	K26
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x78160004,  //  000F  JMPF	R5	#0015
-      0x8C14031B,  //  0010  GETMET	R5	R1	K27
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x88200105,  //  0012  GETMBR	R8	R0	K5
-      0x94201004,  //  0013  GETIDX	R8	R8	R4
-      0x7C140600,  //  0014  CALL	R5	3
-      0x00100909,  //  0015  ADD	R4	R4	K9
-      0x7001FFF3,  //  0016  JMP		#000B
-      0x50140200,  //  0017  LDBOOL	R5	1	0
-      0x80040A00,  //  0018  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ShiftAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x1C0C030E,  //  0000  EQ	R3	R1	K14
-      0x780E0001,  //  0001  JMPF	R3	#0004
-      0x8C0C011C,  //  0002  GETMET	R3	R0	K28
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _calculate_shift
-********************************************************************/
-be_local_closure(class_ShiftAnimation__calculate_shift,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -4453,74 +4305,64 @@ be_local_closure(class_ShiftAnimation__calculate_shift,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
-    be_str_weak(_calculate_shift),
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[64]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C0105,  //  0004  GETMBR	R3	R0	K5
-      0x7C080200,  //  0005  CALL	R2	1
-      0x20080401,  //  0006  NE	R2	R2	R1
-      0x780A0001,  //  0007  JMPF	R2	#000A
-      0x8C08011C,  //  0008  GETMET	R2	R0	K28
-      0x7C080200,  //  0009  CALL	R2	1
-      0x8808010E,  //  000A  GETMBR	R2	R0	K14
-      0x880C010D,  //  000B  GETMBR	R3	R0	K13
-      0x88100102,  //  000C  GETMBR	R4	R0	K2
-      0x8C10091D,  //  000D  GETMET	R4	R4	K29
-      0x7C100200,  //  000E  CALL	R4	1
-      0x4C100000,  //  000F  LDNIL	R4
-      0x20100404,  //  0010  NE	R4	R2	R4
-      0x78120003,  //  0011  JMPF	R4	#0016
-      0x8C10051E,  //  0012  GETMET	R4	R2	K30
-      0x88180102,  //  0013  GETMBR	R6	R0	K2
-      0x581C0007,  //  0014  LDCONST	R7	K7
-      0x7C100600,  //  0015  CALL	R4	3
-      0x88100112,  //  0016  GETMBR	R4	R0	K18
-      0x541600FF,  //  0017  LDINT	R5	256
-      0x0C100805,  //  0018  DIV	R4	R4	R5
-      0x88140112,  //  0019  GETMBR	R5	R0	K18
-      0x541A00FF,  //  001A  LDINT	R6	256
-      0x10140A06,  //  001B  MOD	R5	R5	R6
-      0x58180007,  //  001C  LDCONST	R6	K7
-      0x141C0C01,  //  001D  LT	R7	R6	R1
-      0x781E001F,  //  001E  JMPF	R7	#003F
-      0x041C0C04,  //  001F  SUB	R7	R6	R4
-      0x780E000E,  //  0020  JMPF	R3	#0030
-      0x14200F07,  //  0021  LT	R8	R7	K7
-      0x78220001,  //  0022  JMPF	R8	#0025
-      0x001C0E01,  //  0023  ADD	R7	R7	R1
-      0x7001FFFB,  //  0024  JMP		#0021
-      0x28200E01,  //  0025  GE	R8	R7	R1
-      0x78220001,  //  0026  JMPF	R8	#0029
-      0x041C0E01,  //  0027  SUB	R7	R7	R1
-      0x7001FFFB,  //  0028  JMP		#0025
-      0x88200105,  //  0029  GETMBR	R8	R0	K5
-      0x88240102,  //  002A  GETMBR	R9	R0	K2
-      0x8C24131F,  //  002B  GETMET	R9	R9	K31
-      0x5C2C0E00,  //  002C  MOVE	R11	R7
-      0x7C240400,  //  002D  CALL	R9	2
-      0x98200C09,  //  002E  SETIDX	R8	R6	R9
-      0x7002000C,  //  002F  JMP		#003D
-      0x28200F07,  //  0030  GE	R8	R7	K7
-      0x78220008,  //  0031  JMPF	R8	#003B
-      0x14200E01,  //  0032  LT	R8	R7	R1
-      0x78220006,  //  0033  JMPF	R8	#003B
-      0x88200105,  //  0034  GETMBR	R8	R0	K5
-      0x88240102,  //  0035  GETMBR	R9	R0	K2
-      0x8C24131F,  //  0036  GETMET	R9	R9	K31
-      0x5C2C0E00,  //  0037  MOVE	R11	R7
-      0x7C240400,  //  0038  CALL	R9	2
-      0x98200C09,  //  0039  SETIDX	R8	R6	R9
-      0x70020001,  //  003A  JMP		#003D
-      0x88200105,  //  003B  GETMBR	R8	R0	K5
-      0x98200D08,  //  003C  SETIDX	R8	R6	K8
-      0x00180D09,  //  003D  ADD	R6	R6	K9
-      0x7001FFDD,  //  003E  JMP		#001D
-      0x80000000,  //  003F  RET	0
+    ( &(const binstruction[21]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x4008030A,  //  0002  CONNECT	R2	R1	K10
+      0x4008030B,  //  0003  CONNECT	R2	R1	K11
+      0x4008030C,  //  0004  CONNECT	R2	R1	K12
+      0x4008030D,  //  0005  CONNECT	R2	R1	K13
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
+      0x940C0202,  //  0007  GETIDX	R3	R1	R2
+      0x4C100000,  //  0008  LDNIL	R4
+      0x200C0604,  //  0009  NE	R3	R3	R4
+      0x780E0001,  //  000A  JMPF	R3	#000D
+      0x940C0202,  //  000B  GETIDX	R3	R1	R2
+      0x70020000,  //  000C  JMP		#000E
+      0x580C000E,  //  000D  LDCONST	R3	K14
+      0x60100018,  //  000E  GETGBL	R4	G24
+      0x5814000F,  //  000F  LDCONST	R5	K15
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x881C0110,  //  0011  GETMBR	R7	R0	K16
+      0x88200111,  //  0012  GETMBR	R8	R0	K17
+      0x7C100800,  //  0013  CALL	R4	4
+      0x80040800,  //  0014  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random_range
+********************************************************************/
+be_local_closure(class_JitterAnimation__random_range,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_random_range),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x18080307,  //  0000  LE	R2	R1	K7
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80060E00,  //  0002  RET	1	K7
+      0x8C080112,  //  0003  GETMET	R2	R0	K18
+      0x7C080200,  //  0004  CALL	R2	1
+      0x080C0309,  //  0005  MUL	R3	R1	K9
+      0x000C0703,  //  0006  ADD	R3	R3	K3
+      0x10080403,  //  0007  MOD	R2	R2	R3
+      0x040C0401,  //  0008  SUB	R3	R2	R1
+      0x80040600,  //  0009  RET	1	R3
     })
   )
 );
@@ -4530,7 +4372,7 @@ be_local_closure(class_ShiftAnimation__calculate_shift,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-be_local_closure(class_ShiftAnimation_init,   /* name */
+be_local_closure(class_JitterAnimation_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -4540,20 +4382,25 @@ be_local_closure(class_ShiftAnimation_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x60080003,  //  0000  GETGBL	R2	G3
       0x5C0C0000,  //  0001  MOVE	R3	R0
       0x7C080200,  //  0002  CALL	R2	1
-      0x8C080520,  //  0003  GETMET	R2	R2	K32
+      0x8C080513,  //  0003  GETMET	R2	R2	K19
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
-      0x90022507,  //  0006  SETMBR	R0	K18	K7
-      0x8C08011C,  //  0007  GETMET	R2	R0	K28
-      0x7C080200,  //  0008  CALL	R2	1
-      0x80000000,  //  0009  RET	0
+      0x88080115,  //  0006  GETMBR	R2	R0	K21
+      0x88080516,  //  0007  GETMBR	R2	R2	K22
+      0x540EFFFF,  //  0008  LDINT	R3	65536
+      0x10080403,  //  0009  MOD	R2	R2	R3
+      0x90022802,  //  000A  SETMBR	R0	K20	R2
+      0x90022F07,  //  000B  SETMBR	R0	K23	K7
+      0x8C080118,  //  000C  GETMET	R2	R0	K24
+      0x7C080200,  //  000D  CALL	R2	1
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -4561,29 +4408,429 @@ be_local_closure(class_ShiftAnimation_init,   /* name */
 
 
 /********************************************************************
-** Solidified class: ShiftAnimation
+** Solidified function: _update_jitter
+********************************************************************/
+be_local_closure(class_JitterAnimation__update_jitter,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_update_jitter),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x8C040319,  //  0001  GETMET	R1	R1	K25
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88080110,  //  0003  GETMBR	R2	R0	K16
+      0xB80E0A00,  //  0004  GETNGBL	R3	K5
+      0x8C0C0706,  //  0005  GETMET	R3	R3	K6
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x58180007,  //  0007  LDCONST	R6	K7
+      0x541E00FE,  //  0008  LDINT	R7	255
+      0x58200007,  //  0009  LDCONST	R8	K7
+      0x54260009,  //  000A  LDINT	R9	10
+      0x7C0C0C00,  //  000B  CALL	R3	6
+      0x58100007,  //  000C  LDCONST	R4	K7
+      0x14140801,  //  000D  LT	R5	R4	R1
+      0x78160006,  //  000E  JMPF	R5	#0016
+      0x8814011A,  //  000F  GETMBR	R5	R0	K26
+      0x8C180108,  //  0010  GETMET	R6	R0	K8
+      0x5C200600,  //  0011  MOVE	R8	R3
+      0x7C180400,  //  0012  CALL	R6	2
+      0x98140806,  //  0013  SETIDX	R5	R4	R6
+      0x00100903,  //  0014  ADD	R4	R4	K3
+      0x7001FFF6,  //  0015  JMP		#000D
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _calculate_jitter
+********************************************************************/
+be_local_closure(class_JitterAnimation__calculate_jitter,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_calculate_jitter),
+    &be_const_str_solidified,
+    ( &(const binstruction[72]) {  /* code */
+      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x8C040319,  //  0001  GETMET	R1	R1	K25
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8808011B,  //  0003  GETMBR	R2	R0	K27
+      0x880C0100,  //  0004  GETMBR	R3	R0	K0
+      0x8810011C,  //  0005  GETMBR	R4	R0	K28
+      0x8814011D,  //  0006  GETMBR	R5	R0	K29
+      0x8C140B1E,  //  0007  GETMET	R5	R5	K30
+      0x7C140200,  //  0008  CALL	R5	1
+      0x4C140000,  //  0009  LDNIL	R5
+      0x20140405,  //  000A  NE	R5	R2	R5
+      0x78160003,  //  000B  JMPF	R5	#0010
+      0x8C14051F,  //  000C  GETMET	R5	R2	K31
+      0x881C011D,  //  000D  GETMBR	R7	R0	K29
+      0x58200007,  //  000E  LDCONST	R8	K7
+      0x7C140600,  //  000F  CALL	R5	3
+      0x58140007,  //  0010  LDCONST	R5	K7
+      0x14180A01,  //  0011  LT	R6	R5	R1
+      0x781A0033,  //  0012  JMPF	R6	#0047
+      0x58180020,  //  0013  LDCONST	R6	K32
+      0x1C1C0707,  //  0014  EQ	R7	R3	K7
+      0x741E0001,  //  0015  JMPT	R7	#0018
+      0x1C1C0704,  //  0016  EQ	R7	R3	K4
+      0x781E0018,  //  0017  JMPF	R7	#0031
+      0xB81E0A00,  //  0018  GETNGBL	R7	K5
+      0x8C1C0F06,  //  0019  GETMET	R7	R7	K6
+      0x8824011A,  //  001A  GETMBR	R9	R0	K26
+      0x94241205,  //  001B  GETIDX	R9	R9	R5
+      0x5429FFF5,  //  001C  LDINT	R10	-10
+      0x542E0009,  //  001D  LDINT	R11	10
+      0x44300800,  //  001E  NEG	R12	R4
+      0x54360009,  //  001F  LDINT	R13	10
+      0x0C30180D,  //  0020  DIV	R12	R12	R13
+      0x54360009,  //  0021  LDINT	R13	10
+      0x0C34080D,  //  0022  DIV	R13	R4	R13
+      0x7C1C0C00,  //  0023  CALL	R7	6
+      0x00200A07,  //  0024  ADD	R8	R5	R7
+      0x28241107,  //  0025  GE	R9	R8	K7
+      0x78260007,  //  0026  JMPF	R9	#002F
+      0x14241001,  //  0027  LT	R9	R8	R1
+      0x78260005,  //  0028  JMPF	R9	#002F
+      0x8824011D,  //  0029  GETMBR	R9	R0	K29
+      0x8C241321,  //  002A  GETMET	R9	R9	K33
+      0x5C2C1000,  //  002B  MOVE	R11	R8
+      0x7C240400,  //  002C  CALL	R9	2
+      0x5C181200,  //  002D  MOVE	R6	R9
+      0x70020000,  //  002E  JMP		#0030
+      0x58180020,  //  002F  LDCONST	R6	K32
+      0x70020004,  //  0030  JMP		#0036
+      0x881C011D,  //  0031  GETMBR	R7	R0	K29
+      0x8C1C0F21,  //  0032  GETMET	R7	R7	K33
+      0x5C240A00,  //  0033  MOVE	R9	R5
+      0x7C1C0400,  //  0034  CALL	R7	2
+      0x5C180E00,  //  0035  MOVE	R6	R7
+      0x1C1C0703,  //  0036  EQ	R7	R3	K3
+      0x741E0003,  //  0037  JMPT	R7	#003C
+      0x1C1C0709,  //  0038  EQ	R7	R3	K9
+      0x741E0001,  //  0039  JMPT	R7	#003C
+      0x1C1C0704,  //  003A  EQ	R7	R3	K4
+      0x781E0006,  //  003B  JMPF	R7	#0043
+      0x201C0D20,  //  003C  NE	R7	R6	K32
+      0x781E0004,  //  003D  JMPF	R7	#0043
+      0x8C1C0122,  //  003E  GETMET	R7	R0	K34
+      0x5C240C00,  //  003F  MOVE	R9	R6
+      0x5C280A00,  //  0040  MOVE	R10	R5
+      0x7C1C0600,  //  0041  CALL	R7	3
+      0x5C180E00,  //  0042  MOVE	R6	R7
+      0x881C0123,  //  0043  GETMBR	R7	R0	K35
+      0x981C0A06,  //  0044  SETIDX	R7	R5	R6
+      0x00140B03,  //  0045  ADD	R5	R5	K3
+      0x7001FFC9,  //  0046  JMP		#0011
+      0x80000000,  //  0047  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_JitterAnimation_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0203,  //  0001  EQ	R3	R1	R3
+      0x780E0001,  //  0002  JMPF	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x880C0115,  //  0005  GETMBR	R3	R0	K21
+      0x8C0C0719,  //  0006  GETMET	R3	R3	K25
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x58100007,  //  0008  LDCONST	R4	K7
+      0x14140803,  //  0009  LT	R5	R4	R3
+      0x78160009,  //  000A  JMPF	R5	#0015
+      0x88140324,  //  000B  GETMBR	R5	R1	K36
+      0x14140805,  //  000C  LT	R5	R4	R5
+      0x78160004,  //  000D  JMPF	R5	#0013
+      0x8C140325,  //  000E  GETMET	R5	R1	K37
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x88200123,  //  0010  GETMBR	R8	R0	K35
+      0x94201004,  //  0011  GETIDX	R8	R8	R4
+      0x7C140600,  //  0012  CALL	R5	3
+      0x00100903,  //  0013  ADD	R4	R4	K3
+      0x7001FFF3,  //  0014  JMP		#0009
+      0x50140200,  //  0015  LDBOOL	R5	1	0
+      0x80040A00,  //  0016  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random
+********************************************************************/
+be_local_closure(class_JitterAnimation__random,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_random),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040114,  //  0000  GETMBR	R1	R0	K20
+      0x08040326,  //  0001  MUL	R1	R1	K38
+      0x540A3038,  //  0002  LDINT	R2	12345
+      0x00040202,  //  0003  ADD	R1	R1	R2
+      0x2C040327,  //  0004  AND	R1	R1	K39
+      0x90022801,  //  0005  SETMBR	R0	K20	R1
+      0x88040114,  //  0006  GETMBR	R1	R0	K20
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_JitterAnimation_update,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x88080111,  //  0000  GETMBR	R2	R0	K17
+      0x880C011B,  //  0001  GETMBR	R3	R0	K27
+      0x24100507,  //  0002  GT	R4	R2	K7
+      0x78120014,  //  0003  JMPF	R4	#0019
+      0xB8120A00,  //  0004  GETNGBL	R4	K5
+      0x8C100906,  //  0005  GETMET	R4	R4	K6
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x581C0007,  //  0007  LDCONST	R7	K7
+      0x542200FE,  //  0008  LDINT	R8	255
+      0x58240007,  //  0009  LDCONST	R9	K7
+      0x542A001D,  //  000A  LDINT	R10	30
+      0x7C100C00,  //  000B  CALL	R4	6
+      0x24140907,  //  000C  GT	R5	R4	K7
+      0x78160002,  //  000D  JMPF	R5	#0011
+      0x541603E7,  //  000E  LDINT	R5	1000
+      0x0C140A04,  //  000F  DIV	R5	R5	R4
+      0x70020000,  //  0010  JMP		#0012
+      0x541603E7,  //  0011  LDINT	R5	1000
+      0x88180117,  //  0012  GETMBR	R6	R0	K23
+      0x04180206,  //  0013  SUB	R6	R1	R6
+      0x28180C05,  //  0014  GE	R6	R6	R5
+      0x781A0002,  //  0015  JMPF	R6	#0019
+      0x90022E01,  //  0016  SETMBR	R0	K23	R1
+      0x8C180128,  //  0017  GETMET	R6	R0	K40
+      0x7C180200,  //  0018  CALL	R6	1
+      0x4C100000,  //  0019  LDNIL	R4
+      0x20100604,  //  001A  NE	R4	R3	R4
+      0x78120002,  //  001B  JMPF	R4	#001F
+      0x8C100729,  //  001C  GETMET	R4	R3	K41
+      0x5C180200,  //  001D  MOVE	R6	R1
+      0x7C100400,  //  001E  CALL	R4	2
+      0x8C10012A,  //  001F  GETMET	R4	R0	K42
+      0x7C100200,  //  0020  CALL	R4	1
+      0x50100200,  //  0021  LDBOOL	R4	1	0
+      0x80040800,  //  0022  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_JitterAnimation_start,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08052B,  //  0003  GETMET	R2	R2	K43
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x4C080000,  //  0006  LDNIL	R2
+      0x20080202,  //  0007  NE	R2	R1	R2
+      0x780A0001,  //  0008  JMPF	R2	#000B
+      0x5C080200,  //  0009  MOVE	R2	R1
+      0x70020001,  //  000A  JMP		#000D
+      0x88080115,  //  000B  GETMBR	R2	R0	K21
+      0x88080516,  //  000C  GETMBR	R2	R2	K22
+      0x90022E02,  //  000D  SETMBR	R0	K23	R2
+      0x8C080118,  //  000E  GETMET	R2	R0	K24
+      0x7C080200,  //  000F  CALL	R2	1
+      0x80040000,  //  0010  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _initialize_buffers
+********************************************************************/
+be_local_closure(class_JitterAnimation__initialize_buffers,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_JitterAnimation,     /* shared constants */
+    be_str_weak(_initialize_buffers),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x8C040319,  //  0001  GETMET	R1	R1	K25
+      0x7C040200,  //  0002  CALL	R1	1
+      0x60080012,  //  0003  GETGBL	R2	G18
+      0x7C080000,  //  0004  CALL	R2	0
+      0x90023402,  //  0005  SETMBR	R0	K26	R2
+      0x8808011A,  //  0006  GETMBR	R2	R0	K26
+      0x8C08052C,  //  0007  GETMET	R2	R2	K44
+      0x5C100200,  //  0008  MOVE	R4	R1
+      0x7C080400,  //  0009  CALL	R2	2
+      0xB80A5A00,  //  000A  GETNGBL	R2	K45
+      0x8C08052E,  //  000B  GETMET	R2	R2	K46
+      0x5C100200,  //  000C  MOVE	R4	R1
+      0x7C080400,  //  000D  CALL	R2	2
+      0x90023A02,  //  000E  SETMBR	R0	K29	R2
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90024602,  //  0011  SETMBR	R0	K35	R2
+      0x88080123,  //  0012  GETMBR	R2	R0	K35
+      0x8C08052C,  //  0013  GETMET	R2	R2	K44
+      0x5C100200,  //  0014  MOVE	R4	R1
+      0x7C080400,  //  0015  CALL	R2	2
+      0x58080007,  //  0016  LDCONST	R2	K7
+      0x140C0401,  //  0017  LT	R3	R2	R1
+      0x780E0005,  //  0018  JMPF	R3	#001F
+      0x880C011A,  //  0019  GETMBR	R3	R0	K26
+      0x980C0507,  //  001A  SETIDX	R3	R2	K7
+      0x880C0123,  //  001B  GETMBR	R3	R0	K35
+      0x980C0520,  //  001C  SETIDX	R3	R2	K32
+      0x00080503,  //  001D  ADD	R2	R2	K3
+      0x7001FFF7,  //  001E  JMP		#0017
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: JitterAnimation
 ********************************************************************/
 extern const bclass be_class_Animation;
-be_local_class(ShiftAnimation,
-    3,
+be_local_class(JitterAnimation,
+    5,
     &be_class_Animation,
-    be_nested_map(11,
+    be_nested_map(17,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(current_colors, -1), be_const_var(2) },
-        { be_const_key_weak(_initialize_buffers, -1), be_const_closure(class_ShiftAnimation__initialize_buffers_closure) },
-        { be_const_key_weak(current_offset, 6), be_const_var(0) },
-        { be_const_key_weak(tostring, 2), be_const_closure(class_ShiftAnimation_tostring_closure) },
-        { be_const_key_weak(update, 10), be_const_closure(class_ShiftAnimation_update_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ShiftAnimation_on_param_changed_closure) },
-        { be_const_key_weak(source_frame, -1), be_const_var(1) },
-        { be_const_key_weak(_calculate_shift, -1), be_const_closure(class_ShiftAnimation__calculate_shift_closure) },
+        { be_const_key_weak(_apply_color_jitter, 8), be_const_closure(class_JitterAnimation__apply_color_jitter_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_JitterAnimation_tostring_closure) },
+        { be_const_key_weak(jitter_offsets, 7), be_const_var(2) },
+        { be_const_key_weak(_initialize_buffers, 9), be_const_closure(class_JitterAnimation__initialize_buffers_closure) },
+        { be_const_key_weak(last_jitter_time, -1), be_const_var(1) },
+        { be_const_key_weak(start, -1), be_const_closure(class_JitterAnimation_start_closure) },
+        { be_const_key_weak(update, -1), be_const_closure(class_JitterAnimation_update_closure) },
+        { be_const_key_weak(_update_jitter, 1), be_const_closure(class_JitterAnimation__update_jitter_closure) },
+        { be_const_key_weak(_random, 11), be_const_closure(class_JitterAnimation__random_closure) },
+        { be_const_key_weak(source_frame, -1), be_const_var(3) },
+        { be_const_key_weak(render, -1), be_const_closure(class_JitterAnimation_render_closure) },
+        { be_const_key_weak(current_colors, -1), be_const_var(4) },
+        { be_const_key_weak(random_seed, -1), be_const_var(0) },
+        { be_const_key_weak(_random_range, 6), be_const_closure(class_JitterAnimation__random_range_closure) },
+        { be_const_key_weak(_calculate_jitter, 5), be_const_closure(class_JitterAnimation__calculate_jitter_closure) },
+        { be_const_key_weak(init, 3), be_const_closure(class_JitterAnimation_init_closure) },
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(4,
+        be_const_map( *     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(shift_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(brightness_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(default, -1), be_const_int(40) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(jitter_intensity, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(100) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(jitter_type, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(3) },
+    }))    ) } )) },
+        { be_const_key_weak(color_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(30) },
         { be_const_key_weak(min, -1), be_const_int(0) },
         { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
@@ -4593,24 +4840,23 @@ be_local_class(ShiftAnimation,
         { be_const_key_weak(default, -1), be_const_nil() },
         { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
     }))    ) } )) },
-        { be_const_key_weak(direction, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(position_range, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(-1) },
-        { be_const_key_weak(max, 1), be_const_int(1) },
+        { be_const_key_weak(default, -1), be_const_int(50) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
-        { be_const_key_weak(wrap_around, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
+        { be_const_key_weak(jitter_frequency, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bool(1) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
+        { be_const_key_weak(default, -1), be_const_int(60) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_ShiftAnimation_init_closure) },
-        { be_const_key_weak(render, -1), be_const_closure(class_ShiftAnimation_render_closure) },
     })),
-    be_str_weak(ShiftAnimation)
+    be_str_weak(JitterAnimation)
 );
 // compact class 'RichPaletteColorProvider' ktab size: 47, total: 109 (saved 496 bytes)
 static const bvalue be_ktab_class_RichPaletteColorProvider[47] = {
@@ -5805,65 +6051,47 @@ be_local_closure(color_cycle_from_palette,   /* name */
 
 
 /********************************************************************
-** Solidified function: wave_rainbow_sine
+** Solidified function: list_user_functions
 ********************************************************************/
-be_local_closure(wave_rainbow_sine,   /* name */
+be_local_closure(list_user_functions,   /* name */
   be_nested_proto(
     7,                          /* nstack */
-    1,                          /* argc */
+    0,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(wave_animation),
-    /* K2   */  be_nested_str_weak(rich_palette),
-    /* K3   */  be_nested_str_weak(palette),
-    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
-    /* K5   */  be_nested_str_weak(cycle_period),
-    /* K6   */  be_nested_str_weak(transition_type),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(brightness),
-    /* K9   */  be_nested_str_weak(set_range),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(color),
-    /* K12  */  be_nested_str_weak(wave_type),
-    /* K13  */  be_nested_str_weak(frequency),
-    /* K14  */  be_nested_str_weak(wave_speed),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_animation_user_functions),
+    /* K2   */  be_nested_str_weak(keys),
+    /* K3   */  be_nested_str_weak(push),
+    /* K4   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(wave_rainbow_sine),
+    be_str_weak(list_user_functions),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0xB80E0000,  //  0008  GETNGBL	R3	K0
-      0x880C0704,  //  0009  GETMBR	R3	R3	K4
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0x540E1387,  //  000B  LDINT	R3	5000
-      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
-      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
-      0x540E00FE,  //  000E  LDINT	R3	255
-      0x900A1003,  //  000F  SETMBR	R2	K8	R3
-      0x8C0C0509,  //  0010  GETMET	R3	R2	K9
-      0x5814000A,  //  0011  LDCONST	R5	K10
-      0x541A00FE,  //  0012  LDINT	R6	255
-      0x7C0C0600,  //  0013  CALL	R3	3
-      0x90061602,  //  0014  SETMBR	R1	K11	R2
-      0x9006190A,  //  0015  SETMBR	R1	K12	K10
-      0x540E001F,  //  0016  LDINT	R3	32
-      0x90061A03,  //  0017  SETMBR	R1	K13	R3
-      0x540E0031,  //  0018  LDINT	R3	50
-      0x90061C03,  //  0019  SETMBR	R1	K14	R3
-      0x80040200,  //  001A  RET	1	R1
+    ( &(const binstruction[19]) {  /* code */
+      0xA4020000,  //  0000  IMPORT	R0	K0
+      0x60040012,  //  0001  GETGBL	R1	G18
+      0x7C040000,  //  0002  CALL	R1	0
+      0x60080010,  //  0003  GETGBL	R2	G16
+      0x880C0101,  //  0004  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0005  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020005,  //  0008  EXBLK	0	#000F
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x8C100303,  //  000B  GETMET	R4	R1	K3
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x7C100400,  //  000D  CALL	R4	2
+      0x7001FFF9,  //  000E  JMP		#0009
+      0x58080004,  //  000F  LDCONST	R2	K4
+      0xAC080200,  //  0010  CATCH	R2	1	0
+      0xB0080000,  //  0011  RAISE	2	R0	R0
+      0x80040200,  //  0012  RET	1	R1
     })
   )
 );
@@ -5905,9 +6133,9 @@ be_local_closure(trigger_event,   /* name */
 
 
 /********************************************************************
-** Solidified function: jitter_brightness
+** Solidified function: scale_oscillate
 ********************************************************************/
-be_local_closure(jitter_brightness,   /* name */
+be_local_closure(scale_oscillate,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -5919,12 +6147,12 @@ be_local_closure(jitter_brightness,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(jitter_animation),
-    /* K2   */  be_nested_str_weak(jitter_type),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(brightness_range),
+    /* K1   */  be_nested_str_weak(scale_animation),
+    /* K2   */  be_nested_str_weak(scale_mode),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(scale_speed),
     }),
-    be_str_weak(jitter_brightness),
+    be_str_weak(scale_oscillate),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
@@ -5932,7 +6160,7 @@ be_local_closure(jitter_brightness,   /* name */
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A0027,  //  0005  LDINT	R2	40
+      0x540A007F,  //  0005  LDINT	R2	128
       0x90060802,  //  0006  SETMBR	R1	K4	R2
       0x80040200,  //  0007  RET	1	R1
     })
@@ -6029,792 +6257,51 @@ be_local_closure(unregister_event_handler,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'ScaleAnimation' ktab size: 42, total: 83 (saved 328 bytes)
-static const bvalue be_ktab_class_ScaleAnimation[42] = {
-  /* K0   */  be_nested_str_weak(scale_mode),
-  /* K1   */  be_nested_str_weak(scale_factor),
-  /* K2   */  be_const_int(0),
-  /* K3   */  be_const_int(1),
-  /* K4   */  be_nested_str_weak(_sine),
-  /* K5   */  be_nested_str_weak(scale_phase),
-  /* K6   */  be_nested_str_weak(tasmota),
-  /* K7   */  be_nested_str_weak(scale_uint),
-  /* K8   */  be_const_int(2),
-  /* K9   */  be_nested_str_weak(engine),
-  /* K10  */  be_nested_str_weak(get_strip_length),
-  /* K11  */  be_nested_str_weak(current_colors),
-  /* K12  */  be_nested_str_weak(_initialize_buffers),
-  /* K13  */  be_nested_str_weak(source_animation),
-  /* K14  */  be_nested_str_weak(scale_center),
-  /* K15  */  be_nested_str_weak(interpolation),
-  /* K16  */  be_nested_str_weak(source_frame),
-  /* K17  */  be_nested_str_weak(clear),
-  /* K18  */  be_nested_str_weak(render),
-  /* K19  */  be_nested_str_weak(_get_current_scale_factor),
-  /* K20  */  be_nested_str_weak(get_pixel_color),
-  /* K21  */  be_const_int(-16777216),
-  /* K22  */  be_nested_str_weak(_interpolate_colors),
-  /* K23  */  be_nested_str_weak(scale_speed),
-  /* K24  */  be_nested_str_weak(start_time),
-  /* K25  */  be_nested_str_weak(is_running),
-  /* K26  */  be_nested_str_weak(start),
-  /* K27  */  be_nested_str_weak(update),
-  /* K28  */  be_nested_str_weak(_calculate_scale),
-  /* K29  */  be_nested_str_weak(static),
-  /* K30  */  be_nested_str_weak(oscillate),
-  /* K31  */  be_nested_str_weak(grow),
-  /* K32  */  be_nested_str_weak(shrink),
-  /* K33  */  be_nested_str_weak(unknown),
-  /* K34  */  be_nested_str_weak(ScaleAnimation_X28_X25s_X2C_X20factor_X3D_X25s_X2C_X20speed_X3D_X25s_X29),
-  /* K35  */  be_nested_str_weak(init),
-  /* K36  */  be_nested_str_weak(time_ms),
-  /* K37  */  be_nested_str_weak(animation),
-  /* K38  */  be_nested_str_weak(frame_buffer),
-  /* K39  */  be_nested_str_weak(resize),
-  /* K40  */  be_nested_str_weak(width),
-  /* K41  */  be_nested_str_weak(set_pixel_color),
-};
-
-
-extern const bclass be_class_ScaleAnimation;
 
 /********************************************************************
-** Solidified function: _get_current_scale_factor
+** Solidified function: bounce_basic
 ********************************************************************/
-be_local_closure(class_ScaleAnimation__get_current_scale_factor,   /* name */
+be_local_closure(bounce_basic,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
-    10,                          /* varg */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(_get_current_scale_factor),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(bounce_animation),
+    /* K2   */  be_nested_str_weak(bounce_speed),
+    /* K3   */  be_nested_str_weak(bounce_range),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(damping),
+    /* K6   */  be_nested_str_weak(gravity),
+    /* K7   */  be_nested_str_weak(name),
+    /* K8   */  be_nested_str_weak(bounce_basic),
+    }),
+    be_str_weak(bounce_basic),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C0C0302,  //  0002  EQ	R3	R1	K2
-      0x780E0001,  //  0003  JMPF	R3	#0006
-      0x80040400,  //  0004  RET	1	R2
-      0x70020025,  //  0005  JMP		#002C
-      0x1C0C0303,  //  0006  EQ	R3	R1	K3
-      0x780E000C,  //  0007  JMPF	R3	#0015
-      0x8C0C0104,  //  0008  GETMET	R3	R0	K4
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0xB8120C00,  //  000B  GETNGBL	R4	K6
-      0x8C100907,  //  000C  GETMET	R4	R4	K7
-      0x5C180600,  //  000D  MOVE	R6	R3
-      0x581C0002,  //  000E  LDCONST	R7	K2
-      0x542200FE,  //  000F  LDINT	R8	255
-      0x5426003F,  //  0010  LDINT	R9	64
-      0x542A00FE,  //  0011  LDINT	R10	255
-      0x7C100C00,  //  0012  CALL	R4	6
-      0x80040800,  //  0013  RET	1	R4
-      0x70020016,  //  0014  JMP		#002C
-      0x1C0C0308,  //  0015  EQ	R3	R1	K8
-      0x780E0009,  //  0016  JMPF	R3	#0021
-      0xB80E0C00,  //  0017  GETNGBL	R3	K6
-      0x8C0C0707,  //  0018  GETMET	R3	R3	K7
-      0x88140105,  //  0019  GETMBR	R5	R0	K5
-      0x58180002,  //  001A  LDCONST	R6	K2
-      0x541E00FE,  //  001B  LDINT	R7	255
-      0x5422003F,  //  001C  LDINT	R8	64
-      0x542600FE,  //  001D  LDINT	R9	255
-      0x7C0C0C00,  //  001E  CALL	R3	6
-      0x80040600,  //  001F  RET	1	R3
-      0x7002000A,  //  0020  JMP		#002C
-      0xB80E0C00,  //  0021  GETNGBL	R3	K6
-      0x8C0C0707,  //  0022  GETMET	R3	R3	K7
-      0x541600FE,  //  0023  LDINT	R5	255
-      0x88180105,  //  0024  GETMBR	R6	R0	K5
-      0x04140A06,  //  0025  SUB	R5	R5	R6
-      0x58180002,  //  0026  LDCONST	R6	K2
-      0x541E00FE,  //  0027  LDINT	R7	255
-      0x5422003F,  //  0028  LDINT	R8	64
-      0x542600FE,  //  0029  LDINT	R9	255
-      0x7C0C0C00,  //  002A  CALL	R3	6
-      0x80040600,  //  002B  RET	1	R3
-      0x80000000,  //  002C  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x540A007F,  //  0004  LDINT	R2	128
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x90060704,  //  0006  SETMBR	R1	K3	K4
+      0x540A00F9,  //  0007  LDINT	R2	250
+      0x90060A02,  //  0008  SETMBR	R1	K5	R2
+      0x90060D04,  //  0009  SETMBR	R1	K6	K4
+      0x90060F08,  //  000A  SETMBR	R1	K7	K8
+      0x80040200,  //  000B  RET	1	R1
     })
   )
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified function: _calculate_scale
-********************************************************************/
-be_local_closure(class_ScaleAnimation__calculate_scale,   /* name */
-  be_nested_proto(
-    21,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(_calculate_scale),
-    &be_const_str_solidified,
-    ( &(const binstruction[110]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0001  GETMET	R1	R1	K10
-      0x7C040200,  //  0002  CALL	R1	1
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C010B,  //  0004  GETMBR	R3	R0	K11
-      0x7C080200,  //  0005  CALL	R2	1
-      0x20080401,  //  0006  NE	R2	R2	R1
-      0x780A0001,  //  0007  JMPF	R2	#000A
-      0x8C08010C,  //  0008  GETMET	R2	R0	K12
-      0x7C080200,  //  0009  CALL	R2	1
-      0x8808010D,  //  000A  GETMBR	R2	R0	K13
-      0x880C010E,  //  000B  GETMBR	R3	R0	K14
-      0x8810010F,  //  000C  GETMBR	R4	R0	K15
-      0x88140110,  //  000D  GETMBR	R5	R0	K16
-      0x8C140B11,  //  000E  GETMET	R5	R5	K17
-      0x7C140200,  //  000F  CALL	R5	1
-      0x4C140000,  //  0010  LDNIL	R5
-      0x20140405,  //  0011  NE	R5	R2	R5
-      0x78160003,  //  0012  JMPF	R5	#0017
-      0x8C140512,  //  0013  GETMET	R5	R2	K18
-      0x881C0110,  //  0014  GETMBR	R7	R0	K16
-      0x58200002,  //  0015  LDCONST	R8	K2
-      0x7C140600,  //  0016  CALL	R5	3
-      0x8C140113,  //  0017  GETMET	R5	R0	K19
-      0x7C140200,  //  0018  CALL	R5	1
-      0xB81A0C00,  //  0019  GETNGBL	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x58240002,  //  001C  LDCONST	R9	K2
-      0x542A00FE,  //  001D  LDINT	R10	255
-      0x582C0002,  //  001E  LDCONST	R11	K2
-      0x04300303,  //  001F  SUB	R12	R1	K3
-      0x7C180C00,  //  0020  CALL	R6	6
-      0x581C0002,  //  0021  LDCONST	R7	K2
-      0x14200E01,  //  0022  LT	R8	R7	R1
-      0x78220048,  //  0023  JMPF	R8	#006D
-      0x04200E06,  //  0024  SUB	R8	R7	R6
-      0xB8260C00,  //  0025  GETNGBL	R9	K6
-      0x8C241307,  //  0026  GETMET	R9	R9	K7
-      0x542E007F,  //  0027  LDINT	R11	128
-      0x082C100B,  //  0028  MUL	R11	R8	R11
-      0x58300002,  //  0029  LDCONST	R12	K2
-      0x5436007F,  //  002A  LDINT	R13	128
-      0x543A007F,  //  002B  LDINT	R14	128
-      0x08341A0E,  //  002C  MUL	R13	R13	R14
-      0x58380002,  //  002D  LDCONST	R14	K2
-      0x543E007F,  //  002E  LDINT	R15	128
-      0x083C0A0F,  //  002F  MUL	R15	R5	R15
-      0x7C240C00,  //  0030  CALL	R9	6
-      0x542A007F,  //  0031  LDINT	R10	128
-      0x0C24120A,  //  0032  DIV	R9	R9	R10
-      0x00280C09,  //  0033  ADD	R10	R6	R9
-      0x1C2C0902,  //  0034  EQ	R11	R4	K2
-      0x782E000D,  //  0035  JMPF	R11	#0044
-      0x282C1502,  //  0036  GE	R11	R10	K2
-      0x782E0008,  //  0037  JMPF	R11	#0041
-      0x142C1401,  //  0038  LT	R11	R10	R1
-      0x782E0006,  //  0039  JMPF	R11	#0041
-      0x882C010B,  //  003A  GETMBR	R11	R0	K11
-      0x88300110,  //  003B  GETMBR	R12	R0	K16
-      0x8C301914,  //  003C  GETMET	R12	R12	K20
-      0x5C381400,  //  003D  MOVE	R14	R10
-      0x7C300400,  //  003E  CALL	R12	2
-      0x982C0E0C,  //  003F  SETIDX	R11	R7	R12
-      0x70020001,  //  0040  JMP		#0043
-      0x882C010B,  //  0041  GETMBR	R11	R0	K11
-      0x982C0F15,  //  0042  SETIDX	R11	R7	K21
-      0x70020026,  //  0043  JMP		#006B
-      0x282C1502,  //  0044  GE	R11	R10	K2
-      0x782E0022,  //  0045  JMPF	R11	#0069
-      0x042C0303,  //  0046  SUB	R11	R1	K3
-      0x142C140B,  //  0047  LT	R11	R10	R11
-      0x782E001F,  //  0048  JMPF	R11	#0069
-      0x602C0009,  //  0049  GETGBL	R11	G9
-      0x5C301400,  //  004A  MOVE	R12	R10
-      0x7C2C0200,  //  004B  CALL	R11	1
-      0x60300009,  //  004C  GETGBL	R12	G9
-      0x0434140B,  //  004D  SUB	R13	R10	R11
-      0x543A00FF,  //  004E  LDINT	R14	256
-      0x08341A0E,  //  004F  MUL	R13	R13	R14
-      0x7C300200,  //  0050  CALL	R12	1
-      0x28341702,  //  0051  GE	R13	R11	K2
-      0x78360012,  //  0052  JMPF	R13	#0066
-      0x04340303,  //  0053  SUB	R13	R1	K3
-      0x1434160D,  //  0054  LT	R13	R11	R13
-      0x7836000F,  //  0055  JMPF	R13	#0066
-      0x88340110,  //  0056  GETMBR	R13	R0	K16
-      0x8C341B14,  //  0057  GETMET	R13	R13	K20
-      0x5C3C1600,  //  0058  MOVE	R15	R11
-      0x7C340400,  //  0059  CALL	R13	2
-      0x88380110,  //  005A  GETMBR	R14	R0	K16
-      0x8C381D14,  //  005B  GETMET	R14	R14	K20
-      0x00401703,  //  005C  ADD	R16	R11	K3
-      0x7C380400,  //  005D  CALL	R14	2
-      0x883C010B,  //  005E  GETMBR	R15	R0	K11
-      0x8C400116,  //  005F  GETMET	R16	R0	K22
-      0x5C481A00,  //  0060  MOVE	R18	R13
-      0x5C4C1C00,  //  0061  MOVE	R19	R14
-      0x5C501800,  //  0062  MOVE	R20	R12
-      0x7C400800,  //  0063  CALL	R16	4
-      0x983C0E10,  //  0064  SETIDX	R15	R7	R16
-      0x70020001,  //  0065  JMP		#0068
-      0x8834010B,  //  0066  GETMBR	R13	R0	K11
-      0x98340F15,  //  0067  SETIDX	R13	R7	K21
-      0x70020001,  //  0068  JMP		#006B
-      0x882C010B,  //  0069  GETMBR	R11	R0	K11
-      0x982C0F15,  //  006A  SETIDX	R11	R7	K21
-      0x001C0F03,  //  006B  ADD	R7	R7	K3
-      0x7001FFB4,  //  006C  JMP		#0022
-      0x80000000,  //  006D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_ScaleAnimation_update,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x88080117,  //  0000  GETMBR	R2	R0	K23
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x8810010D,  //  0002  GETMBR	R4	R0	K13
-      0x24140502,  //  0003  GT	R5	R2	K2
-      0x78160013,  //  0004  JMPF	R5	#0019
-      0x24140702,  //  0005  GT	R5	R3	K2
-      0x78160011,  //  0006  JMPF	R5	#0019
-      0x88140118,  //  0007  GETMBR	R5	R0	K24
-      0x04140205,  //  0008  SUB	R5	R1	R5
-      0xB81A0C00,  //  0009  GETNGBL	R6	K6
-      0x8C180D07,  //  000A  GETMET	R6	R6	K7
-      0x5C200400,  //  000B  MOVE	R8	R2
-      0x58240002,  //  000C  LDCONST	R9	K2
-      0x542A00FE,  //  000D  LDINT	R10	255
-      0x582C0002,  //  000E  LDCONST	R11	K2
-      0x58300008,  //  000F  LDCONST	R12	K8
-      0x7C180C00,  //  0010  CALL	R6	6
-      0x241C0D02,  //  0011  GT	R7	R6	K2
-      0x781E0005,  //  0012  JMPF	R7	#0019
-      0x081C0A06,  //  0013  MUL	R7	R5	R6
-      0x542203E7,  //  0014  LDINT	R8	1000
-      0x0C1C0E08,  //  0015  DIV	R7	R7	R8
-      0x542200FF,  //  0016  LDINT	R8	256
-      0x101C0E08,  //  0017  MOD	R7	R7	R8
-      0x90020A07,  //  0018  SETMBR	R0	K5	R7
-      0x4C140000,  //  0019  LDNIL	R5
-      0x20140805,  //  001A  NE	R5	R4	R5
-      0x78160007,  //  001B  JMPF	R5	#0024
-      0x88140919,  //  001C  GETMBR	R5	R4	K25
-      0x74160002,  //  001D  JMPT	R5	#0021
-      0x8C14091A,  //  001E  GETMET	R5	R4	K26
-      0x881C0118,  //  001F  GETMBR	R7	R0	K24
-      0x7C140400,  //  0020  CALL	R5	2
-      0x8C14091B,  //  0021  GETMET	R5	R4	K27
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x7C140400,  //  0023  CALL	R5	2
-      0x8C14011C,  //  0024  GETMET	R5	R0	K28
-      0x7C140200,  //  0025  CALL	R5	1
-      0x50140200,  //  0026  LDBOOL	R5	1	0
-      0x80040A00,  //  0027  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_ScaleAnimation_tostring,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x4008031D,  //  0002  CONNECT	R2	R1	K29
-      0x4008031E,  //  0003  CONNECT	R2	R1	K30
-      0x4008031F,  //  0004  CONNECT	R2	R1	K31
-      0x40080320,  //  0005  CONNECT	R2	R1	K32
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x880C0101,  //  0007  GETMBR	R3	R0	K1
-      0x88100117,  //  0008  GETMBR	R4	R0	K23
-      0x94140202,  //  0009  GETIDX	R5	R1	R2
-      0x4C180000,  //  000A  LDNIL	R6
-      0x20140A06,  //  000B  NE	R5	R5	R6
-      0x78160001,  //  000C  JMPF	R5	#000F
-      0x94140202,  //  000D  GETIDX	R5	R1	R2
-      0x70020000,  //  000E  JMP		#0010
-      0x58140021,  //  000F  LDCONST	R5	K33
-      0x60180018,  //  0010  GETGBL	R6	G24
-      0x581C0022,  //  0011  LDCONST	R7	K34
-      0x5C200A00,  //  0012  MOVE	R8	R5
-      0x5C240600,  //  0013  MOVE	R9	R3
-      0x5C280800,  //  0014  MOVE	R10	R4
-      0x7C180800,  //  0015  CALL	R6	4
-      0x80040C00,  //  0016  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ScaleAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_ScaleAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080523,  //  0003  GETMET	R2	R2	K35
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020B02,  //  0006  SETMBR	R0	K5	K2
-      0x88080109,  //  0007  GETMBR	R2	R0	K9
-      0x88080524,  //  0008  GETMBR	R2	R2	K36
-      0x90023002,  //  0009  SETMBR	R0	K24	R2
-      0x8C08010C,  //  000A  GETMET	R2	R0	K12
-      0x7C080200,  //  000B  CALL	R2	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _sine
-********************************************************************/
-be_local_closure(class_ScaleAnimation__sine,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(_sine),
-    &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x540A003F,  //  0000  LDINT	R2	64
-      0x10080202,  //  0001  MOD	R2	R1	R2
-      0x540E003F,  //  0002  LDINT	R3	64
-      0x140C0203,  //  0003  LT	R3	R1	R3
-      0x780E0009,  //  0004  JMPF	R3	#000F
-      0xB80E0C00,  //  0005  GETNGBL	R3	K6
-      0x8C0C0707,  //  0006  GETMET	R3	R3	K7
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x58180002,  //  0008  LDCONST	R6	K2
-      0x541E003F,  //  0009  LDINT	R7	64
-      0x5422007F,  //  000A  LDINT	R8	128
-      0x542600FE,  //  000B  LDINT	R9	255
-      0x7C0C0C00,  //  000C  CALL	R3	6
-      0x80040600,  //  000D  RET	1	R3
-      0x70020025,  //  000E  JMP		#0035
-      0x540E007F,  //  000F  LDINT	R3	128
-      0x140C0203,  //  0010  LT	R3	R1	R3
-      0x780E000A,  //  0011  JMPF	R3	#001D
-      0xB80E0C00,  //  0012  GETNGBL	R3	K6
-      0x8C0C0707,  //  0013  GETMET	R3	R3	K7
-      0x5416007F,  //  0014  LDINT	R5	128
-      0x04140A01,  //  0015  SUB	R5	R5	R1
-      0x58180002,  //  0016  LDCONST	R6	K2
-      0x541E003F,  //  0017  LDINT	R7	64
-      0x5422007F,  //  0018  LDINT	R8	128
-      0x542600FE,  //  0019  LDINT	R9	255
-      0x7C0C0C00,  //  001A  CALL	R3	6
-      0x80040600,  //  001B  RET	1	R3
-      0x70020017,  //  001C  JMP		#0035
-      0x540E00BF,  //  001D  LDINT	R3	192
-      0x140C0203,  //  001E  LT	R3	R1	R3
-      0x780E000A,  //  001F  JMPF	R3	#002B
-      0xB80E0C00,  //  0020  GETNGBL	R3	K6
-      0x8C0C0707,  //  0021  GETMET	R3	R3	K7
-      0x5416007F,  //  0022  LDINT	R5	128
-      0x04140205,  //  0023  SUB	R5	R1	R5
-      0x58180002,  //  0024  LDCONST	R6	K2
-      0x541E003F,  //  0025  LDINT	R7	64
-      0x5422007F,  //  0026  LDINT	R8	128
-      0x58240002,  //  0027  LDCONST	R9	K2
-      0x7C0C0C00,  //  0028  CALL	R3	6
-      0x80040600,  //  0029  RET	1	R3
-      0x70020009,  //  002A  JMP		#0035
-      0xB80E0C00,  //  002B  GETNGBL	R3	K6
-      0x8C0C0707,  //  002C  GETMET	R3	R3	K7
-      0x541600FF,  //  002D  LDINT	R5	256
-      0x04140A01,  //  002E  SUB	R5	R5	R1
-      0x58180002,  //  002F  LDCONST	R6	K2
-      0x541E003F,  //  0030  LDINT	R7	64
-      0x5422007F,  //  0031  LDINT	R8	128
-      0x58240002,  //  0032  LDCONST	R9	K2
-      0x7C0C0C00,  //  0033  CALL	R3	6
-      0x80040600,  //  0034  RET	1	R3
-      0x80000000,  //  0035  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _initialize_buffers
-********************************************************************/
-be_local_closure(class_ScaleAnimation__initialize_buffers,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(_initialize_buffers),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0001  GETMET	R1	R1	K10
-      0x7C040200,  //  0002  CALL	R1	1
-      0xB80A4A00,  //  0003  GETNGBL	R2	K37
-      0x8C080526,  //  0004  GETMET	R2	R2	K38
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x90022002,  //  0007  SETMBR	R0	K16	R2
-      0x60080012,  //  0008  GETGBL	R2	G18
-      0x7C080000,  //  0009  CALL	R2	0
-      0x90021602,  //  000A  SETMBR	R0	K11	R2
-      0x8808010B,  //  000B  GETMBR	R2	R0	K11
-      0x8C080527,  //  000C  GETMET	R2	R2	K39
-      0x5C100200,  //  000D  MOVE	R4	R1
-      0x7C080400,  //  000E  CALL	R2	2
-      0x58080002,  //  000F  LDCONST	R2	K2
-      0x140C0401,  //  0010  LT	R3	R2	R1
-      0x780E0003,  //  0011  JMPF	R3	#0016
-      0x880C010B,  //  0012  GETMBR	R3	R0	K11
-      0x980C0515,  //  0013  SETIDX	R3	R2	K21
-      0x00080503,  //  0014  ADD	R2	R2	K3
-      0x7001FFF9,  //  0015  JMP		#0010
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_ScaleAnimation_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0203,  //  0001  EQ	R3	R1	R3
-      0x780E0001,  //  0002  JMPF	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x880C0109,  //  0005  GETMBR	R3	R0	K9
-      0x8C0C070A,  //  0006  GETMET	R3	R3	K10
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x58100002,  //  0008  LDCONST	R4	K2
-      0x14140803,  //  0009  LT	R5	R4	R3
-      0x78160009,  //  000A  JMPF	R5	#0015
-      0x88140328,  //  000B  GETMBR	R5	R1	K40
-      0x14140805,  //  000C  LT	R5	R4	R5
-      0x78160004,  //  000D  JMPF	R5	#0013
-      0x8C140329,  //  000E  GETMET	R5	R1	K41
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x8820010B,  //  0010  GETMBR	R8	R0	K11
-      0x94201004,  //  0011  GETIDX	R8	R8	R4
-      0x7C140600,  //  0012  CALL	R5	3
-      0x00100903,  //  0013  ADD	R4	R4	K3
-      0x7001FFF3,  //  0014  JMP		#0009
-      0x50140200,  //  0015  LDBOOL	R5	1	0
-      0x80040A00,  //  0016  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _interpolate_colors
-********************************************************************/
-be_local_closure(class_ScaleAnimation__interpolate_colors,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(_interpolate_colors),
-    &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
-      0x18100702,  //  0000  LE	R4	R3	K2
-      0x78120001,  //  0001  JMPF	R4	#0004
-      0x80040200,  //  0002  RET	1	R1
-      0x70020003,  //  0003  JMP		#0008
-      0x541200FF,  //  0004  LDINT	R4	256
-      0x28100604,  //  0005  GE	R4	R3	R4
-      0x78120000,  //  0006  JMPF	R4	#0008
-      0x80040400,  //  0007  RET	1	R2
-      0x54120017,  //  0008  LDINT	R4	24
-      0x3C100204,  //  0009  SHR	R4	R1	R4
-      0x541600FE,  //  000A  LDINT	R5	255
-      0x2C100805,  //  000B  AND	R4	R4	R5
-      0x5416000F,  //  000C  LDINT	R5	16
-      0x3C140205,  //  000D  SHR	R5	R1	R5
-      0x541A00FE,  //  000E  LDINT	R6	255
-      0x2C140A06,  //  000F  AND	R5	R5	R6
-      0x541A0007,  //  0010  LDINT	R6	8
-      0x3C180206,  //  0011  SHR	R6	R1	R6
-      0x541E00FE,  //  0012  LDINT	R7	255
-      0x2C180C07,  //  0013  AND	R6	R6	R7
-      0x541E00FE,  //  0014  LDINT	R7	255
-      0x2C1C0207,  //  0015  AND	R7	R1	R7
-      0x54220017,  //  0016  LDINT	R8	24
-      0x3C200408,  //  0017  SHR	R8	R2	R8
-      0x542600FE,  //  0018  LDINT	R9	255
-      0x2C201009,  //  0019  AND	R8	R8	R9
-      0x5426000F,  //  001A  LDINT	R9	16
-      0x3C240409,  //  001B  SHR	R9	R2	R9
-      0x542A00FE,  //  001C  LDINT	R10	255
-      0x2C24120A,  //  001D  AND	R9	R9	R10
-      0x542A0007,  //  001E  LDINT	R10	8
-      0x3C28040A,  //  001F  SHR	R10	R2	R10
-      0x542E00FE,  //  0020  LDINT	R11	255
-      0x2C28140B,  //  0021  AND	R10	R10	R11
-      0x542E00FE,  //  0022  LDINT	R11	255
-      0x2C2C040B,  //  0023  AND	R11	R2	R11
-      0x04301004,  //  0024  SUB	R12	R8	R4
-      0x08301803,  //  0025  MUL	R12	R12	R3
-      0x543600FF,  //  0026  LDINT	R13	256
-      0x0C30180D,  //  0027  DIV	R12	R12	R13
-      0x0030080C,  //  0028  ADD	R12	R4	R12
-      0x04341205,  //  0029  SUB	R13	R9	R5
-      0x08341A03,  //  002A  MUL	R13	R13	R3
-      0x543A00FF,  //  002B  LDINT	R14	256
-      0x0C341A0E,  //  002C  DIV	R13	R13	R14
-      0x00340A0D,  //  002D  ADD	R13	R5	R13
-      0x04381406,  //  002E  SUB	R14	R10	R6
-      0x08381C03,  //  002F  MUL	R14	R14	R3
-      0x543E00FF,  //  0030  LDINT	R15	256
-      0x0C381C0F,  //  0031  DIV	R14	R14	R15
-      0x00380C0E,  //  0032  ADD	R14	R6	R14
-      0x043C1607,  //  0033  SUB	R15	R11	R7
-      0x083C1E03,  //  0034  MUL	R15	R15	R3
-      0x544200FF,  //  0035  LDINT	R16	256
-      0x0C3C1E10,  //  0036  DIV	R15	R15	R16
-      0x003C0E0F,  //  0037  ADD	R15	R7	R15
-      0x54420017,  //  0038  LDINT	R16	24
-      0x38401810,  //  0039  SHL	R16	R12	R16
-      0x5446000F,  //  003A  LDINT	R17	16
-      0x38441A11,  //  003B  SHL	R17	R13	R17
-      0x30402011,  //  003C  OR	R16	R16	R17
-      0x54460007,  //  003D  LDINT	R17	8
-      0x38441C11,  //  003E  SHL	R17	R14	R17
-      0x30402011,  //  003F  OR	R16	R16	R17
-      0x3040200F,  //  0040  OR	R16	R16	R15
-      0x80042000,  //  0041  RET	1	R16
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_ScaleAnimation_start,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ScaleAnimation,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08051A,  //  0003  GETMET	R2	R2	K26
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020B02,  //  0006  SETMBR	R0	K5	K2
-      0x4C080000,  //  0007  LDNIL	R2
-      0x1C080202,  //  0008  EQ	R2	R1	R2
-      0x780A0001,  //  0009  JMPF	R2	#000C
-      0x88080109,  //  000A  GETMBR	R2	R0	K9
-      0x88040524,  //  000B  GETMBR	R1	R2	K36
-      0x90023001,  //  000C  SETMBR	R0	K24	R1
-      0x80040000,  //  000D  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: ScaleAnimation
-********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(ScaleAnimation,
-    4,
-    &be_class_Animation,
-    be_nested_map(16,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_calculate_scale, -1), be_const_closure(class_ScaleAnimation__calculate_scale_closure) },
-        { be_const_key_weak(scale_phase, -1), be_const_var(0) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_ScaleAnimation_tostring_closure) },
-        { be_const_key_weak(PARAMS, 10), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(6,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(scale_center, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(scale_speed, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(source_animation, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-        { be_const_key_weak(scale_factor, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(scale_mode, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(3) },
-    }))    ) } )) },
-        { be_const_key_weak(interpolation, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(1) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(update, -1), be_const_closure(class_ScaleAnimation_update_closure) },
-        { be_const_key_weak(_get_current_scale_factor, 2), be_const_closure(class_ScaleAnimation__get_current_scale_factor_closure) },
-        { be_const_key_weak(source_frame, -1), be_const_var(1) },
-        { be_const_key_weak(current_colors, -1), be_const_var(2) },
-        { be_const_key_weak(render, -1), be_const_closure(class_ScaleAnimation_render_closure) },
-        { be_const_key_weak(start_time, -1), be_const_var(3) },
-        { be_const_key_weak(init, 0), be_const_closure(class_ScaleAnimation_init_closure) },
-        { be_const_key_weak(_sine, -1), be_const_closure(class_ScaleAnimation__sine_closure) },
-        { be_const_key_weak(_initialize_buffers, -1), be_const_closure(class_ScaleAnimation__initialize_buffers_closure) },
-        { be_const_key_weak(on_param_changed, 8), be_const_closure(class_ScaleAnimation_on_param_changed_closure) },
-        { be_const_key_weak(_interpolate_colors, -1), be_const_closure(class_ScaleAnimation__interpolate_colors_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_ScaleAnimation_start_closure) },
-    })),
-    be_str_weak(ScaleAnimation)
-);
 
 extern const bclass be_class_PaletteWaveAnimation;
 
@@ -6978,9 +6465,9 @@ be_local_class(PaletteWaveAnimation,
 );
 
 /********************************************************************
-** Solidified function: bounce_basic
+** Solidified function: bounce_constrained
 ********************************************************************/
-be_local_closure(bounce_basic,   /* name */
+be_local_closure(bounce_constrained,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -6995,27 +6482,28 @@ be_local_closure(bounce_basic,   /* name */
     /* K1   */  be_nested_str_weak(bounce_animation),
     /* K2   */  be_nested_str_weak(bounce_speed),
     /* K3   */  be_nested_str_weak(bounce_range),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(damping),
-    /* K6   */  be_nested_str_weak(gravity),
+    /* K4   */  be_nested_str_weak(damping),
+    /* K5   */  be_nested_str_weak(gravity),
+    /* K6   */  be_const_int(0),
     /* K7   */  be_nested_str_weak(name),
-    /* K8   */  be_nested_str_weak(bounce_basic),
+    /* K8   */  be_nested_str_weak(bounce_constrained),
     }),
-    be_str_weak(bounce_basic),
+    be_str_weak(bounce_constrained),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x540A007F,  //  0004  LDINT	R2	128
+      0x540A0095,  //  0004  LDINT	R2	150
       0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x540A00F9,  //  0007  LDINT	R2	250
-      0x90060A02,  //  0008  SETMBR	R1	K5	R2
-      0x90060D04,  //  0009  SETMBR	R1	K6	K4
-      0x90060F08,  //  000A  SETMBR	R1	K7	K8
-      0x80040200,  //  000B  RET	1	R1
+      0x540A000E,  //  0006  LDINT	R2	15
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A00F9,  //  0008  LDINT	R2	250
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x90060B06,  //  000A  SETMBR	R1	K5	K6
+      0x90060F08,  //  000B  SETMBR	R1	K7	K8
+      0x80040200,  //  000C  RET	1	R1
     })
   )
 );
@@ -7177,9 +6665,9 @@ be_local_closure(get_registered_events,   /* name */
 
 
 /********************************************************************
-** Solidified function: bounce_constrained
+** Solidified function: pulsating_animation
 ********************************************************************/
-be_local_closure(bounce_constrained,   /* name */
+be_local_closure(pulsating_animation,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -7189,33 +6677,24 @@ be_local_closure(bounce_constrained,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(bounce_animation),
-    /* K2   */  be_nested_str_weak(bounce_speed),
-    /* K3   */  be_nested_str_weak(bounce_range),
-    /* K4   */  be_nested_str_weak(damping),
-    /* K5   */  be_nested_str_weak(gravity),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(name),
-    /* K8   */  be_nested_str_weak(bounce_constrained),
+    /* K1   */  be_nested_str_weak(breathe_animation),
+    /* K2   */  be_nested_str_weak(curve_factor),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(period),
     }),
-    be_str_weak(bounce_constrained),
+    be_str_weak(pulsating_animation),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x540A0095,  //  0004  LDINT	R2	150
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A000E,  //  0006  LDINT	R2	15
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A00F9,  //  0008  LDINT	R2	250
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x90060B06,  //  000A  SETMBR	R1	K5	K6
-      0x90060F08,  //  000B  SETMBR	R1	K7	K8
-      0x80040200,  //  000C  RET	1	R1
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A03E7,  //  0005  LDINT	R2	1000
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
+      0x80040200,  //  0007  RET	1	R1
     })
   )
 );
@@ -8636,42 +8115,467 @@ be_local_closure(bounce,   /* name */
 );
 /*******************************************************************/
 
+// compact class 'ShiftAnimation' ktab size: 33, total: 62 (saved 232 bytes)
+static const bvalue be_ktab_class_ShiftAnimation[33] = {
+  /* K0   */  be_nested_str_weak(engine),
+  /* K1   */  be_nested_str_weak(get_strip_length),
+  /* K2   */  be_nested_str_weak(source_frame),
+  /* K3   */  be_nested_str_weak(animation),
+  /* K4   */  be_nested_str_weak(frame_buffer),
+  /* K5   */  be_nested_str_weak(current_colors),
+  /* K6   */  be_nested_str_weak(resize),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_const_int(-16777216),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(update),
+  /* K11  */  be_nested_str_weak(shift_speed),
+  /* K12  */  be_nested_str_weak(direction),
+  /* K13  */  be_nested_str_weak(wrap_around),
+  /* K14  */  be_nested_str_weak(source_animation),
+  /* K15  */  be_nested_str_weak(start_time),
+  /* K16  */  be_nested_str_weak(tasmota),
+  /* K17  */  be_nested_str_weak(scale_uint),
+  /* K18  */  be_nested_str_weak(current_offset),
+  /* K19  */  be_nested_str_weak(is_running),
+  /* K20  */  be_nested_str_weak(start),
+  /* K21  */  be_nested_str_weak(_calculate_shift),
+  /* K22  */  be_nested_str_weak(priority),
+  /* K23  */  be_nested_str_weak(right),
+  /* K24  */  be_nested_str_weak(left),
+  /* K25  */  be_nested_str_weak(ShiftAnimation_X28_X25s_X2C_X20speed_X3D_X25s_X2C_X20wrap_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K26  */  be_nested_str_weak(width),
+  /* K27  */  be_nested_str_weak(set_pixel_color),
+  /* K28  */  be_nested_str_weak(_initialize_buffers),
+  /* K29  */  be_nested_str_weak(clear),
+  /* K30  */  be_nested_str_weak(render),
+  /* K31  */  be_nested_str_weak(get_pixel_color),
+  /* K32  */  be_nested_str_weak(init),
+};
+
+
+extern const bclass be_class_ShiftAnimation;
 
 /********************************************************************
-** Solidified function: smooth
+** Solidified function: _initialize_buffers
 ********************************************************************/
-be_local_closure(smooth,   /* name */
+be_local_closure(class_ShiftAnimation__initialize_buffers,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(COSINE),
-    }),
-    be_str_weak(smooth),
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(_initialize_buffers),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
+    ( &(const binstruction[23]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0600,  //  0003  GETNGBL	R2	K3
+      0x8C080504,  //  0004  GETMET	R2	R2	K4
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x90020402,  //  0007  SETMBR	R0	K2	R2
+      0x60080012,  //  0008  GETGBL	R2	G18
+      0x7C080000,  //  0009  CALL	R2	0
+      0x90020A02,  //  000A  SETMBR	R0	K5	R2
+      0x88080105,  //  000B  GETMBR	R2	R0	K5
+      0x8C080506,  //  000C  GETMET	R2	R2	K6
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x7C080400,  //  000E  CALL	R2	2
+      0x58080007,  //  000F  LDCONST	R2	K7
+      0x140C0401,  //  0010  LT	R3	R2	R1
+      0x780E0003,  //  0011  JMPF	R3	#0016
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x980C0508,  //  0013  SETIDX	R3	R2	K8
+      0x00080509,  //  0014  ADD	R2	R2	K9
+      0x7001FFF9,  //  0015  JMP		#0010
+      0x80000000,  //  0016  RET	0
     })
   )
 );
 /*******************************************************************/
 
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_ShiftAnimation_update,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[63]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08050A,  //  0003  GETMET	R2	R2	K10
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8808010B,  //  0006  GETMBR	R2	R0	K11
+      0x880C010C,  //  0007  GETMBR	R3	R0	K12
+      0x8810010D,  //  0008  GETMBR	R4	R0	K13
+      0x8814010E,  //  0009  GETMBR	R5	R0	K14
+      0x88180100,  //  000A  GETMBR	R6	R0	K0
+      0x8C180D01,  //  000B  GETMET	R6	R6	K1
+      0x7C180200,  //  000C  CALL	R6	1
+      0x241C0507,  //  000D  GT	R7	R2	K7
+      0x781E0020,  //  000E  JMPF	R7	#0030
+      0x881C010F,  //  000F  GETMBR	R7	R0	K15
+      0x041C0207,  //  0010  SUB	R7	R1	R7
+      0xB8222000,  //  0011  GETNGBL	R8	K16
+      0x8C201111,  //  0012  GETMET	R8	R8	K17
+      0x5C280400,  //  0013  MOVE	R10	R2
+      0x582C0007,  //  0014  LDCONST	R11	K7
+      0x543200FE,  //  0015  LDINT	R12	255
+      0x58340007,  //  0016  LDCONST	R13	K7
+      0x543A0009,  //  0017  LDINT	R14	10
+      0x543E00FF,  //  0018  LDINT	R15	256
+      0x08381C0F,  //  0019  MUL	R14	R14	R15
+      0x7C200C00,  //  001A  CALL	R8	6
+      0x24241107,  //  001B  GT	R9	R8	K7
+      0x78260012,  //  001C  JMPF	R9	#0030
+      0x08240E08,  //  001D  MUL	R9	R7	R8
+      0x542A03E7,  //  001E  LDINT	R10	1000
+      0x0C24120A,  //  001F  DIV	R9	R9	R10
+      0x08241203,  //  0020  MUL	R9	R9	R3
+      0x7812000C,  //  0021  JMPF	R4	#002F
+      0x542A00FF,  //  0022  LDINT	R10	256
+      0x08280C0A,  //  0023  MUL	R10	R6	R10
+      0x1028120A,  //  0024  MOD	R10	R9	R10
+      0x9002240A,  //  0025  SETMBR	R0	K18	R10
+      0x88280112,  //  0026  GETMBR	R10	R0	K18
+      0x14281507,  //  0027  LT	R10	R10	K7
+      0x782A0004,  //  0028  JMPF	R10	#002E
+      0x542E00FF,  //  0029  LDINT	R11	256
+      0x082C0C0B,  //  002A  MUL	R11	R6	R11
+      0x88280112,  //  002B  GETMBR	R10	R0	K18
+      0x0028140B,  //  002C  ADD	R10	R10	R11
+      0x9002240A,  //  002D  SETMBR	R0	K18	R10
+      0x70020000,  //  002E  JMP		#0030
+      0x90022409,  //  002F  SETMBR	R0	K18	R9
+      0x4C1C0000,  //  0030  LDNIL	R7
+      0x201C0A07,  //  0031  NE	R7	R5	R7
+      0x781E0007,  //  0032  JMPF	R7	#003B
+      0x881C0B13,  //  0033  GETMBR	R7	R5	K19
+      0x741E0002,  //  0034  JMPT	R7	#0038
+      0x8C1C0B14,  //  0035  GETMET	R7	R5	K20
+      0x8824010F,  //  0036  GETMBR	R9	R0	K15
+      0x7C1C0400,  //  0037  CALL	R7	2
+      0x8C1C0B0A,  //  0038  GETMET	R7	R5	K10
+      0x5C240200,  //  0039  MOVE	R9	R1
+      0x7C1C0400,  //  003A  CALL	R7	2
+      0x8C1C0115,  //  003B  GETMET	R7	R0	K21
+      0x7C1C0200,  //  003C  CALL	R7	1
+      0x501C0200,  //  003D  LDBOOL	R7	1	0
+      0x80040E00,  //  003E  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_ShiftAnimation_tostring,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x8804010C,  //  0000  GETMBR	R1	R0	K12
+      0x8808010B,  //  0001  GETMBR	R2	R0	K11
+      0x880C010D,  //  0002  GETMBR	R3	R0	K13
+      0x88100116,  //  0003  GETMBR	R4	R0	K22
+      0x24140307,  //  0004  GT	R5	R1	K7
+      0x78160001,  //  0005  JMPF	R5	#0008
+      0x58140017,  //  0006  LDCONST	R5	K23
+      0x70020000,  //  0007  JMP		#0009
+      0x58140018,  //  0008  LDCONST	R5	K24
+      0x60180018,  //  0009  GETGBL	R6	G24
+      0x581C0019,  //  000A  LDCONST	R7	K25
+      0x5C200A00,  //  000B  MOVE	R8	R5
+      0x5C240400,  //  000C  MOVE	R9	R2
+      0x5C280600,  //  000D  MOVE	R10	R3
+      0x5C2C0800,  //  000E  MOVE	R11	R4
+      0x88300113,  //  000F  GETMBR	R12	R0	K19
+      0x7C180C00,  //  0010  CALL	R6	6
+      0x80040C00,  //  0011  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_ShiftAnimation_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x880C0113,  //  0000  GETMBR	R3	R0	K19
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x880C0100,  //  0007  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x58100007,  //  000A  LDCONST	R4	K7
+      0x14140803,  //  000B  LT	R5	R4	R3
+      0x78160009,  //  000C  JMPF	R5	#0017
+      0x8814031A,  //  000D  GETMBR	R5	R1	K26
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x78160004,  //  000F  JMPF	R5	#0015
+      0x8C14031B,  //  0010  GETMET	R5	R1	K27
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x88200105,  //  0012  GETMBR	R8	R0	K5
+      0x94201004,  //  0013  GETIDX	R8	R8	R4
+      0x7C140600,  //  0014  CALL	R5	3
+      0x00100909,  //  0015  ADD	R4	R4	K9
+      0x7001FFF3,  //  0016  JMP		#000B
+      0x50140200,  //  0017  LDBOOL	R5	1	0
+      0x80040A00,  //  0018  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ShiftAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x1C0C030E,  //  0000  EQ	R3	R1	K14
+      0x780E0001,  //  0001  JMPF	R3	#0004
+      0x8C0C011C,  //  0002  GETMET	R3	R0	K28
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _calculate_shift
+********************************************************************/
+be_local_closure(class_ShiftAnimation__calculate_shift,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(_calculate_shift),
+    &be_const_str_solidified,
+    ( &(const binstruction[64]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C0105,  //  0004  GETMBR	R3	R0	K5
+      0x7C080200,  //  0005  CALL	R2	1
+      0x20080401,  //  0006  NE	R2	R2	R1
+      0x780A0001,  //  0007  JMPF	R2	#000A
+      0x8C08011C,  //  0008  GETMET	R2	R0	K28
+      0x7C080200,  //  0009  CALL	R2	1
+      0x8808010E,  //  000A  GETMBR	R2	R0	K14
+      0x880C010D,  //  000B  GETMBR	R3	R0	K13
+      0x88100102,  //  000C  GETMBR	R4	R0	K2
+      0x8C10091D,  //  000D  GETMET	R4	R4	K29
+      0x7C100200,  //  000E  CALL	R4	1
+      0x4C100000,  //  000F  LDNIL	R4
+      0x20100404,  //  0010  NE	R4	R2	R4
+      0x78120003,  //  0011  JMPF	R4	#0016
+      0x8C10051E,  //  0012  GETMET	R4	R2	K30
+      0x88180102,  //  0013  GETMBR	R6	R0	K2
+      0x581C0007,  //  0014  LDCONST	R7	K7
+      0x7C100600,  //  0015  CALL	R4	3
+      0x88100112,  //  0016  GETMBR	R4	R0	K18
+      0x541600FF,  //  0017  LDINT	R5	256
+      0x0C100805,  //  0018  DIV	R4	R4	R5
+      0x88140112,  //  0019  GETMBR	R5	R0	K18
+      0x541A00FF,  //  001A  LDINT	R6	256
+      0x10140A06,  //  001B  MOD	R5	R5	R6
+      0x58180007,  //  001C  LDCONST	R6	K7
+      0x141C0C01,  //  001D  LT	R7	R6	R1
+      0x781E001F,  //  001E  JMPF	R7	#003F
+      0x041C0C04,  //  001F  SUB	R7	R6	R4
+      0x780E000E,  //  0020  JMPF	R3	#0030
+      0x14200F07,  //  0021  LT	R8	R7	K7
+      0x78220001,  //  0022  JMPF	R8	#0025
+      0x001C0E01,  //  0023  ADD	R7	R7	R1
+      0x7001FFFB,  //  0024  JMP		#0021
+      0x28200E01,  //  0025  GE	R8	R7	R1
+      0x78220001,  //  0026  JMPF	R8	#0029
+      0x041C0E01,  //  0027  SUB	R7	R7	R1
+      0x7001FFFB,  //  0028  JMP		#0025
+      0x88200105,  //  0029  GETMBR	R8	R0	K5
+      0x88240102,  //  002A  GETMBR	R9	R0	K2
+      0x8C24131F,  //  002B  GETMET	R9	R9	K31
+      0x5C2C0E00,  //  002C  MOVE	R11	R7
+      0x7C240400,  //  002D  CALL	R9	2
+      0x98200C09,  //  002E  SETIDX	R8	R6	R9
+      0x7002000C,  //  002F  JMP		#003D
+      0x28200F07,  //  0030  GE	R8	R7	K7
+      0x78220008,  //  0031  JMPF	R8	#003B
+      0x14200E01,  //  0032  LT	R8	R7	R1
+      0x78220006,  //  0033  JMPF	R8	#003B
+      0x88200105,  //  0034  GETMBR	R8	R0	K5
+      0x88240102,  //  0035  GETMBR	R9	R0	K2
+      0x8C24131F,  //  0036  GETMET	R9	R9	K31
+      0x5C2C0E00,  //  0037  MOVE	R11	R7
+      0x7C240400,  //  0038  CALL	R9	2
+      0x98200C09,  //  0039  SETIDX	R8	R6	R9
+      0x70020001,  //  003A  JMP		#003D
+      0x88200105,  //  003B  GETMBR	R8	R0	K5
+      0x98200D08,  //  003C  SETIDX	R8	R6	K8
+      0x00180D09,  //  003D  ADD	R6	R6	K9
+      0x7001FFDD,  //  003E  JMP		#001D
+      0x80000000,  //  003F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_ShiftAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ShiftAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080520,  //  0003  GETMET	R2	R2	K32
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90022507,  //  0006  SETMBR	R0	K18	K7
+      0x8C08011C,  //  0007  GETMET	R2	R0	K28
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: ShiftAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(ShiftAnimation,
+    3,
+    &be_class_Animation,
+    be_nested_map(11,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(current_colors, -1), be_const_var(2) },
+        { be_const_key_weak(_initialize_buffers, -1), be_const_closure(class_ShiftAnimation__initialize_buffers_closure) },
+        { be_const_key_weak(current_offset, 6), be_const_var(0) },
+        { be_const_key_weak(tostring, 2), be_const_closure(class_ShiftAnimation_tostring_closure) },
+        { be_const_key_weak(update, 10), be_const_closure(class_ShiftAnimation_update_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ShiftAnimation_on_param_changed_closure) },
+        { be_const_key_weak(source_frame, -1), be_const_var(1) },
+        { be_const_key_weak(_calculate_shift, -1), be_const_closure(class_ShiftAnimation__calculate_shift_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(4,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(shift_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(source_animation, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_nil() },
+        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
+    }))    ) } )) },
+        { be_const_key_weak(direction, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(1) },
+        { be_const_key_weak(min, -1), be_const_int(-1) },
+        { be_const_key_weak(max, 1), be_const_int(1) },
+    }))    ) } )) },
+        { be_const_key_weak(wrap_around, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_bool(1) },
+        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_ShiftAnimation_init_closure) },
+        { be_const_key_weak(render, -1), be_const_closure(class_ShiftAnimation_render_closure) },
+    })),
+    be_str_weak(ShiftAnimation)
+);
 
 /********************************************************************
 ** Solidified function: jitter_all
@@ -8753,46 +8657,6 @@ be_local_closure(linear,   /* name */
 
 
 /********************************************************************
-** Solidified function: shift_fast_scroll
-********************************************************************/
-be_local_closure(shift_fast_scroll,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(shift_animation),
-    /* K2   */  be_nested_str_weak(direction),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(shift_speed),
-    /* K5   */  be_nested_str_weak(wrap_around),
-    }),
-    be_str_weak(shift_fast_scroll),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A00C7,  //  0005  LDINT	R2	200
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
-      0x50080200,  //  0007  LDBOOL	R2	1	0
-      0x90060A02,  //  0008  SETMBR	R1	K5	R2
-      0x80040200,  //  0009  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: shift_scroll_right
 ********************************************************************/
 be_local_closure(shift_scroll_right,   /* name */
@@ -8826,6 +8690,72 @@ be_local_closure(shift_scroll_right,   /* name */
       0x50080200,  //  0007  LDBOOL	R2	1	0
       0x90060A02,  //  0008  SETMBR	R1	K5	R2
       0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: wave_rainbow_sine
+********************************************************************/
+be_local_closure(wave_rainbow_sine,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(wave_animation),
+    /* K2   */  be_nested_str_weak(rich_palette),
+    /* K3   */  be_nested_str_weak(palette),
+    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
+    /* K5   */  be_nested_str_weak(cycle_period),
+    /* K6   */  be_nested_str_weak(transition_type),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(brightness),
+    /* K9   */  be_nested_str_weak(set_range),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(color),
+    /* K12  */  be_nested_str_weak(wave_type),
+    /* K13  */  be_nested_str_weak(frequency),
+    /* K14  */  be_nested_str_weak(wave_speed),
+    }),
+    be_str_weak(wave_rainbow_sine),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0xB80E0000,  //  0008  GETNGBL	R3	K0
+      0x880C0704,  //  0009  GETMBR	R3	R3	K4
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0x540E1387,  //  000B  LDINT	R3	5000
+      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
+      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
+      0x540E00FE,  //  000E  LDINT	R3	255
+      0x900A1003,  //  000F  SETMBR	R2	K8	R3
+      0x8C0C0509,  //  0010  GETMET	R3	R2	K9
+      0x5814000A,  //  0011  LDCONST	R5	K10
+      0x541A00FE,  //  0012  LDINT	R6	255
+      0x7C0C0600,  //  0013  CALL	R3	3
+      0x90061602,  //  0014  SETMBR	R1	K11	R2
+      0x9006190A,  //  0015  SETMBR	R1	K12	K10
+      0x540E001F,  //  0016  LDINT	R3	32
+      0x90061A03,  //  0017  SETMBR	R1	K13	R3
+      0x540E0031,  //  0018  LDINT	R3	50
+      0x90061C03,  //  0019  SETMBR	R1	K14	R3
+      0x80040200,  //  001A  RET	1	R1
     })
   )
 );
@@ -9183,35 +9113,131 @@ be_local_closure(square,   /* name */
 
 
 /********************************************************************
-** Solidified function: elastic
+** Solidified function: color_cycle_rainbow
 ********************************************************************/
-be_local_closure(elastic,   /* name */
+be_local_closure(color_cycle_rainbow,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    19,                          /* nstack */
+    3,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(ELASTIC),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_const_int(2),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(scale_uint),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(animation),
+    /* K8   */  be_nested_str_weak(color_cycle),
+    /* K9   */  be_nested_str_weak(palette),
+    /* K10  */  be_nested_str_weak(cycle_period),
     }),
-    be_str_weak(elastic),
+    be_str_weak(color_cycle_rainbow),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
+    ( &(const binstruction[97]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0203,  //  0001  EQ	R3	R1	R3
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x140C0300,  //  0003  LT	R3	R1	K0
+      0x780E0000,  //  0004  JMPF	R3	#0006
+      0x54060005,  //  0005  LDINT	R1	6
+      0x600C0012,  //  0006  GETGBL	R3	G18
+      0x7C0C0000,  //  0007  CALL	R3	0
+      0x58100001,  //  0008  LDCONST	R4	K1
+      0x14140801,  //  0009  LT	R5	R4	R1
+      0x7816004B,  //  000A  JMPF	R5	#0057
+      0xB8160400,  //  000B  GETNGBL	R5	K2
+      0x8C140B03,  //  000C  GETMET	R5	R5	K3
+      0x5C1C0800,  //  000D  MOVE	R7	R4
+      0x58200001,  //  000E  LDCONST	R8	K1
+      0x5C240200,  //  000F  MOVE	R9	R1
+      0x58280001,  //  0010  LDCONST	R10	K1
+      0x542E0167,  //  0011  LDINT	R11	360
+      0x7C140C00,  //  0012  CALL	R5	6
+      0x4C180000,  //  0013  LDNIL	R6
+      0x4C1C0000,  //  0014  LDNIL	R7
+      0x4C200000,  //  0015  LDNIL	R8
+      0x5426003B,  //  0016  LDINT	R9	60
+      0x0C240A09,  //  0017  DIV	R9	R5	R9
+      0x542A0005,  //  0018  LDINT	R10	6
+      0x1024120A,  //  0019  MOD	R9	R9	R10
+      0x542A003B,  //  001A  LDINT	R10	60
+      0x0C280A0A,  //  001B  DIV	R10	R5	R10
+      0x04281409,  //  001C  SUB	R10	R10	R9
+      0x542E00FE,  //  001D  LDINT	R11	255
+      0x58300001,  //  001E  LDCONST	R12	K1
+      0x60340009,  //  001F  GETGBL	R13	G9
+      0x043A080A,  //  0020  SUB	R14	K4	R10
+      0x0838160E,  //  0021  MUL	R14	R11	R14
+      0x7C340200,  //  0022  CALL	R13	1
+      0x60380009,  //  0023  GETGBL	R14	G9
+      0x083C160A,  //  0024  MUL	R15	R11	R10
+      0x7C380200,  //  0025  CALL	R14	1
+      0x1C3C1301,  //  0026  EQ	R15	R9	K1
+      0x783E0003,  //  0027  JMPF	R15	#002C
+      0x5C181600,  //  0028  MOVE	R6	R11
+      0x5C1C1C00,  //  0029  MOVE	R7	R14
+      0x5C201800,  //  002A  MOVE	R8	R12
+      0x7002001B,  //  002B  JMP		#0048
+      0x1C3C1304,  //  002C  EQ	R15	R9	K4
+      0x783E0003,  //  002D  JMPF	R15	#0032
+      0x5C181A00,  //  002E  MOVE	R6	R13
+      0x5C1C1600,  //  002F  MOVE	R7	R11
+      0x5C201800,  //  0030  MOVE	R8	R12
+      0x70020015,  //  0031  JMP		#0048
+      0x1C3C1300,  //  0032  EQ	R15	R9	K0
+      0x783E0003,  //  0033  JMPF	R15	#0038
+      0x5C181800,  //  0034  MOVE	R6	R12
+      0x5C1C1600,  //  0035  MOVE	R7	R11
+      0x5C201C00,  //  0036  MOVE	R8	R14
+      0x7002000F,  //  0037  JMP		#0048
+      0x1C3C1305,  //  0038  EQ	R15	R9	K5
+      0x783E0003,  //  0039  JMPF	R15	#003E
+      0x5C181800,  //  003A  MOVE	R6	R12
+      0x5C1C1A00,  //  003B  MOVE	R7	R13
+      0x5C201600,  //  003C  MOVE	R8	R11
+      0x70020009,  //  003D  JMP		#0048
+      0x543E0003,  //  003E  LDINT	R15	4
+      0x1C3C120F,  //  003F  EQ	R15	R9	R15
+      0x783E0003,  //  0040  JMPF	R15	#0045
+      0x5C181C00,  //  0041  MOVE	R6	R14
+      0x5C1C1800,  //  0042  MOVE	R7	R12
+      0x5C201600,  //  0043  MOVE	R8	R11
+      0x70020002,  //  0044  JMP		#0048
+      0x5C181600,  //  0045  MOVE	R6	R11
+      0x5C1C1800,  //  0046  MOVE	R7	R12
+      0x5C201A00,  //  0047  MOVE	R8	R13
+      0x543E00FE,  //  0048  LDINT	R15	255
+      0x54420017,  //  0049  LDINT	R16	24
+      0x383C1E10,  //  004A  SHL	R15	R15	R16
+      0x5442000F,  //  004B  LDINT	R16	16
+      0x38400C10,  //  004C  SHL	R16	R6	R16
+      0x303C1E10,  //  004D  OR	R15	R15	R16
+      0x54420007,  //  004E  LDINT	R16	8
+      0x38400E10,  //  004F  SHL	R16	R7	R16
+      0x303C1E10,  //  0050  OR	R15	R15	R16
+      0x303C1E08,  //  0051  OR	R15	R15	R8
+      0x8C400706,  //  0052  GETMET	R16	R3	K6
+      0x5C481E00,  //  0053  MOVE	R18	R15
+      0x7C400400,  //  0054  CALL	R16	2
+      0x00100904,  //  0055  ADD	R4	R4	K4
+      0x7001FFB1,  //  0056  JMP		#0009
+      0xB8160E00,  //  0057  GETNGBL	R5	K7
+      0x8C140B08,  //  0058  GETMET	R5	R5	K8
+      0x5C1C0000,  //  0059  MOVE	R7	R0
+      0x7C140400,  //  005A  CALL	R5	2
+      0x90161203,  //  005B  SETMBR	R5	K9	R3
+      0x4C180000,  //  005C  LDNIL	R6
+      0x20180406,  //  005D  NE	R6	R2	R6
+      0x781A0000,  //  005E  JMPF	R6	#0060
+      0x90161402,  //  005F  SETMBR	R5	K10	R2
+      0x80040A00,  //  0060  RET	1	R5
     })
   )
 );
@@ -10008,767 +10034,104 @@ be_local_class(NoiseAnimation,
     })),
     be_str_weak(NoiseAnimation)
 );
-// compact class 'AnimationEngine' ktab size: 47, total: 131 (saved 672 bytes)
-static const bvalue be_ktab_class_AnimationEngine[47] = {
-  /* K0   */  be_nested_str_weak(animations),
-  /* K1   */  be_nested_str_weak(is_running),
-  /* K2   */  be_nested_str_weak(stop),
-  /* K3   */  be_nested_str_weak(stop_iteration),
-  /* K4   */  be_nested_str_weak(strip),
-  /* K5   */  be_nested_str_weak(clear),
-  /* K6   */  be_nested_str_weak(show),
-  /* K7   */  be_const_int(1),
-  /* K8   */  be_const_int(0),
-  /* K9   */  be_nested_str_weak(priority),
-  /* K10  */  be_nested_str_weak(sequence_managers),
-  /* K11  */  be_nested_str_weak(remove),
-  /* K12  */  be_nested_str_weak(animation),
-  /* K13  */  be_nested_str_weak(event_manager),
-  /* K14  */  be_nested_str_weak(_process_queued_events),
-  /* K15  */  be_nested_str_weak(value_error),
-  /* K16  */  be_nested_str_weak(strip_X20cannot_X20be_X20nil),
-  /* K17  */  be_nested_str_weak(width),
-  /* K18  */  be_nested_str_weak(length),
-  /* K19  */  be_nested_str_weak(frame_buffer),
-  /* K20  */  be_nested_str_weak(temp_buffer),
-  /* K21  */  be_nested_str_weak(last_update),
-  /* K22  */  be_nested_str_weak(time_ms),
-  /* K23  */  be_nested_str_weak(fast_loop_closure),
-  /* K24  */  be_nested_str_weak(render_needed),
-  /* K25  */  be_nested_str_weak(set_pixel_color),
-  /* K26  */  be_nested_str_weak(get_pixel_color),
-  /* K27  */  be_nested_str_weak(tasmota),
-  /* K28  */  be_nested_str_weak(remove_fast_loop),
-  /* K29  */  be_nested_str_weak(start),
-  /* K30  */  be_nested_str_weak(millis),
-  /* K31  */  be_nested_str_weak(add_fast_loop),
-  /* K32  */  be_nested_str_weak(can_show),
-  /* K33  */  be_nested_str_weak(update),
-  /* K34  */  be_nested_str_weak(_process_events),
-  /* K35  */  be_nested_str_weak(_update_and_render),
-  /* K36  */  be_nested_str_weak(push),
-  /* K37  */  be_nested_str_weak(_sort_animations),
-  /* K38  */  be_nested_str_weak(resume),
-  /* K39  */  be_nested_str_weak(AnimationEngine_X28running_X3D_X25s_X2C_X20animations_X3D_X25s_X2C_X20width_X3D_X25s_X29),
-  /* K40  */  be_nested_str_weak(stop_sequence),
-  /* K41  */  be_nested_str_weak(_clear_strip),
-  /* K42  */  be_nested_str_weak(_render_animations),
-  /* K43  */  be_nested_str_weak(render),
-  /* K44  */  be_nested_str_weak(blend_pixels),
-  /* K45  */  be_nested_str_weak(_output_to_strip),
-  /* K46  */  be_nested_str_weak(name),
+// compact class 'PlasmaAnimation' ktab size: 46, total: 93 (saved 376 bytes)
+static const bvalue be_ktab_class_PlasmaAnimation[46] = {
+  /* K0   */  be_nested_str_weak(start),
+  /* K1   */  be_nested_str_weak(color),
+  /* K2   */  be_nested_str_weak(animation),
+  /* K3   */  be_nested_str_weak(rich_palette),
+  /* K4   */  be_nested_str_weak(engine),
+  /* K5   */  be_nested_str_weak(palette),
+  /* K6   */  be_nested_str_weak(PALETTE_RAINBOW),
+  /* K7   */  be_nested_str_weak(cycle_period),
+  /* K8   */  be_nested_str_weak(transition_type),
+  /* K9   */  be_const_int(1),
+  /* K10  */  be_nested_str_weak(brightness),
+  /* K11  */  be_nested_str_weak(range_min),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(range_max),
+  /* K14  */  be_nested_str_weak(time_phase),
+  /* K15  */  be_nested_str_weak(is_value_provider),
+  /* K16  */  be_nested_str_weak(0x_X2508x),
+  /* K17  */  be_nested_str_weak(PlasmaAnimation_X28color_X3D_X25s_X2C_X20freq_x_X3D_X25s_X2C_X20freq_y_X3D_X25s_X2C_X20time_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K18  */  be_nested_str_weak(freq_x),
+  /* K19  */  be_nested_str_weak(freq_y),
+  /* K20  */  be_nested_str_weak(time_speed),
+  /* K21  */  be_nested_str_weak(priority),
+  /* K22  */  be_nested_str_weak(is_running),
+  /* K23  */  be_nested_str_weak(init),
+  /* K24  */  be_nested_str_weak(current_colors),
+  /* K25  */  be_nested_str_weak(_initialize_colors),
+  /* K26  */  be_nested_str_weak(update),
+  /* K27  */  be_nested_str_weak(start_time),
+  /* K28  */  be_nested_str_weak(tasmota),
+  /* K29  */  be_nested_str_weak(scale_uint),
+  /* K30  */  be_nested_str_weak(_calculate_plasma),
+  /* K31  */  be_nested_str_weak(get_strip_length),
+  /* K32  */  be_nested_str_weak(resize),
+  /* K33  */  be_const_int(-16777216),
+  /* K34  */  be_nested_str_weak(set_param),
+  /* K35  */  be_nested_str_weak(phase_x),
+  /* K36  */  be_nested_str_weak(phase_y),
+  /* K37  */  be_nested_str_weak(blend_mode),
+  /* K38  */  be_nested_str_weak(_sine),
+  /* K39  */  be_const_int(2),
+  /* K40  */  be_nested_str_weak(is_color_provider),
+  /* K41  */  be_nested_str_weak(get_color_for_value),
+  /* K42  */  be_nested_str_weak(resolve_value),
+  /* K43  */  be_nested_str_weak(width),
+  /* K44  */  be_nested_str_weak(set_pixel_color),
+  /* K45  */  be_nested_str_weak(sine_int),
 };
 
 
-extern const bclass be_class_AnimationEngine;
-
-/********************************************************************
-** Solidified function: interrupt_current
-********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_current,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_current),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0xA8020006,  //  0003  EXBLK	0	#000B
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x7C080000,  //  0005  CALL	R2	0
-      0x880C0501,  //  0006  GETMBR	R3	R2	K1
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7001FFF8,  //  000A  JMP		#0004
-      0x58040003,  //  000B  LDCONST	R1	K3
-      0xAC040200,  //  000C  CATCH	R1	1	0
-      0xB0080000,  //  000D  RAISE	2	R0	R0
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _clear_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine__clear_strip,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_clear_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040104,  //  0000  GETMBR	R1	R0	K4
-      0x8C040305,  //  0001  GETMET	R1	R1	K5
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040104,  //  0003  GETMBR	R1	R0	K4
-      0x8C040306,  //  0004  GETMET	R1	R1	K6
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_animations
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_animations,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _sort_animations
-********************************************************************/
-be_local_closure(class_AnimationEngine__sort_animations,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_sort_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x18080307,  //  0003  LE	R2	R1	K7
-      0x780A0000,  //  0004  JMPF	R2	#0006
-      0x80000400,  //  0005  RET	0
-      0x58080007,  //  0006  LDCONST	R2	K7
-      0x140C0401,  //  0007  LT	R3	R2	R1
-      0x780E0016,  //  0008  JMPF	R3	#0020
-      0x880C0100,  //  0009  GETMBR	R3	R0	K0
-      0x940C0602,  //  000A  GETIDX	R3	R3	R2
-      0x5C100400,  //  000B  MOVE	R4	R2
-      0x24140908,  //  000C  GT	R5	R4	K8
-      0x7816000D,  //  000D  JMPF	R5	#001C
-      0x04140907,  //  000E  SUB	R5	R4	K7
-      0x88180100,  //  000F  GETMBR	R6	R0	K0
-      0x94140C05,  //  0010  GETIDX	R5	R6	R5
-      0x88140B09,  //  0011  GETMBR	R5	R5	K9
-      0x88180709,  //  0012  GETMBR	R6	R3	K9
-      0x14140A06,  //  0013  LT	R5	R5	R6
-      0x78160006,  //  0014  JMPF	R5	#001C
-      0x88140100,  //  0015  GETMBR	R5	R0	K0
-      0x04180907,  //  0016  SUB	R6	R4	K7
-      0x881C0100,  //  0017  GETMBR	R7	R0	K0
-      0x94180E06,  //  0018  GETIDX	R6	R7	R6
-      0x98140806,  //  0019  SETIDX	R5	R4	R6
-      0x04100907,  //  001A  SUB	R4	R4	K7
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x88140100,  //  001C  GETMBR	R5	R0	K0
-      0x98140803,  //  001D  SETIDX	R5	R4	R3
-      0x00080507,  //  001E  ADD	R2	R2	K7
-      0x7001FFE6,  //  001F  JMP		#0007
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_sequence_manager
-********************************************************************/
-be_local_closure(class_AnimationEngine_remove_sequence_manager,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(remove_sequence_manager),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x5409FFFE,  //  0000  LDINT	R2	-1
-      0x580C0008,  //  0001  LDCONST	R3	K8
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x8814010A,  //  0003  GETMBR	R5	R0	K10
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x8810010A,  //  0007  GETMBR	R4	R0	K10
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0x5C080600,  //  000B  MOVE	R2	R3
-      0x70020001,  //  000C  JMP		#000F
-      0x000C0707,  //  000D  ADD	R3	R3	K7
-      0x7001FFF2,  //  000E  JMP		#0002
-      0x28100508,  //  000F  GE	R4	R2	K8
-      0x78120005,  //  0010  JMPF	R4	#0017
-      0x8810010A,  //  0011  GETMBR	R4	R0	K10
-      0x8C10090B,  //  0012  GETMET	R4	R4	K11
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x50100200,  //  0015  LDBOOL	R4	1	0
-      0x80040800,  //  0016  RET	1	R4
-      0x50100000,  //  0017  LDBOOL	R4	0	0
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_active
-********************************************************************/
-be_local_closure(class_AnimationEngine_is_active,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(is_active),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _process_events
-********************************************************************/
-be_local_closure(class_AnimationEngine__process_events,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_process_events),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB80A1800,  //  0000  GETNGBL	R2	K12
-      0x8808050D,  //  0001  GETMBR	R2	R2	K13
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x20080403,  //  0003  NE	R2	R2	R3
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0xB80A1800,  //  0005  GETNGBL	R2	K12
-      0x8808050D,  //  0006  GETMBR	R2	R2	K13
-      0x8C08050E,  //  0007  GETMET	R2	R2	K14
-      0x7C080200,  //  0008  CALL	R2	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_AnimationEngine_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0xB0061F10,  //  0003  RAISE	1	K15	K16
-      0x90020801,  //  0004  SETMBR	R0	K4	R1
-      0x8C080312,  //  0005  GETMET	R2	R1	K18
-      0x7C080200,  //  0006  CALL	R2	1
-      0x90022202,  //  0007  SETMBR	R0	K17	R2
-      0x60080012,  //  0008  GETGBL	R2	G18
-      0x7C080000,  //  0009  CALL	R2	0
-      0x90020002,  //  000A  SETMBR	R0	K0	R2
-      0x60080012,  //  000B  GETGBL	R2	G18
-      0x7C080000,  //  000C  CALL	R2	0
-      0x90021402,  //  000D  SETMBR	R0	K10	R2
-      0xB80A1800,  //  000E  GETNGBL	R2	K12
-      0x8C080513,  //  000F  GETMET	R2	R2	K19
-      0x88100111,  //  0010  GETMBR	R4	R0	K17
-      0x7C080400,  //  0011  CALL	R2	2
-      0x90022602,  //  0012  SETMBR	R0	K19	R2
-      0xB80A1800,  //  0013  GETNGBL	R2	K12
-      0x8C080513,  //  0014  GETMET	R2	R2	K19
-      0x88100111,  //  0015  GETMBR	R4	R0	K17
-      0x7C080400,  //  0016  CALL	R2	2
-      0x90022802,  //  0017  SETMBR	R0	K20	R2
-      0x50080000,  //  0018  LDBOOL	R2	0	0
-      0x90020202,  //  0019  SETMBR	R0	K1	R2
-      0x90022B08,  //  001A  SETMBR	R0	K21	K8
-      0x90022D08,  //  001B  SETMBR	R0	K22	K8
-      0x4C080000,  //  001C  LDNIL	R2
-      0x90022E02,  //  001D  SETMBR	R0	K23	R2
-      0x50080000,  //  001E  LDBOOL	R2	0	0
-      0x90023002,  //  001F  SETMBR	R0	K24	R2
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _output_to_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine__output_to_strip,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_output_to_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x58040008,  //  0000  LDCONST	R1	K8
-      0x88080111,  //  0001  GETMBR	R2	R0	K17
-      0x14080202,  //  0002  LT	R2	R1	R2
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080104,  //  0004  GETMBR	R2	R0	K4
-      0x8C080519,  //  0005  GETMET	R2	R2	K25
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x88140113,  //  0007  GETMBR	R5	R0	K19
-      0x8C140B1A,  //  0008  GETMET	R5	R5	K26
-      0x5C1C0200,  //  0009  MOVE	R7	R1
-      0x7C140400,  //  000A  CALL	R5	2
-      0x7C080600,  //  000B  CALL	R2	3
-      0x00040307,  //  000C  ADD	R1	R1	K7
-      0x7001FFF2,  //  000D  JMP		#0001
-      0x88080104,  //  000E  GETMBR	R2	R0	K4
-      0x8C080506,  //  000F  GETMET	R2	R2	K6
-      0x7C080200,  //  0010  CALL	R2	1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_AnimationEngine_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x78060009,  //  0001  JMPF	R1	#000C
-      0x50040000,  //  0002  LDBOOL	R1	0	0
-      0x90020201,  //  0003  SETMBR	R0	K1	R1
-      0x88040117,  //  0004  GETMBR	R1	R0	K23
-      0x4C080000,  //  0005  LDNIL	R2
-      0x20040202,  //  0006  NE	R1	R1	R2
-      0x78060003,  //  0007  JMPF	R1	#000C
-      0xB8063600,  //  0008  GETNGBL	R1	K27
-      0x8C04031C,  //  0009  GETMET	R1	R1	K28
-      0x880C0117,  //  000A  GETMBR	R3	R0	K23
-      0x7C040400,  //  000B  CALL	R1	2
-      0x80040000,  //  000C  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: size
-********************************************************************/
-be_local_closure(class_AnimationEngine_size,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(size),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resume
-********************************************************************/
-be_local_closure(class_AnimationEngine_resume,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(resume),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x74060001,  //  0001  JMPT	R1	#0004
-      0x8C04011D,  //  0002  GETMET	R1	R0	K29
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
+extern const bclass be_class_PlasmaAnimation;
 
 /********************************************************************
 ** Solidified function: start
 ********************************************************************/
-be_local_closure(class_AnimationEngine_start,   /* name */
+be_local_closure(class_PlasmaAnimation_start,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    5,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(on_tick),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
     be_str_weak(start),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x74060021,  //  0001  JMPT	R1	#0024
-      0x50040200,  //  0002  LDBOOL	R1	1	0
-      0x90020201,  //  0003  SETMBR	R0	K1	R1
-      0xB8063600,  //  0004  GETNGBL	R1	K27
-      0x8C04031E,  //  0005  GETMET	R1	R1	K30
-      0x7C040200,  //  0006  CALL	R1	1
-      0x540A0009,  //  0007  LDINT	R2	10
-      0x04040202,  //  0008  SUB	R1	R1	R2
-      0x90022A01,  //  0009  SETMBR	R0	K21	R1
-      0x88040117,  //  000A  GETMBR	R1	R0	K23
-      0x4C080000,  //  000B  LDNIL	R2
-      0x1C040202,  //  000C  EQ	R1	R1	R2
-      0x78060001,  //  000D  JMPF	R1	#0010
-      0x84040000,  //  000E  CLOSURE	R1	P0
-      0x90022E01,  //  000F  SETMBR	R0	K23	R1
-      0x58040008,  //  0010  LDCONST	R1	K8
-      0xB80A3600,  //  0011  GETNGBL	R2	K27
-      0x8C08051E,  //  0012  GETMET	R2	R2	K30
-      0x7C080200,  //  0013  CALL	R2	1
-      0x600C000C,  //  0014  GETGBL	R3	G12
-      0x88100100,  //  0015  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0x140C0203,  //  0017  LT	R3	R1	R3
-      0x780E0006,  //  0018  JMPF	R3	#0020
-      0x880C0100,  //  0019  GETMBR	R3	R0	K0
-      0x940C0601,  //  001A  GETIDX	R3	R3	R1
-      0x8C0C071D,  //  001B  GETMET	R3	R3	K29
-      0x5C140400,  //  001C  MOVE	R5	R2
-      0x7C0C0400,  //  001D  CALL	R3	2
-      0x00040307,  //  001E  ADD	R1	R1	K7
-      0x7001FFF3,  //  001F  JMP		#0014
-      0xB80E3600,  //  0020  GETNGBL	R3	K27
-      0x8C0C071F,  //  0021  GETMET	R3	R3	K31
-      0x88140117,  //  0022  GETMBR	R5	R0	K23
-      0x7C0C0400,  //  0023  CALL	R3	2
-      0xA0000000,  //  0024  CLOSE	R0
-      0x80040000,  //  0025  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_tick
-********************************************************************/
-be_local_closure(class_AnimationEngine_on_tick,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(on_tick),
-    &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x740A0001,  //  0001  JMPT	R2	#0004
-      0x50080000,  //  0002  LDBOOL	R2	0	0
-      0x80040400,  //  0003  RET	1	R2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x1C080202,  //  0005  EQ	R2	R1	R2
-      0x780A0003,  //  0006  JMPF	R2	#000B
-      0xB80A3600,  //  0007  GETNGBL	R2	K27
-      0x8C08051E,  //  0008  GETMET	R2	R2	K30
-      0x7C080200,  //  0009  CALL	R2	1
-      0x5C040400,  //  000A  MOVE	R1	R2
-      0x90022C01,  //  000B  SETMBR	R0	K22	R1
-      0x88080115,  //  000C  GETMBR	R2	R0	K21
-      0x04080202,  //  000D  SUB	R2	R1	R2
-      0x540E0004,  //  000E  LDINT	R3	5
-      0x140C0403,  //  000F  LT	R3	R2	R3
-      0x780E0001,  //  0010  JMPF	R3	#0013
-      0x500C0200,  //  0011  LDBOOL	R3	1	0
-      0x80040600,  //  0012  RET	1	R3
-      0x90022A01,  //  0013  SETMBR	R0	K21	R1
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x880C0720,  //  0015  GETMBR	R3	R3	K32
-      0x4C100000,  //  0016  LDNIL	R4
-      0x200C0604,  //  0017  NE	R3	R3	R4
-      0x780E0005,  //  0018  JMPF	R3	#001F
-      0x880C0104,  //  0019  GETMBR	R3	R0	K4
-      0x8C0C0720,  //  001A  GETMET	R3	R3	K32
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0x740E0001,  //  001C  JMPT	R3	#001F
-      0x500C0200,  //  001D  LDBOOL	R3	1	0
-      0x80040600,  //  001E  RET	1	R3
-      0x580C0008,  //  001F  LDCONST	R3	K8
-      0x6010000C,  //  0020  GETGBL	R4	G12
-      0x8814010A,  //  0021  GETMBR	R5	R0	K10
-      0x7C100200,  //  0022  CALL	R4	1
-      0x14100604,  //  0023  LT	R4	R3	R4
-      0x78120005,  //  0024  JMPF	R4	#002B
-      0x8810010A,  //  0025  GETMBR	R4	R0	K10
-      0x94100803,  //  0026  GETIDX	R4	R4	R3
-      0x8C100921,  //  0027  GETMET	R4	R4	K33
-      0x7C100200,  //  0028  CALL	R4	1
-      0x000C0707,  //  0029  ADD	R3	R3	K7
-      0x7001FFF4,  //  002A  JMP		#0020
-      0x8C100122,  //  002B  GETMET	R4	R0	K34
-      0x5C180200,  //  002C  MOVE	R6	R1
-      0x7C100400,  //  002D  CALL	R4	2
-      0x8C100123,  //  002E  GETMET	R4	R0	K35
-      0x5C180200,  //  002F  MOVE	R6	R1
-      0x7C100400,  //  0030  CALL	R4	2
-      0x50100200,  //  0031  LDBOOL	R4	1	0
-      0x80040800,  //  0032  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_animation
-********************************************************************/
-be_local_closure(class_AnimationEngine_add_animation,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(add_animation),
-    &be_const_str_solidified,
     ( &(const binstruction[28]) {  /* code */
-      0x58080008,  //  0000  LDCONST	R2	K8
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0007,  //  0005  JMPF	R3	#000E
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x1C0C0601,  //  0008  EQ	R3	R3	R1
-      0x780E0001,  //  0009  JMPF	R3	#000C
-      0x500C0000,  //  000A  LDBOOL	R3	0	0
-      0x80040600,  //  000B  RET	1	R3
-      0x00080507,  //  000C  ADD	R2	R2	K7
-      0x7001FFF2,  //  000D  JMP		#0001
-      0x880C0100,  //  000E  GETMBR	R3	R0	K0
-      0x8C0C0724,  //  000F  GETMET	R3	R3	K36
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C0C0125,  //  0012  GETMET	R3	R0	K37
-      0x7C0C0200,  //  0013  CALL	R3	1
-      0x880C0101,  //  0014  GETMBR	R3	R0	K1
-      0x780E0001,  //  0015  JMPF	R3	#0018
-      0x8C0C031D,  //  0016  GETMET	R3	R1	K29
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x500C0200,  //  0018  LDBOOL	R3	1	0
-      0x90023003,  //  0019  SETMBR	R0	K24	R3
-      0x500C0200,  //  001A  LDBOOL	R3	1	0
-      0x80040600,  //  001B  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: cleanup
-********************************************************************/
-be_local_closure(class_AnimationEngine_cleanup,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(cleanup),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x8C040102,  //  0000  GETMET	R1	R0	K2
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040105,  //  0002  GETMET	R1	R0	K5
-      0x7C040200,  //  0003  CALL	R1	1
-      0x4C040000,  //  0004  LDNIL	R1
-      0x90022601,  //  0005  SETMBR	R0	K19	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x90022801,  //  0007  SETMBR	R0	K20	R1
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90020801,  //  0009  SETMBR	R0	K4	R1
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resume_after
-********************************************************************/
-be_local_closure(class_AnimationEngine_resume_after,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(resume_after),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C080126,  //  0000  GETMET	R2	R0	K38
-      0x7C080200,  //  0001  CALL	R2	1
-      0x80000000,  //  0002  RET	0
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x1C080403,  //  0008  EQ	R2	R2	R3
+      0x780A000F,  //  0009  JMPF	R2	#001A
+      0xB80A0400,  //  000A  GETNGBL	R2	K2
+      0x8C080503,  //  000B  GETMET	R2	R2	K3
+      0x88100104,  //  000C  GETMBR	R4	R0	K4
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80E0400,  //  000E  GETNGBL	R3	K2
+      0x880C0706,  //  000F  GETMBR	R3	R3	K6
+      0x900A0A03,  //  0010  SETMBR	R2	K5	R3
+      0x540E1387,  //  0011  LDINT	R3	5000
+      0x900A0E03,  //  0012  SETMBR	R2	K7	R3
+      0x900A1109,  //  0013  SETMBR	R2	K8	K9
+      0x540E00FE,  //  0014  LDINT	R3	255
+      0x900A1403,  //  0015  SETMBR	R2	K10	R3
+      0x900A170C,  //  0016  SETMBR	R2	K11	K12
+      0x540E00FE,  //  0017  LDINT	R3	255
+      0x900A1A03,  //  0018  SETMBR	R2	K13	R3
+      0x90020202,  //  0019  SETMBR	R0	K1	R2
+      0x90021D0C,  //  001A  SETMBR	R0	K14	K12
+      0x80040000,  //  001B  RET	1	R0
     })
   )
 );
@@ -10778,9 +10141,9 @@ be_local_closure(class_AnimationEngine_resume_after,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-be_local_closure(class_AnimationEngine_tostring,   /* name */
+be_local_closure(class_PlasmaAnimation_tostring,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -10788,228 +10151,37 @@ be_local_closure(class_AnimationEngine_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080027,  //  0001  LDCONST	R2	K39
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140100,  //  0004  GETMBR	R5	R0	K0
-      0x7C100200,  //  0005  CALL	R4	1
-      0x88140111,  //  0006  GETMBR	R5	R0	K17
-      0x7C040800,  //  0007  CALL	R1	4
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(class_AnimationEngine_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(clear),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x58040008,  //  0003  LDCONST	R1	K8
-      0x6008000C,  //  0004  GETGBL	R2	G12
-      0x880C010A,  //  0005  GETMBR	R3	R0	K10
-      0x7C080200,  //  0006  CALL	R2	1
-      0x14080202,  //  0007  LT	R2	R1	R2
-      0x780A0005,  //  0008  JMPF	R2	#000F
-      0x8808010A,  //  0009  GETMBR	R2	R0	K10
-      0x94080401,  //  000A  GETIDX	R2	R2	R1
-      0x8C080528,  //  000B  GETMET	R2	R2	K40
-      0x7C080200,  //  000C  CALL	R2	1
-      0x00040307,  //  000D  ADD	R1	R1	K7
-      0x7001FFF4,  //  000E  JMP		#0004
-      0x60080012,  //  000F  GETGBL	R2	G18
-      0x7C080000,  //  0010  CALL	R2	0
-      0x90021402,  //  0011  SETMBR	R0	K10	R2
-      0x50080200,  //  0012  LDBOOL	R2	1	0
-      0x90023002,  //  0013  SETMBR	R0	K24	R2
-      0x80040000,  //  0014  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_strip_length
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_strip_length,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_strip_length),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040111,  //  0000  GETMBR	R1	R0	K17
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_and_render
-********************************************************************/
-be_local_closure(class_AnimationEngine__update_and_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_update_and_render),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x58080008,  //  0000  LDCONST	R2	K8
-      0x580C0008,  //  0001  LDCONST	R3	K8
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140100,  //  0003  GETMBR	R5	R0	K0
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120011,  //  0006  JMPF	R4	#0019
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x8C140921,  //  0009  GETMET	R5	R4	K33
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x78160004,  //  000C  JMPF	R5	#0012
-      0x88180901,  //  000D  GETMBR	R6	R4	K1
-      0x781A0002,  //  000E  JMPF	R6	#0012
-      0x00080507,  //  000F  ADD	R2	R2	K7
-      0x000C0707,  //  0010  ADD	R3	R3	K7
-      0x70020005,  //  0011  JMP		#0018
-      0x88180100,  //  0012  GETMBR	R6	R0	K0
-      0x8C180D0B,  //  0013  GETMET	R6	R6	K11
-      0x5C200600,  //  0014  MOVE	R8	R3
-      0x7C180400,  //  0015  CALL	R6	2
-      0x50180200,  //  0016  LDBOOL	R6	1	0
-      0x90023006,  //  0017  SETMBR	R0	K24	R6
-      0x7001FFE8,  //  0018  JMP		#0002
-      0x1C100508,  //  0019  EQ	R4	R2	K8
-      0x78120006,  //  001A  JMPF	R4	#0022
-      0x88100118,  //  001B  GETMBR	R4	R0	K24
-      0x78120003,  //  001C  JMPF	R4	#0021
-      0x8C100129,  //  001D  GETMET	R4	R0	K41
-      0x7C100200,  //  001E  CALL	R4	1
-      0x50100000,  //  001F  LDBOOL	R4	0	0
-      0x90023004,  //  0020  SETMBR	R0	K24	R4
-      0x80000800,  //  0021  RET	0
-      0x8C10012A,  //  0022  GETMET	R4	R0	K42
-      0x88180100,  //  0023  GETMBR	R6	R0	K0
-      0x5C1C0200,  //  0024  MOVE	R7	R1
-      0x7C100600,  //  0025  CALL	R4	3
-      0x50100000,  //  0026  LDBOOL	R4	0	0
-      0x90023004,  //  0027  SETMBR	R0	K24	R4
-      0x80000000,  //  0028  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: interrupt_all
-********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_all,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_all),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040105,  //  0000  GETMET	R1	R0	K5
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_animation
-********************************************************************/
-be_local_closure(class_AnimationEngine_remove_animation,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(remove_animation),
-    &be_const_str_solidified,
     ( &(const binstruction[27]) {  /* code */
-      0x5409FFFE,  //  0000  LDINT	R2	-1
-      0x580C0008,  //  0001  LDCONST	R3	K8
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140100,  //  0003  GETMBR	R5	R0	K0
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0x5C080600,  //  000B  MOVE	R2	R3
-      0x70020001,  //  000C  JMP		#000F
-      0x000C0707,  //  000D  ADD	R3	R3	K7
-      0x7001FFF2,  //  000E  JMP		#0002
-      0x28100508,  //  000F  GE	R4	R2	K8
-      0x78120007,  //  0010  JMPF	R4	#0019
-      0x88100100,  //  0011  GETMBR	R4	R0	K0
-      0x8C10090B,  //  0012  GETMET	R4	R4	K11
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x50100200,  //  0015  LDBOOL	R4	1	0
-      0x90023004,  //  0016  SETMBR	R0	K24	R4
-      0x50100200,  //  0017  LDBOOL	R4	1	0
-      0x80040800,  //  0018  RET	1	R4
-      0x50100000,  //  0019  LDBOOL	R4	0	0
-      0x80040800,  //  001A  RET	1	R4
+      0x4C040000,  //  0000  LDNIL	R1
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x8C0C070F,  //  0003  GETMET	R3	R3	K15
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x780E0004,  //  0006  JMPF	R3	#000C
+      0x600C0008,  //  0007  GETGBL	R3	G8
+      0x5C100400,  //  0008  MOVE	R4	R2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x5C040600,  //  000A  MOVE	R1	R3
+      0x70020004,  //  000B  JMP		#0011
+      0x600C0018,  //  000C  GETGBL	R3	G24
+      0x58100010,  //  000D  LDCONST	R4	K16
+      0x5C140400,  //  000E  MOVE	R5	R2
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x5C040600,  //  0010  MOVE	R1	R3
+      0x600C0018,  //  0011  GETGBL	R3	G24
+      0x58100011,  //  0012  LDCONST	R4	K17
+      0x5C140200,  //  0013  MOVE	R5	R1
+      0x88180112,  //  0014  GETMBR	R6	R0	K18
+      0x881C0113,  //  0015  GETMBR	R7	R0	K19
+      0x88200114,  //  0016  GETMBR	R8	R0	K20
+      0x88240115,  //  0017  GETMBR	R9	R0	K21
+      0x88280116,  //  0018  GETMBR	R10	R0	K22
+      0x7C0C0E00,  //  0019  CALL	R3	7
+      0x80040600,  //  001A  RET	1	R3
     })
   )
 );
@@ -11017,84 +10189,9 @@ be_local_closure(class_AnimationEngine_remove_animation,   /* name */
 
 
 /********************************************************************
-** Solidified function: _render_animations
+** Solidified function: init
 ********************************************************************/
-be_local_closure(class_AnimationEngine__render_animations,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_render_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x880C0113,  //  0000  GETMBR	R3	R0	K19
-      0x8C0C0705,  //  0001  GETMET	R3	R3	K5
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x580C0008,  //  0003  LDCONST	R3	K8
-      0x6010000C,  //  0004  GETGBL	R4	G12
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x14100604,  //  0007  LT	R4	R3	R4
-      0x7812000E,  //  0008  JMPF	R4	#0018
-      0x94100203,  //  0009  GETIDX	R4	R1	R3
-      0x88140114,  //  000A  GETMBR	R5	R0	K20
-      0x8C140B05,  //  000B  GETMET	R5	R5	K5
-      0x7C140200,  //  000C  CALL	R5	1
-      0x8C14092B,  //  000D  GETMET	R5	R4	K43
-      0x881C0114,  //  000E  GETMBR	R7	R0	K20
-      0x5C200400,  //  000F  MOVE	R8	R2
-      0x7C140600,  //  0010  CALL	R5	3
-      0x78160003,  //  0011  JMPF	R5	#0016
-      0x88180113,  //  0012  GETMBR	R6	R0	K19
-      0x8C180D2C,  //  0013  GETMET	R6	R6	K44
-      0x88200114,  //  0014  GETMBR	R8	R0	K20
-      0x7C180400,  //  0015  CALL	R6	2
-      0x000C0707,  //  0016  ADD	R3	R3	K7
-      0x7001FFEB,  //  0017  JMP		#0004
-      0x8C10012D,  //  0018  GETMET	R4	R0	K45
-      0x7C100200,  //  0019  CALL	R4	1
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_strip,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040104,  //  0000  GETMBR	R1	R0	K4
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_sequence_manager
-********************************************************************/
-be_local_closure(class_AnimationEngine_add_sequence_manager,   /* name */
+be_local_closure(class_PlasmaAnimation_init,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -11104,15 +10201,23 @@ be_local_closure(class_AnimationEngine_add_sequence_manager,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(add_sequence_manager),
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808010A,  //  0000  GETMBR	R2	R0	K10
-      0x8C080524,  //  0001  GETMET	R2	R2	K36
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040000,  //  0004  RET	1	R0
+    ( &(const binstruction[13]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080517,  //  0003  GETMET	R2	R2	K23
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90021D0C,  //  0006  SETMBR	R0	K14	K12
+      0x60080012,  //  0007  GETGBL	R2	G18
+      0x7C080000,  //  0008  CALL	R2	0
+      0x90023002,  //  0009  SETMBR	R0	K24	R2
+      0x8C080119,  //  000A  GETMET	R2	R0	K25
+      0x7C080200,  //  000B  CALL	R2	1
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -11120,11 +10225,11 @@ be_local_closure(class_AnimationEngine_add_sequence_manager,   /* name */
 
 
 /********************************************************************
-** Solidified function: interrupt_animation
+** Solidified function: update
 ********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
+be_local_closure(class_PlasmaAnimation_update,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -11132,36 +10237,45 @@ be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_animation),
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(update),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080008,  //  0000  LDCONST	R2	K8
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8810072E,  //  0008  GETMBR	R4	R3	K46
-      0x4C140000,  //  0009  LDNIL	R5
-      0x20100805,  //  000A  NE	R4	R4	R5
-      0x7812000A,  //  000B  JMPF	R4	#0017
-      0x8810072E,  //  000C  GETMBR	R4	R3	K46
-      0x1C100801,  //  000D  EQ	R4	R4	R1
-      0x78120007,  //  000E  JMPF	R4	#0017
-      0x8C100702,  //  000F  GETMET	R4	R3	K2
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x88100100,  //  0012  GETMBR	R4	R0	K0
-      0x8C10090B,  //  0013  GETMET	R4	R4	K11
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000800,  //  0016  RET	0
-      0x00080507,  //  0017  ADD	R2	R2	K7
-      0x7001FFE7,  //  0018  JMP		#0001
-      0x80000000,  //  0019  RET	0
+    ( &(const binstruction[35]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051A,  //  0003  GETMET	R2	R2	K26
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0001,  //  0006  JMPT	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x88080114,  //  0009  GETMBR	R2	R0	K20
+      0x240C050C,  //  000A  GT	R3	R2	K12
+      0x780E0011,  //  000B  JMPF	R3	#001E
+      0x880C011B,  //  000C  GETMBR	R3	R0	K27
+      0x040C0203,  //  000D  SUB	R3	R1	R3
+      0xB8123800,  //  000E  GETNGBL	R4	K28
+      0x8C10091D,  //  000F  GETMET	R4	R4	K29
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x581C000C,  //  0011  LDCONST	R7	K12
+      0x542200FE,  //  0012  LDINT	R8	255
+      0x5824000C,  //  0013  LDCONST	R9	K12
+      0x542A0007,  //  0014  LDINT	R10	8
+      0x7C100C00,  //  0015  CALL	R4	6
+      0x2414090C,  //  0016  GT	R5	R4	K12
+      0x78160005,  //  0017  JMPF	R5	#001E
+      0x08140604,  //  0018  MUL	R5	R3	R4
+      0x541A03E7,  //  0019  LDINT	R6	1000
+      0x0C140A06,  //  001A  DIV	R5	R5	R6
+      0x541A00FF,  //  001B  LDINT	R6	256
+      0x10140A06,  //  001C  MOD	R5	R5	R6
+      0x90021C05,  //  001D  SETMBR	R0	K14	R5
+      0x8C0C011E,  //  001E  GETMET	R3	R0	K30
+      0x5C140200,  //  001F  MOVE	R5	R1
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0x500C0200,  //  0021  LDBOOL	R3	1	0
+      0x80040600,  //  0022  RET	1	R3
     })
   )
 );
@@ -11169,61 +10283,390 @@ be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
 
 
 /********************************************************************
-** Solidified class: AnimationEngine
+** Solidified function: _initialize_colors
 ********************************************************************/
-be_local_class(AnimationEngine,
-    11,
-    NULL,
-    be_nested_map(38,
+be_local_closure(class_PlasmaAnimation__initialize_colors,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(_initialize_colors),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x8C04031F,  //  0001  GETMET	R1	R1	K31
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88080118,  //  0003  GETMBR	R2	R0	K24
+      0x8C080520,  //  0004  GETMET	R2	R2	K32
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x5808000C,  //  0007  LDCONST	R2	K12
+      0x140C0401,  //  0008  LT	R3	R2	R1
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x880C0118,  //  000A  GETMBR	R3	R0	K24
+      0x980C0521,  //  000B  SETIDX	R3	R2	K33
+      0x00080509,  //  000C  ADD	R2	R2	K9
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_PlasmaAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x1C0C0301,  //  0000  EQ	R3	R1	K1
+      0x780E0015,  //  0001  JMPF	R3	#0018
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0403,  //  0003  EQ	R3	R2	R3
+      0x780E0012,  //  0004  JMPF	R3	#0018
+      0xB80E0400,  //  0005  GETNGBL	R3	K2
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x88140104,  //  0007  GETMBR	R5	R0	K4
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x88100906,  //  000A  GETMBR	R4	R4	K6
+      0x900E0A04,  //  000B  SETMBR	R3	K5	R4
+      0x54121387,  //  000C  LDINT	R4	5000
+      0x900E0E04,  //  000D  SETMBR	R3	K7	R4
+      0x900E1109,  //  000E  SETMBR	R3	K8	K9
+      0x541200FE,  //  000F  LDINT	R4	255
+      0x900E1404,  //  0010  SETMBR	R3	K10	R4
+      0x900E170C,  //  0011  SETMBR	R3	K11	K12
+      0x541200FE,  //  0012  LDINT	R4	255
+      0x900E1A04,  //  0013  SETMBR	R3	K13	R4
+      0x8C100122,  //  0014  GETMET	R4	R0	K34
+      0x58180001,  //  0015  LDCONST	R6	K1
+      0x5C1C0600,  //  0016  MOVE	R7	R3
+      0x7C100600,  //  0017  CALL	R4	3
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _calculate_plasma
+********************************************************************/
+be_local_closure(class_PlasmaAnimation__calculate_plasma,   /* name */
+  be_nested_proto(
+    21,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(_calculate_plasma),
+    &be_const_str_solidified,
+    ( &(const binstruction[103]) {  /* code */
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C08051F,  //  0001  GETMET	R2	R2	K31
+      0x7C080200,  //  0002  CALL	R2	1
+      0x600C000C,  //  0003  GETGBL	R3	G12
+      0x88100118,  //  0004  GETMBR	R4	R0	K24
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x200C0602,  //  0006  NE	R3	R3	R2
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x8C0C0119,  //  0008  GETMET	R3	R0	K25
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x880C0112,  //  000A  GETMBR	R3	R0	K18
+      0x88100113,  //  000B  GETMBR	R4	R0	K19
+      0x88140123,  //  000C  GETMBR	R5	R0	K35
+      0x88180124,  //  000D  GETMBR	R6	R0	K36
+      0x881C0125,  //  000E  GETMBR	R7	R0	K37
+      0x88200101,  //  000F  GETMBR	R8	R0	K1
+      0x5824000C,  //  0010  LDCONST	R9	K12
+      0x14281202,  //  0011  LT	R10	R9	R2
+      0x782A0052,  //  0012  JMPF	R10	#0066
+      0xB82A3800,  //  0013  GETNGBL	R10	K28
+      0x8C28151D,  //  0014  GETMET	R10	R10	K29
+      0x5C301200,  //  0015  MOVE	R12	R9
+      0x5834000C,  //  0016  LDCONST	R13	K12
+      0x04380509,  //  0017  SUB	R14	R2	K9
+      0x583C000C,  //  0018  LDCONST	R15	K12
+      0x544200FE,  //  0019  LDINT	R16	255
+      0x7C280C00,  //  001A  CALL	R10	6
+      0x8C2C0126,  //  001B  GETMET	R11	R0	K38
+      0x08341403,  //  001C  MUL	R13	R10	R3
+      0x543A001F,  //  001D  LDINT	R14	32
+      0x0C341A0E,  //  001E  DIV	R13	R13	R14
+      0x00341A05,  //  001F  ADD	R13	R13	R5
+      0x8838010E,  //  0020  GETMBR	R14	R0	K14
+      0x00341A0E,  //  0021  ADD	R13	R13	R14
+      0x7C2C0400,  //  0022  CALL	R11	2
+      0x8C300126,  //  0023  GETMET	R12	R0	K38
+      0x08381404,  //  0024  MUL	R14	R10	R4
+      0x543E001F,  //  0025  LDINT	R15	32
+      0x0C381C0F,  //  0026  DIV	R14	R14	R15
+      0x00381C06,  //  0027  ADD	R14	R14	R6
+      0x883C010E,  //  0028  GETMBR	R15	R0	K14
+      0x083C1F27,  //  0029  MUL	R15	R15	K39
+      0x00381C0F,  //  002A  ADD	R14	R14	R15
+      0x7C300400,  //  002B  CALL	R12	2
+      0x5834000C,  //  002C  LDCONST	R13	K12
+      0x1C380F0C,  //  002D  EQ	R14	R7	K12
+      0x783A0003,  //  002E  JMPF	R14	#0033
+      0x0038160C,  //  002F  ADD	R14	R11	R12
+      0x0C381D27,  //  0030  DIV	R14	R14	K39
+      0x5C341C00,  //  0031  MOVE	R13	R14
+      0x7002000E,  //  0032  JMP		#0042
+      0x1C380F09,  //  0033  EQ	R14	R7	K9
+      0x783A0009,  //  0034  JMPF	R14	#003F
+      0xB83A3800,  //  0035  GETNGBL	R14	K28
+      0x8C381D1D,  //  0036  GETMET	R14	R14	K29
+      0x5C401600,  //  0037  MOVE	R16	R11
+      0x5844000C,  //  0038  LDCONST	R17	K12
+      0x544A00FE,  //  0039  LDINT	R18	255
+      0x584C000C,  //  003A  LDCONST	R19	K12
+      0x5C501800,  //  003B  MOVE	R20	R12
+      0x7C380C00,  //  003C  CALL	R14	6
+      0x5C341C00,  //  003D  MOVE	R13	R14
+      0x70020002,  //  003E  JMP		#0042
+      0x0038160C,  //  003F  ADD	R14	R11	R12
+      0x0C381D27,  //  0040  DIV	R14	R14	K39
+      0x5C341C00,  //  0041  MOVE	R13	R14
+      0x543A00FE,  //  0042  LDINT	R14	255
+      0x24381A0E,  //  0043  GT	R14	R13	R14
+      0x783A0001,  //  0044  JMPF	R14	#0047
+      0x543600FE,  //  0045  LDINT	R13	255
+      0x70020002,  //  0046  JMP		#004A
+      0x14381B0C,  //  0047  LT	R14	R13	K12
+      0x783A0000,  //  0048  JMPF	R14	#004A
+      0x5834000C,  //  0049  LDCONST	R13	K12
+      0x58380021,  //  004A  LDCONST	R14	K33
+      0xB83E0400,  //  004B  GETNGBL	R15	K2
+      0x8C3C1F28,  //  004C  GETMET	R15	R15	K40
+      0x5C441000,  //  004D  MOVE	R17	R8
+      0x7C3C0400,  //  004E  CALL	R15	2
+      0x783E0009,  //  004F  JMPF	R15	#005A
+      0x883C1129,  //  0050  GETMBR	R15	R8	K41
+      0x4C400000,  //  0051  LDNIL	R16
+      0x203C1E10,  //  0052  NE	R15	R15	R16
+      0x783E0005,  //  0053  JMPF	R15	#005A
+      0x8C3C1129,  //  0054  GETMET	R15	R8	K41
+      0x5C441A00,  //  0055  MOVE	R17	R13
+      0x5848000C,  //  0056  LDCONST	R18	K12
+      0x7C3C0600,  //  0057  CALL	R15	3
+      0x5C381E00,  //  0058  MOVE	R14	R15
+      0x70020007,  //  0059  JMP		#0062
+      0x8C3C012A,  //  005A  GETMET	R15	R0	K42
+      0x5C441000,  //  005B  MOVE	R17	R8
+      0x58480001,  //  005C  LDCONST	R18	K1
+      0x544E0009,  //  005D  LDINT	R19	10
+      0x084C1A13,  //  005E  MUL	R19	R13	R19
+      0x004C0213,  //  005F  ADD	R19	R1	R19
+      0x7C3C0800,  //  0060  CALL	R15	4
+      0x5C381E00,  //  0061  MOVE	R14	R15
+      0x883C0118,  //  0062  GETMBR	R15	R0	K24
+      0x983C120E,  //  0063  SETIDX	R15	R9	R14
+      0x00241309,  //  0064  ADD	R9	R9	K9
+      0x7001FFAA,  //  0065  JMP		#0011
+      0x80000000,  //  0066  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_PlasmaAnimation_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x880C0116,  //  0000  GETMBR	R3	R0	K22
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x880C0104,  //  0007  GETMBR	R3	R0	K4
+      0x8C0C071F,  //  0008  GETMET	R3	R3	K31
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x5810000C,  //  000A  LDCONST	R4	K12
+      0x14140803,  //  000B  LT	R5	R4	R3
+      0x78160009,  //  000C  JMPF	R5	#0017
+      0x8814032B,  //  000D  GETMBR	R5	R1	K43
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x78160004,  //  000F  JMPF	R5	#0015
+      0x8C14032C,  //  0010  GETMET	R5	R1	K44
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x88200118,  //  0012  GETMBR	R8	R0	K24
+      0x94201004,  //  0013  GETIDX	R8	R8	R4
+      0x7C140600,  //  0014  CALL	R5	3
+      0x00100909,  //  0015  ADD	R4	R4	K9
+      0x7001FFF3,  //  0016  JMP		#000B
+      0x50140200,  //  0017  LDBOOL	R5	1	0
+      0x80040A00,  //  0018  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _sine
+********************************************************************/
+be_local_closure(class_PlasmaAnimation__sine,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_PlasmaAnimation,     /* shared constants */
+    be_str_weak(_sine),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0xB80A3800,  //  0000  GETNGBL	R2	K28
+      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x5814000C,  //  0003  LDCONST	R5	K12
+      0x541A00FE,  //  0004  LDINT	R6	255
+      0x581C000C,  //  0005  LDCONST	R7	K12
+      0x54227FFE,  //  0006  LDINT	R8	32767
+      0x7C080C00,  //  0007  CALL	R2	6
+      0xB80E3800,  //  0008  GETNGBL	R3	K28
+      0x8C0C072D,  //  0009  GETMET	R3	R3	K45
+      0x5C140400,  //  000A  MOVE	R5	R2
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0xB8123800,  //  000C  GETNGBL	R4	K28
+      0x8C10091D,  //  000D  GETMET	R4	R4	K29
+      0x5C180600,  //  000E  MOVE	R6	R3
+      0x541DEFFF,  //  000F  LDINT	R7	-4096
+      0x54220FFF,  //  0010  LDINT	R8	4096
+      0x5824000C,  //  0011  LDCONST	R9	K12
+      0x542A00FE,  //  0012  LDINT	R10	255
+      0x7C100C00,  //  0013  CALL	R4	6
+      0x80040800,  //  0014  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: PlasmaAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(PlasmaAnimation,
+    2,
+    &be_class_Animation,
+    be_nested_map(12,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(interrupt_current, 20), be_const_closure(class_AnimationEngine_interrupt_current_closure) },
-        { be_const_key_weak(animations, -1), be_const_var(2) },
-        { be_const_key_weak(add_sequence_manager, -1), be_const_closure(class_AnimationEngine_add_sequence_manager_closure) },
-        { be_const_key_weak(get_animations, 17), be_const_closure(class_AnimationEngine_get_animations_closure) },
-        { be_const_key_weak(_sort_animations, -1), be_const_closure(class_AnimationEngine__sort_animations_closure) },
-        { be_const_key_weak(remove_sequence_manager, -1), be_const_closure(class_AnimationEngine_remove_sequence_manager_closure) },
-        { be_const_key_weak(strip, -1), be_const_var(0) },
-        { be_const_key_weak(_process_events, -1), be_const_closure(class_AnimationEngine__process_events_closure) },
-        { be_const_key_weak(get_strip, -1), be_const_closure(class_AnimationEngine_get_strip_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_AnimationEngine_start_closure) },
-        { be_const_key_weak(_output_to_strip, -1), be_const_closure(class_AnimationEngine__output_to_strip_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(class_AnimationEngine_stop_closure) },
-        { be_const_key_weak(is_active, 23), be_const_closure(class_AnimationEngine_is_active_closure) },
-        { be_const_key_weak(init, 6), be_const_closure(class_AnimationEngine_init_closure) },
-        { be_const_key_weak(resume, -1), be_const_closure(class_AnimationEngine_resume_closure) },
-        { be_const_key_weak(cleanup, -1), be_const_closure(class_AnimationEngine_cleanup_closure) },
-        { be_const_key_weak(on_tick, -1), be_const_closure(class_AnimationEngine_on_tick_closure) },
-        { be_const_key_weak(width, 9), be_const_var(1) },
-        { be_const_key_weak(frame_buffer, 31), be_const_var(4) },
-        { be_const_key_weak(add_animation, 15), be_const_closure(class_AnimationEngine_add_animation_closure) },
-        { be_const_key_weak(remove_animation, 1), be_const_closure(class_AnimationEngine_remove_animation_closure) },
-        { be_const_key_weak(resume_after, 18), be_const_closure(class_AnimationEngine_resume_after_closure) },
-        { be_const_key_weak(clear, -1), be_const_closure(class_AnimationEngine_clear_closure) },
-        { be_const_key_weak(_update_and_render, 36), be_const_closure(class_AnimationEngine__update_and_render_closure) },
-        { be_const_key_weak(fast_loop_closure, -1), be_const_var(9) },
-        { be_const_key_weak(time_ms, 29), be_const_var(8) },
-        { be_const_key_weak(is_running, -1), be_const_var(6) },
-        { be_const_key_weak(last_update, 26), be_const_var(7) },
-        { be_const_key_weak(interrupt_all, 2), be_const_closure(class_AnimationEngine_interrupt_all_closure) },
-        { be_const_key_weak(get_strip_length, -1), be_const_closure(class_AnimationEngine_get_strip_length_closure) },
-        { be_const_key_weak(_render_animations, -1), be_const_closure(class_AnimationEngine__render_animations_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_AnimationEngine_tostring_closure) },
-        { be_const_key_weak(temp_buffer, -1), be_const_var(5) },
-        { be_const_key_weak(render_needed, -1), be_const_var(10) },
-        { be_const_key_weak(_clear_strip, 8), be_const_closure(class_AnimationEngine__clear_strip_closure) },
-        { be_const_key_weak(sequence_managers, -1), be_const_var(3) },
-        { be_const_key_weak(size, -1), be_const_closure(class_AnimationEngine_size_closure) },
-        { be_const_key_weak(interrupt_animation, -1), be_const_closure(class_AnimationEngine_interrupt_animation_closure) },
+        { be_const_key_weak(_sine, -1), be_const_closure(class_PlasmaAnimation__sine_closure) },
+        { be_const_key_weak(tostring, 2), be_const_closure(class_PlasmaAnimation_tostring_closure) },
+        { be_const_key_weak(render, 5), be_const_closure(class_PlasmaAnimation_render_closure) },
+        { be_const_key_weak(init, 9), be_const_closure(class_PlasmaAnimation_init_closure) },
+        { be_const_key_weak(update, -1), be_const_closure(class_PlasmaAnimation_update_closure) },
+        { be_const_key_weak(_calculate_plasma, 7), be_const_closure(class_PlasmaAnimation__calculate_plasma_closure) },
+        { be_const_key_weak(_initialize_colors, -1), be_const_closure(class_PlasmaAnimation__initialize_colors_closure) },
+        { be_const_key_weak(on_param_changed, 6), be_const_closure(class_PlasmaAnimation_on_param_changed_closure) },
+        { be_const_key_weak(time_phase, -1), be_const_var(1) },
+        { be_const_key_weak(current_colors, 10), be_const_var(0) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(7,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(phase_y, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(64) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(freq_x, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(32) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(blend_mode, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(2) },
+    }))    ) } )) },
+        { be_const_key_weak(time_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(50) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(color, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_nil() },
+    }))    ) } )) },
+        { be_const_key_weak(phase_x, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(freq_y, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(23) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(start, 0), be_const_closure(class_PlasmaAnimation_start_closure) },
     })),
-    be_str_weak(AnimationEngine)
+    be_str_weak(PlasmaAnimation)
 );
 
 /********************************************************************
-** Solidified function: pulsating_color_provider
+** Solidified function: noise_fractal
 ********************************************************************/
-be_local_closure(pulsating_color_provider,   /* name */
+be_local_closure(noise_fractal,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -11231,24 +10674,57 @@ be_local_closure(pulsating_color_provider,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(breathe_color),
-    /* K2   */  be_nested_str_weak(curve_factor),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(duration),
+    /* K1   */  be_nested_str_weak(noise_animation),
+    /* K2   */  be_nested_str_weak(rich_palette),
+    /* K3   */  be_nested_str_weak(palette),
+    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
+    /* K5   */  be_nested_str_weak(cycle_period),
+    /* K6   */  be_nested_str_weak(transition_type),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(brightness),
+    /* K9   */  be_nested_str_weak(range_min),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(range_max),
+    /* K12  */  be_nested_str_weak(color),
+    /* K13  */  be_nested_str_weak(scale),
+    /* K14  */  be_nested_str_weak(speed),
+    /* K15  */  be_nested_str_weak(octaves),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(persistence),
     }),
-    be_str_weak(pulsating_color_provider),
+    be_str_weak(noise_fractal),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[28]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A03E7,  //  0005  LDINT	R2	1000
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
-      0x80040200,  //  0007  RET	1	R1
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0xB80E0000,  //  0008  GETNGBL	R3	K0
+      0x880C0704,  //  0009  GETMBR	R3	R3	K4
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0x540E1387,  //  000B  LDINT	R3	5000
+      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
+      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
+      0x540E00FE,  //  000E  LDINT	R3	255
+      0x900A1003,  //  000F  SETMBR	R2	K8	R3
+      0x900A130A,  //  0010  SETMBR	R2	K9	K10
+      0x540E00FE,  //  0011  LDINT	R3	255
+      0x900A1603,  //  0012  SETMBR	R2	K11	R3
+      0x90061802,  //  0013  SETMBR	R1	K12	R2
+      0x540E001D,  //  0014  LDINT	R3	30
+      0x90061A03,  //  0015  SETMBR	R1	K13	R3
+      0x540E0013,  //  0016  LDINT	R3	20
+      0x90061C03,  //  0017  SETMBR	R1	K14	R3
+      0x90061F10,  //  0018  SETMBR	R1	K15	K16
+      0x540E007F,  //  0019  LDINT	R3	128
+      0x90062203,  //  001A  SETMBR	R1	K17	R3
+      0x80040200,  //  001B  RET	1	R1
     })
   )
 );
@@ -11293,3459 +10769,9 @@ be_local_closure(jitter_color,   /* name */
 
 
 /********************************************************************
-** Solidified function: twinkle_rainbow
+** Solidified function: get_user_function
 ********************************************************************/
-be_local_closure(twinkle_rainbow,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(twinkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(density),
-    /* K4   */  be_nested_str_weak(twinkle_speed),
-    /* K5   */  be_nested_str_weak(fade_speed),
-    /* K6   */  be_nested_str_weak(min_brightness),
-    /* K7   */  be_nested_str_weak(max_brightness),
-    }),
-    be_str_weak(twinkle_rainbow),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0077,  //  0006  LDINT	R2	120
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A0005,  //  0008  LDINT	R2	6
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x540A00B3,  //  000A  LDINT	R2	180
-      0x90060A02,  //  000B  SETMBR	R1	K5	R2
-      0x540A001F,  //  000C  LDINT	R2	32
-      0x90060C02,  //  000D  SETMBR	R1	K6	R2
-      0x540A00FE,  //  000E  LDINT	R2	255
-      0x90060E02,  //  000F  SETMBR	R1	K7	R2
-      0x80040200,  //  0010  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gradient_rainbow_linear
-********************************************************************/
-be_local_closure(gradient_rainbow_linear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(gradient_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(gradient_type),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(direction),
-    /* K6   */  be_nested_str_weak(movement_speed),
-    }),
-    be_str_weak(gradient_rainbow_linear),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x90060B04,  //  0007  SETMBR	R1	K5	K4
-      0x540A0031,  //  0008  LDINT	R2	50
-      0x90060C02,  //  0009  SETMBR	R1	K6	R2
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: plasma_fast
-********************************************************************/
-be_local_closure(plasma_fast,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(plasma_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(time_speed),
-    /* K4   */  be_nested_str_weak(freq_x),
-    /* K5   */  be_nested_str_weak(freq_y),
-    /* K6   */  be_nested_str_weak(name),
-    /* K7   */  be_nested_str_weak(plasma_fast),
-    }),
-    be_str_weak(plasma_fast),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0095,  //  0006  LDINT	R2	150
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A002F,  //  0008  LDINT	R2	48
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x540A0022,  //  000A  LDINT	R2	35
-      0x90060A02,  //  000B  SETMBR	R1	K5	R2
-      0x90060D07,  //  000C  SETMBR	R1	K6	K7
-      0x80040200,  //  000D  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_all_event_handlers
-********************************************************************/
-be_local_closure(clear_all_event_handlers,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    0,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(event_manager),
-    /* K2   */  be_nested_str_weak(clear_all_handlers),
-    }),
-    be_str_weak(clear_all_event_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8020000,  //  0000  GETNGBL	R0	K0
-      0x88000101,  //  0001  GETMBR	R0	R0	K1
-      0x8C000102,  //  0002  GETMET	R0	R0	K2
-      0x7C000200,  //  0003  CALL	R0	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'EventManager' ktab size: 30, total: 61 (saved 248 bytes)
-static const bvalue be_ktab_class_EventManager[30] = {
-  /* K0   */  be_nested_str_weak(event_name),
-  /* K1   */  be_nested_str_weak(_X2A),
-  /* K2   */  be_nested_str_weak(global_handlers),
-  /* K3   */  be_nested_str_weak(find),
-  /* K4   */  be_nested_str_weak(remove),
-  /* K5   */  be_nested_str_weak(handlers),
-  /* K6   */  be_nested_str_weak(set_active),
-  /* K7   */  be_nested_str_weak(stop_iteration),
-  /* K8   */  be_nested_str_weak(push),
-  /* K9   */  be_nested_str_weak(get_info),
-  /* K10  */  be_nested_str_weak(keys),
-  /* K11  */  be_nested_str_weak(event_queue),
-  /* K12  */  be_nested_str_weak(is_processing),
-  /* K13  */  be_nested_str_weak(clear),
-  /* K14  */  be_const_int(1),
-  /* K15  */  be_const_int(0),
-  /* K16  */  be_nested_str_weak(priority),
-  /* K17  */  be_nested_str_weak(animation),
-  /* K18  */  be_nested_str_weak(event_handler),
-  /* K19  */  be_nested_str_weak(_sort_handlers),
-  /* K20  */  be_nested_str_weak(contains),
-  /* K21  */  be_nested_str_weak(name),
-  /* K22  */  be_nested_str_weak(data),
-  /* K23  */  be_nested_str_weak(is_active),
-  /* K24  */  be_nested_str_weak(execute),
-  /* K25  */  be_nested_str_weak(Event_X20processing_X20error_X3A),
-  /* K26  */  be_nested_str_weak(_process_queued_events),
-  /* K27  */  be_nested_str_weak(size),
-  /* K28  */  be_nested_str_weak(pop),
-  /* K29  */  be_nested_str_weak(trigger_event),
-};
-
-
-extern const bclass be_class_EventManager;
-
-/********************************************************************
-** Solidified function: unregister_handler
-********************************************************************/
-be_local_closure(class_EventManager_unregister_handler,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(unregister_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x1C080501,  //  0001  EQ	R2	R2	K1
-      0x780A000B,  //  0002  JMPF	R2	#000F
-      0x88080102,  //  0003  GETMBR	R2	R0	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x200C0403,  //  0008  NE	R3	R2	R3
-      0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x8C0C0704,  //  000B  GETMET	R3	R3	K4
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x7002000F,  //  000E  JMP		#001F
-      0x88080105,  //  000F  GETMBR	R2	R0	K5
-      0x8C080503,  //  0010  GETMET	R2	R2	K3
-      0x88100300,  //  0011  GETMBR	R4	R1	K0
-      0x7C080400,  //  0012  CALL	R2	2
-      0x4C0C0000,  //  0013  LDNIL	R3
-      0x200C0403,  //  0014  NE	R3	R2	R3
-      0x780E0008,  //  0015  JMPF	R3	#001F
-      0x8C0C0503,  //  0016  GETMET	R3	R2	K3
-      0x5C140200,  //  0017  MOVE	R5	R1
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x4C100000,  //  0019  LDNIL	R4
-      0x20100604,  //  001A  NE	R4	R3	R4
-      0x78120002,  //  001B  JMPF	R4	#001F
-      0x8C100504,  //  001C  GETMET	R4	R2	K4
-      0x5C180600,  //  001D  MOVE	R6	R3
-      0x7C100400,  //  001E  CALL	R4	2
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_event_active
-********************************************************************/
-be_local_closure(class_EventManager_set_event_active,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(set_event_active),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x880C0105,  //  0000  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0001  GETMET	R3	R3	K3
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x7812000C,  //  0006  JMPF	R4	#0014
-      0x60100010,  //  0007  GETGBL	R4	G16
-      0x5C140600,  //  0008  MOVE	R5	R3
-      0x7C100200,  //  0009  CALL	R4	1
-      0xA8020005,  //  000A  EXBLK	0	#0011
-      0x5C140800,  //  000B  MOVE	R5	R4
-      0x7C140000,  //  000C  CALL	R5	0
-      0x8C180B06,  //  000D  GETMET	R6	R5	K6
-      0x5C200400,  //  000E  MOVE	R8	R2
-      0x7C180400,  //  000F  CALL	R6	2
-      0x7001FFF9,  //  0010  JMP		#000B
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0xAC100200,  //  0012  CATCH	R4	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_handlers
-********************************************************************/
-be_local_closure(class_EventManager_get_handlers,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(get_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020006,  //  0005  EXBLK	0	#000D
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140508,  //  0008  GETMET	R5	R2	K8
-      0x8C1C0909,  //  0009  GETMET	R7	R4	K9
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x7001FFF8,  //  000C  JMP		#0006
-      0x580C0007,  //  000D  LDCONST	R3	K7
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x880C0105,  //  0010  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x4C100000,  //  0014  LDNIL	R4
-      0x20100604,  //  0015  NE	R4	R3	R4
-      0x7812000D,  //  0016  JMPF	R4	#0025
-      0x60100010,  //  0017  GETGBL	R4	G16
-      0x5C140600,  //  0018  MOVE	R5	R3
-      0x7C100200,  //  0019  CALL	R4	1
-      0xA8020006,  //  001A  EXBLK	0	#0022
-      0x5C140800,  //  001B  MOVE	R5	R4
-      0x7C140000,  //  001C  CALL	R5	0
-      0x8C180508,  //  001D  GETMET	R6	R2	K8
-      0x8C200B09,  //  001E  GETMET	R8	R5	K9
-      0x7C200200,  //  001F  CALL	R8	1
-      0x7C180400,  //  0020  CALL	R6	2
-      0x7001FFF8,  //  0021  JMP		#001B
-      0x58100007,  //  0022  LDCONST	R4	K7
-      0xAC100200,  //  0023  CATCH	R4	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x80040400,  //  0025  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_registered_events
-********************************************************************/
-be_local_closure(class_EventManager_get_registered_events,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(get_registered_events),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0105,  //  0003  GETMBR	R3	R0	K5
-      0x8C0C070A,  //  0004  GETMET	R3	R3	K10
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100308,  //  000A  GETMET	R4	R1	K8
-      0x5C180600,  //  000B  MOVE	R6	R3
-      0x7C100400,  //  000C  CALL	R4	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x58080007,  //  000E  LDCONST	R2	K7
-      0xAC080200,  //  000F  CATCH	R2	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x80040200,  //  0011  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_EventManager_init,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x90020A01,  //  0002  SETMBR	R0	K5	R1
-      0x60040012,  //  0003  GETGBL	R1	G18
-      0x7C040000,  //  0004  CALL	R1	0
-      0x90020401,  //  0005  SETMBR	R0	K2	R1
-      0x60040012,  //  0006  GETGBL	R1	G18
-      0x7C040000,  //  0007  CALL	R1	0
-      0x90021601,  //  0008  SETMBR	R0	K11	R1
-      0x50040000,  //  0009  LDBOOL	R1	0	0
-      0x90021801,  //  000A  SETMBR	R0	K12	R1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_all_handlers
-********************************************************************/
-be_local_closure(class_EventManager_clear_all_handlers,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(clear_all_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040105,  //  0000  GETMBR	R1	R0	K5
-      0x8C04030D,  //  0001  GETMET	R1	R1	K13
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C04030D,  //  0004  GETMET	R1	R1	K13
-      0x7C040200,  //  0005  CALL	R1	1
-      0x8804010B,  //  0006  GETMBR	R1	R0	K11
-      0x8C04030D,  //  0007  GETMET	R1	R1	K13
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _sort_handlers
-********************************************************************/
-be_local_closure(class_EventManager__sort_handlers,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(_sort_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0x60080010,  //  0000  GETGBL	R2	G16
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x040C070E,  //  0004  SUB	R3	R3	K14
-      0x400E1C03,  //  0005  CONNECT	R3	K14	R3
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA8020012,  //  0007  EXBLK	0	#001B
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x94100203,  //  000A  GETIDX	R4	R1	R3
-      0x5C140600,  //  000B  MOVE	R5	R3
-      0x24180B0F,  //  000C  GT	R6	R5	K15
-      0x781A000A,  //  000D  JMPF	R6	#0019
-      0x04180B0E,  //  000E  SUB	R6	R5	K14
-      0x94180206,  //  000F  GETIDX	R6	R1	R6
-      0x88180D10,  //  0010  GETMBR	R6	R6	K16
-      0x881C0910,  //  0011  GETMBR	R7	R4	K16
-      0x14180C07,  //  0012  LT	R6	R6	R7
-      0x781A0004,  //  0013  JMPF	R6	#0019
-      0x04180B0E,  //  0014  SUB	R6	R5	K14
-      0x94180206,  //  0015  GETIDX	R6	R1	R6
-      0x98040A06,  //  0016  SETIDX	R1	R5	R6
-      0x04140B0E,  //  0017  SUB	R5	R5	K14
-      0x7001FFF2,  //  0018  JMP		#000C
-      0x98040A04,  //  0019  SETIDX	R1	R5	R4
-      0x7001FFEC,  //  001A  JMP		#0008
-      0x58080007,  //  001B  LDCONST	R2	K7
-      0xAC080200,  //  001C  CATCH	R2	1	0
-      0xB0080000,  //  001D  RAISE	2	R0	R0
-      0x80000000,  //  001E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_handler
-********************************************************************/
-be_local_closure(class_EventManager_register_handler,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    6,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(register_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xB81A2200,  //  0000  GETNGBL	R6	K17
-      0x8C180D12,  //  0001  GETMET	R6	R6	K18
-      0x5C200200,  //  0002  MOVE	R8	R1
-      0x5C240400,  //  0003  MOVE	R9	R2
-      0x5C280600,  //  0004  MOVE	R10	R3
-      0x5C2C0800,  //  0005  MOVE	R11	R4
-      0x5C300A00,  //  0006  MOVE	R12	R5
-      0x7C180C00,  //  0007  CALL	R6	6
-      0x1C1C0301,  //  0008  EQ	R7	R1	K1
-      0x781E0007,  //  0009  JMPF	R7	#0012
-      0x881C0102,  //  000A  GETMBR	R7	R0	K2
-      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
-      0x5C240C00,  //  000C  MOVE	R9	R6
-      0x7C1C0400,  //  000D  CALL	R7	2
-      0x8C1C0113,  //  000E  GETMET	R7	R0	K19
-      0x88240102,  //  000F  GETMBR	R9	R0	K2
-      0x7C1C0400,  //  0010  CALL	R7	2
-      0x70020011,  //  0011  JMP		#0024
-      0x881C0105,  //  0012  GETMBR	R7	R0	K5
-      0x8C1C0F14,  //  0013  GETMET	R7	R7	K20
-      0x5C240200,  //  0014  MOVE	R9	R1
-      0x7C1C0400,  //  0015  CALL	R7	2
-      0x741E0003,  //  0016  JMPT	R7	#001B
-      0x881C0105,  //  0017  GETMBR	R7	R0	K5
-      0x60200012,  //  0018  GETGBL	R8	G18
-      0x7C200000,  //  0019  CALL	R8	0
-      0x981C0208,  //  001A  SETIDX	R7	R1	R8
-      0x881C0105,  //  001B  GETMBR	R7	R0	K5
-      0x941C0E01,  //  001C  GETIDX	R7	R7	R1
-      0x8C1C0F08,  //  001D  GETMET	R7	R7	K8
-      0x5C240C00,  //  001E  MOVE	R9	R6
-      0x7C1C0400,  //  001F  CALL	R7	2
-      0x8C1C0113,  //  0020  GETMET	R7	R0	K19
-      0x88240105,  //  0021  GETMBR	R9	R0	K5
-      0x94241201,  //  0022  GETIDX	R9	R9	R1
-      0x7C1C0400,  //  0023  CALL	R7	2
-      0x80040C00,  //  0024  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: trigger_event
-********************************************************************/
-be_local_closure(class_EventManager_trigger_event,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(trigger_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0x880C010C,  //  0000  GETMBR	R3	R0	K12
-      0x780E0007,  //  0001  JMPF	R3	#000A
-      0x880C010B,  //  0002  GETMBR	R3	R0	K11
-      0x8C0C0708,  //  0003  GETMET	R3	R3	K8
-      0x60140013,  //  0004  GETGBL	R5	G19
-      0x7C140000,  //  0005  CALL	R5	0
-      0x98162A01,  //  0006  SETIDX	R5	K21	R1
-      0x98162C02,  //  0007  SETIDX	R5	K22	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x80000600,  //  0009  RET	0
-      0x500C0200,  //  000A  LDBOOL	R3	1	0
-      0x90021803,  //  000B  SETMBR	R0	K12	R3
-      0xA8020029,  //  000C  EXBLK	0	#0037
-      0x600C0010,  //  000D  GETGBL	R3	G16
-      0x88100102,  //  000E  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0xA802000A,  //  0010  EXBLK	0	#001C
-      0x5C100600,  //  0011  MOVE	R4	R3
-      0x7C100000,  //  0012  CALL	R4	0
-      0x88140917,  //  0013  GETMBR	R5	R4	K23
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x8C140918,  //  0015  GETMET	R5	R4	K24
-      0x601C0013,  //  0016  GETGBL	R7	G19
-      0x7C1C0000,  //  0017  CALL	R7	0
-      0x981E0001,  //  0018  SETIDX	R7	K0	R1
-      0x981E2C02,  //  0019  SETIDX	R7	K22	R2
-      0x7C140400,  //  001A  CALL	R5	2
-      0x7001FFF4,  //  001B  JMP		#0011
-      0x580C0007,  //  001C  LDCONST	R3	K7
-      0xAC0C0200,  //  001D  CATCH	R3	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x880C0105,  //  001F  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0020  GETMET	R3	R3	K3
-      0x5C140200,  //  0021  MOVE	R5	R1
-      0x7C0C0400,  //  0022  CALL	R3	2
-      0x4C100000,  //  0023  LDNIL	R4
-      0x20100604,  //  0024  NE	R4	R3	R4
-      0x7812000E,  //  0025  JMPF	R4	#0035
-      0x60100010,  //  0026  GETGBL	R4	G16
-      0x5C140600,  //  0027  MOVE	R5	R3
-      0x7C100200,  //  0028  CALL	R4	1
-      0xA8020007,  //  0029  EXBLK	0	#0032
-      0x5C140800,  //  002A  MOVE	R5	R4
-      0x7C140000,  //  002B  CALL	R5	0
-      0x88180B17,  //  002C  GETMBR	R6	R5	K23
-      0x781A0002,  //  002D  JMPF	R6	#0031
-      0x8C180B18,  //  002E  GETMET	R6	R5	K24
-      0x5C200400,  //  002F  MOVE	R8	R2
-      0x7C180400,  //  0030  CALL	R6	2
-      0x7001FFF7,  //  0031  JMP		#002A
-      0x58100007,  //  0032  LDCONST	R4	K7
-      0xAC100200,  //  0033  CATCH	R4	1	0
-      0xB0080000,  //  0034  RAISE	2	R0	R0
-      0xA8040001,  //  0035  EXBLK	1	1
-      0x70020008,  //  0036  JMP		#0040
-      0xAC0C0002,  //  0037  CATCH	R3	0	2
-      0x70020005,  //  0038  JMP		#003F
-      0x60140001,  //  0039  GETGBL	R5	G1
-      0x58180019,  //  003A  LDCONST	R6	K25
-      0x5C1C0600,  //  003B  MOVE	R7	R3
-      0x5C200800,  //  003C  MOVE	R8	R4
-      0x7C140600,  //  003D  CALL	R5	3
-      0x70020000,  //  003E  JMP		#0040
-      0xB0080000,  //  003F  RAISE	2	R0	R0
-      0x500C0000,  //  0040  LDBOOL	R3	0	0
-      0x90021803,  //  0041  SETMBR	R0	K12	R3
-      0x8C0C011A,  //  0042  GETMET	R3	R0	K26
-      0x7C0C0200,  //  0043  CALL	R3	1
-      0x80000000,  //  0044  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _process_queued_events
-********************************************************************/
-be_local_closure(class_EventManager__process_queued_events,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventManager,     /* shared constants */
-    be_str_weak(_process_queued_events),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x8804010B,  //  0000  GETMBR	R1	R0	K11
-      0x8C04031B,  //  0001  GETMET	R1	R1	K27
-      0x7C040200,  //  0002  CALL	R1	1
-      0x2404030F,  //  0003  GT	R1	R1	K15
-      0x78060008,  //  0004  JMPF	R1	#000E
-      0x8804010B,  //  0005  GETMBR	R1	R0	K11
-      0x8C04031C,  //  0006  GETMET	R1	R1	K28
-      0x580C000F,  //  0007  LDCONST	R3	K15
-      0x7C040400,  //  0008  CALL	R1	2
-      0x8C08011D,  //  0009  GETMET	R2	R0	K29
-      0x94100315,  //  000A  GETIDX	R4	R1	K21
-      0x94140316,  //  000B  GETIDX	R5	R1	K22
-      0x7C080600,  //  000C  CALL	R2	3
-      0x7001FFF1,  //  000D  JMP		#0000
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: EventManager
-********************************************************************/
-be_local_class(EventManager,
-    4,
-    NULL,
-    be_nested_map(14,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(unregister_handler, -1), be_const_closure(class_EventManager_unregister_handler_closure) },
-        { be_const_key_weak(set_event_active, -1), be_const_closure(class_EventManager_set_event_active_closure) },
-        { be_const_key_weak(handlers, -1), be_const_var(0) },
-        { be_const_key_weak(init, -1), be_const_closure(class_EventManager_init_closure) },
-        { be_const_key_weak(trigger_event, -1), be_const_closure(class_EventManager_trigger_event_closure) },
-        { be_const_key_weak(get_handlers, 3), be_const_closure(class_EventManager_get_handlers_closure) },
-        { be_const_key_weak(clear_all_handlers, -1), be_const_closure(class_EventManager_clear_all_handlers_closure) },
-        { be_const_key_weak(event_queue, -1), be_const_var(2) },
-        { be_const_key_weak(_sort_handlers, -1), be_const_closure(class_EventManager__sort_handlers_closure) },
-        { be_const_key_weak(is_processing, 7), be_const_var(3) },
-        { be_const_key_weak(global_handlers, -1), be_const_var(1) },
-        { be_const_key_weak(register_handler, -1), be_const_closure(class_EventManager_register_handler_closure) },
-        { be_const_key_weak(get_registered_events, 4), be_const_closure(class_EventManager_get_registered_events_closure) },
-        { be_const_key_weak(_process_queued_events, -1), be_const_closure(class_EventManager__process_queued_events_closure) },
-    })),
-    be_str_weak(EventManager)
-);
-
-/********************************************************************
-** Solidified function: twinkle_gentle
-********************************************************************/
-be_local_closure(twinkle_gentle,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(twinkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(density),
-    /* K4   */  be_nested_str_weak(twinkle_speed),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(fade_speed),
-    /* K7   */  be_nested_str_weak(min_brightness),
-    /* K8   */  be_nested_str_weak(max_brightness),
-    }),
-    be_str_weak(twinkle_gentle),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409D6FF,  //  0004  LDINT	R2	-10496
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A003F,  //  0006  LDINT	R2	64
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x90060905,  //  0008  SETMBR	R1	K4	K5
-      0x540A0077,  //  0009  LDINT	R2	120
-      0x90060C02,  //  000A  SETMBR	R1	K6	R2
-      0x540A000F,  //  000B  LDINT	R2	16
-      0x90060E02,  //  000C  SETMBR	R1	K7	R2
-      0x540A00B3,  //  000D  LDINT	R2	180
-      0x90061002,  //  000E  SETMBR	R1	K8	R2
-      0x80040200,  //  000F  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'CompositeColorProvider' ktab size: 15, total: 25 (saved 80 bytes)
-static const bvalue be_ktab_class_CompositeColorProvider[15] = {
-  /* K0   */  be_nested_str_weak(providers),
-  /* K1   */  be_nested_str_weak(push),
-  /* K2   */  be_const_int(0),
-  /* K3   */  be_const_int(1),
-  /* K4   */  be_nested_str_weak(get_color_for_value),
-  /* K5   */  be_nested_str_weak(_blend_colors),
-  /* K6   */  be_nested_str_weak(produce_value),
-  /* K7   */  be_nested_str_weak(CompositeColorProvider_X28providers_X3D_X25s_X2C_X20blend_mode_X3D_X25s_X29),
-  /* K8   */  be_nested_str_weak(blend_mode),
-  /* K9   */  be_nested_str_weak(CompositeColorProvider_X28uninitialized_X29),
-  /* K10  */  be_const_real_hex(0x437F0000),
-  /* K11  */  be_const_int(2),
-  /* K12  */  be_nested_str_weak(tasmota),
-  /* K13  */  be_nested_str_weak(scale_uint),
-  /* K14  */  be_nested_str_weak(init),
-};
-
-
-extern const bclass be_class_CompositeColorProvider;
-
-/********************************************************************
-** Solidified function: add_provider
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_add_provider,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(add_provider),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040000,  //  0004  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color_for_value
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_get_color_for_value,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(get_color_for_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x600C000C,  //  0000  GETGBL	R3	G12
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0702,  //  0003  EQ	R3	R3	K2
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x540DFFFE,  //  0005  LDINT	R3	-1
-      0x80040600,  //  0006  RET	1	R3
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x1C0C0703,  //  000A  EQ	R3	R3	K3
-      0x780E0006,  //  000B  JMPF	R3	#0013
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
-      0x940C0702,  //  000D  GETIDX	R3	R3	K2
-      0x8C0C0704,  //  000E  GETMET	R3	R3	K4
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
-      0x940C0702,  //  0014  GETIDX	R3	R3	K2
-      0x8C0C0704,  //  0015  GETMET	R3	R3	K4
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5C180400,  //  0017  MOVE	R6	R2
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x58100003,  //  0019  LDCONST	R4	K3
-      0x6014000C,  //  001A  GETGBL	R5	G12
-      0x88180100,  //  001B  GETMBR	R6	R0	K0
-      0x7C140200,  //  001C  CALL	R5	1
-      0x14140805,  //  001D  LT	R5	R4	R5
-      0x7816000C,  //  001E  JMPF	R5	#002C
-      0x88140100,  //  001F  GETMBR	R5	R0	K0
-      0x94140A04,  //  0020  GETIDX	R5	R5	R4
-      0x8C140B04,  //  0021  GETMET	R5	R5	K4
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x5C200400,  //  0023  MOVE	R8	R2
-      0x7C140600,  //  0024  CALL	R5	3
-      0x8C180105,  //  0025  GETMET	R6	R0	K5
-      0x5C200600,  //  0026  MOVE	R8	R3
-      0x5C240A00,  //  0027  MOVE	R9	R5
-      0x7C180600,  //  0028  CALL	R6	3
-      0x5C0C0C00,  //  0029  MOVE	R3	R6
-      0x00100903,  //  002A  ADD	R4	R4	K3
-      0x7001FFED,  //  002B  JMP		#001A
-      0x80040600,  //  002C  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_produce_value,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x600C000C,  //  0000  GETGBL	R3	G12
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0702,  //  0003  EQ	R3	R3	K2
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x540DFFFE,  //  0005  LDINT	R3	-1
-      0x80040600,  //  0006  RET	1	R3
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x1C0C0703,  //  000A  EQ	R3	R3	K3
-      0x780E0006,  //  000B  JMPF	R3	#0013
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
-      0x940C0702,  //  000D  GETIDX	R3	R3	K2
-      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
-      0x940C0702,  //  0014  GETIDX	R3	R3	K2
-      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5C180400,  //  0017  MOVE	R6	R2
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x58100003,  //  0019  LDCONST	R4	K3
-      0x6014000C,  //  001A  GETGBL	R5	G12
-      0x88180100,  //  001B  GETMBR	R6	R0	K0
-      0x7C140200,  //  001C  CALL	R5	1
-      0x14140805,  //  001D  LT	R5	R4	R5
-      0x7816000C,  //  001E  JMPF	R5	#002C
-      0x88140100,  //  001F  GETMBR	R5	R0	K0
-      0x94140A04,  //  0020  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0021  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x5C200400,  //  0023  MOVE	R8	R2
-      0x7C140600,  //  0024  CALL	R5	3
-      0x8C180105,  //  0025  GETMET	R6	R0	K5
-      0x5C200600,  //  0026  MOVE	R8	R3
-      0x5C240A00,  //  0027  MOVE	R9	R5
-      0x7C180600,  //  0028  CALL	R6	3
-      0x5C0C0C00,  //  0029  MOVE	R3	R6
-      0x00100903,  //  002A  ADD	R4	R4	K3
-      0x7001FFED,  //  002B  JMP		#001A
-      0x80040600,  //  002C  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_tostring,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0xA802000A,  //  0000  EXBLK	0	#000C
-      0x60040018,  //  0001  GETGBL	R1	G24
-      0x58080007,  //  0002  LDCONST	R2	K7
-      0x600C000C,  //  0003  GETGBL	R3	G12
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x88100108,  //  0006  GETMBR	R4	R0	K8
-      0x7C040600,  //  0007  CALL	R1	3
-      0xA8040001,  //  0008  EXBLK	1	1
-      0x80040200,  //  0009  RET	1	R1
-      0xA8040001,  //  000A  EXBLK	1	1
-      0x70020004,  //  000B  JMP		#0011
-      0xAC040000,  //  000C  CATCH	R1	0	0
-      0x70020001,  //  000D  JMP		#0010
-      0x80061200,  //  000E  RET	1	K9
-      0x70020000,  //  000F  JMP		#0011
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _blend_colors
-********************************************************************/
-be_local_closure(class_CompositeColorProvider__blend_colors,   /* name */
-  be_nested_proto(
-    23,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(_blend_colors),
-    &be_const_str_solidified,
-    ( &(const binstruction[151]) {  /* code */
-      0x880C0108,  //  0000  GETMBR	R3	R0	K8
-      0x54120017,  //  0001  LDINT	R4	24
-      0x3C100204,  //  0002  SHR	R4	R1	R4
-      0x541600FE,  //  0003  LDINT	R5	255
-      0x2C100805,  //  0004  AND	R4	R4	R5
-      0x5416000F,  //  0005  LDINT	R5	16
-      0x3C140205,  //  0006  SHR	R5	R1	R5
-      0x541A00FE,  //  0007  LDINT	R6	255
-      0x2C140A06,  //  0008  AND	R5	R5	R6
-      0x541A0007,  //  0009  LDINT	R6	8
-      0x3C180206,  //  000A  SHR	R6	R1	R6
-      0x541E00FE,  //  000B  LDINT	R7	255
-      0x2C180C07,  //  000C  AND	R6	R6	R7
-      0x541E00FE,  //  000D  LDINT	R7	255
-      0x2C1C0207,  //  000E  AND	R7	R1	R7
-      0x54220017,  //  000F  LDINT	R8	24
-      0x3C200408,  //  0010  SHR	R8	R2	R8
-      0x542600FE,  //  0011  LDINT	R9	255
-      0x2C201009,  //  0012  AND	R8	R8	R9
-      0x5426000F,  //  0013  LDINT	R9	16
-      0x3C240409,  //  0014  SHR	R9	R2	R9
-      0x542A00FE,  //  0015  LDINT	R10	255
-      0x2C24120A,  //  0016  AND	R9	R9	R10
-      0x542A0007,  //  0017  LDINT	R10	8
-      0x3C28040A,  //  0018  SHR	R10	R2	R10
-      0x542E00FE,  //  0019  LDINT	R11	255
-      0x2C28140B,  //  001A  AND	R10	R10	R11
-      0x542E00FE,  //  001B  LDINT	R11	255
-      0x2C2C040B,  //  001C  AND	R11	R2	R11
-      0x4C300000,  //  001D  LDNIL	R12
-      0x4C340000,  //  001E  LDNIL	R13
-      0x4C380000,  //  001F  LDNIL	R14
-      0x4C3C0000,  //  0020  LDNIL	R15
-      0x1C400702,  //  0021  EQ	R16	R3	K2
-      0x7842001C,  //  0022  JMPF	R16	#0040
-      0x0C40110A,  //  0023  DIV	R16	R8	K10
-      0x60440009,  //  0024  GETGBL	R17	G9
-      0x044A0610,  //  0025  SUB	R18	K3	R16
-      0x08480E12,  //  0026  MUL	R18	R7	R18
-      0x084C1610,  //  0027  MUL	R19	R11	R16
-      0x00482413,  //  0028  ADD	R18	R18	R19
-      0x7C440200,  //  0029  CALL	R17	1
-      0x5C342200,  //  002A  MOVE	R13	R17
-      0x60440009,  //  002B  GETGBL	R17	G9
-      0x044A0610,  //  002C  SUB	R18	K3	R16
-      0x08480C12,  //  002D  MUL	R18	R6	R18
-      0x084C1410,  //  002E  MUL	R19	R10	R16
-      0x00482413,  //  002F  ADD	R18	R18	R19
-      0x7C440200,  //  0030  CALL	R17	1
-      0x5C382200,  //  0031  MOVE	R14	R17
-      0x60440009,  //  0032  GETGBL	R17	G9
-      0x044A0610,  //  0033  SUB	R18	K3	R16
-      0x08480A12,  //  0034  MUL	R18	R5	R18
-      0x084C1210,  //  0035  MUL	R19	R9	R16
-      0x00482413,  //  0036  ADD	R18	R18	R19
-      0x7C440200,  //  0037  CALL	R17	1
-      0x5C3C2200,  //  0038  MOVE	R15	R17
-      0x24440808,  //  0039  GT	R17	R4	R8
-      0x78460001,  //  003A  JMPF	R17	#003D
-      0x5C440800,  //  003B  MOVE	R17	R4
-      0x70020000,  //  003C  JMP		#003E
-      0x5C441000,  //  003D  MOVE	R17	R8
-      0x5C302200,  //  003E  MOVE	R12	R17
-      0x7002004C,  //  003F  JMP		#008D
-      0x1C400703,  //  0040  EQ	R16	R3	K3
-      0x78420021,  //  0041  JMPF	R16	#0064
-      0x00400E0B,  //  0042  ADD	R16	R7	R11
-      0x5C342000,  //  0043  MOVE	R13	R16
-      0x00400C0A,  //  0044  ADD	R16	R6	R10
-      0x5C382000,  //  0045  MOVE	R14	R16
-      0x00400A09,  //  0046  ADD	R16	R5	R9
-      0x5C3C2000,  //  0047  MOVE	R15	R16
-      0x24400808,  //  0048  GT	R16	R4	R8
-      0x78420001,  //  0049  JMPF	R16	#004C
-      0x5C400800,  //  004A  MOVE	R16	R4
-      0x70020000,  //  004B  JMP		#004D
-      0x5C401000,  //  004C  MOVE	R16	R8
-      0x5C302000,  //  004D  MOVE	R12	R16
-      0x544200FE,  //  004E  LDINT	R16	255
-      0x24401A10,  //  004F  GT	R16	R13	R16
-      0x78420001,  //  0050  JMPF	R16	#0053
-      0x544200FE,  //  0051  LDINT	R16	255
-      0x70020000,  //  0052  JMP		#0054
-      0x5C401A00,  //  0053  MOVE	R16	R13
-      0x5C342000,  //  0054  MOVE	R13	R16
-      0x544200FE,  //  0055  LDINT	R16	255
-      0x24401C10,  //  0056  GT	R16	R14	R16
-      0x78420001,  //  0057  JMPF	R16	#005A
-      0x544200FE,  //  0058  LDINT	R16	255
-      0x70020000,  //  0059  JMP		#005B
-      0x5C401C00,  //  005A  MOVE	R16	R14
-      0x5C382000,  //  005B  MOVE	R14	R16
-      0x544200FE,  //  005C  LDINT	R16	255
-      0x24401E10,  //  005D  GT	R16	R15	R16
-      0x78420001,  //  005E  JMPF	R16	#0061
-      0x544200FE,  //  005F  LDINT	R16	255
-      0x70020000,  //  0060  JMP		#0062
-      0x5C401E00,  //  0061  MOVE	R16	R15
-      0x5C3C2000,  //  0062  MOVE	R15	R16
-      0x70020028,  //  0063  JMP		#008D
-      0x1C40070B,  //  0064  EQ	R16	R3	K11
-      0x78420026,  //  0065  JMPF	R16	#008D
-      0xB8421800,  //  0066  GETNGBL	R16	K12
-      0x8C40210D,  //  0067  GETMET	R16	R16	K13
-      0x08480E0B,  //  0068  MUL	R18	R7	R11
-      0x584C0002,  //  0069  LDCONST	R19	K2
-      0x545200FE,  //  006A  LDINT	R20	255
-      0x545600FE,  //  006B  LDINT	R21	255
-      0x08502815,  //  006C  MUL	R20	R20	R21
-      0x58540002,  //  006D  LDCONST	R21	K2
-      0x545A00FE,  //  006E  LDINT	R22	255
-      0x7C400C00,  //  006F  CALL	R16	6
-      0x5C342000,  //  0070  MOVE	R13	R16
-      0xB8421800,  //  0071  GETNGBL	R16	K12
-      0x8C40210D,  //  0072  GETMET	R16	R16	K13
-      0x08480C0A,  //  0073  MUL	R18	R6	R10
-      0x584C0002,  //  0074  LDCONST	R19	K2
-      0x545200FE,  //  0075  LDINT	R20	255
-      0x545600FE,  //  0076  LDINT	R21	255
-      0x08502815,  //  0077  MUL	R20	R20	R21
-      0x58540002,  //  0078  LDCONST	R21	K2
-      0x545A00FE,  //  0079  LDINT	R22	255
-      0x7C400C00,  //  007A  CALL	R16	6
-      0x5C382000,  //  007B  MOVE	R14	R16
-      0xB8421800,  //  007C  GETNGBL	R16	K12
-      0x8C40210D,  //  007D  GETMET	R16	R16	K13
-      0x08480A09,  //  007E  MUL	R18	R5	R9
-      0x584C0002,  //  007F  LDCONST	R19	K2
-      0x545200FE,  //  0080  LDINT	R20	255
-      0x545600FE,  //  0081  LDINT	R21	255
-      0x08502815,  //  0082  MUL	R20	R20	R21
-      0x58540002,  //  0083  LDCONST	R21	K2
-      0x545A00FE,  //  0084  LDINT	R22	255
-      0x7C400C00,  //  0085  CALL	R16	6
-      0x5C3C2000,  //  0086  MOVE	R15	R16
-      0x24400808,  //  0087  GT	R16	R4	R8
-      0x78420001,  //  0088  JMPF	R16	#008B
-      0x5C400800,  //  0089  MOVE	R16	R4
-      0x70020000,  //  008A  JMP		#008C
-      0x5C401000,  //  008B  MOVE	R16	R8
-      0x5C302000,  //  008C  MOVE	R12	R16
-      0x54420017,  //  008D  LDINT	R16	24
-      0x38401810,  //  008E  SHL	R16	R12	R16
-      0x5446000F,  //  008F  LDINT	R17	16
-      0x38441E11,  //  0090  SHL	R17	R15	R17
-      0x30402011,  //  0091  OR	R16	R16	R17
-      0x54460007,  //  0092  LDINT	R17	8
-      0x38441C11,  //  0093  SHL	R17	R14	R17
-      0x30402011,  //  0094  OR	R16	R16	R17
-      0x3040200D,  //  0095  OR	R16	R16	R13
-      0x80042000,  //  0096  RET	1	R16
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08050E,  //  0003  GETMET	R2	R2	K14
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: CompositeColorProvider
-********************************************************************/
-extern const bclass be_class_ColorProvider;
-be_local_class(CompositeColorProvider,
-    1,
-    &be_class_ColorProvider,
-    be_nested_map(8,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(add_provider, -1), be_const_closure(class_CompositeColorProvider_add_provider_closure) },
-        { be_const_key_weak(get_color_for_value, 7), be_const_closure(class_CompositeColorProvider_get_color_for_value_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_CompositeColorProvider_init_closure) },
-        { be_const_key_weak(PARAMS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(blend_mode, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-        be_const_int(2),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_CompositeColorProvider_tostring_closure) },
-        { be_const_key_weak(providers, 4), be_const_var(0) },
-        { be_const_key_weak(_blend_colors, -1), be_const_closure(class_CompositeColorProvider__blend_colors_closure) },
-        { be_const_key_weak(produce_value, -1), be_const_closure(class_CompositeColorProvider_produce_value_closure) },
-    })),
-    be_str_weak(CompositeColorProvider)
-);
-
-extern const bclass be_class_PaletteGradientAnimation;
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_PaletteGradientAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(name),
-    /* K2   */  be_nested_str_weak(palette_gradient),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020302,  //  0006  SETMBR	R0	K1	K2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_value_buffer
-********************************************************************/
-be_local_closure(class_PaletteGradientAnimation__update_value_buffer,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shift_period),
-    /* K1   */  be_nested_str_weak(engine),
-    /* K2   */  be_nested_str_weak(get_strip_length),
-    /* K3   */  be_nested_str_weak(value_buffer),
-    /* K4   */  be_nested_str_weak(resize),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(scale_uint),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_const_real_hex(0x447A0000),
-    /* K9   */  be_const_int(1),
-    }),
-    be_str_weak(_update_value_buffer),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x6010000C,  //  0004  GETGBL	R4	G12
-      0x88140103,  //  0005  GETMBR	R5	R0	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x20100803,  //  0007  NE	R4	R4	R3
-      0x78120003,  //  0008  JMPF	R4	#000D
-      0x88100103,  //  0009  GETMBR	R4	R0	K3
-      0x8C100904,  //  000A  GETMET	R4	R4	K4
-      0x5C180600,  //  000B  MOVE	R6	R3
-      0x7C100400,  //  000C  CALL	R4	2
-      0xB8120A00,  //  000D  GETNGBL	R4	K5
-      0x8C100906,  //  000E  GETMET	R4	R4	K6
-      0x10180202,  //  000F  MOD	R6	R1	R2
-      0x581C0007,  //  0010  LDCONST	R7	K7
-      0x5C200400,  //  0011  MOVE	R8	R2
-      0x58240007,  //  0012  LDCONST	R9	K7
-      0x542A03E7,  //  0013  LDINT	R10	1000
-      0x7C100C00,  //  0014  CALL	R4	6
-      0x0C100908,  //  0015  DIV	R4	R4	K8
-      0x60140009,  //  0016  GETGBL	R5	G9
-      0x08180803,  //  0017  MUL	R6	R4	R3
-      0x7C140200,  //  0018  CALL	R5	1
-      0x58180007,  //  0019  LDCONST	R6	K7
-      0x141C0C03,  //  001A  LT	R7	R6	R3
-      0x781E000D,  //  001B  JMPF	R7	#002A
-      0x001C0C05,  //  001C  ADD	R7	R6	R5
-      0x101C0E03,  //  001D  MOD	R7	R7	R3
-      0x88200103,  //  001E  GETMBR	R8	R0	K3
-      0xB8260A00,  //  001F  GETNGBL	R9	K5
-      0x8C241306,  //  0020  GETMET	R9	R9	K6
-      0x5C2C0E00,  //  0021  MOVE	R11	R7
-      0x58300007,  //  0022  LDCONST	R12	K7
-      0x04340709,  //  0023  SUB	R13	R3	K9
-      0x58380007,  //  0024  LDCONST	R14	K7
-      0x543E0063,  //  0025  LDINT	R15	100
-      0x7C240C00,  //  0026  CALL	R9	6
-      0x98200C09,  //  0027  SETIDX	R8	R6	R9
-      0x00180D09,  //  0028  ADD	R6	R6	K9
-      0x7001FFEF,  //  0029  JMP		#001A
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: PaletteGradientAnimation
-********************************************************************/
-extern const bclass be_class_PalettePatternAnimation;
-be_local_class(PaletteGradientAnimation,
-    0,
-    &be_class_PalettePatternAnimation,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(shift_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(10000) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_PaletteGradientAnimation_init_closure) },
-        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteGradientAnimation__update_value_buffer_closure) },
-    })),
-    be_str_weak(PaletteGradientAnimation)
-);
-
-/********************************************************************
-** Solidified function: create_engine
-********************************************************************/
-be_local_closure(create_engine,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(animation_engine),
-    }),
-    be_str_weak(create_engine),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'ColorCycleColorProvider' ktab size: 17, total: 36 (saved 152 bytes)
-static const bvalue be_ktab_class_ColorCycleColorProvider[17] = {
-  /* K0   */  be_nested_str_weak(palette),
-  /* K1   */  be_const_int(0),
-  /* K2   */  be_const_int(1),
-  /* K3   */  be_nested_str_weak(tasmota),
-  /* K4   */  be_nested_str_weak(scale_uint),
-  /* K5   */  be_nested_str_weak(cycle_period),
-  /* K6   */  be_nested_str_weak(current_color),
-  /* K7   */  be_nested_str_weak(current_index),
-  /* K8   */  be_nested_str_weak(next),
-  /* K9   */  be_nested_str_weak(set_param),
-  /* K10  */  be_nested_str_weak(init),
-  /* K11  */  be_nested_str_weak(manual),
-  /* K12  */  be_nested_str_weak(auto),
-  /* K13  */  be_nested_str_weak(ColorCycleColorProvider_X28palette_size_X3D_X25s_X2C_X20cycle_period_X3D_X25s_X2C_X20mode_X3D_X25s_X2C_X20current_index_X3D_X25s_X29),
-  /* K14  */  be_nested_str_weak(ColorCycleColorProvider_X28uninitialized_X29),
-  /* K15  */  be_nested_str_weak(copy),
-  /* K16  */  be_nested_str_weak(push),
-};
-
-
-extern const bclass be_class_ColorCycleColorProvider;
-
-/********************************************************************
-** Solidified function: get_color_for_value
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_get_color_for_value,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(get_color_for_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x6010000C,  //  0001  GETGBL	R4	G12
-      0x5C140600,  //  0002  MOVE	R5	R3
-      0x7C100200,  //  0003  CALL	R4	1
-      0x1C140901,  //  0004  EQ	R5	R4	K1
-      0x78160001,  //  0005  JMPF	R5	#0008
-      0x5415FFFE,  //  0006  LDINT	R5	-1
-      0x80040A00,  //  0007  RET	1	R5
-      0x1C140902,  //  0008  EQ	R5	R4	K2
-      0x78160001,  //  0009  JMPF	R5	#000C
-      0x94140701,  //  000A  GETIDX	R5	R3	K1
-      0x80040A00,  //  000B  RET	1	R5
-      0x14140301,  //  000C  LT	R5	R1	K1
-      0x78160001,  //  000D  JMPF	R5	#0010
-      0x58040001,  //  000E  LDCONST	R1	K1
-      0x70020003,  //  000F  JMP		#0014
-      0x54160063,  //  0010  LDINT	R5	100
-      0x24140205,  //  0011  GT	R5	R1	R5
-      0x78160000,  //  0012  JMPF	R5	#0014
-      0x54060063,  //  0013  LDINT	R1	100
-      0xB8160600,  //  0014  GETNGBL	R5	K3
-      0x8C140B04,  //  0015  GETMET	R5	R5	K4
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x58200001,  //  0017  LDCONST	R8	K1
-      0x54260063,  //  0018  LDINT	R9	100
-      0x58280001,  //  0019  LDCONST	R10	K1
-      0x042C0902,  //  001A  SUB	R11	R4	K2
-      0x7C140C00,  //  001B  CALL	R5	6
-      0x28180A04,  //  001C  GE	R6	R5	R4
-      0x781A0001,  //  001D  JMPF	R6	#0020
-      0x04180902,  //  001E  SUB	R6	R4	K2
-      0x5C140C00,  //  001F  MOVE	R5	R6
-      0x94180605,  //  0020  GETIDX	R6	R3	R5
-      0x80040C00,  //  0021  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_produce_value,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x88100105,  //  0001  GETMBR	R4	R0	K5
-      0x6014000C,  //  0002  GETGBL	R5	G12
-      0x5C180600,  //  0003  MOVE	R6	R3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x1C180B01,  //  0005  EQ	R6	R5	K1
-      0x781A0001,  //  0006  JMPF	R6	#0009
-      0x5419FFFE,  //  0007  LDINT	R6	-1
-      0x80040C00,  //  0008  RET	1	R6
-      0x1C180B02,  //  0009  EQ	R6	R5	K2
-      0x781A0003,  //  000A  JMPF	R6	#000F
-      0x94180701,  //  000B  GETIDX	R6	R3	K1
-      0x90020C06,  //  000C  SETMBR	R0	K6	R6
-      0x88180106,  //  000D  GETMBR	R6	R0	K6
-      0x80040C00,  //  000E  RET	1	R6
-      0x1C180901,  //  000F  EQ	R6	R4	K1
-      0x781A0001,  //  0010  JMPF	R6	#0013
-      0x88180106,  //  0011  GETMBR	R6	R0	K6
-      0x80040C00,  //  0012  RET	1	R6
-      0x10180404,  //  0013  MOD	R6	R2	R4
-      0xB81E0600,  //  0014  GETNGBL	R7	K3
-      0x8C1C0F04,  //  0015  GETMET	R7	R7	K4
-      0x5C240C00,  //  0016  MOVE	R9	R6
-      0x58280001,  //  0017  LDCONST	R10	K1
-      0x042C0902,  //  0018  SUB	R11	R4	K2
-      0x58300001,  //  0019  LDCONST	R12	K1
-      0x04340B02,  //  001A  SUB	R13	R5	K2
-      0x7C1C0C00,  //  001B  CALL	R7	6
-      0x28200E05,  //  001C  GE	R8	R7	R5
-      0x78220001,  //  001D  JMPF	R8	#0020
-      0x04200B02,  //  001E  SUB	R8	R5	K2
-      0x5C1C1000,  //  001F  MOVE	R7	R8
-      0x90020E07,  //  0020  SETMBR	R0	K7	R7
-      0x94200607,  //  0021  GETIDX	R8	R3	R7
-      0x90020C08,  //  0022  SETMBR	R0	K6	R8
-      0x88200106,  //  0023  GETMBR	R8	R0	K6
-      0x80041000,  //  0024  RET	1	R8
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_on_param_changed,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
-      0x780E0010,  //  0001  JMPF	R3	#0013
-      0x5C0C0400,  //  0002  MOVE	R3	R2
-      0x6010000C,  //  0003  GETGBL	R4	G12
-      0x5C140600,  //  0004  MOVE	R5	R3
-      0x7C100200,  //  0005  CALL	R4	1
-      0x24100901,  //  0006  GT	R4	R4	K1
-      0x78120009,  //  0007  JMPF	R4	#0012
-      0x88100107,  //  0008  GETMBR	R4	R0	K7
-      0x6014000C,  //  0009  GETGBL	R5	G12
-      0x5C180600,  //  000A  MOVE	R6	R3
-      0x7C140200,  //  000B  CALL	R5	1
-      0x28100805,  //  000C  GE	R4	R4	R5
-      0x78120000,  //  000D  JMPF	R4	#000F
-      0x90020F01,  //  000E  SETMBR	R0	K7	K1
-      0x88100107,  //  000F  GETMBR	R4	R0	K7
-      0x94100604,  //  0010  GETIDX	R4	R3	R4
-      0x90020C04,  //  0011  SETMBR	R0	K6	R4
-      0x70020017,  //  0012  JMP		#002B
-      0x1C0C0308,  //  0013  EQ	R3	R1	K8
-      0x780E0015,  //  0014  JMPF	R3	#002B
-      0x1C0C0502,  //  0015  EQ	R3	R2	K2
-      0x780E0013,  //  0016  JMPF	R3	#002B
-      0x880C0100,  //  0017  GETMBR	R3	R0	K0
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140600,  //  0019  MOVE	R5	R3
-      0x7C100200,  //  001A  CALL	R4	1
-      0x24100901,  //  001B  GT	R4	R4	K1
-      0x78120009,  //  001C  JMPF	R4	#0027
-      0x88100107,  //  001D  GETMBR	R4	R0	K7
-      0x00100902,  //  001E  ADD	R4	R4	K2
-      0x6014000C,  //  001F  GETGBL	R5	G12
-      0x5C180600,  //  0020  MOVE	R6	R3
-      0x7C140200,  //  0021  CALL	R5	1
-      0x10100805,  //  0022  MOD	R4	R4	R5
-      0x90020E04,  //  0023  SETMBR	R0	K7	R4
-      0x88100107,  //  0024  GETMBR	R4	R0	K7
-      0x94100604,  //  0025  GETIDX	R4	R3	R4
-      0x90020C04,  //  0026  SETMBR	R0	K6	R4
-      0x8C100109,  //  0027  GETMET	R4	R0	K9
-      0x58180008,  //  0028  LDCONST	R6	K8
-      0x581C0001,  //  0029  LDCONST	R7	K1
-      0x7C100600,  //  002A  CALL	R4	3
-      0x80000000,  //  002B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08050A,  //  0003  GETMET	R2	R2	K10
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x940C0501,  //  0007  GETIDX	R3	R2	K1
-      0x90020C03,  //  0008  SETMBR	R0	K6	R3
-      0x90020F01,  //  0009  SETMBR	R0	K7	K1
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0xA8020012,  //  0000  EXBLK	0	#0014
-      0x88040105,  //  0001  GETMBR	R1	R0	K5
-      0x1C040301,  //  0002  EQ	R1	R1	K1
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x5804000B,  //  0004  LDCONST	R1	K11
-      0x70020000,  //  0005  JMP		#0007
-      0x5804000C,  //  0006  LDCONST	R1	K12
-      0x60080018,  //  0007  GETGBL	R2	G24
-      0x580C000D,  //  0008  LDCONST	R3	K13
-      0x6010000C,  //  0009  GETGBL	R4	G12
-      0x88140100,  //  000A  GETMBR	R5	R0	K0
-      0x7C100200,  //  000B  CALL	R4	1
-      0x88140105,  //  000C  GETMBR	R5	R0	K5
-      0x5C180200,  //  000D  MOVE	R6	R1
-      0x881C0107,  //  000E  GETMBR	R7	R0	K7
-      0x7C080A00,  //  000F  CALL	R2	5
-      0xA8040001,  //  0010  EXBLK	1	1
-      0x80040400,  //  0011  RET	1	R2
-      0xA8040001,  //  0012  EXBLK	1	1
-      0x70020004,  //  0013  JMP		#0019
-      0xAC040000,  //  0014  CATCH	R1	0	0
-      0x70020001,  //  0015  JMP		#0018
-      0x80061C00,  //  0016  RET	1	K14
-      0x70020000,  //  0017  JMP		#0019
-      0xB0080000,  //  0018  RAISE	2	R0	R0
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_color
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_add_color,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(add_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C0C050F,  //  0001  GETMET	R3	R2	K15
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C100710,  //  0003  GETMET	R4	R3	K16
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x90020003,  //  0006  SETMBR	R0	K0	R3
-      0x80040000,  //  0007  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: ColorCycleColorProvider
-********************************************************************/
-extern const bclass be_class_ColorProvider;
-be_local_class(ColorCycleColorProvider,
-    2,
-    &be_class_ColorProvider,
-    be_nested_map(9,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(current_color, -1), be_const_var(0) },
-        { be_const_key_weak(current_index, 0), be_const_var(1) },
-        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorCycleColorProvider_get_color_for_value_closure) },
-        { be_const_key_weak(produce_value, -1), be_const_closure(class_ColorCycleColorProvider_produce_value_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ColorCycleColorProvider_on_param_changed_closure) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(cycle_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5000) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(next, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(palette, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(-16776961),
-        be_const_int(-16711936),
-        be_const_int(-65536),
-    }))    ) } )) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, 5), be_const_closure(class_ColorCycleColorProvider_init_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_ColorCycleColorProvider_tostring_closure) },
-        { be_const_key_weak(add_color, -1), be_const_closure(class_ColorCycleColorProvider_add_color_closure) },
-    })),
-    be_str_weak(ColorCycleColorProvider)
-);
-
-/********************************************************************
-** Solidified function: solid
-********************************************************************/
-be_local_closure(solid,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(name),
-    /* K2   */  be_nested_str_weak(solid),
-    }),
-    be_str_weak(solid),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040300,  //  0001  GETMET	R1	R1	K0
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90060302,  //  0004  SETMBR	R1	K1	K2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_color_provider
-********************************************************************/
-be_local_closure(is_color_provider,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(color_provider),
-    }),
-    be_str_weak(is_color_provider),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x6004000F,  //  0000  GETGBL	R1	G15
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
-      0x880C0701,  //  0003  GETMBR	R3	R3	K1
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_event_handlers
-********************************************************************/
-be_local_closure(get_event_handlers,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(event_manager),
-    /* K2   */  be_nested_str_weak(get_handlers),
-    }),
-    be_str_weak(get_event_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C040302,  //  0002  GETMET	R1	R1	K2
-      0x5C0C0000,  //  0003  MOVE	R3	R0
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'WaveAnimation' ktab size: 41, total: 69 (saved 224 bytes)
-static const bvalue be_ktab_class_WaveAnimation[41] = {
-  /* K0   */  be_nested_str_weak(wave_table),
-  /* K1   */  be_nested_str_weak(resize),
-  /* K2   */  be_nested_str_weak(wave_type),
-  /* K3   */  be_const_int(0),
-  /* K4   */  be_nested_str_weak(tasmota),
-  /* K5   */  be_nested_str_weak(scale_uint),
-  /* K6   */  be_const_int(1),
-  /* K7   */  be_const_int(2),
-  /* K8   */  be_nested_str_weak(sine),
-  /* K9   */  be_nested_str_weak(triangle),
-  /* K10  */  be_nested_str_weak(square),
-  /* K11  */  be_nested_str_weak(sawtooth),
-  /* K12  */  be_nested_str_weak(unknown),
-  /* K13  */  be_nested_str_weak(color),
-  /* K14  */  be_nested_str_weak(animation),
-  /* K15  */  be_nested_str_weak(is_value_provider),
-  /* K16  */  be_nested_str_weak(0x_X2508x),
-  /* K17  */  be_nested_str_weak(WaveAnimation_X28_X25s_X2C_X20color_X3D_X25s_X2C_X20freq_X3D_X25s_X2C_X20speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K18  */  be_nested_str_weak(frequency),
-  /* K19  */  be_nested_str_weak(wave_speed),
-  /* K20  */  be_nested_str_weak(priority),
-  /* K21  */  be_nested_str_weak(is_running),
-  /* K22  */  be_nested_str_weak(engine),
-  /* K23  */  be_nested_str_weak(get_strip_length),
-  /* K24  */  be_nested_str_weak(width),
-  /* K25  */  be_nested_str_weak(current_colors),
-  /* K26  */  be_nested_str_weak(size),
-  /* K27  */  be_nested_str_weak(set_pixel_color),
-  /* K28  */  be_nested_str_weak(_init_wave_table),
-  /* K29  */  be_nested_str_weak(update),
-  /* K30  */  be_nested_str_weak(start_time),
-  /* K31  */  be_nested_str_weak(time_offset),
-  /* K32  */  be_nested_str_weak(_calculate_wave),
-  /* K33  */  be_nested_str_weak(init),
-  /* K34  */  be_nested_str_weak(phase),
-  /* K35  */  be_nested_str_weak(amplitude),
-  /* K36  */  be_nested_str_weak(center_level),
-  /* K37  */  be_nested_str_weak(back_color),
-  /* K38  */  be_nested_str_weak(is_color_provider),
-  /* K39  */  be_nested_str_weak(get_color_for_value),
-  /* K40  */  be_nested_str_weak(resolve_value),
-};
-
-
-extern const bclass be_class_WaveAnimation;
-
-/********************************************************************
-** Solidified function: _init_wave_table
-********************************************************************/
-be_local_closure(class_WaveAnimation__init_wave_table,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(_init_wave_table),
-    &be_const_str_solidified,
-    ( &(const binstruction[108]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x540E00FF,  //  0002  LDINT	R3	256
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x58080003,  //  0005  LDCONST	R2	K3
-      0x540E00FF,  //  0006  LDINT	R3	256
-      0x140C0403,  //  0007  LT	R3	R2	R3
-      0x780E0061,  //  0008  JMPF	R3	#006B
-      0x580C0003,  //  0009  LDCONST	R3	K3
-      0x1C100303,  //  000A  EQ	R4	R1	K3
-      0x78120035,  //  000B  JMPF	R4	#0042
-      0x5412003F,  //  000C  LDINT	R4	64
-      0x10100404,  //  000D  MOD	R4	R2	R4
-      0x5416003F,  //  000E  LDINT	R5	64
-      0x14140405,  //  000F  LT	R5	R2	R5
-      0x78160009,  //  0010  JMPF	R5	#001B
-      0xB8160800,  //  0011  GETNGBL	R5	K4
-      0x8C140B05,  //  0012  GETMET	R5	R5	K5
-      0x5C1C0800,  //  0013  MOVE	R7	R4
-      0x58200003,  //  0014  LDCONST	R8	K3
-      0x5426003F,  //  0015  LDINT	R9	64
-      0x542A007F,  //  0016  LDINT	R10	128
-      0x542E00FE,  //  0017  LDINT	R11	255
-      0x7C140C00,  //  0018  CALL	R5	6
-      0x5C0C0A00,  //  0019  MOVE	R3	R5
-      0x70020025,  //  001A  JMP		#0041
-      0x5416007F,  //  001B  LDINT	R5	128
-      0x14140405,  //  001C  LT	R5	R2	R5
-      0x7816000A,  //  001D  JMPF	R5	#0029
-      0xB8160800,  //  001E  GETNGBL	R5	K4
-      0x8C140B05,  //  001F  GETMET	R5	R5	K5
-      0x541E007F,  //  0020  LDINT	R7	128
-      0x041C0E02,  //  0021  SUB	R7	R7	R2
-      0x58200003,  //  0022  LDCONST	R8	K3
-      0x5426003F,  //  0023  LDINT	R9	64
-      0x542A007F,  //  0024  LDINT	R10	128
-      0x542E00FE,  //  0025  LDINT	R11	255
-      0x7C140C00,  //  0026  CALL	R5	6
-      0x5C0C0A00,  //  0027  MOVE	R3	R5
-      0x70020017,  //  0028  JMP		#0041
-      0x541600BF,  //  0029  LDINT	R5	192
-      0x14140405,  //  002A  LT	R5	R2	R5
-      0x7816000A,  //  002B  JMPF	R5	#0037
-      0xB8160800,  //  002C  GETNGBL	R5	K4
-      0x8C140B05,  //  002D  GETMET	R5	R5	K5
-      0x541E007F,  //  002E  LDINT	R7	128
-      0x041C0407,  //  002F  SUB	R7	R2	R7
-      0x58200003,  //  0030  LDCONST	R8	K3
-      0x5426003F,  //  0031  LDINT	R9	64
-      0x542A007F,  //  0032  LDINT	R10	128
-      0x582C0003,  //  0033  LDCONST	R11	K3
-      0x7C140C00,  //  0034  CALL	R5	6
-      0x5C0C0A00,  //  0035  MOVE	R3	R5
-      0x70020009,  //  0036  JMP		#0041
-      0xB8160800,  //  0037  GETNGBL	R5	K4
-      0x8C140B05,  //  0038  GETMET	R5	R5	K5
-      0x541E00FF,  //  0039  LDINT	R7	256
-      0x041C0E02,  //  003A  SUB	R7	R7	R2
-      0x58200003,  //  003B  LDCONST	R8	K3
-      0x5426003F,  //  003C  LDINT	R9	64
-      0x542A007F,  //  003D  LDINT	R10	128
-      0x582C0003,  //  003E  LDCONST	R11	K3
-      0x7C140C00,  //  003F  CALL	R5	6
-      0x5C0C0A00,  //  0040  MOVE	R3	R5
-      0x70020024,  //  0041  JMP		#0067
-      0x1C100306,  //  0042  EQ	R4	R1	K6
-      0x78120017,  //  0043  JMPF	R4	#005C
-      0x5412007F,  //  0044  LDINT	R4	128
-      0x14100404,  //  0045  LT	R4	R2	R4
-      0x78120009,  //  0046  JMPF	R4	#0051
-      0xB8120800,  //  0047  GETNGBL	R4	K4
-      0x8C100905,  //  0048  GETMET	R4	R4	K5
-      0x5C180400,  //  0049  MOVE	R6	R2
-      0x581C0003,  //  004A  LDCONST	R7	K3
-      0x5422007F,  //  004B  LDINT	R8	128
-      0x58240003,  //  004C  LDCONST	R9	K3
-      0x542A00FE,  //  004D  LDINT	R10	255
-      0x7C100C00,  //  004E  CALL	R4	6
-      0x5C0C0800,  //  004F  MOVE	R3	R4
-      0x70020009,  //  0050  JMP		#005B
-      0xB8120800,  //  0051  GETNGBL	R4	K4
-      0x8C100905,  //  0052  GETMET	R4	R4	K5
-      0x541A00FF,  //  0053  LDINT	R6	256
-      0x04180C02,  //  0054  SUB	R6	R6	R2
-      0x581C0003,  //  0055  LDCONST	R7	K3
-      0x5422007F,  //  0056  LDINT	R8	128
-      0x58240003,  //  0057  LDCONST	R9	K3
-      0x542A00FE,  //  0058  LDINT	R10	255
-      0x7C100C00,  //  0059  CALL	R4	6
-      0x5C0C0800,  //  005A  MOVE	R3	R4
-      0x7002000A,  //  005B  JMP		#0067
-      0x1C100307,  //  005C  EQ	R4	R1	K7
-      0x78120007,  //  005D  JMPF	R4	#0066
-      0x5412007F,  //  005E  LDINT	R4	128
-      0x14100404,  //  005F  LT	R4	R2	R4
-      0x78120001,  //  0060  JMPF	R4	#0063
-      0x541200FE,  //  0061  LDINT	R4	255
-      0x70020000,  //  0062  JMP		#0064
-      0x58100003,  //  0063  LDCONST	R4	K3
-      0x5C0C0800,  //  0064  MOVE	R3	R4
-      0x70020000,  //  0065  JMP		#0067
-      0x5C0C0400,  //  0066  MOVE	R3	R2
-      0x88100100,  //  0067  GETMBR	R4	R0	K0
-      0x98100403,  //  0068  SETIDX	R4	R2	R3
-      0x00080506,  //  0069  ADD	R2	R2	K6
-      0x7001FF9A,  //  006A  JMP		#0006
-      0x80000000,  //  006B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_WaveAnimation_tostring,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x40080308,  //  0002  CONNECT	R2	R1	K8
-      0x40080309,  //  0003  CONNECT	R2	R1	K9
-      0x4008030A,  //  0004  CONNECT	R2	R1	K10
-      0x4008030B,  //  0005  CONNECT	R2	R1	K11
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x940C0202,  //  0007  GETIDX	R3	R1	R2
-      0x4C100000,  //  0008  LDNIL	R4
-      0x200C0604,  //  0009  NE	R3	R3	R4
-      0x780E0001,  //  000A  JMPF	R3	#000D
-      0x940C0202,  //  000B  GETIDX	R3	R1	R2
-      0x70020000,  //  000C  JMP		#000E
-      0x580C000C,  //  000D  LDCONST	R3	K12
-      0x8810010D,  //  000E  GETMBR	R4	R0	K13
-      0x4C140000,  //  000F  LDNIL	R5
-      0xB81A1C00,  //  0010  GETNGBL	R6	K14
-      0x8C180D0F,  //  0011  GETMET	R6	R6	K15
-      0x5C200800,  //  0012  MOVE	R8	R4
-      0x7C180400,  //  0013  CALL	R6	2
-      0x781A0004,  //  0014  JMPF	R6	#001A
-      0x60180008,  //  0015  GETGBL	R6	G8
-      0x5C1C0800,  //  0016  MOVE	R7	R4
-      0x7C180200,  //  0017  CALL	R6	1
-      0x5C140C00,  //  0018  MOVE	R5	R6
-      0x70020004,  //  0019  JMP		#001F
-      0x60180018,  //  001A  GETGBL	R6	G24
-      0x581C0010,  //  001B  LDCONST	R7	K16
-      0x5C200800,  //  001C  MOVE	R8	R4
-      0x7C180400,  //  001D  CALL	R6	2
-      0x5C140C00,  //  001E  MOVE	R5	R6
-      0x60180018,  //  001F  GETGBL	R6	G24
-      0x581C0011,  //  0020  LDCONST	R7	K17
-      0x5C200600,  //  0021  MOVE	R8	R3
-      0x5C240A00,  //  0022  MOVE	R9	R5
-      0x88280112,  //  0023  GETMBR	R10	R0	K18
-      0x882C0113,  //  0024  GETMBR	R11	R0	K19
-      0x88300114,  //  0025  GETMBR	R12	R0	K20
-      0x88340115,  //  0026  GETMBR	R13	R0	K21
-      0x7C180E00,  //  0027  CALL	R6	7
-      0x80040C00,  //  0028  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_WaveAnimation_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x880C0115,  //  0000  GETMBR	R3	R0	K21
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x880C0116,  //  0007  GETMBR	R3	R0	K22
-      0x8C0C0717,  //  0008  GETMET	R3	R3	K23
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x14140803,  //  000B  LT	R5	R4	R3
-      0x7816000E,  //  000C  JMPF	R5	#001C
-      0x88140318,  //  000D  GETMBR	R5	R1	K24
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x78160009,  //  000F  JMPF	R5	#001A
-      0x88140119,  //  0010  GETMBR	R5	R0	K25
-      0x8C140B1A,  //  0011  GETMET	R5	R5	K26
-      0x7C140200,  //  0012  CALL	R5	1
-      0x14140805,  //  0013  LT	R5	R4	R5
-      0x78160004,  //  0014  JMPF	R5	#001A
-      0x8C14031B,  //  0015  GETMET	R5	R1	K27
-      0x5C1C0800,  //  0016  MOVE	R7	R4
-      0x88200119,  //  0017  GETMBR	R8	R0	K25
-      0x94201004,  //  0018  GETIDX	R8	R8	R4
-      0x7C140600,  //  0019  CALL	R5	3
-      0x00100906,  //  001A  ADD	R4	R4	K6
-      0x7001FFEE,  //  001B  JMP		#000B
-      0x50140200,  //  001C  LDBOOL	R5	1	0
-      0x80040A00,  //  001D  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_WaveAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x1C0C0302,  //  0000  EQ	R3	R1	K2
-      0x780E0001,  //  0001  JMPF	R3	#0004
-      0x8C0C011C,  //  0002  GETMET	R3	R0	K28
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_WaveAnimation_update,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08051D,  //  0003  GETMET	R2	R2	K29
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0001,  //  0006  JMPT	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x88080113,  //  0009  GETMBR	R2	R0	K19
-      0x240C0503,  //  000A  GT	R3	R2	K3
-      0x780E0011,  //  000B  JMPF	R3	#001E
-      0x880C011E,  //  000C  GETMBR	R3	R0	K30
-      0x040C0203,  //  000D  SUB	R3	R1	R3
-      0xB8120800,  //  000E  GETNGBL	R4	K4
-      0x8C100905,  //  000F  GETMET	R4	R4	K5
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x581C0003,  //  0011  LDCONST	R7	K3
-      0x542200FE,  //  0012  LDINT	R8	255
-      0x58240003,  //  0013  LDCONST	R9	K3
-      0x542A0009,  //  0014  LDINT	R10	10
-      0x7C100C00,  //  0015  CALL	R4	6
-      0x24140903,  //  0016  GT	R5	R4	K3
-      0x78160005,  //  0017  JMPF	R5	#001E
-      0x08140604,  //  0018  MUL	R5	R3	R4
-      0x541A03E7,  //  0019  LDINT	R6	1000
-      0x0C140A06,  //  001A  DIV	R5	R5	R6
-      0x541A00FF,  //  001B  LDINT	R6	256
-      0x10140A06,  //  001C  MOD	R5	R5	R6
-      0x90023E05,  //  001D  SETMBR	R0	K31	R5
-      0x8C0C0120,  //  001E  GETMET	R3	R0	K32
-      0x5C140200,  //  001F  MOVE	R5	R1
-      0x7C0C0400,  //  0020  CALL	R3	2
-      0x500C0200,  //  0021  LDBOOL	R3	1	0
-      0x80040600,  //  0022  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_WaveAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080521,  //  0003  GETMET	R2	R2	K33
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90023202,  //  0008  SETMBR	R0	K25	R2
-      0x90023F03,  //  0009  SETMBR	R0	K31	K3
-      0x60080012,  //  000A  GETGBL	R2	G18
-      0x7C080000,  //  000B  CALL	R2	0
-      0x90020002,  //  000C  SETMBR	R0	K0	R2
-      0x8C08011C,  //  000D  GETMET	R2	R0	K28
-      0x7C080200,  //  000E  CALL	R2	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _calculate_wave
-********************************************************************/
-be_local_closure(class_WaveAnimation__calculate_wave,   /* name */
-  be_nested_proto(
-    27,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_WaveAnimation,     /* shared constants */
-    be_str_weak(_calculate_wave),
-    &be_const_str_solidified,
-    ( &(const binstruction[169]) {  /* code */
-      0x88080116,  //  0000  GETMBR	R2	R0	K22
-      0x8C080517,  //  0001  GETMET	R2	R2	K23
-      0x7C080200,  //  0002  CALL	R2	1
-      0x880C0112,  //  0003  GETMBR	R3	R0	K18
-      0x88100122,  //  0004  GETMBR	R4	R0	K34
-      0x88140123,  //  0005  GETMBR	R5	R0	K35
-      0x88180124,  //  0006  GETMBR	R6	R0	K36
-      0x881C0125,  //  0007  GETMBR	R7	R0	K37
-      0x8820010D,  //  0008  GETMBR	R8	R0	K13
-      0x88240119,  //  0009  GETMBR	R9	R0	K25
-      0x8C24131A,  //  000A  GETMET	R9	R9	K26
-      0x7C240200,  //  000B  CALL	R9	1
-      0x20241202,  //  000C  NE	R9	R9	R2
-      0x78260003,  //  000D  JMPF	R9	#0012
-      0x88240119,  //  000E  GETMBR	R9	R0	K25
-      0x8C241301,  //  000F  GETMET	R9	R9	K1
-      0x5C2C0400,  //  0010  MOVE	R11	R2
-      0x7C240400,  //  0011  CALL	R9	2
-      0x58240003,  //  0012  LDCONST	R9	K3
-      0x14281202,  //  0013  LT	R10	R9	R2
-      0x782A0092,  //  0014  JMPF	R10	#00A8
-      0xB82A0800,  //  0015  GETNGBL	R10	K4
-      0x8C281505,  //  0016  GETMET	R10	R10	K5
-      0x5C301200,  //  0017  MOVE	R12	R9
-      0x58340003,  //  0018  LDCONST	R13	K3
-      0x04380506,  //  0019  SUB	R14	R2	K6
-      0x583C0003,  //  001A  LDCONST	R15	K3
-      0x544200FE,  //  001B  LDINT	R16	255
-      0x7C280C00,  //  001C  CALL	R10	6
-      0x082C1403,  //  001D  MUL	R11	R10	R3
-      0x5432001F,  //  001E  LDINT	R12	32
-      0x0C2C160C,  //  001F  DIV	R11	R11	R12
-      0x002C1604,  //  0020  ADD	R11	R11	R4
-      0x8830011F,  //  0021  GETMBR	R12	R0	K31
-      0x002C160C,  //  0022  ADD	R11	R11	R12
-      0x543200FE,  //  0023  LDINT	R12	255
-      0x2C2C160C,  //  0024  AND	R11	R11	R12
-      0x88300100,  //  0025  GETMBR	R12	R0	K0
-      0x9430180B,  //  0026  GETIDX	R12	R12	R11
-      0xB8360800,  //  0027  GETNGBL	R13	K4
-      0x8C341B05,  //  0028  GETMET	R13	R13	K5
-      0x5C3C0A00,  //  0029  MOVE	R15	R5
-      0x58400003,  //  002A  LDCONST	R16	K3
-      0x544600FE,  //  002B  LDINT	R17	255
-      0x58480003,  //  002C  LDCONST	R18	K3
-      0x544E007F,  //  002D  LDINT	R19	128
-      0x7C340C00,  //  002E  CALL	R13	6
-      0x58380003,  //  002F  LDCONST	R14	K3
-      0x543E007F,  //  0030  LDINT	R15	128
-      0x283C180F,  //  0031  GE	R15	R12	R15
-      0x783E000D,  //  0032  JMPF	R15	#0041
-      0x543E007F,  //  0033  LDINT	R15	128
-      0x043C180F,  //  0034  SUB	R15	R12	R15
-      0xB8420800,  //  0035  GETNGBL	R16	K4
-      0x8C402105,  //  0036  GETMET	R16	R16	K5
-      0x5C481E00,  //  0037  MOVE	R18	R15
-      0x584C0003,  //  0038  LDCONST	R19	K3
-      0x5452007E,  //  0039  LDINT	R20	127
-      0x58540003,  //  003A  LDCONST	R21	K3
-      0x5C581A00,  //  003B  MOVE	R22	R13
-      0x7C400C00,  //  003C  CALL	R16	6
-      0x5C3C2000,  //  003D  MOVE	R15	R16
-      0x00400C0F,  //  003E  ADD	R16	R6	R15
-      0x5C382000,  //  003F  MOVE	R14	R16
-      0x7002000C,  //  0040  JMP		#004E
-      0x543E007F,  //  0041  LDINT	R15	128
-      0x043C1E0C,  //  0042  SUB	R15	R15	R12
-      0xB8420800,  //  0043  GETNGBL	R16	K4
-      0x8C402105,  //  0044  GETMET	R16	R16	K5
-      0x5C481E00,  //  0045  MOVE	R18	R15
-      0x584C0003,  //  0046  LDCONST	R19	K3
-      0x5452007F,  //  0047  LDINT	R20	128
-      0x58540003,  //  0048  LDCONST	R21	K3
-      0x5C581A00,  //  0049  MOVE	R22	R13
-      0x7C400C00,  //  004A  CALL	R16	6
-      0x5C3C2000,  //  004B  MOVE	R15	R16
-      0x04400C0F,  //  004C  SUB	R16	R6	R15
-      0x5C382000,  //  004D  MOVE	R14	R16
-      0x543E00FE,  //  004E  LDINT	R15	255
-      0x243C1C0F,  //  004F  GT	R15	R14	R15
-      0x783E0001,  //  0050  JMPF	R15	#0053
-      0x543A00FE,  //  0051  LDINT	R14	255
-      0x70020002,  //  0052  JMP		#0056
-      0x143C1D03,  //  0053  LT	R15	R14	K3
-      0x783E0000,  //  0054  JMPF	R15	#0056
-      0x58380003,  //  0055  LDCONST	R14	K3
-      0x5C3C0E00,  //  0056  MOVE	R15	R7
-      0x54420009,  //  0057  LDINT	R16	10
-      0x24401C10,  //  0058  GT	R16	R14	R16
-      0x78420049,  //  0059  JMPF	R16	#00A4
-      0xB8421C00,  //  005A  GETNGBL	R16	K14
-      0x8C402126,  //  005B  GETMET	R16	R16	K38
-      0x5C481000,  //  005C  MOVE	R18	R8
-      0x7C400400,  //  005D  CALL	R16	2
-      0x78420009,  //  005E  JMPF	R16	#0069
-      0x88401127,  //  005F  GETMBR	R16	R8	K39
-      0x4C440000,  //  0060  LDNIL	R17
-      0x20402011,  //  0061  NE	R16	R16	R17
-      0x78420005,  //  0062  JMPF	R16	#0069
-      0x8C401127,  //  0063  GETMET	R16	R8	K39
-      0x5C481C00,  //  0064  MOVE	R18	R14
-      0x584C0003,  //  0065  LDCONST	R19	K3
-      0x7C400600,  //  0066  CALL	R16	3
-      0x5C3C2000,  //  0067  MOVE	R15	R16
-      0x7002003A,  //  0068  JMP		#00A4
-      0x8C400128,  //  0069  GETMET	R16	R0	K40
-      0x5C481000,  //  006A  MOVE	R18	R8
-      0x584C000D,  //  006B  LDCONST	R19	K13
-      0x54520009,  //  006C  LDINT	R20	10
-      0x08501C14,  //  006D  MUL	R20	R14	R20
-      0x00500214,  //  006E  ADD	R20	R1	R20
-      0x7C400800,  //  006F  CALL	R16	4
-      0x5C3C2000,  //  0070  MOVE	R15	R16
-      0x54420017,  //  0071  LDINT	R16	24
-      0x3C401E10,  //  0072  SHR	R16	R15	R16
-      0x544600FE,  //  0073  LDINT	R17	255
-      0x2C402011,  //  0074  AND	R16	R16	R17
-      0x5446000F,  //  0075  LDINT	R17	16
-      0x3C441E11,  //  0076  SHR	R17	R15	R17
-      0x544A00FE,  //  0077  LDINT	R18	255
-      0x2C442212,  //  0078  AND	R17	R17	R18
-      0x544A0007,  //  0079  LDINT	R18	8
-      0x3C481E12,  //  007A  SHR	R18	R15	R18
-      0x544E00FE,  //  007B  LDINT	R19	255
-      0x2C482413,  //  007C  AND	R18	R18	R19
-      0x544E00FE,  //  007D  LDINT	R19	255
-      0x2C4C1E13,  //  007E  AND	R19	R15	R19
-      0xB8520800,  //  007F  GETNGBL	R20	K4
-      0x8C502905,  //  0080  GETMET	R20	R20	K5
-      0x5C581C00,  //  0081  MOVE	R22	R14
-      0x585C0003,  //  0082  LDCONST	R23	K3
-      0x546200FE,  //  0083  LDINT	R24	255
-      0x58640003,  //  0084  LDCONST	R25	K3
-      0x5C682200,  //  0085  MOVE	R26	R17
-      0x7C500C00,  //  0086  CALL	R20	6
-      0x5C442800,  //  0087  MOVE	R17	R20
-      0xB8520800,  //  0088  GETNGBL	R20	K4
-      0x8C502905,  //  0089  GETMET	R20	R20	K5
-      0x5C581C00,  //  008A  MOVE	R22	R14
-      0x585C0003,  //  008B  LDCONST	R23	K3
-      0x546200FE,  //  008C  LDINT	R24	255
-      0x58640003,  //  008D  LDCONST	R25	K3
-      0x5C682400,  //  008E  MOVE	R26	R18
-      0x7C500C00,  //  008F  CALL	R20	6
-      0x5C482800,  //  0090  MOVE	R18	R20
-      0xB8520800,  //  0091  GETNGBL	R20	K4
-      0x8C502905,  //  0092  GETMET	R20	R20	K5
-      0x5C581C00,  //  0093  MOVE	R22	R14
-      0x585C0003,  //  0094  LDCONST	R23	K3
-      0x546200FE,  //  0095  LDINT	R24	255
-      0x58640003,  //  0096  LDCONST	R25	K3
-      0x5C682600,  //  0097  MOVE	R26	R19
-      0x7C500C00,  //  0098  CALL	R20	6
-      0x5C4C2800,  //  0099  MOVE	R19	R20
-      0x54520017,  //  009A  LDINT	R20	24
-      0x38502014,  //  009B  SHL	R20	R16	R20
-      0x5456000F,  //  009C  LDINT	R21	16
-      0x38542215,  //  009D  SHL	R21	R17	R21
-      0x30502815,  //  009E  OR	R20	R20	R21
-      0x54560007,  //  009F  LDINT	R21	8
-      0x38542415,  //  00A0  SHL	R21	R18	R21
-      0x30502815,  //  00A1  OR	R20	R20	R21
-      0x30502813,  //  00A2  OR	R20	R20	R19
-      0x5C3C2800,  //  00A3  MOVE	R15	R20
-      0x88400119,  //  00A4  GETMBR	R16	R0	K25
-      0x9840120F,  //  00A5  SETIDX	R16	R9	R15
-      0x00241306,  //  00A6  ADD	R9	R9	K6
-      0x7001FF6A,  //  00A7  JMP		#0013
-      0x80000000,  //  00A8  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: WaveAnimation
-********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(WaveAnimation,
-    3,
-    &be_class_Animation,
-    be_nested_map(11,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(current_colors, -1), be_const_var(0) },
-        { be_const_key_weak(update, -1), be_const_closure(class_WaveAnimation_update_closure) },
-        { be_const_key_weak(wave_table, -1), be_const_var(2) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_WaveAnimation_tostring_closure) },
-        { be_const_key_weak(render, 7), be_const_closure(class_WaveAnimation_render_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_WaveAnimation_on_param_changed_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_WaveAnimation_init_closure) },
-        { be_const_key_weak(time_offset, 1), be_const_var(1) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(8,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(phase, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(frequency, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(32) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(amplitude, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-65536) },
-    }))    ) } )) },
-        { be_const_key_weak(wave_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(wave_type, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(3) },
-    }))    ) } )) },
-        { be_const_key_weak(back_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
-        { be_const_key_weak(center_level, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(_init_wave_table, 6), be_const_closure(class_WaveAnimation__init_wave_table_closure) },
-        { be_const_key_weak(_calculate_wave, -1), be_const_closure(class_WaveAnimation__calculate_wave_closure) },
-    })),
-    be_str_weak(WaveAnimation)
-);
-
-/********************************************************************
-** Solidified function: color_cycle_rainbow
-********************************************************************/
-be_local_closure(color_cycle_rainbow,   /* name */
-  be_nested_proto(
-    19,                          /* nstack */
-    3,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(scale_uint),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(animation),
-    /* K8   */  be_nested_str_weak(color_cycle),
-    /* K9   */  be_nested_str_weak(palette),
-    /* K10  */  be_nested_str_weak(cycle_period),
-    }),
-    be_str_weak(color_cycle_rainbow),
-    &be_const_str_solidified,
-    ( &(const binstruction[97]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0203,  //  0001  EQ	R3	R1	R3
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x140C0300,  //  0003  LT	R3	R1	K0
-      0x780E0000,  //  0004  JMPF	R3	#0006
-      0x54060005,  //  0005  LDINT	R1	6
-      0x600C0012,  //  0006  GETGBL	R3	G18
-      0x7C0C0000,  //  0007  CALL	R3	0
-      0x58100001,  //  0008  LDCONST	R4	K1
-      0x14140801,  //  0009  LT	R5	R4	R1
-      0x7816004B,  //  000A  JMPF	R5	#0057
-      0xB8160400,  //  000B  GETNGBL	R5	K2
-      0x8C140B03,  //  000C  GETMET	R5	R5	K3
-      0x5C1C0800,  //  000D  MOVE	R7	R4
-      0x58200001,  //  000E  LDCONST	R8	K1
-      0x5C240200,  //  000F  MOVE	R9	R1
-      0x58280001,  //  0010  LDCONST	R10	K1
-      0x542E0167,  //  0011  LDINT	R11	360
-      0x7C140C00,  //  0012  CALL	R5	6
-      0x4C180000,  //  0013  LDNIL	R6
-      0x4C1C0000,  //  0014  LDNIL	R7
-      0x4C200000,  //  0015  LDNIL	R8
-      0x5426003B,  //  0016  LDINT	R9	60
-      0x0C240A09,  //  0017  DIV	R9	R5	R9
-      0x542A0005,  //  0018  LDINT	R10	6
-      0x1024120A,  //  0019  MOD	R9	R9	R10
-      0x542A003B,  //  001A  LDINT	R10	60
-      0x0C280A0A,  //  001B  DIV	R10	R5	R10
-      0x04281409,  //  001C  SUB	R10	R10	R9
-      0x542E00FE,  //  001D  LDINT	R11	255
-      0x58300001,  //  001E  LDCONST	R12	K1
-      0x60340009,  //  001F  GETGBL	R13	G9
-      0x043A080A,  //  0020  SUB	R14	K4	R10
-      0x0838160E,  //  0021  MUL	R14	R11	R14
-      0x7C340200,  //  0022  CALL	R13	1
-      0x60380009,  //  0023  GETGBL	R14	G9
-      0x083C160A,  //  0024  MUL	R15	R11	R10
-      0x7C380200,  //  0025  CALL	R14	1
-      0x1C3C1301,  //  0026  EQ	R15	R9	K1
-      0x783E0003,  //  0027  JMPF	R15	#002C
-      0x5C181600,  //  0028  MOVE	R6	R11
-      0x5C1C1C00,  //  0029  MOVE	R7	R14
-      0x5C201800,  //  002A  MOVE	R8	R12
-      0x7002001B,  //  002B  JMP		#0048
-      0x1C3C1304,  //  002C  EQ	R15	R9	K4
-      0x783E0003,  //  002D  JMPF	R15	#0032
-      0x5C181A00,  //  002E  MOVE	R6	R13
-      0x5C1C1600,  //  002F  MOVE	R7	R11
-      0x5C201800,  //  0030  MOVE	R8	R12
-      0x70020015,  //  0031  JMP		#0048
-      0x1C3C1300,  //  0032  EQ	R15	R9	K0
-      0x783E0003,  //  0033  JMPF	R15	#0038
-      0x5C181800,  //  0034  MOVE	R6	R12
-      0x5C1C1600,  //  0035  MOVE	R7	R11
-      0x5C201C00,  //  0036  MOVE	R8	R14
-      0x7002000F,  //  0037  JMP		#0048
-      0x1C3C1305,  //  0038  EQ	R15	R9	K5
-      0x783E0003,  //  0039  JMPF	R15	#003E
-      0x5C181800,  //  003A  MOVE	R6	R12
-      0x5C1C1A00,  //  003B  MOVE	R7	R13
-      0x5C201600,  //  003C  MOVE	R8	R11
-      0x70020009,  //  003D  JMP		#0048
-      0x543E0003,  //  003E  LDINT	R15	4
-      0x1C3C120F,  //  003F  EQ	R15	R9	R15
-      0x783E0003,  //  0040  JMPF	R15	#0045
-      0x5C181C00,  //  0041  MOVE	R6	R14
-      0x5C1C1800,  //  0042  MOVE	R7	R12
-      0x5C201600,  //  0043  MOVE	R8	R11
-      0x70020002,  //  0044  JMP		#0048
-      0x5C181600,  //  0045  MOVE	R6	R11
-      0x5C1C1800,  //  0046  MOVE	R7	R12
-      0x5C201A00,  //  0047  MOVE	R8	R13
-      0x543E00FE,  //  0048  LDINT	R15	255
-      0x54420017,  //  0049  LDINT	R16	24
-      0x383C1E10,  //  004A  SHL	R15	R15	R16
-      0x5442000F,  //  004B  LDINT	R16	16
-      0x38400C10,  //  004C  SHL	R16	R6	R16
-      0x303C1E10,  //  004D  OR	R15	R15	R16
-      0x54420007,  //  004E  LDINT	R16	8
-      0x38400E10,  //  004F  SHL	R16	R7	R16
-      0x303C1E10,  //  0050  OR	R15	R15	R16
-      0x303C1E08,  //  0051  OR	R15	R15	R8
-      0x8C400706,  //  0052  GETMET	R16	R3	K6
-      0x5C481E00,  //  0053  MOVE	R18	R15
-      0x7C400400,  //  0054  CALL	R16	2
-      0x00100904,  //  0055  ADD	R4	R4	K4
-      0x7001FFB1,  //  0056  JMP		#0009
-      0xB8160E00,  //  0057  GETNGBL	R5	K7
-      0x8C140B08,  //  0058  GETMET	R5	R5	K8
-      0x5C1C0000,  //  0059  MOVE	R7	R0
-      0x7C140400,  //  005A  CALL	R5	2
-      0x90161203,  //  005B  SETMBR	R5	K9	R3
-      0x4C180000,  //  005C  LDNIL	R6
-      0x20180406,  //  005D  NE	R6	R2	R6
-      0x781A0000,  //  005E  JMPF	R6	#0060
-      0x90161402,  //  005F  SETMBR	R5	K10	R2
-      0x80040A00,  //  0060  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sparkle_white
-********************************************************************/
-be_local_closure(sparkle_white,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(sparkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(name),
-    /* K4   */  be_nested_str_weak(sparkle_white),
-    }),
-    be_str_weak(sparkle_white),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'EventHandler' ktab size: 8, total: 17 (saved 72 bytes)
-static const bvalue be_ktab_class_EventHandler[8] = {
-  /* K0   */  be_nested_str_weak(is_active),
-  /* K1   */  be_nested_str_weak(condition),
-  /* K2   */  be_nested_str_weak(callback_func),
-  /* K3   */  be_nested_str_weak(event_name),
-  /* K4   */  be_nested_str_weak(priority),
-  /* K5   */  be_const_int(0),
-  /* K6   */  be_nested_str_weak(metadata),
-  /* K7   */  be_nested_str_weak(has_condition),
-};
-
-
-extern const bclass be_class_EventHandler;
-
-/********************************************************************
-** Solidified function: execute
-********************************************************************/
-be_local_closure(class_EventHandler_execute,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(execute),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x740A0001,  //  0001  JMPT	R2	#0004
-      0x50080000,  //  0002  LDBOOL	R2	0	0
-      0x80040400,  //  0003  RET	1	R2
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x20080403,  //  0006  NE	R2	R2	R3
-      0x780A0005,  //  0007  JMPF	R2	#000E
-      0x8C080101,  //  0008  GETMET	R2	R0	K1
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0x740A0001,  //  000B  JMPT	R2	#000E
-      0x50080000,  //  000C  LDBOOL	R2	0	0
-      0x80040400,  //  000D  RET	1	R2
-      0x88080102,  //  000E  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x20080403,  //  0010  NE	R2	R2	R3
-      0x780A0004,  //  0011  JMPF	R2	#0017
-      0x8C080102,  //  0012  GETMET	R2	R0	K2
-      0x5C100200,  //  0013  MOVE	R4	R1
-      0x7C080400,  //  0014  CALL	R2	2
-      0x50080200,  //  0015  LDBOOL	R2	1	0
-      0x80040400,  //  0016  RET	1	R2
-      0x50080000,  //  0017  LDBOOL	R2	0	0
-      0x80040400,  //  0018  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_active
-********************************************************************/
-be_local_closure(class_EventHandler_set_active,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(set_active),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_EventHandler_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    6,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x90020601,  //  0000  SETMBR	R0	K3	R1
-      0x90020402,  //  0001  SETMBR	R0	K2	R2
-      0x4C180000,  //  0002  LDNIL	R6
-      0x20180606,  //  0003  NE	R6	R3	R6
-      0x781A0001,  //  0004  JMPF	R6	#0007
-      0x5C180600,  //  0005  MOVE	R6	R3
-      0x70020000,  //  0006  JMP		#0008
-      0x58180005,  //  0007  LDCONST	R6	K5
-      0x90020806,  //  0008  SETMBR	R0	K4	R6
-      0x90020204,  //  0009  SETMBR	R0	K1	R4
-      0x50180200,  //  000A  LDBOOL	R6	1	0
-      0x90020006,  //  000B  SETMBR	R0	K0	R6
-      0x4C180000,  //  000C  LDNIL	R6
-      0x20180A06,  //  000D  NE	R6	R5	R6
-      0x781A0001,  //  000E  JMPF	R6	#0011
-      0x5C180A00,  //  000F  MOVE	R6	R5
-      0x70020001,  //  0010  JMP		#0013
-      0x60180013,  //  0011  GETGBL	R6	G19
-      0x7C180000,  //  0012  CALL	R6	0
-      0x90020C06,  //  0013  SETMBR	R0	K6	R6
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_info
-********************************************************************/
-be_local_closure(class_EventHandler_get_info,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(get_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080103,  //  0002  GETMBR	R2	R0	K3
-      0x98060602,  //  0003  SETIDX	R1	K3	R2
-      0x88080104,  //  0004  GETMBR	R2	R0	K4
-      0x98060802,  //  0005  SETIDX	R1	K4	R2
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x98060002,  //  0007  SETIDX	R1	K0	R2
-      0x88080101,  //  0008  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0009  LDNIL	R3
-      0x20080403,  //  000A  NE	R2	R2	R3
-      0x98060E02,  //  000B  SETIDX	R1	K7	R2
-      0x88080106,  //  000C  GETMBR	R2	R0	K6
-      0x98060C02,  //  000D  SETIDX	R1	K6	R2
-      0x80040200,  //  000E  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: EventHandler
-********************************************************************/
-be_local_class(EventHandler,
-    6,
-    NULL,
-    be_nested_map(10,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(set_active, -1), be_const_closure(class_EventHandler_set_active_closure) },
-        { be_const_key_weak(metadata, 3), be_const_var(5) },
-        { be_const_key_weak(is_active, 0), be_const_var(4) },
-        { be_const_key_weak(condition, -1), be_const_var(2) },
-        { be_const_key_weak(init, -1), be_const_closure(class_EventHandler_init_closure) },
-        { be_const_key_weak(event_name, 4), be_const_var(0) },
-        { be_const_key_weak(get_info, -1), be_const_closure(class_EventHandler_get_info_closure) },
-        { be_const_key_weak(priority, -1), be_const_var(3) },
-        { be_const_key_weak(execute, 1), be_const_closure(class_EventHandler_execute_closure) },
-        { be_const_key_weak(callback_func, -1), be_const_var(1) },
-    })),
-    be_str_weak(EventHandler)
-);
-// compact class 'Animation' ktab size: 27, total: 52 (saved 200 bytes)
-static const bvalue be_ktab_class_Animation[27] = {
-  /* K0   */  be_nested_str_weak(Animation_X28_X25s_X2C_X20priority_X3D_X25s_X2C_X20duration_X3D_X25s_X2C_X20loop_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K1   */  be_nested_str_weak(name),
-  /* K2   */  be_nested_str_weak(priority),
-  /* K3   */  be_nested_str_weak(duration),
-  /* K4   */  be_nested_str_weak(loop),
-  /* K5   */  be_nested_str_weak(is_running),
-  /* K6   */  be_nested_str_weak(get_color_at),
-  /* K7   */  be_const_int(0),
-  /* K8   */  be_nested_str_weak(get_param_value),
-  /* K9   */  be_nested_str_weak(color),
-  /* K10  */  be_nested_str_weak(update),
-  /* K11  */  be_nested_str_weak(opacity),
-  /* K12  */  be_nested_str_weak(fill_pixels),
-  /* K13  */  be_nested_str_weak(apply_brightness),
-  /* K14  */  be_nested_str_weak(current_time),
-  /* K15  */  be_nested_str_weak(start_time),
-  /* K16  */  be_nested_str_weak(tasmota),
-  /* K17  */  be_nested_str_weak(scale_uint),
-  /* K18  */  be_nested_str_weak(engine),
-  /* K19  */  be_nested_str_weak(time_ms),
-  /* K20  */  be_nested_str_weak(_start_value_providers),
-  /* K21  */  be_nested_str_weak(init),
-  /* K22  */  be_nested_str_weak(values),
-  /* K23  */  be_nested_str_weak(animation),
-  /* K24  */  be_nested_str_weak(is_value_provider),
-  /* K25  */  be_nested_str_weak(start),
-  /* K26  */  be_nested_str_weak(stop_iteration),
-};
-
-
-extern const bclass be_class_Animation;
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_Animation_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
-      0x881C0105,  //  0006  GETMBR	R7	R0	K5
-      0x7C040C00,  //  0007  CALL	R1	6
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color
-********************************************************************/
-be_local_closure(class_Animation_get_color,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(get_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C080106,  //  0000  GETMET	R2	R0	K6
-      0x58100007,  //  0001  LDCONST	R4	K7
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C080600,  //  0003  CALL	R2	3
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color_at
-********************************************************************/
-be_local_closure(class_Animation_get_color_at,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(get_color_at),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C0C0108,  //  0000  GETMET	R3	R0	K8
-      0x58140009,  //  0001  LDCONST	R5	K9
-      0x5C180400,  //  0002  MOVE	R6	R2
-      0x7C0C0600,  //  0003  CALL	R3	3
-      0x80040600,  //  0004  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_Animation_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x880C0105,  //  0000  GETMBR	R3	R0	K5
-      0x5C100600,  //  0001  MOVE	R4	R3
-      0x78120002,  //  0002  JMPF	R4	#0006
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100204,  //  0004  EQ	R4	R1	R4
-      0x78120001,  //  0005  JMPF	R4	#0008
-      0x50100000,  //  0006  LDBOOL	R4	0	0
-      0x80040800,  //  0007  RET	1	R4
-      0x8C10010A,  //  0008  GETMET	R4	R0	K10
-      0x5C180400,  //  0009  MOVE	R6	R2
-      0x7C100400,  //  000A  CALL	R4	2
-      0x88100109,  //  000B  GETMBR	R4	R0	K9
-      0x8814010B,  //  000C  GETMBR	R5	R0	K11
-      0x8C18030C,  //  000D  GETMET	R6	R1	K12
-      0x5C200800,  //  000E  MOVE	R8	R4
-      0x7C180400,  //  000F  CALL	R6	2
-      0x541A00FE,  //  0010  LDINT	R6	255
-      0x14180A06,  //  0011  LT	R6	R5	R6
-      0x781A0002,  //  0012  JMPF	R6	#0016
-      0x8C18030D,  //  0013  GETMET	R6	R1	K13
-      0x5C200A00,  //  0014  MOVE	R8	R5
-      0x7C180400,  //  0015  CALL	R6	2
-      0x50180200,  //  0016  LDBOOL	R6	1	0
-      0x80040C00,  //  0017  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_progress
-********************************************************************/
-be_local_closure(class_Animation_get_progress,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(get_progress),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x88040103,  //  0000  GETMBR	R1	R0	K3
-      0x18080307,  //  0001  LE	R2	R1	K7
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80060E00,  //  0003  RET	1	K7
-      0x8808010E,  //  0004  GETMBR	R2	R0	K14
-      0x880C010F,  //  0005  GETMBR	R3	R0	K15
-      0x04080403,  //  0006  SUB	R2	R2	R3
-      0x100C0401,  //  0007  MOD	R3	R2	R1
-      0x88100104,  //  0008  GETMBR	R4	R0	K4
-      0x5C140800,  //  0009  MOVE	R5	R4
-      0x74160003,  //  000A  JMPT	R5	#000F
-      0x28140401,  //  000B  GE	R5	R2	R1
-      0x78160001,  //  000C  JMPF	R5	#000F
-      0x541600FE,  //  000D  LDINT	R5	255
-      0x80040A00,  //  000E  RET	1	R5
-      0xB8162000,  //  000F  GETNGBL	R5	K16
-      0x8C140B11,  //  0010  GETMET	R5	R5	K17
-      0x5C1C0600,  //  0011  MOVE	R7	R3
-      0x58200007,  //  0012  LDCONST	R8	K7
-      0x5C240200,  //  0013  MOVE	R9	R1
-      0x58280007,  //  0014  LDCONST	R10	K7
-      0x542E00FE,  //  0015  LDINT	R11	255
-      0x7C140C00,  //  0016  CALL	R5	6
-      0x80040A00,  //  0017  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_Animation_on_param_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x1C0C0305,  //  0000  EQ	R3	R1	K5
-      0x780E000E,  //  0001  JMPF	R3	#0011
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x1C0C0403,  //  0003  EQ	R3	R2	R3
-      0x780E0008,  //  0004  JMPF	R3	#000E
-      0x880C0112,  //  0005  GETMBR	R3	R0	K18
-      0x880C0713,  //  0006  GETMBR	R3	R3	K19
-      0x90021E03,  //  0007  SETMBR	R0	K15	R3
-      0x8810010F,  //  0008  GETMBR	R4	R0	K15
-      0x90021C04,  //  0009  SETMBR	R0	K14	R4
-      0x8C100114,  //  000A  GETMET	R4	R0	K20
-      0x5C180600,  //  000B  MOVE	R6	R3
-      0x7C100400,  //  000C  CALL	R4	2
-      0x70020002,  //  000D  JMP		#0011
-      0x500C0000,  //  000E  LDBOOL	R3	0	0
-      0x1C0C0403,  //  000F  EQ	R3	R2	R3
-      0x780DFFFF,  //  0010  JMPF	R3	#0011
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Animation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080515,  //  0003  GETMET	R2	R2	K21
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90021F07,  //  0006  SETMBR	R0	K15	K7
-      0x90021D07,  //  0007  SETMBR	R0	K14	K7
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_Animation_start,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88080116,  //  0000  GETMBR	R2	R0	K22
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x980A0A03,  //  0002  SETIDX	R2	K5	R3
-      0x4C080000,  //  0003  LDNIL	R2
-      0x20080202,  //  0004  NE	R2	R1	R2
-      0x780A0001,  //  0005  JMPF	R2	#0008
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x70020001,  //  0007  JMP		#000A
-      0x88080112,  //  0008  GETMBR	R2	R0	K18
-      0x88080513,  //  0009  GETMBR	R2	R2	K19
-      0x90021E02,  //  000A  SETMBR	R0	K15	R2
-      0x880C010F,  //  000B  GETMBR	R3	R0	K15
-      0x90021C03,  //  000C  SETMBR	R0	K14	R3
-      0x8C0C0114,  //  000D  GETMET	R3	R0	K20
-      0x5C140400,  //  000E  MOVE	R5	R2
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x80040000,  //  0010  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_value_providers
-********************************************************************/
-be_local_closure(class_Animation__start_value_providers,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(_start_value_providers),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x60080010,  //  0000  GETGBL	R2	G16
-      0x880C0116,  //  0001  GETMBR	R3	R0	K22
-      0x7C080200,  //  0002  CALL	R2	1
-      0xA8020011,  //  0003  EXBLK	0	#0016
-      0x5C0C0400,  //  0004  MOVE	R3	R2
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0xB8122E00,  //  0006  GETNGBL	R4	K23
-      0x8C100918,  //  0007  GETMET	R4	R4	K24
-      0x5C180600,  //  0008  MOVE	R6	R3
-      0x7C100400,  //  0009  CALL	R4	2
-      0x78120009,  //  000A  JMPF	R4	#0015
-      0xA8020004,  //  000B  EXBLK	0	#0011
-      0x8C100719,  //  000C  GETMET	R4	R3	K25
-      0x5C180200,  //  000D  MOVE	R6	R1
-      0x7C100400,  //  000E  CALL	R4	2
-      0xA8040001,  //  000F  EXBLK	1	1
-      0x70020003,  //  0010  JMP		#0015
-      0xAC100001,  //  0011  CATCH	R4	0	1
-      0x70020000,  //  0012  JMP		#0014
-      0x70020000,  //  0013  JMP		#0015
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x7001FFED,  //  0015  JMP		#0004
-      0x5808001A,  //  0016  LDCONST	R2	K26
-      0xAC080200,  //  0017  CATCH	R2	1	0
-      0xB0080000,  //  0018  RAISE	2	R0	R0
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_Animation_update,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Animation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x88080105,  //  0000  GETMBR	R2	R0	K5
-      0x5C0C0400,  //  0001  MOVE	R3	R2
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x90021C01,  //  0005  SETMBR	R0	K14	R1
-      0x880C010E,  //  0006  GETMBR	R3	R0	K14
-      0x8810010F,  //  0007  GETMBR	R4	R0	K15
-      0x040C0604,  //  0008  SUB	R3	R3	R4
-      0x88100103,  //  0009  GETMBR	R4	R0	K3
-      0x88140104,  //  000A  GETMBR	R5	R0	K4
-      0x24180907,  //  000B  GT	R6	R4	K7
-      0x781A000D,  //  000C  JMPF	R6	#001B
-      0x28180604,  //  000D  GE	R6	R3	R4
-      0x781A000B,  //  000E  JMPF	R6	#001B
-      0x78160005,  //  000F  JMPF	R5	#0016
-      0x0C180604,  //  0010  DIV	R6	R3	R4
-      0x881C010F,  //  0011  GETMBR	R7	R0	K15
-      0x08200C04,  //  0012  MUL	R8	R6	R4
-      0x001C0E08,  //  0013  ADD	R7	R7	R8
-      0x90021E07,  //  0014  SETMBR	R0	K15	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x88180116,  //  0016  GETMBR	R6	R0	K22
-      0x501C0000,  //  0017  LDBOOL	R7	0	0
-      0x981A0A07,  //  0018  SETIDX	R6	K5	R7
-      0x50180000,  //  0019  LDBOOL	R6	0	0
-      0x80040C00,  //  001A  RET	1	R6
-      0x50180200,  //  001B  LDBOOL	R6	1	0
-      0x80040C00,  //  001C  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: Animation
-********************************************************************/
-extern const bclass be_class_ParameterizedObject;
-be_local_class(Animation,
-    2,
-    &be_class_ParameterizedObject,
-    be_nested_map(13,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(tostring, -1), be_const_closure(class_Animation_tostring_closure) },
-        { be_const_key_weak(get_color, -1), be_const_closure(class_Animation_get_color_closure) },
-        { be_const_key_weak(update, -1), be_const_closure(class_Animation_update_closure) },
-        { be_const_key_weak(render, -1), be_const_closure(class_Animation_render_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Animation_init_closure) },
-        { be_const_key_weak(current_time, -1), be_const_var(1) },
-        { be_const_key_weak(on_param_changed, 4), be_const_closure(class_Animation_on_param_changed_closure) },
-        { be_const_key_weak(get_progress, 5), be_const_closure(class_Animation_get_progress_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_Animation_start_closure) },
-        { be_const_key_weak(_start_value_providers, -1), be_const_closure(class_Animation__start_value_providers_closure) },
-        { be_const_key_weak(start_time, -1), be_const_var(0) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(7,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(priority, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(10) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(name, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_nested_str_weak(animation) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(string) },
-    }))    ) } )) },
-        { be_const_key_weak(color, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(is_running, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bool(0) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
-    }))    ) } )) },
-        { be_const_key_weak(opacity, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(loop, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bool(1) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
-    }))    ) } )) },
-        { be_const_key_weak(duration, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(get_color_at, 2), be_const_closure(class_Animation_get_color_at_closure) },
-    })),
-    be_str_weak(Animation)
-);
-
-/********************************************************************
-** Solidified function: is_user_function
-********************************************************************/
-be_local_closure(is_user_function,   /* name */
+be_local_closure(get_user_function,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
@@ -14758,9 +10784,9 @@ be_local_closure(is_user_function,   /* name */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
     /* K1   */  be_nested_str_weak(_animation_user_functions),
-    /* K2   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(find),
     }),
-    be_str_weak(is_user_function),
+    be_str_weak(get_user_function),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
@@ -14774,550 +10800,6 @@ be_local_closure(is_user_function,   /* name */
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified function: register_user_function
-********************************************************************/
-be_local_closure(register_user_function,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_animation_user_functions),
-    }),
-    be_str_weak(register_user_function),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0501,  //  0001  GETMBR	R3	R2	K1
-      0x980C0001,  //  0002  SETIDX	R3	R0	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'BeaconAnimation' ktab size: 18, total: 22 (saved 32 bytes)
-static const bvalue be_ktab_class_BeaconAnimation[18] = {
-  /* K0   */  be_nested_str_weak(engine),
-  /* K1   */  be_nested_str_weak(time_ms),
-  /* K2   */  be_nested_str_weak(width),
-  /* K3   */  be_nested_str_weak(back_color),
-  /* K4   */  be_nested_str_weak(pos),
-  /* K5   */  be_nested_str_weak(slew_size),
-  /* K6   */  be_nested_str_weak(beacon_size),
-  /* K7   */  be_nested_str_weak(color),
-  /* K8   */  be_const_int(-16777216),
-  /* K9   */  be_nested_str_weak(fill_pixels),
-  /* K10  */  be_const_int(0),
-  /* K11  */  be_nested_str_weak(set_pixel_color),
-  /* K12  */  be_const_int(1),
-  /* K13  */  be_nested_str_weak(tasmota),
-  /* K14  */  be_nested_str_weak(scale_uint),
-  /* K15  */  be_const_int(16777215),
-  /* K16  */  be_nested_str_weak(blend),
-  /* K17  */  be_nested_str_weak(BeaconAnimation_X28color_X3D0x_X2508x_X2C_X20pos_X3D_X25s_X2C_X20beacon_size_X3D_X25s_X2C_X20slew_size_X3D_X25s_X29),
-};
-
-
-extern const bclass be_class_BeaconAnimation;
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_BeaconAnimation_render,   /* name */
-  be_nested_proto(
-    24,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BeaconAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[127]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0203,  //  0001  EQ	R3	R1	R3
-      0x780E0001,  //  0002  JMPF	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C0C0403,  //  0006  EQ	R3	R2	R3
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x88080701,  //  0009  GETMBR	R2	R3	K1
-      0x880C0302,  //  000A  GETMBR	R3	R1	K2
-      0x88100103,  //  000B  GETMBR	R4	R0	K3
-      0x88140104,  //  000C  GETMBR	R5	R0	K4
-      0x88180105,  //  000D  GETMBR	R6	R0	K5
-      0x881C0106,  //  000E  GETMBR	R7	R0	K6
-      0x88200107,  //  000F  GETMBR	R8	R0	K7
-      0x20240908,  //  0010  NE	R9	R4	K8
-      0x78260002,  //  0011  JMPF	R9	#0015
-      0x8C240309,  //  0012  GETMET	R9	R1	K9
-      0x5C2C0800,  //  0013  MOVE	R11	R4
-      0x7C240400,  //  0014  CALL	R9	2
-      0x5C240A00,  //  0015  MOVE	R9	R5
-      0x00280A07,  //  0016  ADD	R10	R5	R7
-      0x142C130A,  //  0017  LT	R11	R9	K10
-      0x782E0000,  //  0018  JMPF	R11	#001A
-      0x5824000A,  //  0019  LDCONST	R9	K10
-      0x282C1403,  //  001A  GE	R11	R10	R3
-      0x782E0000,  //  001B  JMPF	R11	#001D
-      0x5C280600,  //  001C  MOVE	R10	R3
-      0x5C2C1200,  //  001D  MOVE	R11	R9
-      0x1430160A,  //  001E  LT	R12	R11	R10
-      0x78320005,  //  001F  JMPF	R12	#0026
-      0x8C30030B,  //  0020  GETMET	R12	R1	K11
-      0x5C381600,  //  0021  MOVE	R14	R11
-      0x5C3C1000,  //  0022  MOVE	R15	R8
-      0x7C300600,  //  0023  CALL	R12	3
-      0x002C170C,  //  0024  ADD	R11	R11	K12
-      0x7001FFF7,  //  0025  JMP		#001E
-      0x24300D0A,  //  0026  GT	R12	R6	K10
-      0x78320054,  //  0027  JMPF	R12	#007D
-      0x04300A06,  //  0028  SUB	R12	R5	R6
-      0x5C340A00,  //  0029  MOVE	R13	R5
-      0x1438190A,  //  002A  LT	R14	R12	K10
-      0x783A0000,  //  002B  JMPF	R14	#002D
-      0x5830000A,  //  002C  LDCONST	R12	K10
-      0x28381A03,  //  002D  GE	R14	R13	R3
-      0x783A0000,  //  002E  JMPF	R14	#0030
-      0x5C340600,  //  002F  MOVE	R13	R3
-      0x5C2C1800,  //  0030  MOVE	R11	R12
-      0x1438160D,  //  0031  LT	R14	R11	R13
-      0x783A001D,  //  0032  JMPF	R14	#0051
-      0x4C380000,  //  0033  LDNIL	R14
-      0x1C3C0D0C,  //  0034  EQ	R15	R6	K12
-      0x783E0001,  //  0035  JMPF	R15	#0038
-      0x543A007F,  //  0036  LDINT	R14	128
-      0x70020008,  //  0037  JMP		#0041
-      0xB83E1A00,  //  0038  GETNGBL	R15	K13
-      0x8C3C1F0E,  //  0039  GETMET	R15	R15	K14
-      0x5C441600,  //  003A  MOVE	R17	R11
-      0x04480A06,  //  003B  SUB	R18	R5	R6
-      0x044C0B0C,  //  003C  SUB	R19	R5	K12
-      0x545200FE,  //  003D  LDINT	R20	255
-      0x5854000A,  //  003E  LDCONST	R21	K10
-      0x7C3C0C00,  //  003F  CALL	R15	6
-      0x5C381E00,  //  0040  MOVE	R14	R15
-      0x543E00FE,  //  0041  LDINT	R15	255
-      0x043C1E0E,  //  0042  SUB	R15	R15	R14
-      0x54420017,  //  0043  LDINT	R16	24
-      0x38401E10,  //  0044  SHL	R16	R15	R16
-      0x2C44110F,  //  0045  AND	R17	R8	K15
-      0x30402011,  //  0046  OR	R16	R16	R17
-      0x8C440310,  //  0047  GETMET	R17	R1	K16
-      0x5C4C0800,  //  0048  MOVE	R19	R4
-      0x5C502000,  //  0049  MOVE	R20	R16
-      0x7C440600,  //  004A  CALL	R17	3
-      0x8C48030B,  //  004B  GETMET	R18	R1	K11
-      0x5C501600,  //  004C  MOVE	R20	R11
-      0x5C542200,  //  004D  MOVE	R21	R17
-      0x7C480600,  //  004E  CALL	R18	3
-      0x002C170C,  //  004F  ADD	R11	R11	K12
-      0x7001FFDF,  //  0050  JMP		#0031
-      0x00380A07,  //  0051  ADD	R14	R5	R7
-      0x003C0A07,  //  0052  ADD	R15	R5	R7
-      0x003C1E06,  //  0053  ADD	R15	R15	R6
-      0x14401D0A,  //  0054  LT	R16	R14	K10
-      0x78420000,  //  0055  JMPF	R16	#0057
-      0x5838000A,  //  0056  LDCONST	R14	K10
-      0x28401E03,  //  0057  GE	R16	R15	R3
-      0x78420000,  //  0058  JMPF	R16	#005A
-      0x5C3C0600,  //  0059  MOVE	R15	R3
-      0x5C2C1C00,  //  005A  MOVE	R11	R14
-      0x1440160F,  //  005B  LT	R16	R11	R15
-      0x7842001F,  //  005C  JMPF	R16	#007D
-      0x4C400000,  //  005D  LDNIL	R16
-      0x1C440D0C,  //  005E  EQ	R17	R6	K12
-      0x78460001,  //  005F  JMPF	R17	#0062
-      0x5442007F,  //  0060  LDINT	R16	128
-      0x7002000A,  //  0061  JMP		#006D
-      0xB8461A00,  //  0062  GETNGBL	R17	K13
-      0x8C44230E,  //  0063  GETMET	R17	R17	K14
-      0x5C4C1600,  //  0064  MOVE	R19	R11
-      0x00500A07,  //  0065  ADD	R20	R5	R7
-      0x00540A07,  //  0066  ADD	R21	R5	R7
-      0x00542A06,  //  0067  ADD	R21	R21	R6
-      0x04542B0C,  //  0068  SUB	R21	R21	K12
-      0x5858000A,  //  0069  LDCONST	R22	K10
-      0x545E00FE,  //  006A  LDINT	R23	255
-      0x7C440C00,  //  006B  CALL	R17	6
-      0x5C402200,  //  006C  MOVE	R16	R17
-      0x544600FE,  //  006D  LDINT	R17	255
-      0x04442210,  //  006E  SUB	R17	R17	R16
-      0x544A0017,  //  006F  LDINT	R18	24
-      0x38482212,  //  0070  SHL	R18	R17	R18
-      0x2C4C110F,  //  0071  AND	R19	R8	K15
-      0x30482413,  //  0072  OR	R18	R18	R19
-      0x8C4C0310,  //  0073  GETMET	R19	R1	K16
-      0x5C540800,  //  0074  MOVE	R21	R4
-      0x5C582400,  //  0075  MOVE	R22	R18
-      0x7C4C0600,  //  0076  CALL	R19	3
-      0x8C50030B,  //  0077  GETMET	R20	R1	K11
-      0x5C581600,  //  0078  MOVE	R22	R11
-      0x5C5C2600,  //  0079  MOVE	R23	R19
-      0x7C500600,  //  007A  CALL	R20	3
-      0x002C170C,  //  007B  ADD	R11	R11	K12
-      0x7001FFDD,  //  007C  JMP		#005B
-      0x50300200,  //  007D  LDBOOL	R12	1	0
-      0x80041800,  //  007E  RET	1	R12
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_BeaconAnimation_tostring,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BeaconAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080011,  //  0001  LDCONST	R2	K17
-      0x880C0107,  //  0002  GETMBR	R3	R0	K7
-      0x88100104,  //  0003  GETMBR	R4	R0	K4
-      0x88140106,  //  0004  GETMBR	R5	R0	K6
-      0x88180105,  //  0005  GETMBR	R6	R0	K5
-      0x7C040A00,  //  0006  CALL	R1	5
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: BeaconAnimation
-********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(BeaconAnimation,
-    0,
-    &be_class_Animation,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(5,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(back_color, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(slew_size, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(beacon_size, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(render, 2), be_const_closure(class_BeaconAnimation_render_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_BeaconAnimation_tostring_closure) },
-    })),
-    be_str_weak(BeaconAnimation)
-);
-
-/********************************************************************
-** Solidified function: animation_version_string
-********************************************************************/
-be_local_closure(animation_version_string,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(VERSION),
-    /* K2   */  be_nested_str_weak(_X25s_X2E_X25s_X2E_X25s),
-    }),
-    be_str_weak(animation_version_string),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x1C040001,  //  0001  EQ	R1	R0	R1
-      0x78060001,  //  0002  JMPF	R1	#0005
-      0xB8060000,  //  0003  GETNGBL	R1	K0
-      0x88000301,  //  0004  GETMBR	R0	R1	K1
-      0x54060017,  //  0005  LDINT	R1	24
-      0x3C040001,  //  0006  SHR	R1	R0	R1
-      0x540A00FE,  //  0007  LDINT	R2	255
-      0x2C040202,  //  0008  AND	R1	R1	R2
-      0x540A000F,  //  0009  LDINT	R2	16
-      0x3C080002,  //  000A  SHR	R2	R0	R2
-      0x540E00FE,  //  000B  LDINT	R3	255
-      0x2C080403,  //  000C  AND	R2	R2	R3
-      0x540E0007,  //  000D  LDINT	R3	8
-      0x3C0C0003,  //  000E  SHR	R3	R0	R3
-      0x541200FE,  //  000F  LDINT	R4	255
-      0x2C0C0604,  //  0010  AND	R3	R3	R4
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x7C100800,  //  0016  CALL	R4	4
-      0x80040800,  //  0017  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_value_provider
-********************************************************************/
-be_local_closure(is_value_provider,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(value_provider),
-    }),
-    be_str_weak(is_value_provider),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x6004000F,  //  0000  GETGBL	R1	G15
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
-      0x880C0701,  //  0003  GETMBR	R3	R3	K1
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: noise_single_color
-********************************************************************/
-be_local_closure(noise_single_color,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(noise_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(scale),
-    /* K4   */  be_nested_str_weak(speed),
-    /* K5   */  be_nested_str_weak(octaves),
-    /* K6   */  be_const_int(1),
-    }),
-    be_str_weak(noise_single_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0031,  //  0006  LDINT	R2	50
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A001D,  //  0008  LDINT	R2	30
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x90060B06,  //  000A  SETMBR	R1	K5	K6
-      0x80040200,  //  000B  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-extern const bclass be_class_PaletteMeterAnimation;
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_PaletteMeterAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(name),
-    /* K2   */  be_nested_str_weak(palette_meter),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020302,  //  0006  SETMBR	R0	K1	K2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_value_buffer
-********************************************************************/
-be_local_closure(class_PaletteMeterAnimation__update_value_buffer,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(value_func),
-    /* K1   */  be_nested_str_weak(engine),
-    /* K2   */  be_nested_str_weak(get_strip_length),
-    /* K3   */  be_nested_str_weak(value_buffer),
-    /* K4   */  be_nested_str_weak(resize),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(scale_uint),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_const_int(1),
-    }),
-    be_str_weak(_update_value_buffer),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0403,  //  0002  EQ	R3	R2	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x80000600,  //  0004  RET	0
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0006  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x6010000C,  //  0008  GETGBL	R4	G12
-      0x88140103,  //  0009  GETMBR	R5	R0	K3
-      0x7C100200,  //  000A  CALL	R4	1
-      0x20100803,  //  000B  NE	R4	R4	R3
-      0x78120003,  //  000C  JMPF	R4	#0011
-      0x88100103,  //  000D  GETMBR	R4	R0	K3
-      0x8C100904,  //  000E  GETMET	R4	R4	K4
-      0x5C180600,  //  000F  MOVE	R6	R3
-      0x7C100400,  //  0010  CALL	R4	2
-      0x5C100400,  //  0011  MOVE	R4	R2
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x5C180000,  //  0013  MOVE	R6	R0
-      0x7C100400,  //  0014  CALL	R4	2
-      0xB8160A00,  //  0015  GETNGBL	R5	K5
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200007,  //  0018  LDCONST	R8	K7
-      0x54260063,  //  0019  LDINT	R9	100
-      0x58280007,  //  001A  LDCONST	R10	K7
-      0x5C2C0600,  //  001B  MOVE	R11	R3
-      0x7C140C00,  //  001C  CALL	R5	6
-      0x58180007,  //  001D  LDCONST	R6	K7
-      0x141C0C03,  //  001E  LT	R7	R6	R3
-      0x781E0008,  //  001F  JMPF	R7	#0029
-      0x881C0103,  //  0020  GETMBR	R7	R0	K3
-      0x14200C05,  //  0021  LT	R8	R6	R5
-      0x78220001,  //  0022  JMPF	R8	#0025
-      0x54220063,  //  0023  LDINT	R8	100
-      0x70020000,  //  0024  JMP		#0026
-      0x58200007,  //  0025  LDCONST	R8	K7
-      0x981C0C08,  //  0026  SETIDX	R7	R6	R8
-      0x00180D08,  //  0027  ADD	R6	R6	K8
-      0x7001FFF4,  //  0028  JMP		#001E
-      0x80000000,  //  0029  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: PaletteMeterAnimation
-********************************************************************/
-extern const bclass be_class_PalettePatternAnimation;
-be_local_class(PaletteMeterAnimation,
-    0,
-    &be_class_PalettePatternAnimation,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(value_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_PaletteMeterAnimation_init_closure) },
-        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteMeterAnimation__update_value_buffer_closure) },
-    })),
-    be_str_weak(PaletteMeterAnimation)
-);
 extern const bclass be_class_FrameBuffer;
 // compact class 'FrameBuffer' ktab size: 34, total: 114 (saved 640 bytes)
 static const bvalue be_ktab_class_FrameBuffer[34] = {
@@ -16832,9 +12314,9 @@ be_local_class(FrameBuffer,
 );
 
 /********************************************************************
-** Solidified function: ramp
+** Solidified function: plasma_fast
 ********************************************************************/
-be_local_closure(ramp,   /* name */
+be_local_closure(plasma_fast,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -16844,23 +12326,33 @@ be_local_closure(ramp,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(SAWTOOTH),
+    /* K1   */  be_nested_str_weak(plasma_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(time_speed),
+    /* K4   */  be_nested_str_weak(freq_x),
+    /* K5   */  be_nested_str_weak(freq_y),
+    /* K6   */  be_nested_str_weak(name),
+    /* K7   */  be_nested_str_weak(plasma_fast),
     }),
-    be_str_weak(ramp),
+    be_str_weak(plasma_fast),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
+      0x4C080000,  //  0004  LDNIL	R2
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A0095,  //  0006  LDINT	R2	150
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A002F,  //  0008  LDINT	R2	48
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x540A0022,  //  000A  LDINT	R2	35
+      0x90060A02,  //  000B  SETMBR	R1	K5	R2
+      0x90060D07,  //  000C  SETMBR	R1	K6	K7
+      0x80040200,  //  000D  RET	1	R1
     })
   )
 );
@@ -16868,9 +12360,9 @@ be_local_closure(ramp,   /* name */
 
 
 /********************************************************************
-** Solidified function: wave_custom
+** Solidified function: gradient_rainbow_linear
 ********************************************************************/
-be_local_closure(wave_custom,   /* name */
+be_local_closure(gradient_rainbow_linear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -16882,28 +12374,27 @@ be_local_closure(wave_custom,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(wave_animation),
+    /* K1   */  be_nested_str_weak(gradient_animation),
     /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(wave_type),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(frequency),
-    /* K6   */  be_nested_str_weak(wave_speed),
+    /* K3   */  be_nested_str_weak(gradient_type),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(direction),
+    /* K6   */  be_nested_str_weak(movement_speed),
     }),
-    be_str_weak(wave_custom),
+    be_str_weak(gradient_rainbow_linear),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[11]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x5409FEFF,  //  0004  LDINT	R2	-256
+      0x4C080000,  //  0004  LDNIL	R2
       0x90060402,  //  0005  SETMBR	R1	K2	R2
       0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x540A0027,  //  0007  LDINT	R2	40
-      0x90060A02,  //  0008  SETMBR	R1	K5	R2
-      0x540A001D,  //  0009  LDINT	R2	30
-      0x90060C02,  //  000A  SETMBR	R1	K6	R2
-      0x80040200,  //  000B  RET	1	R1
+      0x90060B04,  //  0007  SETMBR	R1	K5	K4
+      0x540A0031,  //  0008  LDINT	R2	50
+      0x90060C02,  //  0009  SETMBR	R1	K6	R2
+      0x80040200,  //  000A  RET	1	R1
     })
   )
 );
@@ -16911,9 +12402,41 @@ be_local_closure(wave_custom,   /* name */
 
 
 /********************************************************************
-** Solidified function: pulsating_animation
+** Solidified function: clear_all_event_handlers
 ********************************************************************/
-be_local_closure(pulsating_animation,   /* name */
+be_local_closure(clear_all_event_handlers,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    0,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(event_manager),
+    /* K2   */  be_nested_str_weak(clear_all_handlers),
+    }),
+    be_str_weak(clear_all_event_handlers),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8020000,  //  0000  GETNGBL	R0	K0
+      0x88000101,  //  0001  GETMBR	R0	R0	K1
+      0x8C000102,  //  0002  GETMET	R0	R0	K2
+      0x7C000200,  //  0003  CALL	R0	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: twinkle_gentle
+********************************************************************/
+be_local_closure(twinkle_gentle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -16923,326 +12446,84 @@ be_local_closure(pulsating_animation,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(breathe_animation),
-    /* K2   */  be_nested_str_weak(curve_factor),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(period),
+    /* K1   */  be_nested_str_weak(twinkle_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(density),
+    /* K4   */  be_nested_str_weak(twinkle_speed),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(fade_speed),
+    /* K7   */  be_nested_str_weak(min_brightness),
+    /* K8   */  be_nested_str_weak(max_brightness),
     }),
-    be_str_weak(pulsating_animation),
+    be_str_weak(twinkle_gentle),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[16]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A03E7,  //  0005  LDINT	R2	1000
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
-      0x80040200,  //  0007  RET	1	R1
+      0x5409D6FF,  //  0004  LDINT	R2	-10496
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A003F,  //  0006  LDINT	R2	64
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x90060905,  //  0008  SETMBR	R1	K4	K5
+      0x540A0077,  //  0009  LDINT	R2	120
+      0x90060C02,  //  000A  SETMBR	R1	K6	R2
+      0x540A000F,  //  000B  LDINT	R2	16
+      0x90060E02,  //  000C  SETMBR	R1	K7	R2
+      0x540A00B3,  //  000D  LDINT	R2	180
+      0x90061002,  //  000E  SETMBR	R1	K8	R2
+      0x80040200,  //  000F  RET	1	R1
     })
   )
 );
 /*******************************************************************/
 
-// compact class 'PalettePatternAnimation' ktab size: 21, total: 40 (saved 152 bytes)
-static const bvalue be_ktab_class_PalettePatternAnimation[21] = {
-  /* K0   */  be_nested_str_weak(pattern_func),
-  /* K1   */  be_nested_str_weak(color_source),
-  /* K2   */  be_nested_str_weak(_initialize_value_buffer),
-  /* K3   */  be_nested_str_weak(is_running),
-  /* K4   */  be_nested_str_weak(engine),
-  /* K5   */  be_nested_str_weak(time_ms),
-  /* K6   */  be_nested_str_weak(start_time),
-  /* K7   */  be_nested_str_weak(get_strip_length),
-  /* K8   */  be_const_int(0),
-  /* K9   */  be_nested_str_weak(width),
-  /* K10  */  be_nested_str_weak(value_buffer),
-  /* K11  */  be_nested_str_weak(get_color_for_value),
-  /* K12  */  be_nested_str_weak(current_color),
-  /* K13  */  be_nested_str_weak(set_pixel_color),
+// compact class 'EventManager' ktab size: 30, total: 61 (saved 248 bytes)
+static const bvalue be_ktab_class_EventManager[30] = {
+  /* K0   */  be_nested_str_weak(event_name),
+  /* K1   */  be_nested_str_weak(_X2A),
+  /* K2   */  be_nested_str_weak(global_handlers),
+  /* K3   */  be_nested_str_weak(find),
+  /* K4   */  be_nested_str_weak(remove),
+  /* K5   */  be_nested_str_weak(handlers),
+  /* K6   */  be_nested_str_weak(set_active),
+  /* K7   */  be_nested_str_weak(stop_iteration),
+  /* K8   */  be_nested_str_weak(push),
+  /* K9   */  be_nested_str_weak(get_info),
+  /* K10  */  be_nested_str_weak(keys),
+  /* K11  */  be_nested_str_weak(event_queue),
+  /* K12  */  be_nested_str_weak(is_processing),
+  /* K13  */  be_nested_str_weak(clear),
   /* K14  */  be_const_int(1),
-  /* K15  */  be_nested_str_weak(resize),
-  /* K16  */  be_nested_str_weak(init),
-  /* K17  */  be_nested_str_weak(PalettePatternAnimation_X28strip_length_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K18  */  be_nested_str_weak(priority),
-  /* K19  */  be_nested_str_weak(update),
-  /* K20  */  be_nested_str_weak(_update_value_buffer),
+  /* K15  */  be_const_int(0),
+  /* K16  */  be_nested_str_weak(priority),
+  /* K17  */  be_nested_str_weak(animation),
+  /* K18  */  be_nested_str_weak(event_handler),
+  /* K19  */  be_nested_str_weak(_sort_handlers),
+  /* K20  */  be_nested_str_weak(contains),
+  /* K21  */  be_nested_str_weak(name),
+  /* K22  */  be_nested_str_weak(data),
+  /* K23  */  be_nested_str_weak(is_active),
+  /* K24  */  be_nested_str_weak(execute),
+  /* K25  */  be_nested_str_weak(Event_X20processing_X20error_X3A),
+  /* K26  */  be_nested_str_weak(_process_queued_events),
+  /* K27  */  be_nested_str_weak(size),
+  /* K28  */  be_nested_str_weak(pop),
+  /* K29  */  be_nested_str_weak(trigger_event),
 };
 
 
-extern const bclass be_class_PalettePatternAnimation;
+extern const bclass be_class_EventManager;
 
 /********************************************************************
-** Solidified function: on_param_changed
+** Solidified function: unregister_handler
 ********************************************************************/
-be_local_closure(class_PalettePatternAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
-      0x740E0001,  //  0001  JMPT	R3	#0004
-      0x1C0C0301,  //  0002  EQ	R3	R1	K1
-      0x780E0001,  //  0003  JMPF	R3	#0006
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation_render,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
-      0x880C0103,  //  0000  GETMBR	R3	R0	K3
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x1C0C0403,  //  0008  EQ	R3	R2	R3
-      0x780E0001,  //  0009  JMPF	R3	#000C
-      0x880C0104,  //  000A  GETMBR	R3	R0	K4
-      0x88080705,  //  000B  GETMBR	R2	R3	K5
-      0x880C0101,  //  000C  GETMBR	R3	R0	K1
-      0x4C100000,  //  000D  LDNIL	R4
-      0x1C100604,  //  000E  EQ	R4	R3	R4
-      0x78120001,  //  000F  JMPF	R4	#0012
-      0x50100000,  //  0010  LDBOOL	R4	0	0
-      0x80040800,  //  0011  RET	1	R4
-      0x88100106,  //  0012  GETMBR	R4	R0	K6
-      0x04100404,  //  0013  SUB	R4	R2	R4
-      0x88140104,  //  0014  GETMBR	R5	R0	K4
-      0x8C140B07,  //  0015  GETMET	R5	R5	K7
-      0x7C140200,  //  0016  CALL	R5	1
-      0x58180008,  //  0017  LDCONST	R6	K8
-      0x141C0C05,  //  0018  LT	R7	R6	R5
-      0x781E0016,  //  0019  JMPF	R7	#0031
-      0x881C0309,  //  001A  GETMBR	R7	R1	K9
-      0x141C0C07,  //  001B  LT	R7	R6	R7
-      0x781E0013,  //  001C  JMPF	R7	#0031
-      0x881C010A,  //  001D  GETMBR	R7	R0	K10
-      0x941C0E06,  //  001E  GETIDX	R7	R7	R6
-      0x4C200000,  //  001F  LDNIL	R8
-      0x8824070B,  //  0020  GETMBR	R9	R3	K11
-      0x4C280000,  //  0021  LDNIL	R10
-      0x2024120A,  //  0022  NE	R9	R9	R10
-      0x78260005,  //  0023  JMPF	R9	#002A
-      0x8C24070B,  //  0024  GETMET	R9	R3	K11
-      0x5C2C0E00,  //  0025  MOVE	R11	R7
-      0x5C300800,  //  0026  MOVE	R12	R4
-      0x7C240600,  //  0027  CALL	R9	3
-      0x5C201200,  //  0028  MOVE	R8	R9
-      0x70020000,  //  0029  JMP		#002B
-      0x8820070C,  //  002A  GETMBR	R8	R3	K12
-      0x8C24030D,  //  002B  GETMET	R9	R1	K13
-      0x5C2C0C00,  //  002C  MOVE	R11	R6
-      0x5C301000,  //  002D  MOVE	R12	R8
-      0x7C240600,  //  002E  CALL	R9	3
-      0x00180D0E,  //  002F  ADD	R6	R6	K14
-      0x7001FFE6,  //  0030  JMP		#0018
-      0x501C0200,  //  0031  LDBOOL	R7	1	0
-      0x80040E00,  //  0032  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_value_buffer
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation__update_value_buffer,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(_update_value_buffer),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0403,  //  0002  EQ	R3	R2	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x80000600,  //  0004  RET	0
-      0x880C0104,  //  0005  GETMBR	R3	R0	K4
-      0x8C0C0707,  //  0006  GETMET	R3	R3	K7
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x6010000C,  //  0008  GETGBL	R4	G12
-      0x8814010A,  //  0009  GETMBR	R5	R0	K10
-      0x7C100200,  //  000A  CALL	R4	1
-      0x20100803,  //  000B  NE	R4	R4	R3
-      0x78120003,  //  000C  JMPF	R4	#0011
-      0x8810010A,  //  000D  GETMBR	R4	R0	K10
-      0x8C10090F,  //  000E  GETMET	R4	R4	K15
-      0x5C180600,  //  000F  MOVE	R6	R3
-      0x7C100400,  //  0010  CALL	R4	2
-      0x58100008,  //  0011  LDCONST	R4	K8
-      0x14140803,  //  0012  LT	R5	R4	R3
-      0x78160008,  //  0013  JMPF	R5	#001D
-      0x8814010A,  //  0014  GETMBR	R5	R0	K10
-      0x5C180400,  //  0015  MOVE	R6	R2
-      0x5C1C0800,  //  0016  MOVE	R7	R4
-      0x5C200200,  //  0017  MOVE	R8	R1
-      0x5C240000,  //  0018  MOVE	R9	R0
-      0x7C180600,  //  0019  CALL	R6	3
-      0x98140806,  //  001A  SETIDX	R5	R4	R6
-      0x0010090E,  //  001B  ADD	R4	R4	K14
-      0x7001FFF4,  //  001C  JMP		#0012
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _initialize_value_buffer
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation__initialize_value_buffer,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(_initialize_value_buffer),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88040104,  //  0000  GETMBR	R1	R0	K4
-      0x8C040307,  //  0001  GETMET	R1	R1	K7
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8808010A,  //  0003  GETMBR	R2	R0	K10
-      0x8C08050F,  //  0004  GETMET	R2	R2	K15
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x58080008,  //  0007  LDCONST	R2	K8
-      0x140C0401,  //  0008  LT	R3	R2	R1
-      0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C010A,  //  000A  GETMBR	R3	R0	K10
-      0x980C0508,  //  000B  SETIDX	R3	R2	K8
-      0x0008050E,  //  000C  ADD	R2	R2	K14
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080510,  //  0003  GETMET	R2	R2	K16
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90021402,  //  0008  SETMBR	R0	K10	R2
-      0x8C080102,  //  0009  GETMET	R2	R0	K2
-      0x7C080200,  //  000A  CALL	R2	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation_tostring,   /* name */
+be_local_closure(class_EventManager_unregister_handler,   /* name */
   be_nested_proto(
     7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040104,  //  0000  GETMBR	R1	R0	K4
-      0x8C040307,  //  0001  GETMET	R1	R1	K7
-      0x7C040200,  //  0002  CALL	R1	1
-      0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0011,  //  0004  LDCONST	R3	K17
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x88140112,  //  0006  GETMBR	R5	R0	K18
-      0x88180103,  //  0007  GETMBR	R6	R0	K3
-      0x7C080800,  //  0008  CALL	R2	4
-      0x80040400,  //  0009  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_PalettePatternAnimation_update,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -17250,348 +12531,42 @@ be_local_closure(class_PalettePatternAnimation_update,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_PalettePatternAnimation,     /* shared constants */
-    be_str_weak(update),
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(unregister_handler),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080513,  //  0003  GETMET	R2	R2	K19
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0001,  //  0006  JMPT	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x88080106,  //  0009  GETMBR	R2	R0	K6
-      0x04080202,  //  000A  SUB	R2	R1	R2
-      0x8C0C0114,  //  000B  GETMET	R3	R0	K20
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x500C0200,  //  000E  LDBOOL	R3	1	0
-      0x80040600,  //  000F  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: PalettePatternAnimation
-********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(PalettePatternAnimation,
-    1,
-    &be_class_Animation,
-    be_nested_map(9,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(update, 1), be_const_closure(class_PalettePatternAnimation_update_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_PalettePatternAnimation_tostring_closure) },
-        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PalettePatternAnimation__update_value_buffer_closure) },
-        { be_const_key_weak(_initialize_value_buffer, -1), be_const_closure(class_PalettePatternAnimation__initialize_value_buffer_closure) },
-        { be_const_key_weak(on_param_changed, 8), be_const_closure(class_PalettePatternAnimation_on_param_changed_closure) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(color_source, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-        { be_const_key_weak(pattern_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, 5), be_const_closure(class_PalettePatternAnimation_init_closure) },
-        { be_const_key_weak(render, 0), be_const_closure(class_PalettePatternAnimation_render_closure) },
-        { be_const_key_weak(value_buffer, -1), be_const_var(0) },
-    })),
-    be_str_weak(PalettePatternAnimation)
-);
-// compact class 'PlasmaAnimation' ktab size: 46, total: 93 (saved 376 bytes)
-static const bvalue be_ktab_class_PlasmaAnimation[46] = {
-  /* K0   */  be_nested_str_weak(start),
-  /* K1   */  be_nested_str_weak(color),
-  /* K2   */  be_nested_str_weak(animation),
-  /* K3   */  be_nested_str_weak(rich_palette),
-  /* K4   */  be_nested_str_weak(engine),
-  /* K5   */  be_nested_str_weak(palette),
-  /* K6   */  be_nested_str_weak(PALETTE_RAINBOW),
-  /* K7   */  be_nested_str_weak(cycle_period),
-  /* K8   */  be_nested_str_weak(transition_type),
-  /* K9   */  be_const_int(1),
-  /* K10  */  be_nested_str_weak(brightness),
-  /* K11  */  be_nested_str_weak(range_min),
-  /* K12  */  be_const_int(0),
-  /* K13  */  be_nested_str_weak(range_max),
-  /* K14  */  be_nested_str_weak(time_phase),
-  /* K15  */  be_nested_str_weak(is_value_provider),
-  /* K16  */  be_nested_str_weak(0x_X2508x),
-  /* K17  */  be_nested_str_weak(PlasmaAnimation_X28color_X3D_X25s_X2C_X20freq_x_X3D_X25s_X2C_X20freq_y_X3D_X25s_X2C_X20time_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K18  */  be_nested_str_weak(freq_x),
-  /* K19  */  be_nested_str_weak(freq_y),
-  /* K20  */  be_nested_str_weak(time_speed),
-  /* K21  */  be_nested_str_weak(priority),
-  /* K22  */  be_nested_str_weak(is_running),
-  /* K23  */  be_nested_str_weak(init),
-  /* K24  */  be_nested_str_weak(current_colors),
-  /* K25  */  be_nested_str_weak(_initialize_colors),
-  /* K26  */  be_nested_str_weak(update),
-  /* K27  */  be_nested_str_weak(start_time),
-  /* K28  */  be_nested_str_weak(tasmota),
-  /* K29  */  be_nested_str_weak(scale_uint),
-  /* K30  */  be_nested_str_weak(_calculate_plasma),
-  /* K31  */  be_nested_str_weak(get_strip_length),
-  /* K32  */  be_nested_str_weak(resize),
-  /* K33  */  be_const_int(-16777216),
-  /* K34  */  be_nested_str_weak(set_param),
-  /* K35  */  be_nested_str_weak(phase_x),
-  /* K36  */  be_nested_str_weak(phase_y),
-  /* K37  */  be_nested_str_weak(blend_mode),
-  /* K38  */  be_nested_str_weak(_sine),
-  /* K39  */  be_const_int(2),
-  /* K40  */  be_nested_str_weak(is_color_provider),
-  /* K41  */  be_nested_str_weak(get_color_for_value),
-  /* K42  */  be_nested_str_weak(resolve_value),
-  /* K43  */  be_nested_str_weak(width),
-  /* K44  */  be_nested_str_weak(set_pixel_color),
-  /* K45  */  be_nested_str_weak(sine_int),
-};
-
-
-extern const bclass be_class_PlasmaAnimation;
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_PlasmaAnimation_start,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x1C080403,  //  0008  EQ	R2	R2	R3
-      0x780A000F,  //  0009  JMPF	R2	#001A
-      0xB80A0400,  //  000A  GETNGBL	R2	K2
-      0x8C080503,  //  000B  GETMET	R2	R2	K3
-      0x88100104,  //  000C  GETMBR	R4	R0	K4
-      0x7C080400,  //  000D  CALL	R2	2
-      0xB80E0400,  //  000E  GETNGBL	R3	K2
-      0x880C0706,  //  000F  GETMBR	R3	R3	K6
-      0x900A0A03,  //  0010  SETMBR	R2	K5	R3
-      0x540E1387,  //  0011  LDINT	R3	5000
-      0x900A0E03,  //  0012  SETMBR	R2	K7	R3
-      0x900A1109,  //  0013  SETMBR	R2	K8	K9
-      0x540E00FE,  //  0014  LDINT	R3	255
-      0x900A1403,  //  0015  SETMBR	R2	K10	R3
-      0x900A170C,  //  0016  SETMBR	R2	K11	K12
-      0x540E00FE,  //  0017  LDINT	R3	255
-      0x900A1A03,  //  0018  SETMBR	R2	K13	R3
-      0x90020202,  //  0019  SETMBR	R0	K1	R2
-      0x90021D0C,  //  001A  SETMBR	R0	K14	K12
-      0x80040000,  //  001B  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_PlasmaAnimation_tostring,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C070F,  //  0003  GETMET	R3	R3	K15
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x780E0004,  //  0006  JMPF	R3	#000C
-      0x600C0008,  //  0007  GETGBL	R3	G8
-      0x5C100400,  //  0008  MOVE	R4	R2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x5C040600,  //  000A  MOVE	R1	R3
-      0x70020004,  //  000B  JMP		#0011
-      0x600C0018,  //  000C  GETGBL	R3	G24
-      0x58100010,  //  000D  LDCONST	R4	K16
-      0x5C140400,  //  000E  MOVE	R5	R2
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x5C040600,  //  0010  MOVE	R1	R3
-      0x600C0018,  //  0011  GETGBL	R3	G24
-      0x58100011,  //  0012  LDCONST	R4	K17
-      0x5C140200,  //  0013  MOVE	R5	R1
-      0x88180112,  //  0014  GETMBR	R6	R0	K18
-      0x881C0113,  //  0015  GETMBR	R7	R0	K19
-      0x88200114,  //  0016  GETMBR	R8	R0	K20
-      0x88240115,  //  0017  GETMBR	R9	R0	K21
-      0x88280116,  //  0018  GETMBR	R10	R0	K22
-      0x7C0C0E00,  //  0019  CALL	R3	7
-      0x80040600,  //  001A  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_PlasmaAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080517,  //  0003  GETMET	R2	R2	K23
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90021D0C,  //  0006  SETMBR	R0	K14	K12
-      0x60080012,  //  0007  GETGBL	R2	G18
-      0x7C080000,  //  0008  CALL	R2	0
-      0x90023002,  //  0009  SETMBR	R0	K24	R2
-      0x8C080119,  //  000A  GETMET	R2	R0	K25
-      0x7C080200,  //  000B  CALL	R2	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_PlasmaAnimation_update,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08051A,  //  0003  GETMET	R2	R2	K26
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0001,  //  0006  JMPT	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x88080114,  //  0009  GETMBR	R2	R0	K20
-      0x240C050C,  //  000A  GT	R3	R2	K12
-      0x780E0011,  //  000B  JMPF	R3	#001E
-      0x880C011B,  //  000C  GETMBR	R3	R0	K27
-      0x040C0203,  //  000D  SUB	R3	R1	R3
-      0xB8123800,  //  000E  GETNGBL	R4	K28
-      0x8C10091D,  //  000F  GETMET	R4	R4	K29
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x581C000C,  //  0011  LDCONST	R7	K12
-      0x542200FE,  //  0012  LDINT	R8	255
-      0x5824000C,  //  0013  LDCONST	R9	K12
-      0x542A0007,  //  0014  LDINT	R10	8
-      0x7C100C00,  //  0015  CALL	R4	6
-      0x2414090C,  //  0016  GT	R5	R4	K12
-      0x78160005,  //  0017  JMPF	R5	#001E
-      0x08140604,  //  0018  MUL	R5	R3	R4
-      0x541A03E7,  //  0019  LDINT	R6	1000
-      0x0C140A06,  //  001A  DIV	R5	R5	R6
-      0x541A00FF,  //  001B  LDINT	R6	256
-      0x10140A06,  //  001C  MOD	R5	R5	R6
-      0x90021C05,  //  001D  SETMBR	R0	K14	R5
-      0x8C0C011E,  //  001E  GETMET	R3	R0	K30
-      0x5C140200,  //  001F  MOVE	R5	R1
-      0x7C0C0400,  //  0020  CALL	R3	2
-      0x500C0200,  //  0021  LDBOOL	R3	1	0
-      0x80040600,  //  0022  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _initialize_colors
-********************************************************************/
-be_local_closure(class_PlasmaAnimation__initialize_colors,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(_initialize_colors),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88040104,  //  0000  GETMBR	R1	R0	K4
-      0x8C04031F,  //  0001  GETMET	R1	R1	K31
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88080118,  //  0003  GETMBR	R2	R0	K24
-      0x8C080520,  //  0004  GETMET	R2	R2	K32
+    ( &(const binstruction[32]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x1C080501,  //  0001  EQ	R2	R2	K1
+      0x780A000B,  //  0002  JMPF	R2	#000F
+      0x88080102,  //  0003  GETMBR	R2	R0	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
       0x5C100200,  //  0005  MOVE	R4	R1
       0x7C080400,  //  0006  CALL	R2	2
-      0x5808000C,  //  0007  LDCONST	R2	K12
-      0x140C0401,  //  0008  LT	R3	R2	R1
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x200C0403,  //  0008  NE	R3	R2	R3
       0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C0118,  //  000A  GETMBR	R3	R0	K24
-      0x980C0521,  //  000B  SETIDX	R3	R2	K33
-      0x00080509,  //  000C  ADD	R2	R2	K9
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x80000000,  //  000E  RET	0
+      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x8C0C0704,  //  000B  GETMET	R3	R3	K4
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x7002000F,  //  000E  JMP		#001F
+      0x88080105,  //  000F  GETMBR	R2	R0	K5
+      0x8C080503,  //  0010  GETMET	R2	R2	K3
+      0x88100300,  //  0011  GETMBR	R4	R1	K0
+      0x7C080400,  //  0012  CALL	R2	2
+      0x4C0C0000,  //  0013  LDNIL	R3
+      0x200C0403,  //  0014  NE	R3	R2	R3
+      0x780E0008,  //  0015  JMPF	R3	#001F
+      0x8C0C0503,  //  0016  GETMET	R3	R2	K3
+      0x5C140200,  //  0017  MOVE	R5	R1
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x4C100000,  //  0019  LDNIL	R4
+      0x20100604,  //  001A  NE	R4	R3	R4
+      0x78120002,  //  001B  JMPF	R4	#001F
+      0x8C100504,  //  001C  GETMET	R4	R2	K4
+      0x5C180600,  //  001D  MOVE	R6	R3
+      0x7C100400,  //  001E  CALL	R4	2
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -17599,183 +12574,9 @@ be_local_closure(class_PlasmaAnimation__initialize_colors,   /* name */
 
 
 /********************************************************************
-** Solidified function: on_param_changed
+** Solidified function: set_event_active
 ********************************************************************/
-be_local_closure(class_PlasmaAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x1C0C0301,  //  0000  EQ	R3	R1	K1
-      0x780E0015,  //  0001  JMPF	R3	#0018
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0403,  //  0003  EQ	R3	R2	R3
-      0x780E0012,  //  0004  JMPF	R3	#0018
-      0xB80E0400,  //  0005  GETNGBL	R3	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x88140104,  //  0007  GETMBR	R5	R0	K4
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100906,  //  000A  GETMBR	R4	R4	K6
-      0x900E0A04,  //  000B  SETMBR	R3	K5	R4
-      0x54121387,  //  000C  LDINT	R4	5000
-      0x900E0E04,  //  000D  SETMBR	R3	K7	R4
-      0x900E1109,  //  000E  SETMBR	R3	K8	K9
-      0x541200FE,  //  000F  LDINT	R4	255
-      0x900E1404,  //  0010  SETMBR	R3	K10	R4
-      0x900E170C,  //  0011  SETMBR	R3	K11	K12
-      0x541200FE,  //  0012  LDINT	R4	255
-      0x900E1A04,  //  0013  SETMBR	R3	K13	R4
-      0x8C100122,  //  0014  GETMET	R4	R0	K34
-      0x58180001,  //  0015  LDCONST	R6	K1
-      0x5C1C0600,  //  0016  MOVE	R7	R3
-      0x7C100600,  //  0017  CALL	R4	3
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _calculate_plasma
-********************************************************************/
-be_local_closure(class_PlasmaAnimation__calculate_plasma,   /* name */
-  be_nested_proto(
-    21,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(_calculate_plasma),
-    &be_const_str_solidified,
-    ( &(const binstruction[103]) {  /* code */
-      0x88080104,  //  0000  GETMBR	R2	R0	K4
-      0x8C08051F,  //  0001  GETMET	R2	R2	K31
-      0x7C080200,  //  0002  CALL	R2	1
-      0x600C000C,  //  0003  GETGBL	R3	G12
-      0x88100118,  //  0004  GETMBR	R4	R0	K24
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x200C0602,  //  0006  NE	R3	R3	R2
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x8C0C0119,  //  0008  GETMET	R3	R0	K25
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x880C0112,  //  000A  GETMBR	R3	R0	K18
-      0x88100113,  //  000B  GETMBR	R4	R0	K19
-      0x88140123,  //  000C  GETMBR	R5	R0	K35
-      0x88180124,  //  000D  GETMBR	R6	R0	K36
-      0x881C0125,  //  000E  GETMBR	R7	R0	K37
-      0x88200101,  //  000F  GETMBR	R8	R0	K1
-      0x5824000C,  //  0010  LDCONST	R9	K12
-      0x14281202,  //  0011  LT	R10	R9	R2
-      0x782A0052,  //  0012  JMPF	R10	#0066
-      0xB82A3800,  //  0013  GETNGBL	R10	K28
-      0x8C28151D,  //  0014  GETMET	R10	R10	K29
-      0x5C301200,  //  0015  MOVE	R12	R9
-      0x5834000C,  //  0016  LDCONST	R13	K12
-      0x04380509,  //  0017  SUB	R14	R2	K9
-      0x583C000C,  //  0018  LDCONST	R15	K12
-      0x544200FE,  //  0019  LDINT	R16	255
-      0x7C280C00,  //  001A  CALL	R10	6
-      0x8C2C0126,  //  001B  GETMET	R11	R0	K38
-      0x08341403,  //  001C  MUL	R13	R10	R3
-      0x543A001F,  //  001D  LDINT	R14	32
-      0x0C341A0E,  //  001E  DIV	R13	R13	R14
-      0x00341A05,  //  001F  ADD	R13	R13	R5
-      0x8838010E,  //  0020  GETMBR	R14	R0	K14
-      0x00341A0E,  //  0021  ADD	R13	R13	R14
-      0x7C2C0400,  //  0022  CALL	R11	2
-      0x8C300126,  //  0023  GETMET	R12	R0	K38
-      0x08381404,  //  0024  MUL	R14	R10	R4
-      0x543E001F,  //  0025  LDINT	R15	32
-      0x0C381C0F,  //  0026  DIV	R14	R14	R15
-      0x00381C06,  //  0027  ADD	R14	R14	R6
-      0x883C010E,  //  0028  GETMBR	R15	R0	K14
-      0x083C1F27,  //  0029  MUL	R15	R15	K39
-      0x00381C0F,  //  002A  ADD	R14	R14	R15
-      0x7C300400,  //  002B  CALL	R12	2
-      0x5834000C,  //  002C  LDCONST	R13	K12
-      0x1C380F0C,  //  002D  EQ	R14	R7	K12
-      0x783A0003,  //  002E  JMPF	R14	#0033
-      0x0038160C,  //  002F  ADD	R14	R11	R12
-      0x0C381D27,  //  0030  DIV	R14	R14	K39
-      0x5C341C00,  //  0031  MOVE	R13	R14
-      0x7002000E,  //  0032  JMP		#0042
-      0x1C380F09,  //  0033  EQ	R14	R7	K9
-      0x783A0009,  //  0034  JMPF	R14	#003F
-      0xB83A3800,  //  0035  GETNGBL	R14	K28
-      0x8C381D1D,  //  0036  GETMET	R14	R14	K29
-      0x5C401600,  //  0037  MOVE	R16	R11
-      0x5844000C,  //  0038  LDCONST	R17	K12
-      0x544A00FE,  //  0039  LDINT	R18	255
-      0x584C000C,  //  003A  LDCONST	R19	K12
-      0x5C501800,  //  003B  MOVE	R20	R12
-      0x7C380C00,  //  003C  CALL	R14	6
-      0x5C341C00,  //  003D  MOVE	R13	R14
-      0x70020002,  //  003E  JMP		#0042
-      0x0038160C,  //  003F  ADD	R14	R11	R12
-      0x0C381D27,  //  0040  DIV	R14	R14	K39
-      0x5C341C00,  //  0041  MOVE	R13	R14
-      0x543A00FE,  //  0042  LDINT	R14	255
-      0x24381A0E,  //  0043  GT	R14	R13	R14
-      0x783A0001,  //  0044  JMPF	R14	#0047
-      0x543600FE,  //  0045  LDINT	R13	255
-      0x70020002,  //  0046  JMP		#004A
-      0x14381B0C,  //  0047  LT	R14	R13	K12
-      0x783A0000,  //  0048  JMPF	R14	#004A
-      0x5834000C,  //  0049  LDCONST	R13	K12
-      0x58380021,  //  004A  LDCONST	R14	K33
-      0xB83E0400,  //  004B  GETNGBL	R15	K2
-      0x8C3C1F28,  //  004C  GETMET	R15	R15	K40
-      0x5C441000,  //  004D  MOVE	R17	R8
-      0x7C3C0400,  //  004E  CALL	R15	2
-      0x783E0009,  //  004F  JMPF	R15	#005A
-      0x883C1129,  //  0050  GETMBR	R15	R8	K41
-      0x4C400000,  //  0051  LDNIL	R16
-      0x203C1E10,  //  0052  NE	R15	R15	R16
-      0x783E0005,  //  0053  JMPF	R15	#005A
-      0x8C3C1129,  //  0054  GETMET	R15	R8	K41
-      0x5C441A00,  //  0055  MOVE	R17	R13
-      0x5848000C,  //  0056  LDCONST	R18	K12
-      0x7C3C0600,  //  0057  CALL	R15	3
-      0x5C381E00,  //  0058  MOVE	R14	R15
-      0x70020007,  //  0059  JMP		#0062
-      0x8C3C012A,  //  005A  GETMET	R15	R0	K42
-      0x5C441000,  //  005B  MOVE	R17	R8
-      0x58480001,  //  005C  LDCONST	R18	K1
-      0x544E0009,  //  005D  LDINT	R19	10
-      0x084C1A13,  //  005E  MUL	R19	R13	R19
-      0x004C0213,  //  005F  ADD	R19	R1	R19
-      0x7C3C0800,  //  0060  CALL	R15	4
-      0x5C381E00,  //  0061  MOVE	R14	R15
-      0x883C0118,  //  0062  GETMBR	R15	R0	K24
-      0x983C120E,  //  0063  SETIDX	R15	R9	R14
-      0x00241309,  //  0064  ADD	R9	R9	K9
-      0x7001FFAA,  //  0065  JMP		#0011
-      0x80000000,  //  0066  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_PlasmaAnimation_render,   /* name */
+be_local_closure(class_EventManager_set_event_active,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
@@ -17785,35 +12586,31 @@ be_local_closure(class_PlasmaAnimation_render,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(render),
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(set_event_active),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x880C0116,  //  0000  GETMBR	R3	R0	K22
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x880C0104,  //  0007  GETMBR	R3	R0	K4
-      0x8C0C071F,  //  0008  GETMET	R3	R3	K31
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x5810000C,  //  000A  LDCONST	R4	K12
-      0x14140803,  //  000B  LT	R5	R4	R3
-      0x78160009,  //  000C  JMPF	R5	#0017
-      0x8814032B,  //  000D  GETMBR	R5	R1	K43
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x78160004,  //  000F  JMPF	R5	#0015
-      0x8C14032C,  //  0010  GETMET	R5	R1	K44
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x88200118,  //  0012  GETMBR	R8	R0	K24
-      0x94201004,  //  0013  GETIDX	R8	R8	R4
-      0x7C140600,  //  0014  CALL	R5	3
-      0x00100909,  //  0015  ADD	R4	R4	K9
-      0x7001FFF3,  //  0016  JMP		#000B
-      0x50140200,  //  0017  LDBOOL	R5	1	0
-      0x80040A00,  //  0018  RET	1	R5
+    ( &(const binstruction[21]) {  /* code */
+      0x880C0105,  //  0000  GETMBR	R3	R0	K5
+      0x8C0C0703,  //  0001  GETMET	R3	R3	K3
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100604,  //  0005  NE	R4	R3	R4
+      0x7812000C,  //  0006  JMPF	R4	#0014
+      0x60100010,  //  0007  GETGBL	R4	G16
+      0x5C140600,  //  0008  MOVE	R5	R3
+      0x7C100200,  //  0009  CALL	R4	1
+      0xA8020005,  //  000A  EXBLK	0	#0011
+      0x5C140800,  //  000B  MOVE	R5	R4
+      0x7C140000,  //  000C  CALL	R5	0
+      0x8C180B06,  //  000D  GETMET	R6	R5	K6
+      0x5C200400,  //  000E  MOVE	R8	R2
+      0x7C180400,  //  000F  CALL	R6	2
+      0x7001FFF9,  //  0010  JMP		#000B
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0xAC100200,  //  0012  CATCH	R4	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -17821,11 +12618,11 @@ be_local_closure(class_PlasmaAnimation_render,   /* name */
 
 
 /********************************************************************
-** Solidified function: _sine
+** Solidified function: get_handlers
 ********************************************************************/
-be_local_closure(class_PlasmaAnimation__sine,   /* name */
+be_local_closure(class_EventManager_get_handlers,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -17833,31 +12630,211 @@ be_local_closure(class_PlasmaAnimation__sine,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_PlasmaAnimation,     /* shared constants */
-    be_str_weak(_sine),
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(get_handlers),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xB80A3800,  //  0000  GETNGBL	R2	K28
-      0x8C08051D,  //  0001  GETMET	R2	R2	K29
+    ( &(const binstruction[38]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020006,  //  0005  EXBLK	0	#000D
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140508,  //  0008  GETMET	R5	R2	K8
+      0x8C1C0909,  //  0009  GETMET	R7	R4	K9
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x7C140400,  //  000B  CALL	R5	2
+      0x7001FFF8,  //  000C  JMP		#0006
+      0x580C0007,  //  000D  LDCONST	R3	K7
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x880C0105,  //  0010  GETMBR	R3	R0	K5
+      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x4C100000,  //  0014  LDNIL	R4
+      0x20100604,  //  0015  NE	R4	R3	R4
+      0x7812000D,  //  0016  JMPF	R4	#0025
+      0x60100010,  //  0017  GETGBL	R4	G16
+      0x5C140600,  //  0018  MOVE	R5	R3
+      0x7C100200,  //  0019  CALL	R4	1
+      0xA8020006,  //  001A  EXBLK	0	#0022
+      0x5C140800,  //  001B  MOVE	R5	R4
+      0x7C140000,  //  001C  CALL	R5	0
+      0x8C180508,  //  001D  GETMET	R6	R2	K8
+      0x8C200B09,  //  001E  GETMET	R8	R5	K9
+      0x7C200200,  //  001F  CALL	R8	1
+      0x7C180400,  //  0020  CALL	R6	2
+      0x7001FFF8,  //  0021  JMP		#001B
+      0x58100007,  //  0022  LDCONST	R4	K7
+      0xAC100200,  //  0023  CATCH	R4	1	0
+      0xB0080000,  //  0024  RAISE	2	R0	R0
+      0x80040400,  //  0025  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_registered_events
+********************************************************************/
+be_local_closure(class_EventManager_get_registered_events,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(get_registered_events),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x60080010,  //  0002  GETGBL	R2	G16
+      0x880C0105,  //  0003  GETMBR	R3	R0	K5
+      0x8C0C070A,  //  0004  GETMET	R3	R3	K10
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020005,  //  0007  EXBLK	0	#000E
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x8C100308,  //  000A  GETMET	R4	R1	K8
+      0x5C180600,  //  000B  MOVE	R6	R3
+      0x7C100400,  //  000C  CALL	R4	2
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x58080007,  //  000E  LDCONST	R2	K7
+      0xAC080200,  //  000F  CATCH	R2	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x80040200,  //  0011  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_EventManager_init,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x90020A01,  //  0002  SETMBR	R0	K5	R1
+      0x60040012,  //  0003  GETGBL	R1	G18
+      0x7C040000,  //  0004  CALL	R1	0
+      0x90020401,  //  0005  SETMBR	R0	K2	R1
+      0x60040012,  //  0006  GETGBL	R1	G18
+      0x7C040000,  //  0007  CALL	R1	0
+      0x90021601,  //  0008  SETMBR	R0	K11	R1
+      0x50040000,  //  0009  LDBOOL	R1	0	0
+      0x90021801,  //  000A  SETMBR	R0	K12	R1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear_all_handlers
+********************************************************************/
+be_local_closure(class_EventManager_clear_all_handlers,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(clear_all_handlers),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040105,  //  0000  GETMBR	R1	R0	K5
+      0x8C04030D,  //  0001  GETMET	R1	R1	K13
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C04030D,  //  0004  GETMET	R1	R1	K13
+      0x7C040200,  //  0005  CALL	R1	1
+      0x8804010B,  //  0006  GETMBR	R1	R0	K11
+      0x8C04030D,  //  0007  GETMET	R1	R1	K13
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _sort_handlers
+********************************************************************/
+be_local_closure(class_EventManager__sort_handlers,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(_sort_handlers),
+    &be_const_str_solidified,
+    ( &(const binstruction[31]) {  /* code */
+      0x60080010,  //  0000  GETGBL	R2	G16
+      0x600C000C,  //  0001  GETGBL	R3	G12
       0x5C100200,  //  0002  MOVE	R4	R1
-      0x5814000C,  //  0003  LDCONST	R5	K12
-      0x541A00FE,  //  0004  LDINT	R6	255
-      0x581C000C,  //  0005  LDCONST	R7	K12
-      0x54227FFE,  //  0006  LDINT	R8	32767
-      0x7C080C00,  //  0007  CALL	R2	6
-      0xB80E3800,  //  0008  GETNGBL	R3	K28
-      0x8C0C072D,  //  0009  GETMET	R3	R3	K45
-      0x5C140400,  //  000A  MOVE	R5	R2
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0xB8123800,  //  000C  GETNGBL	R4	K28
-      0x8C10091D,  //  000D  GETMET	R4	R4	K29
-      0x5C180600,  //  000E  MOVE	R6	R3
-      0x541DEFFF,  //  000F  LDINT	R7	-4096
-      0x54220FFF,  //  0010  LDINT	R8	4096
-      0x5824000C,  //  0011  LDCONST	R9	K12
-      0x542A00FE,  //  0012  LDINT	R10	255
-      0x7C100C00,  //  0013  CALL	R4	6
-      0x80040800,  //  0014  RET	1	R4
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x040C070E,  //  0004  SUB	R3	R3	K14
+      0x400E1C03,  //  0005  CONNECT	R3	K14	R3
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020012,  //  0007  EXBLK	0	#001B
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x94100203,  //  000A  GETIDX	R4	R1	R3
+      0x5C140600,  //  000B  MOVE	R5	R3
+      0x24180B0F,  //  000C  GT	R6	R5	K15
+      0x781A000A,  //  000D  JMPF	R6	#0019
+      0x04180B0E,  //  000E  SUB	R6	R5	K14
+      0x94180206,  //  000F  GETIDX	R6	R1	R6
+      0x88180D10,  //  0010  GETMBR	R6	R6	K16
+      0x881C0910,  //  0011  GETMBR	R7	R4	K16
+      0x14180C07,  //  0012  LT	R6	R6	R7
+      0x781A0004,  //  0013  JMPF	R6	#0019
+      0x04180B0E,  //  0014  SUB	R6	R5	K14
+      0x94180206,  //  0015  GETIDX	R6	R1	R6
+      0x98040A06,  //  0016  SETIDX	R1	R5	R6
+      0x04140B0E,  //  0017  SUB	R5	R5	K14
+      0x7001FFF2,  //  0018  JMP		#000C
+      0x98040A04,  //  0019  SETIDX	R1	R5	R4
+      0x7001FFEC,  //  001A  JMP		#0008
+      0x58080007,  //  001B  LDCONST	R2	K7
+      0xAC080200,  //  001C  CATCH	R2	1	0
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0x80000000,  //  001E  RET	0
     })
   )
 );
@@ -17865,114 +12842,59 @@ be_local_closure(class_PlasmaAnimation__sine,   /* name */
 
 
 /********************************************************************
-** Solidified class: PlasmaAnimation
+** Solidified function: register_handler
 ********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(PlasmaAnimation,
-    2,
-    &be_class_Animation,
-    be_nested_map(12,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_sine, -1), be_const_closure(class_PlasmaAnimation__sine_closure) },
-        { be_const_key_weak(tostring, 2), be_const_closure(class_PlasmaAnimation_tostring_closure) },
-        { be_const_key_weak(render, 5), be_const_closure(class_PlasmaAnimation_render_closure) },
-        { be_const_key_weak(init, 9), be_const_closure(class_PlasmaAnimation_init_closure) },
-        { be_const_key_weak(update, -1), be_const_closure(class_PlasmaAnimation_update_closure) },
-        { be_const_key_weak(_calculate_plasma, 7), be_const_closure(class_PlasmaAnimation__calculate_plasma_closure) },
-        { be_const_key_weak(_initialize_colors, -1), be_const_closure(class_PlasmaAnimation__initialize_colors_closure) },
-        { be_const_key_weak(on_param_changed, 6), be_const_closure(class_PlasmaAnimation_on_param_changed_closure) },
-        { be_const_key_weak(time_phase, -1), be_const_var(1) },
-        { be_const_key_weak(current_colors, 10), be_const_var(0) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(7,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(phase_y, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(64) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(freq_x, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(32) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(blend_mode, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(2) },
-    }))    ) } )) },
-        { be_const_key_weak(time_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(color, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-    }))    ) } )) },
-        { be_const_key_weak(phase_x, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(freq_y, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(23) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(start, 0), be_const_closure(class_PlasmaAnimation_start_closure) },
-    })),
-    be_str_weak(PlasmaAnimation)
-);
-
-/********************************************************************
-** Solidified function: shift_scroll_left
-********************************************************************/
-be_local_closure(shift_scroll_left,   /* name */
+be_local_closure(class_EventManager_register_handler,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
+    13,                          /* nstack */
+    6,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(shift_animation),
-    /* K2   */  be_nested_str_weak(direction),
-    /* K3   */  be_nested_str_weak(shift_speed),
-    /* K4   */  be_nested_str_weak(wrap_around),
-    }),
-    be_str_weak(shift_scroll_left),
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(register_handler),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A007F,  //  0006  LDINT	R2	128
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x50080200,  //  0008  LDBOOL	R2	1	0
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x80040200,  //  000A  RET	1	R1
+    ( &(const binstruction[37]) {  /* code */
+      0xB81A2200,  //  0000  GETNGBL	R6	K17
+      0x8C180D12,  //  0001  GETMET	R6	R6	K18
+      0x5C200200,  //  0002  MOVE	R8	R1
+      0x5C240400,  //  0003  MOVE	R9	R2
+      0x5C280600,  //  0004  MOVE	R10	R3
+      0x5C2C0800,  //  0005  MOVE	R11	R4
+      0x5C300A00,  //  0006  MOVE	R12	R5
+      0x7C180C00,  //  0007  CALL	R6	6
+      0x1C1C0301,  //  0008  EQ	R7	R1	K1
+      0x781E0007,  //  0009  JMPF	R7	#0012
+      0x881C0102,  //  000A  GETMBR	R7	R0	K2
+      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
+      0x5C240C00,  //  000C  MOVE	R9	R6
+      0x7C1C0400,  //  000D  CALL	R7	2
+      0x8C1C0113,  //  000E  GETMET	R7	R0	K19
+      0x88240102,  //  000F  GETMBR	R9	R0	K2
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x70020011,  //  0011  JMP		#0024
+      0x881C0105,  //  0012  GETMBR	R7	R0	K5
+      0x8C1C0F14,  //  0013  GETMET	R7	R7	K20
+      0x5C240200,  //  0014  MOVE	R9	R1
+      0x7C1C0400,  //  0015  CALL	R7	2
+      0x741E0003,  //  0016  JMPT	R7	#001B
+      0x881C0105,  //  0017  GETMBR	R7	R0	K5
+      0x60200012,  //  0018  GETGBL	R8	G18
+      0x7C200000,  //  0019  CALL	R8	0
+      0x981C0208,  //  001A  SETIDX	R7	R1	R8
+      0x881C0105,  //  001B  GETMBR	R7	R0	K5
+      0x941C0E01,  //  001C  GETIDX	R7	R7	R1
+      0x8C1C0F08,  //  001D  GETMET	R7	R7	K8
+      0x5C240C00,  //  001E  MOVE	R9	R6
+      0x7C1C0400,  //  001F  CALL	R7	2
+      0x8C1C0113,  //  0020  GETMET	R7	R0	K19
+      0x88240105,  //  0021  GETMBR	R9	R0	K5
+      0x94241201,  //  0022  GETIDX	R9	R9	R1
+      0x7C1C0400,  //  0023  CALL	R7	2
+      0x80040C00,  //  0024  RET	1	R6
     })
   )
 );
@@ -17980,90 +12902,11 @@ be_local_closure(shift_scroll_left,   /* name */
 
 
 /********************************************************************
-** Solidified function: sparkle_rainbow
+** Solidified function: trigger_event
 ********************************************************************/
-be_local_closure(sparkle_rainbow,   /* name */
+be_local_closure(class_EventManager_trigger_event,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(rich_palette),
-    /* K2   */  be_nested_str_weak(palette),
-    /* K3   */  be_nested_str_weak(PALETTE_RAINBOW),
-    /* K4   */  be_nested_str_weak(cycle_period),
-    /* K5   */  be_nested_str_weak(transition_type),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(sparkle_animation),
-    /* K8   */  be_nested_str_weak(color),
-    /* K9   */  be_nested_str_weak(name),
-    /* K10  */  be_nested_str_weak(sparkle_rainbow),
-    }),
-    be_str_weak(sparkle_rainbow),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x540A1387,  //  0007  LDINT	R2	5000
-      0x90060802,  //  0008  SETMBR	R1	K4	R2
-      0x90060B06,  //  0009  SETMBR	R1	K5	K6
-      0xB80A0000,  //  000A  GETNGBL	R2	K0
-      0x8C080507,  //  000B  GETMET	R2	R2	K7
-      0x5C100000,  //  000C  MOVE	R4	R0
-      0x7C080400,  //  000D  CALL	R2	2
-      0x900A1001,  //  000E  SETMBR	R2	K8	R1
-      0x900A130A,  //  000F  SETMBR	R2	K9	K10
-      0x80040400,  //  0010  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'CrenelPositionAnimation' ktab size: 21, total: 27 (saved 48 bytes)
-static const bvalue be_ktab_class_CrenelPositionAnimation[21] = {
-  /* K0   */  be_nested_str_weak(is_running),
-  /* K1   */  be_nested_str_weak(engine),
-  /* K2   */  be_nested_str_weak(time_ms),
-  /* K3   */  be_nested_str_weak(width),
-  /* K4   */  be_nested_str_weak(back_color),
-  /* K5   */  be_nested_str_weak(pos),
-  /* K6   */  be_nested_str_weak(pulse_size),
-  /* K7   */  be_nested_str_weak(low_size),
-  /* K8   */  be_nested_str_weak(nb_pulse),
-  /* K9   */  be_nested_str_weak(color),
-  /* K10  */  be_const_int(-16777216),
-  /* K11  */  be_nested_str_weak(fill_pixels),
-  /* K12  */  be_const_int(0),
-  /* K13  */  be_const_int(1),
-  /* K14  */  be_nested_str_weak(set_pixel_color),
-  /* K15  */  be_nested_str_weak(get_param),
-  /* K16  */  be_nested_str_weak(animation),
-  /* K17  */  be_nested_str_weak(is_value_provider),
-  /* K18  */  be_nested_str_weak(0x_X2508x),
-  /* K19  */  be_nested_str_weak(CrenelPositionAnimation_X28color_X3D_X25s_X2C_X20pos_X3D_X25s_X2C_X20pulse_size_X3D_X25s_X2C_X20low_size_X3D_X25s_X2C_X20nb_pulse_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K20  */  be_nested_str_weak(priority),
-};
-
-
-extern const bclass be_class_CrenelPositionAnimation;
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_CrenelPositionAnimation_render,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
+    9,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -18071,86 +12914,328 @@ be_local_closure(class_CrenelPositionAnimation_render,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_CrenelPositionAnimation,     /* shared constants */
-    be_str_weak(render),
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(trigger_event),
     &be_const_str_solidified,
-    ( &(const binstruction[76]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+    ( &(const binstruction[69]) {  /* code */
+      0x880C010C,  //  0000  GETMBR	R3	R0	K12
+      0x780E0007,  //  0001  JMPF	R3	#000A
+      0x880C010B,  //  0002  GETMBR	R3	R0	K11
+      0x8C0C0708,  //  0003  GETMET	R3	R3	K8
+      0x60140013,  //  0004  GETGBL	R5	G19
+      0x7C140000,  //  0005  CALL	R5	0
+      0x98162A01,  //  0006  SETIDX	R5	K21	R1
+      0x98162C02,  //  0007  SETIDX	R5	K22	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x80000600,  //  0009  RET	0
+      0x500C0200,  //  000A  LDBOOL	R3	1	0
+      0x90021803,  //  000B  SETMBR	R0	K12	R3
+      0xA8020029,  //  000C  EXBLK	0	#0037
+      0x600C0010,  //  000D  GETGBL	R3	G16
+      0x88100102,  //  000E  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xA802000A,  //  0010  EXBLK	0	#001C
+      0x5C100600,  //  0011  MOVE	R4	R3
+      0x7C100000,  //  0012  CALL	R4	0
+      0x88140917,  //  0013  GETMBR	R5	R4	K23
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x8C140918,  //  0015  GETMET	R5	R4	K24
+      0x601C0013,  //  0016  GETGBL	R7	G19
+      0x7C1C0000,  //  0017  CALL	R7	0
+      0x981E0001,  //  0018  SETIDX	R7	K0	R1
+      0x981E2C02,  //  0019  SETIDX	R7	K22	R2
+      0x7C140400,  //  001A  CALL	R5	2
+      0x7001FFF4,  //  001B  JMP		#0011
+      0x580C0007,  //  001C  LDCONST	R3	K7
+      0xAC0C0200,  //  001D  CATCH	R3	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x880C0105,  //  001F  GETMBR	R3	R0	K5
+      0x8C0C0703,  //  0020  GETMET	R3	R3	K3
+      0x5C140200,  //  0021  MOVE	R5	R1
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x4C100000,  //  0023  LDNIL	R4
+      0x20100604,  //  0024  NE	R4	R3	R4
+      0x7812000E,  //  0025  JMPF	R4	#0035
+      0x60100010,  //  0026  GETGBL	R4	G16
+      0x5C140600,  //  0027  MOVE	R5	R3
+      0x7C100200,  //  0028  CALL	R4	1
+      0xA8020007,  //  0029  EXBLK	0	#0032
+      0x5C140800,  //  002A  MOVE	R5	R4
+      0x7C140000,  //  002B  CALL	R5	0
+      0x88180B17,  //  002C  GETMBR	R6	R5	K23
+      0x781A0002,  //  002D  JMPF	R6	#0031
+      0x8C180B18,  //  002E  GETMET	R6	R5	K24
+      0x5C200400,  //  002F  MOVE	R8	R2
+      0x7C180400,  //  0030  CALL	R6	2
+      0x7001FFF7,  //  0031  JMP		#002A
+      0x58100007,  //  0032  LDCONST	R4	K7
+      0xAC100200,  //  0033  CATCH	R4	1	0
+      0xB0080000,  //  0034  RAISE	2	R0	R0
+      0xA8040001,  //  0035  EXBLK	1	1
+      0x70020008,  //  0036  JMP		#0040
+      0xAC0C0002,  //  0037  CATCH	R3	0	2
+      0x70020005,  //  0038  JMP		#003F
+      0x60140001,  //  0039  GETGBL	R5	G1
+      0x58180019,  //  003A  LDCONST	R6	K25
+      0x5C1C0600,  //  003B  MOVE	R7	R3
+      0x5C200800,  //  003C  MOVE	R8	R4
+      0x7C140600,  //  003D  CALL	R5	3
+      0x70020000,  //  003E  JMP		#0040
+      0xB0080000,  //  003F  RAISE	2	R0	R0
+      0x500C0000,  //  0040  LDBOOL	R3	0	0
+      0x90021803,  //  0041  SETMBR	R0	K12	R3
+      0x8C0C011A,  //  0042  GETMET	R3	R0	K26
+      0x7C0C0200,  //  0043  CALL	R3	1
+      0x80000000,  //  0044  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _process_queued_events
+********************************************************************/
+be_local_closure(class_EventManager__process_queued_events,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventManager,     /* shared constants */
+    be_str_weak(_process_queued_events),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8804010B,  //  0000  GETMBR	R1	R0	K11
+      0x8C04031B,  //  0001  GETMET	R1	R1	K27
+      0x7C040200,  //  0002  CALL	R1	1
+      0x2404030F,  //  0003  GT	R1	R1	K15
+      0x78060008,  //  0004  JMPF	R1	#000E
+      0x8804010B,  //  0005  GETMBR	R1	R0	K11
+      0x8C04031C,  //  0006  GETMET	R1	R1	K28
+      0x580C000F,  //  0007  LDCONST	R3	K15
+      0x7C040400,  //  0008  CALL	R1	2
+      0x8C08011D,  //  0009  GETMET	R2	R0	K29
+      0x94100315,  //  000A  GETIDX	R4	R1	K21
+      0x94140316,  //  000B  GETIDX	R5	R1	K22
+      0x7C080600,  //  000C  CALL	R2	3
+      0x7001FFF1,  //  000D  JMP		#0000
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: EventManager
+********************************************************************/
+be_local_class(EventManager,
+    4,
+    NULL,
+    be_nested_map(14,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(unregister_handler, -1), be_const_closure(class_EventManager_unregister_handler_closure) },
+        { be_const_key_weak(set_event_active, -1), be_const_closure(class_EventManager_set_event_active_closure) },
+        { be_const_key_weak(handlers, -1), be_const_var(0) },
+        { be_const_key_weak(init, -1), be_const_closure(class_EventManager_init_closure) },
+        { be_const_key_weak(trigger_event, -1), be_const_closure(class_EventManager_trigger_event_closure) },
+        { be_const_key_weak(get_handlers, 3), be_const_closure(class_EventManager_get_handlers_closure) },
+        { be_const_key_weak(clear_all_handlers, -1), be_const_closure(class_EventManager_clear_all_handlers_closure) },
+        { be_const_key_weak(event_queue, -1), be_const_var(2) },
+        { be_const_key_weak(_sort_handlers, -1), be_const_closure(class_EventManager__sort_handlers_closure) },
+        { be_const_key_weak(is_processing, 7), be_const_var(3) },
+        { be_const_key_weak(global_handlers, -1), be_const_var(1) },
+        { be_const_key_weak(register_handler, -1), be_const_closure(class_EventManager_register_handler_closure) },
+        { be_const_key_weak(get_registered_events, 4), be_const_closure(class_EventManager_get_registered_events_closure) },
+        { be_const_key_weak(_process_queued_events, -1), be_const_closure(class_EventManager__process_queued_events_closure) },
+    })),
+    be_str_weak(EventManager)
+);
+// compact class 'CompositeColorProvider' ktab size: 15, total: 25 (saved 80 bytes)
+static const bvalue be_ktab_class_CompositeColorProvider[15] = {
+  /* K0   */  be_nested_str_weak(providers),
+  /* K1   */  be_nested_str_weak(push),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_nested_str_weak(get_color_for_value),
+  /* K5   */  be_nested_str_weak(_blend_colors),
+  /* K6   */  be_nested_str_weak(produce_value),
+  /* K7   */  be_nested_str_weak(CompositeColorProvider_X28providers_X3D_X25s_X2C_X20blend_mode_X3D_X25s_X29),
+  /* K8   */  be_nested_str_weak(blend_mode),
+  /* K9   */  be_nested_str_weak(CompositeColorProvider_X28uninitialized_X29),
+  /* K10  */  be_const_real_hex(0x437F0000),
+  /* K11  */  be_const_int(2),
+  /* K12  */  be_nested_str_weak(tasmota),
+  /* K13  */  be_nested_str_weak(scale_uint),
+  /* K14  */  be_nested_str_weak(init),
+};
+
+
+extern const bclass be_class_CompositeColorProvider;
+
+/********************************************************************
+** Solidified function: add_provider
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_add_provider,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(add_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040000,  //  0004  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color_for_value
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_get_color_for_value,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(get_color_for_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x600C000C,  //  0000  GETGBL	R3	G12
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0702,  //  0003  EQ	R3	R3	K2
       0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x540DFFFE,  //  0005  LDINT	R3	-1
       0x80040600,  //  0006  RET	1	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x1C0C0403,  //  0008  EQ	R3	R2	R3
-      0x780E0001,  //  0009  JMPF	R3	#000C
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x88080702,  //  000B  GETMBR	R2	R3	K2
-      0x880C0303,  //  000C  GETMBR	R3	R1	K3
-      0x88100104,  //  000D  GETMBR	R4	R0	K4
-      0x88140105,  //  000E  GETMBR	R5	R0	K5
-      0x88180106,  //  000F  GETMBR	R6	R0	K6
-      0x881C0107,  //  0010  GETMBR	R7	R0	K7
-      0x88200108,  //  0011  GETMBR	R8	R0	K8
-      0x88240109,  //  0012  GETMBR	R9	R0	K9
-      0x60280009,  //  0013  GETGBL	R10	G9
-      0x002C0C07,  //  0014  ADD	R11	R6	R7
-      0x7C280200,  //  0015  CALL	R10	1
-      0x202C090A,  //  0016  NE	R11	R4	K10
-      0x782E0002,  //  0017  JMPF	R11	#001B
-      0x8C2C030B,  //  0018  GETMET	R11	R1	K11
-      0x5C340800,  //  0019  MOVE	R13	R4
-      0x7C2C0400,  //  001A  CALL	R11	2
-      0x182C150C,  //  001B  LE	R11	R10	K12
-      0x782E0000,  //  001C  JMPF	R11	#001E
-      0x5828000D,  //  001D  LDCONST	R10	K13
-      0x1C2C110C,  //  001E  EQ	R11	R8	K12
-      0x782E0001,  //  001F  JMPF	R11	#0022
-      0x502C0200,  //  0020  LDBOOL	R11	1	0
-      0x80041600,  //  0021  RET	1	R11
-      0x142C110C,  //  0022  LT	R11	R8	K12
-      0x782E0006,  //  0023  JMPF	R11	#002B
-      0x002C0A06,  //  0024  ADD	R11	R5	R6
-      0x042C170D,  //  0025  SUB	R11	R11	K13
-      0x102C160A,  //  0026  MOD	R11	R11	R10
-      0x042C1606,  //  0027  SUB	R11	R11	R6
-      0x002C170D,  //  0028  ADD	R11	R11	K13
-      0x5C141600,  //  0029  MOVE	R5	R11
-      0x70020007,  //  002A  JMP		#0033
-      0x442C1400,  //  002B  NEG	R11	R10
-      0x142C0A0B,  //  002C  LT	R11	R5	R11
-      0x782E0004,  //  002D  JMPF	R11	#0033
-      0x202C110C,  //  002E  NE	R11	R8	K12
-      0x782E0002,  //  002F  JMPF	R11	#0033
-      0x00140A0A,  //  0030  ADD	R5	R5	R10
-      0x0420110D,  //  0031  SUB	R8	R8	K13
-      0x7001FFF7,  //  0032  JMP		#002B
-      0x142C0A03,  //  0033  LT	R11	R5	R3
-      0x782E0014,  //  0034  JMPF	R11	#004A
-      0x202C110C,  //  0035  NE	R11	R8	K12
-      0x782E0012,  //  0036  JMPF	R11	#004A
-      0x582C000C,  //  0037  LDCONST	R11	K12
-      0x14300B0C,  //  0038  LT	R12	R5	K12
-      0x78320001,  //  0039  JMPF	R12	#003C
-      0x44300A00,  //  003A  NEG	R12	R5
-      0x5C2C1800,  //  003B  MOVE	R11	R12
-      0x14301606,  //  003C  LT	R12	R11	R6
-      0x78320008,  //  003D  JMPF	R12	#0047
-      0x00300A0B,  //  003E  ADD	R12	R5	R11
-      0x14301803,  //  003F  LT	R12	R12	R3
-      0x78320005,  //  0040  JMPF	R12	#0047
-      0x8C30030E,  //  0041  GETMET	R12	R1	K14
-      0x00380A0B,  //  0042  ADD	R14	R5	R11
-      0x5C3C1200,  //  0043  MOVE	R15	R9
-      0x7C300600,  //  0044  CALL	R12	3
-      0x002C170D,  //  0045  ADD	R11	R11	K13
-      0x7001FFF4,  //  0046  JMP		#003C
-      0x00140A0A,  //  0047  ADD	R5	R5	R10
-      0x0420110D,  //  0048  SUB	R8	R8	K13
-      0x7001FFE8,  //  0049  JMP		#0033
-      0x502C0200,  //  004A  LDBOOL	R11	1	0
-      0x80041600,  //  004B  RET	1	R11
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x1C0C0703,  //  000A  EQ	R3	R3	K3
+      0x780E0006,  //  000B  JMPF	R3	#0013
+      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x940C0702,  //  000D  GETIDX	R3	R3	K2
+      0x8C0C0704,  //  000E  GETMET	R3	R3	K4
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0100,  //  0013  GETMBR	R3	R0	K0
+      0x940C0702,  //  0014  GETIDX	R3	R3	K2
+      0x8C0C0704,  //  0015  GETMET	R3	R3	K4
+      0x5C140200,  //  0016  MOVE	R5	R1
+      0x5C180400,  //  0017  MOVE	R6	R2
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x58100003,  //  0019  LDCONST	R4	K3
+      0x6014000C,  //  001A  GETGBL	R5	G12
+      0x88180100,  //  001B  GETMBR	R6	R0	K0
+      0x7C140200,  //  001C  CALL	R5	1
+      0x14140805,  //  001D  LT	R5	R4	R5
+      0x7816000C,  //  001E  JMPF	R5	#002C
+      0x88140100,  //  001F  GETMBR	R5	R0	K0
+      0x94140A04,  //  0020  GETIDX	R5	R5	R4
+      0x8C140B04,  //  0021  GETMET	R5	R5	K4
+      0x5C1C0200,  //  0022  MOVE	R7	R1
+      0x5C200400,  //  0023  MOVE	R8	R2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C180105,  //  0025  GETMET	R6	R0	K5
+      0x5C200600,  //  0026  MOVE	R8	R3
+      0x5C240A00,  //  0027  MOVE	R9	R5
+      0x7C180600,  //  0028  CALL	R6	3
+      0x5C0C0C00,  //  0029  MOVE	R3	R6
+      0x00100903,  //  002A  ADD	R4	R4	K3
+      0x7001FFED,  //  002B  JMP		#001A
+      0x80040600,  //  002C  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x600C000C,  //  0000  GETGBL	R3	G12
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0702,  //  0003  EQ	R3	R3	K2
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x540DFFFE,  //  0005  LDINT	R3	-1
+      0x80040600,  //  0006  RET	1	R3
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x1C0C0703,  //  000A  EQ	R3	R3	K3
+      0x780E0006,  //  000B  JMPF	R3	#0013
+      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x940C0702,  //  000D  GETIDX	R3	R3	K2
+      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0100,  //  0013  GETMBR	R3	R0	K0
+      0x940C0702,  //  0014  GETIDX	R3	R3	K2
+      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
+      0x5C140200,  //  0016  MOVE	R5	R1
+      0x5C180400,  //  0017  MOVE	R6	R2
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x58100003,  //  0019  LDCONST	R4	K3
+      0x6014000C,  //  001A  GETGBL	R5	G12
+      0x88180100,  //  001B  GETMBR	R6	R0	K0
+      0x7C140200,  //  001C  CALL	R5	1
+      0x14140805,  //  001D  LT	R5	R4	R5
+      0x7816000C,  //  001E  JMPF	R5	#002C
+      0x88140100,  //  001F  GETMBR	R5	R0	K0
+      0x94140A04,  //  0020  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0021  GETMET	R5	R5	K6
+      0x5C1C0200,  //  0022  MOVE	R7	R1
+      0x5C200400,  //  0023  MOVE	R8	R2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C180105,  //  0025  GETMET	R6	R0	K5
+      0x5C200600,  //  0026  MOVE	R8	R3
+      0x5C240A00,  //  0027  MOVE	R9	R5
+      0x7C180600,  //  0028  CALL	R6	3
+      0x5C0C0C00,  //  0029  MOVE	R3	R6
+      0x00100903,  //  002A  ADD	R4	R4	K3
+      0x7001FFED,  //  002B  JMP		#001A
+      0x80040600,  //  002C  RET	1	R3
     })
   )
 );
@@ -18160,9 +13245,9 @@ be_local_closure(class_CrenelPositionAnimation_render,   /* name */
 /********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
-be_local_closure(class_CrenelPositionAnimation_tostring,   /* name */
+be_local_closure(class_CompositeColorProvider_tostring,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -18170,40 +13255,28 @@ be_local_closure(class_CrenelPositionAnimation_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_CrenelPositionAnimation,     /* shared constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x8C08010F,  //  0001  GETMET	R2	R0	K15
-      0x58100009,  //  0002  LDCONST	R4	K9
-      0x7C080400,  //  0003  CALL	R2	2
-      0xB80E2000,  //  0004  GETNGBL	R3	K16
-      0x8C0C0711,  //  0005  GETMET	R3	R3	K17
-      0x5C140400,  //  0006  MOVE	R5	R2
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x600C0008,  //  0009  GETGBL	R3	G8
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x5C040600,  //  000C  MOVE	R1	R3
-      0x70020004,  //  000D  JMP		#0013
-      0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100012,  //  000F  LDCONST	R4	K18
-      0x88140109,  //  0010  GETMBR	R5	R0	K9
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x5C040600,  //  0012  MOVE	R1	R3
-      0x600C0018,  //  0013  GETGBL	R3	G24
-      0x58100013,  //  0014  LDCONST	R4	K19
-      0x5C140200,  //  0015  MOVE	R5	R1
-      0x88180105,  //  0016  GETMBR	R6	R0	K5
-      0x881C0106,  //  0017  GETMBR	R7	R0	K6
-      0x88200107,  //  0018  GETMBR	R8	R0	K7
-      0x88240108,  //  0019  GETMBR	R9	R0	K8
-      0x88280114,  //  001A  GETMBR	R10	R0	K20
-      0x882C0100,  //  001B  GETMBR	R11	R0	K0
-      0x7C0C1000,  //  001C  CALL	R3	8
-      0x80040600,  //  001D  RET	1	R3
+    ( &(const binstruction[18]) {  /* code */
+      0xA802000A,  //  0000  EXBLK	0	#000C
+      0x60040018,  //  0001  GETGBL	R1	G24
+      0x58080007,  //  0002  LDCONST	R2	K7
+      0x600C000C,  //  0003  GETGBL	R3	G12
+      0x88100100,  //  0004  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x88100108,  //  0006  GETMBR	R4	R0	K8
+      0x7C040600,  //  0007  CALL	R1	3
+      0xA8040001,  //  0008  EXBLK	1	1
+      0x80040200,  //  0009  RET	1	R1
+      0xA8040001,  //  000A  EXBLK	1	1
+      0x70020004,  //  000B  JMP		#0011
+      0xAC040000,  //  000C  CATCH	R1	0	0
+      0x70020001,  //  000D  JMP		#0010
+      0x80061200,  //  000E  RET	1	K9
+      0x70020000,  //  000F  JMP		#0011
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -18211,90 +13284,173 @@ be_local_closure(class_CrenelPositionAnimation_tostring,   /* name */
 
 
 /********************************************************************
-** Solidified class: CrenelPositionAnimation
+** Solidified function: _blend_colors
 ********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(CrenelPositionAnimation,
-    0,
-    &be_class_Animation,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(6,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(nb_pulse, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(pulse_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(back_color, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
-        { be_const_key_weak(low_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(3) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(render, 2), be_const_closure(class_CrenelPositionAnimation_render_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_CrenelPositionAnimation_tostring_closure) },
-    })),
-    be_str_weak(CrenelPositionAnimation)
-);
-
-/********************************************************************
-** Solidified function: plasma_rainbow
-********************************************************************/
-be_local_closure(plasma_rainbow,   /* name */
+be_local_closure(class_CompositeColorProvider__blend_colors,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
+    23,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(plasma_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(time_speed),
-    /* K4   */  be_nested_str_weak(name),
-    /* K5   */  be_nested_str_weak(plasma_rainbow),
-    }),
-    be_str_weak(plasma_rainbow),
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(_blend_colors),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0031,  //  0006  LDINT	R2	50
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x90060905,  //  0008  SETMBR	R1	K4	K5
-      0x80040200,  //  0009  RET	1	R1
+    ( &(const binstruction[151]) {  /* code */
+      0x880C0108,  //  0000  GETMBR	R3	R0	K8
+      0x54120017,  //  0001  LDINT	R4	24
+      0x3C100204,  //  0002  SHR	R4	R1	R4
+      0x541600FE,  //  0003  LDINT	R5	255
+      0x2C100805,  //  0004  AND	R4	R4	R5
+      0x5416000F,  //  0005  LDINT	R5	16
+      0x3C140205,  //  0006  SHR	R5	R1	R5
+      0x541A00FE,  //  0007  LDINT	R6	255
+      0x2C140A06,  //  0008  AND	R5	R5	R6
+      0x541A0007,  //  0009  LDINT	R6	8
+      0x3C180206,  //  000A  SHR	R6	R1	R6
+      0x541E00FE,  //  000B  LDINT	R7	255
+      0x2C180C07,  //  000C  AND	R6	R6	R7
+      0x541E00FE,  //  000D  LDINT	R7	255
+      0x2C1C0207,  //  000E  AND	R7	R1	R7
+      0x54220017,  //  000F  LDINT	R8	24
+      0x3C200408,  //  0010  SHR	R8	R2	R8
+      0x542600FE,  //  0011  LDINT	R9	255
+      0x2C201009,  //  0012  AND	R8	R8	R9
+      0x5426000F,  //  0013  LDINT	R9	16
+      0x3C240409,  //  0014  SHR	R9	R2	R9
+      0x542A00FE,  //  0015  LDINT	R10	255
+      0x2C24120A,  //  0016  AND	R9	R9	R10
+      0x542A0007,  //  0017  LDINT	R10	8
+      0x3C28040A,  //  0018  SHR	R10	R2	R10
+      0x542E00FE,  //  0019  LDINT	R11	255
+      0x2C28140B,  //  001A  AND	R10	R10	R11
+      0x542E00FE,  //  001B  LDINT	R11	255
+      0x2C2C040B,  //  001C  AND	R11	R2	R11
+      0x4C300000,  //  001D  LDNIL	R12
+      0x4C340000,  //  001E  LDNIL	R13
+      0x4C380000,  //  001F  LDNIL	R14
+      0x4C3C0000,  //  0020  LDNIL	R15
+      0x1C400702,  //  0021  EQ	R16	R3	K2
+      0x7842001C,  //  0022  JMPF	R16	#0040
+      0x0C40110A,  //  0023  DIV	R16	R8	K10
+      0x60440009,  //  0024  GETGBL	R17	G9
+      0x044A0610,  //  0025  SUB	R18	K3	R16
+      0x08480E12,  //  0026  MUL	R18	R7	R18
+      0x084C1610,  //  0027  MUL	R19	R11	R16
+      0x00482413,  //  0028  ADD	R18	R18	R19
+      0x7C440200,  //  0029  CALL	R17	1
+      0x5C342200,  //  002A  MOVE	R13	R17
+      0x60440009,  //  002B  GETGBL	R17	G9
+      0x044A0610,  //  002C  SUB	R18	K3	R16
+      0x08480C12,  //  002D  MUL	R18	R6	R18
+      0x084C1410,  //  002E  MUL	R19	R10	R16
+      0x00482413,  //  002F  ADD	R18	R18	R19
+      0x7C440200,  //  0030  CALL	R17	1
+      0x5C382200,  //  0031  MOVE	R14	R17
+      0x60440009,  //  0032  GETGBL	R17	G9
+      0x044A0610,  //  0033  SUB	R18	K3	R16
+      0x08480A12,  //  0034  MUL	R18	R5	R18
+      0x084C1210,  //  0035  MUL	R19	R9	R16
+      0x00482413,  //  0036  ADD	R18	R18	R19
+      0x7C440200,  //  0037  CALL	R17	1
+      0x5C3C2200,  //  0038  MOVE	R15	R17
+      0x24440808,  //  0039  GT	R17	R4	R8
+      0x78460001,  //  003A  JMPF	R17	#003D
+      0x5C440800,  //  003B  MOVE	R17	R4
+      0x70020000,  //  003C  JMP		#003E
+      0x5C441000,  //  003D  MOVE	R17	R8
+      0x5C302200,  //  003E  MOVE	R12	R17
+      0x7002004C,  //  003F  JMP		#008D
+      0x1C400703,  //  0040  EQ	R16	R3	K3
+      0x78420021,  //  0041  JMPF	R16	#0064
+      0x00400E0B,  //  0042  ADD	R16	R7	R11
+      0x5C342000,  //  0043  MOVE	R13	R16
+      0x00400C0A,  //  0044  ADD	R16	R6	R10
+      0x5C382000,  //  0045  MOVE	R14	R16
+      0x00400A09,  //  0046  ADD	R16	R5	R9
+      0x5C3C2000,  //  0047  MOVE	R15	R16
+      0x24400808,  //  0048  GT	R16	R4	R8
+      0x78420001,  //  0049  JMPF	R16	#004C
+      0x5C400800,  //  004A  MOVE	R16	R4
+      0x70020000,  //  004B  JMP		#004D
+      0x5C401000,  //  004C  MOVE	R16	R8
+      0x5C302000,  //  004D  MOVE	R12	R16
+      0x544200FE,  //  004E  LDINT	R16	255
+      0x24401A10,  //  004F  GT	R16	R13	R16
+      0x78420001,  //  0050  JMPF	R16	#0053
+      0x544200FE,  //  0051  LDINT	R16	255
+      0x70020000,  //  0052  JMP		#0054
+      0x5C401A00,  //  0053  MOVE	R16	R13
+      0x5C342000,  //  0054  MOVE	R13	R16
+      0x544200FE,  //  0055  LDINT	R16	255
+      0x24401C10,  //  0056  GT	R16	R14	R16
+      0x78420001,  //  0057  JMPF	R16	#005A
+      0x544200FE,  //  0058  LDINT	R16	255
+      0x70020000,  //  0059  JMP		#005B
+      0x5C401C00,  //  005A  MOVE	R16	R14
+      0x5C382000,  //  005B  MOVE	R14	R16
+      0x544200FE,  //  005C  LDINT	R16	255
+      0x24401E10,  //  005D  GT	R16	R15	R16
+      0x78420001,  //  005E  JMPF	R16	#0061
+      0x544200FE,  //  005F  LDINT	R16	255
+      0x70020000,  //  0060  JMP		#0062
+      0x5C401E00,  //  0061  MOVE	R16	R15
+      0x5C3C2000,  //  0062  MOVE	R15	R16
+      0x70020028,  //  0063  JMP		#008D
+      0x1C40070B,  //  0064  EQ	R16	R3	K11
+      0x78420026,  //  0065  JMPF	R16	#008D
+      0xB8421800,  //  0066  GETNGBL	R16	K12
+      0x8C40210D,  //  0067  GETMET	R16	R16	K13
+      0x08480E0B,  //  0068  MUL	R18	R7	R11
+      0x584C0002,  //  0069  LDCONST	R19	K2
+      0x545200FE,  //  006A  LDINT	R20	255
+      0x545600FE,  //  006B  LDINT	R21	255
+      0x08502815,  //  006C  MUL	R20	R20	R21
+      0x58540002,  //  006D  LDCONST	R21	K2
+      0x545A00FE,  //  006E  LDINT	R22	255
+      0x7C400C00,  //  006F  CALL	R16	6
+      0x5C342000,  //  0070  MOVE	R13	R16
+      0xB8421800,  //  0071  GETNGBL	R16	K12
+      0x8C40210D,  //  0072  GETMET	R16	R16	K13
+      0x08480C0A,  //  0073  MUL	R18	R6	R10
+      0x584C0002,  //  0074  LDCONST	R19	K2
+      0x545200FE,  //  0075  LDINT	R20	255
+      0x545600FE,  //  0076  LDINT	R21	255
+      0x08502815,  //  0077  MUL	R20	R20	R21
+      0x58540002,  //  0078  LDCONST	R21	K2
+      0x545A00FE,  //  0079  LDINT	R22	255
+      0x7C400C00,  //  007A  CALL	R16	6
+      0x5C382000,  //  007B  MOVE	R14	R16
+      0xB8421800,  //  007C  GETNGBL	R16	K12
+      0x8C40210D,  //  007D  GETMET	R16	R16	K13
+      0x08480A09,  //  007E  MUL	R18	R5	R9
+      0x584C0002,  //  007F  LDCONST	R19	K2
+      0x545200FE,  //  0080  LDINT	R20	255
+      0x545600FE,  //  0081  LDINT	R21	255
+      0x08502815,  //  0082  MUL	R20	R20	R21
+      0x58540002,  //  0083  LDCONST	R21	K2
+      0x545A00FE,  //  0084  LDINT	R22	255
+      0x7C400C00,  //  0085  CALL	R16	6
+      0x5C3C2000,  //  0086  MOVE	R15	R16
+      0x24400808,  //  0087  GT	R16	R4	R8
+      0x78420001,  //  0088  JMPF	R16	#008B
+      0x5C400800,  //  0089  MOVE	R16	R4
+      0x70020000,  //  008A  JMP		#008C
+      0x5C401000,  //  008B  MOVE	R16	R8
+      0x5C302000,  //  008C  MOVE	R12	R16
+      0x54420017,  //  008D  LDINT	R16	24
+      0x38401810,  //  008E  SHL	R16	R12	R16
+      0x5446000F,  //  008F  LDINT	R17	16
+      0x38441E11,  //  0090  SHL	R17	R15	R17
+      0x30402011,  //  0091  OR	R16	R16	R17
+      0x54460007,  //  0092  LDINT	R17	8
+      0x38441C11,  //  0093  SHL	R17	R14	R17
+      0x30402011,  //  0094  OR	R16	R16	R17
+      0x3040200D,  //  0095  OR	R16	R16	R13
+      0x80042000,  //  0096  RET	1	R16
     })
   )
 );
@@ -18302,81 +13458,1651 @@ be_local_closure(plasma_rainbow,   /* name */
 
 
 /********************************************************************
-** Solidified function: animation_init
+** Solidified function: init
 ********************************************************************/
-be_local_closure(animation_init,   /* name */
+be_local_closure(class_CompositeColorProvider_init,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        7,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(animation),
-        /* K1   */  be_nested_str_weak(introspect),
-        /* K2   */  be_nested_str_weak(contains),
-        /* K3   */  be_nested_str_weak(_ntv),
-        /* K4   */  be_nested_str_weak(undefined),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[16]) {  /* code */
-          0xA4060000,  //  0000  IMPORT	R1	K0
-          0xA40A0200,  //  0001  IMPORT	R2	K1
-          0x8C0C0502,  //  0002  GETMET	R3	R2	K2
-          0x88140303,  //  0003  GETMBR	R5	R1	K3
-          0x5C180000,  //  0004  MOVE	R6	R0
-          0x7C0C0600,  //  0005  CALL	R3	3
-          0x780E0003,  //  0006  JMPF	R3	#000B
-          0x880C0303,  //  0007  GETMBR	R3	R1	K3
-          0x880C0600,  //  0008  GETMBR	R3	R3	R0
-          0x80040600,  //  0009  RET	1	R3
-          0x70020003,  //  000A  JMP		#000F
-          0x600C000B,  //  000B  GETGBL	R3	G11
-          0x58100004,  //  000C  LDCONST	R4	K4
-          0x7C0C0200,  //  000D  CALL	R3	1
-          0x80040600,  //  000E  RET	1	R3
-          0x80000000,  //  000F  RET	0
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(_ntv),
-    /* K2   */  be_nested_str_weak(event_manager),
-    /* K3   */  be_nested_str_weak(EventManager),
-    /* K4   */  be_nested_str_weak(member),
-    }),
-    be_str_weak(animation_init),
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[10]) {  /* code */
-      0x6004000B,  //  0000  GETGBL	R1	G11
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x90060200,  //  0003  SETMBR	R1	K1	R0
-      0x8C080103,  //  0004  GETMET	R2	R0	K3
-      0x7C080200,  //  0005  CALL	R2	1
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x84080000,  //  0007  CLOSURE	R2	P0
-      0x90060802,  //  0008  SETMBR	R1	K4	R2
-      0x80040200,  //  0009  RET	1	R1
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08050E,  //  0003  GETMET	R2	R2	K14
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90020002,  //  0008  SETMBR	R0	K0	R2
+      0x80000000,  //  0009  RET	0
     })
   )
 );
 /*******************************************************************/
 
+
+/********************************************************************
+** Solidified class: CompositeColorProvider
+********************************************************************/
+extern const bclass be_class_ColorProvider;
+be_local_class(CompositeColorProvider,
+    1,
+    &be_class_ColorProvider,
+    be_nested_map(8,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(add_provider, -1), be_const_closure(class_CompositeColorProvider_add_provider_closure) },
+        { be_const_key_weak(get_color_for_value, 7), be_const_closure(class_CompositeColorProvider_get_color_for_value_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_CompositeColorProvider_init_closure) },
+        { be_const_key_weak(PARAMS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(blend_mode, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+    }))    ) } )) },
+        { be_const_key_weak(default, -1), be_const_int(0) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_CompositeColorProvider_tostring_closure) },
+        { be_const_key_weak(providers, 4), be_const_var(0) },
+        { be_const_key_weak(_blend_colors, -1), be_const_closure(class_CompositeColorProvider__blend_colors_closure) },
+        { be_const_key_weak(produce_value, -1), be_const_closure(class_CompositeColorProvider_produce_value_closure) },
+    })),
+    be_str_weak(CompositeColorProvider)
+);
+// compact class 'AnimationEngine' ktab size: 47, total: 131 (saved 672 bytes)
+static const bvalue be_ktab_class_AnimationEngine[47] = {
+  /* K0   */  be_nested_str_weak(animations),
+  /* K1   */  be_nested_str_weak(is_running),
+  /* K2   */  be_nested_str_weak(stop),
+  /* K3   */  be_nested_str_weak(stop_iteration),
+  /* K4   */  be_nested_str_weak(strip),
+  /* K5   */  be_nested_str_weak(clear),
+  /* K6   */  be_nested_str_weak(show),
+  /* K7   */  be_const_int(1),
+  /* K8   */  be_const_int(0),
+  /* K9   */  be_nested_str_weak(priority),
+  /* K10  */  be_nested_str_weak(sequence_managers),
+  /* K11  */  be_nested_str_weak(remove),
+  /* K12  */  be_nested_str_weak(animation),
+  /* K13  */  be_nested_str_weak(event_manager),
+  /* K14  */  be_nested_str_weak(_process_queued_events),
+  /* K15  */  be_nested_str_weak(value_error),
+  /* K16  */  be_nested_str_weak(strip_X20cannot_X20be_X20nil),
+  /* K17  */  be_nested_str_weak(width),
+  /* K18  */  be_nested_str_weak(length),
+  /* K19  */  be_nested_str_weak(frame_buffer),
+  /* K20  */  be_nested_str_weak(temp_buffer),
+  /* K21  */  be_nested_str_weak(last_update),
+  /* K22  */  be_nested_str_weak(time_ms),
+  /* K23  */  be_nested_str_weak(fast_loop_closure),
+  /* K24  */  be_nested_str_weak(render_needed),
+  /* K25  */  be_nested_str_weak(set_pixel_color),
+  /* K26  */  be_nested_str_weak(get_pixel_color),
+  /* K27  */  be_nested_str_weak(tasmota),
+  /* K28  */  be_nested_str_weak(remove_fast_loop),
+  /* K29  */  be_nested_str_weak(start),
+  /* K30  */  be_nested_str_weak(millis),
+  /* K31  */  be_nested_str_weak(add_fast_loop),
+  /* K32  */  be_nested_str_weak(can_show),
+  /* K33  */  be_nested_str_weak(update),
+  /* K34  */  be_nested_str_weak(_process_events),
+  /* K35  */  be_nested_str_weak(_update_and_render),
+  /* K36  */  be_nested_str_weak(push),
+  /* K37  */  be_nested_str_weak(_sort_animations),
+  /* K38  */  be_nested_str_weak(resume),
+  /* K39  */  be_nested_str_weak(AnimationEngine_X28running_X3D_X25s_X2C_X20animations_X3D_X25s_X2C_X20width_X3D_X25s_X29),
+  /* K40  */  be_nested_str_weak(stop_sequence),
+  /* K41  */  be_nested_str_weak(_clear_strip),
+  /* K42  */  be_nested_str_weak(_render_animations),
+  /* K43  */  be_nested_str_weak(render),
+  /* K44  */  be_nested_str_weak(blend_pixels),
+  /* K45  */  be_nested_str_weak(_output_to_strip),
+  /* K46  */  be_nested_str_weak(name),
+};
+
+
+extern const bclass be_class_AnimationEngine;
+
+/********************************************************************
+** Solidified function: interrupt_current
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_current,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_current),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0xA8020006,  //  0003  EXBLK	0	#000B
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x7C080000,  //  0005  CALL	R2	0
+      0x880C0501,  //  0006  GETMBR	R3	R2	K1
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7001FFF8,  //  000A  JMP		#0004
+      0x58040003,  //  000B  LDCONST	R1	K3
+      0xAC040200,  //  000C  CATCH	R1	1	0
+      0xB0080000,  //  000D  RAISE	2	R0	R0
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _clear_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine__clear_strip,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_clear_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x8C040305,  //  0001  GETMET	R1	R1	K5
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040104,  //  0003  GETMBR	R1	R0	K4
+      0x8C040306,  //  0004  GETMET	R1	R1	K6
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_animations,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _sort_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine__sort_animations,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_sort_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x18080307,  //  0003  LE	R2	R1	K7
+      0x780A0000,  //  0004  JMPF	R2	#0006
+      0x80000400,  //  0005  RET	0
+      0x58080007,  //  0006  LDCONST	R2	K7
+      0x140C0401,  //  0007  LT	R3	R2	R1
+      0x780E0016,  //  0008  JMPF	R3	#0020
+      0x880C0100,  //  0009  GETMBR	R3	R0	K0
+      0x940C0602,  //  000A  GETIDX	R3	R3	R2
+      0x5C100400,  //  000B  MOVE	R4	R2
+      0x24140908,  //  000C  GT	R5	R4	K8
+      0x7816000D,  //  000D  JMPF	R5	#001C
+      0x04140907,  //  000E  SUB	R5	R4	K7
+      0x88180100,  //  000F  GETMBR	R6	R0	K0
+      0x94140C05,  //  0010  GETIDX	R5	R6	R5
+      0x88140B09,  //  0011  GETMBR	R5	R5	K9
+      0x88180709,  //  0012  GETMBR	R6	R3	K9
+      0x14140A06,  //  0013  LT	R5	R5	R6
+      0x78160006,  //  0014  JMPF	R5	#001C
+      0x88140100,  //  0015  GETMBR	R5	R0	K0
+      0x04180907,  //  0016  SUB	R6	R4	K7
+      0x881C0100,  //  0017  GETMBR	R7	R0	K0
+      0x94180E06,  //  0018  GETIDX	R6	R7	R6
+      0x98140806,  //  0019  SETIDX	R5	R4	R6
+      0x04100907,  //  001A  SUB	R4	R4	K7
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x88140100,  //  001C  GETMBR	R5	R0	K0
+      0x98140803,  //  001D  SETIDX	R5	R4	R3
+      0x00080507,  //  001E  ADD	R2	R2	K7
+      0x7001FFE6,  //  001F  JMP		#0007
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_sequence_manager
+********************************************************************/
+be_local_closure(class_AnimationEngine_remove_sequence_manager,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(remove_sequence_manager),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x5409FFFE,  //  0000  LDINT	R2	-1
+      0x580C0008,  //  0001  LDCONST	R3	K8
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x8814010A,  //  0003  GETMBR	R5	R0	K10
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x8810010A,  //  0007  GETMBR	R4	R0	K10
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0707,  //  000D  ADD	R3	R3	K7
+      0x7001FFF2,  //  000E  JMP		#0002
+      0x28100508,  //  000F  GE	R4	R2	K8
+      0x78120005,  //  0010  JMPF	R4	#0017
+      0x8810010A,  //  0011  GETMBR	R4	R0	K10
+      0x8C10090B,  //  0012  GETMET	R4	R4	K11
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x50100200,  //  0015  LDBOOL	R4	1	0
+      0x80040800,  //  0016  RET	1	R4
+      0x50100000,  //  0017  LDBOOL	R4	0	0
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_active
+********************************************************************/
+be_local_closure(class_AnimationEngine_is_active,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(is_active),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _process_events
+********************************************************************/
+be_local_closure(class_AnimationEngine__process_events,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_process_events),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB80A1800,  //  0000  GETNGBL	R2	K12
+      0x8808050D,  //  0001  GETMBR	R2	R2	K13
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0xB80A1800,  //  0005  GETNGBL	R2	K12
+      0x8808050D,  //  0006  GETMBR	R2	R2	K13
+      0x8C08050E,  //  0007  GETMET	R2	R2	K14
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_AnimationEngine_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0xB0061F10,  //  0003  RAISE	1	K15	K16
+      0x90020801,  //  0004  SETMBR	R0	K4	R1
+      0x8C080312,  //  0005  GETMET	R2	R1	K18
+      0x7C080200,  //  0006  CALL	R2	1
+      0x90022202,  //  0007  SETMBR	R0	K17	R2
+      0x60080012,  //  0008  GETGBL	R2	G18
+      0x7C080000,  //  0009  CALL	R2	0
+      0x90020002,  //  000A  SETMBR	R0	K0	R2
+      0x60080012,  //  000B  GETGBL	R2	G18
+      0x7C080000,  //  000C  CALL	R2	0
+      0x90021402,  //  000D  SETMBR	R0	K10	R2
+      0xB80A1800,  //  000E  GETNGBL	R2	K12
+      0x8C080513,  //  000F  GETMET	R2	R2	K19
+      0x88100111,  //  0010  GETMBR	R4	R0	K17
+      0x7C080400,  //  0011  CALL	R2	2
+      0x90022602,  //  0012  SETMBR	R0	K19	R2
+      0xB80A1800,  //  0013  GETNGBL	R2	K12
+      0x8C080513,  //  0014  GETMET	R2	R2	K19
+      0x88100111,  //  0015  GETMBR	R4	R0	K17
+      0x7C080400,  //  0016  CALL	R2	2
+      0x90022802,  //  0017  SETMBR	R0	K20	R2
+      0x50080000,  //  0018  LDBOOL	R2	0	0
+      0x90020202,  //  0019  SETMBR	R0	K1	R2
+      0x90022B08,  //  001A  SETMBR	R0	K21	K8
+      0x90022D08,  //  001B  SETMBR	R0	K22	K8
+      0x4C080000,  //  001C  LDNIL	R2
+      0x90022E02,  //  001D  SETMBR	R0	K23	R2
+      0x50080000,  //  001E  LDBOOL	R2	0	0
+      0x90023002,  //  001F  SETMBR	R0	K24	R2
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _output_to_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine__output_to_strip,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_output_to_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x58040008,  //  0000  LDCONST	R1	K8
+      0x88080111,  //  0001  GETMBR	R2	R0	K17
+      0x14080202,  //  0002  LT	R2	R1	R2
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080104,  //  0004  GETMBR	R2	R0	K4
+      0x8C080519,  //  0005  GETMET	R2	R2	K25
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x88140113,  //  0007  GETMBR	R5	R0	K19
+      0x8C140B1A,  //  0008  GETMET	R5	R5	K26
+      0x5C1C0200,  //  0009  MOVE	R7	R1
+      0x7C140400,  //  000A  CALL	R5	2
+      0x7C080600,  //  000B  CALL	R2	3
+      0x00040307,  //  000C  ADD	R1	R1	K7
+      0x7001FFF2,  //  000D  JMP		#0001
+      0x88080104,  //  000E  GETMBR	R2	R0	K4
+      0x8C080506,  //  000F  GETMET	R2	R2	K6
+      0x7C080200,  //  0010  CALL	R2	1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_AnimationEngine_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x78060009,  //  0001  JMPF	R1	#000C
+      0x50040000,  //  0002  LDBOOL	R1	0	0
+      0x90020201,  //  0003  SETMBR	R0	K1	R1
+      0x88040117,  //  0004  GETMBR	R1	R0	K23
+      0x4C080000,  //  0005  LDNIL	R2
+      0x20040202,  //  0006  NE	R1	R1	R2
+      0x78060003,  //  0007  JMPF	R1	#000C
+      0xB8063600,  //  0008  GETNGBL	R1	K27
+      0x8C04031C,  //  0009  GETMET	R1	R1	K28
+      0x880C0117,  //  000A  GETMBR	R3	R0	K23
+      0x7C040400,  //  000B  CALL	R1	2
+      0x80040000,  //  000C  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: size
+********************************************************************/
+be_local_closure(class_AnimationEngine_size,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(size),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resume
+********************************************************************/
+be_local_closure(class_AnimationEngine_resume,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(resume),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x74060001,  //  0001  JMPT	R1	#0004
+      0x8C04011D,  //  0002  GETMET	R1	R0	K29
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_AnimationEngine_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(on_tick),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x74060021,  //  0001  JMPT	R1	#0024
+      0x50040200,  //  0002  LDBOOL	R1	1	0
+      0x90020201,  //  0003  SETMBR	R0	K1	R1
+      0xB8063600,  //  0004  GETNGBL	R1	K27
+      0x8C04031E,  //  0005  GETMET	R1	R1	K30
+      0x7C040200,  //  0006  CALL	R1	1
+      0x540A0009,  //  0007  LDINT	R2	10
+      0x04040202,  //  0008  SUB	R1	R1	R2
+      0x90022A01,  //  0009  SETMBR	R0	K21	R1
+      0x88040117,  //  000A  GETMBR	R1	R0	K23
+      0x4C080000,  //  000B  LDNIL	R2
+      0x1C040202,  //  000C  EQ	R1	R1	R2
+      0x78060001,  //  000D  JMPF	R1	#0010
+      0x84040000,  //  000E  CLOSURE	R1	P0
+      0x90022E01,  //  000F  SETMBR	R0	K23	R1
+      0x58040008,  //  0010  LDCONST	R1	K8
+      0xB80A3600,  //  0011  GETNGBL	R2	K27
+      0x8C08051E,  //  0012  GETMET	R2	R2	K30
+      0x7C080200,  //  0013  CALL	R2	1
+      0x600C000C,  //  0014  GETGBL	R3	G12
+      0x88100100,  //  0015  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0x140C0203,  //  0017  LT	R3	R1	R3
+      0x780E0006,  //  0018  JMPF	R3	#0020
+      0x880C0100,  //  0019  GETMBR	R3	R0	K0
+      0x940C0601,  //  001A  GETIDX	R3	R3	R1
+      0x8C0C071D,  //  001B  GETMET	R3	R3	K29
+      0x5C140400,  //  001C  MOVE	R5	R2
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x00040307,  //  001E  ADD	R1	R1	K7
+      0x7001FFF3,  //  001F  JMP		#0014
+      0xB80E3600,  //  0020  GETNGBL	R3	K27
+      0x8C0C071F,  //  0021  GETMET	R3	R3	K31
+      0x88140117,  //  0022  GETMBR	R5	R0	K23
+      0x7C0C0400,  //  0023  CALL	R3	2
+      0xA0000000,  //  0024  CLOSE	R0
+      0x80040000,  //  0025  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_tick
+********************************************************************/
+be_local_closure(class_AnimationEngine_on_tick,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(on_tick),
+    &be_const_str_solidified,
+    ( &(const binstruction[51]) {  /* code */
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x4C080000,  //  0004  LDNIL	R2
+      0x1C080202,  //  0005  EQ	R2	R1	R2
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0xB80A3600,  //  0007  GETNGBL	R2	K27
+      0x8C08051E,  //  0008  GETMET	R2	R2	K30
+      0x7C080200,  //  0009  CALL	R2	1
+      0x5C040400,  //  000A  MOVE	R1	R2
+      0x90022C01,  //  000B  SETMBR	R0	K22	R1
+      0x88080115,  //  000C  GETMBR	R2	R0	K21
+      0x04080202,  //  000D  SUB	R2	R1	R2
+      0x540E0004,  //  000E  LDINT	R3	5
+      0x140C0403,  //  000F  LT	R3	R2	R3
+      0x780E0001,  //  0010  JMPF	R3	#0013
+      0x500C0200,  //  0011  LDBOOL	R3	1	0
+      0x80040600,  //  0012  RET	1	R3
+      0x90022A01,  //  0013  SETMBR	R0	K21	R1
+      0x880C0104,  //  0014  GETMBR	R3	R0	K4
+      0x880C0720,  //  0015  GETMBR	R3	R3	K32
+      0x4C100000,  //  0016  LDNIL	R4
+      0x200C0604,  //  0017  NE	R3	R3	R4
+      0x780E0005,  //  0018  JMPF	R3	#001F
+      0x880C0104,  //  0019  GETMBR	R3	R0	K4
+      0x8C0C0720,  //  001A  GETMET	R3	R3	K32
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0x740E0001,  //  001C  JMPT	R3	#001F
+      0x500C0200,  //  001D  LDBOOL	R3	1	0
+      0x80040600,  //  001E  RET	1	R3
+      0x580C0008,  //  001F  LDCONST	R3	K8
+      0x6010000C,  //  0020  GETGBL	R4	G12
+      0x8814010A,  //  0021  GETMBR	R5	R0	K10
+      0x7C100200,  //  0022  CALL	R4	1
+      0x14100604,  //  0023  LT	R4	R3	R4
+      0x78120005,  //  0024  JMPF	R4	#002B
+      0x8810010A,  //  0025  GETMBR	R4	R0	K10
+      0x94100803,  //  0026  GETIDX	R4	R4	R3
+      0x8C100921,  //  0027  GETMET	R4	R4	K33
+      0x7C100200,  //  0028  CALL	R4	1
+      0x000C0707,  //  0029  ADD	R3	R3	K7
+      0x7001FFF4,  //  002A  JMP		#0020
+      0x8C100122,  //  002B  GETMET	R4	R0	K34
+      0x5C180200,  //  002C  MOVE	R6	R1
+      0x7C100400,  //  002D  CALL	R4	2
+      0x8C100123,  //  002E  GETMET	R4	R0	K35
+      0x5C180200,  //  002F  MOVE	R6	R1
+      0x7C100400,  //  0030  CALL	R4	2
+      0x50100200,  //  0031  LDBOOL	R4	1	0
+      0x80040800,  //  0032  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine_add_animation,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(add_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x58080008,  //  0000  LDCONST	R2	K8
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0007,  //  0005  JMPF	R3	#000E
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x1C0C0601,  //  0008  EQ	R3	R3	R1
+      0x780E0001,  //  0009  JMPF	R3	#000C
+      0x500C0000,  //  000A  LDBOOL	R3	0	0
+      0x80040600,  //  000B  RET	1	R3
+      0x00080507,  //  000C  ADD	R2	R2	K7
+      0x7001FFF2,  //  000D  JMP		#0001
+      0x880C0100,  //  000E  GETMBR	R3	R0	K0
+      0x8C0C0724,  //  000F  GETMET	R3	R3	K36
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8C0C0125,  //  0012  GETMET	R3	R0	K37
+      0x7C0C0200,  //  0013  CALL	R3	1
+      0x880C0101,  //  0014  GETMBR	R3	R0	K1
+      0x780E0001,  //  0015  JMPF	R3	#0018
+      0x8C0C031D,  //  0016  GETMET	R3	R1	K29
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x500C0200,  //  0018  LDBOOL	R3	1	0
+      0x90023003,  //  0019  SETMBR	R0	K24	R3
+      0x500C0200,  //  001A  LDBOOL	R3	1	0
+      0x80040600,  //  001B  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: cleanup
+********************************************************************/
+be_local_closure(class_AnimationEngine_cleanup,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(cleanup),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x8C040102,  //  0000  GETMET	R1	R0	K2
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040105,  //  0002  GETMET	R1	R0	K5
+      0x7C040200,  //  0003  CALL	R1	1
+      0x4C040000,  //  0004  LDNIL	R1
+      0x90022601,  //  0005  SETMBR	R0	K19	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x90022801,  //  0007  SETMBR	R0	K20	R1
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90020801,  //  0009  SETMBR	R0	K4	R1
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resume_after
+********************************************************************/
+be_local_closure(class_AnimationEngine_resume_after,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(resume_after),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C080126,  //  0000  GETMET	R2	R0	K38
+      0x7C080200,  //  0001  CALL	R2	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_AnimationEngine_tostring,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080027,  //  0001  LDCONST	R2	K39
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x7C100200,  //  0005  CALL	R4	1
+      0x88140111,  //  0006  GETMBR	R5	R0	K17
+      0x7C040800,  //  0007  CALL	R1	4
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_AnimationEngine_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(clear),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x58040008,  //  0003  LDCONST	R1	K8
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C010A,  //  0005  GETMBR	R3	R0	K10
+      0x7C080200,  //  0006  CALL	R2	1
+      0x14080202,  //  0007  LT	R2	R1	R2
+      0x780A0005,  //  0008  JMPF	R2	#000F
+      0x8808010A,  //  0009  GETMBR	R2	R0	K10
+      0x94080401,  //  000A  GETIDX	R2	R2	R1
+      0x8C080528,  //  000B  GETMET	R2	R2	K40
+      0x7C080200,  //  000C  CALL	R2	1
+      0x00040307,  //  000D  ADD	R1	R1	K7
+      0x7001FFF4,  //  000E  JMP		#0004
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90021402,  //  0011  SETMBR	R0	K10	R2
+      0x50080200,  //  0012  LDBOOL	R2	1	0
+      0x90023002,  //  0013  SETMBR	R0	K24	R2
+      0x80040000,  //  0014  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_strip_length
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_strip_length,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_strip_length),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040111,  //  0000  GETMBR	R1	R0	K17
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_and_render
+********************************************************************/
+be_local_closure(class_AnimationEngine__update_and_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_update_and_render),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x58080008,  //  0000  LDCONST	R2	K8
+      0x580C0008,  //  0001  LDCONST	R3	K8
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140100,  //  0003  GETMBR	R5	R0	K0
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120011,  //  0006  JMPF	R4	#0019
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x8C140921,  //  0009  GETMET	R5	R4	K33
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x7C140400,  //  000B  CALL	R5	2
+      0x78160004,  //  000C  JMPF	R5	#0012
+      0x88180901,  //  000D  GETMBR	R6	R4	K1
+      0x781A0002,  //  000E  JMPF	R6	#0012
+      0x00080507,  //  000F  ADD	R2	R2	K7
+      0x000C0707,  //  0010  ADD	R3	R3	K7
+      0x70020005,  //  0011  JMP		#0018
+      0x88180100,  //  0012  GETMBR	R6	R0	K0
+      0x8C180D0B,  //  0013  GETMET	R6	R6	K11
+      0x5C200600,  //  0014  MOVE	R8	R3
+      0x7C180400,  //  0015  CALL	R6	2
+      0x50180200,  //  0016  LDBOOL	R6	1	0
+      0x90023006,  //  0017  SETMBR	R0	K24	R6
+      0x7001FFE8,  //  0018  JMP		#0002
+      0x1C100508,  //  0019  EQ	R4	R2	K8
+      0x78120006,  //  001A  JMPF	R4	#0022
+      0x88100118,  //  001B  GETMBR	R4	R0	K24
+      0x78120003,  //  001C  JMPF	R4	#0021
+      0x8C100129,  //  001D  GETMET	R4	R0	K41
+      0x7C100200,  //  001E  CALL	R4	1
+      0x50100000,  //  001F  LDBOOL	R4	0	0
+      0x90023004,  //  0020  SETMBR	R0	K24	R4
+      0x80000800,  //  0021  RET	0
+      0x8C10012A,  //  0022  GETMET	R4	R0	K42
+      0x88180100,  //  0023  GETMBR	R6	R0	K0
+      0x5C1C0200,  //  0024  MOVE	R7	R1
+      0x7C100600,  //  0025  CALL	R4	3
+      0x50100000,  //  0026  LDBOOL	R4	0	0
+      0x90023004,  //  0027  SETMBR	R0	K24	R4
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: interrupt_all
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_all,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_all),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040105,  //  0000  GETMET	R1	R0	K5
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine_remove_animation,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(remove_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x5409FFFE,  //  0000  LDINT	R2	-1
+      0x580C0008,  //  0001  LDCONST	R3	K8
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140100,  //  0003  GETMBR	R5	R0	K0
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0707,  //  000D  ADD	R3	R3	K7
+      0x7001FFF2,  //  000E  JMP		#0002
+      0x28100508,  //  000F  GE	R4	R2	K8
+      0x78120007,  //  0010  JMPF	R4	#0019
+      0x88100100,  //  0011  GETMBR	R4	R0	K0
+      0x8C10090B,  //  0012  GETMET	R4	R4	K11
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x50100200,  //  0015  LDBOOL	R4	1	0
+      0x90023004,  //  0016  SETMBR	R0	K24	R4
+      0x50100200,  //  0017  LDBOOL	R4	1	0
+      0x80040800,  //  0018  RET	1	R4
+      0x50100000,  //  0019  LDBOOL	R4	0	0
+      0x80040800,  //  001A  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _render_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine__render_animations,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_render_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x880C0113,  //  0000  GETMBR	R3	R0	K19
+      0x8C0C0705,  //  0001  GETMET	R3	R3	K5
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x580C0008,  //  0003  LDCONST	R3	K8
+      0x6010000C,  //  0004  GETGBL	R4	G12
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x14100604,  //  0007  LT	R4	R3	R4
+      0x7812000E,  //  0008  JMPF	R4	#0018
+      0x94100203,  //  0009  GETIDX	R4	R1	R3
+      0x88140114,  //  000A  GETMBR	R5	R0	K20
+      0x8C140B05,  //  000B  GETMET	R5	R5	K5
+      0x7C140200,  //  000C  CALL	R5	1
+      0x8C14092B,  //  000D  GETMET	R5	R4	K43
+      0x881C0114,  //  000E  GETMBR	R7	R0	K20
+      0x5C200400,  //  000F  MOVE	R8	R2
+      0x7C140600,  //  0010  CALL	R5	3
+      0x78160003,  //  0011  JMPF	R5	#0016
+      0x88180113,  //  0012  GETMBR	R6	R0	K19
+      0x8C180D2C,  //  0013  GETMET	R6	R6	K44
+      0x88200114,  //  0014  GETMBR	R8	R0	K20
+      0x7C180400,  //  0015  CALL	R6	2
+      0x000C0707,  //  0016  ADD	R3	R3	K7
+      0x7001FFEB,  //  0017  JMP		#0004
+      0x8C10012D,  //  0018  GETMET	R4	R0	K45
+      0x7C100200,  //  0019  CALL	R4	1
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_strip,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_sequence_manager
+********************************************************************/
+be_local_closure(class_AnimationEngine_add_sequence_manager,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(add_sequence_manager),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8808010A,  //  0000  GETMBR	R2	R0	K10
+      0x8C080524,  //  0001  GETMET	R2	R2	K36
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040000,  //  0004  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: interrupt_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080008,  //  0000  LDCONST	R2	K8
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8810072E,  //  0008  GETMBR	R4	R3	K46
+      0x4C140000,  //  0009  LDNIL	R5
+      0x20100805,  //  000A  NE	R4	R4	R5
+      0x7812000A,  //  000B  JMPF	R4	#0017
+      0x8810072E,  //  000C  GETMBR	R4	R3	K46
+      0x1C100801,  //  000D  EQ	R4	R4	R1
+      0x78120007,  //  000E  JMPF	R4	#0017
+      0x8C100702,  //  000F  GETMET	R4	R3	K2
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x88100100,  //  0012  GETMBR	R4	R0	K0
+      0x8C10090B,  //  0013  GETMET	R4	R4	K11
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x80000800,  //  0016  RET	0
+      0x00080507,  //  0017  ADD	R2	R2	K7
+      0x7001FFE7,  //  0018  JMP		#0001
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: AnimationEngine
+********************************************************************/
+be_local_class(AnimationEngine,
+    11,
+    NULL,
+    be_nested_map(38,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(interrupt_current, 20), be_const_closure(class_AnimationEngine_interrupt_current_closure) },
+        { be_const_key_weak(animations, -1), be_const_var(2) },
+        { be_const_key_weak(add_sequence_manager, -1), be_const_closure(class_AnimationEngine_add_sequence_manager_closure) },
+        { be_const_key_weak(get_animations, 17), be_const_closure(class_AnimationEngine_get_animations_closure) },
+        { be_const_key_weak(_sort_animations, -1), be_const_closure(class_AnimationEngine__sort_animations_closure) },
+        { be_const_key_weak(remove_sequence_manager, -1), be_const_closure(class_AnimationEngine_remove_sequence_manager_closure) },
+        { be_const_key_weak(strip, -1), be_const_var(0) },
+        { be_const_key_weak(_process_events, -1), be_const_closure(class_AnimationEngine__process_events_closure) },
+        { be_const_key_weak(get_strip, -1), be_const_closure(class_AnimationEngine_get_strip_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(class_AnimationEngine_start_closure) },
+        { be_const_key_weak(_output_to_strip, -1), be_const_closure(class_AnimationEngine__output_to_strip_closure) },
+        { be_const_key_weak(stop, -1), be_const_closure(class_AnimationEngine_stop_closure) },
+        { be_const_key_weak(is_active, 23), be_const_closure(class_AnimationEngine_is_active_closure) },
+        { be_const_key_weak(init, 6), be_const_closure(class_AnimationEngine_init_closure) },
+        { be_const_key_weak(resume, -1), be_const_closure(class_AnimationEngine_resume_closure) },
+        { be_const_key_weak(cleanup, -1), be_const_closure(class_AnimationEngine_cleanup_closure) },
+        { be_const_key_weak(on_tick, -1), be_const_closure(class_AnimationEngine_on_tick_closure) },
+        { be_const_key_weak(width, 9), be_const_var(1) },
+        { be_const_key_weak(frame_buffer, 31), be_const_var(4) },
+        { be_const_key_weak(add_animation, 15), be_const_closure(class_AnimationEngine_add_animation_closure) },
+        { be_const_key_weak(remove_animation, 1), be_const_closure(class_AnimationEngine_remove_animation_closure) },
+        { be_const_key_weak(resume_after, 18), be_const_closure(class_AnimationEngine_resume_after_closure) },
+        { be_const_key_weak(clear, -1), be_const_closure(class_AnimationEngine_clear_closure) },
+        { be_const_key_weak(_update_and_render, 36), be_const_closure(class_AnimationEngine__update_and_render_closure) },
+        { be_const_key_weak(fast_loop_closure, -1), be_const_var(9) },
+        { be_const_key_weak(time_ms, 29), be_const_var(8) },
+        { be_const_key_weak(is_running, -1), be_const_var(6) },
+        { be_const_key_weak(last_update, 26), be_const_var(7) },
+        { be_const_key_weak(interrupt_all, 2), be_const_closure(class_AnimationEngine_interrupt_all_closure) },
+        { be_const_key_weak(get_strip_length, -1), be_const_closure(class_AnimationEngine_get_strip_length_closure) },
+        { be_const_key_weak(_render_animations, -1), be_const_closure(class_AnimationEngine__render_animations_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_AnimationEngine_tostring_closure) },
+        { be_const_key_weak(temp_buffer, -1), be_const_var(5) },
+        { be_const_key_weak(render_needed, -1), be_const_var(10) },
+        { be_const_key_weak(_clear_strip, 8), be_const_closure(class_AnimationEngine__clear_strip_closure) },
+        { be_const_key_weak(sequence_managers, -1), be_const_var(3) },
+        { be_const_key_weak(size, -1), be_const_closure(class_AnimationEngine_size_closure) },
+        { be_const_key_weak(interrupt_animation, -1), be_const_closure(class_AnimationEngine_interrupt_animation_closure) },
+    })),
+    be_str_weak(AnimationEngine)
+);
+// compact class 'ColorCycleColorProvider' ktab size: 17, total: 36 (saved 152 bytes)
+static const bvalue be_ktab_class_ColorCycleColorProvider[17] = {
+  /* K0   */  be_nested_str_weak(palette),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_nested_str_weak(tasmota),
+  /* K4   */  be_nested_str_weak(scale_uint),
+  /* K5   */  be_nested_str_weak(cycle_period),
+  /* K6   */  be_nested_str_weak(current_color),
+  /* K7   */  be_nested_str_weak(current_index),
+  /* K8   */  be_nested_str_weak(next),
+  /* K9   */  be_nested_str_weak(set_param),
+  /* K10  */  be_nested_str_weak(init),
+  /* K11  */  be_nested_str_weak(manual),
+  /* K12  */  be_nested_str_weak(auto),
+  /* K13  */  be_nested_str_weak(ColorCycleColorProvider_X28palette_size_X3D_X25s_X2C_X20cycle_period_X3D_X25s_X2C_X20mode_X3D_X25s_X2C_X20current_index_X3D_X25s_X29),
+  /* K14  */  be_nested_str_weak(ColorCycleColorProvider_X28uninitialized_X29),
+  /* K15  */  be_nested_str_weak(copy),
+  /* K16  */  be_nested_str_weak(push),
+};
+
+
+extern const bclass be_class_ColorCycleColorProvider;
+
+/********************************************************************
+** Solidified function: get_color_for_value
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_get_color_for_value,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(get_color_for_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x6010000C,  //  0001  GETGBL	R4	G12
+      0x5C140600,  //  0002  MOVE	R5	R3
+      0x7C100200,  //  0003  CALL	R4	1
+      0x1C140901,  //  0004  EQ	R5	R4	K1
+      0x78160001,  //  0005  JMPF	R5	#0008
+      0x5415FFFE,  //  0006  LDINT	R5	-1
+      0x80040A00,  //  0007  RET	1	R5
+      0x1C140902,  //  0008  EQ	R5	R4	K2
+      0x78160001,  //  0009  JMPF	R5	#000C
+      0x94140701,  //  000A  GETIDX	R5	R3	K1
+      0x80040A00,  //  000B  RET	1	R5
+      0x14140301,  //  000C  LT	R5	R1	K1
+      0x78160001,  //  000D  JMPF	R5	#0010
+      0x58040001,  //  000E  LDCONST	R1	K1
+      0x70020003,  //  000F  JMP		#0014
+      0x54160063,  //  0010  LDINT	R5	100
+      0x24140205,  //  0011  GT	R5	R1	R5
+      0x78160000,  //  0012  JMPF	R5	#0014
+      0x54060063,  //  0013  LDINT	R1	100
+      0xB8160600,  //  0014  GETNGBL	R5	K3
+      0x8C140B04,  //  0015  GETMET	R5	R5	K4
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x58200001,  //  0017  LDCONST	R8	K1
+      0x54260063,  //  0018  LDINT	R9	100
+      0x58280001,  //  0019  LDCONST	R10	K1
+      0x042C0902,  //  001A  SUB	R11	R4	K2
+      0x7C140C00,  //  001B  CALL	R5	6
+      0x28180A04,  //  001C  GE	R6	R5	R4
+      0x781A0001,  //  001D  JMPF	R6	#0020
+      0x04180902,  //  001E  SUB	R6	R4	K2
+      0x5C140C00,  //  001F  MOVE	R5	R6
+      0x94180605,  //  0020  GETIDX	R6	R3	R5
+      0x80040C00,  //  0021  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x88100105,  //  0001  GETMBR	R4	R0	K5
+      0x6014000C,  //  0002  GETGBL	R5	G12
+      0x5C180600,  //  0003  MOVE	R6	R3
+      0x7C140200,  //  0004  CALL	R5	1
+      0x1C180B01,  //  0005  EQ	R6	R5	K1
+      0x781A0001,  //  0006  JMPF	R6	#0009
+      0x5419FFFE,  //  0007  LDINT	R6	-1
+      0x80040C00,  //  0008  RET	1	R6
+      0x1C180B02,  //  0009  EQ	R6	R5	K2
+      0x781A0003,  //  000A  JMPF	R6	#000F
+      0x94180701,  //  000B  GETIDX	R6	R3	K1
+      0x90020C06,  //  000C  SETMBR	R0	K6	R6
+      0x88180106,  //  000D  GETMBR	R6	R0	K6
+      0x80040C00,  //  000E  RET	1	R6
+      0x1C180901,  //  000F  EQ	R6	R4	K1
+      0x781A0001,  //  0010  JMPF	R6	#0013
+      0x88180106,  //  0011  GETMBR	R6	R0	K6
+      0x80040C00,  //  0012  RET	1	R6
+      0x10180404,  //  0013  MOD	R6	R2	R4
+      0xB81E0600,  //  0014  GETNGBL	R7	K3
+      0x8C1C0F04,  //  0015  GETMET	R7	R7	K4
+      0x5C240C00,  //  0016  MOVE	R9	R6
+      0x58280001,  //  0017  LDCONST	R10	K1
+      0x042C0902,  //  0018  SUB	R11	R4	K2
+      0x58300001,  //  0019  LDCONST	R12	K1
+      0x04340B02,  //  001A  SUB	R13	R5	K2
+      0x7C1C0C00,  //  001B  CALL	R7	6
+      0x28200E05,  //  001C  GE	R8	R7	R5
+      0x78220001,  //  001D  JMPF	R8	#0020
+      0x04200B02,  //  001E  SUB	R8	R5	K2
+      0x5C1C1000,  //  001F  MOVE	R7	R8
+      0x90020E07,  //  0020  SETMBR	R0	K7	R7
+      0x94200607,  //  0021  GETIDX	R8	R3	R7
+      0x90020C08,  //  0022  SETMBR	R0	K6	R8
+      0x88200106,  //  0023  GETMBR	R8	R0	K6
+      0x80041000,  //  0024  RET	1	R8
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_on_param_changed,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x780E0010,  //  0001  JMPF	R3	#0013
+      0x5C0C0400,  //  0002  MOVE	R3	R2
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x5C140600,  //  0004  MOVE	R5	R3
+      0x7C100200,  //  0005  CALL	R4	1
+      0x24100901,  //  0006  GT	R4	R4	K1
+      0x78120009,  //  0007  JMPF	R4	#0012
+      0x88100107,  //  0008  GETMBR	R4	R0	K7
+      0x6014000C,  //  0009  GETGBL	R5	G12
+      0x5C180600,  //  000A  MOVE	R6	R3
+      0x7C140200,  //  000B  CALL	R5	1
+      0x28100805,  //  000C  GE	R4	R4	R5
+      0x78120000,  //  000D  JMPF	R4	#000F
+      0x90020F01,  //  000E  SETMBR	R0	K7	K1
+      0x88100107,  //  000F  GETMBR	R4	R0	K7
+      0x94100604,  //  0010  GETIDX	R4	R3	R4
+      0x90020C04,  //  0011  SETMBR	R0	K6	R4
+      0x70020017,  //  0012  JMP		#002B
+      0x1C0C0308,  //  0013  EQ	R3	R1	K8
+      0x780E0015,  //  0014  JMPF	R3	#002B
+      0x1C0C0502,  //  0015  EQ	R3	R2	K2
+      0x780E0013,  //  0016  JMPF	R3	#002B
+      0x880C0100,  //  0017  GETMBR	R3	R0	K0
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140600,  //  0019  MOVE	R5	R3
+      0x7C100200,  //  001A  CALL	R4	1
+      0x24100901,  //  001B  GT	R4	R4	K1
+      0x78120009,  //  001C  JMPF	R4	#0027
+      0x88100107,  //  001D  GETMBR	R4	R0	K7
+      0x00100902,  //  001E  ADD	R4	R4	K2
+      0x6014000C,  //  001F  GETGBL	R5	G12
+      0x5C180600,  //  0020  MOVE	R6	R3
+      0x7C140200,  //  0021  CALL	R5	1
+      0x10100805,  //  0022  MOD	R4	R4	R5
+      0x90020E04,  //  0023  SETMBR	R0	K7	R4
+      0x88100107,  //  0024  GETMBR	R4	R0	K7
+      0x94100604,  //  0025  GETIDX	R4	R3	R4
+      0x90020C04,  //  0026  SETMBR	R0	K6	R4
+      0x8C100109,  //  0027  GETMET	R4	R0	K9
+      0x58180008,  //  0028  LDCONST	R6	K8
+      0x581C0001,  //  0029  LDCONST	R7	K1
+      0x7C100600,  //  002A  CALL	R4	3
+      0x80000000,  //  002B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08050A,  //  0003  GETMET	R2	R2	K10
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
+      0x940C0501,  //  0007  GETIDX	R3	R2	K1
+      0x90020C03,  //  0008  SETMBR	R0	K6	R3
+      0x90020F01,  //  0009  SETMBR	R0	K7	K1
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0xA8020012,  //  0000  EXBLK	0	#0014
+      0x88040105,  //  0001  GETMBR	R1	R0	K5
+      0x1C040301,  //  0002  EQ	R1	R1	K1
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x5804000B,  //  0004  LDCONST	R1	K11
+      0x70020000,  //  0005  JMP		#0007
+      0x5804000C,  //  0006  LDCONST	R1	K12
+      0x60080018,  //  0007  GETGBL	R2	G24
+      0x580C000D,  //  0008  LDCONST	R3	K13
+      0x6010000C,  //  0009  GETGBL	R4	G12
+      0x88140100,  //  000A  GETMBR	R5	R0	K0
+      0x7C100200,  //  000B  CALL	R4	1
+      0x88140105,  //  000C  GETMBR	R5	R0	K5
+      0x5C180200,  //  000D  MOVE	R6	R1
+      0x881C0107,  //  000E  GETMBR	R7	R0	K7
+      0x7C080A00,  //  000F  CALL	R2	5
+      0xA8040001,  //  0010  EXBLK	1	1
+      0x80040400,  //  0011  RET	1	R2
+      0xA8040001,  //  0012  EXBLK	1	1
+      0x70020004,  //  0013  JMP		#0019
+      0xAC040000,  //  0014  CATCH	R1	0	0
+      0x70020001,  //  0015  JMP		#0018
+      0x80061C00,  //  0016  RET	1	K14
+      0x70020000,  //  0017  JMP		#0019
+      0xB0080000,  //  0018  RAISE	2	R0	R0
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_color
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_add_color,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(add_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C0C050F,  //  0001  GETMET	R3	R2	K15
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C100710,  //  0003  GETMET	R4	R3	K16
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x90020003,  //  0006  SETMBR	R0	K0	R3
+      0x80040000,  //  0007  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: ColorCycleColorProvider
+********************************************************************/
+extern const bclass be_class_ColorProvider;
+be_local_class(ColorCycleColorProvider,
+    2,
+    &be_class_ColorProvider,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(current_color, -1), be_const_var(0) },
+        { be_const_key_weak(current_index, 0), be_const_var(1) },
+        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorCycleColorProvider_get_color_for_value_closure) },
+        { be_const_key_weak(produce_value, -1), be_const_closure(class_ColorCycleColorProvider_produce_value_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ColorCycleColorProvider_on_param_changed_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(cycle_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(5000) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(next, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(palette, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(-16776961),
+        be_const_int(-16711936),
+        be_const_int(-65536),
+    }))    ) } )) },
+        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(init, 5), be_const_closure(class_ColorCycleColorProvider_init_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_ColorCycleColorProvider_tostring_closure) },
+        { be_const_key_weak(add_color, -1), be_const_closure(class_ColorCycleColorProvider_add_color_closure) },
+    })),
+    be_str_weak(ColorCycleColorProvider)
+);
 // compact class 'ParameterizedObject' ktab size: 41, total: 85 (saved 352 bytes)
 static const bvalue be_ktab_class_ParameterizedObject[41] = {
   /* K0   */  be_nested_str_weak(introspect),
@@ -19351,9 +16077,765 @@ be_local_class(ParameterizedObject,
 );
 
 /********************************************************************
-** Solidified function: twinkle_classic
+** Solidified function: is_color_provider
 ********************************************************************/
-be_local_closure(twinkle_classic,   /* name */
+be_local_closure(is_color_provider,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(color_provider),
+    }),
+    be_str_weak(is_color_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x6004000F,  //  0000  GETGBL	R1	G15
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0x880C0701,  //  0003  GETMBR	R3	R3	K1
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_event_handlers
+********************************************************************/
+be_local_closure(get_event_handlers,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(event_manager),
+    /* K2   */  be_nested_str_weak(get_handlers),
+    }),
+    be_str_weak(get_event_handlers),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'WaveAnimation' ktab size: 41, total: 69 (saved 224 bytes)
+static const bvalue be_ktab_class_WaveAnimation[41] = {
+  /* K0   */  be_nested_str_weak(wave_table),
+  /* K1   */  be_nested_str_weak(resize),
+  /* K2   */  be_nested_str_weak(wave_type),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_nested_str_weak(tasmota),
+  /* K5   */  be_nested_str_weak(scale_uint),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_const_int(2),
+  /* K8   */  be_nested_str_weak(sine),
+  /* K9   */  be_nested_str_weak(triangle),
+  /* K10  */  be_nested_str_weak(square),
+  /* K11  */  be_nested_str_weak(sawtooth),
+  /* K12  */  be_nested_str_weak(unknown),
+  /* K13  */  be_nested_str_weak(color),
+  /* K14  */  be_nested_str_weak(animation),
+  /* K15  */  be_nested_str_weak(is_value_provider),
+  /* K16  */  be_nested_str_weak(0x_X2508x),
+  /* K17  */  be_nested_str_weak(WaveAnimation_X28_X25s_X2C_X20color_X3D_X25s_X2C_X20freq_X3D_X25s_X2C_X20speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K18  */  be_nested_str_weak(frequency),
+  /* K19  */  be_nested_str_weak(wave_speed),
+  /* K20  */  be_nested_str_weak(priority),
+  /* K21  */  be_nested_str_weak(is_running),
+  /* K22  */  be_nested_str_weak(engine),
+  /* K23  */  be_nested_str_weak(get_strip_length),
+  /* K24  */  be_nested_str_weak(width),
+  /* K25  */  be_nested_str_weak(current_colors),
+  /* K26  */  be_nested_str_weak(size),
+  /* K27  */  be_nested_str_weak(set_pixel_color),
+  /* K28  */  be_nested_str_weak(_init_wave_table),
+  /* K29  */  be_nested_str_weak(update),
+  /* K30  */  be_nested_str_weak(start_time),
+  /* K31  */  be_nested_str_weak(time_offset),
+  /* K32  */  be_nested_str_weak(_calculate_wave),
+  /* K33  */  be_nested_str_weak(init),
+  /* K34  */  be_nested_str_weak(phase),
+  /* K35  */  be_nested_str_weak(amplitude),
+  /* K36  */  be_nested_str_weak(center_level),
+  /* K37  */  be_nested_str_weak(back_color),
+  /* K38  */  be_nested_str_weak(is_color_provider),
+  /* K39  */  be_nested_str_weak(get_color_for_value),
+  /* K40  */  be_nested_str_weak(resolve_value),
+};
+
+
+extern const bclass be_class_WaveAnimation;
+
+/********************************************************************
+** Solidified function: _init_wave_table
+********************************************************************/
+be_local_closure(class_WaveAnimation__init_wave_table,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(_init_wave_table),
+    &be_const_str_solidified,
+    ( &(const binstruction[108]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x540E00FF,  //  0002  LDINT	R3	256
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x58080003,  //  0005  LDCONST	R2	K3
+      0x540E00FF,  //  0006  LDINT	R3	256
+      0x140C0403,  //  0007  LT	R3	R2	R3
+      0x780E0061,  //  0008  JMPF	R3	#006B
+      0x580C0003,  //  0009  LDCONST	R3	K3
+      0x1C100303,  //  000A  EQ	R4	R1	K3
+      0x78120035,  //  000B  JMPF	R4	#0042
+      0x5412003F,  //  000C  LDINT	R4	64
+      0x10100404,  //  000D  MOD	R4	R2	R4
+      0x5416003F,  //  000E  LDINT	R5	64
+      0x14140405,  //  000F  LT	R5	R2	R5
+      0x78160009,  //  0010  JMPF	R5	#001B
+      0xB8160800,  //  0011  GETNGBL	R5	K4
+      0x8C140B05,  //  0012  GETMET	R5	R5	K5
+      0x5C1C0800,  //  0013  MOVE	R7	R4
+      0x58200003,  //  0014  LDCONST	R8	K3
+      0x5426003F,  //  0015  LDINT	R9	64
+      0x542A007F,  //  0016  LDINT	R10	128
+      0x542E00FE,  //  0017  LDINT	R11	255
+      0x7C140C00,  //  0018  CALL	R5	6
+      0x5C0C0A00,  //  0019  MOVE	R3	R5
+      0x70020025,  //  001A  JMP		#0041
+      0x5416007F,  //  001B  LDINT	R5	128
+      0x14140405,  //  001C  LT	R5	R2	R5
+      0x7816000A,  //  001D  JMPF	R5	#0029
+      0xB8160800,  //  001E  GETNGBL	R5	K4
+      0x8C140B05,  //  001F  GETMET	R5	R5	K5
+      0x541E007F,  //  0020  LDINT	R7	128
+      0x041C0E02,  //  0021  SUB	R7	R7	R2
+      0x58200003,  //  0022  LDCONST	R8	K3
+      0x5426003F,  //  0023  LDINT	R9	64
+      0x542A007F,  //  0024  LDINT	R10	128
+      0x542E00FE,  //  0025  LDINT	R11	255
+      0x7C140C00,  //  0026  CALL	R5	6
+      0x5C0C0A00,  //  0027  MOVE	R3	R5
+      0x70020017,  //  0028  JMP		#0041
+      0x541600BF,  //  0029  LDINT	R5	192
+      0x14140405,  //  002A  LT	R5	R2	R5
+      0x7816000A,  //  002B  JMPF	R5	#0037
+      0xB8160800,  //  002C  GETNGBL	R5	K4
+      0x8C140B05,  //  002D  GETMET	R5	R5	K5
+      0x541E007F,  //  002E  LDINT	R7	128
+      0x041C0407,  //  002F  SUB	R7	R2	R7
+      0x58200003,  //  0030  LDCONST	R8	K3
+      0x5426003F,  //  0031  LDINT	R9	64
+      0x542A007F,  //  0032  LDINT	R10	128
+      0x582C0003,  //  0033  LDCONST	R11	K3
+      0x7C140C00,  //  0034  CALL	R5	6
+      0x5C0C0A00,  //  0035  MOVE	R3	R5
+      0x70020009,  //  0036  JMP		#0041
+      0xB8160800,  //  0037  GETNGBL	R5	K4
+      0x8C140B05,  //  0038  GETMET	R5	R5	K5
+      0x541E00FF,  //  0039  LDINT	R7	256
+      0x041C0E02,  //  003A  SUB	R7	R7	R2
+      0x58200003,  //  003B  LDCONST	R8	K3
+      0x5426003F,  //  003C  LDINT	R9	64
+      0x542A007F,  //  003D  LDINT	R10	128
+      0x582C0003,  //  003E  LDCONST	R11	K3
+      0x7C140C00,  //  003F  CALL	R5	6
+      0x5C0C0A00,  //  0040  MOVE	R3	R5
+      0x70020024,  //  0041  JMP		#0067
+      0x1C100306,  //  0042  EQ	R4	R1	K6
+      0x78120017,  //  0043  JMPF	R4	#005C
+      0x5412007F,  //  0044  LDINT	R4	128
+      0x14100404,  //  0045  LT	R4	R2	R4
+      0x78120009,  //  0046  JMPF	R4	#0051
+      0xB8120800,  //  0047  GETNGBL	R4	K4
+      0x8C100905,  //  0048  GETMET	R4	R4	K5
+      0x5C180400,  //  0049  MOVE	R6	R2
+      0x581C0003,  //  004A  LDCONST	R7	K3
+      0x5422007F,  //  004B  LDINT	R8	128
+      0x58240003,  //  004C  LDCONST	R9	K3
+      0x542A00FE,  //  004D  LDINT	R10	255
+      0x7C100C00,  //  004E  CALL	R4	6
+      0x5C0C0800,  //  004F  MOVE	R3	R4
+      0x70020009,  //  0050  JMP		#005B
+      0xB8120800,  //  0051  GETNGBL	R4	K4
+      0x8C100905,  //  0052  GETMET	R4	R4	K5
+      0x541A00FF,  //  0053  LDINT	R6	256
+      0x04180C02,  //  0054  SUB	R6	R6	R2
+      0x581C0003,  //  0055  LDCONST	R7	K3
+      0x5422007F,  //  0056  LDINT	R8	128
+      0x58240003,  //  0057  LDCONST	R9	K3
+      0x542A00FE,  //  0058  LDINT	R10	255
+      0x7C100C00,  //  0059  CALL	R4	6
+      0x5C0C0800,  //  005A  MOVE	R3	R4
+      0x7002000A,  //  005B  JMP		#0067
+      0x1C100307,  //  005C  EQ	R4	R1	K7
+      0x78120007,  //  005D  JMPF	R4	#0066
+      0x5412007F,  //  005E  LDINT	R4	128
+      0x14100404,  //  005F  LT	R4	R2	R4
+      0x78120001,  //  0060  JMPF	R4	#0063
+      0x541200FE,  //  0061  LDINT	R4	255
+      0x70020000,  //  0062  JMP		#0064
+      0x58100003,  //  0063  LDCONST	R4	K3
+      0x5C0C0800,  //  0064  MOVE	R3	R4
+      0x70020000,  //  0065  JMP		#0067
+      0x5C0C0400,  //  0066  MOVE	R3	R2
+      0x88100100,  //  0067  GETMBR	R4	R0	K0
+      0x98100403,  //  0068  SETIDX	R4	R2	R3
+      0x00080506,  //  0069  ADD	R2	R2	K6
+      0x7001FF9A,  //  006A  JMP		#0006
+      0x80000000,  //  006B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_WaveAnimation_tostring,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x40080308,  //  0002  CONNECT	R2	R1	K8
+      0x40080309,  //  0003  CONNECT	R2	R1	K9
+      0x4008030A,  //  0004  CONNECT	R2	R1	K10
+      0x4008030B,  //  0005  CONNECT	R2	R1	K11
+      0x88080102,  //  0006  GETMBR	R2	R0	K2
+      0x940C0202,  //  0007  GETIDX	R3	R1	R2
+      0x4C100000,  //  0008  LDNIL	R4
+      0x200C0604,  //  0009  NE	R3	R3	R4
+      0x780E0001,  //  000A  JMPF	R3	#000D
+      0x940C0202,  //  000B  GETIDX	R3	R1	R2
+      0x70020000,  //  000C  JMP		#000E
+      0x580C000C,  //  000D  LDCONST	R3	K12
+      0x8810010D,  //  000E  GETMBR	R4	R0	K13
+      0x4C140000,  //  000F  LDNIL	R5
+      0xB81A1C00,  //  0010  GETNGBL	R6	K14
+      0x8C180D0F,  //  0011  GETMET	R6	R6	K15
+      0x5C200800,  //  0012  MOVE	R8	R4
+      0x7C180400,  //  0013  CALL	R6	2
+      0x781A0004,  //  0014  JMPF	R6	#001A
+      0x60180008,  //  0015  GETGBL	R6	G8
+      0x5C1C0800,  //  0016  MOVE	R7	R4
+      0x7C180200,  //  0017  CALL	R6	1
+      0x5C140C00,  //  0018  MOVE	R5	R6
+      0x70020004,  //  0019  JMP		#001F
+      0x60180018,  //  001A  GETGBL	R6	G24
+      0x581C0010,  //  001B  LDCONST	R7	K16
+      0x5C200800,  //  001C  MOVE	R8	R4
+      0x7C180400,  //  001D  CALL	R6	2
+      0x5C140C00,  //  001E  MOVE	R5	R6
+      0x60180018,  //  001F  GETGBL	R6	G24
+      0x581C0011,  //  0020  LDCONST	R7	K17
+      0x5C200600,  //  0021  MOVE	R8	R3
+      0x5C240A00,  //  0022  MOVE	R9	R5
+      0x88280112,  //  0023  GETMBR	R10	R0	K18
+      0x882C0113,  //  0024  GETMBR	R11	R0	K19
+      0x88300114,  //  0025  GETMBR	R12	R0	K20
+      0x88340115,  //  0026  GETMBR	R13	R0	K21
+      0x7C180E00,  //  0027  CALL	R6	7
+      0x80040C00,  //  0028  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_WaveAnimation_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x880C0115,  //  0000  GETMBR	R3	R0	K21
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x880C0116,  //  0007  GETMBR	R3	R0	K22
+      0x8C0C0717,  //  0008  GETMET	R3	R3	K23
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x14140803,  //  000B  LT	R5	R4	R3
+      0x7816000E,  //  000C  JMPF	R5	#001C
+      0x88140318,  //  000D  GETMBR	R5	R1	K24
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x78160009,  //  000F  JMPF	R5	#001A
+      0x88140119,  //  0010  GETMBR	R5	R0	K25
+      0x8C140B1A,  //  0011  GETMET	R5	R5	K26
+      0x7C140200,  //  0012  CALL	R5	1
+      0x14140805,  //  0013  LT	R5	R4	R5
+      0x78160004,  //  0014  JMPF	R5	#001A
+      0x8C14031B,  //  0015  GETMET	R5	R1	K27
+      0x5C1C0800,  //  0016  MOVE	R7	R4
+      0x88200119,  //  0017  GETMBR	R8	R0	K25
+      0x94201004,  //  0018  GETIDX	R8	R8	R4
+      0x7C140600,  //  0019  CALL	R5	3
+      0x00100906,  //  001A  ADD	R4	R4	K6
+      0x7001FFEE,  //  001B  JMP		#000B
+      0x50140200,  //  001C  LDBOOL	R5	1	0
+      0x80040A00,  //  001D  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_WaveAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x1C0C0302,  //  0000  EQ	R3	R1	K2
+      0x780E0001,  //  0001  JMPF	R3	#0004
+      0x8C0C011C,  //  0002  GETMET	R3	R0	K28
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_WaveAnimation_update,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051D,  //  0003  GETMET	R2	R2	K29
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0001,  //  0006  JMPT	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x88080113,  //  0009  GETMBR	R2	R0	K19
+      0x240C0503,  //  000A  GT	R3	R2	K3
+      0x780E0011,  //  000B  JMPF	R3	#001E
+      0x880C011E,  //  000C  GETMBR	R3	R0	K30
+      0x040C0203,  //  000D  SUB	R3	R1	R3
+      0xB8120800,  //  000E  GETNGBL	R4	K4
+      0x8C100905,  //  000F  GETMET	R4	R4	K5
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x581C0003,  //  0011  LDCONST	R7	K3
+      0x542200FE,  //  0012  LDINT	R8	255
+      0x58240003,  //  0013  LDCONST	R9	K3
+      0x542A0009,  //  0014  LDINT	R10	10
+      0x7C100C00,  //  0015  CALL	R4	6
+      0x24140903,  //  0016  GT	R5	R4	K3
+      0x78160005,  //  0017  JMPF	R5	#001E
+      0x08140604,  //  0018  MUL	R5	R3	R4
+      0x541A03E7,  //  0019  LDINT	R6	1000
+      0x0C140A06,  //  001A  DIV	R5	R5	R6
+      0x541A00FF,  //  001B  LDINT	R6	256
+      0x10140A06,  //  001C  MOD	R5	R5	R6
+      0x90023E05,  //  001D  SETMBR	R0	K31	R5
+      0x8C0C0120,  //  001E  GETMET	R3	R0	K32
+      0x5C140200,  //  001F  MOVE	R5	R1
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0x500C0200,  //  0021  LDBOOL	R3	1	0
+      0x80040600,  //  0022  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_WaveAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080521,  //  0003  GETMET	R2	R2	K33
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90023202,  //  0008  SETMBR	R0	K25	R2
+      0x90023F03,  //  0009  SETMBR	R0	K31	K3
+      0x60080012,  //  000A  GETGBL	R2	G18
+      0x7C080000,  //  000B  CALL	R2	0
+      0x90020002,  //  000C  SETMBR	R0	K0	R2
+      0x8C08011C,  //  000D  GETMET	R2	R0	K28
+      0x7C080200,  //  000E  CALL	R2	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _calculate_wave
+********************************************************************/
+be_local_closure(class_WaveAnimation__calculate_wave,   /* name */
+  be_nested_proto(
+    27,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_WaveAnimation,     /* shared constants */
+    be_str_weak(_calculate_wave),
+    &be_const_str_solidified,
+    ( &(const binstruction[169]) {  /* code */
+      0x88080116,  //  0000  GETMBR	R2	R0	K22
+      0x8C080517,  //  0001  GETMET	R2	R2	K23
+      0x7C080200,  //  0002  CALL	R2	1
+      0x880C0112,  //  0003  GETMBR	R3	R0	K18
+      0x88100122,  //  0004  GETMBR	R4	R0	K34
+      0x88140123,  //  0005  GETMBR	R5	R0	K35
+      0x88180124,  //  0006  GETMBR	R6	R0	K36
+      0x881C0125,  //  0007  GETMBR	R7	R0	K37
+      0x8820010D,  //  0008  GETMBR	R8	R0	K13
+      0x88240119,  //  0009  GETMBR	R9	R0	K25
+      0x8C24131A,  //  000A  GETMET	R9	R9	K26
+      0x7C240200,  //  000B  CALL	R9	1
+      0x20241202,  //  000C  NE	R9	R9	R2
+      0x78260003,  //  000D  JMPF	R9	#0012
+      0x88240119,  //  000E  GETMBR	R9	R0	K25
+      0x8C241301,  //  000F  GETMET	R9	R9	K1
+      0x5C2C0400,  //  0010  MOVE	R11	R2
+      0x7C240400,  //  0011  CALL	R9	2
+      0x58240003,  //  0012  LDCONST	R9	K3
+      0x14281202,  //  0013  LT	R10	R9	R2
+      0x782A0092,  //  0014  JMPF	R10	#00A8
+      0xB82A0800,  //  0015  GETNGBL	R10	K4
+      0x8C281505,  //  0016  GETMET	R10	R10	K5
+      0x5C301200,  //  0017  MOVE	R12	R9
+      0x58340003,  //  0018  LDCONST	R13	K3
+      0x04380506,  //  0019  SUB	R14	R2	K6
+      0x583C0003,  //  001A  LDCONST	R15	K3
+      0x544200FE,  //  001B  LDINT	R16	255
+      0x7C280C00,  //  001C  CALL	R10	6
+      0x082C1403,  //  001D  MUL	R11	R10	R3
+      0x5432001F,  //  001E  LDINT	R12	32
+      0x0C2C160C,  //  001F  DIV	R11	R11	R12
+      0x002C1604,  //  0020  ADD	R11	R11	R4
+      0x8830011F,  //  0021  GETMBR	R12	R0	K31
+      0x002C160C,  //  0022  ADD	R11	R11	R12
+      0x543200FE,  //  0023  LDINT	R12	255
+      0x2C2C160C,  //  0024  AND	R11	R11	R12
+      0x88300100,  //  0025  GETMBR	R12	R0	K0
+      0x9430180B,  //  0026  GETIDX	R12	R12	R11
+      0xB8360800,  //  0027  GETNGBL	R13	K4
+      0x8C341B05,  //  0028  GETMET	R13	R13	K5
+      0x5C3C0A00,  //  0029  MOVE	R15	R5
+      0x58400003,  //  002A  LDCONST	R16	K3
+      0x544600FE,  //  002B  LDINT	R17	255
+      0x58480003,  //  002C  LDCONST	R18	K3
+      0x544E007F,  //  002D  LDINT	R19	128
+      0x7C340C00,  //  002E  CALL	R13	6
+      0x58380003,  //  002F  LDCONST	R14	K3
+      0x543E007F,  //  0030  LDINT	R15	128
+      0x283C180F,  //  0031  GE	R15	R12	R15
+      0x783E000D,  //  0032  JMPF	R15	#0041
+      0x543E007F,  //  0033  LDINT	R15	128
+      0x043C180F,  //  0034  SUB	R15	R12	R15
+      0xB8420800,  //  0035  GETNGBL	R16	K4
+      0x8C402105,  //  0036  GETMET	R16	R16	K5
+      0x5C481E00,  //  0037  MOVE	R18	R15
+      0x584C0003,  //  0038  LDCONST	R19	K3
+      0x5452007E,  //  0039  LDINT	R20	127
+      0x58540003,  //  003A  LDCONST	R21	K3
+      0x5C581A00,  //  003B  MOVE	R22	R13
+      0x7C400C00,  //  003C  CALL	R16	6
+      0x5C3C2000,  //  003D  MOVE	R15	R16
+      0x00400C0F,  //  003E  ADD	R16	R6	R15
+      0x5C382000,  //  003F  MOVE	R14	R16
+      0x7002000C,  //  0040  JMP		#004E
+      0x543E007F,  //  0041  LDINT	R15	128
+      0x043C1E0C,  //  0042  SUB	R15	R15	R12
+      0xB8420800,  //  0043  GETNGBL	R16	K4
+      0x8C402105,  //  0044  GETMET	R16	R16	K5
+      0x5C481E00,  //  0045  MOVE	R18	R15
+      0x584C0003,  //  0046  LDCONST	R19	K3
+      0x5452007F,  //  0047  LDINT	R20	128
+      0x58540003,  //  0048  LDCONST	R21	K3
+      0x5C581A00,  //  0049  MOVE	R22	R13
+      0x7C400C00,  //  004A  CALL	R16	6
+      0x5C3C2000,  //  004B  MOVE	R15	R16
+      0x04400C0F,  //  004C  SUB	R16	R6	R15
+      0x5C382000,  //  004D  MOVE	R14	R16
+      0x543E00FE,  //  004E  LDINT	R15	255
+      0x243C1C0F,  //  004F  GT	R15	R14	R15
+      0x783E0001,  //  0050  JMPF	R15	#0053
+      0x543A00FE,  //  0051  LDINT	R14	255
+      0x70020002,  //  0052  JMP		#0056
+      0x143C1D03,  //  0053  LT	R15	R14	K3
+      0x783E0000,  //  0054  JMPF	R15	#0056
+      0x58380003,  //  0055  LDCONST	R14	K3
+      0x5C3C0E00,  //  0056  MOVE	R15	R7
+      0x54420009,  //  0057  LDINT	R16	10
+      0x24401C10,  //  0058  GT	R16	R14	R16
+      0x78420049,  //  0059  JMPF	R16	#00A4
+      0xB8421C00,  //  005A  GETNGBL	R16	K14
+      0x8C402126,  //  005B  GETMET	R16	R16	K38
+      0x5C481000,  //  005C  MOVE	R18	R8
+      0x7C400400,  //  005D  CALL	R16	2
+      0x78420009,  //  005E  JMPF	R16	#0069
+      0x88401127,  //  005F  GETMBR	R16	R8	K39
+      0x4C440000,  //  0060  LDNIL	R17
+      0x20402011,  //  0061  NE	R16	R16	R17
+      0x78420005,  //  0062  JMPF	R16	#0069
+      0x8C401127,  //  0063  GETMET	R16	R8	K39
+      0x5C481C00,  //  0064  MOVE	R18	R14
+      0x584C0003,  //  0065  LDCONST	R19	K3
+      0x7C400600,  //  0066  CALL	R16	3
+      0x5C3C2000,  //  0067  MOVE	R15	R16
+      0x7002003A,  //  0068  JMP		#00A4
+      0x8C400128,  //  0069  GETMET	R16	R0	K40
+      0x5C481000,  //  006A  MOVE	R18	R8
+      0x584C000D,  //  006B  LDCONST	R19	K13
+      0x54520009,  //  006C  LDINT	R20	10
+      0x08501C14,  //  006D  MUL	R20	R14	R20
+      0x00500214,  //  006E  ADD	R20	R1	R20
+      0x7C400800,  //  006F  CALL	R16	4
+      0x5C3C2000,  //  0070  MOVE	R15	R16
+      0x54420017,  //  0071  LDINT	R16	24
+      0x3C401E10,  //  0072  SHR	R16	R15	R16
+      0x544600FE,  //  0073  LDINT	R17	255
+      0x2C402011,  //  0074  AND	R16	R16	R17
+      0x5446000F,  //  0075  LDINT	R17	16
+      0x3C441E11,  //  0076  SHR	R17	R15	R17
+      0x544A00FE,  //  0077  LDINT	R18	255
+      0x2C442212,  //  0078  AND	R17	R17	R18
+      0x544A0007,  //  0079  LDINT	R18	8
+      0x3C481E12,  //  007A  SHR	R18	R15	R18
+      0x544E00FE,  //  007B  LDINT	R19	255
+      0x2C482413,  //  007C  AND	R18	R18	R19
+      0x544E00FE,  //  007D  LDINT	R19	255
+      0x2C4C1E13,  //  007E  AND	R19	R15	R19
+      0xB8520800,  //  007F  GETNGBL	R20	K4
+      0x8C502905,  //  0080  GETMET	R20	R20	K5
+      0x5C581C00,  //  0081  MOVE	R22	R14
+      0x585C0003,  //  0082  LDCONST	R23	K3
+      0x546200FE,  //  0083  LDINT	R24	255
+      0x58640003,  //  0084  LDCONST	R25	K3
+      0x5C682200,  //  0085  MOVE	R26	R17
+      0x7C500C00,  //  0086  CALL	R20	6
+      0x5C442800,  //  0087  MOVE	R17	R20
+      0xB8520800,  //  0088  GETNGBL	R20	K4
+      0x8C502905,  //  0089  GETMET	R20	R20	K5
+      0x5C581C00,  //  008A  MOVE	R22	R14
+      0x585C0003,  //  008B  LDCONST	R23	K3
+      0x546200FE,  //  008C  LDINT	R24	255
+      0x58640003,  //  008D  LDCONST	R25	K3
+      0x5C682400,  //  008E  MOVE	R26	R18
+      0x7C500C00,  //  008F  CALL	R20	6
+      0x5C482800,  //  0090  MOVE	R18	R20
+      0xB8520800,  //  0091  GETNGBL	R20	K4
+      0x8C502905,  //  0092  GETMET	R20	R20	K5
+      0x5C581C00,  //  0093  MOVE	R22	R14
+      0x585C0003,  //  0094  LDCONST	R23	K3
+      0x546200FE,  //  0095  LDINT	R24	255
+      0x58640003,  //  0096  LDCONST	R25	K3
+      0x5C682600,  //  0097  MOVE	R26	R19
+      0x7C500C00,  //  0098  CALL	R20	6
+      0x5C4C2800,  //  0099  MOVE	R19	R20
+      0x54520017,  //  009A  LDINT	R20	24
+      0x38502014,  //  009B  SHL	R20	R16	R20
+      0x5456000F,  //  009C  LDINT	R21	16
+      0x38542215,  //  009D  SHL	R21	R17	R21
+      0x30502815,  //  009E  OR	R20	R20	R21
+      0x54560007,  //  009F  LDINT	R21	8
+      0x38542415,  //  00A0  SHL	R21	R18	R21
+      0x30502815,  //  00A1  OR	R20	R20	R21
+      0x30502813,  //  00A2  OR	R20	R20	R19
+      0x5C3C2800,  //  00A3  MOVE	R15	R20
+      0x88400119,  //  00A4  GETMBR	R16	R0	K25
+      0x9840120F,  //  00A5  SETIDX	R16	R9	R15
+      0x00241306,  //  00A6  ADD	R9	R9	K6
+      0x7001FF6A,  //  00A7  JMP		#0013
+      0x80000000,  //  00A8  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: WaveAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(WaveAnimation,
+    3,
+    &be_class_Animation,
+    be_nested_map(11,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(current_colors, -1), be_const_var(0) },
+        { be_const_key_weak(update, -1), be_const_closure(class_WaveAnimation_update_closure) },
+        { be_const_key_weak(wave_table, -1), be_const_var(2) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_WaveAnimation_tostring_closure) },
+        { be_const_key_weak(render, 7), be_const_closure(class_WaveAnimation_render_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_WaveAnimation_on_param_changed_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_WaveAnimation_init_closure) },
+        { be_const_key_weak(time_offset, 1), be_const_var(1) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(8,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(phase, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(frequency, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(32) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(amplitude, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-65536) },
+    }))    ) } )) },
+        { be_const_key_weak(wave_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(50) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(wave_type, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(3) },
+    }))    ) } )) },
+        { be_const_key_weak(back_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-16777216) },
+    }))    ) } )) },
+        { be_const_key_weak(center_level, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(_init_wave_table, 6), be_const_closure(class_WaveAnimation__init_wave_table_closure) },
+        { be_const_key_weak(_calculate_wave, -1), be_const_closure(class_WaveAnimation__calculate_wave_closure) },
+    })),
+    be_str_weak(WaveAnimation)
+);
+
+/********************************************************************
+** Solidified function: twinkle_rainbow
+********************************************************************/
+be_local_closure(twinkle_rainbow,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -19373,7 +16855,7 @@ be_local_closure(twinkle_classic,   /* name */
     /* K6   */  be_nested_str_weak(min_brightness),
     /* K7   */  be_nested_str_weak(max_brightness),
     }),
-    be_str_weak(twinkle_classic),
+    be_str_weak(twinkle_rainbow),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
@@ -19382,7 +16864,7 @@ be_local_closure(twinkle_classic,   /* name */
       0x7C040400,  //  0003  CALL	R1	2
       0x5409FFFE,  //  0004  LDINT	R2	-1
       0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0095,  //  0006  LDINT	R2	150
+      0x540A0077,  //  0006  LDINT	R2	120
       0x90060602,  //  0007  SETMBR	R1	K3	R2
       0x540A0005,  //  0008  LDINT	R2	6
       0x90060802,  //  0009  SETMBR	R1	K4	R2
@@ -19393,6 +16875,2356 @@ be_local_closure(twinkle_classic,   /* name */
       0x540A00FE,  //  000E  LDINT	R2	255
       0x90060E02,  //  000F  SETMBR	R1	K7	R2
       0x80040200,  //  0010  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_engine
+********************************************************************/
+be_local_closure(create_engine,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(animation_engine),
+    }),
+    be_str_weak(create_engine),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'EventHandler' ktab size: 8, total: 17 (saved 72 bytes)
+static const bvalue be_ktab_class_EventHandler[8] = {
+  /* K0   */  be_nested_str_weak(is_active),
+  /* K1   */  be_nested_str_weak(condition),
+  /* K2   */  be_nested_str_weak(callback_func),
+  /* K3   */  be_nested_str_weak(event_name),
+  /* K4   */  be_nested_str_weak(priority),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(metadata),
+  /* K7   */  be_nested_str_weak(has_condition),
+};
+
+
+extern const bclass be_class_EventHandler;
+
+/********************************************************************
+** Solidified function: execute
+********************************************************************/
+be_local_closure(class_EventHandler_execute,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventHandler,     /* shared constants */
+    be_str_weak(execute),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x20080403,  //  0006  NE	R2	R2	R3
+      0x780A0005,  //  0007  JMPF	R2	#000E
+      0x8C080101,  //  0008  GETMET	R2	R0	K1
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x740A0001,  //  000B  JMPT	R2	#000E
+      0x50080000,  //  000C  LDBOOL	R2	0	0
+      0x80040400,  //  000D  RET	1	R2
+      0x88080102,  //  000E  GETMBR	R2	R0	K2
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x20080403,  //  0010  NE	R2	R2	R3
+      0x780A0004,  //  0011  JMPF	R2	#0017
+      0x8C080102,  //  0012  GETMET	R2	R0	K2
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x50080200,  //  0015  LDBOOL	R2	1	0
+      0x80040400,  //  0016  RET	1	R2
+      0x50080000,  //  0017  LDBOOL	R2	0	0
+      0x80040400,  //  0018  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_active
+********************************************************************/
+be_local_closure(class_EventHandler_set_active,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventHandler,     /* shared constants */
+    be_str_weak(set_active),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_EventHandler_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    6,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventHandler,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x90020601,  //  0000  SETMBR	R0	K3	R1
+      0x90020402,  //  0001  SETMBR	R0	K2	R2
+      0x4C180000,  //  0002  LDNIL	R6
+      0x20180606,  //  0003  NE	R6	R3	R6
+      0x781A0001,  //  0004  JMPF	R6	#0007
+      0x5C180600,  //  0005  MOVE	R6	R3
+      0x70020000,  //  0006  JMP		#0008
+      0x58180005,  //  0007  LDCONST	R6	K5
+      0x90020806,  //  0008  SETMBR	R0	K4	R6
+      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x50180200,  //  000A  LDBOOL	R6	1	0
+      0x90020006,  //  000B  SETMBR	R0	K0	R6
+      0x4C180000,  //  000C  LDNIL	R6
+      0x20180A06,  //  000D  NE	R6	R5	R6
+      0x781A0001,  //  000E  JMPF	R6	#0011
+      0x5C180A00,  //  000F  MOVE	R6	R5
+      0x70020001,  //  0010  JMP		#0013
+      0x60180013,  //  0011  GETGBL	R6	G19
+      0x7C180000,  //  0012  CALL	R6	0
+      0x90020C06,  //  0013  SETMBR	R0	K6	R6
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_info
+********************************************************************/
+be_local_closure(class_EventHandler_get_info,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventHandler,     /* shared constants */
+    be_str_weak(get_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080103,  //  0002  GETMBR	R2	R0	K3
+      0x98060602,  //  0003  SETIDX	R1	K3	R2
+      0x88080104,  //  0004  GETMBR	R2	R0	K4
+      0x98060802,  //  0005  SETIDX	R1	K4	R2
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
+      0x98060002,  //  0007  SETIDX	R1	K0	R2
+      0x88080101,  //  0008  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0009  LDNIL	R3
+      0x20080403,  //  000A  NE	R2	R2	R3
+      0x98060E02,  //  000B  SETIDX	R1	K7	R2
+      0x88080106,  //  000C  GETMBR	R2	R0	K6
+      0x98060C02,  //  000D  SETIDX	R1	K6	R2
+      0x80040200,  //  000E  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: EventHandler
+********************************************************************/
+be_local_class(EventHandler,
+    6,
+    NULL,
+    be_nested_map(10,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(set_active, -1), be_const_closure(class_EventHandler_set_active_closure) },
+        { be_const_key_weak(metadata, 3), be_const_var(5) },
+        { be_const_key_weak(is_active, 0), be_const_var(4) },
+        { be_const_key_weak(condition, -1), be_const_var(2) },
+        { be_const_key_weak(init, -1), be_const_closure(class_EventHandler_init_closure) },
+        { be_const_key_weak(event_name, 4), be_const_var(0) },
+        { be_const_key_weak(get_info, -1), be_const_closure(class_EventHandler_get_info_closure) },
+        { be_const_key_weak(priority, -1), be_const_var(3) },
+        { be_const_key_weak(execute, 1), be_const_closure(class_EventHandler_execute_closure) },
+        { be_const_key_weak(callback_func, -1), be_const_var(1) },
+    })),
+    be_str_weak(EventHandler)
+);
+// compact class 'Animation' ktab size: 27, total: 52 (saved 200 bytes)
+static const bvalue be_ktab_class_Animation[27] = {
+  /* K0   */  be_nested_str_weak(Animation_X28_X25s_X2C_X20priority_X3D_X25s_X2C_X20duration_X3D_X25s_X2C_X20loop_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K1   */  be_nested_str_weak(name),
+  /* K2   */  be_nested_str_weak(priority),
+  /* K3   */  be_nested_str_weak(duration),
+  /* K4   */  be_nested_str_weak(loop),
+  /* K5   */  be_nested_str_weak(is_running),
+  /* K6   */  be_nested_str_weak(get_color_at),
+  /* K7   */  be_const_int(0),
+  /* K8   */  be_nested_str_weak(get_param_value),
+  /* K9   */  be_nested_str_weak(color),
+  /* K10  */  be_nested_str_weak(update),
+  /* K11  */  be_nested_str_weak(opacity),
+  /* K12  */  be_nested_str_weak(fill_pixels),
+  /* K13  */  be_nested_str_weak(apply_brightness),
+  /* K14  */  be_nested_str_weak(current_time),
+  /* K15  */  be_nested_str_weak(start_time),
+  /* K16  */  be_nested_str_weak(tasmota),
+  /* K17  */  be_nested_str_weak(scale_uint),
+  /* K18  */  be_nested_str_weak(engine),
+  /* K19  */  be_nested_str_weak(time_ms),
+  /* K20  */  be_nested_str_weak(_start_value_providers),
+  /* K21  */  be_nested_str_weak(init),
+  /* K22  */  be_nested_str_weak(values),
+  /* K23  */  be_nested_str_weak(animation),
+  /* K24  */  be_nested_str_weak(is_value_provider),
+  /* K25  */  be_nested_str_weak(start),
+  /* K26  */  be_nested_str_weak(stop_iteration),
+};
+
+
+extern const bclass be_class_Animation;
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_Animation_tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x881C0105,  //  0006  GETMBR	R7	R0	K5
+      0x7C040C00,  //  0007  CALL	R1	6
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color
+********************************************************************/
+be_local_closure(class_Animation_get_color,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(get_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C080106,  //  0000  GETMET	R2	R0	K6
+      0x58100007,  //  0001  LDCONST	R4	K7
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C080600,  //  0003  CALL	R2	3
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color_at
+********************************************************************/
+be_local_closure(class_Animation_get_color_at,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(get_color_at),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C0C0108,  //  0000  GETMET	R3	R0	K8
+      0x58140009,  //  0001  LDCONST	R5	K9
+      0x5C180400,  //  0002  MOVE	R6	R2
+      0x7C0C0600,  //  0003  CALL	R3	3
+      0x80040600,  //  0004  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_Animation_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x880C0105,  //  0000  GETMBR	R3	R0	K5
+      0x5C100600,  //  0001  MOVE	R4	R3
+      0x78120002,  //  0002  JMPF	R4	#0006
+      0x4C100000,  //  0003  LDNIL	R4
+      0x1C100204,  //  0004  EQ	R4	R1	R4
+      0x78120001,  //  0005  JMPF	R4	#0008
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x80040800,  //  0007  RET	1	R4
+      0x8C10010A,  //  0008  GETMET	R4	R0	K10
+      0x5C180400,  //  0009  MOVE	R6	R2
+      0x7C100400,  //  000A  CALL	R4	2
+      0x88100109,  //  000B  GETMBR	R4	R0	K9
+      0x8814010B,  //  000C  GETMBR	R5	R0	K11
+      0x8C18030C,  //  000D  GETMET	R6	R1	K12
+      0x5C200800,  //  000E  MOVE	R8	R4
+      0x7C180400,  //  000F  CALL	R6	2
+      0x541A00FE,  //  0010  LDINT	R6	255
+      0x14180A06,  //  0011  LT	R6	R5	R6
+      0x781A0002,  //  0012  JMPF	R6	#0016
+      0x8C18030D,  //  0013  GETMET	R6	R1	K13
+      0x5C200A00,  //  0014  MOVE	R8	R5
+      0x7C180400,  //  0015  CALL	R6	2
+      0x50180200,  //  0016  LDBOOL	R6	1	0
+      0x80040C00,  //  0017  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_progress
+********************************************************************/
+be_local_closure(class_Animation_get_progress,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(get_progress),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x88040103,  //  0000  GETMBR	R1	R0	K3
+      0x18080307,  //  0001  LE	R2	R1	K7
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80060E00,  //  0003  RET	1	K7
+      0x8808010E,  //  0004  GETMBR	R2	R0	K14
+      0x880C010F,  //  0005  GETMBR	R3	R0	K15
+      0x04080403,  //  0006  SUB	R2	R2	R3
+      0x100C0401,  //  0007  MOD	R3	R2	R1
+      0x88100104,  //  0008  GETMBR	R4	R0	K4
+      0x5C140800,  //  0009  MOVE	R5	R4
+      0x74160003,  //  000A  JMPT	R5	#000F
+      0x28140401,  //  000B  GE	R5	R2	R1
+      0x78160001,  //  000C  JMPF	R5	#000F
+      0x541600FE,  //  000D  LDINT	R5	255
+      0x80040A00,  //  000E  RET	1	R5
+      0xB8162000,  //  000F  GETNGBL	R5	K16
+      0x8C140B11,  //  0010  GETMET	R5	R5	K17
+      0x5C1C0600,  //  0011  MOVE	R7	R3
+      0x58200007,  //  0012  LDCONST	R8	K7
+      0x5C240200,  //  0013  MOVE	R9	R1
+      0x58280007,  //  0014  LDCONST	R10	K7
+      0x542E00FE,  //  0015  LDINT	R11	255
+      0x7C140C00,  //  0016  CALL	R5	6
+      0x80040A00,  //  0017  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_Animation_on_param_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x1C0C0305,  //  0000  EQ	R3	R1	K5
+      0x780E000E,  //  0001  JMPF	R3	#0011
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x1C0C0403,  //  0003  EQ	R3	R2	R3
+      0x780E0008,  //  0004  JMPF	R3	#000E
+      0x880C0112,  //  0005  GETMBR	R3	R0	K18
+      0x880C0713,  //  0006  GETMBR	R3	R3	K19
+      0x90021E03,  //  0007  SETMBR	R0	K15	R3
+      0x8810010F,  //  0008  GETMBR	R4	R0	K15
+      0x90021C04,  //  0009  SETMBR	R0	K14	R4
+      0x8C100114,  //  000A  GETMET	R4	R0	K20
+      0x5C180600,  //  000B  MOVE	R6	R3
+      0x7C100400,  //  000C  CALL	R4	2
+      0x70020002,  //  000D  JMP		#0011
+      0x500C0000,  //  000E  LDBOOL	R3	0	0
+      0x1C0C0403,  //  000F  EQ	R3	R2	R3
+      0x780DFFFF,  //  0010  JMPF	R3	#0011
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Animation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080515,  //  0003  GETMET	R2	R2	K21
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90021F07,  //  0006  SETMBR	R0	K15	K7
+      0x90021D07,  //  0007  SETMBR	R0	K14	K7
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_Animation_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080116,  //  0000  GETMBR	R2	R0	K22
+      0x500C0200,  //  0001  LDBOOL	R3	1	0
+      0x980A0A03,  //  0002  SETIDX	R2	K5	R3
+      0x4C080000,  //  0003  LDNIL	R2
+      0x20080202,  //  0004  NE	R2	R1	R2
+      0x780A0001,  //  0005  JMPF	R2	#0008
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x70020001,  //  0007  JMP		#000A
+      0x88080112,  //  0008  GETMBR	R2	R0	K18
+      0x88080513,  //  0009  GETMBR	R2	R2	K19
+      0x90021E02,  //  000A  SETMBR	R0	K15	R2
+      0x880C010F,  //  000B  GETMBR	R3	R0	K15
+      0x90021C03,  //  000C  SETMBR	R0	K14	R3
+      0x8C0C0114,  //  000D  GETMET	R3	R0	K20
+      0x5C140400,  //  000E  MOVE	R5	R2
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x80040000,  //  0010  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_value_providers
+********************************************************************/
+be_local_closure(class_Animation__start_value_providers,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(_start_value_providers),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x60080010,  //  0000  GETGBL	R2	G16
+      0x880C0116,  //  0001  GETMBR	R3	R0	K22
+      0x7C080200,  //  0002  CALL	R2	1
+      0xA8020011,  //  0003  EXBLK	0	#0016
+      0x5C0C0400,  //  0004  MOVE	R3	R2
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0xB8122E00,  //  0006  GETNGBL	R4	K23
+      0x8C100918,  //  0007  GETMET	R4	R4	K24
+      0x5C180600,  //  0008  MOVE	R6	R3
+      0x7C100400,  //  0009  CALL	R4	2
+      0x78120009,  //  000A  JMPF	R4	#0015
+      0xA8020004,  //  000B  EXBLK	0	#0011
+      0x8C100719,  //  000C  GETMET	R4	R3	K25
+      0x5C180200,  //  000D  MOVE	R6	R1
+      0x7C100400,  //  000E  CALL	R4	2
+      0xA8040001,  //  000F  EXBLK	1	1
+      0x70020003,  //  0010  JMP		#0015
+      0xAC100001,  //  0011  CATCH	R4	0	1
+      0x70020000,  //  0012  JMP		#0014
+      0x70020000,  //  0013  JMP		#0015
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x7001FFED,  //  0015  JMP		#0004
+      0x5808001A,  //  0016  LDCONST	R2	K26
+      0xAC080200,  //  0017  CATCH	R2	1	0
+      0xB0080000,  //  0018  RAISE	2	R0	R0
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_Animation_update,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Animation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x88080105,  //  0000  GETMBR	R2	R0	K5
+      0x5C0C0400,  //  0001  MOVE	R3	R2
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x90021C01,  //  0005  SETMBR	R0	K14	R1
+      0x880C010E,  //  0006  GETMBR	R3	R0	K14
+      0x8810010F,  //  0007  GETMBR	R4	R0	K15
+      0x040C0604,  //  0008  SUB	R3	R3	R4
+      0x88100103,  //  0009  GETMBR	R4	R0	K3
+      0x88140104,  //  000A  GETMBR	R5	R0	K4
+      0x24180907,  //  000B  GT	R6	R4	K7
+      0x781A000D,  //  000C  JMPF	R6	#001B
+      0x28180604,  //  000D  GE	R6	R3	R4
+      0x781A000B,  //  000E  JMPF	R6	#001B
+      0x78160005,  //  000F  JMPF	R5	#0016
+      0x0C180604,  //  0010  DIV	R6	R3	R4
+      0x881C010F,  //  0011  GETMBR	R7	R0	K15
+      0x08200C04,  //  0012  MUL	R8	R6	R4
+      0x001C0E08,  //  0013  ADD	R7	R7	R8
+      0x90021E07,  //  0014  SETMBR	R0	K15	R7
+      0x70020004,  //  0015  JMP		#001B
+      0x88180116,  //  0016  GETMBR	R6	R0	K22
+      0x501C0000,  //  0017  LDBOOL	R7	0	0
+      0x981A0A07,  //  0018  SETIDX	R6	K5	R7
+      0x50180000,  //  0019  LDBOOL	R6	0	0
+      0x80040C00,  //  001A  RET	1	R6
+      0x50180200,  //  001B  LDBOOL	R6	1	0
+      0x80040C00,  //  001C  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Animation
+********************************************************************/
+extern const bclass be_class_ParameterizedObject;
+be_local_class(Animation,
+    2,
+    &be_class_ParameterizedObject,
+    be_nested_map(13,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(tostring, -1), be_const_closure(class_Animation_tostring_closure) },
+        { be_const_key_weak(get_color, -1), be_const_closure(class_Animation_get_color_closure) },
+        { be_const_key_weak(update, -1), be_const_closure(class_Animation_update_closure) },
+        { be_const_key_weak(render, -1), be_const_closure(class_Animation_render_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_Animation_init_closure) },
+        { be_const_key_weak(current_time, -1), be_const_var(1) },
+        { be_const_key_weak(on_param_changed, 4), be_const_closure(class_Animation_on_param_changed_closure) },
+        { be_const_key_weak(get_progress, 5), be_const_closure(class_Animation_get_progress_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(class_Animation_start_closure) },
+        { be_const_key_weak(_start_value_providers, -1), be_const_closure(class_Animation__start_value_providers_closure) },
+        { be_const_key_weak(start_time, -1), be_const_var(0) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(7,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(priority, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(10) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(name, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_nested_str_weak(animation) },
+        { be_const_key_weak(type, -1), be_nested_str_weak(string) },
+    }))    ) } )) },
+        { be_const_key_weak(color, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(is_running, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_bool(0) },
+        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
+    }))    ) } )) },
+        { be_const_key_weak(opacity, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(255) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(loop, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_bool(1) },
+        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
+    }))    ) } )) },
+        { be_const_key_weak(duration, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(get_color_at, 2), be_const_closure(class_Animation_get_color_at_closure) },
+    })),
+    be_str_weak(Animation)
+);
+
+/********************************************************************
+** Solidified function: is_user_function
+********************************************************************/
+be_local_closure(is_user_function,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_animation_user_functions),
+    /* K2   */  be_nested_str_weak(contains),
+    }),
+    be_str_weak(is_user_function),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080301,  //  0001  GETMBR	R2	R1	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_user_function
+********************************************************************/
+be_local_closure(register_user_function,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_animation_user_functions),
+    }),
+    be_str_weak(register_user_function),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x880C0501,  //  0001  GETMBR	R3	R2	K1
+      0x980C0001,  //  0002  SETIDX	R3	R0	R1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'BeaconAnimation' ktab size: 18, total: 22 (saved 32 bytes)
+static const bvalue be_ktab_class_BeaconAnimation[18] = {
+  /* K0   */  be_nested_str_weak(engine),
+  /* K1   */  be_nested_str_weak(time_ms),
+  /* K2   */  be_nested_str_weak(width),
+  /* K3   */  be_nested_str_weak(back_color),
+  /* K4   */  be_nested_str_weak(pos),
+  /* K5   */  be_nested_str_weak(slew_size),
+  /* K6   */  be_nested_str_weak(beacon_size),
+  /* K7   */  be_nested_str_weak(color),
+  /* K8   */  be_const_int(-16777216),
+  /* K9   */  be_nested_str_weak(fill_pixels),
+  /* K10  */  be_const_int(0),
+  /* K11  */  be_nested_str_weak(set_pixel_color),
+  /* K12  */  be_const_int(1),
+  /* K13  */  be_nested_str_weak(tasmota),
+  /* K14  */  be_nested_str_weak(scale_uint),
+  /* K15  */  be_const_int(16777215),
+  /* K16  */  be_nested_str_weak(blend),
+  /* K17  */  be_nested_str_weak(BeaconAnimation_X28color_X3D0x_X2508x_X2C_X20pos_X3D_X25s_X2C_X20beacon_size_X3D_X25s_X2C_X20slew_size_X3D_X25s_X29),
+};
+
+
+extern const bclass be_class_BeaconAnimation;
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_BeaconAnimation_render,   /* name */
+  be_nested_proto(
+    24,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BeaconAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[127]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0203,  //  0001  EQ	R3	R1	R3
+      0x780E0001,  //  0002  JMPF	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C0C0403,  //  0006  EQ	R3	R2	R3
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x88080701,  //  0009  GETMBR	R2	R3	K1
+      0x880C0302,  //  000A  GETMBR	R3	R1	K2
+      0x88100103,  //  000B  GETMBR	R4	R0	K3
+      0x88140104,  //  000C  GETMBR	R5	R0	K4
+      0x88180105,  //  000D  GETMBR	R6	R0	K5
+      0x881C0106,  //  000E  GETMBR	R7	R0	K6
+      0x88200107,  //  000F  GETMBR	R8	R0	K7
+      0x20240908,  //  0010  NE	R9	R4	K8
+      0x78260002,  //  0011  JMPF	R9	#0015
+      0x8C240309,  //  0012  GETMET	R9	R1	K9
+      0x5C2C0800,  //  0013  MOVE	R11	R4
+      0x7C240400,  //  0014  CALL	R9	2
+      0x5C240A00,  //  0015  MOVE	R9	R5
+      0x00280A07,  //  0016  ADD	R10	R5	R7
+      0x142C130A,  //  0017  LT	R11	R9	K10
+      0x782E0000,  //  0018  JMPF	R11	#001A
+      0x5824000A,  //  0019  LDCONST	R9	K10
+      0x282C1403,  //  001A  GE	R11	R10	R3
+      0x782E0000,  //  001B  JMPF	R11	#001D
+      0x5C280600,  //  001C  MOVE	R10	R3
+      0x5C2C1200,  //  001D  MOVE	R11	R9
+      0x1430160A,  //  001E  LT	R12	R11	R10
+      0x78320005,  //  001F  JMPF	R12	#0026
+      0x8C30030B,  //  0020  GETMET	R12	R1	K11
+      0x5C381600,  //  0021  MOVE	R14	R11
+      0x5C3C1000,  //  0022  MOVE	R15	R8
+      0x7C300600,  //  0023  CALL	R12	3
+      0x002C170C,  //  0024  ADD	R11	R11	K12
+      0x7001FFF7,  //  0025  JMP		#001E
+      0x24300D0A,  //  0026  GT	R12	R6	K10
+      0x78320054,  //  0027  JMPF	R12	#007D
+      0x04300A06,  //  0028  SUB	R12	R5	R6
+      0x5C340A00,  //  0029  MOVE	R13	R5
+      0x1438190A,  //  002A  LT	R14	R12	K10
+      0x783A0000,  //  002B  JMPF	R14	#002D
+      0x5830000A,  //  002C  LDCONST	R12	K10
+      0x28381A03,  //  002D  GE	R14	R13	R3
+      0x783A0000,  //  002E  JMPF	R14	#0030
+      0x5C340600,  //  002F  MOVE	R13	R3
+      0x5C2C1800,  //  0030  MOVE	R11	R12
+      0x1438160D,  //  0031  LT	R14	R11	R13
+      0x783A001D,  //  0032  JMPF	R14	#0051
+      0x4C380000,  //  0033  LDNIL	R14
+      0x1C3C0D0C,  //  0034  EQ	R15	R6	K12
+      0x783E0001,  //  0035  JMPF	R15	#0038
+      0x543A007F,  //  0036  LDINT	R14	128
+      0x70020008,  //  0037  JMP		#0041
+      0xB83E1A00,  //  0038  GETNGBL	R15	K13
+      0x8C3C1F0E,  //  0039  GETMET	R15	R15	K14
+      0x5C441600,  //  003A  MOVE	R17	R11
+      0x04480A06,  //  003B  SUB	R18	R5	R6
+      0x044C0B0C,  //  003C  SUB	R19	R5	K12
+      0x545200FE,  //  003D  LDINT	R20	255
+      0x5854000A,  //  003E  LDCONST	R21	K10
+      0x7C3C0C00,  //  003F  CALL	R15	6
+      0x5C381E00,  //  0040  MOVE	R14	R15
+      0x543E00FE,  //  0041  LDINT	R15	255
+      0x043C1E0E,  //  0042  SUB	R15	R15	R14
+      0x54420017,  //  0043  LDINT	R16	24
+      0x38401E10,  //  0044  SHL	R16	R15	R16
+      0x2C44110F,  //  0045  AND	R17	R8	K15
+      0x30402011,  //  0046  OR	R16	R16	R17
+      0x8C440310,  //  0047  GETMET	R17	R1	K16
+      0x5C4C0800,  //  0048  MOVE	R19	R4
+      0x5C502000,  //  0049  MOVE	R20	R16
+      0x7C440600,  //  004A  CALL	R17	3
+      0x8C48030B,  //  004B  GETMET	R18	R1	K11
+      0x5C501600,  //  004C  MOVE	R20	R11
+      0x5C542200,  //  004D  MOVE	R21	R17
+      0x7C480600,  //  004E  CALL	R18	3
+      0x002C170C,  //  004F  ADD	R11	R11	K12
+      0x7001FFDF,  //  0050  JMP		#0031
+      0x00380A07,  //  0051  ADD	R14	R5	R7
+      0x003C0A07,  //  0052  ADD	R15	R5	R7
+      0x003C1E06,  //  0053  ADD	R15	R15	R6
+      0x14401D0A,  //  0054  LT	R16	R14	K10
+      0x78420000,  //  0055  JMPF	R16	#0057
+      0x5838000A,  //  0056  LDCONST	R14	K10
+      0x28401E03,  //  0057  GE	R16	R15	R3
+      0x78420000,  //  0058  JMPF	R16	#005A
+      0x5C3C0600,  //  0059  MOVE	R15	R3
+      0x5C2C1C00,  //  005A  MOVE	R11	R14
+      0x1440160F,  //  005B  LT	R16	R11	R15
+      0x7842001F,  //  005C  JMPF	R16	#007D
+      0x4C400000,  //  005D  LDNIL	R16
+      0x1C440D0C,  //  005E  EQ	R17	R6	K12
+      0x78460001,  //  005F  JMPF	R17	#0062
+      0x5442007F,  //  0060  LDINT	R16	128
+      0x7002000A,  //  0061  JMP		#006D
+      0xB8461A00,  //  0062  GETNGBL	R17	K13
+      0x8C44230E,  //  0063  GETMET	R17	R17	K14
+      0x5C4C1600,  //  0064  MOVE	R19	R11
+      0x00500A07,  //  0065  ADD	R20	R5	R7
+      0x00540A07,  //  0066  ADD	R21	R5	R7
+      0x00542A06,  //  0067  ADD	R21	R21	R6
+      0x04542B0C,  //  0068  SUB	R21	R21	K12
+      0x5858000A,  //  0069  LDCONST	R22	K10
+      0x545E00FE,  //  006A  LDINT	R23	255
+      0x7C440C00,  //  006B  CALL	R17	6
+      0x5C402200,  //  006C  MOVE	R16	R17
+      0x544600FE,  //  006D  LDINT	R17	255
+      0x04442210,  //  006E  SUB	R17	R17	R16
+      0x544A0017,  //  006F  LDINT	R18	24
+      0x38482212,  //  0070  SHL	R18	R17	R18
+      0x2C4C110F,  //  0071  AND	R19	R8	K15
+      0x30482413,  //  0072  OR	R18	R18	R19
+      0x8C4C0310,  //  0073  GETMET	R19	R1	K16
+      0x5C540800,  //  0074  MOVE	R21	R4
+      0x5C582400,  //  0075  MOVE	R22	R18
+      0x7C4C0600,  //  0076  CALL	R19	3
+      0x8C50030B,  //  0077  GETMET	R20	R1	K11
+      0x5C581600,  //  0078  MOVE	R22	R11
+      0x5C5C2600,  //  0079  MOVE	R23	R19
+      0x7C500600,  //  007A  CALL	R20	3
+      0x002C170C,  //  007B  ADD	R11	R11	K12
+      0x7001FFDD,  //  007C  JMP		#005B
+      0x50300200,  //  007D  LDBOOL	R12	1	0
+      0x80041800,  //  007E  RET	1	R12
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_BeaconAnimation_tostring,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BeaconAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080011,  //  0001  LDCONST	R2	K17
+      0x880C0107,  //  0002  GETMBR	R3	R0	K7
+      0x88100104,  //  0003  GETMBR	R4	R0	K4
+      0x88140106,  //  0004  GETMBR	R5	R0	K6
+      0x88180105,  //  0005  GETMBR	R6	R0	K5
+      0x7C040A00,  //  0006  CALL	R1	5
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: BeaconAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(BeaconAnimation,
+    0,
+    &be_class_Animation,
+    be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(back_color, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-16777216) },
+    }))    ) } )) },
+        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(slew_size, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(beacon_size, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(1) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(render, 2), be_const_closure(class_BeaconAnimation_render_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_BeaconAnimation_tostring_closure) },
+    })),
+    be_str_weak(BeaconAnimation)
+);
+
+/********************************************************************
+** Solidified function: animation_version_string
+********************************************************************/
+be_local_closure(animation_version_string,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(VERSION),
+    /* K2   */  be_nested_str_weak(_X25s_X2E_X25s_X2E_X25s),
+    }),
+    be_str_weak(animation_version_string),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x1C040001,  //  0001  EQ	R1	R0	R1
+      0x78060001,  //  0002  JMPF	R1	#0005
+      0xB8060000,  //  0003  GETNGBL	R1	K0
+      0x88000301,  //  0004  GETMBR	R0	R1	K1
+      0x54060017,  //  0005  LDINT	R1	24
+      0x3C040001,  //  0006  SHR	R1	R0	R1
+      0x540A00FE,  //  0007  LDINT	R2	255
+      0x2C040202,  //  0008  AND	R1	R1	R2
+      0x540A000F,  //  0009  LDINT	R2	16
+      0x3C080002,  //  000A  SHR	R2	R0	R2
+      0x540E00FE,  //  000B  LDINT	R3	255
+      0x2C080403,  //  000C  AND	R2	R2	R3
+      0x540E0007,  //  000D  LDINT	R3	8
+      0x3C0C0003,  //  000E  SHR	R3	R0	R3
+      0x541200FE,  //  000F  LDINT	R4	255
+      0x2C0C0604,  //  0010  AND	R3	R3	R4
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x7C100800,  //  0016  CALL	R4	4
+      0x80040800,  //  0017  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sparkle_white
+********************************************************************/
+be_local_closure(sparkle_white,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(sparkle_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(name),
+    /* K4   */  be_nested_str_weak(sparkle_white),
+    }),
+    be_str_weak(sparkle_white),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FFFE,  //  0004  LDINT	R2	-1
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x90060704,  //  0006  SETMBR	R1	K3	K4
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: elastic
+********************************************************************/
+be_local_closure(elastic,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(ELASTIC),
+    }),
+    be_str_weak(elastic),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: noise_single_color
+********************************************************************/
+be_local_closure(noise_single_color,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(noise_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(scale),
+    /* K4   */  be_nested_str_weak(speed),
+    /* K5   */  be_nested_str_weak(octaves),
+    /* K6   */  be_const_int(1),
+    }),
+    be_str_weak(noise_single_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FFFE,  //  0004  LDINT	R2	-1
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A0031,  //  0006  LDINT	R2	50
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A001D,  //  0008  LDINT	R2	30
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x90060B06,  //  000A  SETMBR	R1	K5	K6
+      0x80040200,  //  000B  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+extern const bclass be_class_PaletteMeterAnimation;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_PaletteMeterAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(name),
+    /* K2   */  be_nested_str_weak(palette_meter),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020302,  //  0006  SETMBR	R0	K1	K2
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_value_buffer
+********************************************************************/
+be_local_closure(class_PaletteMeterAnimation__update_value_buffer,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(value_func),
+    /* K1   */  be_nested_str_weak(engine),
+    /* K2   */  be_nested_str_weak(get_strip_length),
+    /* K3   */  be_nested_str_weak(value_buffer),
+    /* K4   */  be_nested_str_weak(resize),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(scale_uint),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_const_int(1),
+    }),
+    be_str_weak(_update_value_buffer),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0403,  //  0002  EQ	R3	R2	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80000600,  //  0004  RET	0
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0006  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x6010000C,  //  0008  GETGBL	R4	G12
+      0x88140103,  //  0009  GETMBR	R5	R0	K3
+      0x7C100200,  //  000A  CALL	R4	1
+      0x20100803,  //  000B  NE	R4	R4	R3
+      0x78120003,  //  000C  JMPF	R4	#0011
+      0x88100103,  //  000D  GETMBR	R4	R0	K3
+      0x8C100904,  //  000E  GETMET	R4	R4	K4
+      0x5C180600,  //  000F  MOVE	R6	R3
+      0x7C100400,  //  0010  CALL	R4	2
+      0x5C100400,  //  0011  MOVE	R4	R2
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x5C180000,  //  0013  MOVE	R6	R0
+      0x7C100400,  //  0014  CALL	R4	2
+      0xB8160A00,  //  0015  GETNGBL	R5	K5
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200007,  //  0018  LDCONST	R8	K7
+      0x54260063,  //  0019  LDINT	R9	100
+      0x58280007,  //  001A  LDCONST	R10	K7
+      0x5C2C0600,  //  001B  MOVE	R11	R3
+      0x7C140C00,  //  001C  CALL	R5	6
+      0x58180007,  //  001D  LDCONST	R6	K7
+      0x141C0C03,  //  001E  LT	R7	R6	R3
+      0x781E0008,  //  001F  JMPF	R7	#0029
+      0x881C0103,  //  0020  GETMBR	R7	R0	K3
+      0x14200C05,  //  0021  LT	R8	R6	R5
+      0x78220001,  //  0022  JMPF	R8	#0025
+      0x54220063,  //  0023  LDINT	R8	100
+      0x70020000,  //  0024  JMP		#0026
+      0x58200007,  //  0025  LDCONST	R8	K7
+      0x981C0C08,  //  0026  SETIDX	R7	R6	R8
+      0x00180D08,  //  0027  ADD	R6	R6	K8
+      0x7001FFF4,  //  0028  JMP		#001E
+      0x80000000,  //  0029  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: PaletteMeterAnimation
+********************************************************************/
+extern const bclass be_class_PalettePatternAnimation;
+be_local_class(PaletteMeterAnimation,
+    0,
+    &be_class_PalettePatternAnimation,
+    be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(value_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_nil() },
+        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_PaletteMeterAnimation_init_closure) },
+        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteMeterAnimation__update_value_buffer_closure) },
+    })),
+    be_str_weak(PaletteMeterAnimation)
+);
+
+/********************************************************************
+** Solidified function: is_value_provider
+********************************************************************/
+be_local_closure(is_value_provider,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(value_provider),
+    }),
+    be_str_weak(is_value_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x6004000F,  //  0000  GETGBL	R1	G15
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0x880C0701,  //  0003  GETMBR	R3	R3	K1
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ramp
+********************************************************************/
+be_local_closure(ramp,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(SAWTOOTH),
+    }),
+    be_str_weak(ramp),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: wave_custom
+********************************************************************/
+be_local_closure(wave_custom,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(wave_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(wave_type),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(frequency),
+    /* K6   */  be_nested_str_weak(wave_speed),
+    }),
+    be_str_weak(wave_custom),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FEFF,  //  0004  LDINT	R2	-256
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x90060704,  //  0006  SETMBR	R1	K3	K4
+      0x540A0027,  //  0007  LDINT	R2	40
+      0x90060A02,  //  0008  SETMBR	R1	K5	R2
+      0x540A001D,  //  0009  LDINT	R2	30
+      0x90060C02,  //  000A  SETMBR	R1	K6	R2
+      0x80040200,  //  000B  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'BreatheColorProvider' ktab size: 18, total: 29 (saved 88 bytes)
+static const bvalue be_ktab_class_BreatheColorProvider[18] = {
+  /* K0   */  be_nested_str_weak(BreatheColorProvider_X28base_color_X3D0x_X2508x_X2C_X20min_brightness_X3D_X25s_X2C_X20max_brightness_X3D_X25s_X2C_X20duration_X3D_X25s_X2C_X20curve_factor_X3D_X25s_X29),
+  /* K1   */  be_nested_str_weak(base_color),
+  /* K2   */  be_nested_str_weak(min_brightness),
+  /* K3   */  be_nested_str_weak(max_brightness),
+  /* K4   */  be_nested_str_weak(duration),
+  /* K5   */  be_nested_str_weak(curve_factor),
+  /* K6   */  be_const_int(1),
+  /* K7   */  be_nested_str_weak(form),
+  /* K8   */  be_nested_str_weak(animation),
+  /* K9   */  be_nested_str_weak(COSINE),
+  /* K10  */  be_nested_str_weak(on_param_changed),
+  /* K11  */  be_nested_str_weak(produce_value),
+  /* K12  */  be_nested_str_weak(tasmota),
+  /* K13  */  be_nested_str_weak(scale_uint),
+  /* K14  */  be_const_int(0),
+  /* K15  */  be_nested_str_weak(init),
+  /* K16  */  be_nested_str_weak(min_value),
+  /* K17  */  be_nested_str_weak(max_value),
+};
+
+
+extern const bclass be_class_BreatheColorProvider;
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_BreatheColorProvider_tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BreatheColorProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x881C0105,  //  0006  GETMBR	R7	R0	K5
+      0x7C040C00,  //  0007  CALL	R1	6
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_BreatheColorProvider_on_param_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BreatheColorProvider,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x1C0C0305,  //  0000  EQ	R3	R1	K5
+      0x780E0008,  //  0001  JMPF	R3	#000B
+      0x1C0C0506,  //  0002  EQ	R3	R2	K6
+      0x780E0003,  //  0003  JMPF	R3	#0008
+      0xB80E1000,  //  0004  GETNGBL	R3	K8
+      0x880C0709,  //  0005  GETMBR	R3	R3	K9
+      0x90020E03,  //  0006  SETMBR	R0	K7	R3
+      0x70020002,  //  0007  JMP		#000B
+      0xB80E1000,  //  0008  GETNGBL	R3	K8
+      0x880C0709,  //  0009  GETMBR	R3	R3	K9
+      0x90020E03,  //  000A  SETMBR	R0	K7	R3
+      0x600C0003,  //  000B  GETGBL	R3	G3
+      0x5C100000,  //  000C  MOVE	R4	R0
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x8C0C070A,  //  000E  GETMET	R3	R3	K10
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_BreatheColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BreatheColorProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[82]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C070B,  //  0003  GETMET	R3	R3	K11
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x88100105,  //  0007  GETMBR	R4	R0	K5
+      0x5C140600,  //  0008  MOVE	R5	R3
+      0x24180906,  //  0009  GT	R6	R4	K6
+      0x781A0019,  //  000A  JMPF	R6	#0025
+      0xB81A1800,  //  000B  GETNGBL	R6	K12
+      0x8C180D0D,  //  000C  GETMET	R6	R6	K13
+      0x5C200600,  //  000D  MOVE	R8	R3
+      0x5824000E,  //  000E  LDCONST	R9	K14
+      0x542A00FE,  //  000F  LDINT	R10	255
+      0x582C000E,  //  0010  LDCONST	R11	K14
+      0x54321FFF,  //  0011  LDINT	R12	8192
+      0x7C180C00,  //  0012  CALL	R6	6
+      0x5C1C0800,  //  0013  MOVE	R7	R4
+      0x24200F06,  //  0014  GT	R8	R7	K6
+      0x78220005,  //  0015  JMPF	R8	#001C
+      0x08200C06,  //  0016  MUL	R8	R6	R6
+      0x54261FFF,  //  0017  LDINT	R9	8192
+      0x0C201009,  //  0018  DIV	R8	R8	R9
+      0x5C181000,  //  0019  MOVE	R6	R8
+      0x041C0F06,  //  001A  SUB	R7	R7	K6
+      0x7001FFF7,  //  001B  JMP		#0014
+      0xB8221800,  //  001C  GETNGBL	R8	K12
+      0x8C20110D,  //  001D  GETMET	R8	R8	K13
+      0x5C280C00,  //  001E  MOVE	R10	R6
+      0x582C000E,  //  001F  LDCONST	R11	K14
+      0x54321FFF,  //  0020  LDINT	R12	8192
+      0x5834000E,  //  0021  LDCONST	R13	K14
+      0x543A00FE,  //  0022  LDINT	R14	255
+      0x7C200C00,  //  0023  CALL	R8	6
+      0x5C141000,  //  0024  MOVE	R5	R8
+      0xB81A1800,  //  0025  GETNGBL	R6	K12
+      0x8C180D0D,  //  0026  GETMET	R6	R6	K13
+      0x5C200A00,  //  0027  MOVE	R8	R5
+      0x5824000E,  //  0028  LDCONST	R9	K14
+      0x542A00FE,  //  0029  LDINT	R10	255
+      0x882C0102,  //  002A  GETMBR	R11	R0	K2
+      0x88300103,  //  002B  GETMBR	R12	R0	K3
+      0x7C180C00,  //  002C  CALL	R6	6
+      0x881C0101,  //  002D  GETMBR	R7	R0	K1
+      0x54220017,  //  002E  LDINT	R8	24
+      0x3C200E08,  //  002F  SHR	R8	R7	R8
+      0x542600FE,  //  0030  LDINT	R9	255
+      0x2C201009,  //  0031  AND	R8	R8	R9
+      0x5426000F,  //  0032  LDINT	R9	16
+      0x3C240E09,  //  0033  SHR	R9	R7	R9
+      0x542A00FE,  //  0034  LDINT	R10	255
+      0x2C24120A,  //  0035  AND	R9	R9	R10
+      0x542A0007,  //  0036  LDINT	R10	8
+      0x3C280E0A,  //  0037  SHR	R10	R7	R10
+      0x542E00FE,  //  0038  LDINT	R11	255
+      0x2C28140B,  //  0039  AND	R10	R10	R11
+      0x542E00FE,  //  003A  LDINT	R11	255
+      0x2C2C0E0B,  //  003B  AND	R11	R7	R11
+      0x08301206,  //  003C  MUL	R12	R9	R6
+      0x543600FE,  //  003D  LDINT	R13	255
+      0x0C30180D,  //  003E  DIV	R12	R12	R13
+      0x5C241800,  //  003F  MOVE	R9	R12
+      0x08301406,  //  0040  MUL	R12	R10	R6
+      0x543600FE,  //  0041  LDINT	R13	255
+      0x0C30180D,  //  0042  DIV	R12	R12	R13
+      0x5C281800,  //  0043  MOVE	R10	R12
+      0x08301606,  //  0044  MUL	R12	R11	R6
+      0x543600FE,  //  0045  LDINT	R13	255
+      0x0C30180D,  //  0046  DIV	R12	R12	R13
+      0x5C2C1800,  //  0047  MOVE	R11	R12
+      0x54320017,  //  0048  LDINT	R12	24
+      0x3830100C,  //  0049  SHL	R12	R8	R12
+      0x5436000F,  //  004A  LDINT	R13	16
+      0x3834120D,  //  004B  SHL	R13	R9	R13
+      0x3030180D,  //  004C  OR	R12	R12	R13
+      0x54360007,  //  004D  LDINT	R13	8
+      0x3834140D,  //  004E  SHL	R13	R10	R13
+      0x3030180D,  //  004F  OR	R12	R12	R13
+      0x3030180B,  //  0050  OR	R12	R12	R11
+      0x80041800,  //  0051  RET	1	R12
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_BreatheColorProvider_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_BreatheColorProvider,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08050F,  //  0003  GETMET	R2	R2	K15
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0xB80A1000,  //  0006  GETNGBL	R2	K8
+      0x88080509,  //  0007  GETMBR	R2	R2	K9
+      0x90020E02,  //  0008  SETMBR	R0	K7	R2
+      0x9002210E,  //  0009  SETMBR	R0	K16	K14
+      0x540A00FE,  //  000A  LDINT	R2	255
+      0x90022202,  //  000B  SETMBR	R0	K17	R2
+      0x540A0BB7,  //  000C  LDINT	R2	3000
+      0x90020802,  //  000D  SETMBR	R0	K4	R2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: BreatheColorProvider
+********************************************************************/
+extern const bclass be_class_OscillatorValueProvider;
+be_local_class(BreatheColorProvider,
+    0,
+    &be_class_OscillatorValueProvider,
+    be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(tostring, 1), be_const_closure(class_BreatheColorProvider_tostring_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_BreatheColorProvider_init_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_BreatheColorProvider_on_param_changed_closure) },
+        { be_const_key_weak(PARAMS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(4,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(base_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(max_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(255) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(curve_factor, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(2) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
+        { be_const_key_weak(max, 1), be_const_int(5) },
+    }))    ) } )) },
+        { be_const_key_weak(min_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(produce_value, -1), be_const_closure(class_BreatheColorProvider_produce_value_closure) },
+    })),
+    be_str_weak(BreatheColorProvider)
+);
+
+/********************************************************************
+** Solidified function: ease_in
+********************************************************************/
+be_local_closure(ease_in,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(EASE_IN),
+    }),
+    be_str_weak(ease_in),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'StripLengthProvider' ktab size: 5, total: 8 (saved 24 bytes)
+static const bvalue be_ktab_class_StripLengthProvider[5] = {
+  /* K0   */  be_nested_str_weak(engine),
+  /* K1   */  be_const_int(0),
+  /* K2   */  be_nested_str_weak(width),
+  /* K3   */  be_nested_str_weak(StripLengthProvider_X28length_X3D_X25s_X29),
+  /* K4   */  be_nested_str_weak(StripLengthProvider_X28length_X3Dunknown_X29),
+};
+
+
+extern const bclass be_class_StripLengthProvider;
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_StripLengthProvider_produce_value,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_StripLengthProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80060200,  //  0004  RET	1	K1
+      0x880C0100,  //  0005  GETMBR	R3	R0	K0
+      0x880C0702,  //  0006  GETMBR	R3	R3	K2
+      0x80040600,  //  0007  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_StripLengthProvider_tostring,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_StripLengthProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0xA802000F,  //  0000  EXBLK	0	#0011
+      0x88040100,  //  0001  GETMBR	R1	R0	K0
+      0x4C080000,  //  0002  LDNIL	R2
+      0x20040202,  //  0003  NE	R1	R1	R2
+      0x78060002,  //  0004  JMPF	R1	#0008
+      0x88040100,  //  0005  GETMBR	R1	R0	K0
+      0x88040302,  //  0006  GETMBR	R1	R1	K2
+      0x70020000,  //  0007  JMP		#0009
+      0x58040001,  //  0008  LDCONST	R1	K1
+      0x60080018,  //  0009  GETGBL	R2	G24
+      0x580C0003,  //  000A  LDCONST	R3	K3
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x7C080400,  //  000C  CALL	R2	2
+      0xA8040001,  //  000D  EXBLK	1	1
+      0x80040400,  //  000E  RET	1	R2
+      0xA8040001,  //  000F  EXBLK	1	1
+      0x70020004,  //  0010  JMP		#0016
+      0xAC040000,  //  0011  CATCH	R1	0	0
+      0x70020001,  //  0012  JMP		#0015
+      0x80060800,  //  0013  RET	1	K4
+      0x70020000,  //  0014  JMP		#0016
+      0xB0080000,  //  0015  RAISE	2	R0	R0
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: StripLengthProvider
+********************************************************************/
+extern const bclass be_class_ValueProvider;
+be_local_class(StripLengthProvider,
+    0,
+    &be_class_ValueProvider,
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(tostring, -1), be_const_closure(class_StripLengthProvider_tostring_closure) },
+        { be_const_key_weak(produce_value, 0), be_const_closure(class_StripLengthProvider_produce_value_closure) },
+    })),
+    be_str_weak(StripLengthProvider)
+);
+
+/********************************************************************
+** Solidified function: shift_scroll_left
+********************************************************************/
+be_local_closure(shift_scroll_left,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(shift_animation),
+    /* K2   */  be_nested_str_weak(direction),
+    /* K3   */  be_nested_str_weak(shift_speed),
+    /* K4   */  be_nested_str_weak(wrap_around),
+    }),
+    be_str_weak(shift_scroll_left),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FFFE,  //  0004  LDINT	R2	-1
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A007F,  //  0006  LDINT	R2	128
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x50080200,  //  0008  LDBOOL	R2	1	0
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sparkle_rainbow
+********************************************************************/
+be_local_closure(sparkle_rainbow,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(rich_palette),
+    /* K2   */  be_nested_str_weak(palette),
+    /* K3   */  be_nested_str_weak(PALETTE_RAINBOW),
+    /* K4   */  be_nested_str_weak(cycle_period),
+    /* K5   */  be_nested_str_weak(transition_type),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(sparkle_animation),
+    /* K8   */  be_nested_str_weak(color),
+    /* K9   */  be_nested_str_weak(name),
+    /* K10  */  be_nested_str_weak(sparkle_rainbow),
+    }),
+    be_str_weak(sparkle_rainbow),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x540A1387,  //  0007  LDINT	R2	5000
+      0x90060802,  //  0008  SETMBR	R1	K4	R2
+      0x90060B06,  //  0009  SETMBR	R1	K5	K6
+      0xB80A0000,  //  000A  GETNGBL	R2	K0
+      0x8C080507,  //  000B  GETMET	R2	R2	K7
+      0x5C100000,  //  000C  MOVE	R4	R0
+      0x7C080400,  //  000D  CALL	R2	2
+      0x900A1001,  //  000E  SETMBR	R2	K8	R1
+      0x900A130A,  //  000F  SETMBR	R2	K9	K10
+      0x80040400,  //  0010  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'CrenelPositionAnimation' ktab size: 21, total: 27 (saved 48 bytes)
+static const bvalue be_ktab_class_CrenelPositionAnimation[21] = {
+  /* K0   */  be_nested_str_weak(is_running),
+  /* K1   */  be_nested_str_weak(engine),
+  /* K2   */  be_nested_str_weak(time_ms),
+  /* K3   */  be_nested_str_weak(width),
+  /* K4   */  be_nested_str_weak(back_color),
+  /* K5   */  be_nested_str_weak(pos),
+  /* K6   */  be_nested_str_weak(pulse_size),
+  /* K7   */  be_nested_str_weak(low_size),
+  /* K8   */  be_nested_str_weak(nb_pulse),
+  /* K9   */  be_nested_str_weak(color),
+  /* K10  */  be_const_int(-16777216),
+  /* K11  */  be_nested_str_weak(fill_pixels),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_const_int(1),
+  /* K14  */  be_nested_str_weak(set_pixel_color),
+  /* K15  */  be_nested_str_weak(get_param),
+  /* K16  */  be_nested_str_weak(animation),
+  /* K17  */  be_nested_str_weak(is_value_provider),
+  /* K18  */  be_nested_str_weak(0x_X2508x),
+  /* K19  */  be_nested_str_weak(CrenelPositionAnimation_X28color_X3D_X25s_X2C_X20pos_X3D_X25s_X2C_X20pulse_size_X3D_X25s_X2C_X20low_size_X3D_X25s_X2C_X20nb_pulse_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K20  */  be_nested_str_weak(priority),
+};
+
+
+extern const bclass be_class_CrenelPositionAnimation;
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_CrenelPositionAnimation_render,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CrenelPositionAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[76]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x1C0C0403,  //  0008  EQ	R3	R2	R3
+      0x780E0001,  //  0009  JMPF	R3	#000C
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x88080702,  //  000B  GETMBR	R2	R3	K2
+      0x880C0303,  //  000C  GETMBR	R3	R1	K3
+      0x88100104,  //  000D  GETMBR	R4	R0	K4
+      0x88140105,  //  000E  GETMBR	R5	R0	K5
+      0x88180106,  //  000F  GETMBR	R6	R0	K6
+      0x881C0107,  //  0010  GETMBR	R7	R0	K7
+      0x88200108,  //  0011  GETMBR	R8	R0	K8
+      0x88240109,  //  0012  GETMBR	R9	R0	K9
+      0x60280009,  //  0013  GETGBL	R10	G9
+      0x002C0C07,  //  0014  ADD	R11	R6	R7
+      0x7C280200,  //  0015  CALL	R10	1
+      0x202C090A,  //  0016  NE	R11	R4	K10
+      0x782E0002,  //  0017  JMPF	R11	#001B
+      0x8C2C030B,  //  0018  GETMET	R11	R1	K11
+      0x5C340800,  //  0019  MOVE	R13	R4
+      0x7C2C0400,  //  001A  CALL	R11	2
+      0x182C150C,  //  001B  LE	R11	R10	K12
+      0x782E0000,  //  001C  JMPF	R11	#001E
+      0x5828000D,  //  001D  LDCONST	R10	K13
+      0x1C2C110C,  //  001E  EQ	R11	R8	K12
+      0x782E0001,  //  001F  JMPF	R11	#0022
+      0x502C0200,  //  0020  LDBOOL	R11	1	0
+      0x80041600,  //  0021  RET	1	R11
+      0x142C110C,  //  0022  LT	R11	R8	K12
+      0x782E0006,  //  0023  JMPF	R11	#002B
+      0x002C0A06,  //  0024  ADD	R11	R5	R6
+      0x042C170D,  //  0025  SUB	R11	R11	K13
+      0x102C160A,  //  0026  MOD	R11	R11	R10
+      0x042C1606,  //  0027  SUB	R11	R11	R6
+      0x002C170D,  //  0028  ADD	R11	R11	K13
+      0x5C141600,  //  0029  MOVE	R5	R11
+      0x70020007,  //  002A  JMP		#0033
+      0x442C1400,  //  002B  NEG	R11	R10
+      0x142C0A0B,  //  002C  LT	R11	R5	R11
+      0x782E0004,  //  002D  JMPF	R11	#0033
+      0x202C110C,  //  002E  NE	R11	R8	K12
+      0x782E0002,  //  002F  JMPF	R11	#0033
+      0x00140A0A,  //  0030  ADD	R5	R5	R10
+      0x0420110D,  //  0031  SUB	R8	R8	K13
+      0x7001FFF7,  //  0032  JMP		#002B
+      0x142C0A03,  //  0033  LT	R11	R5	R3
+      0x782E0014,  //  0034  JMPF	R11	#004A
+      0x202C110C,  //  0035  NE	R11	R8	K12
+      0x782E0012,  //  0036  JMPF	R11	#004A
+      0x582C000C,  //  0037  LDCONST	R11	K12
+      0x14300B0C,  //  0038  LT	R12	R5	K12
+      0x78320001,  //  0039  JMPF	R12	#003C
+      0x44300A00,  //  003A  NEG	R12	R5
+      0x5C2C1800,  //  003B  MOVE	R11	R12
+      0x14301606,  //  003C  LT	R12	R11	R6
+      0x78320008,  //  003D  JMPF	R12	#0047
+      0x00300A0B,  //  003E  ADD	R12	R5	R11
+      0x14301803,  //  003F  LT	R12	R12	R3
+      0x78320005,  //  0040  JMPF	R12	#0047
+      0x8C30030E,  //  0041  GETMET	R12	R1	K14
+      0x00380A0B,  //  0042  ADD	R14	R5	R11
+      0x5C3C1200,  //  0043  MOVE	R15	R9
+      0x7C300600,  //  0044  CALL	R12	3
+      0x002C170D,  //  0045  ADD	R11	R11	K13
+      0x7001FFF4,  //  0046  JMP		#003C
+      0x00140A0A,  //  0047  ADD	R5	R5	R10
+      0x0420110D,  //  0048  SUB	R8	R8	K13
+      0x7001FFE8,  //  0049  JMP		#0033
+      0x502C0200,  //  004A  LDBOOL	R11	1	0
+      0x80041600,  //  004B  RET	1	R11
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_CrenelPositionAnimation_tostring,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CrenelPositionAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x8C08010F,  //  0001  GETMET	R2	R0	K15
+      0x58100009,  //  0002  LDCONST	R4	K9
+      0x7C080400,  //  0003  CALL	R2	2
+      0xB80E2000,  //  0004  GETNGBL	R3	K16
+      0x8C0C0711,  //  0005  GETMET	R3	R3	K17
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x600C0008,  //  0009  GETGBL	R3	G8
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x5C040600,  //  000C  MOVE	R1	R3
+      0x70020004,  //  000D  JMP		#0013
+      0x600C0018,  //  000E  GETGBL	R3	G24
+      0x58100012,  //  000F  LDCONST	R4	K18
+      0x88140109,  //  0010  GETMBR	R5	R0	K9
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x5C040600,  //  0012  MOVE	R1	R3
+      0x600C0018,  //  0013  GETGBL	R3	G24
+      0x58100013,  //  0014  LDCONST	R4	K19
+      0x5C140200,  //  0015  MOVE	R5	R1
+      0x88180105,  //  0016  GETMBR	R6	R0	K5
+      0x881C0106,  //  0017  GETMBR	R7	R0	K6
+      0x88200107,  //  0018  GETMBR	R8	R0	K7
+      0x88240108,  //  0019  GETMBR	R9	R0	K8
+      0x88280114,  //  001A  GETMBR	R10	R0	K20
+      0x882C0100,  //  001B  GETMBR	R11	R0	K0
+      0x7C0C1000,  //  001C  CALL	R3	8
+      0x80040600,  //  001D  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: CrenelPositionAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(CrenelPositionAnimation,
+    0,
+    &be_class_Animation,
+    be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(6,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(nb_pulse, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(pulse_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(1) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(back_color, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-16777216) },
+    }))    ) } )) },
+        { be_const_key_weak(low_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(3) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(render, 2), be_const_closure(class_CrenelPositionAnimation_render_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_CrenelPositionAnimation_tostring_closure) },
+    })),
+    be_str_weak(CrenelPositionAnimation)
+);
+
+/********************************************************************
+** Solidified function: plasma_rainbow
+********************************************************************/
+be_local_closure(plasma_rainbow,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(plasma_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(time_speed),
+    /* K4   */  be_nested_str_weak(name),
+    /* K5   */  be_nested_str_weak(plasma_rainbow),
+    }),
+    be_str_weak(plasma_rainbow),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x4C080000,  //  0004  LDNIL	R2
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A0031,  //  0006  LDINT	R2	50
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x90060905,  //  0008  SETMBR	R1	K4	K5
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: animation_init
+********************************************************************/
+be_local_closure(animation_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        7,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(animation),
+        /* K1   */  be_nested_str_weak(introspect),
+        /* K2   */  be_nested_str_weak(contains),
+        /* K3   */  be_nested_str_weak(_ntv),
+        /* K4   */  be_nested_str_weak(undefined),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[16]) {  /* code */
+          0xA4060000,  //  0000  IMPORT	R1	K0
+          0xA40A0200,  //  0001  IMPORT	R2	K1
+          0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+          0x88140303,  //  0003  GETMBR	R5	R1	K3
+          0x5C180000,  //  0004  MOVE	R6	R0
+          0x7C0C0600,  //  0005  CALL	R3	3
+          0x780E0003,  //  0006  JMPF	R3	#000B
+          0x880C0303,  //  0007  GETMBR	R3	R1	K3
+          0x880C0600,  //  0008  GETMBR	R3	R3	R0
+          0x80040600,  //  0009  RET	1	R3
+          0x70020003,  //  000A  JMP		#000F
+          0x600C000B,  //  000B  GETGBL	R3	G11
+          0x58100004,  //  000C  LDCONST	R4	K4
+          0x7C0C0200,  //  000D  CALL	R3	1
+          0x80040600,  //  000E  RET	1	R3
+          0x80000000,  //  000F  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(_ntv),
+    /* K2   */  be_nested_str_weak(event_manager),
+    /* K3   */  be_nested_str_weak(EventManager),
+    /* K4   */  be_nested_str_weak(member),
+    }),
+    be_str_weak(animation_init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x6004000B,  //  0000  GETGBL	R1	G11
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x90060200,  //  0003  SETMBR	R1	K1	R0
+      0x8C080103,  //  0004  GETMET	R2	R0	K3
+      0x7C080200,  //  0005  CALL	R2	1
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x84080000,  //  0007  CLOSURE	R2	P0
+      0x90060802,  //  0008  SETMBR	R1	K4	R2
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: solid
+********************************************************************/
+be_local_closure(solid,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(name),
+    /* K2   */  be_nested_str_weak(solid),
+    }),
+    be_str_weak(solid),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040300,  //  0001  GETMET	R1	R1	K0
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060302,  //  0004  SETMBR	R1	K1	K2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -20083,49 +19915,641 @@ be_local_class(SparkleAnimation,
     })),
     be_str_weak(SparkleAnimation)
 );
+// compact class 'TwinkleAnimation' ktab size: 37, total: 67 (saved 240 bytes)
+static const bvalue be_ktab_class_TwinkleAnimation[37] = {
+  /* K0   */  be_nested_str_weak(twinkle_speed),
+  /* K1   */  be_const_int(1),
+  /* K2   */  be_nested_str_weak(set_param),
+  /* K3   */  be_nested_str_weak(fade_speed),
+  /* K4   */  be_nested_str_weak(density),
+  /* K5   */  be_nested_str_weak(min_brightness),
+  /* K6   */  be_nested_str_weak(max_brightness),
+  /* K7   */  be_nested_str_weak(color),
+  /* K8   */  be_nested_str_weak(engine),
+  /* K9   */  be_nested_str_weak(get_strip_length),
+  /* K10  */  be_nested_str_weak(twinkle_states),
+  /* K11  */  be_nested_str_weak(_initialize_arrays),
+  /* K12  */  be_const_int(0),
+  /* K13  */  be_nested_str_weak(current_colors),
+  /* K14  */  be_nested_str_weak(tasmota),
+  /* K15  */  be_nested_str_weak(scale_uint),
+  /* K16  */  be_const_int(16777215),
+  /* K17  */  be_nested_str_weak(_random_range),
+  /* K18  */  be_nested_str_weak(get_param),
+  /* K19  */  be_nested_str_weak(animation),
+  /* K20  */  be_nested_str_weak(is_value_provider),
+  /* K21  */  be_nested_str_weak(0x_X2508x),
+  /* K22  */  be_nested_str_weak(TwinkleAnimation_X28color_X3D_X25s_X2C_X20density_X3D_X25s_X2C_X20twinkle_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K23  */  be_nested_str_weak(priority),
+  /* K24  */  be_nested_str_weak(is_running),
+  /* K25  */  be_nested_str_weak(init),
+  /* K26  */  be_nested_str_weak(last_update),
+  /* K27  */  be_nested_str_weak(random_seed),
+  /* K28  */  be_nested_str_weak(time_ms),
+  /* K29  */  be_nested_str_weak(width),
+  /* K30  */  be_nested_str_weak(set_pixel_color),
+  /* K31  */  be_nested_str_weak(update),
+  /* K32  */  be_nested_str_weak(_update_twinkle_simulation),
+  /* K33  */  be_nested_str_weak(resize),
+  /* K34  */  be_const_int(1103515245),
+  /* K35  */  be_const_int(2147483647),
+  /* K36  */  be_nested_str_weak(_random),
+};
+
+
+extern const bclass be_class_TwinkleAnimation;
 
 /********************************************************************
-** Solidified function: list_user_functions
+** Solidified function: on_param_changed
 ********************************************************************/
-be_local_closure(list_user_functions,   /* name */
+be_local_closure(class_TwinkleAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x780E0010,  //  0001  JMPF	R3	#0013
+      0x540E0031,  //  0002  LDINT	R3	50
+      0x280C0403,  //  0003  GE	R3	R2	R3
+      0x780E000D,  //  0004  JMPF	R3	#0013
+      0x540E03E7,  //  0005  LDINT	R3	1000
+      0x0C0C0602,  //  0006  DIV	R3	R3	R2
+      0x14100701,  //  0007  LT	R4	R3	K1
+      0x78120001,  //  0008  JMPF	R4	#000B
+      0x580C0001,  //  0009  LDCONST	R3	K1
+      0x70020003,  //  000A  JMP		#000F
+      0x54120013,  //  000B  LDINT	R4	20
+      0x24100604,  //  000C  GT	R4	R3	R4
+      0x78120000,  //  000D  JMPF	R4	#000F
+      0x540E0013,  //  000E  LDINT	R3	20
+      0x8C100102,  //  000F  GETMET	R4	R0	K2
+      0x58180000,  //  0010  LDCONST	R6	K0
+      0x5C1C0600,  //  0011  MOVE	R7	R3
+      0x7C100600,  //  0012  CALL	R4	3
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_twinkle_simulation
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__update_twinkle_simulation,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_update_twinkle_simulation),
+    &be_const_str_solidified,
+    ( &(const binstruction[94]) {  /* code */
+      0x88080103,  //  0000  GETMBR	R2	R0	K3
+      0x880C0104,  //  0001  GETMBR	R3	R0	K4
+      0x88100105,  //  0002  GETMBR	R4	R0	K5
+      0x88140106,  //  0003  GETMBR	R5	R0	K6
+      0x88180107,  //  0004  GETMBR	R6	R0	K7
+      0x881C0108,  //  0005  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  0006  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0007  CALL	R7	1
+      0x6020000C,  //  0008  GETGBL	R8	G12
+      0x8824010A,  //  0009  GETMBR	R9	R0	K10
+      0x7C200200,  //  000A  CALL	R8	1
+      0x20201007,  //  000B  NE	R8	R8	R7
+      0x78220001,  //  000C  JMPF	R8	#000F
+      0x8C20010B,  //  000D  GETMET	R8	R0	K11
+      0x7C200200,  //  000E  CALL	R8	1
+      0x5820000C,  //  000F  LDCONST	R8	K12
+      0x14241007,  //  0010  LT	R9	R8	R7
+      0x7826001F,  //  0011  JMPF	R9	#0032
+      0x8824010D,  //  0012  GETMBR	R9	R0	K13
+      0x94241208,  //  0013  GETIDX	R9	R9	R8
+      0x542A0017,  //  0014  LDINT	R10	24
+      0x3C28120A,  //  0015  SHR	R10	R9	R10
+      0x542E00FE,  //  0016  LDINT	R11	255
+      0x2C28140B,  //  0017  AND	R10	R10	R11
+      0x242C150C,  //  0018  GT	R11	R10	K12
+      0x782E0015,  //  0019  JMPF	R11	#0030
+      0xB82E1C00,  //  001A  GETNGBL	R11	K14
+      0x8C2C170F,  //  001B  GETMET	R11	R11	K15
+      0x5C340400,  //  001C  MOVE	R13	R2
+      0x5838000C,  //  001D  LDCONST	R14	K12
+      0x543E00FE,  //  001E  LDINT	R15	255
+      0x58400001,  //  001F  LDCONST	R16	K1
+      0x54460013,  //  0020  LDINT	R17	20
+      0x7C2C0C00,  //  0021  CALL	R11	6
+      0x1830140B,  //  0022  LE	R12	R10	R11
+      0x78320004,  //  0023  JMPF	R12	#0029
+      0x8830010A,  //  0024  GETMBR	R12	R0	K10
+      0x9830110C,  //  0025  SETIDX	R12	R8	K12
+      0x8830010D,  //  0026  GETMBR	R12	R0	K13
+      0x9830110C,  //  0027  SETIDX	R12	R8	K12
+      0x70020006,  //  0028  JMP		#0030
+      0x0430140B,  //  0029  SUB	R12	R10	R11
+      0x2C341310,  //  002A  AND	R13	R9	K16
+      0x8838010D,  //  002B  GETMBR	R14	R0	K13
+      0x543E0017,  //  002C  LDINT	R15	24
+      0x383C180F,  //  002D  SHL	R15	R12	R15
+      0x303C1E0D,  //  002E  OR	R15	R15	R13
+      0x9838100F,  //  002F  SETIDX	R14	R8	R15
+      0x00201101,  //  0030  ADD	R8	R8	K1
+      0x7001FFDD,  //  0031  JMP		#0010
+      0x5824000C,  //  0032  LDCONST	R9	K12
+      0x14281207,  //  0033  LT	R10	R9	R7
+      0x782A0027,  //  0034  JMPF	R10	#005D
+      0x8828010A,  //  0035  GETMBR	R10	R0	K10
+      0x94281409,  //  0036  GETIDX	R10	R10	R9
+      0x1C28150C,  //  0037  EQ	R10	R10	K12
+      0x782A0021,  //  0038  JMPF	R10	#005B
+      0x8C280111,  //  0039  GETMET	R10	R0	K17
+      0x543200FE,  //  003A  LDINT	R12	255
+      0x7C280400,  //  003B  CALL	R10	2
+      0x14281403,  //  003C  LT	R10	R10	R3
+      0x782A001C,  //  003D  JMPF	R10	#005B
+      0x8C280111,  //  003E  GETMET	R10	R0	K17
+      0x04300A04,  //  003F  SUB	R12	R5	R4
+      0x00301901,  //  0040  ADD	R12	R12	K1
+      0x7C280400,  //  0041  CALL	R10	2
+      0x0028080A,  //  0042  ADD	R10	R4	R10
+      0x5C2C0C00,  //  0043  MOVE	R11	R6
+      0x5432000F,  //  0044  LDINT	R12	16
+      0x3C30160C,  //  0045  SHR	R12	R11	R12
+      0x543600FE,  //  0046  LDINT	R13	255
+      0x2C30180D,  //  0047  AND	R12	R12	R13
+      0x54360007,  //  0048  LDINT	R13	8
+      0x3C34160D,  //  0049  SHR	R13	R11	R13
+      0x543A00FE,  //  004A  LDINT	R14	255
+      0x2C341A0E,  //  004B  AND	R13	R13	R14
+      0x543A00FE,  //  004C  LDINT	R14	255
+      0x2C38160E,  //  004D  AND	R14	R11	R14
+      0x883C010A,  //  004E  GETMBR	R15	R0	K10
+      0x983C1301,  //  004F  SETIDX	R15	R9	K1
+      0x883C010D,  //  0050  GETMBR	R15	R0	K13
+      0x54420017,  //  0051  LDINT	R16	24
+      0x38401410,  //  0052  SHL	R16	R10	R16
+      0x5446000F,  //  0053  LDINT	R17	16
+      0x38441811,  //  0054  SHL	R17	R12	R17
+      0x30402011,  //  0055  OR	R16	R16	R17
+      0x54460007,  //  0056  LDINT	R17	8
+      0x38441A11,  //  0057  SHL	R17	R13	R17
+      0x30402011,  //  0058  OR	R16	R16	R17
+      0x3040200E,  //  0059  OR	R16	R16	R14
+      0x983C1210,  //  005A  SETIDX	R15	R9	R16
+      0x00241301,  //  005B  ADD	R9	R9	K1
+      0x7001FFD5,  //  005C  JMP		#0033
+      0x80000000,  //  005D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_tostring,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x8C080112,  //  0001  GETMET	R2	R0	K18
+      0x58100007,  //  0002  LDCONST	R4	K7
+      0x7C080400,  //  0003  CALL	R2	2
+      0xB80E2600,  //  0004  GETNGBL	R3	K19
+      0x8C0C0714,  //  0005  GETMET	R3	R3	K20
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x600C0008,  //  0009  GETGBL	R3	G8
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x5C040600,  //  000C  MOVE	R1	R3
+      0x70020004,  //  000D  JMP		#0013
+      0x600C0018,  //  000E  GETGBL	R3	G24
+      0x58100015,  //  000F  LDCONST	R4	K21
+      0x88140107,  //  0010  GETMBR	R5	R0	K7
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x5C040600,  //  0012  MOVE	R1	R3
+      0x600C0018,  //  0013  GETGBL	R3	G24
+      0x58100016,  //  0014  LDCONST	R4	K22
+      0x5C140200,  //  0015  MOVE	R5	R1
+      0x88180104,  //  0016  GETMBR	R6	R0	K4
+      0x881C0100,  //  0017  GETMBR	R7	R0	K0
+      0x88200117,  //  0018  GETMBR	R8	R0	K23
+      0x88240118,  //  0019  GETMBR	R9	R0	K24
+      0x7C0C0C00,  //  001A  CALL	R3	6
+      0x80040600,  //  001B  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080519,  //  0003  GETMET	R2	R2	K25
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90021402,  //  0008  SETMBR	R0	K10	R2
+      0x60080012,  //  0009  GETGBL	R2	G18
+      0x7C080000,  //  000A  CALL	R2	0
+      0x90021A02,  //  000B  SETMBR	R0	K13	R2
+      0x9002350C,  //  000C  SETMBR	R0	K26	K12
+      0x88080108,  //  000D  GETMBR	R2	R0	K8
+      0x8808051C,  //  000E  GETMBR	R2	R2	K28
+      0x540EFFFF,  //  000F  LDINT	R3	65536
+      0x10080403,  //  0010  MOD	R2	R2	R3
+      0x90023602,  //  0011  SETMBR	R0	K27	R2
+      0x8C08010B,  //  0012  GETMET	R2	R0	K11
+      0x7C080200,  //  0013  CALL	R2	1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_render,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x880C0118,  //  0000  GETMBR	R3	R0	K24
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x1C0C0403,  //  0008  EQ	R3	R2	R3
+      0x780E0001,  //  0009  JMPF	R3	#000C
+      0x880C0108,  //  000A  GETMBR	R3	R0	K8
+      0x8808071C,  //  000B  GETMBR	R2	R3	K28
+      0x880C0108,  //  000C  GETMBR	R3	R0	K8
+      0x8C0C0709,  //  000D  GETMET	R3	R3	K9
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x6010000C,  //  000F  GETGBL	R4	G12
+      0x8814010A,  //  0010  GETMBR	R5	R0	K10
+      0x7C100200,  //  0011  CALL	R4	1
+      0x20100803,  //  0012  NE	R4	R4	R3
+      0x78120001,  //  0013  JMPF	R4	#0016
+      0x8C10010B,  //  0014  GETMET	R4	R0	K11
+      0x7C100200,  //  0015  CALL	R4	1
+      0x50100000,  //  0016  LDBOOL	R4	0	0
+      0x5814000C,  //  0017  LDCONST	R5	K12
+      0x14180A03,  //  0018  LT	R6	R5	R3
+      0x781A0011,  //  0019  JMPF	R6	#002C
+      0x8818031D,  //  001A  GETMBR	R6	R1	K29
+      0x14180A06,  //  001B  LT	R6	R5	R6
+      0x781A000C,  //  001C  JMPF	R6	#002A
+      0x8818010D,  //  001D  GETMBR	R6	R0	K13
+      0x94180C05,  //  001E  GETIDX	R6	R6	R5
+      0x541E0017,  //  001F  LDINT	R7	24
+      0x3C1C0C07,  //  0020  SHR	R7	R6	R7
+      0x542200FE,  //  0021  LDINT	R8	255
+      0x2C1C0E08,  //  0022  AND	R7	R7	R8
+      0x241C0F0C,  //  0023  GT	R7	R7	K12
+      0x781E0004,  //  0024  JMPF	R7	#002A
+      0x8C1C031E,  //  0025  GETMET	R7	R1	K30
+      0x5C240A00,  //  0026  MOVE	R9	R5
+      0x5C280C00,  //  0027  MOVE	R10	R6
+      0x7C1C0600,  //  0028  CALL	R7	3
+      0x50100200,  //  0029  LDBOOL	R4	1	0
+      0x00140B01,  //  002A  ADD	R5	R5	K1
+      0x7001FFEB,  //  002B  JMP		#0018
+      0x80040800,  //  002C  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_update,   /* name */
   be_nested_proto(
     7,                          /* nstack */
-    0,                          /* argc */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051F,  //  0003  GETMET	R2	R2	K31
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0001,  //  0006  JMPT	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x4C080000,  //  0009  LDNIL	R2
+      0x1C080202,  //  000A  EQ	R2	R1	R2
+      0x780A0001,  //  000B  JMPF	R2	#000E
+      0x88080108,  //  000C  GETMBR	R2	R0	K8
+      0x8804051C,  //  000D  GETMBR	R1	R2	K28
+      0x88080100,  //  000E  GETMBR	R2	R0	K0
+      0x540E03E7,  //  000F  LDINT	R3	1000
+      0x0C0C0602,  //  0010  DIV	R3	R3	R2
+      0x8810011A,  //  0011  GETMBR	R4	R0	K26
+      0x04100204,  //  0012  SUB	R4	R1	R4
+      0x28100803,  //  0013  GE	R4	R4	R3
+      0x78120003,  //  0014  JMPF	R4	#0019
+      0x90023401,  //  0015  SETMBR	R0	K26	R1
+      0x8C100120,  //  0016  GETMET	R4	R0	K32
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x7C100400,  //  0018  CALL	R4	2
+      0x50100200,  //  0019  LDBOOL	R4	1	0
+      0x80040800,  //  001A  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _initialize_arrays
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_initialize_arrays),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040108,  //  0000  GETMBR	R1	R0	K8
+      0x8C040309,  //  0001  GETMET	R1	R1	K9
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8808010A,  //  0003  GETMBR	R2	R0	K10
+      0x8C080521,  //  0004  GETMET	R2	R2	K33
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x8808010D,  //  0007  GETMBR	R2	R0	K13
+      0x8C080521,  //  0008  GETMET	R2	R2	K33
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x5808000C,  //  000B  LDCONST	R2	K12
+      0x140C0401,  //  000C  LT	R3	R2	R1
+      0x780E0005,  //  000D  JMPF	R3	#0014
+      0x880C010A,  //  000E  GETMBR	R3	R0	K10
+      0x980C050C,  //  000F  SETIDX	R3	R2	K12
+      0x880C010D,  //  0010  GETMBR	R3	R0	K13
+      0x980C050C,  //  0011  SETIDX	R3	R2	K12
+      0x00080501,  //  0012  ADD	R2	R2	K1
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__random,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_random),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8804011B,  //  0000  GETMBR	R1	R0	K27
+      0x08040322,  //  0001  MUL	R1	R1	K34
+      0x540A3038,  //  0002  LDINT	R2	12345
+      0x00040202,  //  0003  ADD	R1	R1	R2
+      0x2C040323,  //  0004  AND	R1	R1	K35
+      0x90023601,  //  0005  SETMBR	R0	K27	R1
+      0x8804011B,  //  0006  GETMBR	R1	R0	K27
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random_range
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__random_range,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_random_range),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x1808030C,  //  0000  LE	R2	R1	K12
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80061800,  //  0002  RET	1	K12
+      0x8C080124,  //  0003  GETMET	R2	R0	K36
+      0x7C080200,  //  0004  CALL	R2	1
+      0x10080401,  //  0005  MOD	R2	R2	R1
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: TwinkleAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(TwinkleAnimation,
+    4,
+    &be_class_Animation,
+    be_nested_map(14,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(_random_range, -1), be_const_closure(class_TwinkleAnimation__random_range_closure) },
+        { be_const_key_weak(twinkle_states, -1), be_const_var(0) },
+        { be_const_key_weak(init, -1), be_const_closure(class_TwinkleAnimation_init_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_TwinkleAnimation_tostring_closure) },
+        { be_const_key_weak(random_seed, -1), be_const_var(3) },
+        { be_const_key_weak(PARAMS, 6), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(6,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(fade_speed, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(180) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(twinkle_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(6) },
+        { be_const_key_weak(min, -1), be_const_int(1) },
+        { be_const_key_weak(max, 1), be_const_int(5000) },
+    }))    ) } )) },
+        { be_const_key_weak(density, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(128) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(max_brightness, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(255) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(-1) },
+    }))    ) } )) },
+        { be_const_key_weak(min_brightness, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(default, -1), be_const_int(32) },
+        { be_const_key_weak(min, -1), be_const_int(0) },
+        { be_const_key_weak(max, 1), be_const_int(255) },
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(_random, 9), be_const_closure(class_TwinkleAnimation__random_closure) },
+        { be_const_key_weak(last_update, -1), be_const_var(2) },
+        { be_const_key_weak(update, -1), be_const_closure(class_TwinkleAnimation_update_closure) },
+        { be_const_key_weak(_initialize_arrays, 10), be_const_closure(class_TwinkleAnimation__initialize_arrays_closure) },
+        { be_const_key_weak(render, 2), be_const_closure(class_TwinkleAnimation_render_closure) },
+        { be_const_key_weak(current_colors, -1), be_const_var(1) },
+        { be_const_key_weak(_update_twinkle_simulation, 1), be_const_closure(class_TwinkleAnimation__update_twinkle_simulation_closure) },
+        { be_const_key_weak(on_param_changed, 0), be_const_closure(class_TwinkleAnimation_on_param_changed_closure) },
+    })),
+    be_str_weak(TwinkleAnimation)
+);
+
+/********************************************************************
+** Solidified function: twinkle_classic
+********************************************************************/
+be_local_closure(twinkle_classic,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_animation_user_functions),
-    /* K2   */  be_nested_str_weak(keys),
-    /* K3   */  be_nested_str_weak(push),
-    /* K4   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(twinkle_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(density),
+    /* K4   */  be_nested_str_weak(twinkle_speed),
+    /* K5   */  be_nested_str_weak(fade_speed),
+    /* K6   */  be_nested_str_weak(min_brightness),
+    /* K7   */  be_nested_str_weak(max_brightness),
     }),
-    be_str_weak(list_user_functions),
+    be_str_weak(twinkle_classic),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4020000,  //  0000  IMPORT	R0	K0
-      0x60040012,  //  0001  GETGBL	R1	G18
-      0x7C040000,  //  0002  CALL	R1	0
-      0x60080010,  //  0003  GETGBL	R2	G16
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0005  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020005,  //  0008  EXBLK	0	#000F
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x8C100303,  //  000B  GETMET	R4	R1	K3
-      0x5C180600,  //  000C  MOVE	R6	R3
-      0x7C100400,  //  000D  CALL	R4	2
-      0x7001FFF9,  //  000E  JMP		#0009
-      0x58080004,  //  000F  LDCONST	R2	K4
-      0xAC080200,  //  0010  CATCH	R2	1	0
-      0xB0080000,  //  0011  RAISE	2	R0	R0
-      0x80040200,  //  0012  RET	1	R1
+    ( &(const binstruction[17]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FFFE,  //  0004  LDINT	R2	-1
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A0095,  //  0006  LDINT	R2	150
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A0005,  //  0008  LDINT	R2	6
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x540A00B3,  //  000A  LDINT	R2	180
+      0x90060A02,  //  000B  SETMBR	R1	K5	R2
+      0x540A001F,  //  000C  LDINT	R2	32
+      0x90060C02,  //  000D  SETMBR	R1	K6	R2
+      0x540A00FE,  //  000E  LDINT	R2	255
+      0x90060E02,  //  000F  SETMBR	R1	K7	R2
+      0x80040200,  //  0010  RET	1	R1
     })
   )
 );
@@ -20161,6 +20585,79 @@ be_local_closure(sine,   /* name */
       0xB80A0000,  //  0004  GETNGBL	R2	K0
       0x88080503,  //  0005  GETMBR	R2	R2	K3
       0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: smooth
+********************************************************************/
+be_local_closure(smooth,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(COSINE),
+    }),
+    be_str_weak(smooth),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pulsating_color_provider
+********************************************************************/
+be_local_closure(pulsating_color_provider,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(breathe_color),
+    /* K2   */  be_nested_str_weak(curve_factor),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(duration),
+    }),
+    be_str_weak(pulsating_color_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A03E7,  //  0005  LDINT	R2	1000
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
       0x80040200,  //  0007  RET	1	R1
     })
   )
@@ -20240,364 +20737,6 @@ be_local_class(ColorProvider,
     })),
     be_str_weak(ColorProvider)
 );
-// compact class 'BreatheColorProvider' ktab size: 18, total: 29 (saved 88 bytes)
-static const bvalue be_ktab_class_BreatheColorProvider[18] = {
-  /* K0   */  be_nested_str_weak(BreatheColorProvider_X28base_color_X3D0x_X2508x_X2C_X20min_brightness_X3D_X25s_X2C_X20max_brightness_X3D_X25s_X2C_X20duration_X3D_X25s_X2C_X20curve_factor_X3D_X25s_X29),
-  /* K1   */  be_nested_str_weak(base_color),
-  /* K2   */  be_nested_str_weak(min_brightness),
-  /* K3   */  be_nested_str_weak(max_brightness),
-  /* K4   */  be_nested_str_weak(duration),
-  /* K5   */  be_nested_str_weak(curve_factor),
-  /* K6   */  be_const_int(1),
-  /* K7   */  be_nested_str_weak(form),
-  /* K8   */  be_nested_str_weak(animation),
-  /* K9   */  be_nested_str_weak(COSINE),
-  /* K10  */  be_nested_str_weak(on_param_changed),
-  /* K11  */  be_nested_str_weak(produce_value),
-  /* K12  */  be_nested_str_weak(tasmota),
-  /* K13  */  be_nested_str_weak(scale_uint),
-  /* K14  */  be_const_int(0),
-  /* K15  */  be_nested_str_weak(init),
-  /* K16  */  be_nested_str_weak(min_value),
-  /* K17  */  be_nested_str_weak(max_value),
-};
-
-
-extern const bclass be_class_BreatheColorProvider;
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_BreatheColorProvider_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BreatheColorProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
-      0x881C0105,  //  0006  GETMBR	R7	R0	K5
-      0x7C040C00,  //  0007  CALL	R1	6
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_BreatheColorProvider_on_param_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BreatheColorProvider,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x1C0C0305,  //  0000  EQ	R3	R1	K5
-      0x780E0008,  //  0001  JMPF	R3	#000B
-      0x1C0C0506,  //  0002  EQ	R3	R2	K6
-      0x780E0003,  //  0003  JMPF	R3	#0008
-      0xB80E1000,  //  0004  GETNGBL	R3	K8
-      0x880C0709,  //  0005  GETMBR	R3	R3	K9
-      0x90020E03,  //  0006  SETMBR	R0	K7	R3
-      0x70020002,  //  0007  JMP		#000B
-      0xB80E1000,  //  0008  GETNGBL	R3	K8
-      0x880C0709,  //  0009  GETMBR	R3	R3	K9
-      0x90020E03,  //  000A  SETMBR	R0	K7	R3
-      0x600C0003,  //  000B  GETGBL	R3	G3
-      0x5C100000,  //  000C  MOVE	R4	R0
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C070A,  //  000E  GETMET	R3	R3	K10
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_BreatheColorProvider_produce_value,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BreatheColorProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[82]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C070B,  //  0003  GETMET	R3	R3	K11
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x88100105,  //  0007  GETMBR	R4	R0	K5
-      0x5C140600,  //  0008  MOVE	R5	R3
-      0x24180906,  //  0009  GT	R6	R4	K6
-      0x781A0019,  //  000A  JMPF	R6	#0025
-      0xB81A1800,  //  000B  GETNGBL	R6	K12
-      0x8C180D0D,  //  000C  GETMET	R6	R6	K13
-      0x5C200600,  //  000D  MOVE	R8	R3
-      0x5824000E,  //  000E  LDCONST	R9	K14
-      0x542A00FE,  //  000F  LDINT	R10	255
-      0x582C000E,  //  0010  LDCONST	R11	K14
-      0x54321FFF,  //  0011  LDINT	R12	8192
-      0x7C180C00,  //  0012  CALL	R6	6
-      0x5C1C0800,  //  0013  MOVE	R7	R4
-      0x24200F06,  //  0014  GT	R8	R7	K6
-      0x78220005,  //  0015  JMPF	R8	#001C
-      0x08200C06,  //  0016  MUL	R8	R6	R6
-      0x54261FFF,  //  0017  LDINT	R9	8192
-      0x0C201009,  //  0018  DIV	R8	R8	R9
-      0x5C181000,  //  0019  MOVE	R6	R8
-      0x041C0F06,  //  001A  SUB	R7	R7	K6
-      0x7001FFF7,  //  001B  JMP		#0014
-      0xB8221800,  //  001C  GETNGBL	R8	K12
-      0x8C20110D,  //  001D  GETMET	R8	R8	K13
-      0x5C280C00,  //  001E  MOVE	R10	R6
-      0x582C000E,  //  001F  LDCONST	R11	K14
-      0x54321FFF,  //  0020  LDINT	R12	8192
-      0x5834000E,  //  0021  LDCONST	R13	K14
-      0x543A00FE,  //  0022  LDINT	R14	255
-      0x7C200C00,  //  0023  CALL	R8	6
-      0x5C141000,  //  0024  MOVE	R5	R8
-      0xB81A1800,  //  0025  GETNGBL	R6	K12
-      0x8C180D0D,  //  0026  GETMET	R6	R6	K13
-      0x5C200A00,  //  0027  MOVE	R8	R5
-      0x5824000E,  //  0028  LDCONST	R9	K14
-      0x542A00FE,  //  0029  LDINT	R10	255
-      0x882C0102,  //  002A  GETMBR	R11	R0	K2
-      0x88300103,  //  002B  GETMBR	R12	R0	K3
-      0x7C180C00,  //  002C  CALL	R6	6
-      0x881C0101,  //  002D  GETMBR	R7	R0	K1
-      0x54220017,  //  002E  LDINT	R8	24
-      0x3C200E08,  //  002F  SHR	R8	R7	R8
-      0x542600FE,  //  0030  LDINT	R9	255
-      0x2C201009,  //  0031  AND	R8	R8	R9
-      0x5426000F,  //  0032  LDINT	R9	16
-      0x3C240E09,  //  0033  SHR	R9	R7	R9
-      0x542A00FE,  //  0034  LDINT	R10	255
-      0x2C24120A,  //  0035  AND	R9	R9	R10
-      0x542A0007,  //  0036  LDINT	R10	8
-      0x3C280E0A,  //  0037  SHR	R10	R7	R10
-      0x542E00FE,  //  0038  LDINT	R11	255
-      0x2C28140B,  //  0039  AND	R10	R10	R11
-      0x542E00FE,  //  003A  LDINT	R11	255
-      0x2C2C0E0B,  //  003B  AND	R11	R7	R11
-      0x08301206,  //  003C  MUL	R12	R9	R6
-      0x543600FE,  //  003D  LDINT	R13	255
-      0x0C30180D,  //  003E  DIV	R12	R12	R13
-      0x5C241800,  //  003F  MOVE	R9	R12
-      0x08301406,  //  0040  MUL	R12	R10	R6
-      0x543600FE,  //  0041  LDINT	R13	255
-      0x0C30180D,  //  0042  DIV	R12	R12	R13
-      0x5C281800,  //  0043  MOVE	R10	R12
-      0x08301606,  //  0044  MUL	R12	R11	R6
-      0x543600FE,  //  0045  LDINT	R13	255
-      0x0C30180D,  //  0046  DIV	R12	R12	R13
-      0x5C2C1800,  //  0047  MOVE	R11	R12
-      0x54320017,  //  0048  LDINT	R12	24
-      0x3830100C,  //  0049  SHL	R12	R8	R12
-      0x5436000F,  //  004A  LDINT	R13	16
-      0x3834120D,  //  004B  SHL	R13	R9	R13
-      0x3030180D,  //  004C  OR	R12	R12	R13
-      0x54360007,  //  004D  LDINT	R13	8
-      0x3834140D,  //  004E  SHL	R13	R10	R13
-      0x3030180D,  //  004F  OR	R12	R12	R13
-      0x3030180B,  //  0050  OR	R12	R12	R11
-      0x80041800,  //  0051  RET	1	R12
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_BreatheColorProvider_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_BreatheColorProvider,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08050F,  //  0003  GETMET	R2	R2	K15
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0xB80A1000,  //  0006  GETNGBL	R2	K8
-      0x88080509,  //  0007  GETMBR	R2	R2	K9
-      0x90020E02,  //  0008  SETMBR	R0	K7	R2
-      0x9002210E,  //  0009  SETMBR	R0	K16	K14
-      0x540A00FE,  //  000A  LDINT	R2	255
-      0x90022202,  //  000B  SETMBR	R0	K17	R2
-      0x540A0BB7,  //  000C  LDINT	R2	3000
-      0x90020802,  //  000D  SETMBR	R0	K4	R2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: BreatheColorProvider
-********************************************************************/
-extern const bclass be_class_OscillatorValueProvider;
-be_local_class(BreatheColorProvider,
-    0,
-    &be_class_OscillatorValueProvider,
-    be_nested_map(5,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(tostring, 1), be_const_closure(class_BreatheColorProvider_tostring_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_BreatheColorProvider_init_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_BreatheColorProvider_on_param_changed_closure) },
-        { be_const_key_weak(PARAMS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(4,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(base_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(max_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(curve_factor, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(2) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(5) },
-    }))    ) } )) },
-        { be_const_key_weak(min_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(produce_value, -1), be_const_closure(class_BreatheColorProvider_produce_value_closure) },
-    })),
-    be_str_weak(BreatheColorProvider)
-);
-
-/********************************************************************
-** Solidified function: noise_fractal
-********************************************************************/
-be_local_closure(noise_fractal,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(noise_animation),
-    /* K2   */  be_nested_str_weak(rich_palette),
-    /* K3   */  be_nested_str_weak(palette),
-    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
-    /* K5   */  be_nested_str_weak(cycle_period),
-    /* K6   */  be_nested_str_weak(transition_type),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(brightness),
-    /* K9   */  be_nested_str_weak(range_min),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(range_max),
-    /* K12  */  be_nested_str_weak(color),
-    /* K13  */  be_nested_str_weak(scale),
-    /* K14  */  be_nested_str_weak(speed),
-    /* K15  */  be_nested_str_weak(octaves),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(persistence),
-    }),
-    be_str_weak(noise_fractal),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0xB80E0000,  //  0008  GETNGBL	R3	K0
-      0x880C0704,  //  0009  GETMBR	R3	R3	K4
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0x540E1387,  //  000B  LDINT	R3	5000
-      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
-      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
-      0x540E00FE,  //  000E  LDINT	R3	255
-      0x900A1003,  //  000F  SETMBR	R2	K8	R3
-      0x900A130A,  //  0010  SETMBR	R2	K9	K10
-      0x540E00FE,  //  0011  LDINT	R3	255
-      0x900A1603,  //  0012  SETMBR	R2	K11	R3
-      0x90061802,  //  0013  SETMBR	R1	K12	R2
-      0x540E001D,  //  0014  LDINT	R3	30
-      0x90061A03,  //  0015  SETMBR	R1	K13	R3
-      0x540E0013,  //  0016  LDINT	R3	20
-      0x90061C03,  //  0017  SETMBR	R1	K14	R3
-      0x90061F10,  //  0018  SETMBR	R1	K15	K16
-      0x540E007F,  //  0019  LDINT	R3	128
-      0x90062203,  //  001A  SETMBR	R1	K17	R3
-      0x80040200,  //  001B  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
 // compact class 'GradientAnimation' ktab size: 43, total: 82 (saved 312 bytes)
 static const bvalue be_ktab_class_GradientAnimation[43] = {
   /* K0   */  be_nested_str_weak(update),
@@ -21380,171 +21519,136 @@ be_local_class(ValueProvider,
 );
 
 /********************************************************************
-** Solidified function: ease_in
-********************************************************************/
-be_local_closure(ease_in,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(EASE_IN),
-    }),
-    be_str_weak(ease_in),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified module: animation
 ********************************************************************/
 be_local_module(animation,
     "animation",
-    be_nested_map(123,
+    be_nested_map(124,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(rich_palette, -1), be_const_class(be_class_RichPaletteColorProvider) },
-        { be_const_key_weak(VERSION, 31), be_const_int(65536) },
-        { be_const_key_weak(shift_scroll_right, 68), be_const_closure(shift_scroll_right_closure) },
-        { be_const_key_weak(wave_rainbow_sine, 89), be_const_closure(wave_rainbow_sine_closure) },
-        { be_const_key_weak(jitter_brightness, -1), be_const_closure(jitter_brightness_closure) },
-        { be_const_key_weak(parameterized_object, -1), be_const_class(be_class_ParameterizedObject) },
-        { be_const_key_weak(plasma_rainbow, -1), be_const_closure(plasma_rainbow_closure) },
-        { be_const_key_weak(create_wait_step, 44), be_const_closure(create_wait_step_closure) },
-        { be_const_key_weak(set_event_active, -1), be_const_closure(set_event_active_closure) },
-        { be_const_key_weak(oscillator_value, -1), be_const_class(be_class_OscillatorValueProvider) },
+        { be_const_key_weak(EASE_IN, -1), be_const_int(6) },
         { be_const_key_weak(value_provider, -1), be_const_class(be_class_ValueProvider) },
-        { be_const_key_weak(BOUNCE, 63), be_const_int(9) },
-        { be_const_key_weak(gradient_rainbow_radial, -1), be_const_closure(gradient_rainbow_radial_closure) },
-        { be_const_key_weak(palette_wave_animation, -1), be_const_class(be_class_PaletteWaveAnimation) },
-        { be_const_key_weak(twinkle_rainbow, 116), be_const_closure(twinkle_rainbow_closure) },
-        { be_const_key_weak(noise_fractal, -1), be_const_closure(noise_fractal_closure) },
-        { be_const_key_weak(animation_controller, -1), be_const_closure(animation_controller_closure) },
-        { be_const_key_weak(jitter_animation, 26), be_const_class(be_class_JitterAnimation) },
-        { be_const_key_weak(trigger_event, -1), be_const_closure(trigger_event_closure) },
-        { be_const_key_weak(PALETTE_RGB, -1), be_const_bytes_instance(00FF00008000FF00FF0000FF) },
-        { be_const_key_weak(plasma_animation, -1), be_const_class(be_class_PlasmaAnimation) },
-        { be_const_key_weak(breathe_color, -1), be_const_class(be_class_BreatheColorProvider) },
-        { be_const_key_weak(get_registered_events, -1), be_const_closure(get_registered_events_closure) },
-        { be_const_key_weak(crenel_position_animation, -1), be_const_class(be_class_CrenelPositionAnimation) },
-        { be_const_key_weak(sine, -1), be_const_closure(sine_closure) },
-        { be_const_key_weak(list_user_functions, 73), be_const_closure(list_user_functions_closure) },
-        { be_const_key_weak(sparkle_animation, -1), be_const_class(be_class_SparkleAnimation) },
-        { be_const_key_weak(LINEAR, 49), be_const_int(1) },
-        { be_const_key_weak(ELASTIC, -1), be_const_int(8) },
-        { be_const_key_weak(sparkle_rainbow, -1), be_const_closure(sparkle_rainbow_closure) },
-        { be_const_key_weak(ease_out, 14), be_const_closure(ease_out_closure) },
-        { be_const_key_weak(twinkle_classic, -1), be_const_closure(twinkle_classic_closure) },
-        { be_const_key_weak(frame_buffer, -1), be_const_class(be_class_FrameBuffer) },
-        { be_const_key_weak(init, -1), be_const_closure(animation_init_closure) },
-        { be_const_key_weak(create_engine, 25), be_const_closure(create_engine_closure) },
-        { be_const_key_weak(wave_single_sine, -1), be_const_closure(wave_single_sine_closure) },
-        { be_const_key_weak(rich_palette_animation, 84), be_const_class(be_class_RichPaletteAnimation) },
-        { be_const_key_weak(color_provider, -1), be_const_class(be_class_ColorProvider) },
-        { be_const_key_weak(color_cycle, -1), be_const_class(be_class_ColorCycleColorProvider) },
-        { be_const_key_weak(event_handler, -1), be_const_class(be_class_EventHandler) },
-        { be_const_key_weak(is_value_provider, -1), be_const_closure(is_value_provider_closure) },
-        { be_const_key_weak(EventManager, -1), be_const_class(be_class_EventManager) },
-        { be_const_key_weak(wave_custom, -1), be_const_closure(wave_custom_closure) },
-        { be_const_key_weak(EASE_OUT, 15), be_const_int(7) },
-        { be_const_key_weak(shift_scroll_left, -1), be_const_closure(shift_scroll_left_closure) },
-        { be_const_key_weak(shift_animation, 61), be_const_class(be_class_ShiftAnimation) },
-        { be_const_key_weak(jitter_all, 57), be_const_closure(jitter_all_closure) },
-        { be_const_key_weak(palette_pattern_animation, -1), be_const_class(be_class_PalettePatternAnimation) },
-        { be_const_key_weak(bounce_basic, -1), be_const_closure(bounce_basic_closure) },
-        { be_const_key_weak(EASE_IN, 101), be_const_int(6) },
-        { be_const_key_weak(twinkle_animation, 76), be_const_class(be_class_TwinkleAnimation) },
-        { be_const_key_weak(scale_oscillate, 100), be_const_closure(scale_oscillate_closure) },
-        { be_const_key_weak(jitter_position, -1), be_const_closure(jitter_position_closure) },
-        { be_const_key_weak(scale_grow, 23), be_const_closure(scale_grow_closure) },
-        { be_const_key_weak(bounce, -1), be_const_closure(bounce_closure) },
-        { be_const_key_weak(comet_animation, -1), be_const_class(be_class_CometAnimation) },
-        { be_const_key_weak(ramp, 80), be_const_closure(ramp_closure) },
-        { be_const_key_weak(palette_meter_animation, -1), be_const_class(be_class_PaletteMeterAnimation) },
-        { be_const_key_weak(animation, -1), be_const_class(be_class_Animation) },
-        { be_const_key_weak(noise_single_color, -1), be_const_closure(noise_single_color_closure) },
-        { be_const_key_weak(SINE, 102), be_const_int(5) },
-        { be_const_key_weak(TRIANGLE, 78), be_const_int(2) },
-        { be_const_key_weak(shift_fast_scroll, -1), be_const_closure(shift_fast_scroll_closure) },
-        { be_const_key_weak(SAWTOOTH, -1), be_const_int(1) },
-        { be_const_key_weak(noise_rainbow, 10), be_const_closure(noise_rainbow_closure) },
-        { be_const_key_weak(is_user_function, -1), be_const_closure(is_user_function_closure) },
-        { be_const_key_weak(version_string, -1), be_const_closure(animation_version_string_closure) },
-        { be_const_key_weak(twinkle_solid, -1), be_const_closure(twinkle_solid_closure) },
-        { be_const_key_weak(beacon_animation, -1), be_const_class(be_class_BeaconAnimation) },
-        { be_const_key_weak(register_user_function, -1), be_const_closure(register_user_function_closure) },
-        { be_const_key_weak(fire_animation, 47), be_const_class(be_class_FireAnimation) },
-        { be_const_key_weak(pulsating_color, 82), be_const_closure(pulsating_color_provider_closure) },
-        { be_const_key_weak(elastic, -1), be_const_closure(elastic_closure) },
-        { be_const_key_weak(color_cycle_rainbow, -1), be_const_closure(color_cycle_rainbow_closure) },
-        { be_const_key_weak(breathe_animation, -1), be_const_class(be_class_BreatheAnimation) },
-        { be_const_key_weak(ease_in, -1), be_const_closure(ease_in_closure) },
-        { be_const_key_weak(is_color_provider, -1), be_const_closure(is_color_provider_closure) },
-        { be_const_key_weak(wave_animation, -1), be_const_class(be_class_WaveAnimation) },
-        { be_const_key_weak(palette_gradient_animation, -1), be_const_class(be_class_PaletteGradientAnimation) },
-        { be_const_key_weak(PALETTE_OCEAN, -1), be_const_bytes_instance(00000080400000FF8000FFFFC000FF80FF008000) },
-        { be_const_key_weak(noise_animation, -1), be_const_class(be_class_NoiseAnimation) },
-        { be_const_key_weak(SequenceManager, -1), be_const_class(be_class_SequenceManager) },
-        { be_const_key_weak(twinkle_gentle, -1), be_const_closure(twinkle_gentle_closure) },
-        { be_const_key_weak(sawtooth, 96), be_const_closure(sawtooth_closure) },
-        { be_const_key_weak(clear_all_event_handlers, -1), be_const_closure(clear_all_event_handlers_closure) },
-        { be_const_key_weak(create_play_step, -1), be_const_closure(create_play_step_closure) },
-        { be_const_key_weak(get_user_function, 24), be_const_closure(get_user_function_closure) },
-        { be_const_key_weak(gradient_two_color_linear, 9), be_const_closure(gradient_two_color_linear_closure) },
-        { be_const_key_weak(linear, -1), be_const_closure(linear_closure) },
-        { be_const_key_weak(plasma_fast, 72), be_const_closure(plasma_fast_closure) },
-        { be_const_key_weak(init_strip, -1), be_const_closure(animation_init_strip_closure) },
-        { be_const_key_weak(static_value, -1), be_const_class(be_class_StaticValueProvider) },
-        { be_const_key_weak(gradient_animation, -1), be_const_class(be_class_GradientAnimation) },
-        { be_const_key_weak(get_event_handlers, -1), be_const_closure(get_event_handlers_closure) },
-        { be_const_key_weak(color_cycle_from_palette, -1), be_const_closure(color_cycle_from_palette_closure) },
-        { be_const_key_weak(static_color, 111), be_const_class(be_class_StaticColorProvider) },
-        { be_const_key_weak(animation_engine, -1), be_const_class(be_class_AnimationEngine) },
-        { be_const_key_weak(composite_color, -1), be_const_class(be_class_CompositeColorProvider) },
-        { be_const_key_weak(SQUARE, 21), be_const_int(3) },
-        { be_const_key_weak(sparkle_white, -1), be_const_closure(sparkle_white_closure) },
-        { be_const_key_weak(square, 115), be_const_closure(square_closure) },
-        { be_const_key_weak(register_event_handler, 74), be_const_closure(register_event_handler_closure) },
-        { be_const_key_weak(COSINE, -1), be_const_int(4) },
-        { be_const_key_weak(PALETTE_FOREST, -1), be_const_bytes_instance(0000640040228B228032CD32C09AFF9AFF90EE90) },
-        { be_const_key_weak(PALETTE_SUNSET_TICKS, -1), be_const_bytes_instance(28FF450028FF8C0028FFD70028FF69B4288000802819197000000080) },
-        { be_const_key_weak(scale_static, 33), be_const_closure(scale_static_closure) },
-        { be_const_key_weak(triangle, 108), be_const_closure(triangle_closure) },
-        { be_const_key_weak(bounce_animation, 56), be_const_class(be_class_BounceAnimation) },
+        { be_const_key_weak(BOUNCE, -1), be_const_int(9) },
+        { be_const_key_weak(jitter_brightness, 62), be_const_closure(jitter_brightness_closure) },
+        { be_const_key_weak(gradient_animation, 16), be_const_class(be_class_GradientAnimation) },
+        { be_const_key_weak(PALETTE_FIRE, 39), be_const_bytes_instance(000000004080000080FF0000C0FF8000FFFFFF00) },
+        { be_const_key_weak(twinkle_intense, 37), be_const_closure(twinkle_intense_closure) },
+        { be_const_key_weak(color_provider, 49), be_const_class(be_class_ColorProvider) },
+        { be_const_key_weak(PALETTE_RGB, 45), be_const_bytes_instance(00FF00008000FF00FF0000FF) },
+        { be_const_key_weak(pulsating_color, -1), be_const_closure(pulsating_color_provider_closure) },
         { be_const_key_weak(smooth, -1), be_const_closure(smooth_closure) },
-        { be_const_key_weak(pulsating_animation, -1), be_const_closure(pulsating_animation_closure) },
-        { be_const_key_weak(PALETTE_RAINBOW, -1), be_const_bytes_instance(00FF000024FFA50049FFFF006E00FF00920000FFB74B0082DBEE82EEFFFF0000) },
+        { be_const_key_weak(ease_in, -1), be_const_closure(ease_in_closure) },
+        { be_const_key_weak(LINEAR, 83), be_const_int(1) },
+        { be_const_key_weak(oscillator_value, -1), be_const_class(be_class_OscillatorValueProvider) },
+        { be_const_key_weak(animation_controller, 95), be_const_closure(animation_controller_closure) },
+        { be_const_key_weak(list_user_functions, -1), be_const_closure(list_user_functions_closure) },
+        { be_const_key_weak(sine, -1), be_const_closure(sine_closure) },
+        { be_const_key_weak(breathe_color, -1), be_const_class(be_class_BreatheColorProvider) },
+        { be_const_key_weak(create_wait_step, 24), be_const_closure(create_wait_step_closure) },
+        { be_const_key_weak(SequenceManager, 41), be_const_class(be_class_SequenceManager) },
+        { be_const_key_weak(gradient_two_color_linear, 69), be_const_closure(gradient_two_color_linear_closure) },
+        { be_const_key_weak(crenel_position_animation, -1), be_const_class(be_class_CrenelPositionAnimation) },
+        { be_const_key_weak(color_cycle_from_palette, 86), be_const_closure(color_cycle_from_palette_closure) },
+        { be_const_key_weak(register_user_function, -1), be_const_closure(register_user_function_closure) },
+        { be_const_key_weak(twinkle_animation, 38), be_const_class(be_class_TwinkleAnimation) },
+        { be_const_key_weak(twinkle_gentle, -1), be_const_closure(twinkle_gentle_closure) },
+        { be_const_key_weak(sparkle_animation, -1), be_const_class(be_class_SparkleAnimation) },
+        { be_const_key_weak(solid, 55), be_const_closure(solid_closure) },
+        { be_const_key_weak(noise_animation, -1), be_const_class(be_class_NoiseAnimation) },
+        { be_const_key_weak(init, -1), be_const_closure(animation_init_closure) },
+        { be_const_key_weak(plasma_rainbow, -1), be_const_closure(plasma_rainbow_closure) },
+        { be_const_key_weak(shift_scroll_left, 61), be_const_closure(shift_scroll_left_closure) },
+        { be_const_key_weak(sparkle_rainbow, -1), be_const_closure(sparkle_rainbow_closure) },
+        { be_const_key_weak(strip_length, 71), be_const_class(be_class_StripLengthProvider) },
+        { be_const_key_weak(TRIANGLE, 59), be_const_int(2) },
+        { be_const_key_weak(unregister_event_handler, 10), be_const_closure(unregister_event_handler_closure) },
+        { be_const_key_weak(twinkle_classic, -1), be_const_closure(twinkle_classic_closure) },
+        { be_const_key_weak(wave_custom, 98), be_const_closure(wave_custom_closure) },
+        { be_const_key_weak(EventManager, 117), be_const_class(be_class_EventManager) },
+        { be_const_key_weak(is_value_provider, -1), be_const_closure(is_value_provider_closure) },
+        { be_const_key_weak(fire_animation, 47), be_const_class(be_class_FireAnimation) },
+        { be_const_key_weak(palette_meter_animation, 82), be_const_class(be_class_PaletteMeterAnimation) },
+        { be_const_key_weak(sawtooth, -1), be_const_closure(sawtooth_closure) },
+        { be_const_key_weak(wave_single_sine, 79), be_const_closure(wave_single_sine_closure) },
+        { be_const_key_weak(palette_pattern_animation, 76), be_const_class(be_class_PalettePatternAnimation) },
+        { be_const_key_weak(elastic, 74), be_const_closure(elastic_closure) },
+        { be_const_key_weak(PALETTE_SUNSET_TICKS, 17), be_const_bytes_instance(28FF450028FF8C0028FFD70028FF69B4288000802819197000000080) },
+        { be_const_key_weak(EASE_OUT, 99), be_const_int(7) },
+        { be_const_key_weak(SINE, -1), be_const_int(5) },
+        { be_const_key_weak(register_event_handler, -1), be_const_closure(register_event_handler_closure) },
         { be_const_key_weak(rich_palette_rainbow, -1), be_const_closure(rich_palette_rainbow_closure) },
-        { be_const_key_weak(PALETTE_FIRE, 54), be_const_bytes_instance(000000004080000080FF0000C0FF8000FFFFFF00) },
-        { be_const_key_weak(jitter_color, 59), be_const_closure(jitter_color_closure) },
-        { be_const_key_weak(create_stop_step, 11), be_const_closure(create_stop_step_closure) },
-        { be_const_key_weak(unregister_event_handler, -1), be_const_closure(unregister_event_handler_closure) },
-        { be_const_key_weak(scale_animation, 90), be_const_class(be_class_ScaleAnimation) },
+        { be_const_key_weak(pulsating_animation, -1), be_const_closure(pulsating_animation_closure) },
+        { be_const_key_weak(trigger_event, 7), be_const_closure(trigger_event_closure) },
+        { be_const_key_weak(version_string, -1), be_const_closure(animation_version_string_closure) },
+        { be_const_key_weak(sparkle_white, -1), be_const_closure(sparkle_white_closure) },
+        { be_const_key_weak(beacon_animation, -1), be_const_class(be_class_BeaconAnimation) },
+        { be_const_key_weak(create_engine, 26), be_const_closure(create_engine_closure) },
+        { be_const_key_weak(ramp, -1), be_const_closure(ramp_closure) },
+        { be_const_key_weak(jitter_animation, 81), be_const_class(be_class_JitterAnimation) },
+        { be_const_key_weak(animation, -1), be_const_class(be_class_Animation) },
+        { be_const_key_weak(ease_out, 80), be_const_closure(ease_out_closure) },
+        { be_const_key_weak(jitter_color, 94), be_const_closure(jitter_color_closure) },
+        { be_const_key_weak(twinkle_solid, -1), be_const_closure(twinkle_solid_closure) },
+        { be_const_key_weak(breathe_animation, 111), be_const_class(be_class_BreatheAnimation) },
+        { be_const_key_weak(linear, -1), be_const_closure(linear_closure) },
+        { be_const_key_weak(scale_grow, -1), be_const_closure(scale_grow_closure) },
+        { be_const_key_weak(shift_animation, 30), be_const_class(be_class_ShiftAnimation) },
+        { be_const_key_weak(create_play_step, 97), be_const_closure(create_play_step_closure) },
+        { be_const_key_weak(wave_animation, -1), be_const_class(be_class_WaveAnimation) },
+        { be_const_key_weak(get_event_handlers, 115), be_const_closure(get_event_handlers_closure) },
+        { be_const_key_weak(comet_animation, 9), be_const_class(be_class_CometAnimation) },
+        { be_const_key_weak(rich_palette_animation, -1), be_const_class(be_class_RichPaletteAnimation) },
+        { be_const_key_weak(noise_rainbow, -1), be_const_closure(noise_rainbow_closure) },
+        { be_const_key_weak(palette_wave_animation, 75), be_const_class(be_class_PaletteWaveAnimation) },
+        { be_const_key_weak(parameterized_object, -1), be_const_class(be_class_ParameterizedObject) },
+        { be_const_key_weak(color_cycle, -1), be_const_class(be_class_ColorCycleColorProvider) },
+        { be_const_key_weak(animation_engine, -1), be_const_class(be_class_AnimationEngine) },
+        { be_const_key_weak(shift_scroll_right, 119), be_const_closure(shift_scroll_right_closure) },
+        { be_const_key_weak(is_user_function, -1), be_const_closure(is_user_function_closure) },
+        { be_const_key_weak(clear_all_event_handlers, -1), be_const_closure(clear_all_event_handlers_closure) },
+        { be_const_key_weak(get_registered_events, 42), be_const_closure(get_registered_events_closure) },
+        { be_const_key_weak(plasma_fast, 108), be_const_closure(plasma_fast_closure) },
+        { be_const_key_weak(noise_fractal, 101), be_const_closure(noise_fractal_closure) },
+        { be_const_key_weak(get_user_function, 87), be_const_closure(get_user_function_closure) },
+        { be_const_key_weak(event_handler, -1), be_const_class(be_class_EventHandler) },
+        { be_const_key_weak(frame_buffer, 2), be_const_class(be_class_FrameBuffer) },
+        { be_const_key_weak(plasma_animation, -1), be_const_class(be_class_PlasmaAnimation) },
+        { be_const_key_weak(color_cycle_rainbow, -1), be_const_closure(color_cycle_rainbow_closure) },
+        { be_const_key_weak(gradient_rainbow_linear, 27), be_const_closure(gradient_rainbow_linear_closure) },
+        { be_const_key_weak(PALETTE_OCEAN, -1), be_const_bytes_instance(00000080400000FF8000FFFFC000FF80FF008000) },
+        { be_const_key_weak(noise_single_color, -1), be_const_closure(noise_single_color_closure) },
+        { be_const_key_weak(set_event_active, 29), be_const_closure(set_event_active_closure) },
+        { be_const_key_weak(SAWTOOTH, -1), be_const_int(1) },
+        { be_const_key_weak(bounce, 34), be_const_closure(bounce_closure) },
+        { be_const_key_weak(wave_rainbow_sine, -1), be_const_closure(wave_rainbow_sine_closure) },
+        { be_const_key_weak(COSINE, -1), be_const_int(4) },
+        { be_const_key_weak(composite_color, 4), be_const_class(be_class_CompositeColorProvider) },
+        { be_const_key_weak(jitter_all, -1), be_const_closure(jitter_all_closure) },
+        { be_const_key_weak(shift_fast_scroll, -1), be_const_closure(shift_fast_scroll_closure) },
+        { be_const_key_weak(bounce_animation, -1), be_const_class(be_class_BounceAnimation) },
+        { be_const_key_weak(palette_gradient_animation, -1), be_const_class(be_class_PaletteGradientAnimation) },
+        { be_const_key_weak(VERSION, -1), be_const_int(65536) },
+        { be_const_key_weak(init_strip, -1), be_const_closure(animation_init_strip_closure) },
+        { be_const_key_weak(rich_palette, 31), be_const_class(be_class_RichPaletteColorProvider) },
+        { be_const_key_weak(scale_animation, -1), be_const_class(be_class_ScaleAnimation) },
+        { be_const_key_weak(PALETTE_RAINBOW, 68), be_const_bytes_instance(00FF000024FFA50049FFFF006E00FF00920000FFB74B0082DBEE82EEFFFF0000) },
+        { be_const_key_weak(SQUARE, 33), be_const_int(3) },
+        { be_const_key_weak(jitter_position, 0), be_const_closure(jitter_position_closure) },
+        { be_const_key_weak(gradient_rainbow_radial, -1), be_const_closure(gradient_rainbow_radial_closure) },
+        { be_const_key_weak(create_stop_step, -1), be_const_closure(create_stop_step_closure) },
+        { be_const_key_weak(square, -1), be_const_closure(square_closure) },
+        { be_const_key_weak(static_color, -1), be_const_class(be_class_StaticColorProvider) },
+        { be_const_key_weak(PALETTE_FOREST, 77), be_const_bytes_instance(0000640040228B228032CD32C09AFF9AFF90EE90) },
+        { be_const_key_weak(triangle, -1), be_const_closure(triangle_closure) },
+        { be_const_key_weak(twinkle_rainbow, 1), be_const_closure(twinkle_rainbow_closure) },
+        { be_const_key_weak(bounce_basic, 118), be_const_closure(bounce_basic_closure) },
+        { be_const_key_weak(scale_static, -1), be_const_closure(scale_static_closure) },
+        { be_const_key_weak(global, -1), be_const_closure(animation_global_closure) },
+        { be_const_key_weak(scale_oscillate, -1), be_const_closure(scale_oscillate_closure) },
+        { be_const_key_weak(ELASTIC, -1), be_const_int(8) },
+        { be_const_key_weak(bounce_gravity, -1), be_const_closure(bounce_gravity_closure) },
+        { be_const_key_weak(static_value, -1), be_const_class(be_class_StaticValueProvider) },
         { be_const_key_weak(bounce_constrained, -1), be_const_closure(bounce_constrained_closure) },
-        { be_const_key_weak(solid, -1), be_const_closure(solid_closure) },
-        { be_const_key_weak(bounce_gravity, 69), be_const_closure(bounce_gravity_closure) },
-        { be_const_key_weak(twinkle_intense, 110), be_const_closure(twinkle_intense_closure) },
-        { be_const_key_weak(gradient_rainbow_linear, -1), be_const_closure(gradient_rainbow_linear_closure) },
-        { be_const_key_weak(global, 66), be_const_closure(animation_global_closure) },
+        { be_const_key_weak(is_color_provider, 54), be_const_closure(is_color_provider_closure) },
     }))
 );
 BE_EXPORT_VARIABLE be_define_const_native_module(animation);

--- a/lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be
+++ b/lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be
@@ -1,0 +1,158 @@
+# Test file for StripLengthProvider class
+#
+# This file contains tests for the StripLengthProvider class which provides
+# access to the LED strip length as a dynamic value provider.
+#
+# Command to run test is:
+#    ./berry -s -g -m lib/libesp32/berry_animation/src -e "import tasmota" lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be
+
+import animation
+
+print("Testing StripLengthProvider...")
+
+# Create a mock LED strip for testing
+class MockStrip
+  var _length
+  
+  def init(length)
+    self._length = length
+  end
+  
+  def length()
+    return self._length
+  end
+  
+  def set_pixel_color(index, color)
+    # Mock implementation - do nothing
+  end
+  
+  def show()
+    # Mock implementation - do nothing
+  end
+  
+  def clear()
+    # Mock implementation - do nothing
+  end
+  
+  def can_show()
+    return true
+  end
+end
+
+# Test basic functionality
+def test_basic_functionality()
+  print("  Testing basic functionality...")
+  
+  # Test with different strip lengths
+  var test_lengths = [10, 30, 60, 144]
+  
+  for length : test_lengths
+    # Create mock strip and engine
+    var strip = MockStrip(length)
+    var engine = animation.animation_engine(strip)
+    
+    # Create StripLengthProvider
+    var provider = animation.strip_length(engine)
+    
+    # Test the provider
+    var result = provider.produce_value("length", 1000)
+    assert(result == length, f"Expected {length}, got {result}")
+    
+    # Test that parameter name doesn't matter
+    var result2 = provider.produce_value("width", 2000)
+    assert(result2 == length, f"Expected {length}, got {result2}")
+    
+    # Test that time doesn't matter
+    var result3 = provider.produce_value("size", nil)
+    assert(result3 == length, f"Expected {length}, got {result3}")
+  end
+  
+  print("    ✓ Basic functionality tests passed")
+end
+
+# Test string representation
+def test_string_representation()
+  print("  Testing string representation...")
+  
+  var strip = MockStrip(42)
+  var engine = animation.animation_engine(strip)
+  var provider = animation.strip_length(engine)
+  
+  var str_repr = str(provider)
+  assert(str_repr == "StripLengthProvider(length=42)", f"Unexpected string representation: {str_repr}")
+  
+  print("    ✓ String representation test passed")
+end
+
+# Test error handling
+def test_error_handling()
+  print("  Testing error handling...")
+  
+  # Test with nil engine (should raise error during construction)
+  try
+    var provider_nil = animation.strip_length(nil)
+    assert(false, "Should have raised an error with nil engine")
+  except "value_error"
+    # Expected behavior
+  except .. as e
+    assert(false, f"Unexpected error: {e}")
+  end
+  
+  print("    ✓ Error handling test passed")
+end
+
+# Test integration with animation system
+def test_integration()
+  print("  Testing integration with animation system...")
+  
+  var strip = MockStrip(20)
+  var engine = animation.animation_engine(strip)
+  var provider = animation.strip_length(engine)
+  
+  # Test that it's recognized as a value provider
+  assert(animation.is_value_provider(provider), "Should be recognized as a value provider")
+  
+  # Test that it can be used as a parameter value
+  var solid_anim = animation.solid(engine)
+  solid_anim.color = 0xFF0000FF
+  
+  # This should work without errors (though the animation won't use strip_length directly)
+  var length_value = provider.produce_value("test", engine.time_ms)
+  assert(length_value == 20, f"Expected 20, got {length_value}")
+  
+  print("    ✓ Integration test passed")
+end
+
+# Test consistency with engine properties
+def test_engine_consistency()
+  print("  Testing consistency with engine properties...")
+  
+  var strip = MockStrip(100)
+  var engine = animation.animation_engine(strip)
+  var provider = animation.strip_length(engine)
+  
+  # Test that provider returns same value as engine properties
+  var provider_length = provider.produce_value("length", 0)
+  var engine_width = engine.width
+  var engine_strip_length = engine.get_strip_length()
+  
+  assert(provider_length == engine_width, f"Provider length {provider_length} != engine width {engine_width}")
+  assert(provider_length == engine_strip_length, f"Provider length {provider_length} != engine strip length {engine_strip_length}")
+  
+  print("    ✓ Engine consistency test passed")
+end
+
+# Run all tests
+def run_all_tests()
+  test_basic_functionality()
+  test_string_representation()
+  test_error_handling()
+  test_integration()
+  test_engine_consistency()
+  
+  print("All StripLengthProvider tests passed!")
+  return true
+end
+
+# Execute tests
+run_all_tests()

--- a/lib/libesp32/berry_animation/src/tests/test_all.be
+++ b/lib/libesp32/berry_animation/src/tests/test_all.be
@@ -94,6 +94,7 @@ def run_all_tests()
     "lib/libesp32/berry_animation/src/tests/oscillator_value_provider_test.be",
     "lib/libesp32/berry_animation/src/tests/oscillator_ease_test.be",
     "lib/libesp32/berry_animation/src/tests/oscillator_elastic_bounce_test.be",
+    "lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be",
     "lib/libesp32/berry_animation/src/tests/breathe_color_provider_test.be",
     
     # DSL tests


### PR DESCRIPTION
## Description:

Berry animation framework, add `strip_length` value provider to dynamically get the length of the strip, this will allow animation to adapt to the actual length at runtime.

```python
set strip_len = strip_length() # Get the current strip length
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
