### PR TITLE
Berry extensions add logs when installation fails

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/extension_manager.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/extension_manager.be
@@ -179,6 +179,7 @@ class Extension_manager
   # @param tapp_fname : string - name of tapp file to install from repository
   def install_from_store(tapp_fname)
     import string
+    import path
     # sanitize
     tapp_fname = self.tapp_name(tapp_fname)
     # add '.tapp' extension if it is not present
@@ -198,8 +199,14 @@ class Extension_manager
         log(f"EXT: return_code={r}", 2)
         return
       end
-      cl.write_file(local_file)
+      var ret = cl.write_file(local_file)
       cl.close()
+      # test if file exists and tell its size
+      if path.exists(local_file)        
+        log(f"EXT: file written to '{local_file}' ret={ret}")
+      else
+        raise "file_error", f"could not download into '{local_file}' ret={ret}"
+      end
     except .. as e, m
       tasmota.log(format("CFG: exception '%s' - '%s'", e, m), 2)
       return nil

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_extension_manager.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_extension_manager.h
@@ -4,8 +4,8 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Extension_manager;
-// compact class 'Extension_manager' ktab size: 157, total: 254 (saved 776 bytes)
-static const bvalue be_ktab_class_Extension_manager[157] = {
+// compact class 'Extension_manager' ktab size: 161, total: 259 (saved 784 bytes)
+static const bvalue be_ktab_class_Extension_manager[161] = {
   /* K0   */  be_nested_str(tasmota),
   /* K1   */  be_nested_str(arch),
   /* K2   */  be_nested_str(0x_X2508X),
@@ -81,88 +81,92 @@ static const bvalue be_ktab_class_Extension_manager[157] = {
   /* K72  */  be_nested_str(content_button),
   /* K73  */  be_nested_str(BUTTON_MANAGEMENT),
   /* K74  */  be_nested_str(content_stop),
-  /* K75  */  be_nested_str(tapp_name),
-  /* K76  */  be_nested_str(endswith),
-  /* K77  */  be_nested_str(_X25s_X25s_X25s),
-  /* K78  */  be_nested_str(EXT_REPO_FOLDER),
-  /* K79  */  be_nested_str(EXT_X3A_X20installing_X20from_X20_X27_X25s_X27),
-  /* K80  */  be_nested_str(_X25s_X25s),
-  /* K81  */  be_nested_str(EXT_FOLDER),
-  /* K82  */  be_nested_str(EXT_X3A_X20return_code_X3D_X25s),
-  /* K83  */  be_nested_str(write_file),
-  /* K84  */  be_nested_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27),
-  /* K85  */  be_nested_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3Dbut_part_mgr_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27ext_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EExtension_X20Manager_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K86  */  be_nested_str(list_extensions),
-  /* K87  */  be_nested_str(stop_iteration),
-  /* K88  */  be_nested_str(path),
-  /* K89  */  be_nested_str(listdir),
-  /* K90  */  be_nested_str(_X2Etapp_),
-  /* K91  */  be_nested_str(push),
-  /* K92  */  be_nested_str(check_privileged_access),
-  /* K93  */  be_nested_str(arg_name),
-  /* K94  */  be_const_int(2147483647),
-  /* K95  */  be_nested_str(load),
-  /* K96  */  be_nested_str(unload_extension),
-  /* K97  */  be_nested_str(tapp_),
-  /* K98  */  be_nested_str(tapp),
-  /* K99  */  be_nested_str(rename),
-  /* K100 */  be_nested_str(remove),
-  /* K101 */  be_nested_str(EXT_X3A_X20wrong_X20action_X20_X27_X25s_X27),
-  /* K102 */  be_nested_str(d),
-  /* K103 */  be_nested_str(u),
-  /* K104 */  be_nested_str(install_from_store),
-  /* K105 */  be_nested_str(i),
-  /* K106 */  be_nested_str(redirect),
-  /* K107 */  be_nested_str(_X2Fext),
-  /* K108 */  be_nested_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-  /* K109 */  be_nested_str(Parameter_X20error),
-  /* K110 */  be_nested_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
-  /* K111 */  be_nested_str(BUTTON_CONFIGURATION),
-  /* K112 */  be_nested_str(on),
-  /* K113 */  be_nested_str(HTTP_GET),
-  /* K114 */  be_nested_str(HTTP_POST),
-  /* K115 */  be_nested_str(sortedmap),
-  /* K116 */  be_nested_str(EXT_X3A_X20unable_X20to_X20read_X20details_X20from_X20_X27_X25s_X27),
-  /* K117 */  be_nested_str(add_driver),
-  /* K118 */  be_nested_str(json),
-  /* K119 */  be_nested_str(content_open),
-  /* K120 */  be_nested_str(text_X2Fhtml),
-  /* K121 */  be_nested_str(load_manifest),
-  /* K122 */  be_nested_str(_X3Cb_X20id_X3D_X27store_X27_X3E_X5B_X20_X3Cspan_X20style_X3D_X27color_X3Avar_X28_X2D_X2Dc_btnrst_X29_X3B_X27_X3EError_X20loading_X20manifest_X2E_X3C_X2Fspan_X3E_X20_X5D_X3C_X2Fb_X3E),
-  /* K123 */  be_nested_str(_X3Cp_X3E_X3Csmall_X3E_X25s_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E),
-  /* K124 */  be_nested_str(content_close),
-  /* K125 */  be_nested_str(count),
-  /* K126 */  be_nested_str(_X22name_X22_X3A),
-  /* K127 */  be_nested_str(_X3Cfieldset_X20id_X3D_X27store_X27_X3E),
-  /* K128 */  be_nested_str(_X3Cdiv_X20class_X3D_X27store_X2Dheader_X27_X3E_X3Cspan_X3EBrowse_X20Extensions_X3C_X2Fspan_X3E_X3Cspan_X20class_X3D_X27store_X2Dstats_X27_X3E_X25s_X20available_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
-  /* K129 */  be_nested_str(_X3Cinput_X20type_X3D_X27text_X27_X20placeholder_X3D_X27Search_X20extensions_X2E_X2E_X2E_X27_X20onkeyup_X3D_X27filterExtensions_X28this_X2Evalue_X29_X27_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-  /* K130 */  be_nested_str(list_installed_ext),
-  /* K131 */  be_nested_str(_X0A),
-  /* K132 */  be_nested_str(manifest_decode),
-  /* K133 */  be_nested_str(version_string),
-  /* K134 */  be_nested_str(file),
-  /* K135 */  be_nested_str(replace),
-  /* K136 */  be_nested_str(_X5Cn),
-  /* K137 */  be_nested_str(_X3Cbr_X3E),
-  /* K138 */  be_nested_str(author),
-  /* K139 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dstore_X2Ditem_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Dheader_X27_X20onclick_X3D_X27toggleDesc_X28_X22_X25s_X22_X29_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Dtitle_X27_X3E_X3Cspan_X20class_X3D_X27ext_X2Dname_X27_X3E_X25s_X3C_X2Fspan_X3E_X3Cspan_X20class_X3D_X27ext_X2Dversion_X27_X3E_X3Csmall_X3E_X25s_X3C_X2Fsmall_X3E_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
-  /* K140 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dbadges_X27_X3E_X3Cspan_X20class_X3D_X27update_X2Dbadge_X27_X3EUpgrade_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
-  /* K141 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dbadges_X27_X3E_X3Cspan_X20class_X3D_X27installed_X2Dbadge_X27_X3EInstalled_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
-  /* K142 */  be_nested_str(_X3Cspan_X20id_X3D_X27arrow_X2D_X25s_X27_X20class_X3D_X27ext_X2Darrow_X27_X3E_XE2_X96_XB6_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E_X3Cdiv_X20id_X3D_X27desc_X2D_X25s_X27_X20class_X3D_X27ext_X2Ddetails_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Ddesc_X27_X3E_X25s),
-  /* K143 */  be_nested_str(_X3Cbr_X3E_X25s_X20_XE2_X86_X92_X20_X25s),
-  /* K144 */  be_nested_str(_X3C_X2Fdiv_X3E_X3Cform_X20action_X3D_X27_X2Fext_X27_X20method_X3D_X27post_X27_X20class_X3D_X27ext_X2Dactions_X27_X3E_X3Cdiv_X20style_X3D_X27width_X3A30_X25_X27_X3E_X3C_X2Fdiv_X3E),
-  /* K145 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20name_X3D_X27u_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20upgrade_X20of_X20_X25s_X22_X29_X27_X3EUpgrade_X3C_X2Fbutton_X3E),
-  /* K146 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20style_X3D_X27visibility_X3Ahidden_X3B_X27_X3E_X3C_X2Fbutton_X3E),
-  /* K147 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X20bred_X27_X20name_X3D_X27d_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20deletion_X20of_X20_X25s_X22_X29_X27_X3EUninstall_X3C_X2Fbutton_X3E),
-  /* K148 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20style_X3D_X27visibility_X3Ahidden_X3B_X27_X3E_X3C_X2Fbutton_X3E_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X20bgrn_X27_X20name_X3D_X27i_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20installation_X20of_X20_X25s_X22_X29_X27_X3EInstall_X3C_X2Fbutton_X3E),
-  /* K149 */  be_nested_str(v_X25s_X2E_X25s_X2E_X25s_X2E_X25s),
-  /* K150 */  be_nested_str(has_arg),
-  /* K151 */  be_nested_str(store),
-  /* K152 */  be_nested_str(page_extensions_store),
-  /* K153 */  be_nested_str(page_extensions_mgr),
-  /* K154 */  be_nested_str(EXT_X3A_X20unable_X20to_X20parse_X20manifest_X20line_X20_X27_X25s_X27),
-  /* K155 */  be_nested_str(EXT_X3A_X20manifest_X20is_X20missing_X20_X27name_X2Ffile_X2Fversion_X27_X20in_X20map_X20_X27_X25s_X27),
-  /* K156 */  be_nested_str(_X5Bno_X20description_X5D),
+  /* K75  */  be_nested_str(path),
+  /* K76  */  be_nested_str(tapp_name),
+  /* K77  */  be_nested_str(endswith),
+  /* K78  */  be_nested_str(_X25s_X25s_X25s),
+  /* K79  */  be_nested_str(EXT_REPO_FOLDER),
+  /* K80  */  be_nested_str(EXT_X3A_X20installing_X20from_X20_X27_X25s_X27),
+  /* K81  */  be_nested_str(_X25s_X25s),
+  /* K82  */  be_nested_str(EXT_FOLDER),
+  /* K83  */  be_nested_str(EXT_X3A_X20return_code_X3D_X25s),
+  /* K84  */  be_nested_str(write_file),
+  /* K85  */  be_nested_str(exists),
+  /* K86  */  be_nested_str(EXT_X3A_X20file_X20written_X20to_X20_X27_X25s_X27_X20ret_X3D_X25s),
+  /* K87  */  be_nested_str(could_X20not_X20download_X20into_X20_X27_X25s_X27_X20ret_X3D_X25s),
+  /* K88  */  be_nested_str(file_error),
+  /* K89  */  be_nested_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27),
+  /* K90  */  be_nested_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3Dbut_part_mgr_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27ext_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EExtension_X20Manager_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K91  */  be_nested_str(list_extensions),
+  /* K92  */  be_nested_str(stop_iteration),
+  /* K93  */  be_nested_str(listdir),
+  /* K94  */  be_nested_str(_X2Etapp_),
+  /* K95  */  be_nested_str(push),
+  /* K96  */  be_nested_str(check_privileged_access),
+  /* K97  */  be_nested_str(arg_name),
+  /* K98  */  be_const_int(2147483647),
+  /* K99  */  be_nested_str(load),
+  /* K100 */  be_nested_str(unload_extension),
+  /* K101 */  be_nested_str(tapp_),
+  /* K102 */  be_nested_str(tapp),
+  /* K103 */  be_nested_str(rename),
+  /* K104 */  be_nested_str(remove),
+  /* K105 */  be_nested_str(EXT_X3A_X20wrong_X20action_X20_X27_X25s_X27),
+  /* K106 */  be_nested_str(d),
+  /* K107 */  be_nested_str(u),
+  /* K108 */  be_nested_str(install_from_store),
+  /* K109 */  be_nested_str(i),
+  /* K110 */  be_nested_str(redirect),
+  /* K111 */  be_nested_str(_X2Fext),
+  /* K112 */  be_nested_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+  /* K113 */  be_nested_str(Parameter_X20error),
+  /* K114 */  be_nested_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+  /* K115 */  be_nested_str(BUTTON_CONFIGURATION),
+  /* K116 */  be_nested_str(on),
+  /* K117 */  be_nested_str(HTTP_GET),
+  /* K118 */  be_nested_str(HTTP_POST),
+  /* K119 */  be_nested_str(sortedmap),
+  /* K120 */  be_nested_str(EXT_X3A_X20unable_X20to_X20read_X20details_X20from_X20_X27_X25s_X27),
+  /* K121 */  be_nested_str(add_driver),
+  /* K122 */  be_nested_str(json),
+  /* K123 */  be_nested_str(content_open),
+  /* K124 */  be_nested_str(text_X2Fhtml),
+  /* K125 */  be_nested_str(load_manifest),
+  /* K126 */  be_nested_str(_X3Cb_X20id_X3D_X27store_X27_X3E_X5B_X20_X3Cspan_X20style_X3D_X27color_X3Avar_X28_X2D_X2Dc_btnrst_X29_X3B_X27_X3EError_X20loading_X20manifest_X2E_X3C_X2Fspan_X3E_X20_X5D_X3C_X2Fb_X3E),
+  /* K127 */  be_nested_str(_X3Cp_X3E_X3Csmall_X3E_X25s_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E),
+  /* K128 */  be_nested_str(content_close),
+  /* K129 */  be_nested_str(count),
+  /* K130 */  be_nested_str(_X22name_X22_X3A),
+  /* K131 */  be_nested_str(_X3Cfieldset_X20id_X3D_X27store_X27_X3E),
+  /* K132 */  be_nested_str(_X3Cdiv_X20class_X3D_X27store_X2Dheader_X27_X3E_X3Cspan_X3EBrowse_X20Extensions_X3C_X2Fspan_X3E_X3Cspan_X20class_X3D_X27store_X2Dstats_X27_X3E_X25s_X20available_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
+  /* K133 */  be_nested_str(_X3Cinput_X20type_X3D_X27text_X27_X20placeholder_X3D_X27Search_X20extensions_X2E_X2E_X2E_X27_X20onkeyup_X3D_X27filterExtensions_X28this_X2Evalue_X29_X27_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+  /* K134 */  be_nested_str(list_installed_ext),
+  /* K135 */  be_nested_str(_X0A),
+  /* K136 */  be_nested_str(manifest_decode),
+  /* K137 */  be_nested_str(version_string),
+  /* K138 */  be_nested_str(file),
+  /* K139 */  be_nested_str(replace),
+  /* K140 */  be_nested_str(_X5Cn),
+  /* K141 */  be_nested_str(_X3Cbr_X3E),
+  /* K142 */  be_nested_str(author),
+  /* K143 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dstore_X2Ditem_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Dheader_X27_X20onclick_X3D_X27toggleDesc_X28_X22_X25s_X22_X29_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Dtitle_X27_X3E_X3Cspan_X20class_X3D_X27ext_X2Dname_X27_X3E_X25s_X3C_X2Fspan_X3E_X3Cspan_X20class_X3D_X27ext_X2Dversion_X27_X3E_X3Csmall_X3E_X25s_X3C_X2Fsmall_X3E_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
+  /* K144 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dbadges_X27_X3E_X3Cspan_X20class_X3D_X27update_X2Dbadge_X27_X3EUpgrade_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
+  /* K145 */  be_nested_str(_X3Cdiv_X20class_X3D_X27ext_X2Dbadges_X27_X3E_X3Cspan_X20class_X3D_X27installed_X2Dbadge_X27_X3EInstalled_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E),
+  /* K146 */  be_nested_str(_X3Cspan_X20id_X3D_X27arrow_X2D_X25s_X27_X20class_X3D_X27ext_X2Darrow_X27_X3E_XE2_X96_XB6_X3C_X2Fspan_X3E_X3C_X2Fdiv_X3E_X3Cdiv_X20id_X3D_X27desc_X2D_X25s_X27_X20class_X3D_X27ext_X2Ddetails_X27_X3E_X3Cdiv_X20class_X3D_X27ext_X2Ddesc_X27_X3E_X25s),
+  /* K147 */  be_nested_str(_X3Cbr_X3E_X25s_X20_XE2_X86_X92_X20_X25s),
+  /* K148 */  be_nested_str(_X3C_X2Fdiv_X3E_X3Cform_X20action_X3D_X27_X2Fext_X27_X20method_X3D_X27post_X27_X20class_X3D_X27ext_X2Dactions_X27_X3E_X3Cdiv_X20style_X3D_X27width_X3A30_X25_X27_X3E_X3C_X2Fdiv_X3E),
+  /* K149 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20name_X3D_X27u_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20upgrade_X20of_X20_X25s_X22_X29_X27_X3EUpgrade_X3C_X2Fbutton_X3E),
+  /* K150 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20style_X3D_X27visibility_X3Ahidden_X3B_X27_X3E_X3C_X2Fbutton_X3E),
+  /* K151 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X20bred_X27_X20name_X3D_X27d_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20deletion_X20of_X20_X25s_X22_X29_X27_X3EUninstall_X3C_X2Fbutton_X3E),
+  /* K152 */  be_nested_str(_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X27_X20style_X3D_X27visibility_X3Ahidden_X3B_X27_X3E_X3C_X2Fbutton_X3E_X3Cbutton_X20type_X3D_X27submit_X27_X20class_X3D_X27btn_X2Daction_X20bgrn_X27_X20name_X3D_X27i_X25s_X27_X20onclick_X3D_X27return_X20confirm_X28_X22Confirm_X20installation_X20of_X20_X25s_X22_X29_X27_X3EInstall_X3C_X2Fbutton_X3E),
+  /* K153 */  be_nested_str(v_X25s_X2E_X25s_X2E_X25s_X2E_X25s),
+  /* K154 */  be_nested_str(has_arg),
+  /* K155 */  be_nested_str(store),
+  /* K156 */  be_nested_str(page_extensions_store),
+  /* K157 */  be_nested_str(page_extensions_mgr),
+  /* K158 */  be_nested_str(EXT_X3A_X20unable_X20to_X20parse_X20manifest_X20line_X20_X27_X25s_X27),
+  /* K159 */  be_nested_str(EXT_X3A_X20manifest_X20is_X20missing_X20_X27name_X2Ffile_X2Fversion_X27_X20in_X20map_X20_X27_X25s_X27),
+  /* K160 */  be_nested_str(_X5Bno_X20description_X5D),
 };
 
 
@@ -517,7 +521,7 @@ be_local_closure(class_Extension_manager_page_extensions_mgr,   /* name */
 ********************************************************************/
 be_local_closure(class_Extension_manager_install_from_store,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    14,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -528,79 +532,98 @@ be_local_closure(class_Extension_manager_install_from_store,   /* name */
     &be_ktab_class_Extension_manager,     /* shared constants */
     &be_const_str_install_from_store,
     &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
+    ( &(const binstruction[91]) {  /* code */
       0xA40A2A00,  //  0000  IMPORT	R2	K21
-      0x8C0C014B,  //  0001  GETMET	R3	R0	K75
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x5C040600,  //  0004  MOVE	R1	R3
-      0x8C0C054C,  //  0005  GETMET	R3	R2	K76
-      0x5C140200,  //  0006  MOVE	R5	R1
-      0x5818001B,  //  0007  LDCONST	R6	K27
-      0x7C0C0600,  //  0008  CALL	R3	3
-      0x740E0000,  //  0009  JMPT	R3	#000B
-      0x0004031B,  //  000A  ADD	R1	R1	K27
-      0x600C0018,  //  000B  GETGBL	R3	G24
-      0x5810004D,  //  000C  LDCONST	R4	K77
-      0x88140105,  //  000D  GETMBR	R5	R0	K5
-      0x8818014E,  //  000E  GETMBR	R6	R0	K78
-      0x5C1C0200,  //  000F  MOVE	R7	R1
-      0x7C0C0800,  //  0010  CALL	R3	4
-      0xB8120E00,  //  0011  GETNGBL	R4	K7
-      0x60140018,  //  0012  GETGBL	R5	G24
-      0x5818004F,  //  0013  LDCONST	R6	K79
-      0x5C1C0600,  //  0014  MOVE	R7	R3
-      0x7C140400,  //  0015  CALL	R5	2
-      0x58180009,  //  0016  LDCONST	R6	K9
-      0x7C100400,  //  0017  CALL	R4	2
-      0xA802001E,  //  0018  EXBLK	0	#0038
-      0x60100018,  //  0019  GETGBL	R4	G24
-      0x58140050,  //  001A  LDCONST	R5	K80
-      0x88180151,  //  001B  GETMBR	R6	R0	K81
-      0x5C1C0200,  //  001C  MOVE	R7	R1
-      0x7C100600,  //  001D  CALL	R4	3
-      0xB8161400,  //  001E  GETNGBL	R5	K10
-      0x7C140000,  //  001F  CALL	R5	0
-      0x8C180B0B,  //  0020  GETMET	R6	R5	K11
-      0x5C200600,  //  0021  MOVE	R8	R3
-      0x7C180400,  //  0022  CALL	R6	2
-      0x8C180B0C,  //  0023  GETMET	R6	R5	K12
-      0x7C180200,  //  0024  CALL	R6	1
-      0x541E00C7,  //  0025  LDINT	R7	200
-      0x201C0C07,  //  0026  NE	R7	R6	R7
-      0x781E0008,  //  0027  JMPF	R7	#0031
-      0xB81E0E00,  //  0028  GETNGBL	R7	K7
-      0x60200018,  //  0029  GETGBL	R8	G24
-      0x58240052,  //  002A  LDCONST	R9	K82
-      0x5C280C00,  //  002B  MOVE	R10	R6
-      0x7C200400,  //  002C  CALL	R8	2
-      0x5824000E,  //  002D  LDCONST	R9	K14
-      0x7C1C0400,  //  002E  CALL	R7	2
-      0xA8040001,  //  002F  EXBLK	1	1
-      0x80000E00,  //  0030  RET	0
-      0x8C1C0B53,  //  0031  GETMET	R7	R5	K83
-      0x5C240800,  //  0032  MOVE	R9	R4
-      0x7C1C0400,  //  0033  CALL	R7	2
-      0x8C1C0B12,  //  0034  GETMET	R7	R5	K18
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0xA8040001,  //  0036  EXBLK	1	1
-      0x7002000E,  //  0037  JMP		#0047
-      0xAC100002,  //  0038  CATCH	R4	0	2
-      0x7002000B,  //  0039  JMP		#0046
-      0xB81A0000,  //  003A  GETNGBL	R6	K0
-      0x8C180D07,  //  003B  GETMET	R6	R6	K7
-      0x60200018,  //  003C  GETGBL	R8	G24
-      0x58240054,  //  003D  LDCONST	R9	K84
-      0x5C280800,  //  003E  MOVE	R10	R4
-      0x5C2C0A00,  //  003F  MOVE	R11	R5
-      0x7C200600,  //  0040  CALL	R8	3
-      0x5824000E,  //  0041  LDCONST	R9	K14
-      0x7C180600,  //  0042  CALL	R6	3
-      0x4C180000,  //  0043  LDNIL	R6
-      0x80040C00,  //  0044  RET	1	R6
-      0x70020000,  //  0045  JMP		#0047
-      0xB0080000,  //  0046  RAISE	2	R0	R0
-      0x80000000,  //  0047  RET	0
+      0xA40E9600,  //  0001  IMPORT	R3	K75
+      0x8C10014C,  //  0002  GETMET	R4	R0	K76
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C100400,  //  0004  CALL	R4	2
+      0x5C040800,  //  0005  MOVE	R1	R4
+      0x8C10054D,  //  0006  GETMET	R4	R2	K77
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x581C001B,  //  0008  LDCONST	R7	K27
+      0x7C100600,  //  0009  CALL	R4	3
+      0x74120000,  //  000A  JMPT	R4	#000C
+      0x0004031B,  //  000B  ADD	R1	R1	K27
+      0x60100018,  //  000C  GETGBL	R4	G24
+      0x5814004E,  //  000D  LDCONST	R5	K78
+      0x88180105,  //  000E  GETMBR	R6	R0	K5
+      0x881C014F,  //  000F  GETMBR	R7	R0	K79
+      0x5C200200,  //  0010  MOVE	R8	R1
+      0x7C100800,  //  0011  CALL	R4	4
+      0xB8160E00,  //  0012  GETNGBL	R5	K7
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0050,  //  0014  LDCONST	R7	K80
+      0x5C200800,  //  0015  MOVE	R8	R4
+      0x7C180400,  //  0016  CALL	R6	2
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x7C140400,  //  0018  CALL	R5	2
+      0xA8020030,  //  0019  EXBLK	0	#004B
+      0x60140018,  //  001A  GETGBL	R5	G24
+      0x58180051,  //  001B  LDCONST	R6	K81
+      0x881C0152,  //  001C  GETMBR	R7	R0	K82
+      0x5C200200,  //  001D  MOVE	R8	R1
+      0x7C140600,  //  001E  CALL	R5	3
+      0xB81A1400,  //  001F  GETNGBL	R6	K10
+      0x7C180000,  //  0020  CALL	R6	0
+      0x8C1C0D0B,  //  0021  GETMET	R7	R6	K11
+      0x5C240800,  //  0022  MOVE	R9	R4
+      0x7C1C0400,  //  0023  CALL	R7	2
+      0x8C1C0D0C,  //  0024  GETMET	R7	R6	K12
+      0x7C1C0200,  //  0025  CALL	R7	1
+      0x542200C7,  //  0026  LDINT	R8	200
+      0x20200E08,  //  0027  NE	R8	R7	R8
+      0x78220008,  //  0028  JMPF	R8	#0032
+      0xB8220E00,  //  0029  GETNGBL	R8	K7
+      0x60240018,  //  002A  GETGBL	R9	G24
+      0x58280053,  //  002B  LDCONST	R10	K83
+      0x5C2C0E00,  //  002C  MOVE	R11	R7
+      0x7C240400,  //  002D  CALL	R9	2
+      0x5828000E,  //  002E  LDCONST	R10	K14
+      0x7C200400,  //  002F  CALL	R8	2
+      0xA8040001,  //  0030  EXBLK	1	1
+      0x80001000,  //  0031  RET	0
+      0x8C200D54,  //  0032  GETMET	R8	R6	K84
+      0x5C280A00,  //  0033  MOVE	R10	R5
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C240D12,  //  0035  GETMET	R9	R6	K18
+      0x7C240200,  //  0036  CALL	R9	1
+      0x8C240755,  //  0037  GETMET	R9	R3	K85
+      0x5C2C0A00,  //  0038  MOVE	R11	R5
+      0x7C240400,  //  0039  CALL	R9	2
+      0x78260007,  //  003A  JMPF	R9	#0043
+      0xB8260E00,  //  003B  GETNGBL	R9	K7
+      0x60280018,  //  003C  GETGBL	R10	G24
+      0x582C0056,  //  003D  LDCONST	R11	K86
+      0x5C300A00,  //  003E  MOVE	R12	R5
+      0x5C341000,  //  003F  MOVE	R13	R8
+      0x7C280600,  //  0040  CALL	R10	3
+      0x7C240200,  //  0041  CALL	R9	1
+      0x70020005,  //  0042  JMP		#0049
+      0x60240018,  //  0043  GETGBL	R9	G24
+      0x58280057,  //  0044  LDCONST	R10	K87
+      0x5C2C0A00,  //  0045  MOVE	R11	R5
+      0x5C301000,  //  0046  MOVE	R12	R8
+      0x7C240600,  //  0047  CALL	R9	3
+      0xB006B009,  //  0048  RAISE	1	K88	R9
+      0xA8040001,  //  0049  EXBLK	1	1
+      0x7002000E,  //  004A  JMP		#005A
+      0xAC140002,  //  004B  CATCH	R5	0	2
+      0x7002000B,  //  004C  JMP		#0059
+      0xB81E0000,  //  004D  GETNGBL	R7	K0
+      0x8C1C0F07,  //  004E  GETMET	R7	R7	K7
+      0x60240018,  //  004F  GETGBL	R9	G24
+      0x58280059,  //  0050  LDCONST	R10	K89
+      0x5C2C0A00,  //  0051  MOVE	R11	R5
+      0x5C300C00,  //  0052  MOVE	R12	R6
+      0x7C240600,  //  0053  CALL	R9	3
+      0x5828000E,  //  0054  LDCONST	R10	K14
+      0x7C1C0600,  //  0055  CALL	R7	3
+      0x4C1C0000,  //  0056  LDNIL	R7
+      0x80040E00,  //  0057  RET	1	R7
+      0x70020000,  //  0058  JMP		#005A
+      0xB0080000,  //  0059  RAISE	2	R0	R0
+      0x80000000,  //  005A  RET	0
     })
   )
 );
@@ -626,7 +649,7 @@ be_local_closure(class_Extension_manager_web_add_button,   /* name */
     ( &(const binstruction[ 5]) {  /* code */
       0xA4063A00,  //  0000  IMPORT	R1	K29
       0x8C080321,  //  0001  GETMET	R2	R1	K33
-      0x58100055,  //  0002  LDCONST	R4	K85
+      0x5810005A,  //  0002  LDCONST	R4	K90
       0x7C080400,  //  0003  CALL	R2	2
       0x80000000,  //  0004  RET	0
     })
@@ -656,18 +679,18 @@ be_local_closure(class_Extension_manager_list_installed_ext,   /* name */
       0x60040013,  //  0001  GETGBL	R1	G19
       0x7C040000,  //  0002  CALL	R1	0
       0x60080010,  //  0003  GETGBL	R2	G16
-      0x8C0C0156,  //  0004  GETMET	R3	R0	K86
+      0x8C0C015B,  //  0004  GETMET	R3	R0	K91
       0x7C0C0200,  //  0005  CALL	R3	1
       0x7C080200,  //  0006  CALL	R2	1
       0xA8020006,  //  0007  EXBLK	0	#000F
       0x5C0C0400,  //  0008  MOVE	R3	R2
       0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C10014B,  //  000A  GETMET	R4	R0	K75
+      0x8C10014C,  //  000A  GETMET	R4	R0	K76
       0x5C180600,  //  000B  MOVE	R6	R3
       0x7C100400,  //  000C  CALL	R4	2
       0x98040803,  //  000D  SETIDX	R1	R4	R3
       0x7001FFF8,  //  000E  JMP		#0008
-      0x58080057,  //  000F  LDCONST	R2	K87
+      0x5808005C,  //  000F  LDCONST	R2	K92
       0xAC080200,  //  0010  CATCH	R2	1	0
       0xB0080000,  //  0011  RAISE	2	R0	R0
       0x80040200,  //  0012  RET	1	R1
@@ -695,34 +718,34 @@ be_local_closure(class_Extension_manager_list_extensions,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
       0x58000014,  //  0000  LDCONST	R0	K20
-      0xA406B000,  //  0001  IMPORT	R1	K88
+      0xA4069600,  //  0001  IMPORT	R1	K75
       0xA40A2A00,  //  0002  IMPORT	R2	K21
       0x600C0012,  //  0003  GETGBL	R3	G18
       0x7C0C0000,  //  0004  CALL	R3	0
       0x60100010,  //  0005  GETGBL	R4	G16
-      0x8C140359,  //  0006  GETMET	R5	R1	K89
-      0x881C0151,  //  0007  GETMBR	R7	R0	K81
+      0x8C14035D,  //  0006  GETMET	R5	R1	K93
+      0x881C0152,  //  0007  GETMBR	R7	R0	K82
       0x7C140400,  //  0008  CALL	R5	2
       0x7C100200,  //  0009  CALL	R4	1
       0xA8020010,  //  000A  EXBLK	0	#001C
       0x5C140800,  //  000B  MOVE	R5	R4
       0x7C140000,  //  000C  CALL	R5	0
-      0x8C18054C,  //  000D  GETMET	R6	R2	K76
+      0x8C18054D,  //  000D  GETMET	R6	R2	K77
       0x5C200A00,  //  000E  MOVE	R8	R5
       0x5824001B,  //  000F  LDCONST	R9	K27
       0x7C180600,  //  0010  CALL	R6	3
       0x741A0004,  //  0011  JMPT	R6	#0017
-      0x8C18054C,  //  0012  GETMET	R6	R2	K76
+      0x8C18054D,  //  0012  GETMET	R6	R2	K77
       0x5C200A00,  //  0013  MOVE	R8	R5
-      0x5824005A,  //  0014  LDCONST	R9	K90
+      0x5824005E,  //  0014  LDCONST	R9	K94
       0x7C180600,  //  0015  CALL	R6	3
       0x781A0003,  //  0016  JMPF	R6	#001B
-      0x8C18075B,  //  0017  GETMET	R6	R3	K91
-      0x88200151,  //  0018  GETMBR	R8	R0	K81
+      0x8C18075F,  //  0017  GETMET	R6	R3	K95
+      0x88200152,  //  0018  GETMBR	R8	R0	K82
       0x00201005,  //  0019  ADD	R8	R8	R5
       0x7C180400,  //  001A  CALL	R6	2
       0x7001FFEE,  //  001B  JMP		#000B
-      0x58100057,  //  001C  LDCONST	R4	K87
+      0x5810005C,  //  001C  LDCONST	R4	K92
       0xAC100200,  //  001D  CATCH	R4	1	0
       0xB0080000,  //  001E  RAISE	2	R0	R0
       0x80040600,  //  001F  RET	1	R3
@@ -750,33 +773,33 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[165]) {  /* code */
       0xA4063A00,  //  0000  IMPORT	R1	K29
-      0xA40AB000,  //  0001  IMPORT	R2	K88
+      0xA40A9600,  //  0001  IMPORT	R2	K75
       0xA40E2A00,  //  0002  IMPORT	R3	K21
-      0x8C10035C,  //  0003  GETMET	R4	R1	K92
+      0x8C100360,  //  0003  GETMET	R4	R1	K96
       0x7C100200,  //  0004  CALL	R4	1
       0x74120001,  //  0005  JMPT	R4	#0008
       0x4C100000,  //  0006  LDNIL	R4
       0x80040800,  //  0007  RET	1	R4
       0xA8020079,  //  0008  EXBLK	0	#0083
-      0x8C10035D,  //  0009  GETMET	R4	R1	K93
+      0x8C100361,  //  0009  GETMET	R4	R1	K97
       0x58180016,  //  000A  LDCONST	R6	K22
       0x7C100400,  //  000B  CALL	R4	2
       0x94140916,  //  000C  GETIDX	R5	R4	K22
-      0x401A2F5E,  //  000D  CONNECT	R6	K23	K94
+      0x401A2F62,  //  000D  CONNECT	R6	K23	K98
       0x94180806,  //  000E  GETIDX	R6	R4	R6
       0x1C1C0B3A,  //  000F  EQ	R7	R5	K58
       0x781E0006,  //  0010  JMPF	R7	#0018
       0x201C0D2D,  //  0011  NE	R7	R6	K45
       0x781E0003,  //  0012  JMPF	R7	#0017
       0xB81E0000,  //  0013  GETNGBL	R7	K0
-      0x8C1C0F5F,  //  0014  GETMET	R7	R7	K95
+      0x8C1C0F63,  //  0014  GETMET	R7	R7	K99
       0x5C240C00,  //  0015  MOVE	R9	R6
       0x7C1C0400,  //  0016  CALL	R7	2
       0x70020063,  //  0017  JMP		#007C
       0x1C1C0B39,  //  0018  EQ	R7	R5	K57
       0x781E0004,  //  0019  JMPF	R7	#001F
       0xB81E0000,  //  001A  GETNGBL	R7	K0
-      0x8C1C0F60,  //  001B  GETMET	R7	R7	K96
+      0x8C1C0F64,  //  001B  GETMET	R7	R7	K100
       0x5C240C00,  //  001C  MOVE	R9	R6
       0x7C1C0400,  //  001D  CALL	R7	2
       0x7002005C,  //  001E  JMP		#007C
@@ -787,7 +810,7 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
       0x4C1C0000,  //  0023  LDNIL	R7
       0x1C200B3E,  //  0024  EQ	R8	R5	K62
       0x7822000A,  //  0025  JMPF	R8	#0031
-      0x8C20074C,  //  0026  GETMET	R8	R3	K76
+      0x8C20074D,  //  0026  GETMET	R8	R3	K77
       0x5C280C00,  //  0027  MOVE	R10	R6
       0x582C001B,  //  0028  LDCONST	R11	K27
       0x7C200600,  //  0029  CALL	R8	3
@@ -795,23 +818,23 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
       0x5421FFFA,  //  002B  LDINT	R8	-5
       0x40222C08,  //  002C  CONNECT	R8	K22	R8
       0x94200C08,  //  002D  GETIDX	R8	R6	R8
-      0x00201161,  //  002E  ADD	R8	R8	K97
+      0x00201165,  //  002E  ADD	R8	R8	K101
       0x5C1C1000,  //  002F  MOVE	R7	R8
       0x7002000B,  //  0030  JMP		#003D
       0x1C200B3F,  //  0031  EQ	R8	R5	K63
       0x78220009,  //  0032  JMPF	R8	#003D
-      0x8C20074C,  //  0033  GETMET	R8	R3	K76
+      0x8C20074D,  //  0033  GETMET	R8	R3	K77
       0x5C280C00,  //  0034  MOVE	R10	R6
-      0x582C005A,  //  0035  LDCONST	R11	K90
+      0x582C005E,  //  0035  LDCONST	R11	K94
       0x7C200600,  //  0036  CALL	R8	3
       0x78220004,  //  0037  JMPF	R8	#003D
       0x5421FFF9,  //  0038  LDINT	R8	-6
       0x40222C08,  //  0039  CONNECT	R8	K22	R8
       0x94200C08,  //  003A  GETIDX	R8	R6	R8
-      0x00201162,  //  003B  ADD	R8	R8	K98
+      0x00201166,  //  003B  ADD	R8	R8	K102
       0x5C1C1000,  //  003C  MOVE	R7	R8
       0x781E0016,  //  003D  JMPF	R7	#0055
-      0x8C200563,  //  003E  GETMET	R8	R2	K99
+      0x8C200567,  //  003E  GETMET	R8	R2	K103
       0x5C280C00,  //  003F  MOVE	R10	R6
       0x5C2C0E00,  //  0040  MOVE	R11	R7
       0x7C200600,  //  0041  CALL	R8	3
@@ -830,52 +853,52 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
       0x98240E0A,  //  004E  SETIDX	R9	R7	R10
       0xB8260000,  //  004F  GETNGBL	R9	K0
       0x8824132A,  //  0050  GETMBR	R9	R9	K42
-      0x8C241364,  //  0051  GETMET	R9	R9	K100
+      0x8C241368,  //  0051  GETMET	R9	R9	K104
       0x5C2C0C00,  //  0052  MOVE	R11	R6
       0x7C240400,  //  0053  CALL	R9	2
       0x70020006,  //  0054  JMP		#005C
       0xB8220E00,  //  0055  GETNGBL	R8	K7
       0x60240018,  //  0056  GETGBL	R9	G24
-      0x58280065,  //  0057  LDCONST	R10	K101
+      0x58280069,  //  0057  LDCONST	R10	K105
       0x5C2C0800,  //  0058  MOVE	R11	R4
       0x7C240400,  //  0059  CALL	R9	2
       0x58280009,  //  005A  LDCONST	R10	K9
       0x7C200400,  //  005B  CALL	R8	2
       0x7002001E,  //  005C  JMP		#007C
-      0x1C1C0B66,  //  005D  EQ	R7	R5	K102
+      0x1C1C0B6A,  //  005D  EQ	R7	R5	K106
       0x781E0009,  //  005E  JMPF	R7	#0069
       0x201C0D2D,  //  005F  NE	R7	R6	K45
       0x781E0006,  //  0060  JMPF	R7	#0068
       0xB81E0000,  //  0061  GETNGBL	R7	K0
-      0x8C1C0F60,  //  0062  GETMET	R7	R7	K96
+      0x8C1C0F64,  //  0062  GETMET	R7	R7	K100
       0x5C240C00,  //  0063  MOVE	R9	R6
       0x7C1C0400,  //  0064  CALL	R7	2
-      0x8C1C0564,  //  0065  GETMET	R7	R2	K100
+      0x8C1C0568,  //  0065  GETMET	R7	R2	K104
       0x5C240C00,  //  0066  MOVE	R9	R6
       0x7C1C0400,  //  0067  CALL	R7	2
       0x70020012,  //  0068  JMP		#007C
-      0x1C1C0B67,  //  0069  EQ	R7	R5	K103
+      0x1C1C0B6B,  //  0069  EQ	R7	R5	K107
       0x781E0009,  //  006A  JMPF	R7	#0075
       0xB81E0000,  //  006B  GETNGBL	R7	K0
-      0x8C1C0F60,  //  006C  GETMET	R7	R7	K96
+      0x8C1C0F64,  //  006C  GETMET	R7	R7	K100
       0x5C240C00,  //  006D  MOVE	R9	R6
       0x7C1C0400,  //  006E  CALL	R7	2
-      0x8C1C0168,  //  006F  GETMET	R7	R0	K104
-      0x8C24014B,  //  0070  GETMET	R9	R0	K75
+      0x8C1C016C,  //  006F  GETMET	R7	R0	K108
+      0x8C24014C,  //  0070  GETMET	R9	R0	K76
       0x5C2C0C00,  //  0071  MOVE	R11	R6
       0x7C240400,  //  0072  CALL	R9	2
       0x7C1C0400,  //  0073  CALL	R7	2
       0x70020006,  //  0074  JMP		#007C
-      0x1C1C0B69,  //  0075  EQ	R7	R5	K105
+      0x1C1C0B6D,  //  0075  EQ	R7	R5	K109
       0x781E0004,  //  0076  JMPF	R7	#007C
-      0x8C1C0168,  //  0077  GETMET	R7	R0	K104
-      0x8C24014B,  //  0078  GETMET	R9	R0	K75
+      0x8C1C016C,  //  0077  GETMET	R7	R0	K108
+      0x8C24014C,  //  0078  GETMET	R9	R0	K76
       0x5C2C0C00,  //  0079  MOVE	R11	R6
       0x7C240400,  //  007A  CALL	R9	2
       0x7C1C0400,  //  007B  CALL	R7	2
-      0x8C1C036A,  //  007C  GETMET	R7	R1	K106
+      0x8C1C036E,  //  007C  GETMET	R7	R1	K110
       0x60240018,  //  007D  GETGBL	R9	G24
-      0x5828006B,  //  007E  LDCONST	R10	K107
+      0x5828006F,  //  007E  LDCONST	R10	K111
       0x7C240200,  //  007F  CALL	R9	1
       0x7C1C0400,  //  0080  CALL	R7	2
       0xA8040001,  //  0081  EXBLK	1	1
@@ -884,20 +907,20 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
       0x7002001D,  //  0084  JMP		#00A3
       0xB81A0E00,  //  0085  GETNGBL	R6	K7
       0x601C0018,  //  0086  GETGBL	R7	G24
-      0x5820006C,  //  0087  LDCONST	R8	K108
+      0x58200070,  //  0087  LDCONST	R8	K112
       0x5C240800,  //  0088  MOVE	R9	R4
       0x5C280A00,  //  0089  MOVE	R10	R5
       0x7C1C0600,  //  008A  CALL	R7	3
       0x5820000E,  //  008B  LDCONST	R8	K14
       0x7C180400,  //  008C  CALL	R6	2
       0x8C18031E,  //  008D  GETMET	R6	R1	K30
-      0x5820006D,  //  008E  LDCONST	R8	K109
+      0x58200071,  //  008E  LDCONST	R8	K113
       0x7C180400,  //  008F  CALL	R6	2
       0x8C180320,  //  0090  GETMET	R6	R1	K32
       0x7C180200,  //  0091  CALL	R6	1
       0x8C180321,  //  0092  GETMET	R6	R1	K33
       0x60200018,  //  0093  GETGBL	R8	G24
-      0x5824006E,  //  0094  LDCONST	R9	K110
+      0x58240072,  //  0094  LDCONST	R9	K114
       0x8C280328,  //  0095  GETMET	R10	R1	K40
       0x5C300800,  //  0096  MOVE	R12	R4
       0x7C280400,  //  0097  CALL	R10	2
@@ -907,7 +930,7 @@ be_local_closure(class_Extension_manager_page_extensions_ctl,   /* name */
       0x7C200600,  //  009B  CALL	R8	3
       0x7C180400,  //  009C  CALL	R6	2
       0x8C180348,  //  009D  GETMET	R6	R1	K72
-      0x8820036F,  //  009E  GETMBR	R8	R1	K111
+      0x88200373,  //  009E  GETMBR	R8	R1	K115
       0x7C180400,  //  009F  CALL	R6	2
       0x8C18034A,  //  00A0  GETMET	R6	R1	K74
       0x7C180200,  //  00A1  CALL	R6	1
@@ -985,15 +1008,15 @@ be_local_closure(class_Extension_manager_web_add_handler,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0xA4063A00,  //  0000  IMPORT	R1	K29
-      0x8C080370,  //  0001  GETMET	R2	R1	K112
-      0x5810006B,  //  0002  LDCONST	R4	K107
+      0x8C080374,  //  0001  GETMET	R2	R1	K116
+      0x5810006F,  //  0002  LDCONST	R4	K111
       0x84140000,  //  0003  CLOSURE	R5	P0
-      0x88180371,  //  0004  GETMBR	R6	R1	K113
+      0x88180375,  //  0004  GETMBR	R6	R1	K117
       0x7C080800,  //  0005  CALL	R2	4
-      0x8C080370,  //  0006  GETMET	R2	R1	K112
-      0x5810006B,  //  0007  LDCONST	R4	K107
+      0x8C080374,  //  0006  GETMET	R2	R1	K116
+      0x5810006F,  //  0007  LDCONST	R4	K111
       0x84140001,  //  0008  CLOSURE	R5	P1
-      0x88180372,  //  0009  GETMBR	R6	R1	K114
+      0x88180376,  //  0009  GETMBR	R6	R1	K118
       0x7C080800,  //  000A  CALL	R2	4
       0xA0000000,  //  000B  CLOSE	R0
       0x80000000,  //  000C  RET	0
@@ -1022,10 +1045,10 @@ be_local_closure(class_Extension_manager_list_extensions_in_fs,   /* name */
     ( &(const binstruction[36]) {  /* code */
       0x58000014,  //  0000  LDCONST	R0	K20
       0xA4062A00,  //  0001  IMPORT	R1	K21
-      0xB80AE600,  //  0002  GETNGBL	R2	K115
+      0xB80AEE00,  //  0002  GETNGBL	R2	K119
       0x7C080000,  //  0003  CALL	R2	0
       0x600C0010,  //  0004  GETGBL	R3	G16
-      0x8C100156,  //  0005  GETMET	R4	R0	K86
+      0x8C10015B,  //  0005  GETMET	R4	R0	K91
       0x7C100200,  //  0006  CALL	R4	1
       0x7C0C0200,  //  0007  CALL	R3	1
       0xA8020016,  //  0008  EXBLK	0	#0020
@@ -1046,13 +1069,13 @@ be_local_closure(class_Extension_manager_list_extensions_in_fs,   /* name */
       0x70020006,  //  0017  JMP		#001F
       0xB81A0E00,  //  0018  GETNGBL	R6	K7
       0x601C0018,  //  0019  GETGBL	R7	G24
-      0x58200074,  //  001A  LDCONST	R8	K116
+      0x58200078,  //  001A  LDCONST	R8	K120
       0x5C240800,  //  001B  MOVE	R9	R4
       0x7C1C0400,  //  001C  CALL	R7	2
       0x58200009,  //  001D  LDCONST	R8	K9
       0x7C180400,  //  001E  CALL	R6	2
       0x7001FFE8,  //  001F  JMP		#0009
-      0x580C0057,  //  0020  LDCONST	R3	K87
+      0x580C005C,  //  0020  LDCONST	R3	K92
       0xAC0C0200,  //  0021  CATCH	R3	1	0
       0xB0080000,  //  0022  RAISE	2	R0	R0
       0x80040400,  //  0023  RET	1	R2
@@ -1080,7 +1103,7 @@ be_local_closure(class_Extension_manager_init,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040375,  //  0001  GETMET	R1	R1	K117
+      0x8C040379,  //  0001  GETMET	R1	R1	K121
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0x80000000,  //  0004  RET	0
@@ -1109,14 +1132,14 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
     ( &(const binstruction[210]) {  /* code */
       0xA4063A00,  //  0000  IMPORT	R1	K29
       0xA40A2A00,  //  0001  IMPORT	R2	K21
-      0xA40EEC00,  //  0002  IMPORT	R3	K118
-      0x8C100377,  //  0003  GETMET	R4	R1	K119
+      0xA40EF400,  //  0002  IMPORT	R3	K122
+      0x8C10037B,  //  0003  GETMET	R4	R1	K123
       0x541A00C7,  //  0004  LDINT	R6	200
-      0x581C0078,  //  0005  LDCONST	R7	K120
+      0x581C007C,  //  0005  LDCONST	R7	K124
       0x7C100600,  //  0006  CALL	R4	3
       0x4C100000,  //  0007  LDNIL	R4
       0xA8020004,  //  0008  EXBLK	0	#000E
-      0x8C140179,  //  0009  GETMET	R5	R0	K121
+      0x8C14017D,  //  0009  GETMET	R5	R0	K125
       0x7C140200,  //  000A  CALL	R5	1
       0x5C100A00,  //  000B  MOVE	R4	R5
       0xA8040001,  //  000C  EXBLK	1	1
@@ -1124,38 +1147,38 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0xAC140002,  //  000E  CATCH	R5	0	2
       0x7002000E,  //  000F  JMP		#001F
       0x8C1C0321,  //  0010  GETMET	R7	R1	K33
-      0x5824007A,  //  0011  LDCONST	R9	K122
+      0x5824007E,  //  0011  LDCONST	R9	K126
       0x7C1C0400,  //  0012  CALL	R7	2
       0x8C1C0321,  //  0013  GETMET	R7	R1	K33
       0x60240018,  //  0014  GETGBL	R9	G24
-      0x5828007B,  //  0015  LDCONST	R10	K123
+      0x5828007F,  //  0015  LDCONST	R10	K127
       0x8C2C0328,  //  0016  GETMET	R11	R1	K40
       0x5C340C00,  //  0017  MOVE	R13	R6
       0x7C2C0400,  //  0018  CALL	R11	2
       0x7C240400,  //  0019  CALL	R9	2
       0x7C1C0400,  //  001A  CALL	R7	2
-      0x8C1C037C,  //  001B  GETMET	R7	R1	K124
+      0x8C1C0380,  //  001B  GETMET	R7	R1	K128
       0x7C1C0200,  //  001C  CALL	R7	1
       0x80000E00,  //  001D  RET	0
       0x70020000,  //  001E  JMP		#0020
       0xB0080000,  //  001F  RAISE	2	R0	R0
-      0x8C14057D,  //  0020  GETMET	R5	R2	K125
+      0x8C140581,  //  0020  GETMET	R5	R2	K129
       0x5C1C0800,  //  0021  MOVE	R7	R4
-      0x5820007E,  //  0022  LDCONST	R8	K126
+      0x58200082,  //  0022  LDCONST	R8	K130
       0x7C140600,  //  0023  CALL	R5	3
       0x8C180321,  //  0024  GETMET	R6	R1	K33
-      0x5820007F,  //  0025  LDCONST	R8	K127
+      0x58200083,  //  0025  LDCONST	R8	K131
       0x7C180400,  //  0026  CALL	R6	2
       0x8C180321,  //  0027  GETMET	R6	R1	K33
       0x60200018,  //  0028  GETGBL	R8	G24
-      0x58240080,  //  0029  LDCONST	R9	K128
+      0x58240084,  //  0029  LDCONST	R9	K132
       0x5C280A00,  //  002A  MOVE	R10	R5
       0x7C200400,  //  002B  CALL	R8	2
       0x7C180400,  //  002C  CALL	R6	2
       0x8C180321,  //  002D  GETMET	R6	R1	K33
-      0x58200081,  //  002E  LDCONST	R8	K129
+      0x58200085,  //  002E  LDCONST	R8	K133
       0x7C180400,  //  002F  CALL	R6	2
-      0x8C180182,  //  0030  GETMET	R6	R0	K130
+      0x8C180186,  //  0030  GETMET	R6	R0	K134
       0x7C180200,  //  0031  CALL	R6	1
       0x581C0017,  //  0032  LDCONST	R7	K23
       0x58200016,  //  0033  LDCONST	R8	K22
@@ -1166,7 +1189,7 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x78260092,  //  0038  JMPF	R9	#00CC
       0x8C24051A,  //  0039  GETMET	R9	R2	K26
       0x5C2C0800,  //  003A  MOVE	R11	R4
-      0x58300083,  //  003B  LDCONST	R12	K131
+      0x58300087,  //  003B  LDCONST	R12	K135
       0x5C341000,  //  003C  MOVE	R13	R8
       0x7C240800,  //  003D  CALL	R9	4
       0x14281316,  //  003E  LT	R10	R9	K22
@@ -1177,33 +1200,33 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x5C241400,  //  0043  MOVE	R9	R10
       0x40281009,  //  0044  CONNECT	R10	R8	R9
       0x9428080A,  //  0045  GETIDX	R10	R4	R10
-      0x8C2C0184,  //  0046  GETMET	R11	R0	K132
+      0x8C2C0188,  //  0046  GETMET	R11	R0	K136
       0x5C341400,  //  0047  MOVE	R13	R10
       0x7C2C0400,  //  0048  CALL	R11	2
       0x4C300000,  //  0049  LDNIL	R12
       0x2030160C,  //  004A  NE	R12	R11	R12
       0x7832007C,  //  004B  JMPF	R12	#00C9
       0x94301703,  //  004C  GETIDX	R12	R11	K3
-      0x8C340185,  //  004D  GETMET	R13	R0	K133
+      0x8C340189,  //  004D  GETMET	R13	R0	K137
       0x5C3C1800,  //  004E  MOVE	R15	R12
       0x7C340400,  //  004F  CALL	R13	2
       0x8C380328,  //  0050  GETMET	R14	R1	K40
       0x94401733,  //  0051  GETIDX	R16	R11	K51
       0x7C380400,  //  0052  CALL	R14	2
-      0x943C1786,  //  0053  GETIDX	R15	R11	K134
-      0x8C400587,  //  0054  GETMET	R16	R2	K135
+      0x943C178A,  //  0053  GETIDX	R15	R11	K138
+      0x8C40058B,  //  0054  GETMET	R16	R2	K139
       0x8C480328,  //  0055  GETMET	R18	R1	K40
       0x94501735,  //  0056  GETIDX	R20	R11	K53
       0x7C480400,  //  0057  CALL	R18	2
-      0x584C0088,  //  0058  LDCONST	R19	K136
-      0x58500089,  //  0059  LDCONST	R20	K137
+      0x584C008C,  //  0058  LDCONST	R19	K140
+      0x5850008D,  //  0059  LDCONST	R20	K141
       0x7C400800,  //  005A  CALL	R16	4
-      0x9444178A,  //  005B  GETIDX	R17	R11	K138
+      0x9444178E,  //  005B  GETIDX	R17	R11	K142
       0x50480000,  //  005C  LDBOOL	R18	0	0
       0x4C4C0000,  //  005D  LDNIL	R19
       0x4C500000,  //  005E  LDNIL	R20
-      0x8C54014B,  //  005F  GETMET	R21	R0	K75
-      0x945C1786,  //  0060  GETIDX	R23	R11	K134
+      0x8C54014C,  //  005F  GETMET	R21	R0	K76
+      0x945C178A,  //  0060  GETIDX	R23	R11	K138
       0x7C540400,  //  0061  CALL	R21	2
       0x5C502A00,  //  0062  MOVE	R20	R21
       0x8C540328,  //  0063  GETMET	R21	R1	K40
@@ -1238,26 +1261,26 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x505C0200,  //  0080  LDBOOL	R23	1	0
       0x8C600321,  //  0081  GETMET	R24	R1	K33
       0x60680018,  //  0082  GETGBL	R26	G24
-      0x586C008B,  //  0083  LDCONST	R27	K139
+      0x586C008F,  //  0083  LDCONST	R27	K143
       0x5C700E00,  //  0084  MOVE	R28	R7
       0x5C741C00,  //  0085  MOVE	R29	R14
-      0x8C780185,  //  0086  GETMET	R30	R0	K133
+      0x8C780189,  //  0086  GETMET	R30	R0	K137
       0x5C801800,  //  0087  MOVE	R32	R12
       0x7C780400,  //  0088  CALL	R30	2
       0x7C680800,  //  0089  CALL	R26	4
       0x7C600400,  //  008A  CALL	R24	2
       0x785E0003,  //  008B  JMPF	R23	#0090
       0x8C600321,  //  008C  GETMET	R24	R1	K33
-      0x5868008C,  //  008D  LDCONST	R26	K140
+      0x58680090,  //  008D  LDCONST	R26	K144
       0x7C600400,  //  008E  CALL	R24	2
       0x70020003,  //  008F  JMP		#0094
       0x784A0002,  //  0090  JMPF	R18	#0094
       0x8C600321,  //  0091  GETMET	R24	R1	K33
-      0x5868008D,  //  0092  LDCONST	R26	K141
+      0x58680091,  //  0092  LDCONST	R26	K145
       0x7C600400,  //  0093  CALL	R24	2
       0x8C600321,  //  0094  GETMET	R24	R1	K33
       0x60680018,  //  0095  GETGBL	R26	G24
-      0x586C008E,  //  0096  LDCONST	R27	K142
+      0x586C0092,  //  0096  LDCONST	R27	K146
       0x5C700E00,  //  0097  MOVE	R28	R7
       0x5C740E00,  //  0098  MOVE	R29	R7
       0x5C782000,  //  0099  MOVE	R30	R16
@@ -1266,32 +1289,32 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x785E0008,  //  009C  JMPF	R23	#00A6
       0x8C600321,  //  009D  GETMET	R24	R1	K33
       0x60680018,  //  009E  GETGBL	R26	G24
-      0x586C008F,  //  009F  LDCONST	R27	K143
-      0x8C700185,  //  00A0  GETMET	R28	R0	K133
+      0x586C0093,  //  009F  LDCONST	R27	K147
+      0x8C700189,  //  00A0  GETMET	R28	R0	K137
       0x5C782600,  //  00A1  MOVE	R30	R19
       0x7C700400,  //  00A2  CALL	R28	2
       0x5C741A00,  //  00A3  MOVE	R29	R13
       0x7C680600,  //  00A4  CALL	R26	3
       0x7C600400,  //  00A5  CALL	R24	2
       0x8C600321,  //  00A6  GETMET	R24	R1	K33
-      0x58680090,  //  00A7  LDCONST	R26	K144
+      0x58680094,  //  00A7  LDCONST	R26	K148
       0x7C600400,  //  00A8  CALL	R24	2
       0x784A0013,  //  00A9  JMPF	R18	#00BE
       0x785E0007,  //  00AA  JMPF	R23	#00B3
       0x8C600321,  //  00AB  GETMET	R24	R1	K33
       0x60680018,  //  00AC  GETGBL	R26	G24
-      0x586C0091,  //  00AD  LDCONST	R27	K145
+      0x586C0095,  //  00AD  LDCONST	R27	K149
       0x5C702C00,  //  00AE  MOVE	R28	R22
       0x5C742C00,  //  00AF  MOVE	R29	R22
       0x7C680600,  //  00B0  CALL	R26	3
       0x7C600400,  //  00B1  CALL	R24	2
       0x70020002,  //  00B2  JMP		#00B6
       0x8C600321,  //  00B3  GETMET	R24	R1	K33
-      0x58680092,  //  00B4  LDCONST	R26	K146
+      0x58680096,  //  00B4  LDCONST	R26	K150
       0x7C600400,  //  00B5  CALL	R24	2
       0x8C600321,  //  00B6  GETMET	R24	R1	K33
       0x60680018,  //  00B7  GETGBL	R26	G24
-      0x586C0093,  //  00B8  LDCONST	R27	K147
+      0x586C0097,  //  00B8  LDCONST	R27	K151
       0x5C702C00,  //  00B9  MOVE	R28	R22
       0x5C742C00,  //  00BA  MOVE	R29	R22
       0x7C680600,  //  00BB  CALL	R26	3
@@ -1299,7 +1322,7 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x70020006,  //  00BD  JMP		#00C5
       0x8C600321,  //  00BE  GETMET	R24	R1	K33
       0x60680018,  //  00BF  GETGBL	R26	G24
-      0x586C0094,  //  00C0  LDCONST	R27	K148
+      0x586C0098,  //  00C0  LDCONST	R27	K152
       0x5C702A00,  //  00C1  MOVE	R28	R21
       0x5C741C00,  //  00C2  MOVE	R29	R14
       0x7C680600,  //  00C3  CALL	R26	3
@@ -1314,7 +1337,7 @@ be_local_closure(class_Extension_manager_page_extensions_store,   /* name */
       0x8C240321,  //  00CC  GETMET	R9	R1	K33
       0x582C0045,  //  00CD  LDCONST	R11	K69
       0x7C240400,  //  00CE  CALL	R9	2
-      0x8C24037C,  //  00CF  GETMET	R9	R1	K124
+      0x8C240380,  //  00CF  GETMET	R9	R1	K128
       0x7C240200,  //  00D0  CALL	R9	1
       0x80000000,  //  00D1  RET	0
     })
@@ -1342,7 +1365,7 @@ be_local_closure(class_Extension_manager_version_string,   /* name */
     ( &(const binstruction[19]) {  /* code */
       0x58040014,  //  0000  LDCONST	R1	K20
       0x60080018,  //  0001  GETGBL	R2	G24
-      0x580C0095,  //  0002  LDCONST	R3	K149
+      0x580C0099,  //  0002  LDCONST	R3	K153
       0x54120017,  //  0003  LDINT	R4	24
       0x3C100004,  //  0004  SHR	R4	R0	R4
       0x541600FE,  //  0005  LDINT	R5	255
@@ -1383,20 +1406,20 @@ be_local_closure(class_Extension_manager_page_extensions_mgr_dispatcher,   /* na
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
       0xA4063A00,  //  0000  IMPORT	R1	K29
-      0x8C08035C,  //  0001  GETMET	R2	R1	K92
+      0x8C080360,  //  0001  GETMET	R2	R1	K96
       0x7C080200,  //  0002  CALL	R2	1
       0x740A0001,  //  0003  JMPT	R2	#0006
       0x4C080000,  //  0004  LDNIL	R2
       0x80040400,  //  0005  RET	1	R2
-      0x8C080396,  //  0006  GETMET	R2	R1	K150
-      0x58100097,  //  0007  LDCONST	R4	K151
+      0x8C08039A,  //  0006  GETMET	R2	R1	K154
+      0x5810009B,  //  0007  LDCONST	R4	K155
       0x7C080400,  //  0008  CALL	R2	2
       0x780A0003,  //  0009  JMPF	R2	#000E
-      0x8C080198,  //  000A  GETMET	R2	R0	K152
+      0x8C08019C,  //  000A  GETMET	R2	R0	K156
       0x7C080200,  //  000B  CALL	R2	1
       0x80040400,  //  000C  RET	1	R2
       0x70020002,  //  000D  JMP		#0011
-      0x8C080199,  //  000E  GETMET	R2	R0	K153
+      0x8C08019D,  //  000E  GETMET	R2	R0	K157
       0x7C080200,  //  000F  CALL	R2	1
       0x80040400,  //  0010  RET	1	R2
       0x80000000,  //  0011  RET	0
@@ -1424,8 +1447,8 @@ be_local_closure(class_Extension_manager_manifest_decode,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[58]) {  /* code */
       0x58040014,  //  0000  LDCONST	R1	K20
-      0xA40AEC00,  //  0001  IMPORT	R2	K118
-      0x8C0C055F,  //  0002  GETMET	R3	R2	K95
+      0xA40AF400,  //  0001  IMPORT	R2	K122
+      0x8C0C0563,  //  0002  GETMET	R3	R2	K99
       0x5C140000,  //  0003  MOVE	R5	R0
       0x7C0C0400,  //  0004  CALL	R3	2
       0x4C100000,  //  0005  LDNIL	R4
@@ -1433,7 +1456,7 @@ be_local_closure(class_Extension_manager_manifest_decode,   /* name */
       0x78120008,  //  0007  JMPF	R4	#0011
       0xB8120E00,  //  0008  GETNGBL	R4	K7
       0x60140018,  //  0009  GETGBL	R5	G24
-      0x5818009A,  //  000A  LDCONST	R6	K154
+      0x5818009E,  //  000A  LDCONST	R6	K158
       0x5C1C0000,  //  000B  MOVE	R7	R0
       0x7C140400,  //  000C  CALL	R5	2
       0x58180009,  //  000D  LDCONST	R6	K9
@@ -1445,7 +1468,7 @@ be_local_closure(class_Extension_manager_manifest_decode,   /* name */
       0x7C100400,  //  0013  CALL	R4	2
       0x78120007,  //  0014  JMPF	R4	#001D
       0x8C10072B,  //  0015  GETMET	R4	R3	K43
-      0x58180086,  //  0016  LDCONST	R6	K134
+      0x5818008A,  //  0016  LDCONST	R6	K138
       0x7C100400,  //  0017  CALL	R4	2
       0x78120003,  //  0018  JMPF	R4	#001D
       0x8C10072B,  //  0019  GETMET	R4	R3	K43
@@ -1454,7 +1477,7 @@ be_local_closure(class_Extension_manager_manifest_decode,   /* name */
       0x74120007,  //  001C  JMPT	R4	#0025
       0xB8120E00,  //  001D  GETNGBL	R4	K7
       0x60140018,  //  001E  GETGBL	R5	G24
-      0x5818009B,  //  001F  LDCONST	R6	K155
+      0x5818009F,  //  001F  LDCONST	R6	K159
       0x5C1C0600,  //  0020  MOVE	R7	R3
       0x7C140400,  //  0021  CALL	R5	2
       0x7C100200,  //  0022  CALL	R4	1
@@ -1464,22 +1487,22 @@ be_local_closure(class_Extension_manager_manifest_decode,   /* name */
       0x7C100000,  //  0026  CALL	R4	0
       0x94140733,  //  0027  GETIDX	R5	R3	K51
       0x98126605,  //  0028  SETIDX	R4	K51	R5
-      0x94140786,  //  0029  GETIDX	R5	R3	K134
-      0x98130C05,  //  002A  SETIDX	R4	K134	R5
+      0x9414078A,  //  0029  GETIDX	R5	R3	K138
+      0x98131405,  //  002A  SETIDX	R4	K138	R5
       0x60140009,  //  002B  GETGBL	R5	G9
       0x94180703,  //  002C  GETIDX	R6	R3	K3
       0x7C140200,  //  002D  CALL	R5	1
       0x98120605,  //  002E  SETIDX	R4	K3	R5
       0x8C14071A,  //  002F  GETMET	R5	R3	K26
       0x581C0035,  //  0030  LDCONST	R7	K53
-      0x5820009C,  //  0031  LDCONST	R8	K156
+      0x582000A0,  //  0031  LDCONST	R8	K160
       0x7C140600,  //  0032  CALL	R5	3
       0x98126A05,  //  0033  SETIDX	R4	K53	R5
       0x8C14071A,  //  0034  GETMET	R5	R3	K26
-      0x581C008A,  //  0035  LDCONST	R7	K138
+      0x581C008E,  //  0035  LDCONST	R7	K142
       0x5820002D,  //  0036  LDCONST	R8	K45
       0x7C140600,  //  0037  CALL	R5	3
-      0x98131405,  //  0038  SETIDX	R4	K138	R5
+      0x98131C05,  //  0038  SETIDX	R4	K142	R5
       0x80040800,  //  0039  RET	1	R4
     })
   )


### PR DESCRIPTION
## Description:

Berry extensions add logs when installation fails

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
