### PR TITLE
Berry 'animate' framework is DEPRECATED, will be replace by 'animation' framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry multiplication between string and int
 
 ### Breaking Changed
+- Berry `animate` framework is DEPRECATED, will be replace by `animation` framework
 
 ### Changed
 - ESP32 Platform from 2025.07.31 to 2025.08.30, Framework (Arduino Core) from v3.1.3.250712 to v3.1.3.250808 and IDF from v5.3.3.250707 to v5.3.3.250801 (#23778)

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -172,7 +172,9 @@ BERRY_LOCAL const bntvmodule_t* const be_module_table[] = {
 #endif // USE_UNISHOX_COMPRESSION
 
 #if defined(USE_WS2812) && !defined(USE_WS2812_FORCE_NEOPIXELBUS)
+  #ifdef USE_BERRY_ANIMATE
     &be_native_module(animate),
+  #endif // USE_BERRY_ANIMATE
 #endif // USE_WS2812
 
 #ifdef USE_LVGL

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -620,6 +620,7 @@
 // #define USE_LIGHT_ARTNET                         // Add support for DMX/ArtNet via UDP on port 6454 (+3.5k code)
   #define USE_LIGHT_ARTNET_MCAST 239,255,25,54   // Multicast address used to listen: 239.255.25.54
 
+  #define USE_BERRY_ANIMATE                      // Legacy tentative for LED animation framework, DEPRECATED
   // #define USE_BERRY_ANIMATION                    // New animation framework with dedicated language (ESP32x only, experimental, 117k not yet optimized)
     // #define USE_BERRY_ANIMATION_DSL                // DSL transpiler for new animation framework (not mandatory if DSL is transpiled externally, +59k not optimized yet)
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -32,7 +32,9 @@ extern "C" {
   #include "berry_matter.h"
 #endif
 #ifdef USE_WS2812
-  #include "berry_animate.h"
+  #ifdef USE_BERRY_ANIMATE
+    #include "berry_animate.h"
+  #endif // USE_BERRY_ANIMATE
   #ifdef USE_BERRY_ANIMATION
     #include "berry_animation.h"
   #endif // USE_BERRY_ANIMATION


### PR DESCRIPTION
## Description:

Berry `animate` framework is DEPRECATED, will be replace by `animation` framework.

It is now conditioned to `#define USE_BERRY_ANIMATE` that will be soon not included in pre-compiled binaries.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
