### PR TITLE
Update esp8266 and esp32 Platform to 2025.10.xx

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -137,12 +137,13 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.09.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.10.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
+
 
 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,8 +97,9 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.09.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.10.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+
 


### PR DESCRIPTION
## Description:

- fix breaking change issue in metrics (esp-idf-size v2.0.0)
- update esptool v5.1.0
- refactored Python venv setup penv
- **NO** changes in Arduino core

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
