### PR TITLE
core/net: add AsyncHttpClientLight + Berry async webclient; keep HTTPClient.h enums; replace old backend by default

### DIFF
--- a/lib/libesp32/HttpClientLight/src/AsyncHttpClientLight.cpp
+++ b/lib/libesp32/HttpClientLight/src/AsyncHttpClientLight.cpp
@@ -1,0 +1,1572 @@
+/*
+ * AsyncHttpClientLight.cpp  - Created on: 26.08.2025
+ *
+ * Copyright (C) 2025 by Martin Macák <macak@msb.sk>
+ *
+ * Async HTTP/HTTPS client for ESP32 (WDT-friendly)
+ *
+ * Features
+ * - HTTP: lwIP socket transport (IClientLite + AsyncTcpAdapter) with SO_LINGER (RST-close) to reduce TIME_WAIT pressure
+ * - HTTPS: BearSSL::WiFiClientSecure_light
+ * - API and error codes compatible with Arduino HTTPClient/HTTPClientLight semantics
+ *
+ * Async extensions
+ * - asyncGETStart(), asyncPOSTStart(): launch a request in the background (FreeRTOS worker), non-blocking for the caller
+ * - asyncState(): query status; after ASYNC_DONE you can use getString()/getSize()/writeToStream() without further I/O
+ * - asyncAbort(): best-effort cancellation of an in-flight async request
+ * Note: in async mode the response body is stored in an internal RAM buffer (hard cap kAsyncBodyLimit).
+ *
+ * Acknowledgments: API/error-code compatibility inspired by Arduino HTTPClient / Tasmota HTTPClientLight.
+ * This file contains an independent implementation; no source code was copied.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+
+#include "AsyncHttpClientLight.h"
+#include <base64.h>
+#include "WiFiHelper.h"
+#include <ctype.h>
+
+// --------- Utils (SHA1 pin parsing) ------------------------------------
+static inline int hexval_local(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  c = toupper((unsigned char)c);
+  if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+  return -1;
+}
+static bool parse_sha1_pin_local(const char* in, uint8_t out[20]) {
+  if (!in) return false;
+  char buf[41]; int n = 0;
+  for (const char* p = in; *p && n < 40; ++p) {
+    if (*p == ':' || *p == ' ') continue;
+    int hv = hexval_local(*p);
+    if (hv < 0) return false;
+    buf[n++] = (char)toupper((unsigned char)*p);
+  }
+  if (n != 40) return false;
+  for (int i=0;i<20;i++){
+    int hi = hexval_local(buf[2*i]);
+    int lo = hexval_local(buf[2*i+1]);
+    if (hi < 0 || lo < 0) return false;
+    out[i] = (uint8_t)((hi<<4)|lo);
+  }
+  return true;
+}
+
+// ======================== AsyncTcpAdapter (HTTP) =======================
+bool AsyncHttpClientLight::AsyncTcpAdapter::connect_fd(const struct sockaddr_in& sa, int32_t timeout_ms) {
+  stop();
+
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) return false;
+
+  // nonblocking connect + select with timeout
+  int flags = fcntl(fd, F_GETFL, 0);
+  fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+  int res = ::connect(fd, (const struct sockaddr*)&sa, sizeof(sa));
+  if (res < 0 && errno != EINPROGRESS) { ::close(fd); return false; }
+
+  fd_set w; FD_ZERO(&w); FD_SET(fd, &w);
+  struct timeval tv;
+  tv.tv_sec  = timeout_ms / 1000;
+  tv.tv_usec = (timeout_ms % 1000) * 1000;
+  int sel = ::select(fd+1, nullptr, &w, nullptr, &tv);
+  if (sel <= 0) { ::close(fd); return false; }
+
+  int soerr = 0; socklen_t slen = sizeof(soerr);
+  if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &slen) != 0 || soerr != 0) {
+    ::close(fd); return false;
+  }
+
+#ifdef TCP_NODELAY
+  int one = 1;
+  setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+#endif
+
+  _fd = fd;
+  _isConnected = true;
+  return true;
+}
+
+bool AsyncHttpClientLight::AsyncTcpAdapter::connectIP(IPAddress ip, uint16_t port, int32_t timeout_ms) {
+  struct sockaddr_in sa; memset(&sa, 0, sizeof(sa));
+  sa.sin_family = AF_INET;
+  sa.sin_port   = htons(port);
+  sa.sin_addr.s_addr = (in_addr_t)ip;
+  return connect_fd(sa, timeout_ms);
+}
+
+bool AsyncHttpClientLight::AsyncTcpAdapter::connectHost(const char* host, uint16_t port, int32_t timeout_ms) {
+  IPAddress ip;
+  if (!WiFiHelper::hostByName(host, ip)) return false;
+  return connectIP(ip, port, timeout_ms);
+}
+
+size_t AsyncHttpClientLight::AsyncTcpAdapter::write(const uint8_t* data, size_t len) {
+  if (_fd < 0 || !_isConnected) return 0;
+  int s = ::send(_fd, data, len, MSG_DONTWAIT);
+  if (s < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK) { stop(); }
+    return 0;
+  }
+  return (size_t)s;
+}
+
+int AsyncHttpClientLight::AsyncTcpAdapter::read(uint8_t* buf, size_t len) {
+  if (_fd < 0 || !_isConnected) return -1;
+  int r = ::recv(_fd, buf, len, MSG_DONTWAIT);
+  if (r == 0) { stop(); return 0; }   // peer close
+  if (r < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK) { stop(); }
+    return 0;
+  }
+  return r;
+}
+
+int AsyncHttpClientLight::AsyncTcpAdapter::available() {
+  if (_fd < 0 || !_isConnected) return 0;
+  int bytes = 0;
+  if (ioctl(_fd, FIONREAD, &bytes) < 0) return 0;
+  return bytes;
+}
+
+void AsyncHttpClientLight::AsyncTcpAdapter::stop() {
+  if (_fd >= 0) {
+#if ASYNCHTTP_HTTP_LINGER_RST
+    struct linger sl; sl.l_onoff = 1; sl.l_linger = 0;
+    (void)setsockopt(_fd, SOL_SOCKET, SO_LINGER, &sl, sizeof(sl));
+#endif
+    ::close(_fd);
+  }
+  _fd = -1;
+  _isConnected = false;
+}
+
+// ======================== BearSslAdapter (HTTPS) =======================
+#ifdef USE_WEBCLIENT_HTTPS
+AsyncHttpClientLight::BearSslAdapter::BearSslAdapter(
+    const uint8_t* pin1, bool hasPin1,
+    const uint8_t* pin2, bool hasPin2,
+    bool rsaOnly) {
+
+  _cli.reset(new BearSSL::WiFiClientSecure_light(16384, 0));
+  static const uint8_t any[20] = {0};
+
+  if (hasPin1 || hasPin2) {
+    const uint8_t* p1 = hasPin1 ? pin1 : any;
+    const uint8_t* p2 = hasPin2 ? pin2 : any;
+    _cli->setInsecure(); 
+    _cli->setPubKeyFingerprint(p1, p2, /*allow_all=*/false);
+  } else {
+    _cli->setPubKeyFingerprint(any, any, /*allow_all=*/true);
+  }
+  _cli->setRSAOnly(rsaOnly);
+}
+
+bool AsyncHttpClientLight::BearSslAdapter::connectHost(const char* host, uint16_t port, int32_t timeout_ms) {
+  return _cli->connect(host, port, timeout_ms);
+}
+bool AsyncHttpClientLight::BearSslAdapter::connectIP(IPAddress ip, uint16_t port, int32_t timeout_ms) {
+  return _cli->connect(ip, port, timeout_ms);
+}
+size_t AsyncHttpClientLight::BearSslAdapter::write(const uint8_t* data, size_t len) { return _cli->write(data, len); }
+int    AsyncHttpClientLight::BearSslAdapter::read(uint8_t* buf, size_t len)        { return _cli->read(buf, len); }
+int    AsyncHttpClientLight::BearSslAdapter::available()                            { return _cli->available(); }
+bool   AsyncHttpClientLight::BearSslAdapter::connected()                            { return _cli->connected(); }
+void   AsyncHttpClientLight::BearSslAdapter::stop()                                 { _cli->stop(); }
+void   AsyncHttpClientLight::BearSslAdapter::setTimeout(uint16_t ms)                { _cli->setTimeout(ms); }
+#endif
+
+// ======================== AsyncHttpClientLight core =====================
+
+AsyncHttpClientLight::AsyncHttpClientLight() {
+#ifdef ESP32
+  _busy = xSemaphoreCreateMutex();
+#endif
+}
+
+AsyncHttpClientLight::~AsyncHttpClientLight() {
+  end();
+  if (_currentHeaders) { delete[] _currentHeaders; _currentHeaders = nullptr; }
+#ifdef ESP32
+  if (_asyncDone) { vSemaphoreDelete(_asyncDone); _asyncDone = nullptr; }
+  if (_busy) { vSemaphoreDelete(_busy); _busy = nullptr; }
+#endif
+}
+
+bool AsyncHttpClientLight::setPubKeyPins(const char* pin1, const char* pin2) {
+  _hasPin1 = _hasPin2 = false;
+  if (pin1 && *pin1) _hasPin1 = parse_sha1_pin_local(pin1, _pin1);
+  if (pin2 && *pin2) _hasPin2 = parse_sha1_pin_local(pin2, _pin2);
+  if (!_hasPin1) memset(_pin1, 0, sizeof(_pin1));
+  if (!_hasPin2) memset(_pin2, 0, sizeof(_pin2));
+  return _hasPin1 || _hasPin2;
+}
+void AsyncHttpClientLight::clearPubKeyPins() { _hasPin1 = _hasPin2 = false; memset(_pin1,0,sizeof(_pin1)); memset(_pin2,0,sizeof(_pin2)); }
+
+void AsyncHttpClientLight::setAuthorization(const char * user, const char * password) {
+  if (user && password) {
+    String auth = user; auth += ":"; auth += password;
+    _base64Authorization = base64::encode(auth);
+  }
+}
+void AsyncHttpClientLight::setAuthorization(const char * auth) { if (auth) _base64Authorization = auth; }
+
+void AsyncHttpClientLight::setTimeout(uint16_t timeout) {
+  _tcpTimeout = timeout;
+  if (_transport) _transport->setTimeout(timeout);
+}
+
+bool AsyncHttpClientLight::begin(String url) {
+  _port = 0; _secure = false; _headers = ""; _returnCode = 0; _size = -1; _location = "";
+  _bodyPending = false; // BODY_PENDING reset
+  return beginInternal(url, url.startsWith("https") ? "https" : "http");
+}
+
+bool AsyncHttpClientLight::beginInternal(String url, const char* expectedProto) {
+  int index = url.indexOf(':');
+  if (index < 0) return false;
+  _protocol = url.substring(0, index);
+  if (_protocol != expectedProto) return false;
+
+  url.remove(0, (index + 3)); // remove http(s)://
+
+  index = url.indexOf('/');
+  String host = (index >= 0) ? url.substring(0, index) : url;
+  url.remove(0, (index >= 0) ? index : url.length());
+
+  // auth
+  index = host.indexOf('@');
+  if (index >= 0) {
+    String auth = host.substring(0, index);
+    host.remove(0, index + 1);
+    _base64Authorization = base64::encode(auth);
+  }
+
+  // port
+  index = host.indexOf(':');
+  if (index >= 0) {
+    _host = host.substring(0, index);
+    host.remove(0, (index + 1));
+    _port = host.toInt();
+  } else {
+    _host = host;
+  }
+
+  if (_port == 0) _port = (_protocol == "https") ? 443 : 80;
+  _secure = (_protocol == "https");
+  _uri = url.length() ? url : "/";
+
+  _transport.reset();
+  if (_secure) {
+#ifdef USE_WEBCLIENT_HTTPS
+    _transport.reset(new BearSslAdapter(_pin1, _hasPin1, _pin2, _hasPin2, _rsaOnly));
+#else
+    return false;
+#endif
+  } else {
+    _transport.reset(new AsyncTcpAdapter());
+  }
+  if (_transport) _transport->setTimeout(_tcpTimeout);
+  return true;
+}
+
+void AsyncHttpClientLight::end() {
+  if (_transport) _transport->stop();
+  _transport.reset();
+  _headers = ""; _base64Authorization = ""; _size = -1; _returnCode = 0; _location = "";
+  _bodyPending = false; // BODY_PENDING reset
+}
+
+bool AsyncHttpClientLight::connected() {
+  return _transport && _transport->connected();
+}
+
+bool AsyncHttpClientLight::connectTransport() {
+  if (!_transport) return false;
+  return _transport->connectHost(_host.c_str(), _port, _connectTimeout);
+}
+
+bool AsyncHttpClientLight::ensureConnected() {
+  if (!_transport) return false;
+  if (_transport->connected()) return true;
+  return connectTransport();
+}
+
+// ---------- headers add/collect ---------------------------------------
+
+void AsyncHttpClientLight::addHeader(const String& name, const String& value, bool first, bool replace) {
+  if (!name.equalsIgnoreCase(F("Connection")) &&
+      !name.equalsIgnoreCase(F("User-Agent")) &&
+      !name.equalsIgnoreCase(F("Host")) &&
+      !(name.equalsIgnoreCase(F("Authorization")) && _base64Authorization.length())) {
+
+    String headerLine = name; headerLine += ": ";
+
+    if (replace) {
+      int headerStart = _headers.indexOf(headerLine);
+      if (headerStart != -1 && (headerStart == 0 || _headers[headerStart - 1] == '\n')) {
+        int headerEnd = _headers.indexOf('\n', headerStart);
+        _headers = _headers.substring(0, headerStart) + _headers.substring(headerEnd + 1);
+      }
+    }
+
+    headerLine += value; headerLine += "\r\n";
+    if (first) _headers = headerLine + _headers;
+    else       _headers += headerLine;
+  }
+}
+
+void AsyncHttpClientLight::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
+  if (_currentHeaders) { delete[] _currentHeaders; _currentHeaders = nullptr; }
+  _headerKeysCount = headerKeysCount;
+  if (_headerKeysCount) {
+    _currentHeaders = new RequestArgument[_headerKeysCount];
+    for (size_t i=0;i<_headerKeysCount;i++) _currentHeaders[i].key = headerKeys[i];
+  }
+}
+
+String AsyncHttpClientLight::header(const char* name) const {
+  for (size_t i=0;i<_headerKeysCount;i++) {
+    if (_currentHeaders[i].key.equalsIgnoreCase(name)) return _currentHeaders[i].value;
+  }
+  return String();
+}
+String AsyncHttpClientLight::header(size_t i) const {
+  if (i < _headerKeysCount) return _currentHeaders[i].value;
+  return String();
+}
+String AsyncHttpClientLight::headerName(size_t i) const {
+  if (i < _headerKeysCount) return _currentHeaders[i].key;
+  return String();
+}
+bool AsyncHttpClientLight::hasHeader(const char* name) const {
+  for (size_t i=0;i<_headerKeysCount;i++) {
+    if (_currentHeaders[i].key.equalsIgnoreCase(name) && _currentHeaders[i].value.length() > 0) return true;
+  }
+  return false;
+}
+
+// ---------- robust write (1× reconnect 0-sent headers) ------------
+
+bool AsyncHttpClientLight::writeAllWithOneReconnect(const uint8_t* data, size_t len, bool allow_retry_if_zero_sent) {
+  if (!_transport) return false;
+
+  auto try_send = [&](const uint8_t* p, size_t l, size_t& sent_total)->bool {
+    uint32_t start = millis();
+    sent_total = 0;
+    const uint8_t* cur = p;
+    size_t left = l;
+    while (left) {
+      if (!_transport->connected()) return false;
+      size_t s = _transport->write(cur, left);
+      if (s > 0) {
+        cur += s; left -= s; sent_total += s;
+        start = millis();
+      } else {
+        delay(1);
+        if ((millis()-start) > (uint32_t)_tcpTimeout) return false;
+      }
+    }
+    return true;
+  };
+
+  size_t first_sent = 0;
+  bool ok = try_send(data, len, first_sent);
+  if (ok) return true;
+
+  if (allow_retry_if_zero_sent && first_sent == 0 && _reuse) {
+    _transport->stop();
+    if (!connectTransport()) return false;
+    size_t second_sent = 0;
+    return try_send(data, len, second_sent);
+  }
+  return false;
+}
+
+// ---------- send header line -------------------------------------------
+
+bool AsyncHttpClientLight::sendHeader(const char * method) {
+  // BODY_PENDING
+  if (_bodyPending) {
+    if (_transport) _transport->stop();
+    _bodyPending = false;
+  }
+
+  if (!ensureConnected()) return false;
+
+  String header = String(method) + " " + _uri + F(" HTTP/1.");
+  header += _useHTTP10 ? "0" : "1";
+
+  header += String(F("\r\nHost: ")) + _host;
+  if (_port != 80 && _port != 443) { header += ':'; header += String(_port); }
+  header += String(F("\r\nUser-Agent: ")) + _userAgent +
+            F("\r\nConnection: ");
+  header += (_reuse ? F("keep-alive") : F("close"));
+  header += "\r\n";
+
+  // identities only
+  if (!_useHTTP10) {
+    header += F("Accept-Encoding: identity\r\n");
+  }
+
+  if (_base64Authorization.length()) {
+    String auth = _base64Authorization; auth.replace("\n", "");
+    header += F("Authorization: Basic "); header += auth; header += "\r\n";
+  }
+
+  header += _headers + "\r\n";
+
+  return writeAllWithOneReconnect((const uint8_t*)header.c_str(), header.length(), /*allow_retry_if_zero_sent=*/true);
+}
+
+// ---------- handle response headers ------------------------------------
+
+int AsyncHttpClientLight::handleHeaderResponse() {
+  if (!_transport || !_transport->connected()) return HTTPC_ERROR_NOT_CONNECTED;
+
+  String te;
+  _canReuse = _reuse;
+  _transferEncoding = HTTPC_TE_IDENTITY;
+
+  auto readLine = [&](String& out)->bool{
+    out = "";
+    uint32_t start = millis();
+    char c;
+    while (true) {
+      int avail = _transport->available();
+      if (avail <= 0) {
+        delay(1);
+        if ((millis()-start) > (uint32_t)_tcpTimeout) return false;
+        continue;
+      }
+      int r = _transport->read((uint8_t*)&c, 1);
+      if (r == 1) {
+        if (c == '\r') continue;
+        if (c == '\n') return true;
+        out += c;
+      }
+    }
+  };
+
+  bool firstLine = true;
+  _size = -1;
+  _returnCode = 0;
+  _location = "";
+
+  while (_transport->connected()) {
+    String line;
+    if (!readLine(line)) return HTTPC_ERROR_READ_TIMEOUT;
+
+    if (line.length() == 0) {
+      if (te.length()) {
+        if (te.equalsIgnoreCase("chunked"))      _transferEncoding = HTTPC_TE_CHUNKED;
+        else if (te.equalsIgnoreCase("identity")) _transferEncoding = HTTPC_TE_IDENTITY;
+        else return HTTPC_ERROR_ENCODING;
+      } else _transferEncoding = HTTPC_TE_IDENTITY;
+
+      // BODY_PENDING: by headers
+      _bodyPending = (_transferEncoding == HTTPC_TE_CHUNKED) || (_size > 0);
+
+      return _returnCode ? _returnCode : HTTPC_ERROR_NO_HTTP_SERVER;
+    }
+
+    if (firstLine) {
+      firstLine = false;
+      if (_canReuse && line.startsWith("HTTP/1.")) _canReuse = (line[sizeof "HTTP/1." - 1] != '0');
+      int cp = line.indexOf(' ');
+      if (cp > 0) {
+        int next = line.indexOf(' ', cp+1);
+        _returnCode = line.substring(cp+1, next > 0 ? next : line.length()).toInt();
+      }
+      continue;
+    }
+
+    int colon = line.indexOf(':');
+    if (colon > 0) {
+      String name = line.substring(0, colon);
+      String value = line.substring(colon+1); value.trim();
+
+      if (name.equalsIgnoreCase("Content-Length")) _size = value.toInt();
+      if (_canReuse && name.equalsIgnoreCase("Connection")) {
+        if (value.indexOf("close") >= 0 && value.indexOf("keep-alive") < 0) _canReuse = false;
+      }
+      if (name.equalsIgnoreCase("Transfer-Encoding")) te = value;
+      if (name.equalsIgnoreCase("Location")) _location = value;
+
+      for (size_t i=0;i<_headerKeysCount;i++) {
+        if (_currentHeaders[i].key.equalsIgnoreCase(name)) {
+          _currentHeaders[i].value = value;
+          break;
+        }
+      }
+    }
+  }
+  return HTTPC_ERROR_CONNECTION_LOST;
+}
+
+// ---------- body read (sync) -------------------------------------------
+
+int AsyncHttpClientLight::writeToStreamDataBlock(Stream * stream, int size) {
+  int len = size;
+  int bytesWritten = 0;
+  uint8_t buf[HTTP_TCP_BUFFER_SIZE];
+
+  while (_transport && _transport->connected() && (len > 0 || len == -1)) {
+    int avail = _transport->available();
+    if (avail <= 0) { delay(1); continue; }
+    int wish = avail;
+    if (len > 0 && wish > len) wish = len;
+    if (wish > (int)sizeof(buf)) wish = sizeof(buf);
+    int r = _transport->read(buf, wish);
+    if (r > 0) {
+      int w = stream->write(buf, r);
+      if (w != r) return HTTPC_ERROR_STREAM_WRITE;
+      bytesWritten += w;
+      if (len > 0) len -= r;
+    }
+  }
+
+  if ((size > 0) && (size != bytesWritten)) return HTTPC_ERROR_STREAM_WRITE;
+  return bytesWritten;
+}
+
+int AsyncHttpClientLight::writeToStream(Stream * stream) {
+  // FAST-PATH: async DONE → from internal buffer
+  if (_asyncState == ASYNC_DONE) {
+    const String& s = _asyncBody;
+    size_t n = s.length();
+    if (n == 0) return 0;
+    size_t w = stream->write((const uint8_t*)s.c_str(), n);
+    return (w == n) ? (int)n : HTTPC_ERROR_STREAM_WRITE;
+  }
+
+  _lastStream = stream;
+  IntOpArg a{ this };
+  return runJob(&Job_WriteToStream, &a);
+}
+
+String AsyncHttpClientLight::getString(void) {
+  // FAST-PATH: async DONE → return from internal buffer
+  if (_asyncState == ASYNC_DONE) {
+    return String(_asyncBody);
+  }
+
+  _lastString = String();
+  IntOpArg a{ this };
+  int rc = runJob(&Job_GetString, &a);
+  if (rc < 0) return String();
+  String out = _lastString;
+  _lastString = String();
+  return out;
+}
+
+// ---------- requests (sync) --------------------------------------------
+
+int AsyncHttpClientLight::POST(uint8_t * payload, size_t size) {
+  SendBufArg a{ this, "POST", payload, size };
+  return runJob(&Job_SendBuf, &a);
+}
+
+int AsyncHttpClientLight::POST(String payload) {
+  SendStrArg a{ this, "POST", payload };
+  return runJob(&Job_SendStr, &a);
+}
+
+int AsyncHttpClientLight::PUT(uint8_t * payload, size_t size) {
+  SendBufArg a{ this, "PUT", payload, size };
+  return runJob(&Job_SendBuf, &a);
+}
+
+int AsyncHttpClientLight::PUT(String payload) {
+  SendStrArg a{ this, "PUT", payload };
+  return runJob(&Job_SendStr, &a);
+}
+
+int AsyncHttpClientLight::PATCH(uint8_t * payload, size_t size) {
+  SendBufArg a{ this, "PATCH", payload, size };
+  return runJob(&Job_SendBuf, &a);
+}
+
+int AsyncHttpClientLight::PATCH(String payload) {
+  SendStrArg a{ this, "PATCH", payload };
+  return runJob(&Job_SendStr, &a);
+}
+
+int AsyncHttpClientLight::DELETE(uint8_t * payload, size_t size) {
+  SendBufArg a{ this, "DELETE", payload, size };
+  return runJob(&Job_SendBuf, &a);
+}
+
+int AsyncHttpClientLight::DELETE(String payload) {
+  SendStrArg a{ this, "DELETE", payload };
+  return runJob(&Job_SendStr, &a);
+}
+
+int AsyncHttpClientLight::sendRequest(const char * method, String payload) {
+  SendStrArg a{ this, method, payload };
+  return runJob(&Job_SendStr, &a);
+}
+int AsyncHttpClientLight::sendRequest(const char * method, uint8_t * payload, size_t size) {
+  SendBufArg a{ this, method, payload, size };
+  return runJob(&Job_SendBuf, &a);
+}
+int AsyncHttpClientLight::sendRequest(const char * method, Stream * stream, size_t size) {
+  SendStrmArg a{ this, method, stream, size };
+  return runJob(&Job_SendStrm, &a);
+}
+int AsyncHttpClientLight::GET() { IntOpArg a{ this }; return runJob(&Job_GET, &a); }
+
+// ---------- error text --------------------------------------------------
+
+String AsyncHttpClientLight::errorToString(int error) {
+  switch (error) {
+    case HTTPC_ERROR_CONNECTION_REFUSED: return F("connection refused");
+    case HTTPC_ERROR_SEND_HEADER_FAILED: return F("send header failed");
+    case HTTPC_ERROR_SEND_PAYLOAD_FAILED:return F("send payload failed");
+    case HTTPC_ERROR_NOT_CONNECTED:      return F("not connected");
+    case HTTPC_ERROR_CONNECTION_LOST:    return F("connection lost");
+    case HTTPC_ERROR_NO_STREAM:          return F("no stream");
+    case HTTPC_ERROR_NO_HTTP_SERVER:     return F("no HTTP server");
+    case HTTPC_ERROR_TOO_LESS_RAM:       return F("too less ram");
+    case HTTPC_ERROR_ENCODING:           return F("Transfer-Encoding not supported");
+    case HTTPC_ERROR_STREAM_WRITE:       return F("Stream write error");
+    case HTTPC_ERROR_READ_TIMEOUT:       return F("read Timeout");
+    default: return String();
+  }
+}
+
+// ---------- redirects / URL --------------------------------------------
+
+bool AsyncHttpClientLight::setURL(const String& url) {
+  if (url.length() && url[0] == '/') {
+    _uri = url;
+    _headers = ""; _size = -1; _returnCode = 0; _location = "";
+    return true;
+  }
+  if (!url.startsWith(_protocol + ':')) return false;
+  return beginInternal(url, _protocol.c_str());
+}
+
+// ======================== RTOS worker infra ============================
+#ifdef ESP32
+
+void AsyncHttpClientLight::WorkerTask(void* pv) {
+  Job* job = reinterpret_cast<Job*>(pv);
+  int res = HTTPC_ERROR_NOT_CONNECTED;
+  if (job && job->fn) res = job->fn(job->arg);
+  if (job) {
+    job->result = res;
+    if (job->done) xSemaphoreGive(job->done);
+  }
+  vTaskDelete(nullptr);
+}
+
+int AsyncHttpClientLight::runJob(Job::Fn fn, void* arg) {
+  if (_busy) xSemaphoreTake(_busy, portMAX_DELAY);
+
+  Job job;
+  job.fn = fn;
+  job.arg = arg;
+  job.result = HTTPC_ERROR_NOT_CONNECTED;
+  job.done = xSemaphoreCreateBinary();
+  if (!job.done) {
+    if (_busy) xSemaphoreGive(_busy);
+    return HTTPC_ERROR_TOO_LESS_RAM;
+  }
+
+  TaskHandle_t th = nullptr;
+  BaseType_t ok = xTaskCreate(
+      &WorkerTask, "AHttpWkr",
+      ASYNCHTTP_WKR_STACK / sizeof(StackType_t),
+      &job, tskIDLE_PRIORITY + 1, &th);
+
+  if (ok != pdPASS || th == nullptr) {
+    vSemaphoreDelete(job.done);
+    if (_busy) xSemaphoreGive(_busy);
+    return HTTPC_ERROR_TOO_LESS_RAM;
+  }
+
+  while (true) {
+    if (xSemaphoreTake(job.done, pdMS_TO_TICKS(_waitSliceMs)) == pdTRUE) break;
+    delay(0); // feed WDT
+  }
+
+  vSemaphoreDelete(job.done);
+  if (_busy) xSemaphoreGive(_busy);
+
+  return job.result;
+}
+
+// Non-blocking job – 1 queued, 0 busy, <0 error
+int AsyncHttpClientLight::startJob(Job::Fn fn, void* arg) {
+  if (!_busy) return HTTPC_ERROR_NOT_CONNECTED;
+
+  if (_asyncState == ASYNC_RUNNING) return 0;
+
+  xSemaphoreTake(_busy, portMAX_DELAY);
+
+  // long live Job on heap – released in asyncState() after done
+  _asyncJob = new (std::nothrow) Job();
+  if (!_asyncJob) {
+    xSemaphoreGive(_busy);
+    return HTTPC_ERROR_TOO_LESS_RAM;
+  }
+  _asyncJob->fn = fn;
+  _asyncJob->arg = arg;
+  _asyncJob->result = HTTPC_ERROR_NOT_CONNECTED;
+  _asyncDone = xSemaphoreCreateBinary();
+  if (!_asyncDone) {
+    delete _asyncJob; _asyncJob = nullptr;
+    xSemaphoreGive(_busy);
+    return HTTPC_ERROR_TOO_LESS_RAM;
+  }
+  _asyncJob->done = _asyncDone;
+
+  _asyncTask = nullptr;
+  BaseType_t ok = xTaskCreate(
+      &WorkerTask, "AHttpWkrA",
+      ASYNCHTTP_WKR_STACK / sizeof(StackType_t),
+      _asyncJob, tskIDLE_PRIORITY + 1, &_asyncTask);
+
+  if (ok != pdPASS || _asyncTask == nullptr) {
+    vSemaphoreDelete(_asyncDone); _asyncDone = nullptr;
+    delete _asyncJob; _asyncJob = nullptr;
+    xSemaphoreGive(_busy);
+    return HTTPC_ERROR_TOO_LESS_RAM;
+  }
+
+  // we run async
+  return 1;
+}
+#endif // ESP32
+
+// ======================== Job implements (sync) =====================
+
+int AsyncHttpClientLight::Job_GET(void* arg) {
+  auto* a = reinterpret_cast<IntOpArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+
+  for (size_t i=0;i<a->self->_headerKeysCount;i++) {
+    if (a->self->_currentHeaders[i].value.length()) a->self->_currentHeaders[i].value.clear();
+  }
+
+  if (!a->self->sendHeader("GET")) return HTTPC_ERROR_SEND_HEADER_FAILED;
+  return a->self->handleHeaderResponse();
+}
+
+int AsyncHttpClientLight::Job_SendBuf(void* arg) {
+  auto* a = reinterpret_cast<SendBufArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+
+  int code = HTTPC_ERROR_NOT_CONNECTED;
+  bool redirect = false;
+  uint16_t redirectCount = 0;
+  const char* method = a->method;
+  uint8_t* payload = a->payload;
+  size_t size = a->size;
+
+  do {
+    for (size_t i = 0; i < a->self->_headerKeysCount; i++) {
+      if (a->self->_currentHeaders[i].value.length()) a->self->_currentHeaders[i].value.clear();
+    }
+    a->self->_returnCode = 0;
+    a->self->_size = -1;
+    a->self->_location = "";
+    a->self->_transferEncoding = HTTPC_TE_IDENTITY;
+
+    if (payload && size > 0) {
+      a->self->addHeader(F("Content-Length"), String(size), false, true);
+    }
+
+    if (!a->self->sendHeader(method)) {
+      return HTTPC_ERROR_SEND_HEADER_FAILED;
+    }
+
+    // payload
+    if (payload && size > 0) {
+      uint8_t* p = payload;
+      size_t left = size;
+      uint32_t start = millis();
+      while (left) {
+        if (!a->self->connected()) return HTTPC_ERROR_CONNECTION_LOST;
+        size_t w = a->self->_transport->write(p, left);
+        if (w > 0) { p += w; left -= w; start = millis(); }
+        else {
+          delay(1);
+          if ((millis() - start) > (uint32_t)a->self->_tcpTimeout) {
+            return HTTPC_ERROR_SEND_PAYLOAD_FAILED;
+          }
+        }
+      }
+    }
+
+    code = a->self->handleHeaderResponse();
+
+    redirect = false;
+    if (a->self->_followRedirects != HTTPC_DISABLE_FOLLOW_REDIRECTS &&
+        redirectCount < a->self->_redirectLimit &&
+        a->self->_location.length() > 0) {
+      switch (code) {
+        case 301: case 307:
+          if (a->self->_followRedirects == HTTPC_FORCE_FOLLOW_REDIRECTS ||
+              !strcmp(method, "GET") || !strcmp(method, "HEAD")) {
+            redirectCount++;
+            if (!a->self->setURL(a->self->_location)) break;
+            redirect = true;
+          }
+          break;
+        case 302: case 303:
+          redirectCount++;
+          if (!a->self->setURL(a->self->_location)) break;
+          method = "GET";
+          payload = nullptr;
+          size = 0;
+          redirect = true;
+          break;
+        default:
+          break;
+      }
+    }
+  } while (redirect);
+
+  return code;
+}
+
+int AsyncHttpClientLight::Job_SendStr(void* arg) {
+  auto* a = reinterpret_cast<SendStrArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+  int code;
+  bool redirect=false; uint16_t redirectCount=0;
+  const char* method = a->method;
+  String payload = a->payload;
+  do {
+    for (size_t i=0;i<a->self->_headerKeysCount;i++) if (a->self->_currentHeaders[i].value.length()) a->self->_currentHeaders[i].value.clear();
+    a->self->_returnCode = 0; a->self->_size = -1; a->self->_location = ""; a->self->_transferEncoding = HTTPC_TE_IDENTITY;
+
+    if (payload.length() > 0) a->self->addHeader(F("Content-Length"), String(payload.length()), false, true);
+
+    if (!a->self->sendHeader(method)) return HTTPC_ERROR_SEND_HEADER_FAILED;
+
+    // telo
+    if (payload.length() > 0) {
+      const uint8_t* p = (const uint8_t*)payload.c_str(); size_t left = payload.length();
+      uint32_t start = millis();
+      while (left) {
+        if (!a->self->connected()) return HTTPC_ERROR_CONNECTION_LOST;
+        size_t w = a->self->_transport->write(p, left);
+        if (w > 0) { p += w; left -= w; start = millis(); }
+        else {
+          delay(1);
+          if ((millis()-start) > (uint32_t)a->self->_tcpTimeout) return HTTPC_ERROR_SEND_PAYLOAD_FAILED;
+        }
+      }
+    }
+
+    code = a->self->handleHeaderResponse();
+
+    redirect = false;
+    if (a->self->_followRedirects != HTTPC_DISABLE_FOLLOW_REDIRECTS &&
+        redirectCount < a->self->_redirectLimit &&
+        a->self->_location.length() > 0) {
+      switch (code) {
+        case 301: case 307:
+          if (a->self->_followRedirects == HTTPC_FORCE_FOLLOW_REDIRECTS ||
+              !strcmp(method, "GET") || !strcmp(method, "HEAD")) {
+            redirectCount++;
+            if (!a->self->setURL(a->self->_location)) break;
+            redirect = true;
+          }
+          break;
+        case 302: case 303:
+          redirectCount++;
+          if (!a->self->setURL(a->self->_location)) break;
+          method = "GET";
+          payload = String();
+          redirect = true;
+          break;
+        default: break;
+      }
+    }
+  } while (redirect);
+  return code;
+}
+
+int AsyncHttpClientLight::Job_SendStrm(void* arg) {
+  auto* a = reinterpret_cast<SendStrmArg*>(arg);
+  if (!a || !a->self || !a->stream) return HTTPC_ERROR_NO_STREAM;
+
+  if(!a->self->ensureConnected()) return HTTPC_ERROR_CONNECTION_REFUSED;
+  if(a->size > 0) a->self->addHeader("Content-Length", String(a->size), false, true);
+  if(!a->self->sendHeader(a->method)) return HTTPC_ERROR_SEND_HEADER_FAILED;
+
+  int buff_size = HTTP_TCP_BUFFER_SIZE;
+  int len = a->size;
+  if(len == 0) len = -1;
+  if((len > 0) && (len < HTTP_TCP_BUFFER_SIZE)) buff_size = len;
+
+  std::unique_ptr<uint8_t[]> buff(new (std::nothrow) uint8_t[buff_size]);
+  if(!buff) return HTTPC_ERROR_TOO_LESS_RAM;
+
+  int bytesWritten = 0;
+  while(a->self->connected() && (a->stream->available() > -1) && (len > 0 || len == -1)) {
+    int sizeAvailable = a->stream->available();
+    if(sizeAvailable) {
+      int readBytes = sizeAvailable;
+      if(len > 0 && readBytes > len) readBytes = len;
+      if(readBytes > buff_size) readBytes = buff_size;
+
+      int bytesRead = a->stream->readBytes(buff.get(), readBytes);
+
+      uint32_t start = millis();
+      int left = bytesRead;
+      const uint8_t* p = buff.get();
+      while (left > 0) {
+        if (!a->self->connected()) return HTTPC_ERROR_CONNECTION_LOST;
+        int w = (int)a->self->_transport->write(p, left);
+        if (w > 0) { p += w; left -= w; bytesWritten += w; start = millis(); }
+        else {
+          delay(1);
+          if ((millis()-start) > (uint32_t)a->self->_tcpTimeout) return HTTPC_ERROR_SEND_PAYLOAD_FAILED;
+        }
+      }
+    } else {
+      delay(1);
+    }
+  }
+
+  int rc = a->self->handleHeaderResponse();
+  return rc;
+}
+
+int AsyncHttpClientLight::Job_WriteToStream(void* arg) {
+  auto* a = reinterpret_cast<IntOpArg*>(arg);
+  if (!a || !a->self || !a->self->_lastStream) return HTTPC_ERROR_NO_STREAM;
+
+  int ret = 0;
+
+  if (a->self->_transferEncoding == HTTPC_TE_IDENTITY) {
+    int r = a->self->writeToStreamDataBlock(a->self->_lastStream, a->self->_size);
+    if (r < 0) return r;
+    ret = r;
+  } else if (a->self->_transferEncoding == HTTPC_TE_CHUNKED) {
+    auto readLine = [&](String& out)->bool {
+      out = "";
+      char c;
+      uint32_t start = millis();
+      while (true) {
+        int avail = a->self->_transport ? a->self->_transport->available() : 0;
+        if (avail <= 0) {
+          delay(1);
+          if ((millis() - start) > (uint32_t)a->self->_tcpTimeout) return false;
+          continue;
+        }
+        int r = a->self->_transport->read((uint8_t*)&c, 1);
+        if (r == 1) {
+          if (c == '\r') continue;
+          if (c == '\n') return true;
+          out += c;
+        }
+      }
+    };
+
+    while (true) {
+      // chunk size line
+      String h;
+      if (!readLine(h)) {
+        if (a->self->_transport) a->self->_transport->stop();
+        a->self->_bodyPending = false;
+        return HTTPC_ERROR_READ_TIMEOUT;
+      }
+      h.trim();
+      int chunk = (int) strtol(h.c_str(), nullptr, 16);
+
+      if (chunk <= 0) {
+        String tmp;
+        if (!readLine(tmp)) {
+          if (a->self->_transport) a->self->_transport->stop();
+          a->self->_bodyPending = false;
+          return HTTPC_ERROR_READ_TIMEOUT;
+        }
+        while (true) {
+          String t;
+          if (!readLine(t)) {
+            if (a->self->_transport) a->self->_transport->stop();
+            a->self->_bodyPending = false;
+            return HTTPC_ERROR_READ_TIMEOUT;
+          }
+          if (t.length() == 0) break;
+        }
+        break; // end
+      }
+
+      int remaining = chunk;
+      while (remaining > 0) {
+        uint8_t buf[HTTP_TCP_BUFFER_SIZE];
+        int wish = remaining;
+        if (wish > (int)sizeof(buf)) wish = sizeof(buf);
+
+        uint32_t start = millis();
+        while (a->self->_transport->available() <= 0) {
+          delay(1);
+          if ((millis() - start) > (uint32_t)a->self->_tcpTimeout) {
+            if (a->self->_transport) a->self->_transport->stop();
+            a->self->_bodyPending = false;
+            return HTTPC_ERROR_READ_TIMEOUT;
+          }
+        }
+
+        int avail = a->self->_transport->available();
+        if (wish > avail) wish = avail;
+
+        int r = a->self->_transport->read(buf, wish);
+        if (r > 0) {
+          int w = a->self->_lastStream->write(buf, r);
+          if (w != r) return HTTPC_ERROR_STREAM_WRITE;
+          ret += r;
+          remaining -= r;
+        }
+      }
+
+      // CRLF after chunks
+      char crlf[2]; int got = 0;
+      uint32_t t2 = millis();
+      while (got < 2) {
+        if ((millis() - t2) > (uint32_t)a->self->_tcpTimeout) {
+          if (a->self->_transport) a->self->_transport->stop();
+          a->self->_bodyPending = false;
+          return HTTPC_ERROR_READ_TIMEOUT;
+        }
+        if (a->self->_transport->available() <= 0) { delay(1); continue; }
+        int r = a->self->_transport->read((uint8_t*)&crlf[got], 1);
+        if (r == 1) got++;
+      }
+      if (crlf[0] != '\r' || crlf[1] != '\n') return HTTPC_ERROR_READ_TIMEOUT;
+    }
+  } else {
+    return HTTPC_ERROR_ENCODING;
+  }
+
+  // BODY 
+  a->self->_bodyPending = false;
+
+  if (!a->self->_reuse || !a->self->_canReuse) {
+    a->self->_transport->stop();
+  }
+  return ret;
+}
+
+int AsyncHttpClientLight::Job_GetString(void* arg) {
+  auto* a = reinterpret_cast<IntOpArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+
+  StreamString s;
+  int expect = a->self->_size;
+  if (expect < 0) expect = 1024;
+  (void)s.reserve(expect + 1);
+
+  int ret = 0;
+
+  if (a->self->_transferEncoding == HTTPC_TE_IDENTITY) {
+    int r = a->self->writeToStreamDataBlock(&s, a->self->_size);
+    if (r < 0) return r;
+    ret = r;
+  } else if (a->self->_transferEncoding == HTTPC_TE_CHUNKED) {
+    auto readLine = [&](String& out)->bool {
+      out = "";
+      char c;
+      uint32_t start = millis();
+      while (true) {
+        int avail = a->self->_transport ? a->self->_transport->available() : 0;
+        if (avail <= 0) {
+          delay(1);
+          if ((millis() - start) > (uint32_t)a->self->_tcpTimeout) return false;
+          continue;
+        }
+        int r = a->self->_transport->read((uint8_t*)&c, 1);
+        if (r == 1) {
+          if (c == '\r') continue;
+          if (c == '\n') return true;
+          out += c;
+        }
+      }
+    };
+
+    while (true) {
+      String h;
+      if (!readLine(h)) {
+        if (a->self->_transport) a->self->_transport->stop();
+        a->self->_bodyPending = false;
+        return HTTPC_ERROR_READ_TIMEOUT;
+      }
+      h.trim();
+      int chunk = (int) strtol(h.c_str(), nullptr, 16);
+
+      if (chunk <= 0) {
+        String tmp;
+        if (!readLine(tmp)) {
+          if (a->self->_transport) a->self->_transport->stop();
+          a->self->_bodyPending = false;
+          return HTTPC_ERROR_READ_TIMEOUT;
+        }
+        while (true) {
+          String t;
+          if (!readLine(t)) {
+            if (a->self->_transport) a->self->_transport->stop();
+            a->self->_bodyPending = false;
+            return HTTPC_ERROR_READ_TIMEOUT;
+          }
+          if (t.length() == 0) break;
+        }
+        break; // end
+      }
+
+      int remaining = chunk;
+      while (remaining > 0) {
+        uint8_t buf[HTTP_TCP_BUFFER_SIZE];
+        int wish = remaining;
+        if (wish > (int)sizeof(buf)) wish = sizeof(buf);
+
+        uint32_t start = millis();
+        while (a->self->_transport->available() <= 0) {
+          delay(1);
+          if ((millis() - start) > (uint32_t)a->self->_tcpTimeout) {
+            if (a->self->_transport) a->self->_transport->stop();
+            a->self->_bodyPending = false;
+            return HTTPC_ERROR_READ_TIMEOUT;
+          }
+        }
+
+        int avail = a->self->_transport->available();
+        if (wish > avail) wish = avail;
+
+        int r = a->self->_transport->read(buf, wish);
+        if (r > 0) {
+          int w = s.write(buf, r);
+          if (w != r) return HTTPC_ERROR_STREAM_WRITE;
+          ret += r;
+          remaining -= r;
+        }
+      }
+
+      // CRLF after chunk
+      char crlf[2]; int got = 0;
+      uint32_t t2 = millis();
+      while (got < 2) {
+        if ((millis() - t2) > (uint32_t)a->self->_tcpTimeout) {
+          if (a->self->_transport) a->self->_transport->stop();
+          a->self->_bodyPending = false;
+          return HTTPC_ERROR_READ_TIMEOUT;
+        }
+        if (a->self->_transport->available() <= 0) { delay(1); continue; }
+        int r = a->self->_transport->read((uint8_t*)&crlf[got], 1);
+        if (r == 1) got++;
+      }
+      if (crlf[0] != '\r' || crlf[1] != '\n') return HTTPC_ERROR_READ_TIMEOUT;
+    }
+  } else {
+    return HTTPC_ERROR_ENCODING;
+  }
+
+  a->self->_bodyPending = false;
+
+  if (!a->self->_reuse || !a->self->_canReuse) {
+    a->self->_transport->stop();
+  }
+
+  a->self->_lastString = (String)s;
+  return 0;
+}
+
+// ======================== Async „lite“ implement ===================
+
+// Helper routine: read the entire BODY into a StreamString with a size limit and abort check.
+// Returns the number of bytes read, or <0 on error.
+int AsyncHttpClientLight::readBodyToStreamString(StreamString& s, int size_limit) {
+  int read_total = 0;
+
+  auto bail = [&](int err)->int{
+    if (_transport) _transport->stop();
+    _bodyPending = false;
+    return err;
+  };
+
+  auto push = [&](const uint8_t* buf, int n)->bool{
+    if (n <= 0) return true;
+    int left = n;
+    while (left) {
+      size_t w = s.write(buf, left);
+      if ((int)w <= 0) return false;
+      buf += w; left -= (int)w;
+    }
+    return true;
+  };
+
+  // identity
+  if (_transferEncoding == HTTPC_TE_IDENTITY) {
+    int remaining = _size;
+    if (remaining < 0) remaining = size_limit; // max to limit if we dont know content height
+
+    while (remaining != 0) {
+      if (_asyncAbortReq) return bail(HTTPC_ERROR_CONNECTION_LOST);
+
+      int avail = _transport ? _transport->available() : 0;
+      if (avail <= 0) { delay(1); continue; }
+
+      if (avail > remaining && remaining > 0) avail = remaining;
+      if (avail > HTTP_TCP_BUFFER_SIZE) avail = HTTP_TCP_BUFFER_SIZE;
+
+      uint8_t buf[HTTP_TCP_BUFFER_SIZE];
+      int r = _transport->read(buf, avail);
+      if (r > 0) {
+        // limit
+        int room = size_limit - read_total;
+        if (room <= 0) { // limit done - close
+          return bail(0);
+        }
+        int take = (r > room) ? room : r;
+        if (!push(buf, take)) return bail(HTTPC_ERROR_STREAM_WRITE);
+        read_total += take;
+        if (remaining > 0) remaining -= r;
+      }
+    }
+  }
+  // chunked
+  else if (_transferEncoding == HTTPC_TE_CHUNKED) {
+    auto readLine = [&](String& out)->bool {
+      out = "";
+      char c;
+      uint32_t start = millis();
+      while (true) {
+        if (_asyncAbortReq) return false;
+        int avail = _transport ? _transport->available() : 0;
+        if (avail <= 0) {
+          delay(1);
+          if ((millis() - start) > (uint32_t)_tcpTimeout) return false;
+          continue;
+        }
+        int r = _transport->read((uint8_t*)&c, 1);
+        if (r == 1) { if (c == '\r') continue; if (c == '\n') return true; out += c; }
+      }
+    };
+
+    while (true) {
+      if (_asyncAbortReq) return bail(HTTPC_ERROR_CONNECTION_LOST);
+      String h; if (!readLine(h)) return bail(HTTPC_ERROR_READ_TIMEOUT);
+      h.trim();
+      int chunk = (int) strtol(h.c_str(), nullptr, 16);
+      if (chunk <= 0) {
+        String tmp;
+        if (!readLine(tmp)) return bail(HTTPC_ERROR_READ_TIMEOUT);
+        while (true) { String t; if (!readLine(t)) return bail(HTTPC_ERROR_READ_TIMEOUT); if (t.length() == 0) break; }
+        break; // end
+      }
+
+      int remaining = chunk;
+      while (remaining > 0) {
+        if (_asyncAbortReq) return bail(HTTPC_ERROR_CONNECTION_LOST);
+        uint8_t buf[HTTP_TCP_BUFFER_SIZE];
+        int wish = remaining;
+        if (wish > (int)sizeof(buf)) wish = sizeof(buf);
+
+        uint32_t start = millis();
+        while (_transport->available() <= 0) {
+          if (_asyncAbortReq) return bail(HTTPC_ERROR_CONNECTION_LOST);
+          delay(1);
+          if ((millis() - start) > (uint32_t)_tcpTimeout) return bail(HTTPC_ERROR_READ_TIMEOUT);
+        }
+
+        int avail = _transport->available();
+        if (wish > avail) wish = avail;
+
+        int r = _transport->read(buf, wish);
+        if (r > 0) {
+          int room = size_limit - read_total;
+          if (room <= 0) return bail(0);
+          int take = (r > room) ? room : r;
+          if (!push(buf, take)) return bail(HTTPC_ERROR_STREAM_WRITE);
+          read_total += take;
+          remaining -= r;
+        }
+      }
+
+      // CRLF za chunkom
+      char crlf[2]; int got = 0;
+      uint32_t t2 = millis();
+      while (got < 2) {
+        if (_asyncAbortReq) return bail(HTTPC_ERROR_CONNECTION_LOST);
+        if ((millis() - t2) > (uint32_t)_tcpTimeout) return bail(HTTPC_ERROR_READ_TIMEOUT);
+        if (_transport->available() <= 0) { delay(1); continue; }
+        int r = _transport->read((uint8_t*)&crlf[got], 1);
+        if (r == 1) got++;
+      }
+      if (crlf[0] != '\r' || crlf[1] != '\n') return bail(HTTPC_ERROR_READ_TIMEOUT);
+    }
+  } else {
+    return HTTPC_ERROR_ENCODING;
+  }
+
+  // body read done
+  _bodyPending = false;
+  return read_total;
+}
+
+
+// ---------- Async jobs --------------------------------------------------
+
+int AsyncHttpClientLight::Job_AsyncGET(void* arg) {
+  auto* a = reinterpret_cast<AsyncGetArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+  AsyncHttpClientLight* self = a->self;
+  delete a; // arg on heap – release
+
+  // reset per-request
+  for (size_t i=0;i<self->_headerKeysCount;i++) if (self->_currentHeaders[i].value.length()) self->_currentHeaders[i].value.clear();
+  self->_returnCode = 0; self->_size = -1; self->_location = "";
+  self->_transferEncoding = HTTPC_TE_IDENTITY;
+
+  if (!self->sendHeader("GET")) { self->_asyncHttpCode = HTTPC_ERROR_SEND_HEADER_FAILED; return HTTPC_ERROR_SEND_HEADER_FAILED; }
+  int code = self->handleHeaderResponse();
+  self->_asyncHttpCode = code;
+  if (code < 0) return code;
+
+  // buffer limit
+  self->_asyncBody = StreamString();
+  int expected = (self->_size > 0) ? self->_size : 1024;
+  if (expected > (int)AsyncHttpClientLight::kAsyncBodyLimit) expected = AsyncHttpClientLight::kAsyncBodyLimit;
+  (void)self->_asyncBody.reserve(expected + 1);
+
+  int r = self->readBodyToStreamString(self->_asyncBody, (int)AsyncHttpClientLight::kAsyncBodyLimit);
+  if (r < 0) { self->_asyncRxBytes = r; return r; }
+  self->_asyncRxBytes = r;
+
+  if (!self->_reuse || !self->_canReuse) {
+    if (self->_transport) self->_transport->stop();
+  }
+  return 0;
+}
+
+int AsyncHttpClientLight::Job_AsyncPOST_Buf(void* arg) {
+  auto* a = reinterpret_cast<AsyncPostBufArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+  AsyncHttpClientLight* self = a->self;
+
+  // no payload copy, reading from pointer
+  uint8_t* payload = a->payload;
+  size_t   size    = a->size;
+  delete a; // arg on heap
+
+  // HEADERS
+  for (size_t i=0;i<self->_headerKeysCount;i++) if (self->_currentHeaders[i].value.length()) self->_currentHeaders[i].value.clear();
+  self->_returnCode = 0; self->_size = -1; self->_location = "";
+  self->_transferEncoding = HTTPC_TE_IDENTITY;
+
+  if (payload && size > 0) self->addHeader(F("Content-Length"), String(size), false, true);
+
+  if (!self->sendHeader("POST")) { self->_asyncHttpCode = HTTPC_ERROR_SEND_HEADER_FAILED; return HTTPC_ERROR_SEND_HEADER_FAILED; }
+
+  // BODY
+  if (payload && size > 0) {
+    const uint8_t* p = payload; size_t left = size;
+    uint32_t start = millis();
+    while (left) {
+      if (self->_asyncAbortReq) { if (self->_transport) self->_transport->stop(); self->_asyncHttpCode = HTTPC_ERROR_CONNECTION_LOST; return HTTPC_ERROR_CONNECTION_LOST; }
+      if (!self->connected()) return HTTPC_ERROR_CONNECTION_LOST;
+      size_t w = self->_transport->write(p, left);
+      if (w > 0) { p += w; left -= w; start = millis(); }
+      else {
+        delay(1);
+        if ((millis()-start) > (uint32_t)self->_tcpTimeout) { self->_asyncHttpCode = HTTPC_ERROR_SEND_PAYLOAD_FAILED; return HTTPC_ERROR_SEND_PAYLOAD_FAILED; }
+      }
+    }
+  }
+
+  int code = self->handleHeaderResponse();
+  self->_asyncHttpCode = code;
+  if (code < 0) return code;
+
+  self->_asyncBody = StreamString();
+  int expected = (self->_size > 0) ? self->_size : 1024;
+  if (expected > (int)AsyncHttpClientLight::kAsyncBodyLimit) expected = AsyncHttpClientLight::kAsyncBodyLimit;
+  (void)self->_asyncBody.reserve(expected + 1);
+
+  int r = self->readBodyToStreamString(self->_asyncBody, (int)AsyncHttpClientLight::kAsyncBodyLimit);
+  if (r < 0) { self->_asyncRxBytes = r; return r; }
+  self->_asyncRxBytes = r;
+
+  if (!self->_reuse || !self->_canReuse) {
+    if (self->_transport) self->_transport->stop();
+  }
+  return 0;
+}
+
+int AsyncHttpClientLight::Job_AsyncPOST_Str(void* arg) {
+  auto* a = reinterpret_cast<AsyncPostStrArg*>(arg);
+  if (!a || !a->self) return HTTPC_ERROR_NOT_CONNECTED;
+  AsyncHttpClientLight* self = a->self;
+  String payload = a->payload;
+  delete a;
+
+  for (size_t i=0;i<self->_headerKeysCount;i++) if (self->_currentHeaders[i].value.length()) self->_currentHeaders[i].value.clear();
+  self->_returnCode = 0; self->_size = -1; self->_location = "";
+  self->_transferEncoding = HTTPC_TE_IDENTITY;
+
+  if (payload.length() > 0) self->addHeader(F("Content-Length"), String(payload.length()), false, true);
+
+  if (!self->sendHeader("POST")) { self->_asyncHttpCode = HTTPC_ERROR_SEND_HEADER_FAILED; return HTTPC_ERROR_SEND_HEADER_FAILED; }
+
+  if (payload.length() > 0) {
+    const uint8_t* p = (const uint8_t*)payload.c_str(); size_t left = payload.length();
+    uint32_t start = millis();
+    while (left) {
+      if (self->_asyncAbortReq) { if (self->_transport) self->_transport->stop(); self->_asyncHttpCode = HTTPC_ERROR_CONNECTION_LOST; return HTTPC_ERROR_CONNECTION_LOST; }
+      if (!self->connected()) return HTTPC_ERROR_CONNECTION_LOST;
+      size_t w = self->_transport->write(p, left);
+      if (w > 0) { p += w; left -= w; start = millis(); }
+      else {
+        delay(1);
+        if ((millis()-start) > (uint32_t)self->_tcpTimeout) { self->_asyncHttpCode = HTTPC_ERROR_SEND_PAYLOAD_FAILED; return HTTPC_ERROR_SEND_PAYLOAD_FAILED; }
+      }
+    }
+  }
+
+  int code = self->handleHeaderResponse();
+  self->_asyncHttpCode = code;
+  if (code < 0) return code;
+
+  self->_asyncBody = StreamString();
+  int expected = (self->_size > 0) ? self->_size : 1024;
+  if (expected > (int)AsyncHttpClientLight::kAsyncBodyLimit) expected = AsyncHttpClientLight::kAsyncBodyLimit;
+  (void)self->_asyncBody.reserve(expected + 1);
+
+  int r = self->readBodyToStreamString(self->_asyncBody, (int)AsyncHttpClientLight::kAsyncBodyLimit);
+  if (r < 0) { self->_asyncRxBytes = r; return r; }
+  self->_asyncRxBytes = r;
+
+  if (!self->_reuse || !self->_canReuse) {
+    if (self->_transport) self->_transport->stop();
+  }
+  return 0;
+}
+
+// ---------- Async API ---------------------------------------------------
+
+int AsyncHttpClientLight::asyncGETStart() {
+#ifdef ESP32
+  _asyncAbortReq = false;
+  _asyncOp = AOP_GET;
+  _asyncHttpCode = HTTPC_ERROR_NOT_CONNECTED;
+  _asyncRxBytes = -1;
+  // arg on heap – release in Job_AsyncGET
+  auto* arg = new (std::nothrow) AsyncGetArg{ this };
+  if (!arg) { _asyncState = ASYNC_ERROR; return HTTPC_ERROR_TOO_LESS_RAM; }
+
+  int q = startJob(&Job_AsyncGET, arg);
+  if (q <= 0) {
+    _asyncState = (q < 0 ? ASYNC_ERROR : ASYNC_IDLE);
+    return q;
+  }
+  _asyncState = ASYNC_RUNNING;
+  return 1;
+#else
+  return HTTPC_ERROR_NOT_CONNECTED;
+#endif
+}
+
+int AsyncHttpClientLight::asyncPOSTStart(uint8_t* payload, size_t size) {
+#ifdef ESP32
+  _asyncAbortReq = false;
+  _asyncOp = AOP_POST;
+  _asyncHttpCode = HTTPC_ERROR_NOT_CONNECTED;
+  _asyncRxBytes = -1;
+  auto* arg = new (std::nothrow) AsyncPostBufArg{ this, payload, size };
+  if (!arg) { _asyncState = ASYNC_ERROR; return HTTPC_ERROR_TOO_LESS_RAM; }
+
+  int q = startJob(&Job_AsyncPOST_Buf, arg);
+  if (q <= 0) {
+    _asyncState = (q < 0 ? ASYNC_ERROR : ASYNC_IDLE);
+    return q;
+  }
+  _asyncState = ASYNC_RUNNING;
+  return 1;
+#else
+  return HTTPC_ERROR_NOT_CONNECTED;
+#endif
+}
+
+int AsyncHttpClientLight::asyncPOSTStart(const String& payload) {
+#ifdef ESP32
+  _asyncAbortReq = false;
+  _asyncOp = AOP_POST;
+  _asyncHttpCode = HTTPC_ERROR_NOT_CONNECTED;
+  _asyncRxBytes = -1;
+  auto* arg = new (std::nothrow) AsyncPostStrArg{ this, payload };
+  if (!arg) { _asyncState = ASYNC_ERROR; return HTTPC_ERROR_TOO_LESS_RAM; }
+
+  int q = startJob(&Job_AsyncPOST_Str, arg);
+  if (q <= 0) {
+    _asyncState = (q < 0 ? ASYNC_ERROR : ASYNC_IDLE);
+    return q;
+  }
+  _asyncState = ASYNC_RUNNING;
+  return 1;
+#else
+  return HTTPC_ERROR_NOT_CONNECTED;
+#endif
+}
+
+AsyncHttpClientLight::AsyncState_t
+AsyncHttpClientLight::asyncState(int* httpCodeOut, int* bytesOut) const {
+#ifdef ESP32
+  // const → we still need to touch/update state (poll + cleanup)
+  auto* self = const_cast<AsyncHttpClientLight*>(this);
+
+  if (self->_asyncState == ASYNC_RUNNING && self->_asyncDone) {
+    // non-blocking poll
+    if (xSemaphoreTake(self->_asyncDone, 0) == pdTRUE) {
+      // job done
+      vSemaphoreDelete(self->_asyncDone); self->_asyncDone = nullptr;
+
+      // result set in v _asyncHttpCode/_asyncRxBytes a _asyncBody
+      if (self->_asyncAbortReq) self->_asyncState = ASYNC_ABORTED;
+      else self->_asyncState = (self->_asyncHttpCode >= 0 ? ASYNC_DONE : ASYNC_ERROR);
+
+      // release mutex
+      if (self->_busy) xSemaphoreGive(self->_busy);
+
+      // release heap jobs
+      if (self->_asyncJob) { delete self->_asyncJob; self->_asyncJob = nullptr; }
+      self->_asyncTask = nullptr;
+    }
+  }
+
+  if (httpCodeOut) *httpCodeOut = self->_asyncHttpCode;
+  if (bytesOut)    *bytesOut    = self->_asyncRxBytes;
+  return self->_asyncState;
+#else
+  (void)httpCodeOut; (void)bytesOut;
+  return ASYNC_ERROR;
+#endif
+}
+
+void AsyncHttpClientLight::asyncAbort() {
+  _asyncAbortReq = true;
+}
+
+// ---------- Friend wrapper (public access to private helper) -----------
+int ahcl_readBodyToStreamString(AsyncHttpClientLight* self, StreamString& s, int size_limit) {
+  if (!self) return HTTPC_ERROR_NOT_CONNECTED;
+  return self->readBodyToStreamString(s, size_limit);
+}

--- a/lib/libesp32/HttpClientLight/src/AsyncHttpClientLight.h
+++ b/lib/libesp32/HttpClientLight/src/AsyncHttpClientLight.h
@@ -1,0 +1,343 @@
+/*
+ * AsyncHttpClientLight.h  - Created on: 26.08.2025
+ *
+ * Copyright (C) 2025 by Martin Macák <macak@msb.sk>
+ *
+ * Async HTTP/HTTPS client for ESP32 (WDT-friendly)
+ *
+ * Features
+ * - HTTP: lwIP socket transport (IClientLite + AsyncTcpAdapter) with SO_LINGER (RST-close) to reduce TIME_WAIT pressure
+ * - HTTPS: BearSSL::WiFiClientSecure_light
+ * - API and error codes compatible with Arduino HTTPClient/HTTPClientLight semantics
+ *
+ * Async extensions
+ * - asyncGETStart(), asyncPOSTStart(): launch a request in the background (FreeRTOS worker), non-blocking for the caller
+ * - asyncState(): query status; after ASYNC_DONE you can use getString()/getSize()/writeToStream() without further I/O
+ * - asyncAbort(): best-effort cancellation of an in-flight async request
+ * Note: in async mode the response body is stored in an internal RAM buffer (hard cap kAsyncBodyLimit).
+ *
+ * Acknowledgments: API/error-code compatibility inspired by Arduino HTTPClient / Tasmota HTTPClientLight.
+ * This file contains an independent implementation; no source code was copied.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <Arduino.h>
+#include <WiFiClient.h>
+#include <Stream.h>
+#include <StreamString.h>
+
+#include "tasmota_options.h"
+#include <HTTPClient.h>
+
+#ifdef ESP32
+  #include <freertos/FreeRTOS.h>
+  #include <freertos/task.h>
+  #include <freertos/semphr.h>
+  #include <lwip/sockets.h>
+  #include <lwip/netdb.h>
+  #include <fcntl.h>
+  #include <errno.h>
+  #include <sys/ioctl.h>
+#endif
+
+#include <memory>
+
+#ifndef HTTPC_ERROR_CONNECTION_REFUSED
+#define HTTPC_ERROR_CONNECTION_REFUSED   (-1)
+#define HTTPC_ERROR_SEND_HEADER_FAILED   (-2)
+#define HTTPC_ERROR_SEND_PAYLOAD_FAILED  (-3)
+#define HTTPC_ERROR_NOT_CONNECTED        (-4)
+#define HTTPC_ERROR_CONNECTION_LOST      (-5)
+#define HTTPC_ERROR_NO_STREAM            (-6)
+#define HTTPC_ERROR_NO_HTTP_SERVER       (-7)
+#define HTTPC_ERROR_TOO_LESS_RAM         (-8)
+#define HTTPC_ERROR_ENCODING             (-9)
+#define HTTPC_ERROR_STREAM_WRITE         (-10)
+#define HTTPC_ERROR_READ_TIMEOUT         (-11)
+#endif
+
+#ifndef HTTP_TCP_BUFFER_SIZE
+#define HTTP_TCP_BUFFER_SIZE 1460
+#endif
+
+#ifndef ASYNCHTTP_WKR_STACK
+  #define ASYNCHTTP_WKR_STACK 12288
+#endif
+#ifndef ASYNCHTTP_WAIT_SLICE_MS
+  #define ASYNCHTTP_WAIT_SLICE_MS 25
+#endif
+
+// Enable RST-close (SO_LINGER) on the raw HTTP socket (reduces TIME_WAIT pressure)
+#ifndef ASYNCHTTP_HTTP_LINGER_RST
+  #define ASYNCHTTP_HTTP_LINGER_RST 1
+#endif
+
+#ifdef USE_WEBCLIENT_HTTPS
+  #include "WiFiClientSecureLightBearSSL.h"
+#endif
+
+class AsyncHttpClientLight {
+public:
+  AsyncHttpClientLight();
+  ~AsyncHttpClientLight();
+
+  bool begin(String url);
+  bool begin(String url, const char* CAcert) { (void)CAcert; return begin(url); }
+  void end();
+
+  bool connected();
+
+  void setReuse(bool reuse) { _reuse = reuse; }
+  void setUserAgent(const String& userAgent) { _userAgent = userAgent; }
+  void setAuthorization(const char * user, const char * password);
+  void setAuthorization(const char * auth);
+  void setConnectTimeout(int32_t connectTimeout) { _connectTimeout = connectTimeout; }
+  void setTimeout(uint16_t timeout);
+  void useHTTP10(bool useHTTP10) { _useHTTP10 = useHTTP10; _reuse = !useHTTP10; }
+  void setFollowRedirects(followRedirects_t follow) { _followRedirects = follow; }
+  void setRedirectLimit(uint16_t limit) { _redirectLimit = limit; }
+  void setWaitSliceMs(uint32_t ms) { _waitSliceMs = ms ? ms : 1; }
+
+  bool setPubKeyPins(const char* pin1, const char* pin2 = nullptr);
+  void clearPubKeyPins();
+  void setRSAOnly(bool rsaOnly) { _rsaOnly = rsaOnly; }
+
+  // sync calls
+  int GET();
+  int POST(uint8_t * payload, size_t size);
+  int POST(String payload);
+  int PUT(uint8_t * payload, size_t size);
+  int PUT(String payload);
+  int PATCH(uint8_t * payload, size_t size);
+  int PATCH(String payload);
+  int DELETE(uint8_t * payload, size_t size);
+  int DELETE(String payload);
+  int sendRequest(const char * type, String payload);
+  int sendRequest(const char * type, uint8_t * payload = nullptr, size_t size = 0);
+  int sendRequest(const char * type, Stream * stream, size_t size = 0);
+
+  int    getSize(void) const { return _size; }
+  String getString(void);                 
+  int    writeToStream(Stream * stream);
+
+  void   addHeader(const String& name, const String& value, bool first=false, bool replace=true);
+  void   collectHeaders(const char* headerKeys[], const size_t headerKeysCount);
+  String header(const char* name) const;
+  String header(const String& name) const { return header(name.c_str()); }
+  String header(size_t i) const;
+  String headerName(size_t i) const;
+  int    headers() const { return (int)_headerKeysCount; }
+  bool   hasHeader(const char* name) const;
+
+  bool   setURL(const String &url);
+  const String &getLocation(void) const { return _location; }
+
+  static String errorToString(int error);
+
+  // async calls
+
+  enum AsyncState_t : uint8_t {
+    ASYNC_IDLE     = 0,
+    ASYNC_RUNNING  = 1,
+    ASYNC_DONE     = 2,
+    ASYNC_ERROR    = 3,
+    ASYNC_ABORTED  = 4
+  };
+
+
+  int  asyncGETStart();
+  int  asyncPOSTStart(uint8_t* payload, size_t size);
+  int  asyncPOSTStart(const String& payload);
+
+  AsyncState_t asyncState(int* httpCodeOut = nullptr, int* bytesOut = nullptr) const;
+
+  bool asyncBusy() const { return _asyncState == ASYNC_RUNNING; }
+  void asyncAbort();
+
+private:
+  int readBodyToStreamString(StreamString& s, int size_limit);
+
+  struct IClientLite {
+    virtual ~IClientLite() {}
+    virtual bool connectHost(const char* host, uint16_t port, int32_t timeout_ms) = 0;
+    virtual bool connectIP(IPAddress ip, uint16_t port, int32_t timeout_ms) = 0;
+    virtual size_t write(const uint8_t* data, size_t len) = 0;
+    virtual int    read(uint8_t* buf, size_t len) = 0;
+    virtual int    available() = 0;
+    virtual bool   connected() = 0;
+    virtual void   stop() = 0;
+    virtual void   setTimeout(uint16_t ms) = 0;
+  };
+
+  class AsyncTcpAdapter : public IClientLite {
+  public:
+    AsyncTcpAdapter() {}
+    ~AsyncTcpAdapter() override { stop(); }
+
+    bool connectHost(const char* host, uint16_t port, int32_t timeout_ms) override;
+    bool connectIP(IPAddress ip, uint16_t port, int32_t timeout_ms) override;
+    size_t write(const uint8_t* data, size_t len) override;
+    int    read(uint8_t* buf, size_t len) override;
+    int    available() override;
+    bool   connected() override { return _isConnected && _fd >= 0; }
+    void   stop() override;
+    void   setTimeout(uint16_t ms) override { _rwTimeout = ms; }
+
+  private:
+    int      _fd = -1;
+    bool     _isConnected = false;
+    uint16_t _rwTimeout = 5000;
+
+    bool connect_fd(const struct sockaddr_in& sa, int32_t timeout_ms);
+  };
+
+#ifdef USE_WEBCLIENT_HTTPS
+  class BearSslAdapter : public IClientLite {
+  public:
+    BearSslAdapter(const uint8_t* pin1, bool hasPin1,
+                   const uint8_t* pin2, bool hasPin2,
+                   bool rsaOnly);
+    ~BearSslAdapter() override { stop(); }
+
+    bool connectHost(const char* host, uint16_t port, int32_t timeout_ms) override;
+    bool connectIP(IPAddress ip, uint16_t port, int32_t timeout_ms) override;
+    size_t write(const uint8_t* data, size_t len) override;
+    int    read(uint8_t* buf, size_t len) override;
+    int    available() override;
+    bool   connected() override;
+    void   stop() override;
+    void   setTimeout(uint16_t ms) override;
+
+  private:
+    std::unique_ptr<BearSSL::WiFiClientSecure_light> _cli;
+  };
+#endif
+
+  bool beginInternal(String url, const char* expectedProto);
+  bool ensureConnected();
+  bool connectTransport();
+  bool sendHeader(const char * method);
+  int  handleHeaderResponse();
+  int  writeToStreamDataBlock(Stream * stream, int size);
+  bool writeAllWithOneReconnect(const uint8_t* data, size_t len, bool allow_retry_if_zero_sent);
+
+#ifdef ESP32
+  struct Job {
+    typedef int (*Fn)(void* arg);
+    Fn fn = nullptr;
+    void* arg = nullptr;
+    int result = HTTPC_ERROR_NOT_CONNECTED;
+    SemaphoreHandle_t done = nullptr;
+  };
+  static void WorkerTask(void* pv);
+
+  // Blocking execution of a job (existing sync calls)
+  int  runJob(Job::Fn fn, void* arg);
+
+  // Non-blocking job start (for async mode): 1=queued, 0=busy, <0=error.
+  int  startJob(Job::Fn fn, void* arg);
+#endif
+
+  struct SendBufArg { AsyncHttpClientLight* self; const char* method; uint8_t* payload; size_t size; };
+  struct SendStrArg { AsyncHttpClientLight* self; const char* method; String payload; };
+  struct SendStrmArg{ AsyncHttpClientLight* self; const char* method; Stream* stream; size_t size; };
+  struct IntOpArg   { AsyncHttpClientLight* self; };
+
+  static int Job_GET(void* arg);
+  static int Job_SendBuf(void* arg);
+  static int Job_SendStr(void* arg);
+  static int Job_SendStrm(void* arg);
+  static int Job_WriteToStream(void* arg);
+  static int Job_GetString(void* arg);
+
+  // --- async jobs---
+  struct AsyncGetArg     { AsyncHttpClientLight* self; };
+  struct AsyncPostBufArg { AsyncHttpClientLight* self; uint8_t* payload; size_t size; };
+  struct AsyncPostStrArg { AsyncHttpClientLight* self; String payload; };
+
+  static int Job_AsyncGET(void* arg);
+  static int Job_AsyncPOST_Buf(void* arg);
+  static int Job_AsyncPOST_Str(void* arg);
+
+  // =======================
+  // URL / HTTP state
+  // =======================
+  String _protocol, _host, _uri;
+  uint16_t _port = 0;
+  bool _secure = false;
+
+  String _headers;
+  String _userAgent = F("AsyncHttpClientLight");
+  String _base64Authorization;
+  uint16_t _tcpTimeout = 5000;
+  int32_t  _connectTimeout = 10000;
+  bool _reuse = true;
+  bool _canReuse = false;
+  bool _useHTTP10 = false;
+  int  _returnCode = 0;
+  int  _size = -1;
+  transferEncoding_t _transferEncoding = HTTPC_TE_IDENTITY;
+  String _location;
+  followRedirects_t _followRedirects = HTTPC_DISABLE_FOLLOW_REDIRECTS;
+  uint16_t _redirectLimit = 5;
+
+  bool _bodyPending = false;
+
+  struct RequestArgument { String key; String value; };
+  RequestArgument* _currentHeaders = nullptr;
+  size_t           _headerKeysCount = 0;
+
+  bool _hasPin1=false, _hasPin2=false, _rsaOnly=false;
+  uint8_t _pin1[20] = {0}, _pin2[20] = {0};
+
+  std::unique_ptr<IClientLite> _transport;
+
+#ifdef ESP32
+  SemaphoreHandle_t _busy = nullptr;       // Parallel operations watchdog
+#endif
+  uint32_t _waitSliceMs = ASYNCHTTP_WAIT_SLICE_MS;
+
+  Stream* _lastStream = nullptr;
+  String  _lastString;
+
+  // -------------------------
+  // Async internal state
+  // -------------------------
+  enum AsyncOp_t : uint8_t { AOP_NONE=0, AOP_GET=1, AOP_POST=2 };
+  AsyncOp_t     _asyncOp = AOP_NONE;
+  AsyncState_t  _asyncState = ASYNC_IDLE;
+  volatile bool _asyncAbortReq = false;
+
+  // HTTP result and metadata after completion (or on error)
+  int           _asyncHttpCode = HTTPC_ERROR_NOT_CONNECTED;
+  int           _asyncRxBytes  = -1;
+
+  // RAM buffer for the response body in async mode (hard cap to protect the heap)
+  static constexpr size_t kAsyncBodyLimit = 16384;
+  StreamString  _asyncBody;
+
+#ifdef ESP32
+  // RTOS/polling internals
+  Job*             _asyncJob  = nullptr;
+  SemaphoreHandle_t _asyncDone = nullptr;
+  TaskHandle_t     _asyncTask = nullptr;
+#endif
+
+// ---------------------------------------------------------
+// FRIEND: the free-function helper in .cpp has access to private members
+// ---------------------------------------------------------
+  friend int ahcl_readBodyToStreamString(AsyncHttpClientLight* self, StreamString& s, int size_limit);
+};

--- a/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
@@ -1,5 +1,7 @@
 /********************************************************************
  * Webclient mapped to Arduino framework
+ * 
+ * 2025 - Update to use with ASYNC Webclient
  *
  * To use: `d = webclient()`
  *
@@ -30,6 +32,19 @@ extern int wc_writeflash(bvm *vm);
 extern int wc_getsize(bvm *vm);
 extern int wc_getbytes(bvm *vm);
 
+/* --- TLS pinning extensions --- */
+extern int wc_tls_pin_pubkey(bvm *vm);
+extern int wc_tls_clear_pins(bvm *vm);
+extern int wc_tls_set_rsa_only(bvm *vm);
+/* ------------------------------- */
+
+/* --- Async extensions --- */
+extern int wc_async_get_start(bvm *vm);
+extern int wc_async_post_start(bvm *vm);   /* payload: string|bytes */
+extern int wc_async_state(bvm *vm);
+extern int wc_async_abort(bvm *vm);
+/* ------------------------ */
+
 #include "be_fixed_be_class_webclient.h"
 
 void be_load_webclient_lib(bvm *vm) {
@@ -37,14 +52,30 @@ void be_load_webclient_lib(bvm *vm) {
     be_setglobal(vm, "webclient");
     be_pop(vm, 1);
 }
+
 /* @const_object_info_begin
 
 class be_class_webclient (scope: global, name: webclient) {
     .p, var
     .w, var
+
+    // súkromné interné polia (len pre native vrstvu)
+    ._last_code, var
+    ._last_rx, var
+    .__async_hold, var
+
+    // verejné zrkadlá pre Berry skripty
+    last_code, var
+    last_rx, var
+
     init, func(wc_init)
     deinit, func(wc_deinit)
     url_encode, static_func(wc_urlencode)
+
+    // TLS pinning API
+    tls_pin_pubkey, func(wc_tls_pin_pubkey)
+    tls_clear_pins, func(wc_tls_clear_pins)
+    tls_set_rsa_only, func(wc_tls_set_rsa_only)
 
     begin, func(wc_begin)
     set_timeouts, func(wc_set_timeouts)
@@ -57,16 +88,29 @@ class be_class_webclient (scope: global, name: webclient) {
     get_header, func(wc_get_header)
 
     close, func(wc_close)
+
+    // header helpers (both spellings kept for compatibility)
+    addheader, func(wc_addheader)
     add_header, func(wc_addheader)
+
+    // synchronous HTTP verbs
     GET, func(wc_GET)
     POST, func(wc_POST)
     PUT, func(wc_PUT)
     PATCH, func(wc_PATCH)
     DELETE, func(wc_DELETE)
+
+    // response accessors
     get_string, func(wc_getstring)
     write_file, func(wc_writefile)
     write_flash, func(wc_writeflash)
     get_size, func(wc_getsize)
     get_bytes, func(wc_getbytes)
+
+    // --- async controls ---
+    async_get_start, func(wc_async_get_start)
+    async_post_start, func(wc_async_post_start)
+    async_state, func(wc_async_state)
+    async_abort, func(wc_async_abort)
 }
 @const_object_info_end */

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -1,28 +1,56 @@
 /*
-  xdrv_52_3_berry_webserver.ino - Berry scripting language, webserver module
-
-  Copyright (C) 2021 Stephan Hadinger, Berry language by Guan Wenliang https://github.com/Skiars/berry
-
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * xdrv_52_3_berry_webserver.ino — Berry scripting language, webserver/webclient module
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Copyright (C) 2021 Stephan Hadinger
+ * Berry language by Guan Wenliang — https://github.com/Skiars/berry
+ *
+ * Modifications (2025): Webclient update and integration with AsyncHttpClientLight
+ * instead of HttpClientLight, adding asynchronous GET/POST and TLS pinning.
+ * Copyright (C) 2025 Martin Macák <macak@msb.sk>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ----- 2025 UPDATE -----
+ *
+ * Webclient changes:
+ * - Switched to AsyncHttpClientLight backend (replacing HttpClientLight).
+ * - Added asynchronous HTTP on HTTP & HTTPS (TLS):
+ *     * async_get_start() -> int
+ *     * async_post_start(body: string|bytes) -> int
+ *     * async_state()      // call at least once after a job finishes to publish results and cleanup
+ *     * async_abort()      // best-effort cancellation if a job is in progress
+ *
+ * TLS pinning (with optional RSA-only hardening):
+ *   - tls_pin_pubkey(fp1: string [, fp2: string]) -> self
+ *     // Pin server public-key SHA-1 fingerprint ("AA:BB:...:FF" or 40 hex chars, case-insensitive).
+ *   - tls_clear_pins() -> self
+ *   - tls_set_rsa_only(bool) -> self
+ *
+ * Other helpers:
+ *   - set_follow_redirects(bool) -> self
+ *
+ * Notes:
+ * - Always call async_state() at least once after an async job completes to publish
+ *   last_code/last_rx and release internal resources before reusing the same instance.
+ */
 
 // also includes tcp_client
 
 #ifdef USE_BERRY
 
 #include <berry.h>
-#include "HttpClientLight.h"
+#include "AsyncHttpClientLight.h"
 #include "be_sys.h"
 
 // Tasmota extension
@@ -31,46 +59,24 @@ extern File * be_get_arduino_file(void *hfile);
 String wc_UrlEncode(const String& text) {
   const char hex[] = "0123456789ABCDEF";
 
-	String encoded = "";
-	int len = text.length();
-	int i = 0;
-	while (i < len)	{
-		char decodedChar = text.charAt(i++);
-
+  String encoded = "";
+  int len = text.length();
+  int i = 0;
+  while (i < len) {
+    char decodedChar = text.charAt(i++);
     if (('a' <= decodedChar && decodedChar <= 'z') ||
         ('A' <= decodedChar && decodedChar <= 'Z') ||
         ('0' <= decodedChar && decodedChar <= '9') ||
         ('=' == decodedChar)) {
       encoded += decodedChar;
-		} else {
+    } else {
       encoded += '%';
-			encoded += hex[decodedChar >> 4];
-			encoded += hex[decodedChar & 0xF];
+      encoded += hex[(decodedChar >> 4) & 0xF];
+      encoded += hex[decodedChar & 0xF];
     }
-
-	}
-	return encoded;
+  }
+  return encoded;
 }
-
-/*********************************************************************************************\
- * Int constants
- *********************************************************************************************/
-// const be_const_member_t webserver_constants[] = {
-//     { "BUTTON_CONFIGURATION", BUTTON_CONFIGURATION },
-//     { "BUTTON_INFORMATION", BUTTON_INFORMATION },
-//     { "BUTTON_MAIN", BUTTON_MAIN },
-//     { "BUTTON_MANAGEMENT", BUTTON_MANAGEMENT },
-//     { "BUTTON_MODULE", BUTTON_MODULE },
-//     { "HTTP_ADMIN", HTTP_ADMIN },
-//     { "HTTP_ANY", HTTP_ANY },
-//     { "HTTP_GET", HTTP_GET },
-//     { "HTTP_MANAGER", HTTP_MANAGER },
-//     { "HTTP_MANAGER_RESET_ONLY", HTTP_MANAGER_RESET_ONLY },
-//     { "HTTP_OFF", HTTP_OFF },
-//     { "HTTP_OPTIONS", HTTP_OPTIONS },
-//     { "HTTP_POST", HTTP_POST },
-//     { "HTTP_USER", HTTP_USER },
-// };
 
 /*********************************************************************************************\
  * Native functions mapped to Berry functions
@@ -79,18 +85,80 @@ String wc_UrlEncode(const String& text) {
  *
 \*********************************************************************************************/
 extern "C" {
-  // Berry: ``
-  //
+
+  // ---------------- TLS PINNING (Berry API) ----------------
+
+  // wc.tls_pin_pubkey(fprint1 [, fprint2]) -> self
+  int32_t wc_tls_pin_pubkey(struct bvm *vm) {
+    const int32_t argc = be_top(vm);
+    if (argc < 2 || !be_isstring(vm, 2)) {
+      be_raise(vm, "type_error", "tls_pin_pubkey(fp1[, fp2]) expects string");
+    }
+    const char *fp1 = be_tostring(vm, 2);
+    const char *fp2 = (argc >= 3 && be_isstring(vm, 3)) ? be_tostring(vm, 3) : nullptr;
+
+    AsyncHttpClientLight *cl = nullptr;
+    be_getmember(vm, 1, ".p");
+    if (be_iscomptr(vm, -1)) { cl = (AsyncHttpClientLight*) be_tocomptr(vm, -1); }
+    be_pop(vm, 1);
+    if (!cl) { be_raise(vm, "value_error", "HTTP client not initialized"); }
+
+    if (!cl->setPubKeyPins(fp1, fp2)) {
+      be_raise(vm, "value_error", "bad fingerprint (need 40 hex, colons optional)");
+    }
+
+    be_pushvalue(vm, 1);
+    be_return(vm);
+  }
+
+  // wc.tls_clear_pins() -> self
+  int32_t wc_tls_clear_pins(struct bvm *vm) {
+    AsyncHttpClientLight *cl = nullptr;
+    be_getmember(vm, 1, ".p");
+    if (be_iscomptr(vm, -1)) { cl = (AsyncHttpClientLight*) be_tocomptr(vm, -1); }
+    be_pop(vm, 1);
+    if (!cl) { be_raise(vm, "value_error", "HTTP client not initialized"); }
+
+    cl->clearPubKeyPins();
+
+    be_pushvalue(vm, 1);
+    be_return(vm);
+  }
+
+  // wc.tls_set_rsa_only(bool) -> self
+  int32_t wc_tls_set_rsa_only(struct bvm *vm) {
+    const int32_t argc = be_top(vm);
+    if (argc < 2 || !be_isbool(vm, 2)) {
+      be_raise(vm, "type_error", "tls_set_rsa_only(bool) expects boolean");
+    }
+    const bool rsa_only = be_tobool(vm, 2);
+
+    AsyncHttpClientLight *cl = nullptr;
+    be_getmember(vm, 1, ".p");
+    if (be_iscomptr(vm, -1)) { cl = (AsyncHttpClientLight*) be_tocomptr(vm, -1); }
+    be_pop(vm, 1);
+    if (!cl) { be_raise(vm, "value_error", "HTTP client not initialized"); }
+
+    cl->setRSAOnly(rsa_only);
+
+    be_pushvalue(vm, 1);
+    be_return(vm);
+  }
+
+  // ---------------------------------------------------------
+
   int32_t wc_init(struct bvm *vm);
   int32_t wc_init(struct bvm *vm) {
     WiFiClient * wcl = new WiFiClient();
     be_pushcomptr(vm, (void*) wcl);
     be_setmember(vm, 1, ".w");
-    HTTPClientLight * cl = new HTTPClientLight();
+
+    AsyncHttpClientLight * cl = new AsyncHttpClientLight();
     cl->setUserAgent(USE_BERRY_WEBCLIENT_USERAGENT);
-    cl->setConnectTimeout(USE_BERRY_WEBCLIENT_TIMEOUT);   // set default timeout
+    cl->setConnectTimeout(USE_BERRY_WEBCLIENT_TIMEOUT);   // default timeout
     be_pushcomptr(vm, (void*) cl);
     be_setmember(vm, 1, ".p");
+
     be_return_nil(vm);
   }
 
@@ -108,11 +176,11 @@ extern "C" {
     be_return_nil(vm);
   }
 
-  HTTPClientLight * wc_getclient(struct bvm *vm) {
+  AsyncHttpClientLight * wc_getclient(struct bvm *vm) {
     be_getmember(vm, 1, ".p");
     void *p = be_tocomptr(vm, -1);
     be_pop(vm, 1);
-    return (HTTPClientLight*) p;
+    return (AsyncHttpClientLight*) p;
   }
 
   WiFiClient * wc_getwificlient(struct bvm *vm) {
@@ -132,14 +200,15 @@ extern "C" {
 
   int32_t wc_deinit(struct bvm *vm);
   int32_t wc_deinit(struct bvm *vm) {
-    // int32_t argc = be_top(vm); // Get the number of arguments
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     if (cl != nullptr) { delete cl; }
     be_pushnil(vm);
     be_setmember(vm, 1, ".p");
+
     WiFiClient * wcl = wc_getwificlient(vm);
     if (wcl != nullptr) { delete wcl; }
     be_setmember(vm, 1, ".w");
+
     be_return_nil(vm);
   }
 
@@ -154,12 +223,11 @@ extern "C" {
   // wc.url_encode(string) -> string  (static method)
   int32_t wc_urlencode(struct bvm *vm);
   int32_t wc_urlencode(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc >= 1 && be_isstring(vm, 1)) {
+    if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
       const char * s = be_tostring(vm, 1);
       String url = wc_UrlEncode(String(s));
       be_pushstring(vm, url.c_str());
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
@@ -167,16 +235,17 @@ extern "C" {
   // wc.begin(url:string) -> self
   int32_t wc_begin(struct bvm *vm);
   int32_t wc_begin(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc == 1 || !be_tostring(vm, 2)) { be_raise(vm, "attribute_error", "missing URL as string"); }
+    if (be_top(vm) < 2 || !be_isstring(vm, 2)) {
+      be_raise(vm, "attribute_error", "missing URL as string");
+    }
     const char * url = be_tostring(vm, 2);
-    HTTPClientLight * cl = wc_getclient(vm);
-    // open connection
-    if (!cl->begin(url)) {
-      be_raise(vm, "value_error", "unsupported protocol");
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+
+    if (!cl->begin(String(url))) {   // tries http, falls back to https path
+      be_raise(vm, "value_error", "begin() failed (unsupported URL?)");
     }
     be_pushvalue(vm, 1);
-    be_return(vm);  /* return self */
+    be_return(vm);
   }
 
   // tcp.connect(address:string, port:int [, timeout_ms:int]) -> bool
@@ -187,18 +256,13 @@ extern "C" {
       WiFiClient * tcp = wc_getwificlient_p(vm);
       const char * address = be_tostring(vm, 2);
       int32_t port = be_toint(vm, 3);
-      int32_t timeout = USE_BERRY_WEBCLIENT_TIMEOUT;   // default timeout of 2 seconds
-      if (argc >= 4) {
-        timeout = be_toint(vm, 4);
-      }
-      // open connection
+      int32_t timeout = USE_BERRY_WEBCLIENT_TIMEOUT;   // default 2s
+      if (argc >= 4) { timeout = be_toint(vm, 4); }
       IPAddress ipaddr;
       bool success = WifiHostByName(address, ipaddr);
-      if (success) {
-        success = tcp->connect(ipaddr, port, timeout);
-      }
+      if (success) { success = tcp->connect(ipaddr, port, timeout); }
       be_pushbool(vm, success);
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, "attribute_error", NULL);
   }
@@ -206,7 +270,7 @@ extern "C" {
   // wc.close(void) -> nil
   int32_t wc_close(struct bvm *vm);
   int32_t wc_close(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     cl->end();
     be_return_nil(vm);
   }
@@ -228,31 +292,26 @@ extern "C" {
     be_return(vm);
   }
 
-  // wc.wc_set_timeouts([http_timeout_ms:int, tcp_timeout_ms:int]) -> self
+  // wc.set_timeouts([http_timeout_ms:int, tcp_timeout_ms:int]) -> self
   int32_t wc_set_timeouts(struct bvm *vm);
   int32_t wc_set_timeouts(struct bvm *vm) {
     int32_t argc = be_top(vm);
-    HTTPClientLight * cl = wc_getclient(vm);
-    if (argc >= 2) {
-      cl->setTimeout(be_toint(vm, 2));
-    }
-    if (argc >= 3) {
-      cl->setConnectTimeout(be_toint(vm, 3));
-    }
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+    if (argc >= 2) { cl->setTimeout(be_toint(vm, 2)); }
+    if (argc >= 3) { cl->setConnectTimeout(be_toint(vm, 3)); }
     be_pushvalue(vm, 1);
-    be_return(vm);  /* return self */
+    be_return(vm);
   }
 
   // wc.set_useragent(user_agent:string) -> self
   int32_t wc_set_useragent(struct bvm *vm);
   int32_t wc_set_useragent(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isstring(vm, 2)) {
-      HTTPClientLight * cl = wc_getclient(vm);
+    if (be_top(vm) >= 2 && be_isstring(vm, 2)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * useragent = be_tostring(vm, 2);
       cl->setUserAgent(String(useragent));
       be_pushvalue(vm, 1);
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
@@ -260,13 +319,12 @@ extern "C" {
   // wc.set_follow_redirects(bool) -> self
   int32_t wc_set_follow_redirects(struct bvm *vm);
   int32_t wc_set_follow_redirects(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isbool(vm, 2)) {
-      HTTPClientLight * cl = wc_getclient(vm);
+    if (be_top(vm) >= 2 && be_isbool(vm, 2)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       bbool follow = be_tobool(vm, 2);
       cl->setFollowRedirects(follow ? HTTPC_STRICT_FOLLOW_REDIRECTS : HTTPC_DISABLE_FOLLOW_REDIRECTS);
       be_pushvalue(vm, 1);
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
@@ -276,42 +334,39 @@ extern "C" {
   int32_t wc_collect_headers(struct bvm *vm) {
     int32_t argc = be_top(vm);
     if (argc >= 2) {
-      size_t header_len = argc-1;
-      const char** header_array = (const char**) be_os_malloc((header_len) * sizeof(const char*));
+      size_t header_len = (size_t)(argc - 1);
+      const char** header_array = (const char**) be_os_malloc(header_len * sizeof(const char*));
       if (!header_array) { be_throw(vm, BE_MALLOC_FAIL); }
-
-      for (int32_t i = 0; i < header_len; i++) {
+      for (int32_t i = 0; i < (int32_t)header_len; i++) {
         header_array[i] = be_tostring(vm, i + 2);
       }
-      HTTPClientLight * cl = wc_getclient(vm);
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       cl->collectHeaders(header_array, header_len);
-
       be_os_free(header_array);
     }
     be_pushvalue(vm, 1);
-    be_return(vm);  /* return self */
+    be_return(vm);
   }
 
   // wc.get_header(header_name:string) -> string
   int32_t wc_get_header(struct bvm *vm);
   int32_t wc_get_header(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isstring(vm, 2)) {
-      HTTPClientLight * cl = wc_getclient(vm);
+    if (be_top(vm) >= 2 && be_isstring(vm, 2)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * header_name = be_tostring(vm, 2);
       String ret = cl->header(header_name);
       be_pushstring(vm, ret.c_str());
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // wc.wc_set_auth(auth:string | (user:string, password:string)) -> self
+  // wc.set_auth(auth:string | (user:string, password:string)) -> self
   int32_t wc_set_auth(struct bvm *vm);
   int32_t wc_set_auth(struct bvm *vm) {
     int32_t argc = be_top(vm);
     if (argc >= 2 && be_isstring(vm, 2) && (argc < 3 || be_isstring(vm, 3))) {
-      HTTPClientLight * cl = wc_getclient(vm);
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * user = be_tostring(vm, 2);
       if (argc == 2) {
         cl->setAuthorization(user);
@@ -320,7 +375,7 @@ extern "C" {
         cl->setAuthorization(user, password);
       }
       be_pushvalue(vm, 1);
-      be_return(vm);  /* return self */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
@@ -329,32 +384,26 @@ extern "C" {
   int32_t wc_addheader(struct bvm *vm);
   int32_t wc_addheader(struct bvm *vm) {
     int32_t argc = be_top(vm);
-    if (argc >= 3 && (be_isstring(vm, 2) || be_isstring(vm, 2))) {
-      HTTPClientLight * cl = wc_getclient(vm);
-
+    if (argc >= 3 && be_isstring(vm, 2) && be_isstring(vm, 3)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * name = be_tostring(vm, 2);
       const char * value = be_tostring(vm, 3);
       bool first = false;
       bool replace = true;
-      if (argc >= 4) {
-        first = be_tobool(vm, 4);
-      }
-      if (argc >= 5) {
-        replace = be_tobool(vm, 5);
-      }
-      // do the call
+      if (argc >= 4) { first = be_tobool(vm, 4); }
+      if (argc >= 5) { replace = be_tobool(vm, 5); }
       cl->addHeader(String(name), String(value), first, replace);
       be_return_nil(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // cw.connected(void) -> bool
+  // wc.connected(void) -> bool
   int32_t wc_connected(struct bvm *vm);
   int32_t wc_connected(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     be_pushbool(vm, cl->connected());
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 
   // tcp.connected(void) -> bool
@@ -362,7 +411,7 @@ extern "C" {
   int32_t wc_tcp_connected(struct bvm *vm) {
     WiFiClient * tcp = wc_getwificlient_p(vm);
     be_pushbool(vm, tcp->connected());
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 
   // tcp.write(bytes | string) -> int
@@ -373,15 +422,15 @@ extern "C" {
       WiFiClient * tcp = wc_getwificlient_p(vm);
       const char * buf = nullptr;
       size_t buf_len = 0;
-      if (be_isstring(vm, 2)) {  // string
+      if (be_isstring(vm, 2)) {
         buf = be_tostring(vm, 2);
         buf_len = strlen(buf);
-      } else { // bytes
+      } else {
         buf = (const char*) be_tobytes(vm, 2, &buf_len);
       }
-      size_t bw = tcp->write(buf, buf_len);
-      be_pushint(vm, bw);
-      be_return(vm);  /* return code */
+      size_t bw = tcp->write((const uint8_t*)buf, buf_len);
+      be_pushint(vm, (int32_t)bw);
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
@@ -390,7 +439,7 @@ extern "C" {
   int32_t wc_tcp_read(struct bvm *vm);
   int32_t wc_tcp_read(struct bvm *vm) {
     WiFiClient * tcp = wc_getwificlient_p(vm);
-    int32_t max_read = -1;      // by default read as much as we can
+    int32_t max_read = -1;
     if (be_top(vm) >= 2 && be_isint(vm, 2)) {
       max_read = be_toint(vm, 2);
     }
@@ -398,21 +447,19 @@ extern "C" {
     if (btr <= 0) {
       be_pushstring(vm, "");
     } else {
-      if ((max_read >= 0) && (btr > max_read)) {
-        btr = max_read;
-      }
+      if ((max_read >= 0) && (btr > max_read)) { btr = max_read; }
       char * buf = (char*) be_pushbuffer(vm, btr);
       int32_t btr2 = tcp->read((uint8_t*) buf, btr);
       be_pushnstring(vm, buf, btr2);
     }
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 
   // tcp.readbytes() -> bytes
   int32_t wc_tcp_readbytes(struct bvm *vm);
   int32_t wc_tcp_readbytes(struct bvm *vm) {
     WiFiClient * tcp = wc_getwificlient_p(vm);
-    int32_t max_read = -1;      // by default read as much as we can
+    int32_t max_read = -1;
     if (be_top(vm) >= 2 && be_isint(vm, 2)) {
       max_read = be_toint(vm, 2);
     }
@@ -420,40 +467,38 @@ extern "C" {
     if (btr <= 0) {
       be_pushbytes(vm, nullptr, 0);
     } else {
-      if ((max_read >= 0) && (btr > max_read)) {
-        btr = max_read;
-      }
+      if ((max_read >= 0) && (btr > max_read)) { btr = max_read; }
       uint8_t * buf = (uint8_t*) be_pushbuffer(vm, btr);
       int32_t btr2 = tcp->read(buf, btr);
       be_pushbytes(vm, buf, btr2);
     }
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 
   void wc_errorCodeMessage(int32_t httpCode, uint32_t http_connect_time) {
     if (httpCode < 0) {
       if (httpCode <= -1000) {
-        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "TLS connection error %d after %d ms", -httpCode - 1000, millis() - http_connect_time);
+        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "TLS connection error %d after %d ms", -httpCode - 1000, (int)(millis() - http_connect_time));
       } else if (httpCode == -1) {
-        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "Connection timeout after %d ms", httpCode, millis() - http_connect_time);
+        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "Connection timeout after %d ms", (int)(millis() - http_connect_time));
       } else {
-        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "Connection error %d after %d ms", httpCode, millis() - http_connect_time);
+        AddLog(LOG_LEVEL_INFO, D_LOG_HTTP "Connection error %d after %d ms", httpCode, (int)(millis() - http_connect_time));
       }
     } else {
       AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_HTTP "Connected in %d ms, stack low mark %d"),
-        millis() - http_connect_time, uxTaskGetStackHighWaterMark(nullptr));
+        (int)(millis() - http_connect_time), uxTaskGetStackHighWaterMark(nullptr));
     }
   }
 
-  // cw.GET(void) -> httpCode:int
+  // wc.GET(void) -> httpCode:int
   int32_t wc_GET(struct bvm *vm);
   int32_t wc_GET(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     uint32_t http_connect_time = millis();
     int32_t httpCode = cl->GET();
     wc_errorCodeMessage(httpCode, http_connect_time);
     be_pushint(vm, httpCode);
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 
   // Combined function for POST/PUT/PATCH/DELETE
@@ -467,7 +512,7 @@ extern "C" {
   int32_t wc_PostPutPatchDelete(struct bvm *vm, int32_t op) {
     int32_t argc = be_top(vm);
     if (argc >= 2 && (be_isstring(vm, 2) || be_isbytes(vm, 2))) {
-      HTTPClientLight * cl = wc_getclient(vm);
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * buf = nullptr;
       size_t buf_len = 0;
       if (be_isstring(vm, 2)) {  // string
@@ -479,73 +524,122 @@ extern "C" {
       uint32_t http_connect_time = millis();
       int32_t httpCode;
       switch (op) {
-        case wc_PUT_op:
-          httpCode = cl->PUT((uint8_t*)buf, buf_len);
-          break;
-        case wc_PATCH_op:
-          httpCode = cl->PATCH((uint8_t*)buf, buf_len);
-          break;
-        case wc_DELETE_op:
-          httpCode = cl->DELETE((uint8_t*)buf, buf_len);
-          break;
+        case wc_PUT_op:    httpCode = cl->PUT((uint8_t*)buf, buf_len);    break;
+        case wc_PATCH_op:  httpCode = cl->PATCH((uint8_t*)buf, buf_len);  break;
+        case wc_DELETE_op: httpCode = cl->DELETE((uint8_t*)buf, buf_len); break;
         case wc_POST_op:
-        default:
-          httpCode = cl->POST((uint8_t*)buf, buf_len);
-          break;
+        default:           httpCode = cl->POST((uint8_t*)buf, buf_len);   break;
       }
       wc_errorCodeMessage(httpCode, http_connect_time);
       be_pushint(vm, httpCode);
-      be_return(vm);  /* return code */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // ------- ASYNC API (NEW) ---------------------------------------------
+
+  // wc.async_get_start() -> int (1 started, 0 busy, <0 error)
+  int32_t wc_async_get_start(struct bvm *vm) {
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+    int32_t rc = cl->asyncGETStart();
+    be_pushint(vm, rc);
+    be_return(vm);
+  }
+
+  // wc.async_post_start(str | bytes) -> int (1 started, 0 busy, <0 error)
+  int32_t wc_async_post_start(struct bvm *vm) {
+    int32_t argc = be_top(vm);
+    if (argc < 2) {
+      be_raise(vm, "type_error", "async_post_start(payload) expects string or bytes");
+    }
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+
+    if (be_isstring(vm, 2)) {
+      const char * s = be_tostring(vm, 2);
+      int32_t rc = cl->asyncPOSTStart(String(s));
+      be_pushint(vm, rc);
+      be_return(vm);
+    } else if (be_isbytes(vm, 2)) {
+      size_t len = 0;
+      const uint8_t * p = (const uint8_t *) be_tobytes(vm, 2, &len);
+      // drž payload, aby ho GC nevyhodil kým beží job
+      be_pushvalue(vm, 2);
+      be_setmember(vm, 1, ".__async_hold");
+      int32_t rc = cl->asyncPOSTStart((uint8_t*)p, len);
+      be_pushint(vm, rc);
+      be_return(vm);
+    }
+    be_raise(vm, "type_error", "async_post_start(payload) expects string or bytes");
+  }
+
+  // wc.async_state() -> int (state)
+  int32_t wc_async_state(struct bvm *vm) {
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+    int http_code = 0;
+    int rx_bytes  = -1;
+    AsyncHttpClientLight::AsyncState_t st = cl->asyncState(&http_code, &rx_bytes);
+
+    // publish meta do objektu (súkromné aj verejné zrkadlá)
+    be_pushint(vm, http_code);       be_setmember(vm, 1, "._last_code");
+    be_pushint(vm, http_code);       be_setmember(vm, 1, "last_code");     // <-- public mirror
+
+    be_pushint(vm, rx_bytes);        be_setmember(vm, 1, "._last_rx");
+    be_pushint(vm, rx_bytes);        be_setmember(vm, 1, "last_rx");       // <-- public mirror
+
+    if (st != AsyncHttpClientLight::ASYNC_RUNNING) {
+
+      be_pushnil(vm);
+      be_setmember(vm, 1, ".__async_hold");
+    }
+
+    be_pushint(vm, (int32_t)st);
+    be_return(vm);
+  }
+
+  // wc.async_abort() -> nil
+  int32_t wc_async_abort(struct bvm *vm) {
+    AsyncHttpClientLight * cl = wc_getclient(vm);
+    cl->asyncAbort();
+    be_return_nil(vm);
+  }
+
+  // ---------------------------------------------------------------------
 
   // wc.POST(string | bytes) -> httpCode:int
   int32_t wc_POST(struct bvm *vm);
-  int32_t wc_POST(struct bvm *vm) {
-    return wc_PostPutPatchDelete(vm, wc_POST_op);
-  }
+  int32_t wc_POST(struct bvm *vm) { return wc_PostPutPatchDelete(vm, wc_POST_op); }
 
   // wc.PUT(string | bytes) -> httpCode:int
   int32_t wc_PUT(struct bvm *vm);
-  int32_t wc_PUT(struct bvm *vm) {
-    return wc_PostPutPatchDelete(vm, wc_PUT_op);
-  }
+  int32_t wc_PUT(struct bvm *vm) { return wc_PostPutPatchDelete(vm, wc_PUT_op); }
 
   // wc.PATCH(string | bytes) -> httpCode:int
   int32_t wc_PATCH(struct bvm *vm);
-  int32_t wc_PATCH(struct bvm *vm) {
-    return wc_PostPutPatchDelete(vm, wc_PATCH_op);
-  }
+  int32_t wc_PATCH(struct bvm *vm) { return wc_PostPutPatchDelete(vm, wc_PATCH_op); }
 
   // wc.DELETE(string | bytes) -> httpCode:int
   int32_t wc_DELETE(struct bvm *vm);
-  int32_t wc_DELETE(struct bvm *vm) {
-    return wc_PostPutPatchDelete(vm, wc_DELETE_op);
-  }
+  int32_t wc_DELETE(struct bvm *vm) { return wc_PostPutPatchDelete(vm, wc_DELETE_op); }
 
   int32_t wc_getstring(struct bvm *vm);
   int32_t wc_getstring(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     int32_t sz = cl->getSize();
-    // abort if we exceed 32KB size, things will not go well otherwise
     if (sz >= 32767) {
       be_raise(vm, "value_error", "response size too big (>32KB)");
     }
     String payload = cl->getString();
     be_pushstring(vm, payload.c_str());
-    cl->end();  // free allocated memory ~16KB
-    be_return(vm);  /* return code */
+    // cl->end();  // free ~16KB  => no auto-close here (reuse stays ON)
+    be_return(vm);
   }
 
   int32_t wc_writefile(struct bvm *vm);
   int32_t wc_writefile(struct bvm *vm) {
-    int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isstring(vm, 2)) {
-      HTTPClientLight * cl = wc_getclient(vm);
+    if (be_top(vm) >= 2 && be_isstring(vm, 2)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
       const char * fname = be_tostring(vm, 2);
-
       void * f = be_fopen(fname, "w");
       int ret = -1;
       if (f) {
@@ -554,22 +648,22 @@ extern "C" {
       }
       be_fclose(f);
       be_pushint(vm, ret);
-      be_return(vm);  /* return code */
+      be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }
 
   int32_t wc_getsize(struct bvm *vm);
   int32_t wc_getsize(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     be_pushint(vm, cl->getSize());
-    be_return(vm);  /* return code */
+    be_return(vm);
   }
 }
 
 extern size_t FlashWriteSubSector(uint32_t address_start, const uint8_t *data, size_t size);
 
-const uint32_t STREAM_FLASH_PROGRESS_THRESHOLD_KB = 100;    // display log entry every 100kB
+const uint32_t STREAM_FLASH_PROGRESS_THRESHOLD_KB = 100;
 const uint32_t STREAM_FLASH_PROGRESS_THRESHOLD = STREAM_FLASH_PROGRESS_THRESHOLD_KB * 1024;
 
 class StreamFlash: public Stream
@@ -578,25 +672,19 @@ public:
   StreamFlash(uint32_t addr) : addr_start(addr), offset(0) {};
 
   size_t write(const uint8_t *buffer, size_t size) override {
-    // AddLog(LOG_LEVEL_INFO, "FLASH: addr=%p  hex=%*_H  size=%i", addr_start + offset, 32, buffer, size);
+#if ESP_IDF_VERSION_MAJOR < 5
     if (size > 0) {
-#if ESP_IDF_VERSION_MAJOR < 5     // TODO later
       esp_err_t ret = spi_flash_write(addr_start + offset, buffer, size);
       if (ret != ESP_OK)  { return 0; }  // error
       offset += size;
-
-      // shall we display a progress indicator?
       if (((offset - size) / STREAM_FLASH_PROGRESS_THRESHOLD) != (offset / STREAM_FLASH_PROGRESS_THRESHOLD)) {
         AddLog(LOG_LEVEL_DEBUG, D_LOG_UPLOAD "Progress %d kB", offset / 1024);
       }
-#endif
     }
+#endif
     return size;
   }
-  size_t write(uint8_t data) override {
-    write(&data, 1);
-    return 1;
-  }
+  size_t write(uint8_t data) override { write(&data, 1); return 1; }
 
   int available() override { return 0; }
   int read() override { return -1; }
@@ -604,32 +692,30 @@ public:
   void flush() override { }
 
 protected:
-  uint32_t addr_start;      // start address
-  uint32_t offset;          // how many bytes have already been written
+  uint32_t addr_start;
+  uint32_t offset;
 };
 
 extern "C" {
   int32_t wc_writeflash(struct bvm *vm);
   int32_t wc_writeflash(struct bvm *vm) {
 #if ESP_IDF_VERSION_MAJOR < 5
-    int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isint(vm, 2)) {
-      HTTPClientLight * cl = wc_getclient(vm);
-      uint32_t addr = be_toint(vm, 2);
+    if (be_top(vm) >= 2 && be_isint(vm, 2)) {
+      AsyncHttpClientLight * cl = wc_getclient(vm);
+      uint32_t addr = (uint32_t)be_toint(vm, 2);
       if (addr < 0x10000 || addr >= 0x400000) {
-        be_raisef(vm, "value_error", "invalid flash address 0x04X", addr);
+        be_raisef(vm, "value_error", "invalid flash address 0x%04X", addr);
       }
-      if (addr & (SPI_FLASH_SEC_SIZE-1) != 0) {
+      if ((addr & (SPI_FLASH_SEC_SIZE-1)) != 0) {
         be_raisef(vm, "value_error", "invalid flash address, must be at %iKB boundary 0x%04X", SPI_FLASH_SEC_SIZE/1024, addr);
       }
       int32_t size = cl->getSize();
-      if (size <= 0 || addr+size >= 0x400000) {
+      if (size <= 0 || addr + (uint32_t)size >= 0x400000) {
         be_raisef(vm, "value_error", "invalid flash size 0x%04X", size);
       }
 
       int32_t size_rounded_4k = (size + SPI_FLASH_SEC_SIZE - 1) & ~(SPI_FLASH_SEC_SIZE - 1);
 
-      //  erase region
       esp_err_t ret;
       AddLog(LOG_LEVEL_DEBUG, D_LOG_UPLOAD "erasing flash at 0x%04X length 0x%04X", addr, size_rounded_4k);
       ret = spi_flash_erase_range(addr, size_rounded_4k);
@@ -649,7 +735,7 @@ extern "C" {
       AddLog(LOG_LEVEL_DEBUG, D_LOG_UPLOAD "flash writing succesful");
 
       be_pushint(vm, written);
-      be_return(vm);  /* return code */
+      be_return(vm);
     }
 #endif
     be_raise(vm, kTypeError, nullptr);
@@ -664,57 +750,47 @@ public:
   StreamBeBytesWriter(bvm *vm_in, int increment = 1024) : vm(vm_in), offset(0), incr(increment) {};
 
   size_t write(const uint8_t *buffer, size_t size) override {
-    // we need size, not len, so can;t just get len with be_tobytes
     be_getmember(vm, -1, ".size");
     int32_t signed_size = be_toint(vm, -1);
     be_pop(vm, 1);  /* bytes() instance is at top */
 
-    // if it won't fit, make the bytes object bigger
-    if (offset + size > signed_size){
-      int newsize = offset + size + incr;
+    if (offset + (int32_t)size > signed_size){
+      int newsize = offset + (int32_t)size + incr;
       AddLog(LOG_LEVEL_INFO, "BE: realloc bytes in StreamBeBytesWriter newsize=%i", newsize);
       be_getmember(vm, -1, "resize");
       be_pushvalue(vm, -2);
-      be_pushint(vm, size);
-      be_call(vm, 2); /* call b.resize(size) */
-      be_pop(vm, 3);  /* bytes() instance is at top */      
+      be_pushint(vm, newsize);          // FIX: use newsize
+      be_call(vm, 2); /* call b.resize(newsize) */
+      be_pop(vm, 3);  /* bytes() instance is at top */
 
-      // checkw e got it, because Berry just maxes out?
       be_getmember(vm, -1, ".size");
       signed_size = be_toint(vm, -1);
-      be_pop(vm, 1);  /* bytes() instance is at top */
-      if (offset + size > signed_size){
-        // what should we raise here???
+      be_pop(vm, 1);
+      if (offset + (int32_t)size > signed_size){
         be_raise(vm, "alloc_error", "did not get enough extra bytes");
       }
     }
 
-    // AddLog(LOG_LEVEL_INFO, "FLASH: addr=%p  hex=%*_H  size=%i", addr_start + offset, 32, buffer, size);
-    if (offset + size > signed_size){
+    if (offset + (int32_t)size > signed_size){
       AddLog(LOG_LEVEL_ERROR, "BERRYWC: buffer overrun");
       return size;
     }
 
-    char *bytebuf = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internam buffer of size 'size' */
+    char *bytebuf = (char*) be_tobytes(vm, -1, NULL);
     if (!bytebuf){
       AddLog(LOG_LEVEL_ERROR, "BERRYWC: buffer null??");
       return size;
     }
 
-    // stream in our chunk
     memcpy(bytebuf + offset, buffer, size);
-    offset += size;
+    offset += (int32_t)size;
 
-    // set the len
     be_pushint(vm, offset);
     be_setmember(vm, -2, ".len");
     be_pop(vm, 1);
     return size;
   }
-  size_t write(uint8_t data) override {
-    write(&data, 1);
-    return 1;
-  }
+  size_t write(uint8_t data) override { write(&data, 1); return 1; }
 
   int available() override { return 0; }
   int read() override { return -1; }
@@ -722,29 +798,25 @@ public:
   void flush() override { }
 
 protected:
-  bvm *vm;                // the berry VM
-  uint32_t offset;       // how many bytes have already been written
-  size_t incr;           // amount to add to size if it does not fit.
+  bvm *vm;
+  int32_t offset;
+  size_t incr;
 };
 
 extern "C" {
   int32_t wc_getbytes(struct bvm *vm);
   int32_t wc_getbytes(struct bvm *vm) {
-    HTTPClientLight * cl = wc_getclient(vm);
+    AsyncHttpClientLight * cl = wc_getclient(vm);
     int32_t sz = cl->getSize();
-    // abort if we exceed 32KB size, things will not go well otherwise
     if (sz >= 32767) {
       be_raise(vm, "value_error", "response size too big (>32KB)");
     }
-    // default to 1K starter if contetn-length not present
     if (sz < 0) sz = 1024;
-    // create a bytes object at top of stack.
-    // the streamwriter knows how to get it. 
-    uint8_t * buf = (uint8_t*) be_pushbytes(vm, nullptr, sz);
+    (void) be_pushbytes(vm, nullptr, sz);
     StreamBeBytesWriter memory_writer(vm);
-    int32_t written = cl->writeToStream(&memory_writer);
-    cl->end();  // free allocated memory ~16KB
-    be_return(vm);  /* return code */
+    (void) cl->writeToStream(&memory_writer);
+    // cl->end();  // No sense wheen using stream!
+    be_return(vm);
   }
 }
 


### PR DESCRIPTION
## Description:

Introduce a self-contained async HTTP/HTTPS client for ESP32 (AsyncHttpClientLight) and integrate it directly into the Berry webclient module. The old HttpClientLight backend is replaced by default (no feature flag). Code still include <HTTPClient.h> only for the enum/constant types (e.g., followRedirects_t, transferEncoding_t, HTTPC_TE_*).

**Why**

- Non-blocking GET/POST for telemetry/RPC without freezing the Berry VM.
- Lower TIME_WAIT pressure and safer connection reuse.
- TLS public-key pinning, optional RSA-only hardening.
- Keep API/error-code compatibility while modernizing internals.

**What changed**

**AsyncHttpClientLight (new core client)**

- HTTP via lwIP sockets (IClientLite + non-blocking AsyncTcpAdapter) with SO_LINGER (RST-close) to reduce TIME_WAIT.
- HTTPS via BearSSL WiFiClientSecure_light, with:
- tls_pin_pubkey(fp1[,fp2]) (SHA-1 pubkey fingerprints, one or two pins)
- tls_set_rsa_only(true) optional hardening.
- Redirects (strict): 301/307 for GET/HEAD; 302/303 switch to GET; configurable limit (default 5).
- Chunked & identity decoding; reuse honored unless prior body wasn’t drained (auto reconnect).
- FreeRTOS worker (WDT-friendly): asyncGETStart(), asyncPOSTStart(...), asyncState(), asyncAbort().
- Error codes aligned with HTTPClientLight (−1..−11).
- Async in-RAM body buffer capped ~16 KB (heap safety). Use sync streaming for larger bodies.

**Berry webclient (updated bindings)**

- New methods: async_get_start(), async_post_start(str|bytes), async_state(), async_abort().
- async_state() publishes last_code (HTTP or negative error) and last_rx (received bytes), and frees hidden holds for byte payloads.
- Headers added via add_header() persist per instance; they reset on begin() and after redirects (re-add if needed).
- Sync API unchanged: GET/POST/PUT/PATCH/DELETE, get_string/bytes, write_file/flash.

**Dependency note**

<HTTPClient.h> remains included only for enum/constant types. No Arduino HTTPClient source code is copied; transport, parsing and async infra are independent.

**Compatibility**

- Existing Berry scripts using sync APIs remain compatible.
- OTA/firmware workflows (sync GET + streaming) are unaffected.

**Operational notes**

- Call async_state() at least once after an async job finishes to publish results and clean up before reusing the same instance.
- Add Content-Type once after begin() (e.g., application/json); re-add after begin() or a redirect.
- Don’t call close() while an async job is running.

**Typical use cases:**

**Secure periodic telemetry over HTTP(S) + local MQTT**

- Use webclient for encrypted REST telemetry to the cloud while keeping MQTT for LAN/HA use.
- Pattern: create one client per endpoint, begin() once, add Content-Type: application/json, then call async_post_start(payload) from your scheduler and occasionally async_state() to publish last_code/last_rx and clean up.
- Keeps the Berry VM responsive; no long blocking writes. For large uploads/downloads, fall back to sync streaming (write_file, get_bytes).

**RPC long-polling (e.g., ThingsBoard) without tight polling loops**

- With async GET you can keep a long-poll open (e.g., ?timeout=60) instead of reconnecting every few seconds.
- Pattern: async_get_start() on /rpc?timeout=60, periodically call async_state():
- When async_state() returns DONE, parse the body, execute the command (optionally via async POST reply), then immediately start the next long-poll (async_get_start() again).
- When it returns RUNNING, do nothing (connection is open); VM stays free for other tasks.
- This reduces connection churn, lowers TIME_WAIT pressure, and prevents VM stalls seen with previous sync blocking mode.

**Risk**

- ESP32-only paths; HTTPS relies on existing BearSSL light.
- Behavior changes confined to the webclient backend; public sync APIs preserved.

**Test plan**

- Sync: GET large binary → write_file(); verify size/hash; chunked and identity.
- Async: burst async_post_start() with periodic async_state(); check last_code/last_rx, stable heap, no WDT.
- Redirects: verify 301/302/303/307 and header reset behavior.
- TLS: good vs bad fingerprint; RSA-only against ECDSA cert (should fail).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
