### PR TITLE
Berry add argument to `werbserver.content_send_style`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - ESP32 Platform from 2025.08.30 to 2025.09.30, Framework (Arduino Core) from v3.1.3.250808 to v3.1.4 and IDF from v5.3.3.250801 to v5.3.4.250826 (#23888)
 - Use HAL instead of ROM for SHA HW acceleration as used by TLS (#23902)
+- Berry add argument to `werbserver.content_send_style`
 
 ### Fixed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -268,11 +268,17 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // Berry: `webserver.content_send_style() -> nil`
+  // Berry: `webserver.content_send_style([style : string]) -> nil`
   //
   int32_t w_webserver_content_send_style(struct bvm *vm);
   int32_t w_webserver_content_send_style(struct bvm *vm) {
-    WSContentSendStyle();
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * head_content = be_tostring(vm, 1);
+      WSContentSendStyle_P("%s", head_content);
+    } else {
+      WSContentSendStyle();
+    }
     be_return_nil(vm);
   }
 


### PR DESCRIPTION
## Description:

Berry add optional argument to `werbserver.content_send_style` to pass additional CSS styles to the `<head>` section.

No functional change for existing code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
