### PR TITLE
Update esp8266 Platform to 2025.09.00

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -137,11 +137,12 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.08.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.09.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
+
 


### PR DESCRIPTION
## Description:

Updates in esp8266 Platform:
- check for git
- install all Python deps with uv
- generate Python venv with uv
- remove timeouts and retries for tool download and installation

no changes in Arduino esp8266 core

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
