### PR TITLE
Berry multiplication between string and int

### DIFF
--- a/.doc_for_ai/BERRY_LANGUAGE_REFERENCE.md
+++ b/.doc_for_ai/BERRY_LANGUAGE_REFERENCE.md
@@ -181,6 +181,19 @@ print(i)    # Only i is accessible here
 - `/`: Division
 - `%`: Modulo (remainder)
 
+**String Multiplication**: The `*` operator supports string multiplication when the left operand is a string and the right operand is an integer or boolean:
+
+```berry
+"aze" * 3        # "azeazeaze" - repeat string 3 times
+"aze" * 0        # "" - empty string
+"aze" * true     # "aze" - string if true
+"aze" * false    # "" - empty string if false
+
+# Common use cases:
+"  " * indent    # Create indentation spaces
+f"{n} time{'s' * bool(n >= 2)}"  # Conditional pluralization
+```
+
 #### Relational Operators
 - `<`: Less than
 - `<=`: Less than or equal to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - ESP32 ROM SHA Hardware Acceleration to BearSSL (#23819)
 - Extend state JSON message with functional hostname and ipaddress which could be WiFi or Ethernet
+- Berry multiplication between string and int
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -77,6 +77,50 @@ bstring* be_strcat(bvm *vm, bstring *s1, bstring *s2)
     }
 }
 
+bstring* be_strmul(bvm *vm, bstring *s1, bint n)
+{
+    /* Handle edge cases */
+    if (n == 1) {
+        return s1;
+    }
+
+    size_t string_len = (size_t)str_len(s1);
+    if ((n <= 0) || (string_len == 0)) {
+        return be_newstrn(vm, "", 0);
+    }
+    
+    /* Check for potential overflow */
+    if (n > (bint)(vm->bytesmaxsize / string_len)) {
+        be_raise(vm, "runtime_error", "string multiplication result too large");
+    }
+    
+    size_t total_len = string_len * (size_t)n;
+    
+    /* Use the same pattern as be_strcat for short vs long strings */
+    if (total_len <= SHORT_STR_MAX_LEN) {
+        char buf[SHORT_STR_MAX_LEN + 1];
+        const char *src = str(s1);
+        char *dst = buf;
+        
+        for (bint i = 0; i < n; i++) {
+            memcpy(dst, src, string_len);
+            dst += string_len;
+        }
+        buf[total_len] = '\0';
+        return be_newstrn(vm, buf, total_len);
+    } else {
+        /* Long string */
+        bstring *result = be_newstrn(vm, NULL, total_len);
+        char *dst = (char*)str(result);
+        const char *src = str(s1);
+        
+        for (bint i = 0; i < n; i++) {
+            memcpy(dst + i * string_len, src, string_len);
+        }
+        return result;
+    }
+}
+
 int be_strcmp(bstring *s1, bstring *s2)
 {
     if (be_eqstr(s1, s2)) {

--- a/lib/libesp32/berry/src/be_strlib.h
+++ b/lib/libesp32/berry/src/be_strlib.h
@@ -16,6 +16,7 @@ extern "C" {
 #endif
 
 bstring* be_strcat(bvm *vm, bstring *s1, bstring *s2);
+bstring* be_strmul(bvm *vm, bstring *s1, bint n);
 int be_strcmp(bstring *s1, bstring *s2);
 bstring* be_num2str(bvm *vm, bvalue *v);
 void be_val2str(bvm *vm, int index);

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -175,13 +175,6 @@ assert(f"S = {a}" == 'S = foobar{0}')
 assert(f"S = {a:i}" == 'S = 0')
 assert(f"{a=}" == 'a=foobar{0}')
 
-# new option for f-strings, '::' encodes for ':'
-assert(f"{true ? 1 :: 2}" == "1")
-assert(f"{false ? 1 :: 2}" == "2")
-assert(f"{false ? 1 :: 2 : i}" == " 2")
-assert(f"{false ? 1 :: 2:i}" == "2")
-assert(f"{false ? 1 :: 2:04i}" == "0002")
-
 # startswith case sensitive
 assert(string.startswith("", "") == true)
 assert(string.startswith("qwerty", "qw") == true)
@@ -220,3 +213,103 @@ assert(string.endswith("qwerty", "tY", true) == true)
 assert(string.endswith("qwerty", "TY", true) == true)
 assert(string.endswith("qwerty", "tr", true) == false)
 assert(string.endswith("qwerty", "qwertyw", true) == false)
+
+# unicode literals
+assert("\uF014" == "\xEF\x80\x94")
+
+# string multiplication tests
+# Basic integer multiplication
+assert("aze" * 3 == "azeazeaze")
+assert("ab" * 5 == "ababababab")
+assert("x" * 1 == "x")
+assert("hello" * 2 == "hellohello")
+
+# Zero and negative multiplication
+assert("aze" * 0 == "")
+assert("hello" * -1 == "")
+assert("test" * -5 == "")
+
+# Boolean multiplication
+assert("aze" * true == "aze")
+assert("aze" * false == "")
+assert("hello" * true == "hello")
+assert("world" * false == "")
+
+# Empty string multiplication
+assert("" * 0 == "")
+assert("" * 1 == "")
+assert("" * 5 == "")
+assert("" * 100 == "")
+assert("" * true == "")
+assert("" * false == "")
+
+# Single character multiplication
+assert("a" * 10 == "aaaaaaaaaa")
+assert("z" * 0 == "")
+assert("!" * 3 == "!!!")
+
+# Large multiplication (testing performance and memory)
+var large_result = "abc" * 20
+assert(size(large_result) == 60)
+assert(large_result == "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc")
+
+# Edge cases with special characters
+assert("\n" * 3 == "\n\n\n")
+assert("\t" * 2 == "\t\t")
+assert("\"" * 4 == "\"\"\"\"")
+assert("\\" * 3 == "\\\\\\")
+
+# Verify that regular multiplication still works
+assert(3 * 4 == 12)
+assert(2.5 * 4 == 10)
+assert(5 * 3 == 15)
+assert(0 * 10 == 0)
+
+# Test that invalid combinations still throw errors
+try
+    var result = "hello" * "world"
+    assert(false, "Should have thrown an error")
+except 'type_error'
+    # Expected error
+end
+
+try
+    var result = "hello" * 3.14
+    assert(false, "Should have thrown an error")
+except 'type_error'
+    # Expected error
+end
+
+try
+    var result = "hello" * nil
+    assert(false, "Should have thrown an error")
+except 'type_error'
+    # Expected error
+end
+
+# Test with variables
+var s = "test"
+var count = 3
+assert(s * count == "testtesttest")
+
+var bool_true = true
+var bool_false = false
+assert(s * bool_true == "test")
+assert(s * bool_false == "")
+
+# Test chaining and expressions
+assert(("a" * 2) + ("b" * 3) == "aabbb")
+assert("x" * (1 + 2) == "xxx")
+assert("y" * (true && true) == "y")
+assert("z" * (false || false) == "")
+
+# Test with longer strings
+var long_str = "Hello, World!"
+assert(long_str * 0 == "")
+assert(long_str * 1 == "Hello, World!")
+assert(long_str * 2 == "Hello, World!Hello, World!")
+
+# Test boundary conditions
+assert("a" * 64 == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")  # SHORT_STR_MAX_LEN
+var very_long = "a" * 100  # Should use long string path
+assert(size(very_long) == 100)


### PR DESCRIPTION
## Description:

**String Multiplication**: The `*` operator supports string multiplication when the left operand is a string and the right operand is an integer or boolean:

```berry
"aze" * 3        # "azeazeaze" - repeat string 3 times
"aze" * 0        # "" - empty string
"aze" * true     # "aze" - string if true
"aze" * false    # "" - empty string if false
# Common use cases:
"  " * indent    # Create indentation spaces
f"{n} time{'s' * bool(n >= 2)}"  # Conditional pluralization
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
