### PR TITLE
remove not needed idf components from HybridCompile safeboot variants

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -86,6 +86,15 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               re1.5
                               DHT sensor library
                               ccronexpr
+custom_component_remove     =
+                              espressif/network_provisioning
+                              espressif/esp_modem
+                              espressif/esp-dsp
+                              espressif/esp32-camera
+                              espressif/mdns
+                              espressif/esp_jpg
+                              espressif/fb_gfx
+                              espressif/cmake_utilities
 
 [core32]
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.08.30/platform-espressif32.zip

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -47,6 +47,7 @@ custom_sdkconfig        = '# CONFIG_SPIRAM is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_RX_FRAME_INVALID is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_RX_FIFO_CORRUPT is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_LISTEN_ONLY_DOM is not set'
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32solo1-safeboot]
 extends                 = env:tasmota32_base
@@ -69,6 +70,7 @@ custom_sdkconfig        = '# CONFIG_SPIRAM is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_RX_FRAME_INVALID is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_RX_FIFO_CORRUPT is not set'
                           '# CONFIG_TWAI_ERRATA_FIX_LISTEN_ONLY_DOM is not set'
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32s2-safeboot]
 extends                 = env:tasmota32_base
@@ -155,9 +157,7 @@ custom_sdkconfig        =
                           '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
-custom_component_remove = espressif/esp_hosted
-                          espressif/esp_wifi_remote
-                          espressif/esp_modem
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c5ser-safeboot]
 platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55
@@ -184,9 +184,7 @@ custom_sdkconfig        =
                           '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
-custom_component_remove = espressif/esp_hosted
-                          espressif/esp_wifi_remote
-                          espressif/esp_modem
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6-safeboot]
 extends                 = env:tasmota32_base
@@ -206,9 +204,7 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
-custom_component_remove = espressif/esp_hosted
-                          espressif/esp_wifi_remote
-                          espressif/esp_modem
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6ser-safeboot]
 extends                 = env:tasmota32_base
@@ -228,9 +224,7 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
-custom_component_remove = espressif/esp_hosted
-                          espressif/esp_wifi_remote
-                          espressif/esp_modem
+custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32s3ser-safeboot]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

No functional change. Reduce compile time by removing not used/needed components

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
