### PR TITLE
Update be_modtab.c, #ifdef nesting for USE_BERRY_ANIMATION

### DIFF
--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -83,6 +83,8 @@ be_extern_native_module(haspmota);
 #endif // USE_LVGL_HASPMOTA
 #endif // USE_LVGL
 #ifdef USE_MATTER_DEVICE
+be_extern_native_module(matter);
+#endif // USE_MATTER_DEVICE
 #ifdef USE_WS2812
 #ifdef USE_BERRY_ANIMATION
 be_extern_native_module(animation);
@@ -91,8 +93,6 @@ be_extern_native_module(animation_dsl);
 #endif // USE_BERRY_ANIMATION_DSL
 #endif // USE_BERRY_ANIMATION
 #endif // USE_WS2812
-be_extern_native_module(matter);
-#endif // USE_MATTER_DEVICE
 
 /* user-defined modules declare start */
 


### PR DESCRIPTION
Adjustment of #ifdef nesting, as confirmed by @s-hadinger  https://discord.com/channels/479389167382691863/826169659811168276/1416406702613598228

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
