### PR TITLE
Platform 2025.09.30

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.4
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,7 +97,7 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.08.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.09.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- Arduino espressif32 branch master from 2025.09.07 (Tasmota modified)
- Updated IDF 5.3.4 release (Tasmota modified)
- Tasmota Platform v2025.09.30 (many changes and refactorings)

not directly related but may solve install issues. VSC extension pioarduino updated. Completely new installer!
Deinstall Platformio VSC extension and install pioarduino VSC **instead**.  Both can not be installed!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
