### PR TITLE
replace break with continue in MPU_6050Detect()

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_32_mpu6050.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_32_mpu6050.ino
@@ -121,7 +121,7 @@ void MPU_6050Detect(void)
   for (uint32_t i = 0; i < sizeof(MPU_6050_addresses); i++)
   {
     MPU_6050_address = MPU_6050_addresses[i];
-    if (!I2cSetDevice(MPU_6050_address)) { break; }
+    if (!I2cSetDevice(MPU_6050_address)) { continue; }
     mpu6050.setAddr(MPU_6050_addresses[i]);
 
 #ifdef USE_MPU6050_DMP


### PR DESCRIPTION
## Description:
This PR fixes a bug in MPU_6050Detect() where break statement instead of continue was used. Probably a typo. The **break** statement breaks the **for** loop on the first I2cSetDevice() error, effectively making the address **0x69** unusable.

I don't have an ESP32 to test it with Tasmota core ESP32, but on my Wemos D1 mini I was able to get an MPU6050 running on i2c 

`
00:00:00.001 HDW: ESP8266EX
00:00:00.046 CFG: Loaded from flash at F9, Count 52
00:00:00.051 FRC: Some settings have been reset (2)
00:00:00.062 Project tasmota - Tasmota Version 15.0.1.4(tasmota)-2_7_8(2025-09-27T20:07:28)
00:00:00.854 I2C: MPU6050 found at 0x69
`

I was also able to get some values (with USE_MPU6050_DMP defined):
`
19:13:44.368 MQT: tele/tasmota_CCA6FB/SENSOR = {"Time":"2025-09-27T19:13:44","ANALOG":{"A0":89},"MPU6050":{"Temperature":25.7,"AccelXAxis":1375.00,"AccelYAxis":-381.00,"AccelZAxis":1316.00,"GyroXAxis":22.00,"GyroYAxis":40.00,"GyroZAxis":26.00,"Yaw":22.37,"Pitch":45.11,"Roll":-11.27},"TempUnit":"C"}
`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
