### PR TITLE
Fix Linker error with latest esp-hosted-mcu version

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
@@ -20,6 +20,7 @@
 #endif  //#include "port_esp_hosted_host_config.h"
 #include "esp_hosted_api_types.h"
 #include "esp_hosted_ota.h"
+#include "esp_hosted_transport_config.h"
 
 struct Hosted_t {
   char *hosted_ota_url;                     // Hosted MCU OTA URL

--- a/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
@@ -15,7 +15,11 @@
 #define XDRV_84               84
 
 #include "esp_hosted.h"
+
+extern "C" {
 #include "esp_hosted_transport_config.h"
+}
+
 #include "port/esp/freertos/include/port_esp_hosted_host_config.h"
 
 struct Hosted_t {

--- a/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_84_esp32_hosted.ino
@@ -15,12 +15,8 @@
 #define XDRV_84               84
 
 #include "esp_hosted.h"
-#if __has_include("port/esp/freertos/include/port_esp_hosted_host_config.h")
-#include "port/esp/freertos/include/port_esp_hosted_host_config.h"
-#endif  //#include "port_esp_hosted_host_config.h"
-#include "esp_hosted_api_types.h"
-#include "esp_hosted_ota.h"
 #include "esp_hosted_transport_config.h"
+#include "port/esp/freertos/include/port_esp_hosted_host_config.h"
 
 struct Hosted_t {
   char *hosted_ota_url;                     // Hosted MCU OTA URL


### PR DESCRIPTION
## Description:

the PR ensures Linker includes the needed functions

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
