### PR TITLE
changes for newest esp-hosted-mcu

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
@@ -15,6 +15,9 @@
 #define XDRV_84               84
 
 #include "esp_hosted.h"
+#if __has_include("port/esp/freertos/include/port_esp_hosted_host_config.h")
+#include "port/esp/freertos/include/port_esp_hosted_host_config.h"
+#endif  //#include "port_esp_hosted_host_config.h"
 #include "esp_hosted_api_types.h"
 #include "esp_hosted_ota.h"
 


### PR DESCRIPTION
## Description:

The newest version of component esp-hosted-mcu v2.3.2 has been refactored and needs an additional *.h file to be included
Only relevant for ESP32-P4. The change is backwards compatible

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
