### PR TITLE
Update statedata.be with stop() method

### DIFF
--- a/tasmota/berry/examples/statedata.be
+++ b/tasmota/berry/examples/statedata.be
@@ -35,6 +35,10 @@ class mqttdata_cls
     mqtt.subscribe("tele/#", /topic, idx, data, databytes -> self.handle_state_data(topic, idx, data, databytes))
   end
 
+  def stop()
+    tasmota.remove_driver(self)
+  end
+
   def handle_state_data(full_topic, idx, data, databytes)
     import json
 


### PR DESCRIPTION
Code was calling stop() when reinitialized, but method was not defined

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
