### PR TITLE
Berry alternative to strnlen

### DIFF
--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -806,7 +806,10 @@ static int m_asstring(bvm *vm)
 {
     buf_impl attr = bytes_check_data(vm, 0);
     check_ptr(vm, &attr);
-    size_t safe_len = strnlen((const char*) attr.bufptr, attr.len);
+    /* equivalent to strnlen() */
+    const char* str = (const char*) attr.bufptr;
+    const char* found = memchr(str, '\0', attr.len);
+    size_t safe_len = found ? (size_t)(found - str) : (size_t)attr.len;
     be_pushnstring(vm, (const char*) attr.bufptr, safe_len);
     be_return(vm);
 }


### PR DESCRIPTION
## Description:

Avoid using `strnlen()` which is non-standard and use an alternative implementation.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
