### PR TITLE
Berry animation native frame_buffer and optimization

### DIFF
--- a/lib/libesp32/berry_animation/docs/ANIMATION_DEVELOPMENT.md
+++ b/lib/libesp32/berry_animation/docs/ANIMATION_DEVELOPMENT.md
@@ -490,7 +490,7 @@ import animation
 def test_my_animation()
   # Create LED strip and engine for testing
   var strip = global.Leds(10)  # Use built-in LED strip for testing
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test basic construction
   var anim = animation.my_animation(engine)
@@ -532,7 +532,7 @@ Test with the animation engine:
 
 ```berry
 var strip = global.Leds(30)  # Use built-in LED strip
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 var anim = animation.my_animation(engine)
 
 # Set parameters

--- a/lib/libesp32/berry_animation/solidify_all.be
+++ b/lib/libesp32/berry_animation/solidify_all.be
@@ -19,7 +19,7 @@ var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,M
 for g:string2.split(globs, ",")
   global.(g) = nil
 end
-# special case to declane animation
+# special case to declare animation
 global.animation = module("animation")
 
 var prefix_dir = "src/"

--- a/lib/libesp32/berry_animation/src/animations/beacon.be
+++ b/lib/libesp32/berry_animation/src/animations/beacon.be
@@ -17,18 +17,20 @@
 # 2: `slew_size`, number of pixels to fade from back to fore color, can be `0`
 # 3: `beacon_size`, number of pixels of the beacon
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:BeaconAnimation,weak
 class BeaconAnimation : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
   
   # Parameter definitions following the new specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": 0xFFFFFFFF},
     "back_color": {"default": 0xFF000000},
     "pos": {"default": 0},
     "beacon_size": {"min": 0, "default": 1},
     "slew_size": {"min": 0, "default": 0}
-  }
+  })
 
   # Render the beacon to the provided frame buffer
   #

--- a/lib/libesp32/berry_animation/src/animations/breathe.be
+++ b/lib/libesp32/berry_animation/src/animations/breathe.be
@@ -8,19 +8,21 @@
 # - curve_factor 1: Pure cosine wave (equivalent to pulse animation)
 # - curve_factor 2-5: Natural breathing with pauses at peaks (5 = most pronounced pauses)
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:BreatheAnimation,weak
 class BreatheAnimation : animation.animation
   # Non-parameter instance variables only
   var breathe_provider # Internal breathe color provider
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "base_color": {"default": 0xFFFFFFFF},               # The base color to breathe (32-bit ARGB value)
     "min_brightness": {"min": 0, "max": 255, "default": 0},      # Minimum brightness level (0-255)
     "max_brightness": {"min": 0, "max": 255, "default": 255},    # Maximum brightness level (0-255)
     "period": {"min": 100, "default": 3000},             # Time for one complete breathe cycle in milliseconds
     "curve_factor": {"min": 1, "max": 5, "default": 2}   # Factor to control breathing curve shape (1=cosine wave, 2-5=curved breathing with pauses)
-  }
+  })
   
   # Initialize a new Breathe animation
   # Following parameterized class specification - engine parameter only

--- a/lib/libesp32/berry_animation/src/animations/comet.be
+++ b/lib/libesp32/berry_animation/src/animations/comet.be
@@ -6,20 +6,22 @@
 # The comet uses sub-pixel positioning (1/256th pixels) for smooth movement and supports
 # both wrapping around the strip and bouncing off the ends.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:CometAnimation,weak
 class CometAnimation : animation.animation
   # Non-parameter instance variables only
   var head_position    # Current position of the comet head (in 1/256th pixels for smooth movement)
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # 'color' for the comet head (32-bit ARGB value), inherited from animation class
     "tail_length": {"min": 1, "max": 50, "default": 5}, # Length of the comet tail in pixels
     "speed": {"min": 1, "max": 25600, "default": 2560}, # Movement speed in 1/256th pixels per second
     "direction": {"enum": [-1, 1], "default": 1},       # Direction of movement (1 = forward, -1 = backward)
     "wrap_around": {"min": 0, "max": 1, "default": 1},  # Whether comet wraps around the strip (bool)
     "fade_factor": {"min": 0, "max": 255, "default": 179} # How quickly the tail fades (0-255, 255 = no fade)
-  }
+  })
   
   # Initialize a new Comet animation
   # Following parameterized class specification - engine parameter only

--- a/lib/libesp32/berry_animation/src/animations/crenel_position.be
+++ b/lib/libesp32/berry_animation/src/animations/crenel_position.be
@@ -18,19 +18,21 @@
 # 3: `low_size`, number of pixel until next pos - full cycle is 2 + 3
 # 4: `nb_pulse`, number of pulses, or `-1` for infinite
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:CrenelPositionAnimation,weak
 class CrenelPositionAnimation : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
   
   # Parameter definitions with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # 'color' for the comet head (32-bit ARGB value), inherited from animation class
     "back_color": {"default": 0xFF000000},      # background color, TODO change to transparent
     "pos": {"default": 0},                      # start of the pulse (in pixel)
     "pulse_size": {"min": 0, "default": 1},     # number of pixels of the pulse
     "low_size": {"min": 0, "default": 3},       # number of pixel until next pos - full cycle is 2 + 3
     "nb_pulse": {"default": -1}                 # number of pulses, or `-1` for infinite
-  }
+  })
   
   # Render the crenel pattern to the provided frame buffer
   #

--- a/lib/libesp32/berry_animation/src/animations/fire.be
+++ b/lib/libesp32/berry_animation/src/animations/fire.be
@@ -3,6 +3,8 @@
 # This animation creates a realistic fire effect with flickering flames.
 # The fire uses random intensity variations and warm colors to simulate flames.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:FireAnimation,weak
 class FireAnimation : animation.animation
   # Non-parameter instance variables only
@@ -12,14 +14,14 @@ class FireAnimation : animation.animation
   var random_seed      # Seed for random number generation
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # 'color' for the comet head (32-bit ARGB value), inherited from animation class
     "intensity": {"min": 0, "max": 255, "default": 180},
     "flicker_speed": {"min": 1, "max": 20, "default": 8},
     "flicker_amount": {"min": 0, "max": 255, "default": 100},
     "cooling_rate": {"min": 0, "max": 255, "default": 55},
     "sparking_rate": {"min": 0, "max": 255, "default": 120}
-  }
+  })
   
   # Initialize a new Fire animation
   #

--- a/lib/libesp32/berry_animation/src/animations/gradient.be
+++ b/lib/libesp32/berry_animation/src/animations/gradient.be
@@ -3,6 +3,8 @@
 # This animation creates smooth color gradients that can be linear or radial,
 # with optional movement and color transitions over time.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:GradientAnimation,weak
 class GradientAnimation : animation.animation
   # Non-parameter instance variables only
@@ -10,14 +12,14 @@ class GradientAnimation : animation.animation
   var phase_offset       # Current phase offset for movement
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": nil, "nillable": true},
     "gradient_type": {"min": 0, "max": 1, "default": 0},
     "direction": {"min": 0, "max": 255, "default": 0},
     "center_pos": {"min": 0, "max": 255, "default": 128},
     "spread": {"min": 1, "max": 255, "default": 255},
     "movement_speed": {"min": 0, "max": 255, "default": 0}
-  }
+  })
   
   # Initialize a new Gradient animation
   def init(engine)

--- a/lib/libesp32/berry_animation/src/animations/noise.be
+++ b/lib/libesp32/berry_animation/src/animations/noise.be
@@ -3,6 +3,8 @@
 # This animation creates pseudo-random noise patterns with configurable
 # scale, speed, and color mapping through palettes or single colors.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:NoiseAnimation,weak
 class NoiseAnimation : animation.animation
   # Non-parameter instance variables only
@@ -11,14 +13,14 @@ class NoiseAnimation : animation.animation
   var noise_table        # Pre-computed noise values for performance
   
   # Parameter definitions following new specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": nil},
     "scale": {"min": 1, "max": 255, "default": 50},
     "speed": {"min": 0, "max": 255, "default": 30},
     "octaves": {"min": 1, "max": 4, "default": 1},
     "persistence": {"min": 0, "max": 255, "default": 128},
     "seed": {"min": 0, "max": 65535, "default": 12345}
-  }
+  })
   
   # Initialize a new Noise animation
   def init(engine)

--- a/lib/libesp32/berry_animation/src/animations/palette_pattern.be
+++ b/lib/libesp32/berry_animation/src/animations/palette_pattern.be
@@ -6,16 +6,18 @@
 # This version supports both RichPaletteAnimation and ColorProvider instances as color sources,
 # allowing for more flexible usage of color providers.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:PalettePatternAnimation,weak
 class PalettePatternAnimation : animation.animation
   var value_buffer     # Buffer to store values for each pixel (bytes object)
   
   # Static definitions of parameters with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # Palette pattern-specific parameters
     "color_source": {"default": nil, "type": "instance"},
     "pattern_func": {"default": nil, "type": "function"}
-  }
+  })
   
   # Initialize a new PalettePattern animation
   #
@@ -158,11 +160,11 @@ end
 #@ solidify:PaletteWaveAnimation,weak
 class PaletteWaveAnimation : PalettePatternAnimation
   # Static definitions of parameters with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # Wave-specific parameters only
     "wave_period": {"min": 1, "default": 5000},
     "wave_length": {"min": 1, "default": 10}
-  }
+  })
   
   # Initialize a new wave pattern animation
   #
@@ -211,12 +213,12 @@ end
 #@ solidify:PaletteGradientAnimation,weak
 class PaletteGradientAnimation : PalettePatternAnimation
   # Static definitions of parameters with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # Gradient-specific parameters only
     "shift_period": {"min": 0, "default": 0},           # Time for one complete shift cycle in ms (0 = static)
     "spatial_period": {"min": 0, "default": 0},         # Spatial period in pixels (0 = full strip)
     "phase_shift": {"min": 0, "max": 100, "default": 0} # Phase shift as percentage (0-100)
-  }
+  })
   
   # Initialize a new gradient pattern animation
   #
@@ -273,10 +275,10 @@ end
 #@ solidify:PaletteMeterAnimation,weak
 class PaletteMeterAnimation : PalettePatternAnimation
   # Static definitions of parameters with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # Meter-specific parameters only
     "value_func": {"default": nil, "type": "function"}
-  }
+  })
   
   # Initialize a new meter pattern animation
   #

--- a/lib/libesp32/berry_animation/src/animations/rich_palette_animation.be
+++ b/lib/libesp32/berry_animation/src/animations/rich_palette_animation.be
@@ -7,13 +7,15 @@
 #
 # Follows the parameterized class specification with parameter forwarding pattern.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:RichPaletteAnimation,weak
 class RichPaletteAnimation : animation.animation
   # Non-parameter instance variables only
   var color_provider   # Internal RichPaletteColorProvider instance
   
   # Parameter definitions - only RichPaletteColorProvider parameters (Animation params inherited)
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     # RichPaletteColorProvider parameters (forwarded to internal provider)
     "palette": {"type": "instance", "default": nil},
     "cycle_period": {"min": 0, "default": 5000},
@@ -21,7 +23,7 @@ class RichPaletteAnimation : animation.animation
     "brightness": {"min": 0, "max": 255, "default": 255},
     "range_min": {"default": 0},
     "range_max": {"default": 255}
-  }
+  })
   
   # Initialize a new RichPaletteAnimation
   #

--- a/lib/libesp32/berry_animation/src/animations/twinkle.be
+++ b/lib/libesp32/berry_animation/src/animations/twinkle.be
@@ -3,6 +3,8 @@
 # This animation creates a twinkling stars effect with random lights
 # appearing and fading at different positions with customizable density and timing.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:TwinkleAnimation,weak
 class TwinkleAnimation : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
@@ -14,14 +16,14 @@ class TwinkleAnimation : animation.animation
   var random_seed      # Seed for random number generation
   
   # Parameter definitions with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": 0xFFFFFFFF},
     "density": {"min": 0, "max": 255, "default": 128},
     "twinkle_speed": {"min": 1, "max": 5000, "default": 6},
     "fade_speed": {"min": 0, "max": 255, "default": 180},
     "min_brightness": {"min": 0, "max": 255, "default": 32},
     "max_brightness": {"min": 0, "max": 255, "default": 255}
-  }
+  })
   
   # Initialize a new Twinkle animation
   #

--- a/lib/libesp32/berry_animation/src/animations/wave.be
+++ b/lib/libesp32/berry_animation/src/animations/wave.be
@@ -3,6 +3,8 @@
 # This animation creates various wave patterns (sine, triangle, square, sawtooth)
 # with configurable amplitude, frequency, phase, and movement speed.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:WaveAnimation,weak
 class WaveAnimation : animation.animation
   # Non-parameter instance variables only
@@ -11,7 +13,7 @@ class WaveAnimation : animation.animation
   var wave_table         # Pre-computed wave table for performance
   
   # Parameter definitions for WaveAnimation
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": 0xFFFF0000},
     "back_color": {"default": 0xFF000000},
     "wave_type": {"min": 0, "max": 3, "default": 0},
@@ -20,7 +22,7 @@ class WaveAnimation : animation.animation
     "phase": {"min": 0, "max": 255, "default": 0},
     "wave_speed": {"min": 0, "max": 255, "default": 50},
     "center_level": {"min": 0, "max": 255, "default": 128}
-  }
+  })
   
   # Initialize a new Wave animation
   #

--- a/lib/libesp32/berry_animation/src/animations_future/bounce.be
+++ b/lib/libesp32/berry_animation/src/animations_future/bounce.be
@@ -3,6 +3,8 @@
 # This animation creates bouncing effects where patterns bounce back and forth
 # across the LED strip with configurable physics and damping.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:BounceAnimation,weak
 class BounceAnimation : animation.animation
   # Non-parameter instance variables only
@@ -14,13 +16,13 @@ class BounceAnimation : animation.animation
   var last_update_time   # Last update time for physics calculation
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "source_animation": {"type": "instance", "default": nil},
     "bounce_speed": {"min": 0, "max": 255, "default": 128},
     "bounce_range": {"min": 0, "max": 1000, "default": 0},
     "damping": {"min": 0, "max": 255, "default": 250},
     "gravity": {"min": 0, "max": 255, "default": 0}
-  }
+  })
   
   # Initialize a new Bounce animation
   def init(engine)

--- a/lib/libesp32/berry_animation/src/animations_future/jitter.be
+++ b/lib/libesp32/berry_animation/src/animations_future/jitter.be
@@ -3,6 +3,8 @@
 # This animation adds random jitter/shake effects to patterns with configurable
 # intensity, frequency, and jitter types (position, color, brightness).
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:JitterAnimation,weak
 class JitterAnimation : animation.animation
   # Non-parameter instance variables only
@@ -13,7 +15,7 @@ class JitterAnimation : animation.animation
   var current_colors     # Array of current colors for each pixel
   
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "source_animation": {"type": "instance", "default": nil},
     "jitter_intensity": {"min": 0, "max": 255, "default": 100},
     "jitter_frequency": {"min": 0, "max": 255, "default": 60},
@@ -21,7 +23,7 @@ class JitterAnimation : animation.animation
     "position_range": {"min": 0, "max": 255, "default": 50},
     "color_range": {"min": 0, "max": 255, "default": 30},
     "brightness_range": {"min": 0, "max": 255, "default": 40}
-  }
+  })
   
   # Initialize a new Jitter animation
   def init(engine)

--- a/lib/libesp32/berry_animation/src/animations_future/plasma.be
+++ b/lib/libesp32/berry_animation/src/animations_future/plasma.be
@@ -3,6 +3,8 @@
 # This animation creates classic plasma effects using sine wave interference
 # patterns with configurable frequencies, phases, and time-based animation.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:PlasmaAnimation,weak
 class PlasmaAnimation : animation.animation
   # Non-parameter instance variables only
@@ -10,7 +12,7 @@ class PlasmaAnimation : animation.animation
   var time_phase         # Current time-based phase
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": nil},
     "freq_x": {"min": 1, "max": 255, "default": 32},
     "freq_y": {"min": 1, "max": 255, "default": 23},
@@ -18,7 +20,7 @@ class PlasmaAnimation : animation.animation
     "phase_y": {"min": 0, "max": 255, "default": 64},
     "time_speed": {"min": 0, "max": 255, "default": 50},
     "blend_mode": {"min": 0, "max": 2, "default": 0}
-  }
+  })
   
   # Initialize a new Plasma animation
   #

--- a/lib/libesp32/berry_animation/src/animations_future/scale.be
+++ b/lib/libesp32/berry_animation/src/animations_future/scale.be
@@ -3,6 +3,8 @@
 # This animation scales patterns up or down with configurable scaling factors,
 # interpolation methods, and center points.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:ScaleAnimation,weak
 class ScaleAnimation : animation.animation
   # Non-parameter instance variables only
@@ -12,14 +14,14 @@ class ScaleAnimation : animation.animation
   var start_time         # Animation start time
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "source_animation": {"type": "instance", "default": nil},
     "scale_factor": {"min": 1, "max": 255, "default": 128},
     "scale_speed": {"min": 0, "max": 255, "default": 0},
     "scale_mode": {"min": 0, "max": 3, "default": 0},
     "scale_center": {"min": 0, "max": 255, "default": 128},
     "interpolation": {"min": 0, "max": 1, "default": 1}
-  }
+  })
   
   # Initialize a new Scale animation
   # @param engine: AnimationEngine - Required animation engine

--- a/lib/libesp32/berry_animation/src/animations_future/shift.be
+++ b/lib/libesp32/berry_animation/src/animations_future/shift.be
@@ -3,6 +3,8 @@
 # This animation shifts/scrolls patterns horizontally across the LED strip
 # with configurable speed, direction, and wrapping behavior.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:ShiftAnimation,weak
 class ShiftAnimation : animation.animation
   # Non-parameter instance variables only
@@ -11,12 +13,12 @@ class ShiftAnimation : animation.animation
   var current_colors     # Array of current colors for each pixel
   
   # Parameter definitions with constraints
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "source_animation": {"type": "instance", "default": nil},
     "shift_speed": {"min": 0, "max": 255, "default": 128},
     "direction": {"min": -1, "max": 1, "default": 1},
     "wrap_around": {"type": "bool", "default": true}
-  }
+  })
   
   # Initialize a new Shift animation
   def init(engine)

--- a/lib/libesp32/berry_animation/src/animations_future/sparkle.be
+++ b/lib/libesp32/berry_animation/src/animations_future/sparkle.be
@@ -3,6 +3,8 @@
 # This animation creates random sparkles that appear and fade out over time,
 # with configurable density, fade speed, and colors.
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:SparkleAnimation,weak
 class SparkleAnimation : animation.animation
   # Non-parameter instance variables only
@@ -13,7 +15,7 @@ class SparkleAnimation : animation.animation
   var last_update        # Last update time for frame timing
   
   # Parameter definitions following parameterized class specification
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": 0xFFFFFFFF},
     "back_color": {"default": 0xFF000000},
     "density": {"min": 0, "max": 255, "default": 30},
@@ -21,7 +23,7 @@ class SparkleAnimation : animation.animation
     "sparkle_duration": {"min": 0, "max": 255, "default": 60},
     "min_brightness": {"min": 0, "max": 255, "default": 100},
     "max_brightness": {"min": 0, "max": 255, "default": 255}
-  }
+  })
   
   # Initialize a new Sparkle animation
   # @param engine: AnimationEngine - Required animation engine reference

--- a/lib/libesp32/berry_animation/src/be_frame_buffer_ntv.c
+++ b/lib/libesp32/berry_animation/src/be_frame_buffer_ntv.c
@@ -31,6 +31,7 @@ class be_class_FrameBufferNtv (scope: global, name: FrameBufferNtv, strings: wea
   apply_opacity, static_func(be_animation_ntv_apply_opacity)
   apply_brightness, static_func(be_animation_ntv_apply_brightness)
   fill_pixels, static_func(be_animation_ntv_fill_pixels)
+//   paste_pixels, func(be_leds_paste_pixels)
 }
 @const_object_info_end */
 

--- a/lib/libesp32/berry_animation/src/be_frame_buffer_ntv_impl.cpp
+++ b/lib/libesp32/berry_animation/src/be_frame_buffer_ntv_impl.cpp
@@ -603,6 +603,47 @@ extern "C" {
     
     be_return_nil(vm);
   }
+
+  // // Leds_frame.paste_pixels(neopixel:bytes(), led_buffer:bytes(), bri:int 0..100, gamma:bool)
+  // //
+  // // Copy from ARGB buffer to RGB
+  // int32_t be_leds_paste_pixels(bvm *vm);
+  // int32_t be_leds_paste_pixels(bvm *vm) {
+  //   int32_t top = be_top(vm); // Get the number of arguments
+  //   if (top >= 2 && be_isbytes(vm, 2)) {
+  //     size_t src_len = 0;
+  //     uint32_t * src_buf = (uint32_t*) be_tobytes(vm, 1, &src_len);
+  //     size_t dest_len = 0;
+  //     uint8_t * dest_buf = (uint8_t*) be_tobytes(vm, 2, &dest_len);
+
+  //     uint32_t bri255 = 255;
+  //     if (top >= 3 && be_isint(vm, 3)) {
+  //       bri255 = be_toint(vm, 3);
+  //     }
+  //     bool gamma = false;
+  //     if (top >= 4 && be_isbool(vm, 4)) {
+  //       gamma = be_tobool(vm, 4);
+  //     }
+
+  //     size_t pixels_count = src_len / 4;
+  //     if (pixels_count > dest_len / 3) { pixels_count = dest_len / 3; }
+  //     if (pixels_count > 0) {
+  //       for (size_t i = 0; i < pixels_count; i++) {
+  //         uint32_t src_argb = ApplyBriGamma(src_buf[i], bri255, gamma);
+  //         uint32_t src_r = (src_argb >> 16) & 0xFF;
+  //         uint32_t src_g = (src_argb >>  8) & 0xFF;
+  //         uint32_t src_b = (src_argb      ) & 0xFF;
+  //         dest_buf[i * 3 + 0] = src_r;
+  //         dest_buf[i * 3 + 1] = src_g;
+  //         dest_buf[i * 3 + 2] = src_b;
+  //       }
+  //     }
+  //     be_return_nil(vm);
+  //   }
+  //   be_raise(vm, "type_error", nullptr);
+  // }
+
+
 }
 
 #endif // USE_BERRY_ANIMATION

--- a/lib/libesp32/berry_animation/src/core/animation_base.be
+++ b/lib/libesp32/berry_animation/src/core/animation_base.be
@@ -7,19 +7,21 @@
 # This is the unified base class for all visual elements in the framework.
 # A Pattern is simply an Animation with infinite duration (duration = 0).
 
+import "./core/param_encoder" as encode_constraints
+
 class Animation : animation.parameterized_object
   # Non-parameter instance variables only
   var opacity_frame   # Frame buffer for opacity animation rendering
   
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "name": {"type": "string", "default": "animation"}, # Optional name for the animation
     "priority": {"min": 0, "default": 10},              # Rendering priority (higher = on top, 0-255)
     "duration": {"min": 0, "default": 0},               # Animation duration in ms (0 = infinite)
     "loop": {"type": "bool", "default": false},         # Whether to loop when duration is reached
     "opacity": {"type": "any", "default": 255},         # Animation opacity (0-255 number or Animation instance)
     "color": {"default": 0xFFFFFFFF}                    # Base color in ARGB format (0xAARRGGBB)
-  }
+  })
 
   # Initialize a new animation
   #

--- a/lib/libesp32/berry_animation/src/core/animation_engine.be
+++ b/lib/libesp32/berry_animation/src/core/animation_engine.be
@@ -165,9 +165,7 @@ class AnimationEngine
       return self._add_animation(obj)
     else
       # Unknown type - provide helpful error message
-      import introspect
-      var class_name = introspect.name(obj)
-      raise "type_error", f"Cannot add object of type '{class_name}' to engine. Expected Animation or SequenceManager."
+      raise "type_error", "only Animation or SequenceManager"
     end
   end
   
@@ -182,8 +180,7 @@ class AnimationEngine
     elif isinstance(obj, animation.animation)
       return self.remove_animation(obj)
     else
-      # Unknown type - provide helpful error message
-      raise "type_error", f"Cannot remove object of type '{classname(obj)}' from engine. Expected Animation or SequenceManager."
+      # Unknown type - ignore
     end
   end
   
@@ -502,14 +499,8 @@ class AnimationEngine
   
   # String representation
   def tostring()
-    return f"AnimationEngine(running={self.is_running}, animations={size(self.animations)}, width={self.width})"
+    return f"AnimationEngine(running={self.is_running})"
   end
 end
 
-# Main function to create the animation engine
-def create_engine(strip)
-  return animation.animation_engine(strip)
-end
-
-return {'animation_engine': AnimationEngine,
-        'create_engine': create_engine}
+return {'create_engine': AnimationEngine}

--- a/lib/libesp32/berry_animation/src/core/event_handler.be
+++ b/lib/libesp32/berry_animation/src/core/event_handler.be
@@ -46,15 +46,15 @@ class EventHandler
   end
   
   # Get handler info for debugging
-  def get_info()
-    return {
-      "event_name": self.event_name,
-      "priority": self.priority,
-      "is_active": self.is_active,
-      "has_condition": self.condition != nil,
-      "metadata": self.metadata
-    }
-  end
+  # def get_info()
+  #   return {
+  #     "event_name": self.event_name,
+  #     "priority": self.priority,
+  #     "is_active": self.is_active,
+  #     "has_condition": self.condition != nil,
+  #     "metadata": self.metadata
+  #   }
+  # end
 end
 
 #@ solidify:EventManager,weak

--- a/lib/libesp32/berry_animation/src/core/param_encoder.be
+++ b/lib/libesp32/berry_animation/src/core/param_encoder.be
@@ -1,0 +1,284 @@
+# Parameter Constraint Encoder for Berry Animation Framework
+#
+# This module provides functions to encode parameter constraints into a compact
+# bytes() format with type-prefixed values for maximum flexibility and correctness.
+#
+# Encoding Format:
+# ----------------
+# Byte 0: Constraint mask (bit field)
+#   Bit 0 (0x01): has_min
+#   Bit 1 (0x02): has_max
+#   Bit 2 (0x04): has_default
+#   Bit 3 (0x08): has_explicit_type
+#   Bit 4 (0x10): has_enum
+#   Bit 5 (0x20): is_nillable
+#   Bits 6-7: reserved
+#
+# Bytes 1+: Values in order (min, max, default, enum)
+#   Each value is prefixed with its own type byte, followed by the value data.
+#
+# Value Type Codes:
+#   0x00 = int8 (1 byte, signed -128 to 127)
+#   0x01 = int16 (2 bytes, signed -32768 to 32767)
+#   0x02 = int32 (4 bytes, signed integer)
+#   0x03 = string (1-byte length prefix + string bytes)
+#   0x04 = bytes (2-byte length prefix + byte data)
+#   0x05 = bool (1 byte, 0 or 1)
+#   0x06 = nil (0 bytes)
+#
+# Value Encoding (each value has: type_byte + data):
+#   - min: [type_byte][value_data]
+#   - max: [type_byte][value_data]
+#   - default: [type_byte][value_data]
+#   - enum: [count_byte][type_byte][value_data][type_byte][value_data]...
+#   - explicit_type: [type_code] (only if has_explicit_type bit is set)
+#
+# Explicit Type Codes (semantic types for validation) (1 byte):
+#   0x00 = int
+#   0x01 = string
+#   0x02 = bytes
+#   0x03 = bool
+#   0x04 = any
+#   0x05 = instance
+#   0x06 = function
+
+# Encode a full PARAMS map into a map of encoded constraints
+#
+# @param params_map: map - Map of parameter names to constraint definitions
+# @return map - Map of parameter names to encoded bytes() objects
+#
+# Example:
+#   encode_constraints({"color": {"default": 0xFFFFFFFF}, "size": {"min": 0, "max": 255, "default": 128}})
+#   => {"color": bytes("04 02 FFFFFFFF"), "size": bytes("07 00 00 FF 80")}
+def encode_constraints(params_map)
+  # Nested function: Encode a single constraint map into bytes() format
+  def encode_single_constraint(constraint_map)
+    # Nested helper: Determine the appropriate type code for a value
+    def get_type_code(value)
+      var value_type = type(value)
+      if value == nil  return 0x06 #-NIL-#
+      elif value_type == "bool"  return 0x05 #-BOOL-#
+      elif value_type == "string"  return 0x03 #-STRING-#
+      elif value_type == "instance" && isinstance(value, bytes)  return 0x04 #-BYTES-#
+      elif value_type == "int"
+        # Use signed ranges: int8 for -128 to 127, int16 for larger values
+        if value >= -128 && value <= 127  return 0x00 #-INT8-#
+        elif value >= -32768 && value <= 32767  return 0x01 #-INT16-#
+        else  return 0x02 #-INT32-#  end
+      else  return 0x02 #-INT32-#  end
+    end
+    
+    # Nested helper: Encode a single value with its type prefix
+    def encode_value_with_type(value, result)
+      var type_code = get_type_code(value)
+      result.add(type_code, 1)  # Add type byte prefix
+      
+      if type_code == 0x06 #-NIL-#  return
+      elif type_code == 0x05 #-BOOL-#  result.add(value ? 1 : 0, 1)
+      elif type_code == 0x00 #-INT8-#  result.add(value & 0xFF, 1)
+      elif type_code == 0x01 #-INT16-#  result.add(value & 0xFFFF, 2)
+      elif type_code == 0x02 #-INT32-#  result.add(value, 4)
+      elif type_code == 0x03 #-STRING-#
+        var str_bytes = bytes().fromstring(value)
+        result.add(size(str_bytes), 1)
+        result .. str_bytes
+      elif type_code == 0x04 #-BYTES-#
+        result.add(size(value), 2)
+        result .. value
+      end
+    end
+    
+    var mask = 0
+    var result = bytes()
+    
+    # Reserve space for mask only (will be set at the end)
+    result.resize(1)
+    
+    # Helper: Convert explicit type string to type code
+    def get_explicit_type_code(type_str)
+      if type_str == "int"  return 0x00
+      elif type_str == "string"  return 0x01
+      elif type_str == "bytes"  return 0x02
+      elif type_str == "bool"  return 0x03
+      elif type_str == "any"  return 0x04
+      elif type_str == "instance"  return 0x05
+      elif type_str == "function"  return 0x06
+      end
+      return 0x04  # Default to "any"
+    end
+    
+    # Check if explicit type is specified
+    var explicit_type_code = nil
+    if constraint_map.contains("type")
+      explicit_type_code = get_explicit_type_code(constraint_map["type"])
+    end
+    
+    # Encode min value (with type prefix)
+    if constraint_map.contains("min")
+      mask |= 0x01 #-HAS_MIN-#
+      encode_value_with_type(constraint_map["min"], result)
+    end
+    
+    # Encode max value (with type prefix)
+    if constraint_map.contains("max")
+      mask |= 0x02 #-HAS_MAX-#
+      encode_value_with_type(constraint_map["max"], result)
+    end
+    
+    # Encode default value (with type prefix)
+    if constraint_map.contains("default")
+      mask |= 0x04 #-HAS_DEFAULT-#
+      encode_value_with_type(constraint_map["default"], result)
+    end
+    
+    # Encode explicit type code if present (1 byte)
+    if explicit_type_code != nil
+      mask |= 0x08 #-HAS_EXPLICIT_TYPE-#
+      result.add(explicit_type_code, 1)
+    end
+    
+    # Encode enum values (each with type prefix)
+    if constraint_map.contains("enum")
+      mask |= 0x10 #-HAS_ENUM-#
+      var enum_list = constraint_map["enum"]
+      result.add(size(enum_list), 1)  # Enum count
+      for val : enum_list
+        encode_value_with_type(val, result)
+      end
+    end
+    
+    # Set nillable flag
+    if constraint_map.contains("nillable") && constraint_map["nillable"]
+      mask |= 0x20 #-IS_NILLABLE-#
+    end
+    
+    # Write mask at the beginning
+    result.set(0, mask, 1)
+    
+    return result
+  end
+  
+  # Encode each parameter constraint
+  var result = {}
+  for param_name : params_map.keys()
+    result[param_name] = encode_single_constraint(params_map[param_name])
+  end
+  return result
+end
+
+# # Decode a single value from bytes according to type code
+# #
+# # @param encoded_bytes: bytes - bytes() object to read from
+# # @param offset: int - Offset to start reading from
+# # @param type_code: int - Type code for decoding
+# # @return [value, new_offset] - Decoded value and new offset
+# def decode_value(encoded_bytes, offset, type_code)
+#   if type_code == 0x06 #-NIL-#
+#     return [nil, offset]
+#   elif type_code == 0x05 #-BOOL-#
+#     return [encoded_bytes[offset] != 0, offset + 1]
+#   elif type_code == 0x00 #-INT8-#
+#     var val = encoded_bytes[offset]
+#     # Handle signed int8
+#     if val > 127
+#       val = val - 256
+#     end
+#     return [val, offset + 1]
+#   elif type_code == 0x01 #-INT16-#
+#     var val = encoded_bytes.get(offset, 2)
+#     # Handle signed int16
+#     if val > 32767
+#       val = val - 65536
+#     end
+#     return [val, offset + 2]
+#   elif type_code == 0x02 #-INT32-#
+#     return [encoded_bytes.get(offset, 4), offset + 4]
+#   elif type_code == 0x03 #-STRING-#
+#     var length = encoded_bytes[offset]
+#     var str_bytes = encoded_bytes[offset + 1 .. offset + length]
+#     return [str_bytes.asstring(), offset + 1 + length]
+#   elif type_code == 0x04 #-BYTES-#
+#     var length = encoded_bytes.get(offset, 2)
+#     var byte_data = encoded_bytes[offset + 2 .. offset + 2 + length - 1]
+#     return [byte_data, offset + 2 + length]
+#   end
+#   
+#   return [nil, offset]
+# end
+
+# # Decode an encoded constraint bytes() back into a map
+# #
+# # @param encoded_bytes: bytes - Encoded constraint as bytes() object
+# # @return map - Decoded constraint map
+# #
+# # Example:
+# #   decode_constraint(bytes("07 00 00 FF 80"))
+# #   => {"min": 0, "max": 255, "default": 128}
+# def decode_constraint(encoded_bytes)
+#   if size(encoded_bytes) < 2
+#     return {}
+#   end
+#   
+#   var mask = encoded_bytes[0]
+#   var type_code = encoded_bytes[1]
+#   var offset = 2
+#   var result = {}
+#   
+#   # Decode min value
+#   if mask & 0x01 #-HAS_MIN-#
+#     var decoded = decode_value(encoded_bytes, offset, type_code)
+#     result["min"] = decoded[0]
+#     offset = decoded[1]
+#   end
+#   
+#   # Decode max value
+#   if mask & 0x02 #-HAS_MAX-#
+#     var decoded = decode_value(encoded_bytes, offset, type_code)
+#     result["max"] = decoded[0]
+#     offset = decoded[1]
+#   end
+#   
+#   # Decode default value
+#   if mask & 0x04 #-HAS_DEFAULT-#
+#     var decoded = decode_value(encoded_bytes, offset, type_code)
+#     result["default"] = decoded[0]
+#     offset = decoded[1]
+#   end
+#   
+#   # Decode enum values
+#   if mask & 0x10 #-HAS_ENUM-#
+#     var count = encoded_bytes[offset]
+#     offset += 1
+#     result["enum"] = []
+#     var i = 0
+#     while i < count
+#       var decoded = decode_value(encoded_bytes, offset, type_code)
+#       result["enum"].push(decoded[0])
+#       offset = decoded[1]
+#       i += 1
+#     end
+#   end
+#   
+#   # Set nillable flag
+#   if mask & 0x20 #-IS_NILLABLE-#
+#     result["nillable"] = true
+#   end
+#   
+#   # Add type annotation if not default int32
+#   if type_code == 0x03 #-STRING-#
+#     result["type"] = "string"
+#   elif type_code == 0x04 #-BYTES-#
+#     result["type"] = "bytes"
+#   elif type_code == 0x05 #-BOOL-#
+#     result["type"] = "bool"
+#   elif type_code == 0x06 #-NIL-#
+#     result["type"] = "nil"
+#   end
+#   
+#   return result
+# end
+
+# Export only the encode function (decode not needed - use constraint_mask/constraint_find instead)
+# Note: constraint_mask() and constraint_find() are static methods
+# in ParameterizedObject class for accessing encoded constraints
+return encode_constraints

--- a/lib/libesp32/berry_animation/src/core/parameterized_object.be
+++ b/lib/libesp32/berry_animation/src/core/parameterized_object.be
@@ -8,22 +8,24 @@
 # through member() and setmember() methods. Subclasses should not declare instance
 # variables for parameters, but use the PARAMS system only.
 
+import "./core/param_encoder" as encode_constraints
+
 class ParameterizedObject
   var values          # Map storing all parameter values
   var engine          # Reference to the animation engine
   var start_time      # Time when object started (ms) (int), value is set at first call to update() or render()
   
   # Static parameter definitions - should be overridden by subclasses
-  static var PARAMS = {
-    "is_running": {"type": "bool", "default": false}   # Whether the object is active
-  }
+  static var PARAMS = encode_constraints(
+    {"is_running": {"type": "bool", "default": false}
+  })   # Whether the object is active
   
   # Initialize parameter system
   #
   # @param engine: AnimationEngine - Reference to the animation engine (required)
   def init(engine)
     if engine == nil || type(engine) != "instance"
-      raise "value_error", "ParameterizedObject requires an engine parameter"
+      raise "value_error", "missing engine parameter"
     end
     
     self.engine = engine
@@ -45,9 +47,10 @@ class ParameterizedObject
         for param_name : class_params.keys()
           # Only set if not already set (child class defaults take precedence)
           if !self.values.contains(param_name)
-            var param_def = class_params[param_name]
-            if param_def.contains("default")
-              self.values[param_name] = param_def["default"]
+            var encoded_constraints = class_params[param_name]
+            # Use static method to check for default value
+            if self.constraint_mask(encoded_constraints, "default")
+              self.values[param_name] = self.constraint_find(encoded_constraints, "default")
             end
           end
         end
@@ -86,7 +89,7 @@ class ParameterizedObject
   # Private method to get parameter definition from the class hierarchy
   #
   # @param name: string - Parameter name
-  # @return map - Parameter definition or nil if not found
+  # @return bytes - Encoded parameter constraints or nil if not found
   def _get_param_def(name)
     import introspect
     
@@ -97,7 +100,7 @@ class ParameterizedObject
       if introspect.contains(current_class, "PARAMS")
         var class_params = current_class.PARAMS
         if class_params.contains(name)
-          return class_params[name]
+          return class_params[name]  # Returns encoded bytes
         end
       end
       
@@ -163,9 +166,9 @@ class ParameterizedObject
   def _resolve_parameter_value(name, time_ms)
     if !self.values.contains(name)
       # Return default if available from class hierarchy
-      var param_def = self._get_param_def(name)
-      if param_def != nil && param_def.contains("default")
-        return param_def["default"]
+      var encoded_constraints = self._get_param_def(name)
+      if encoded_constraints != nil && self.constraint_mask(encoded_constraints, "default")
+        return self.constraint_find(encoded_constraints, "default")
       end
       return nil
     end
@@ -188,9 +191,9 @@ class ParameterizedObject
   # @param value: any - Value to validate (may be modified for real->int conversion)
   # @return any - Validated value (potentially converted from real to int)
   def _validate_param(name, value)
-    var constraints = self._get_param_def(name)
-    if constraints == nil
-      raise "value_error", f"Parameter '{name}' is not defined for class '{classname(self)}'"
+    var encoded_constraints = self._get_param_def(name)
+    if encoded_constraints == nil
+      raise "attribute_error", f"'{classname(self)}' object has no attribute '{name}'"
     end
     
     # Accept ValueProvider instances for all parameters
@@ -201,24 +204,21 @@ class ParameterizedObject
     # Handle nil values
     if value == nil
       # Check if nil is explicitly allowed via nillable attribute
-      if constraints.contains("nillable") && constraints["nillable"] == true
+      if self.constraint_mask(encoded_constraints, "nillable")
         return value  # nil is allowed for this parameter
       end
       
       # Check if there's a default value (nil is acceptable if there's a default)
-      if constraints.contains("default")
+      if self.constraint_mask(encoded_constraints, "default")
         return value  # nil is acceptable, will use default
       end
       
       # nil is not allowed for this parameter
-      raise "value_error", f"Parameter '{name}' does not accept nil values"
+      raise "value_error", f"'{name}' does not accept nil values"
     end
     
     # Type validation - default type is "int" if not specified
-    var expected_type = "int"  # Default type
-    if constraints.contains("type")
-      expected_type = constraints["type"]
-    end
+    var expected_type = self.constraint_find(encoded_constraints, "type", "int")
     
     # Get actual type for validation
     var actual_type = type(value)
@@ -235,29 +235,34 @@ class ParameterizedObject
         if actual_type == "instance" && isinstance(value, bytes)
           actual_type = "bytes"
         elif actual_type != "instance" || !isinstance(value, bytes)
-          raise "value_error", f"Parameter '{name}' expects type '{expected_type}' but got '{actual_type}' (value: {value})"
+          raise "value_error", f"'{name}' expects type '{expected_type}' but got '{actual_type}' (value: {value})"
         end
       elif expected_type != actual_type
-        raise "value_error", f"Parameter '{name}' expects type '{expected_type}' but got '{actual_type}' (value: {value})"
+        raise "value_error", f"'{name}' expects type '{expected_type}' but got '{actual_type}' (value: {value})"
       end
     end
     
     # Range validation for integer values only
     if actual_type == "int"
-      if constraints.contains("min") && value < constraints["min"]
-        raise "value_error", f"Parameter '{name}' value {value} is below minimum {constraints['min']}"
+      if self.constraint_mask(encoded_constraints, "min")
+        var min_val = self.constraint_find(encoded_constraints, "min")
+        if value < min_val
+          raise "value_error", f"'{name}' value {value} is below minimum {min_val}"
+        end
       end
-      if constraints.contains("max") && value > constraints["max"]
-        raise "value_error", f"Parameter '{name}' value {value} is above maximum {constraints['max']}"
+      if self.constraint_mask(encoded_constraints, "max")
+        var max_val = self.constraint_find(encoded_constraints, "max")
+        if value > max_val
+          raise "value_error", f"'{name}' value {value} is above maximum {max_val}"
+        end
       end
     end
     
     # Enum validation
-    if constraints.contains("enum")
+    if self.constraint_mask(encoded_constraints, "enum")
       var valid = false
-      import introspect
-      var enum_list = constraints["enum"]
-      var list_size = enum_list.size()
+      var enum_list = self.constraint_find(encoded_constraints, "enum")
+      var list_size = size(enum_list)
       var i = 0
       while (i < list_size)
         var enum_value = enum_list[i]
@@ -268,7 +273,7 @@ class ParameterizedObject
         i += 1
       end
       if !valid
-        raise "value_error", f"Parameter '{name}' value {value} is not in allowed values {enum_list}"
+        raise "value_error", f"'{name}' value {value} is not in allowed values {enum_list}"
       end
     end
     
@@ -307,9 +312,9 @@ class ParameterizedObject
     end
     
     # Fall back to parameter default from class hierarchy
-    var param_def = self._get_param_def(name)
-    if param_def != nil && param_def.contains("default")
-      return param_def["default"]
+    var encoded_constraints = self._get_param_def(name)
+    if encoded_constraints != nil && self.constraint_mask(encoded_constraints, "default")
+      return self.constraint_find(encoded_constraints, "default", default_value)
     end
     
     return default_value
@@ -322,23 +327,11 @@ class ParameterizedObject
   # @param time_ms: int - Current time in milliseconds
   # @return any - The resolved value (static or from provider)
   def resolve_value(value, param_name, time_ms)
-    if value == nil
-      return nil
-    end
-    
-    if animation.is_value_provider(value)
+    if animation.is_value_provider(value)             # this also captures 'nil'
       return value.produce_value(param_name, time_ms)
     else
       return value
     end
-  end
-  
-  # Get parameter metadata
-  #
-  # @param name: string - Parameter name
-  # @return map - Parameter metadata or nil if not found
-  def get_param_metadata(name)
-    return self._get_param_def(name)
   end
   
   # Helper method to get a resolved value from either a static value or a value provider
@@ -362,9 +355,9 @@ class ParameterizedObject
     if time_ms == nil
       time_ms = self.engine.time_ms
     end
-    if time_ms == nil
-      raise "value_error", "engine.time_ms should not be 'nil'"
-    end
+    # if time_ms == nil
+    #   raise "value_error", "engine.time_ms should not be 'nil'"
+    # end
     if self.start_time == nil
       self.start_time = time_ms
     end
@@ -384,9 +377,9 @@ class ParameterizedObject
     if time_ms == nil
       time_ms = self.engine.time_ms
     end
-    if time_ms == nil
-      raise "value_error", "engine.time_ms should not be 'nil'"
-    end
+    # if time_ms == nil
+    #   raise "value_error", "engine.time_ms should not be 'nil'"
+    # end
     if self.start_time != nil   # reset time only if it was already started
       self.start_time = time_ms
     end
@@ -430,6 +423,260 @@ class ParameterizedObject
   # @return bool - True if objects are different instances
   def !=(other)
     return !(self == other)
+  end
+  
+  # ============================================================================
+  # STATIC METHODS FOR ENCODED CONSTRAINT ACCESS
+  # ============================================================================
+  # PARAMETER CONSTRAINT ENCODING
+  # ==============================
+  #
+  # Parameter constraints are encoded into a compact bytes() format for efficient
+  # storage and transmission. Each value is prefixed with its own type byte for
+  # maximum flexibility and correctness.
+  #
+  # Byte 0: Constraint mask (bit field)
+  #   Bit 0 (0x01): has_min
+  #   Bit 1 (0x02): has_max
+  #   Bit 2 (0x04): has_default
+  #   Bit 3 (0x08): has_explicit_type
+  #   Bit 4 (0x10): has_enum
+  #   Bit 5 (0x20): is_nillable
+  #   Bits 6-7: reserved
+  #
+  # Bytes 1+: Type-prefixed values in order (min, max, default, enum)
+  #   Each value consists of: [type_byte][value_data]
+  #
+  # Value Type Codes:
+  #   0x00 = int8 (1 byte, signed -128 to 127)
+  #   0x01 = int16 (2 bytes, signed -32768 to 32767)
+  #   0x02 = int32 (4 bytes, signed integer)
+  #   0x03 = string (1-byte length prefix + string bytes)
+  #   0x04 = bytes (2-byte length prefix + byte data)
+  #   0x05 = bool (1 byte, 0 or 1)
+  #   0x06 = nil (0 bytes)
+  #
+  # Explicit Type Codes (semantic types for validation) (1 byte):
+  #   0x00 = int
+  #   0x01 = string
+  #   0x02 = bytes
+  #   0x03 = bool
+  #   0x04 = any
+  #   0x05 = instance
+  #   0x06 = function
+  #
+  # ENCODING EXAMPLES:
+  #
+  # {"min": 0, "max": 255, "default": 128}
+  #   => bytes("07 00 00 01 00FF 00 0080")  # 8 bytes
+  #   Breakdown:
+  #     07 = mask (has_min|has_max|has_default)
+  #     00 00 = min (type=int8, value=0)
+  #     01 00FF = max (type=int16, value=255)
+  #     00 0080 = default (type=int8, value=128)
+  #
+  # {"enum": [1, 2, 3], "default": 1}
+  #   => bytes("0C 00 01 03 00 01 00 02 00 03")  # 10 bytes
+  #   Breakdown:
+  #     0C = mask (has_enum|has_default)
+  #     00 01 = default (type=int8, value=1)
+  #     03 = enum count (3 values)
+  #     00 01 = enum[0] (type=int8, value=1)
+  #     00 02 = enum[1] (type=int8, value=2)
+  #     00 03 = enum[2] (type=int8, value=3)
+  #
+  # {"default": nil, "nillable": true}
+  #   => bytes("14 06")  # 2 bytes
+  #   Breakdown:
+  #     14 = mask (has_default|is_nillable)
+  #     06 = default (type=nil, no value data)
+  #
+  # USAGE:
+  #
+  # Encoding constraints (see param_encoder.be):
+  #   import param_encoder
+  #   var encoded = param_encoder.encode_constraints({"min": 0, "max": 255, "default": 128})
+  #
+  # Checking if constraint contains a field:
+  #   if ParameterizedObject.constraint_mask(encoded, "min")
+  #     print("Has min constraint")
+  #   end
+  #
+  # Getting constraint field value:
+  #   var min_val = ParameterizedObject.constraint_find(encoded, "min", 0)
+  #   var max_val = ParameterizedObject.constraint_find(encoded, "max", 255)
+  # ============================================================================
+  # Check if an encoded constraint contains a specific field (monolithic, no sub-calls)
+  #
+  # This static method provides fast access to encoded constraint metadata without
+  # decoding the entire constraint. It directly checks the mask byte to determine
+  # if a field is present.
+  #
+  # @param encoded_bytes: bytes - Encoded constraint in Hybrid format
+  # @param name: string - Field name ("min", "max", "default", "enum", "nillable", "type")
+  # @return bool - True if field exists, false otherwise
+  #
+  # Example:
+  #   var encoded = bytes("07 00 00 FF 80")  # min=0, max=255, default=128
+  #   ParameterizedObject.constraint_mask(encoded, "min")      # => true
+  #   ParameterizedObject.constraint_mask(encoded, "enum")     # => false
+  static var _MASK = [
+    "min",      #- 0x01 HAS_MIN-#
+    "max",      #- 0x02, HAS_MAX-#
+    "default",  #- 0x04, HAS_DEFAULT-#
+    "type",     #- 0x08, HAS_EXPLICIT_TYPE-#
+    "enum",     #- 0x10, HAS_ENUM-#
+    "nillable", #- 0x20, IS_NILLABLE-#
+  ]
+  static var _TYPES = [
+    "int",        # 0x00
+    "string",     # 0x01
+    "bytes",      # 0x02
+    "bool",       # 0x03
+    "any",        # 0x04
+    "instance",   # 0x05
+    "function"    # 0x06
+  ]
+  static def constraint_mask(encoded_bytes, name)
+    if size(encoded_bytes) > 0
+      var index_mask = _class._MASK.find(name)
+      if (index_mask != nil)
+        return (encoded_bytes[0] & (1 << index_mask))
+      end
+    end
+    return 0
+  end
+  
+  # Find and return an encoded constraint field value (monolithic, no sub-calls)
+  #
+  # This static method extracts a specific field value from an encoded constraint
+  # without decoding the entire structure. It performs direct byte reading with
+  # inline type handling for maximum efficiency.
+  #
+  # @param encoded_bytes: bytes - Encoded constraint in Hybrid format
+  # @param name: string - Field name ("min", "max", "default", "enum", "nillable", "type")
+  # @param default: any - Default value if field not found
+  # @return any - Field value or default
+  #
+  # Supported field names:
+  #   - "min": Minimum value constraint (int)
+  #   - "max": Maximum value constraint (int)
+  #   - "default": Default value (any type)
+  #   - "enum": List of allowed values (array)
+  #   - "nillable": Whether nil is allowed (bool)
+  #   - "type": Explicit type string ("int", "string", "bytes", "bool", "any", "instance", "function")
+  #
+  # Example:
+  #   var encoded = bytes("07 00 00 FF 80")  # min=0, max=255, default=128
+  #   ParameterizedObject.constraint_find(encoded, "min", 0)       # => 0
+  #   ParameterizedObject.constraint_find(encoded, "max", 255)     # => 255
+  #   ParameterizedObject.constraint_find(encoded, "default", 100) # => 128
+  #   ParameterizedObject.constraint_find(encoded, "enum", nil)    # => nil (not present)
+  
+  static def constraint_find(encoded_bytes, name, default)
+
+    # Helper: Skip a value with type prefix and return new offset
+    def _skip_typed_value(encoded_bytes, offset)
+      if offset >= size(encoded_bytes)  return 0  end
+      var type_code = encoded_bytes[offset]
+      
+      if type_code == 0x06 #-NIL-#  return 1
+      elif type_code == 0x05 #-BOOL-#  return 2
+      elif type_code == 0x00 #-INT8-#  return 2
+      elif type_code == 0x01 #-INT16-#  return 3
+      elif type_code == 0x02 #-INT32-#  return 5
+      elif type_code == 0x03 #-STRING-#  return 2 + encoded_bytes[offset + 1]
+      elif type_code == 0x04 #-BYTES-#  return 3 + encoded_bytes.get(offset + 1, 2)
+      end
+      return 0
+    end
+
+    # Helper: Read a value with type prefix and return [value, new_offset]
+    def _read_typed_value(encoded_bytes, offset)
+      if offset >= size(encoded_bytes)  return nil  end
+      var type_code = encoded_bytes[offset]
+      offset += 1  # Skip type byte
+      
+      if type_code == 0x06 #-NIL-#  return nil
+      elif type_code == 0x05 #-BOOL-#
+        return encoded_bytes[offset] != 0
+      elif type_code == 0x00 #-INT8-# 
+        var v = encoded_bytes[offset]
+        return v > 127 ? v - 256 : v
+      elif type_code == 0x01 #-INT16-#
+        var v = encoded_bytes.get(offset, 2)
+        return v > 32767 ? v - 65536 : v
+      elif type_code == 0x02 #-INT32-#
+        return encoded_bytes.get(offset, 4)
+      elif type_code == 0x03 #-STRING-#
+        var len = encoded_bytes[offset]
+        return encoded_bytes[offset + 1 .. offset + len].asstring()
+      elif type_code == 0x04 #-BYTES-#
+        var len = encoded_bytes.get(offset, 2)
+        return encoded_bytes[offset + 2 .. offset + len + 1]
+      end
+      return nil
+    end
+
+    if size(encoded_bytes) < 1  return default  end
+    var mask = encoded_bytes[0]
+    var offset = 1
+    
+    # Quick check if field exists
+    var target_mask = _class._MASK.find(name)   # nil or 0..5
+    if (target_mask == nil) return default  end
+    target_mask = (1 << target_mask)
+
+    # If no match, quick fail
+    if !(mask & target_mask)  return default  end
+
+    # Easy check if 'nillable'
+    if target_mask == 0x20 #-IS_NILLABLE-#
+      return true           # since 'mask & target_mask' is true, we know we should return true
+    end
+
+    # Skip fields before target
+    if target_mask > 0x01 #-HAS_MIN-# && (mask & 0x01 #-HAS_MIN-#)
+      offset += _skip_typed_value(encoded_bytes, offset)
+    end
+    if target_mask > 0x02 #-HAS_MAX-# && (mask & 0x02 #-HAS_MAX-#)
+      offset += _skip_typed_value(encoded_bytes, offset)
+    end
+    if target_mask > 0x04 #-HAS_DEFAULT-# && (mask & 0x04 #-HAS_DEFAULT-#)
+      offset += _skip_typed_value(encoded_bytes, offset)
+    end
+    if target_mask > 0x08 #-HAS_EXPLICIT_TYPE-# && (mask & 0x08 #-HAS_EXPLICIT_TYPE-#)
+      offset += 1
+    end
+    if offset >= size(encoded_bytes)  return default  end   # sanity check
+
+    # Special case for explicit_type
+    if target_mask == 0x08 #-HAS_EXPLICIT_TYPE-#
+      # Read explicit type code and convert to string
+      var type_byte = encoded_bytes[offset]                 # sanity check above guarantees that index is correct
+      if type_byte < size(_class._TYPES)
+        return _class._TYPES[type_byte]
+      end
+      return default
+    end    
+    
+    # Read target value
+    if target_mask == 0x10 #-HAS_ENUM-#
+      var count = encoded_bytes[offset]
+      offset += 1
+      var result = []
+      var i = 0
+      while i < count
+        var val_and_offset = 
+        result.push(_read_typed_value(encoded_bytes, offset))
+        offset += _skip_typed_value(encoded_bytes, offset)
+        i += 1
+      end
+      return result
+    end
+
+    # All other cases
+    return _read_typed_value(encoded_bytes, offset)
   end
 end
 

--- a/lib/libesp32/berry_animation/src/core/sequence_manager.be
+++ b/lib/libesp32/berry_animation/src/core/sequence_manager.be
@@ -413,22 +413,22 @@ class SequenceManager
     return self.is_running
   end
   
-  # Get current step info for debugging
-  def get_current_step_info()
-    if !self.is_running || self.step_index >= size(self.steps)
-      return nil
-    end
+  # # Get current step info for debugging
+  # def get_current_step_info()
+  #   if !self.is_running || self.step_index >= size(self.steps)
+  #     return nil
+  #   end
     
-    return {
-      "step_index": self.step_index,
-      "total_steps": size(self.steps),
-      "current_step": self.steps[self.step_index],
-      "elapsed_ms": self.engine.time_ms - self.step_start_time,
-      "repeat_count": self.repeat_count,
-      "current_iteration": self.current_iteration,
-      "is_repeat_sequence": self.is_repeat_sequence
-    }
-  end
+  #   return {
+  #     "step_index": self.step_index,
+  #     "total_steps": size(self.steps),
+  #     "current_step": self.steps[self.step_index],
+  #     "elapsed_ms": self.engine.time_ms - self.step_start_time,
+  #     "repeat_count": self.repeat_count,
+  #     "current_iteration": self.current_iteration,
+  #     "is_repeat_sequence": self.is_repeat_sequence
+  #   }
+  # end
 end
 
 return {'SequenceManager': SequenceManager}

--- a/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
@@ -9,16 +9,18 @@
 # - curve_factor 1: Pure cosine wave (smooth pulsing)
 # - curve_factor 2-5: Natural breathing with pauses at peaks (5 = most pronounced pauses)
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:BreatheColorProvider,weak
 class BreatheColorProvider : animation.oscillator_value
   # Additional parameter definitions for color-specific functionality
   # The oscillator parameters (min_value, max_value, duration, form, etc.) are inherited
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "base_color": {"default": 0xFFFFFFFF},               # The base color to modulate (32-bit ARGB value)
     "min_brightness": {"min": 0, "max": 255, "default": 0},      # Minimum brightness level (0-255)
     "max_brightness": {"min": 0, "max": 255, "default": 255},    # Maximum brightness level (0-255)
     "curve_factor": {"min": 1, "max": 5, "default": 2}   # Factor to control breathing curve shape (1=cosine wave, 2-5=curved breathing with pauses)
-  }
+  })
   
   # Initialize a new Breathe Color Provider
   # Following parameterized class specification - engine parameter only

--- a/lib/libesp32/berry_animation/src/providers/closure_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/closure_value_provider.be
@@ -15,14 +15,16 @@
 #   animation.brightness = provider
 #   
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:ClosureValueProvider,weak
 class ClosureValueProvider : animation.value_provider
   var _closure                # We keep the closure as instance variable for faster dereferencing, in addition to PARAMS
 
   # Static parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "closure": {"type": "function", "default": nil}
-  }
+  })
   
   # Method called when a parameter is changed
   # Copy "closure" parameter to _closure instance variable

--- a/lib/libesp32/berry_animation/src/providers/color_cycle_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/color_cycle_color_provider.be
@@ -11,6 +11,8 @@
 # - Constructor takes only 'engine' parameter
 # - All other parameters set via virtual member assignment after creation
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:ColorCycleColorProvider,weak
 class ColorCycleColorProvider : animation.color_provider
   # Non-parameter instance variables only
@@ -18,7 +20,7 @@ class ColorCycleColorProvider : animation.color_provider
   var current_index   # Current color index for next functionality
   
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "palette": {"type": "bytes", "default":
       bytes(          # Palette bytes in AARRGGBB format
         "FF0000FF"    # Blue
@@ -29,7 +31,7 @@ class ColorCycleColorProvider : animation.color_provider
     "cycle_period": {"min": 0, "default": 5000},  # 0 = manual only, >0 = auto cycle time in ms
     "next": {"default": 0},  # Write `<n>` to move to next <n> colors
     "palette_size": {"type": "int", "default": 3}  # Read-only: number of colors in palette
-  }
+  })
   
   # Initialize a new ColorCycleColorProvider
   #
@@ -50,10 +52,10 @@ class ColorCycleColorProvider : animation.color_provider
   def _get_palette_bytes()
     var palette_bytes = self.palette
     if palette_bytes == nil
-      # Get default from PARAMS
-      var param_def = self._get_param_def("palette")
-      if param_def != nil && param_def.contains("default")
-        palette_bytes = param_def["default"]
+      # Get default from PARAMS using encoded constraints
+      var encoded_constraints = self._get_param_def("palette")
+      if encoded_constraints != nil && self.constraint_mask(encoded_constraints, "default")
+        palette_bytes = self.constraint_find(encoded_constraints, "default", nil)
       end
     end
     return palette_bytes

--- a/lib/libesp32/berry_animation/src/providers/composite_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/composite_color_provider.be
@@ -7,15 +7,17 @@
 # - Constructor takes only 'engine' parameter
 # - All other parameters set via virtual member assignment after creation
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:CompositeColorProvider,weak
 class CompositeColorProvider : animation.color_provider
   # Non-parameter instance variables only
   var providers        # List of color providers
   
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "blend_mode": {"enum": [0, 1, 2], "default": 0}  # 0=overlay, 1=add, 2=multiply
-  }
+  })
   
   # Initialize a new CompositeColorProvider
   #

--- a/lib/libesp32/berry_animation/src/providers/iteration_number_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/iteration_number_provider.be
@@ -19,10 +19,14 @@
 #     }
 #   }
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:IterationNumberProvider,weak
 class IterationNumberProvider : animation.value_provider
   # Static parameter definitions (no parameters needed)
-  static var PARAMS = {}
+  static var PARAMS = encode_constraints({
+    
+  })
   
   # Produce the current iteration number from the animation engine
   #

--- a/lib/libesp32/berry_animation/src/providers/oscillator_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/oscillator_value_provider.be
@@ -9,6 +9,8 @@
 # - SQUARE (3): Square wave alternating between a and b
 # - COSINE (4): Smooth cosine wave from a to b
 
+import "./core/param_encoder" as encode_constraints
+
 # Waveform constants
 var SAWTOOTH = 1
 var LINEAR = 1
@@ -30,14 +32,14 @@ class OscillatorValueProvider : animation.value_provider
   static var form_names = ["", "SAWTOOTH", "TRIANGLE", "SQUARE", "COSINE", "SINE", "EASE_IN", "EASE_OUT", "ELASTIC", "BOUNCE"]
   
   # Parameter definitions for the oscillator
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "min_value": {"default": 0},
     "max_value": {"default": 100},
     "duration": {"min": 1, "default": 1000},
     "form": {"enum": [1, 2, 3, 4, 5, 6, 7, 8, 9], "default": 1},
     "phase": {"min": 0, "max": 100, "default": 0},
     "duty_cycle": {"min": 0, "max": 100, "default": 50}
-  }
+  })
   
   # Initialize a new OscillatorValueProvider
   #

--- a/lib/libesp32/berry_animation/src/providers/rich_palette_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/rich_palette_color_provider.be
@@ -7,6 +7,8 @@
 # - Constructor takes only 'engine' parameter
 # - All other parameters set via virtual member assignment after creation
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:RichPaletteColorProvider,weak
 class RichPaletteColorProvider : animation.color_provider
   # Non-parameter instance variables only
@@ -17,14 +19,14 @@ class RichPaletteColorProvider : animation.color_provider
   var light_state      # light_state instance for proper color calculations
   
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "palette": {"type": "bytes", "default": nil},  # Palette bytes or predefined palette constant
     "cycle_period": {"min": 0, "default": 5000},  # 5 seconds default, 0 = value-based only
     "transition_type": {"enum": [animation.LINEAR, animation.SINE], "default": animation.SINE},
     "brightness": {"min": 0, "max": 255, "default": 255},
     "range_min": {"default": 0},
     "range_max": {"default": 255}
-  }
+  })
   
   # Initialize a new RichPaletteColorProvider
   #

--- a/lib/libesp32/berry_animation/src/providers/static_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/static_color_provider.be
@@ -7,12 +7,14 @@
 # - Constructor takes only 'engine' parameter
 # - All other parameters set via virtual member assignment after creation
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:StaticColorProvider,weak
 class StaticColorProvider : animation.color_provider
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "color": {"default": 0xFFFFFFFF}  # Default to white
-  }
+  })
   
   # Produce the solid color for any parameter name
   #

--- a/lib/libesp32/berry_animation/src/providers/static_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/static_value_provider.be
@@ -11,12 +11,14 @@
 # - Constructor takes only 'engine' parameter
 # - Value is set via virtual member assignment after creation
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:StaticValueProvider,weak
 class StaticValueProvider : animation.value_provider
   # Parameter definitions
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "value": {"default": nil, "type": "any"}
-  }
+  })
   
   # Comparison operators to make StaticValueProvider work with validation code
   def <(other)

--- a/lib/libesp32/berry_animation/src/providers/value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/value_provider.be
@@ -12,10 +12,14 @@
 # - All other parameters set via virtual member assignment
 # - No setter/getter methods for parameters
 
+import "./core/param_encoder" as encode_constraints
+
 #@ solidify:ValueProvider,weak
 class ValueProvider : animation.parameterized_object
   # Static parameter definitions - can be overridden by subclasses
-  static var PARAMS = {}
+  static var PARAMS = encode_constraints({
+    
+  })
   
   # Initialize the value provider
   #

--- a/lib/libesp32/berry_animation/src/solidify/solidified_animation.h
+++ b/lib/libesp32/berry_animation/src/solidify/solidified_animation.h
@@ -209,38 +209,11 @@ be_local_class(BreatheAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(base_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(curve_factor, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(2) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(5) },
-    }))    ) } )) },
-        { be_const_key_weak(min_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(max_brightness, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(3000) },
-        { be_const_key_weak(min, -1), be_const_int(100) },
-    }))    ) } )) },
+        { be_const_key_weak(max_brightness, -1), be_const_bytes_instance(07000001FF0001FF00) },
+        { be_const_key_weak(curve_factor, -1), be_const_bytes_instance(07000100050002) },
+        { be_const_key_weak(min_brightness, -1), be_const_bytes_instance(07000001FF000000) },
+        { be_const_key_weak(base_color, 0), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(period, -1), be_const_bytes_instance(05006401B80B) },
     }))    ) } )) },
         { be_const_key_weak(init, 2), be_const_closure(class_BreatheAnimation_init_closure) },
         { be_const_key_weak(breathe_provider, -1), be_const_var(0) },
@@ -469,464 +442,39 @@ be_local_closure(twinkle_solid,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'CompositeColorProvider' ktab size: 14, total: 24 (saved 80 bytes)
-static const bvalue be_ktab_class_CompositeColorProvider[14] = {
-  /* K0   */  be_nested_str_weak(providers),
-  /* K1   */  be_nested_str_weak(push),
-  /* K2   */  be_const_int(0),
-  /* K3   */  be_const_int(1),
-  /* K4   */  be_nested_str_weak(get_color_for_value),
-  /* K5   */  be_nested_str_weak(_blend_colors),
-  /* K6   */  be_nested_str_weak(produce_value),
-  /* K7   */  be_nested_str_weak(CompositeColorProvider_X28providers_X3D_X25s_X2C_X20blend_mode_X3D_X25s_X29),
-  /* K8   */  be_nested_str_weak(blend_mode),
-  /* K9   */  be_const_real_hex(0x437F0000),
-  /* K10  */  be_const_int(2),
-  /* K11  */  be_nested_str_weak(tasmota),
-  /* K12  */  be_nested_str_weak(scale_uint),
-  /* K13  */  be_nested_str_weak(init),
-};
-
-
-extern const bclass be_class_CompositeColorProvider;
 
 /********************************************************************
-** Solidified function: add_provider
+** Solidified function: get_user_function
 ********************************************************************/
-be_local_closure(class_CompositeColorProvider_add_provider,   /* name */
+be_local_closure(get_user_function,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(add_provider),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040000,  //  0004  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color_for_value
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_get_color_for_value,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(get_color_for_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x600C000C,  //  0000  GETGBL	R3	G12
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0702,  //  0003  EQ	R3	R3	K2
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x540DFFFE,  //  0005  LDINT	R3	-1
-      0x80040600,  //  0006  RET	1	R3
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x1C0C0703,  //  000A  EQ	R3	R3	K3
-      0x780E0006,  //  000B  JMPF	R3	#0013
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
-      0x940C0702,  //  000D  GETIDX	R3	R3	K2
-      0x8C0C0704,  //  000E  GETMET	R3	R3	K4
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
-      0x940C0702,  //  0014  GETIDX	R3	R3	K2
-      0x8C0C0704,  //  0015  GETMET	R3	R3	K4
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5C180400,  //  0017  MOVE	R6	R2
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x58100003,  //  0019  LDCONST	R4	K3
-      0x6014000C,  //  001A  GETGBL	R5	G12
-      0x88180100,  //  001B  GETMBR	R6	R0	K0
-      0x7C140200,  //  001C  CALL	R5	1
-      0x14140805,  //  001D  LT	R5	R4	R5
-      0x7816000C,  //  001E  JMPF	R5	#002C
-      0x88140100,  //  001F  GETMBR	R5	R0	K0
-      0x94140A04,  //  0020  GETIDX	R5	R5	R4
-      0x8C140B04,  //  0021  GETMET	R5	R5	K4
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x5C200400,  //  0023  MOVE	R8	R2
-      0x7C140600,  //  0024  CALL	R5	3
-      0x8C180105,  //  0025  GETMET	R6	R0	K5
-      0x5C200600,  //  0026  MOVE	R8	R3
-      0x5C240A00,  //  0027  MOVE	R9	R5
-      0x7C180600,  //  0028  CALL	R6	3
-      0x5C0C0C00,  //  0029  MOVE	R3	R6
-      0x00100903,  //  002A  ADD	R4	R4	K3
-      0x7001FFED,  //  002B  JMP		#001A
-      0x80040600,  //  002C  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_produce_value,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x600C000C,  //  0000  GETGBL	R3	G12
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0702,  //  0003  EQ	R3	R3	K2
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x540DFFFE,  //  0005  LDINT	R3	-1
-      0x80040600,  //  0006  RET	1	R3
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x1C0C0703,  //  000A  EQ	R3	R3	K3
-      0x780E0006,  //  000B  JMPF	R3	#0013
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
-      0x940C0702,  //  000D  GETIDX	R3	R3	K2
-      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
-      0x940C0702,  //  0014  GETIDX	R3	R3	K2
-      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5C180400,  //  0017  MOVE	R6	R2
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x58100003,  //  0019  LDCONST	R4	K3
-      0x6014000C,  //  001A  GETGBL	R5	G12
-      0x88180100,  //  001B  GETMBR	R6	R0	K0
-      0x7C140200,  //  001C  CALL	R5	1
-      0x14140805,  //  001D  LT	R5	R4	R5
-      0x7816000C,  //  001E  JMPF	R5	#002C
-      0x88140100,  //  001F  GETMBR	R5	R0	K0
-      0x94140A04,  //  0020  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0021  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x5C200400,  //  0023  MOVE	R8	R2
-      0x7C140600,  //  0024  CALL	R5	3
-      0x8C180105,  //  0025  GETMET	R6	R0	K5
-      0x5C200600,  //  0026  MOVE	R8	R3
-      0x5C240A00,  //  0027  MOVE	R9	R5
-      0x7C180600,  //  0028  CALL	R6	3
-      0x5C0C0C00,  //  0029  MOVE	R3	R6
-      0x00100903,  //  002A  ADD	R4	R4	K3
-      0x7001FFED,  //  002B  JMP		#001A
-      0x80040600,  //  002C  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_tostring,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
-    10,                          /* varg */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(tostring),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(_user_functions),
+    /* K2   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(get_user_function),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080007,  //  0001  LDCONST	R2	K7
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x88100108,  //  0005  GETMBR	R4	R0	K8
-      0x7C040600,  //  0006  CALL	R1	3
-      0x80040200,  //  0007  RET	1	R1
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified function: _blend_colors
-********************************************************************/
-be_local_closure(class_CompositeColorProvider__blend_colors,   /* name */
-  be_nested_proto(
-    23,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(_blend_colors),
-    &be_const_str_solidified,
-    ( &(const binstruction[151]) {  /* code */
-      0x880C0108,  //  0000  GETMBR	R3	R0	K8
-      0x54120017,  //  0001  LDINT	R4	24
-      0x3C100204,  //  0002  SHR	R4	R1	R4
-      0x541600FE,  //  0003  LDINT	R5	255
-      0x2C100805,  //  0004  AND	R4	R4	R5
-      0x5416000F,  //  0005  LDINT	R5	16
-      0x3C140205,  //  0006  SHR	R5	R1	R5
-      0x541A00FE,  //  0007  LDINT	R6	255
-      0x2C140A06,  //  0008  AND	R5	R5	R6
-      0x541A0007,  //  0009  LDINT	R6	8
-      0x3C180206,  //  000A  SHR	R6	R1	R6
-      0x541E00FE,  //  000B  LDINT	R7	255
-      0x2C180C07,  //  000C  AND	R6	R6	R7
-      0x541E00FE,  //  000D  LDINT	R7	255
-      0x2C1C0207,  //  000E  AND	R7	R1	R7
-      0x54220017,  //  000F  LDINT	R8	24
-      0x3C200408,  //  0010  SHR	R8	R2	R8
-      0x542600FE,  //  0011  LDINT	R9	255
-      0x2C201009,  //  0012  AND	R8	R8	R9
-      0x5426000F,  //  0013  LDINT	R9	16
-      0x3C240409,  //  0014  SHR	R9	R2	R9
-      0x542A00FE,  //  0015  LDINT	R10	255
-      0x2C24120A,  //  0016  AND	R9	R9	R10
-      0x542A0007,  //  0017  LDINT	R10	8
-      0x3C28040A,  //  0018  SHR	R10	R2	R10
-      0x542E00FE,  //  0019  LDINT	R11	255
-      0x2C28140B,  //  001A  AND	R10	R10	R11
-      0x542E00FE,  //  001B  LDINT	R11	255
-      0x2C2C040B,  //  001C  AND	R11	R2	R11
-      0x4C300000,  //  001D  LDNIL	R12
-      0x4C340000,  //  001E  LDNIL	R13
-      0x4C380000,  //  001F  LDNIL	R14
-      0x4C3C0000,  //  0020  LDNIL	R15
-      0x1C400702,  //  0021  EQ	R16	R3	K2
-      0x7842001C,  //  0022  JMPF	R16	#0040
-      0x0C401109,  //  0023  DIV	R16	R8	K9
-      0x60440009,  //  0024  GETGBL	R17	G9
-      0x044A0610,  //  0025  SUB	R18	K3	R16
-      0x08480E12,  //  0026  MUL	R18	R7	R18
-      0x084C1610,  //  0027  MUL	R19	R11	R16
-      0x00482413,  //  0028  ADD	R18	R18	R19
-      0x7C440200,  //  0029  CALL	R17	1
-      0x5C342200,  //  002A  MOVE	R13	R17
-      0x60440009,  //  002B  GETGBL	R17	G9
-      0x044A0610,  //  002C  SUB	R18	K3	R16
-      0x08480C12,  //  002D  MUL	R18	R6	R18
-      0x084C1410,  //  002E  MUL	R19	R10	R16
-      0x00482413,  //  002F  ADD	R18	R18	R19
-      0x7C440200,  //  0030  CALL	R17	1
-      0x5C382200,  //  0031  MOVE	R14	R17
-      0x60440009,  //  0032  GETGBL	R17	G9
-      0x044A0610,  //  0033  SUB	R18	K3	R16
-      0x08480A12,  //  0034  MUL	R18	R5	R18
-      0x084C1210,  //  0035  MUL	R19	R9	R16
-      0x00482413,  //  0036  ADD	R18	R18	R19
-      0x7C440200,  //  0037  CALL	R17	1
-      0x5C3C2200,  //  0038  MOVE	R15	R17
-      0x24440808,  //  0039  GT	R17	R4	R8
-      0x78460001,  //  003A  JMPF	R17	#003D
-      0x5C440800,  //  003B  MOVE	R17	R4
-      0x70020000,  //  003C  JMP		#003E
-      0x5C441000,  //  003D  MOVE	R17	R8
-      0x5C302200,  //  003E  MOVE	R12	R17
-      0x7002004C,  //  003F  JMP		#008D
-      0x1C400703,  //  0040  EQ	R16	R3	K3
-      0x78420021,  //  0041  JMPF	R16	#0064
-      0x00400E0B,  //  0042  ADD	R16	R7	R11
-      0x5C342000,  //  0043  MOVE	R13	R16
-      0x00400C0A,  //  0044  ADD	R16	R6	R10
-      0x5C382000,  //  0045  MOVE	R14	R16
-      0x00400A09,  //  0046  ADD	R16	R5	R9
-      0x5C3C2000,  //  0047  MOVE	R15	R16
-      0x24400808,  //  0048  GT	R16	R4	R8
-      0x78420001,  //  0049  JMPF	R16	#004C
-      0x5C400800,  //  004A  MOVE	R16	R4
-      0x70020000,  //  004B  JMP		#004D
-      0x5C401000,  //  004C  MOVE	R16	R8
-      0x5C302000,  //  004D  MOVE	R12	R16
-      0x544200FE,  //  004E  LDINT	R16	255
-      0x24401A10,  //  004F  GT	R16	R13	R16
-      0x78420001,  //  0050  JMPF	R16	#0053
-      0x544200FE,  //  0051  LDINT	R16	255
-      0x70020000,  //  0052  JMP		#0054
-      0x5C401A00,  //  0053  MOVE	R16	R13
-      0x5C342000,  //  0054  MOVE	R13	R16
-      0x544200FE,  //  0055  LDINT	R16	255
-      0x24401C10,  //  0056  GT	R16	R14	R16
-      0x78420001,  //  0057  JMPF	R16	#005A
-      0x544200FE,  //  0058  LDINT	R16	255
-      0x70020000,  //  0059  JMP		#005B
-      0x5C401C00,  //  005A  MOVE	R16	R14
-      0x5C382000,  //  005B  MOVE	R14	R16
-      0x544200FE,  //  005C  LDINT	R16	255
-      0x24401E10,  //  005D  GT	R16	R15	R16
-      0x78420001,  //  005E  JMPF	R16	#0061
-      0x544200FE,  //  005F  LDINT	R16	255
-      0x70020000,  //  0060  JMP		#0062
-      0x5C401E00,  //  0061  MOVE	R16	R15
-      0x5C3C2000,  //  0062  MOVE	R15	R16
-      0x70020028,  //  0063  JMP		#008D
-      0x1C40070A,  //  0064  EQ	R16	R3	K10
-      0x78420026,  //  0065  JMPF	R16	#008D
-      0xB8421600,  //  0066  GETNGBL	R16	K11
-      0x8C40210C,  //  0067  GETMET	R16	R16	K12
-      0x08480E0B,  //  0068  MUL	R18	R7	R11
-      0x584C0002,  //  0069  LDCONST	R19	K2
-      0x545200FE,  //  006A  LDINT	R20	255
-      0x545600FE,  //  006B  LDINT	R21	255
-      0x08502815,  //  006C  MUL	R20	R20	R21
-      0x58540002,  //  006D  LDCONST	R21	K2
-      0x545A00FE,  //  006E  LDINT	R22	255
-      0x7C400C00,  //  006F  CALL	R16	6
-      0x5C342000,  //  0070  MOVE	R13	R16
-      0xB8421600,  //  0071  GETNGBL	R16	K11
-      0x8C40210C,  //  0072  GETMET	R16	R16	K12
-      0x08480C0A,  //  0073  MUL	R18	R6	R10
-      0x584C0002,  //  0074  LDCONST	R19	K2
-      0x545200FE,  //  0075  LDINT	R20	255
-      0x545600FE,  //  0076  LDINT	R21	255
-      0x08502815,  //  0077  MUL	R20	R20	R21
-      0x58540002,  //  0078  LDCONST	R21	K2
-      0x545A00FE,  //  0079  LDINT	R22	255
-      0x7C400C00,  //  007A  CALL	R16	6
-      0x5C382000,  //  007B  MOVE	R14	R16
-      0xB8421600,  //  007C  GETNGBL	R16	K11
-      0x8C40210C,  //  007D  GETMET	R16	R16	K12
-      0x08480A09,  //  007E  MUL	R18	R5	R9
-      0x584C0002,  //  007F  LDCONST	R19	K2
-      0x545200FE,  //  0080  LDINT	R20	255
-      0x545600FE,  //  0081  LDINT	R21	255
-      0x08502815,  //  0082  MUL	R20	R20	R21
-      0x58540002,  //  0083  LDCONST	R21	K2
-      0x545A00FE,  //  0084  LDINT	R22	255
-      0x7C400C00,  //  0085  CALL	R16	6
-      0x5C3C2000,  //  0086  MOVE	R15	R16
-      0x24400808,  //  0087  GT	R16	R4	R8
-      0x78420001,  //  0088  JMPF	R16	#008B
-      0x5C400800,  //  0089  MOVE	R16	R4
-      0x70020000,  //  008A  JMP		#008C
-      0x5C401000,  //  008B  MOVE	R16	R8
-      0x5C302000,  //  008C  MOVE	R12	R16
-      0x54420017,  //  008D  LDINT	R16	24
-      0x38401810,  //  008E  SHL	R16	R12	R16
-      0x5446000F,  //  008F  LDINT	R17	16
-      0x38441E11,  //  0090  SHL	R17	R15	R17
-      0x30402011,  //  0091  OR	R16	R16	R17
-      0x54460007,  //  0092  LDINT	R17	8
-      0x38441C11,  //  0093  SHL	R17	R14	R17
-      0x30402011,  //  0094  OR	R16	R16	R17
-      0x3040200D,  //  0095  OR	R16	R16	R13
-      0x80042000,  //  0096  RET	1	R16
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_CompositeColorProvider_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_CompositeColorProvider,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08050D,  //  0003  GETMET	R2	R2	K13
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90020002,  //  0008  SETMBR	R0	K0	R2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: CompositeColorProvider
-********************************************************************/
-extern const bclass be_class_ColorProvider;
-be_local_class(CompositeColorProvider,
-    1,
-    &be_class_ColorProvider,
-    be_nested_map(8,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(add_provider, -1), be_const_closure(class_CompositeColorProvider_add_provider_closure) },
-        { be_const_key_weak(get_color_for_value, 7), be_const_closure(class_CompositeColorProvider_get_color_for_value_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_CompositeColorProvider_init_closure) },
-        { be_const_key_weak(PARAMS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(blend_mode, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-        be_const_int(2),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_CompositeColorProvider_tostring_closure) },
-        { be_const_key_weak(providers, 4), be_const_var(0) },
-        { be_const_key_weak(_blend_colors, -1), be_const_closure(class_CompositeColorProvider__blend_colors_closure) },
-        { be_const_key_weak(produce_value, -1), be_const_closure(class_CompositeColorProvider_produce_value_closure) },
-    })),
-    be_str_weak(CompositeColorProvider)
-);
 // compact class 'EventManager' ktab size: 30, total: 61 (saved 248 bytes)
 static const bvalue be_ktab_class_EventManager[30] = {
   /* K0   */  be_nested_str_weak(event_name),
@@ -1502,199 +1050,52 @@ be_local_class(EventManager,
     })),
     be_str_weak(EventManager)
 );
-// compact class 'SequenceManager' ktab size: 44, total: 164 (saved 960 bytes)
-static const bvalue be_ktab_class_SequenceManager[44] = {
-  /* K0   */  be_nested_str_weak(step_index),
-  /* K1   */  be_nested_str_weak(steps),
-  /* K2   */  be_nested_str_weak(complete_iteration),
-  /* K3   */  be_nested_str_weak(type),
-  /* K4   */  be_nested_str_weak(play),
-  /* K5   */  be_nested_str_weak(animation),
-  /* K6   */  be_nested_str_weak(engine),
-  /* K7   */  be_nested_str_weak(get_animations),
-  /* K8   */  be_nested_str_weak(stop_iteration),
-  /* K9   */  be_nested_str_weak(add),
-  /* K10  */  be_nested_str_weak(start),
-  /* K11  */  be_nested_str_weak(wait),
-  /* K12  */  be_nested_str_weak(stop),
-  /* K13  */  be_nested_str_weak(remove),
-  /* K14  */  be_nested_str_weak(closure),
-  /* K15  */  be_nested_str_weak(subsequence),
-  /* K16  */  be_nested_str_weak(sequence_manager),
-  /* K17  */  be_nested_str_weak(step_start_time),
-  /* K18  */  be_nested_str_weak(push),
-  /* K19  */  be_nested_str_weak(duration),
-  /* K20  */  be_const_int(0),
-  /* K21  */  be_const_int(1),
-  /* K22  */  be_nested_str_weak(execute_current_step),
-  /* K23  */  be_nested_str_weak(is_running),
-  /* K24  */  be_nested_str_weak(update),
-  /* K25  */  be_nested_str_weak(advance_to_next_step),
-  /* K26  */  be_nested_str_weak(execute_closure_steps_batch),
-  /* K27  */  be_nested_str_weak(contains),
-  /* K28  */  be_nested_str_weak(total_steps),
-  /* K29  */  be_nested_str_weak(current_step),
-  /* K30  */  be_nested_str_weak(elapsed_ms),
-  /* K31  */  be_nested_str_weak(time_ms),
-  /* K32  */  be_nested_str_weak(repeat_count),
-  /* K33  */  be_nested_str_weak(current_iteration),
-  /* K34  */  be_nested_str_weak(is_repeat_sequence),
-  /* K35  */  be_nested_str_weak(update_current_iteration),
-  /* K36  */  be_nested_str_weak(get_resolved_repeat_count),
-  /* K37  */  be_nested_str_weak(pop_iteration_context),
-  /* K38  */  be_nested_str_weak(active_sequence),
-  /* K39  */  be_nested_str_weak(sequence_state),
-  /* K40  */  be_nested_str_weak(stop_all_subsequences),
-  /* K41  */  be_nested_str_weak(execute_closure_steps_batch_atomic),
-  /* K42  */  be_nested_str_weak(function),
-  /* K43  */  be_nested_str_weak(push_iteration_context),
+// compact class 'SequenceManager' ktab size: 40, total: 152 (saved 896 bytes)
+static const bvalue be_ktab_class_SequenceManager[40] = {
+  /* K0   */  be_nested_str_weak(steps),
+  /* K1   */  be_nested_str_weak(push),
+  /* K2   */  be_nested_str_weak(type),
+  /* K3   */  be_nested_str_weak(play),
+  /* K4   */  be_nested_str_weak(animation),
+  /* K5   */  be_nested_str_weak(duration),
+  /* K6   */  be_const_int(0),
+  /* K7   */  be_nested_str_weak(step_index),
+  /* K8   */  be_nested_str_weak(complete_iteration),
+  /* K9   */  be_nested_str_weak(engine),
+  /* K10  */  be_nested_str_weak(get_animations),
+  /* K11  */  be_nested_str_weak(stop_iteration),
+  /* K12  */  be_nested_str_weak(add),
+  /* K13  */  be_nested_str_weak(start),
+  /* K14  */  be_nested_str_weak(wait),
+  /* K15  */  be_nested_str_weak(stop),
+  /* K16  */  be_nested_str_weak(remove),
+  /* K17  */  be_nested_str_weak(closure),
+  /* K18  */  be_nested_str_weak(subsequence),
+  /* K19  */  be_nested_str_weak(sequence_manager),
+  /* K20  */  be_nested_str_weak(step_start_time),
+  /* K21  */  be_nested_str_weak(is_running),
+  /* K22  */  be_nested_str_weak(update),
+  /* K23  */  be_nested_str_weak(advance_to_next_step),
+  /* K24  */  be_nested_str_weak(execute_closure_steps_batch),
+  /* K25  */  be_nested_str_weak(contains),
+  /* K26  */  be_nested_str_weak(active_sequence),
+  /* K27  */  be_nested_str_weak(sequence_state),
+  /* K28  */  be_nested_str_weak(repeat_count),
+  /* K29  */  be_const_int(1),
+  /* K30  */  be_nested_str_weak(current_iteration),
+  /* K31  */  be_nested_str_weak(is_repeat_sequence),
+  /* K32  */  be_nested_str_weak(execute_closure_steps_batch_atomic),
+  /* K33  */  be_nested_str_weak(execute_current_step),
+  /* K34  */  be_nested_str_weak(pop_iteration_context),
+  /* K35  */  be_nested_str_weak(stop_all_subsequences),
+  /* K36  */  be_nested_str_weak(push_iteration_context),
+  /* K37  */  be_nested_str_weak(function),
+  /* K38  */  be_nested_str_weak(update_current_iteration),
+  /* K39  */  be_nested_str_weak(get_resolved_repeat_count),
 };
 
 
 extern const bclass be_class_SequenceManager;
-
-/********************************************************************
-** Solidified function: execute_current_step
-********************************************************************/
-be_local_closure(class_SequenceManager_execute_current_step,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(execute_current_step),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x28080403,  //  0004  GE	R2	R2	R3
-      0x780A0003,  //  0005  JMPF	R2	#000A
-      0x8C080102,  //  0006  GETMET	R2	R0	K2
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x80000400,  //  0009  RET	0
-      0x88080101,  //  000A  GETMBR	R2	R0	K1
-      0x880C0100,  //  000B  GETMBR	R3	R0	K0
-      0x94080403,  //  000C  GETIDX	R2	R2	R3
-      0x940C0503,  //  000D  GETIDX	R3	R2	K3
-      0x1C0C0704,  //  000E  EQ	R3	R3	K4
-      0x780E001E,  //  000F  JMPF	R3	#002F
-      0x940C0505,  //  0010  GETIDX	R3	R2	K5
-      0x88100106,  //  0011  GETMBR	R4	R0	K6
-      0x8C100907,  //  0012  GETMET	R4	R4	K7
-      0x7C100200,  //  0013  CALL	R4	1
-      0x50140000,  //  0014  LDBOOL	R5	0	0
-      0x60180010,  //  0015  GETGBL	R6	G16
-      0x5C1C0800,  //  0016  MOVE	R7	R4
-      0x7C180200,  //  0017  CALL	R6	1
-      0xA8020008,  //  0018  EXBLK	0	#0022
-      0x5C1C0C00,  //  0019  MOVE	R7	R6
-      0x7C1C0000,  //  001A  CALL	R7	0
-      0x1C200E03,  //  001B  EQ	R8	R7	R3
-      0x78220001,  //  001C  JMPF	R8	#001F
-      0x50140200,  //  001D  LDBOOL	R5	1	0
-      0x70020000,  //  001E  JMP		#0020
-      0x7001FFF8,  //  001F  JMP		#0019
-      0xA8040001,  //  0020  EXBLK	1	1
-      0x70020002,  //  0021  JMP		#0025
-      0x58180008,  //  0022  LDCONST	R6	K8
-      0xAC180200,  //  0023  CATCH	R6	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x5C180A00,  //  0025  MOVE	R6	R5
-      0x741A0003,  //  0026  JMPT	R6	#002B
-      0x88180106,  //  0027  GETMBR	R6	R0	K6
-      0x8C180D09,  //  0028  GETMET	R6	R6	K9
-      0x5C200600,  //  0029  MOVE	R8	R3
-      0x7C180400,  //  002A  CALL	R6	2
-      0x8C18070A,  //  002B  GETMET	R6	R3	K10
-      0x5C200200,  //  002C  MOVE	R8	R1
-      0x7C180400,  //  002D  CALL	R6	2
-      0x7002001E,  //  002E  JMP		#004E
-      0x940C0503,  //  002F  GETIDX	R3	R2	K3
-      0x1C0C070B,  //  0030  EQ	R3	R3	K11
-      0x780E0000,  //  0031  JMPF	R3	#0033
-      0x7002001A,  //  0032  JMP		#004E
-      0x940C0503,  //  0033  GETIDX	R3	R2	K3
-      0x1C0C070C,  //  0034  EQ	R3	R3	K12
-      0x780E0005,  //  0035  JMPF	R3	#003C
-      0x940C0505,  //  0036  GETIDX	R3	R2	K5
-      0x88100106,  //  0037  GETMBR	R4	R0	K6
-      0x8C10090D,  //  0038  GETMET	R4	R4	K13
-      0x5C180600,  //  0039  MOVE	R6	R3
-      0x7C100400,  //  003A  CALL	R4	2
-      0x70020011,  //  003B  JMP		#004E
-      0x940C0503,  //  003C  GETIDX	R3	R2	K3
-      0x1C0C070E,  //  003D  EQ	R3	R3	K14
-      0x780E0007,  //  003E  JMPF	R3	#0047
-      0x940C050E,  //  003F  GETIDX	R3	R2	K14
-      0x4C100000,  //  0040  LDNIL	R4
-      0x20100604,  //  0041  NE	R4	R3	R4
-      0x78120002,  //  0042  JMPF	R4	#0046
-      0x5C100600,  //  0043  MOVE	R4	R3
-      0x88140106,  //  0044  GETMBR	R5	R0	K6
-      0x7C100200,  //  0045  CALL	R4	1
-      0x70020006,  //  0046  JMP		#004E
-      0x940C0503,  //  0047  GETIDX	R3	R2	K3
-      0x1C0C070F,  //  0048  EQ	R3	R3	K15
-      0x780E0003,  //  0049  JMPF	R3	#004E
-      0x940C0510,  //  004A  GETIDX	R3	R2	K16
-      0x8C10070A,  //  004B  GETMET	R4	R3	K10
-      0x5C180200,  //  004C  MOVE	R6	R1
-      0x7C100400,  //  004D  CALL	R4	2
-      0x90022201,  //  004E  SETMBR	R0	K17	R1
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop_all_subsequences
-********************************************************************/
-be_local_closure(class_SequenceManager_stop_all_subsequences,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(stop_all_subsequences),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0xA8020008,  //  0003  EXBLK	0	#000D
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x7C080000,  //  0005  CALL	R2	0
-      0x940C0503,  //  0006  GETIDX	R3	R2	K3
-      0x1C0C070F,  //  0007  EQ	R3	R3	K15
-      0x780E0002,  //  0008  JMPF	R3	#000C
-      0x940C0510,  //  0009  GETIDX	R3	R2	K16
-      0x8C10070C,  //  000A  GETMET	R4	R3	K12
-      0x7C100200,  //  000B  CALL	R4	1
-      0x7001FFF6,  //  000C  JMP		#0004
-      0x58040008,  //  000D  LDCONST	R1	K8
-      0xAC040200,  //  000E  CATCH	R1	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x80040000,  //  0010  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified function: push_play_step
@@ -1713,19 +1114,19 @@ be_local_closure(class_SequenceManager_push_play_step,   /* name */
     be_str_weak(push_play_step),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x880C0101,  //  0000  GETMBR	R3	R0	K1
-      0x8C0C0712,  //  0001  GETMET	R3	R3	K18
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x60140013,  //  0002  GETGBL	R5	G19
       0x7C140000,  //  0003  CALL	R5	0
-      0x98160704,  //  0004  SETIDX	R5	K3	K4
-      0x98160A01,  //  0005  SETIDX	R5	K5	R1
+      0x98160503,  //  0004  SETIDX	R5	K2	K3
+      0x98160801,  //  0005  SETIDX	R5	K4	R1
       0x4C180000,  //  0006  LDNIL	R6
       0x20180406,  //  0007  NE	R6	R2	R6
       0x781A0001,  //  0008  JMPF	R6	#000B
       0x5C180400,  //  0009  MOVE	R6	R2
       0x70020000,  //  000A  JMP		#000C
-      0x58180014,  //  000B  LDCONST	R6	K20
-      0x98162606,  //  000C  SETIDX	R5	K19	R6
+      0x58180006,  //  000B  LDCONST	R6	K6
+      0x98160A06,  //  000C  SETIDX	R5	K5	R6
       0x7C0C0400,  //  000D  CALL	R3	2
       0x80040000,  //  000E  RET	1	R0
     })
@@ -1735,9 +1136,9 @@ be_local_closure(class_SequenceManager_push_play_step,   /* name */
 
 
 /********************************************************************
-** Solidified function: push_repeat_subsequence
+** Solidified function: push_step
 ********************************************************************/
-be_local_closure(class_SequenceManager_push_repeat_subsequence,   /* name */
+be_local_closure(class_SequenceManager_push_step,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -1748,15 +1149,555 @@ be_local_closure(class_SequenceManager_push_repeat_subsequence,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(push_repeat_subsequence),
+    be_str_weak(push_step),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040000,  //  0004  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: execute_current_step
+********************************************************************/
+be_local_closure(class_SequenceManager_execute_current_step,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(execute_current_step),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x28080403,  //  0004  GE	R2	R2	R3
+      0x780A0003,  //  0005  JMPF	R2	#000A
+      0x8C080108,  //  0006  GETMET	R2	R0	K8
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x80000400,  //  0009  RET	0
+      0x88080100,  //  000A  GETMBR	R2	R0	K0
+      0x880C0107,  //  000B  GETMBR	R3	R0	K7
+      0x94080403,  //  000C  GETIDX	R2	R2	R3
+      0x940C0502,  //  000D  GETIDX	R3	R2	K2
+      0x1C0C0703,  //  000E  EQ	R3	R3	K3
+      0x780E001E,  //  000F  JMPF	R3	#002F
+      0x940C0504,  //  0010  GETIDX	R3	R2	K4
+      0x88100109,  //  0011  GETMBR	R4	R0	K9
+      0x8C10090A,  //  0012  GETMET	R4	R4	K10
+      0x7C100200,  //  0013  CALL	R4	1
+      0x50140000,  //  0014  LDBOOL	R5	0	0
+      0x60180010,  //  0015  GETGBL	R6	G16
+      0x5C1C0800,  //  0016  MOVE	R7	R4
+      0x7C180200,  //  0017  CALL	R6	1
+      0xA8020008,  //  0018  EXBLK	0	#0022
+      0x5C1C0C00,  //  0019  MOVE	R7	R6
+      0x7C1C0000,  //  001A  CALL	R7	0
+      0x1C200E03,  //  001B  EQ	R8	R7	R3
+      0x78220001,  //  001C  JMPF	R8	#001F
+      0x50140200,  //  001D  LDBOOL	R5	1	0
+      0x70020000,  //  001E  JMP		#0020
+      0x7001FFF8,  //  001F  JMP		#0019
+      0xA8040001,  //  0020  EXBLK	1	1
+      0x70020002,  //  0021  JMP		#0025
+      0x5818000B,  //  0022  LDCONST	R6	K11
+      0xAC180200,  //  0023  CATCH	R6	1	0
+      0xB0080000,  //  0024  RAISE	2	R0	R0
+      0x5C180A00,  //  0025  MOVE	R6	R5
+      0x741A0003,  //  0026  JMPT	R6	#002B
+      0x88180109,  //  0027  GETMBR	R6	R0	K9
+      0x8C180D0C,  //  0028  GETMET	R6	R6	K12
+      0x5C200600,  //  0029  MOVE	R8	R3
+      0x7C180400,  //  002A  CALL	R6	2
+      0x8C18070D,  //  002B  GETMET	R6	R3	K13
+      0x5C200200,  //  002C  MOVE	R8	R1
+      0x7C180400,  //  002D  CALL	R6	2
+      0x7002001E,  //  002E  JMP		#004E
+      0x940C0502,  //  002F  GETIDX	R3	R2	K2
+      0x1C0C070E,  //  0030  EQ	R3	R3	K14
+      0x780E0000,  //  0031  JMPF	R3	#0033
+      0x7002001A,  //  0032  JMP		#004E
+      0x940C0502,  //  0033  GETIDX	R3	R2	K2
+      0x1C0C070F,  //  0034  EQ	R3	R3	K15
+      0x780E0005,  //  0035  JMPF	R3	#003C
+      0x940C0504,  //  0036  GETIDX	R3	R2	K4
+      0x88100109,  //  0037  GETMBR	R4	R0	K9
+      0x8C100910,  //  0038  GETMET	R4	R4	K16
+      0x5C180600,  //  0039  MOVE	R6	R3
+      0x7C100400,  //  003A  CALL	R4	2
+      0x70020011,  //  003B  JMP		#004E
+      0x940C0502,  //  003C  GETIDX	R3	R2	K2
+      0x1C0C0711,  //  003D  EQ	R3	R3	K17
+      0x780E0007,  //  003E  JMPF	R3	#0047
+      0x940C0511,  //  003F  GETIDX	R3	R2	K17
+      0x4C100000,  //  0040  LDNIL	R4
+      0x20100604,  //  0041  NE	R4	R3	R4
+      0x78120002,  //  0042  JMPF	R4	#0046
+      0x5C100600,  //  0043  MOVE	R4	R3
+      0x88140109,  //  0044  GETMBR	R5	R0	K9
+      0x7C100200,  //  0045  CALL	R4	1
+      0x70020006,  //  0046  JMP		#004E
+      0x940C0502,  //  0047  GETIDX	R3	R2	K2
+      0x1C0C0712,  //  0048  EQ	R3	R3	K18
+      0x780E0003,  //  0049  JMPF	R3	#004E
+      0x940C0513,  //  004A  GETIDX	R3	R2	K19
+      0x8C10070D,  //  004B  GETMET	R4	R3	K13
+      0x5C180200,  //  004C  MOVE	R6	R1
+      0x7C100400,  //  004D  CALL	R4	2
+      0x90022801,  //  004E  SETMBR	R0	K20	R1
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_SequenceManager_update,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x88080115,  //  0000  GETMBR	R2	R0	K21
+      0x780A0004,  //  0001  JMPF	R2	#0007
+      0x6008000C,  //  0002  GETGBL	R2	G12
+      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x1C080506,  //  0005  EQ	R2	R2	K6
+      0x780A0001,  //  0006  JMPF	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x880C0107,  //  000A  GETMBR	R3	R0	K7
+      0x94080403,  //  000B  GETIDX	R2	R2	R3
+      0x940C0502,  //  000C  GETIDX	R3	R2	K2
+      0x1C0C0712,  //  000D  EQ	R3	R3	K18
+      0x780E0008,  //  000E  JMPF	R3	#0018
+      0x940C0513,  //  000F  GETIDX	R3	R2	K19
+      0x8C100716,  //  0010  GETMET	R4	R3	K22
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x7C100400,  //  0012  CALL	R4	2
+      0x74120002,  //  0013  JMPT	R4	#0017
+      0x8C100117,  //  0014  GETMET	R4	R0	K23
+      0x5C180200,  //  0015  MOVE	R6	R1
+      0x7C100400,  //  0016  CALL	R4	2
+      0x70020019,  //  0017  JMP		#0032
+      0x940C0502,  //  0018  GETIDX	R3	R2	K2
+      0x1C0C0711,  //  0019  EQ	R3	R3	K17
+      0x780E0003,  //  001A  JMPF	R3	#001F
+      0x8C0C0118,  //  001B  GETMET	R3	R0	K24
+      0x5C140200,  //  001C  MOVE	R5	R1
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x70020012,  //  001E  JMP		#0032
+      0x8C0C0519,  //  001F  GETMET	R3	R2	K25
+      0x58140005,  //  0020  LDCONST	R5	K5
+      0x7C0C0400,  //  0021  CALL	R3	2
+      0x780E000B,  //  0022  JMPF	R3	#002F
+      0x940C0505,  //  0023  GETIDX	R3	R2	K5
+      0x240C0706,  //  0024  GT	R3	R3	K6
+      0x780E0008,  //  0025  JMPF	R3	#002F
+      0x880C0114,  //  0026  GETMBR	R3	R0	K20
+      0x040C0203,  //  0027  SUB	R3	R1	R3
+      0x94100505,  //  0028  GETIDX	R4	R2	K5
+      0x28100604,  //  0029  GE	R4	R3	R4
+      0x78120002,  //  002A  JMPF	R4	#002E
+      0x8C100117,  //  002B  GETMET	R4	R0	K23
+      0x5C180200,  //  002C  MOVE	R6	R1
+      0x7C100400,  //  002D  CALL	R4	2
+      0x70020002,  //  002E  JMP		#0032
+      0x8C0C0117,  //  002F  GETMET	R3	R0	K23
+      0x5C140200,  //  0030  MOVE	R5	R1
+      0x7C0C0400,  //  0031  CALL	R3	2
+      0x880C0115,  //  0032  GETMBR	R3	R0	K21
+      0x80040600,  //  0033  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_SequenceManager_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x90021201,  //  0000  SETMBR	R0	K9	R1
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x90023403,  //  0002  SETMBR	R0	K26	R3
+      0x600C0013,  //  0003  GETGBL	R3	G19
+      0x7C0C0000,  //  0004  CALL	R3	0
+      0x90023603,  //  0005  SETMBR	R0	K27	R3
+      0x90020F06,  //  0006  SETMBR	R0	K7	K6
+      0x90022906,  //  0007  SETMBR	R0	K20	K6
+      0x600C0012,  //  0008  GETGBL	R3	G18
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x90020003,  //  000A  SETMBR	R0	K0	R3
+      0x500C0000,  //  000B  LDBOOL	R3	0	0
+      0x90022A03,  //  000C  SETMBR	R0	K21	R3
+      0x4C0C0000,  //  000D  LDNIL	R3
+      0x200C0403,  //  000E  NE	R3	R2	R3
+      0x780E0001,  //  000F  JMPF	R3	#0012
+      0x5C0C0400,  //  0010  MOVE	R3	R2
+      0x70020000,  //  0011  JMP		#0013
+      0x580C001D,  //  0012  LDCONST	R3	K29
+      0x90023803,  //  0013  SETMBR	R0	K28	R3
+      0x90023D06,  //  0014  SETMBR	R0	K30	K6
+      0x4C0C0000,  //  0015  LDNIL	R3
+      0x200C0403,  //  0016  NE	R3	R2	R3
+      0x780E0001,  //  0017  JMPF	R3	#001A
+      0x200C051D,  //  0018  NE	R3	R2	K29
+      0x740E0000,  //  0019  JMPT	R3	#001B
+      0x500C0001,  //  001A  LDBOOL	R3	0	1
+      0x500C0200,  //  001B  LDBOOL	R3	1	0
+      0x90023E03,  //  001C  SETMBR	R0	K31	R3
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: advance_to_next_step
+********************************************************************/
+be_local_closure(class_SequenceManager_advance_to_next_step,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(advance_to_next_step),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x880C0107,  //  0001  GETMBR	R3	R0	K7
+      0x94080403,  //  0002  GETIDX	R2	R2	R3
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x94100502,  //  0004  GETIDX	R4	R2	K2
+      0x1C100903,  //  0005  EQ	R4	R4	K3
+      0x78120004,  //  0006  JMPF	R4	#000C
+      0x8C100519,  //  0007  GETMET	R4	R2	K25
+      0x58180005,  //  0008  LDCONST	R6	K5
+      0x7C100400,  //  0009  CALL	R4	2
+      0x78120000,  //  000A  JMPF	R4	#000C
+      0x940C0504,  //  000B  GETIDX	R3	R2	K4
+      0x88100107,  //  000C  GETMBR	R4	R0	K7
+      0x0010091D,  //  000D  ADD	R4	R4	K29
+      0x90020E04,  //  000E  SETMBR	R0	K7	R4
+      0x88100107,  //  000F  GETMBR	R4	R0	K7
+      0x6014000C,  //  0010  GETGBL	R5	G12
+      0x88180100,  //  0011  GETMBR	R6	R0	K0
+      0x7C140200,  //  0012  CALL	R5	1
+      0x28100805,  //  0013  GE	R4	R4	R5
+      0x7812000A,  //  0014  JMPF	R4	#0020
+      0x4C100000,  //  0015  LDNIL	R4
+      0x20100604,  //  0016  NE	R4	R3	R4
+      0x78120003,  //  0017  JMPF	R4	#001C
+      0x88100109,  //  0018  GETMBR	R4	R0	K9
+      0x8C100910,  //  0019  GETMET	R4	R4	K16
+      0x5C180600,  //  001A  MOVE	R6	R3
+      0x7C100400,  //  001B  CALL	R4	2
+      0x8C100108,  //  001C  GETMET	R4	R0	K8
+      0x5C180200,  //  001D  MOVE	R6	R1
+      0x7C100400,  //  001E  CALL	R4	2
+      0x70020003,  //  001F  JMP		#0024
+      0x8C100120,  //  0020  GETMET	R4	R0	K32
+      0x5C180200,  //  0021  MOVE	R6	R1
+      0x5C1C0600,  //  0022  MOVE	R7	R3
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: execute_closure_steps_batch
+********************************************************************/
+be_local_closure(class_SequenceManager_execute_closure_steps_batch,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(execute_closure_steps_batch),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x14080403,  //  0004  LT	R2	R2	R3
+      0x780A0012,  //  0005  JMPF	R2	#0019
+      0x88080100,  //  0006  GETMBR	R2	R0	K0
+      0x880C0107,  //  0007  GETMBR	R3	R0	K7
+      0x94080403,  //  0008  GETIDX	R2	R2	R3
+      0x940C0502,  //  0009  GETIDX	R3	R2	K2
+      0x1C0C0711,  //  000A  EQ	R3	R3	K17
+      0x780E000A,  //  000B  JMPF	R3	#0017
+      0x940C0511,  //  000C  GETIDX	R3	R2	K17
+      0x4C100000,  //  000D  LDNIL	R4
+      0x20100604,  //  000E  NE	R4	R3	R4
+      0x78120002,  //  000F  JMPF	R4	#0013
+      0x5C100600,  //  0010  MOVE	R4	R3
+      0x88140109,  //  0011  GETMBR	R5	R0	K9
+      0x7C100200,  //  0012  CALL	R4	1
+      0x88100107,  //  0013  GETMBR	R4	R0	K7
+      0x0010091D,  //  0014  ADD	R4	R4	K29
+      0x90020E04,  //  0015  SETMBR	R0	K7	R4
+      0x70020000,  //  0016  JMP		#0018
+      0x70020000,  //  0017  JMP		#0019
+      0x7001FFE6,  //  0018  JMP		#0000
+      0x88080107,  //  0019  GETMBR	R2	R0	K7
+      0x600C000C,  //  001A  GETGBL	R3	G12
+      0x88100100,  //  001B  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  001C  CALL	R3	1
+      0x14080403,  //  001D  LT	R2	R2	R3
+      0x780A0003,  //  001E  JMPF	R2	#0023
+      0x8C080121,  //  001F  GETMET	R2	R0	K33
+      0x5C100200,  //  0020  MOVE	R4	R1
+      0x7C080400,  //  0021  CALL	R2	2
+      0x70020002,  //  0022  JMP		#0026
+      0x8C080108,  //  0023  GETMET	R2	R0	K8
+      0x5C100200,  //  0024  MOVE	R4	R1
+      0x7C080400,  //  0025  CALL	R2	2
+      0x80000000,  //  0026  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_SequenceManager_stop,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x78060020,  //  0001  JMPF	R1	#0023
+      0x50040000,  //  0002  LDBOOL	R1	0	0
+      0x90022A01,  //  0003  SETMBR	R0	K21	R1
+      0x8804011F,  //  0004  GETMBR	R1	R0	K31
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040109,  //  0006  GETMBR	R1	R0	K9
+      0x8C040322,  //  0007  GETMET	R1	R1	K34
+      0x7C040200,  //  0008  CALL	R1	1
+      0x88040107,  //  0009  GETMBR	R1	R0	K7
+      0x6008000C,  //  000A  GETGBL	R2	G12
+      0x880C0100,  //  000B  GETMBR	R3	R0	K0
+      0x7C080200,  //  000C  CALL	R2	1
+      0x14040202,  //  000D  LT	R1	R1	R2
+      0x78060011,  //  000E  JMPF	R1	#0021
+      0x88040100,  //  000F  GETMBR	R1	R0	K0
+      0x88080107,  //  0010  GETMBR	R2	R0	K7
+      0x94040202,  //  0011  GETIDX	R1	R1	R2
+      0x94080302,  //  0012  GETIDX	R2	R1	K2
+      0x1C080503,  //  0013  EQ	R2	R2	K3
+      0x780A0005,  //  0014  JMPF	R2	#001B
+      0x94080304,  //  0015  GETIDX	R2	R1	K4
+      0x880C0109,  //  0016  GETMBR	R3	R0	K9
+      0x8C0C0710,  //  0017  GETMET	R3	R3	K16
+      0x5C140400,  //  0018  MOVE	R5	R2
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0x70020005,  //  001A  JMP		#0021
+      0x94080302,  //  001B  GETIDX	R2	R1	K2
+      0x1C080512,  //  001C  EQ	R2	R2	K18
+      0x780A0002,  //  001D  JMPF	R2	#0021
+      0x94080313,  //  001E  GETIDX	R2	R1	K19
+      0x8C0C050F,  //  001F  GETMET	R3	R2	K15
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x8C040123,  //  0021  GETMET	R1	R0	K35
+      0x7C040200,  //  0022  CALL	R1	1
+      0x80040000,  //  0023  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: execute_closure_steps_batch_atomic
+********************************************************************/
+be_local_closure(class_SequenceManager_execute_closure_steps_batch_atomic,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(execute_closure_steps_batch_atomic),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0x880C0107,  //  0000  GETMBR	R3	R0	K7
+      0x6010000C,  //  0001  GETGBL	R4	G12
+      0x88140100,  //  0002  GETMBR	R5	R0	K0
+      0x7C100200,  //  0003  CALL	R4	1
+      0x140C0604,  //  0004  LT	R3	R3	R4
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x88100107,  //  0007  GETMBR	R4	R0	K7
+      0x940C0604,  //  0008  GETIDX	R3	R3	R4
+      0x94100702,  //  0009  GETIDX	R4	R3	K2
+      0x1C100911,  //  000A  EQ	R4	R4	K17
+      0x7812000A,  //  000B  JMPF	R4	#0017
+      0x94100711,  //  000C  GETIDX	R4	R3	K17
+      0x4C140000,  //  000D  LDNIL	R5
+      0x20140805,  //  000E  NE	R5	R4	R5
+      0x78160002,  //  000F  JMPF	R5	#0013
+      0x5C140800,  //  0010  MOVE	R5	R4
+      0x88180109,  //  0011  GETMBR	R6	R0	K9
+      0x7C140200,  //  0012  CALL	R5	1
+      0x88140107,  //  0013  GETMBR	R5	R0	K7
+      0x00140B1D,  //  0014  ADD	R5	R5	K29
+      0x90020E05,  //  0015  SETMBR	R0	K7	R5
+      0x70020000,  //  0016  JMP		#0018
+      0x70020000,  //  0017  JMP		#0019
+      0x7001FFE6,  //  0018  JMP		#0000
+      0x4C0C0000,  //  0019  LDNIL	R3
+      0x50100000,  //  001A  LDBOOL	R4	0	0
+      0x88140107,  //  001B  GETMBR	R5	R0	K7
+      0x6018000C,  //  001C  GETGBL	R6	G12
+      0x881C0100,  //  001D  GETMBR	R7	R0	K0
+      0x7C180200,  //  001E  CALL	R6	1
+      0x14140A06,  //  001F  LT	R5	R5	R6
+      0x7816000B,  //  0020  JMPF	R5	#002D
+      0x88140100,  //  0021  GETMBR	R5	R0	K0
+      0x88180107,  //  0022  GETMBR	R6	R0	K7
+      0x940C0A06,  //  0023  GETIDX	R3	R5	R6
+      0x94180702,  //  0024  GETIDX	R6	R3	K2
+      0x1C180D03,  //  0025  EQ	R6	R6	K3
+      0x781A0005,  //  0026  JMPF	R6	#002D
+      0x4C180000,  //  0027  LDNIL	R6
+      0x20180406,  //  0028  NE	R6	R2	R6
+      0x781A0002,  //  0029  JMPF	R6	#002D
+      0x94180704,  //  002A  GETIDX	R6	R3	K4
+      0x1C180C02,  //  002B  EQ	R6	R6	R2
+      0x5C100C00,  //  002C  MOVE	R4	R6
+      0x78120004,  //  002D  JMPF	R4	#0033
+      0x90022801,  //  002E  SETMBR	R0	K20	R1
+      0x8C14050D,  //  002F  GETMET	R5	R2	K13
+      0x5C1C0200,  //  0030  MOVE	R7	R1
+      0x7C140400,  //  0031  CALL	R5	2
+      0x7002000F,  //  0032  JMP		#0043
+      0x88140107,  //  0033  GETMBR	R5	R0	K7
+      0x6018000C,  //  0034  GETGBL	R6	G12
+      0x881C0100,  //  0035  GETMBR	R7	R0	K0
+      0x7C180200,  //  0036  CALL	R6	1
+      0x14140A06,  //  0037  LT	R5	R5	R6
+      0x78160002,  //  0038  JMPF	R5	#003C
+      0x8C140121,  //  0039  GETMET	R5	R0	K33
+      0x5C1C0200,  //  003A  MOVE	R7	R1
+      0x7C140400,  //  003B  CALL	R5	2
+      0x4C140000,  //  003C  LDNIL	R5
+      0x20140405,  //  003D  NE	R5	R2	R5
+      0x78160003,  //  003E  JMPF	R5	#0043
+      0x88140109,  //  003F  GETMBR	R5	R0	K9
+      0x8C140B10,  //  0040  GETMET	R5	R5	K16
+      0x5C1C0400,  //  0041  MOVE	R7	R2
+      0x7C140400,  //  0042  CALL	R5	2
+      0x88140107,  //  0043  GETMBR	R5	R0	K7
+      0x6018000C,  //  0044  GETGBL	R6	G12
+      0x881C0100,  //  0045  GETMBR	R7	R0	K0
+      0x7C180200,  //  0046  CALL	R6	1
+      0x28140A06,  //  0047  GE	R5	R5	R6
+      0x78160002,  //  0048  JMPF	R5	#004C
+      0x8C140108,  //  0049  GETMET	R5	R0	K8
+      0x5C1C0200,  //  004A  MOVE	R7	R1
+      0x7C140400,  //  004B  CALL	R5	2
+      0x80000000,  //  004C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: push_wait_step
+********************************************************************/
+be_local_closure(class_SequenceManager_push_wait_step,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(push_wait_step),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x8C080512,  //  0001  GETMET	R2	R2	K18
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x60100013,  //  0002  GETGBL	R4	G19
       0x7C100000,  //  0003  CALL	R4	0
-      0x9812070F,  //  0004  SETIDX	R4	K3	K15
-      0x98122001,  //  0005  SETIDX	R4	K16	R1
+      0x9812050E,  //  0004  SETIDX	R4	K2	K14
+      0x98120A01,  //  0005  SETIDX	R4	K5	R1
       0x7C080400,  //  0006  CALL	R2	2
       0x80040000,  //  0007  RET	1	R0
     })
@@ -1782,586 +1723,12 @@ be_local_closure(class_SequenceManager_push_closure_step,   /* name */
     be_str_weak(push_closure_step),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x8C080512,  //  0001  GETMET	R2	R2	K18
-      0x60100013,  //  0002  GETGBL	R4	G19
-      0x7C100000,  //  0003  CALL	R4	0
-      0x9812070E,  //  0004  SETIDX	R4	K3	K14
-      0x98121C01,  //  0005  SETIDX	R4	K14	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x80040000,  //  0007  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: execute_closure_steps_batch_atomic
-********************************************************************/
-be_local_closure(class_SequenceManager_execute_closure_steps_batch_atomic,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(execute_closure_steps_batch_atomic),
-    &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x6010000C,  //  0001  GETGBL	R4	G12
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x7C100200,  //  0003  CALL	R4	1
-      0x140C0604,  //  0004  LT	R3	R3	R4
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x940C0604,  //  0008  GETIDX	R3	R3	R4
-      0x94100703,  //  0009  GETIDX	R4	R3	K3
-      0x1C10090E,  //  000A  EQ	R4	R4	K14
-      0x7812000A,  //  000B  JMPF	R4	#0017
-      0x9410070E,  //  000C  GETIDX	R4	R3	K14
-      0x4C140000,  //  000D  LDNIL	R5
-      0x20140805,  //  000E  NE	R5	R4	R5
-      0x78160002,  //  000F  JMPF	R5	#0013
-      0x5C140800,  //  0010  MOVE	R5	R4
-      0x88180106,  //  0011  GETMBR	R6	R0	K6
-      0x7C140200,  //  0012  CALL	R5	1
-      0x88140100,  //  0013  GETMBR	R5	R0	K0
-      0x00140B15,  //  0014  ADD	R5	R5	K21
-      0x90020005,  //  0015  SETMBR	R0	K0	R5
-      0x70020000,  //  0016  JMP		#0018
-      0x70020000,  //  0017  JMP		#0019
-      0x7001FFE6,  //  0018  JMP		#0000
-      0x4C0C0000,  //  0019  LDNIL	R3
-      0x50100000,  //  001A  LDBOOL	R4	0	0
-      0x88140100,  //  001B  GETMBR	R5	R0	K0
-      0x6018000C,  //  001C  GETGBL	R6	G12
-      0x881C0101,  //  001D  GETMBR	R7	R0	K1
-      0x7C180200,  //  001E  CALL	R6	1
-      0x14140A06,  //  001F  LT	R5	R5	R6
-      0x7816000B,  //  0020  JMPF	R5	#002D
-      0x88140101,  //  0021  GETMBR	R5	R0	K1
-      0x88180100,  //  0022  GETMBR	R6	R0	K0
-      0x940C0A06,  //  0023  GETIDX	R3	R5	R6
-      0x94180703,  //  0024  GETIDX	R6	R3	K3
-      0x1C180D04,  //  0025  EQ	R6	R6	K4
-      0x781A0005,  //  0026  JMPF	R6	#002D
-      0x4C180000,  //  0027  LDNIL	R6
-      0x20180406,  //  0028  NE	R6	R2	R6
-      0x781A0002,  //  0029  JMPF	R6	#002D
-      0x94180705,  //  002A  GETIDX	R6	R3	K5
-      0x1C180C02,  //  002B  EQ	R6	R6	R2
-      0x5C100C00,  //  002C  MOVE	R4	R6
-      0x78120004,  //  002D  JMPF	R4	#0033
-      0x90022201,  //  002E  SETMBR	R0	K17	R1
-      0x8C14050A,  //  002F  GETMET	R5	R2	K10
-      0x5C1C0200,  //  0030  MOVE	R7	R1
-      0x7C140400,  //  0031  CALL	R5	2
-      0x7002000F,  //  0032  JMP		#0043
-      0x88140100,  //  0033  GETMBR	R5	R0	K0
-      0x6018000C,  //  0034  GETGBL	R6	G12
-      0x881C0101,  //  0035  GETMBR	R7	R0	K1
-      0x7C180200,  //  0036  CALL	R6	1
-      0x14140A06,  //  0037  LT	R5	R5	R6
-      0x78160002,  //  0038  JMPF	R5	#003C
-      0x8C140116,  //  0039  GETMET	R5	R0	K22
-      0x5C1C0200,  //  003A  MOVE	R7	R1
-      0x7C140400,  //  003B  CALL	R5	2
-      0x4C140000,  //  003C  LDNIL	R5
-      0x20140405,  //  003D  NE	R5	R2	R5
-      0x78160003,  //  003E  JMPF	R5	#0043
-      0x88140106,  //  003F  GETMBR	R5	R0	K6
-      0x8C140B0D,  //  0040  GETMET	R5	R5	K13
-      0x5C1C0400,  //  0041  MOVE	R7	R2
-      0x7C140400,  //  0042  CALL	R5	2
-      0x88140100,  //  0043  GETMBR	R5	R0	K0
-      0x6018000C,  //  0044  GETGBL	R6	G12
-      0x881C0101,  //  0045  GETMBR	R7	R0	K1
-      0x7C180200,  //  0046  CALL	R6	1
-      0x28140A06,  //  0047  GE	R5	R5	R6
-      0x78160002,  //  0048  JMPF	R5	#004C
-      0x8C140102,  //  0049  GETMET	R5	R0	K2
-      0x5C1C0200,  //  004A  MOVE	R7	R1
-      0x7C140400,  //  004B  CALL	R5	2
-      0x80000000,  //  004C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_SequenceManager_update,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x88080117,  //  0000  GETMBR	R2	R0	K23
-      0x780A0004,  //  0001  JMPF	R2	#0007
-      0x6008000C,  //  0002  GETGBL	R2	G12
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x1C080514,  //  0005  EQ	R2	R2	K20
-      0x780A0001,  //  0006  JMPF	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
-      0x94080403,  //  000B  GETIDX	R2	R2	R3
-      0x940C0503,  //  000C  GETIDX	R3	R2	K3
-      0x1C0C070F,  //  000D  EQ	R3	R3	K15
-      0x780E0008,  //  000E  JMPF	R3	#0018
-      0x940C0510,  //  000F  GETIDX	R3	R2	K16
-      0x8C100718,  //  0010  GETMET	R4	R3	K24
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x7C100400,  //  0012  CALL	R4	2
-      0x74120002,  //  0013  JMPT	R4	#0017
-      0x8C100119,  //  0014  GETMET	R4	R0	K25
-      0x5C180200,  //  0015  MOVE	R6	R1
-      0x7C100400,  //  0016  CALL	R4	2
-      0x70020019,  //  0017  JMP		#0032
-      0x940C0503,  //  0018  GETIDX	R3	R2	K3
-      0x1C0C070E,  //  0019  EQ	R3	R3	K14
-      0x780E0003,  //  001A  JMPF	R3	#001F
-      0x8C0C011A,  //  001B  GETMET	R3	R0	K26
-      0x5C140200,  //  001C  MOVE	R5	R1
-      0x7C0C0400,  //  001D  CALL	R3	2
-      0x70020012,  //  001E  JMP		#0032
-      0x8C0C051B,  //  001F  GETMET	R3	R2	K27
-      0x58140013,  //  0020  LDCONST	R5	K19
-      0x7C0C0400,  //  0021  CALL	R3	2
-      0x780E000B,  //  0022  JMPF	R3	#002F
-      0x940C0513,  //  0023  GETIDX	R3	R2	K19
-      0x240C0714,  //  0024  GT	R3	R3	K20
-      0x780E0008,  //  0025  JMPF	R3	#002F
-      0x880C0111,  //  0026  GETMBR	R3	R0	K17
-      0x040C0203,  //  0027  SUB	R3	R1	R3
-      0x94100513,  //  0028  GETIDX	R4	R2	K19
-      0x28100604,  //  0029  GE	R4	R3	R4
-      0x78120002,  //  002A  JMPF	R4	#002E
-      0x8C100119,  //  002B  GETMET	R4	R0	K25
-      0x5C180200,  //  002C  MOVE	R6	R1
-      0x7C100400,  //  002D  CALL	R4	2
-      0x70020002,  //  002E  JMP		#0032
-      0x8C0C0119,  //  002F  GETMET	R3	R0	K25
-      0x5C140200,  //  0030  MOVE	R5	R1
-      0x7C0C0400,  //  0031  CALL	R3	2
-      0x880C0117,  //  0032  GETMBR	R3	R0	K23
-      0x80040600,  //  0033  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: execute_closure_steps_batch
-********************************************************************/
-be_local_closure(class_SequenceManager_execute_closure_steps_batch,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(execute_closure_steps_batch),
-    &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x14080403,  //  0004  LT	R2	R2	R3
-      0x780A0012,  //  0005  JMPF	R2	#0019
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x94080403,  //  0008  GETIDX	R2	R2	R3
-      0x940C0503,  //  0009  GETIDX	R3	R2	K3
-      0x1C0C070E,  //  000A  EQ	R3	R3	K14
-      0x780E000A,  //  000B  JMPF	R3	#0017
-      0x940C050E,  //  000C  GETIDX	R3	R2	K14
-      0x4C100000,  //  000D  LDNIL	R4
-      0x20100604,  //  000E  NE	R4	R3	R4
-      0x78120002,  //  000F  JMPF	R4	#0013
-      0x5C100600,  //  0010  MOVE	R4	R3
-      0x88140106,  //  0011  GETMBR	R5	R0	K6
-      0x7C100200,  //  0012  CALL	R4	1
-      0x88100100,  //  0013  GETMBR	R4	R0	K0
-      0x00100915,  //  0014  ADD	R4	R4	K21
-      0x90020004,  //  0015  SETMBR	R0	K0	R4
-      0x70020000,  //  0016  JMP		#0018
-      0x70020000,  //  0017  JMP		#0019
-      0x7001FFE6,  //  0018  JMP		#0000
-      0x88080100,  //  0019  GETMBR	R2	R0	K0
-      0x600C000C,  //  001A  GETGBL	R3	G12
-      0x88100101,  //  001B  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  001C  CALL	R3	1
-      0x14080403,  //  001D  LT	R2	R2	R3
-      0x780A0003,  //  001E  JMPF	R2	#0023
-      0x8C080116,  //  001F  GETMET	R2	R0	K22
-      0x5C100200,  //  0020  MOVE	R4	R1
-      0x7C080400,  //  0021  CALL	R2	2
-      0x70020002,  //  0022  JMP		#0026
-      0x8C080102,  //  0023  GETMET	R2	R0	K2
-      0x5C100200,  //  0024  MOVE	R4	R1
-      0x7C080400,  //  0025  CALL	R2	2
-      0x80000000,  //  0026  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_sequence_running
-********************************************************************/
-be_local_closure(class_SequenceManager_is_sequence_running,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(is_sequence_running),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040117,  //  0000  GETMBR	R1	R0	K23
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: push_step
-********************************************************************/
-be_local_closure(class_SequenceManager_push_step,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(push_step),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x8C080512,  //  0001  GETMET	R2	R2	K18
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040000,  //  0004  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_current_step_info
-********************************************************************/
-be_local_closure(class_SequenceManager_get_current_step_info,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(get_current_step_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x88040117,  //  0000  GETMBR	R1	R0	K23
-      0x78060005,  //  0001  JMPF	R1	#0008
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x28040202,  //  0006  GE	R1	R1	R2
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x4C040000,  //  0008  LDNIL	R1
-      0x80040200,  //  0009  RET	1	R1
-      0x60040013,  //  000A  GETGBL	R1	G19
-      0x7C040000,  //  000B  CALL	R1	0
-      0x88080100,  //  000C  GETMBR	R2	R0	K0
-      0x98060002,  //  000D  SETIDX	R1	K0	R2
-      0x6008000C,  //  000E  GETGBL	R2	G12
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
-      0x7C080200,  //  0010  CALL	R2	1
-      0x98063802,  //  0011  SETIDX	R1	K28	R2
-      0x88080101,  //  0012  GETMBR	R2	R0	K1
-      0x880C0100,  //  0013  GETMBR	R3	R0	K0
-      0x94080403,  //  0014  GETIDX	R2	R2	R3
-      0x98063A02,  //  0015  SETIDX	R1	K29	R2
-      0x88080106,  //  0016  GETMBR	R2	R0	K6
-      0x8808051F,  //  0017  GETMBR	R2	R2	K31
-      0x880C0111,  //  0018  GETMBR	R3	R0	K17
-      0x04080403,  //  0019  SUB	R2	R2	R3
-      0x98063C02,  //  001A  SETIDX	R1	K30	R2
-      0x88080120,  //  001B  GETMBR	R2	R0	K32
-      0x98064002,  //  001C  SETIDX	R1	K32	R2
-      0x88080121,  //  001D  GETMBR	R2	R0	K33
-      0x98064202,  //  001E  SETIDX	R1	K33	R2
-      0x88080122,  //  001F  GETMBR	R2	R0	K34
-      0x98064402,  //  0020  SETIDX	R1	K34	R2
-      0x80040200,  //  0021  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: complete_iteration
-********************************************************************/
-be_local_closure(class_SequenceManager_complete_iteration,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(complete_iteration),
-    &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
-      0x88080121,  //  0000  GETMBR	R2	R0	K33
-      0x00080515,  //  0001  ADD	R2	R2	K21
-      0x90024202,  //  0002  SETMBR	R0	K33	R2
-      0x88080122,  //  0003  GETMBR	R2	R0	K34
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0x88080106,  //  0005  GETMBR	R2	R0	K6
-      0x8C080523,  //  0006  GETMET	R2	R2	K35
-      0x88100121,  //  0007  GETMBR	R4	R0	K33
-      0x7C080400,  //  0008  CALL	R2	2
-      0x8C080124,  //  0009  GETMET	R2	R0	K36
-      0x7C080200,  //  000A  CALL	R2	1
-      0x540DFFFE,  //  000B  LDINT	R3	-1
-      0x1C0C0403,  //  000C  EQ	R3	R2	R3
-      0x740E0002,  //  000D  JMPT	R3	#0011
-      0x880C0121,  //  000E  GETMBR	R3	R0	K33
-      0x140C0602,  //  000F  LT	R3	R3	R2
-      0x780E0023,  //  0010  JMPF	R3	#0035
-      0x90020114,  //  0011  SETMBR	R0	K0	K20
-      0x880C0100,  //  0012  GETMBR	R3	R0	K0
-      0x6010000C,  //  0013  GETGBL	R4	G12
-      0x88140101,  //  0014  GETMBR	R5	R0	K1
-      0x7C100200,  //  0015  CALL	R4	1
-      0x140C0604,  //  0016  LT	R3	R3	R4
-      0x780E0012,  //  0017  JMPF	R3	#002B
-      0x880C0101,  //  0018  GETMBR	R3	R0	K1
-      0x88100100,  //  0019  GETMBR	R4	R0	K0
-      0x940C0604,  //  001A  GETIDX	R3	R3	R4
-      0x94100703,  //  001B  GETIDX	R4	R3	K3
-      0x1C10090E,  //  001C  EQ	R4	R4	K14
-      0x7812000A,  //  001D  JMPF	R4	#0029
-      0x9410070E,  //  001E  GETIDX	R4	R3	K14
-      0x4C140000,  //  001F  LDNIL	R5
-      0x20140805,  //  0020  NE	R5	R4	R5
-      0x78160002,  //  0021  JMPF	R5	#0025
-      0x5C140800,  //  0022  MOVE	R5	R4
-      0x88180106,  //  0023  GETMBR	R6	R0	K6
-      0x7C140200,  //  0024  CALL	R5	1
-      0x88140100,  //  0025  GETMBR	R5	R0	K0
-      0x00140B15,  //  0026  ADD	R5	R5	K21
-      0x90020005,  //  0027  SETMBR	R0	K0	R5
-      0x70020000,  //  0028  JMP		#002A
-      0x70020000,  //  0029  JMP		#002B
-      0x7001FFE6,  //  002A  JMP		#0012
-      0x880C0100,  //  002B  GETMBR	R3	R0	K0
-      0x6010000C,  //  002C  GETGBL	R4	G12
-      0x88140101,  //  002D  GETMBR	R5	R0	K1
-      0x7C100200,  //  002E  CALL	R4	1
-      0x140C0604,  //  002F  LT	R3	R3	R4
-      0x780E0002,  //  0030  JMPF	R3	#0034
-      0x8C0C0116,  //  0031  GETMET	R3	R0	K22
-      0x5C140200,  //  0032  MOVE	R5	R1
-      0x7C0C0400,  //  0033  CALL	R3	2
-      0x70020006,  //  0034  JMP		#003C
-      0x500C0000,  //  0035  LDBOOL	R3	0	0
-      0x90022E03,  //  0036  SETMBR	R0	K23	R3
-      0x880C0122,  //  0037  GETMBR	R3	R0	K34
-      0x780E0002,  //  0038  JMPF	R3	#003C
-      0x880C0106,  //  0039  GETMBR	R3	R0	K6
-      0x8C0C0725,  //  003A  GETMET	R3	R3	K37
-      0x7C0C0200,  //  003B  CALL	R3	1
-      0x80000000,  //  003C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_SequenceManager_init,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x90020C01,  //  0000  SETMBR	R0	K6	R1
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x90024C03,  //  0002  SETMBR	R0	K38	R3
-      0x600C0013,  //  0003  GETGBL	R3	G19
-      0x7C0C0000,  //  0004  CALL	R3	0
-      0x90024E03,  //  0005  SETMBR	R0	K39	R3
-      0x90020114,  //  0006  SETMBR	R0	K0	K20
-      0x90022314,  //  0007  SETMBR	R0	K17	K20
-      0x600C0012,  //  0008  GETGBL	R3	G18
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x90020203,  //  000A  SETMBR	R0	K1	R3
-      0x500C0000,  //  000B  LDBOOL	R3	0	0
-      0x90022E03,  //  000C  SETMBR	R0	K23	R3
-      0x4C0C0000,  //  000D  LDNIL	R3
-      0x200C0403,  //  000E  NE	R3	R2	R3
-      0x780E0001,  //  000F  JMPF	R3	#0012
-      0x5C0C0400,  //  0010  MOVE	R3	R2
-      0x70020000,  //  0011  JMP		#0013
-      0x580C0015,  //  0012  LDCONST	R3	K21
-      0x90024003,  //  0013  SETMBR	R0	K32	R3
-      0x90024314,  //  0014  SETMBR	R0	K33	K20
-      0x4C0C0000,  //  0015  LDNIL	R3
-      0x200C0403,  //  0016  NE	R3	R2	R3
-      0x780E0001,  //  0017  JMPF	R3	#001A
-      0x200C0515,  //  0018  NE	R3	R2	K21
-      0x740E0000,  //  0019  JMPT	R3	#001B
-      0x500C0001,  //  001A  LDBOOL	R3	0	1
-      0x500C0200,  //  001B  LDBOOL	R3	1	0
-      0x90024403,  //  001C  SETMBR	R0	K34	R3
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_SequenceManager_stop,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0x88040117,  //  0000  GETMBR	R1	R0	K23
-      0x78060020,  //  0001  JMPF	R1	#0023
-      0x50040000,  //  0002  LDBOOL	R1	0	0
-      0x90022E01,  //  0003  SETMBR	R0	K23	R1
-      0x88040122,  //  0004  GETMBR	R1	R0	K34
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040106,  //  0006  GETMBR	R1	R0	K6
-      0x8C040325,  //  0007  GETMET	R1	R1	K37
-      0x7C040200,  //  0008  CALL	R1	1
-      0x88040100,  //  0009  GETMBR	R1	R0	K0
-      0x6008000C,  //  000A  GETGBL	R2	G12
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x7C080200,  //  000C  CALL	R2	1
-      0x14040202,  //  000D  LT	R1	R1	R2
-      0x78060011,  //  000E  JMPF	R1	#0021
-      0x88040101,  //  000F  GETMBR	R1	R0	K1
-      0x88080100,  //  0010  GETMBR	R2	R0	K0
-      0x94040202,  //  0011  GETIDX	R1	R1	R2
-      0x94080303,  //  0012  GETIDX	R2	R1	K3
-      0x1C080504,  //  0013  EQ	R2	R2	K4
-      0x780A0005,  //  0014  JMPF	R2	#001B
-      0x94080305,  //  0015  GETIDX	R2	R1	K5
-      0x880C0106,  //  0016  GETMBR	R3	R0	K6
-      0x8C0C070D,  //  0017  GETMET	R3	R3	K13
-      0x5C140400,  //  0018  MOVE	R5	R2
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0x70020005,  //  001A  JMP		#0021
-      0x94080303,  //  001B  GETIDX	R2	R1	K3
-      0x1C08050F,  //  001C  EQ	R2	R2	K15
-      0x780A0002,  //  001D  JMPF	R2	#0021
-      0x94080310,  //  001E  GETIDX	R2	R1	K16
-      0x8C0C050C,  //  001F  GETMET	R3	R2	K12
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x8C040128,  //  0021  GETMET	R1	R0	K40
-      0x7C040200,  //  0022  CALL	R1	1
-      0x80040000,  //  0023  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: push_wait_step
-********************************************************************/
-be_local_closure(class_SequenceManager_push_wait_step,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(push_wait_step),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x8C080512,  //  0001  GETMET	R2	R2	K18
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x60100013,  //  0002  GETGBL	R4	G19
       0x7C100000,  //  0003  CALL	R4	0
-      0x9812070B,  //  0004  SETIDX	R4	K3	K11
-      0x98122601,  //  0005  SETIDX	R4	K19	R1
+      0x98120511,  //  0004  SETIDX	R4	K2	K17
+      0x98122201,  //  0005  SETIDX	R4	K17	R1
       0x7C080400,  //  0006  CALL	R2	2
       0x80040000,  //  0007  RET	1	R0
     })
@@ -2371,11 +1738,11 @@ be_local_closure(class_SequenceManager_push_wait_step,   /* name */
 
 
 /********************************************************************
-** Solidified function: advance_to_next_step
+** Solidified function: start
 ********************************************************************/
-be_local_closure(class_SequenceManager_advance_to_next_step,   /* name */
+be_local_closure(class_SequenceManager_start,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -2384,46 +1751,66 @@ be_local_closure(class_SequenceManager_advance_to_next_step,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(advance_to_next_step),
+    be_str_weak(start),
     &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x88080101,  //  0000  GETMBR	R2	R0	K1
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x94080403,  //  0002  GETIDX	R2	R2	R3
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x94100503,  //  0004  GETIDX	R4	R2	K3
-      0x1C100904,  //  0005  EQ	R4	R4	K4
-      0x78120004,  //  0006  JMPF	R4	#000C
-      0x8C10051B,  //  0007  GETMET	R4	R2	K27
-      0x58180013,  //  0008  LDCONST	R6	K19
-      0x7C100400,  //  0009  CALL	R4	2
-      0x78120000,  //  000A  JMPF	R4	#000C
-      0x940C0505,  //  000B  GETIDX	R3	R2	K5
-      0x88100100,  //  000C  GETMBR	R4	R0	K0
-      0x00100915,  //  000D  ADD	R4	R4	K21
-      0x90020004,  //  000E  SETMBR	R0	K0	R4
-      0x88100100,  //  000F  GETMBR	R4	R0	K0
-      0x6014000C,  //  0010  GETGBL	R5	G12
-      0x88180101,  //  0011  GETMBR	R6	R0	K1
-      0x7C140200,  //  0012  CALL	R5	1
-      0x28100805,  //  0013  GE	R4	R4	R5
-      0x7812000A,  //  0014  JMPF	R4	#0020
-      0x4C100000,  //  0015  LDNIL	R4
-      0x20100604,  //  0016  NE	R4	R3	R4
-      0x78120003,  //  0017  JMPF	R4	#001C
-      0x88100106,  //  0018  GETMBR	R4	R0	K6
-      0x8C10090D,  //  0019  GETMET	R4	R4	K13
-      0x5C180600,  //  001A  MOVE	R6	R3
-      0x7C100400,  //  001B  CALL	R4	2
-      0x8C100102,  //  001C  GETMET	R4	R0	K2
-      0x5C180200,  //  001D  MOVE	R6	R1
-      0x7C100400,  //  001E  CALL	R4	2
-      0x70020003,  //  001F  JMP		#0024
-      0x8C100129,  //  0020  GETMET	R4	R0	K41
-      0x5C180200,  //  0021  MOVE	R6	R1
-      0x5C1C0600,  //  0022  MOVE	R7	R3
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
+    ( &(const binstruction[57]) {  /* code */
+      0x88080115,  //  0000  GETMBR	R2	R0	K21
+      0x780A0003,  //  0001  JMPF	R2	#0006
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x90022A02,  //  0003  SETMBR	R0	K21	R2
+      0x8C080123,  //  0004  GETMET	R2	R0	K35
+      0x7C080200,  //  0005  CALL	R2	1
+      0x90020F06,  //  0006  SETMBR	R0	K7	K6
+      0x90022801,  //  0007  SETMBR	R0	K20	R1
+      0x90023D06,  //  0008  SETMBR	R0	K30	K6
+      0x50080200,  //  0009  LDBOOL	R2	1	0
+      0x90022A02,  //  000A  SETMBR	R0	K21	R2
+      0x8808011F,  //  000B  GETMBR	R2	R0	K31
+      0x780A0003,  //  000C  JMPF	R2	#0011
+      0x88080109,  //  000D  GETMBR	R2	R0	K9
+      0x8C080524,  //  000E  GETMET	R2	R2	K36
+      0x8810011E,  //  000F  GETMBR	R4	R0	K30
+      0x7C080400,  //  0010  CALL	R2	2
+      0x6008000C,  //  0011  GETGBL	R2	G12
+      0x880C0100,  //  0012  GETMBR	R3	R0	K0
+      0x7C080200,  //  0013  CALL	R2	1
+      0x24080506,  //  0014  GT	R2	R2	K6
+      0x780A0021,  //  0015  JMPF	R2	#0038
+      0x88080107,  //  0016  GETMBR	R2	R0	K7
+      0x600C000C,  //  0017  GETGBL	R3	G12
+      0x88100100,  //  0018  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0019  CALL	R3	1
+      0x14080403,  //  001A  LT	R2	R2	R3
+      0x780A0012,  //  001B  JMPF	R2	#002F
+      0x88080100,  //  001C  GETMBR	R2	R0	K0
+      0x880C0107,  //  001D  GETMBR	R3	R0	K7
+      0x94080403,  //  001E  GETIDX	R2	R2	R3
+      0x940C0502,  //  001F  GETIDX	R3	R2	K2
+      0x1C0C0711,  //  0020  EQ	R3	R3	K17
+      0x780E000A,  //  0021  JMPF	R3	#002D
+      0x940C0511,  //  0022  GETIDX	R3	R2	K17
+      0x4C100000,  //  0023  LDNIL	R4
+      0x20100604,  //  0024  NE	R4	R3	R4
+      0x78120002,  //  0025  JMPF	R4	#0029
+      0x5C100600,  //  0026  MOVE	R4	R3
+      0x88140109,  //  0027  GETMBR	R5	R0	K9
+      0x7C100200,  //  0028  CALL	R4	1
+      0x88100107,  //  0029  GETMBR	R4	R0	K7
+      0x0010091D,  //  002A  ADD	R4	R4	K29
+      0x90020E04,  //  002B  SETMBR	R0	K7	R4
+      0x70020000,  //  002C  JMP		#002E
+      0x70020000,  //  002D  JMP		#002F
+      0x7001FFE6,  //  002E  JMP		#0016
+      0x88080107,  //  002F  GETMBR	R2	R0	K7
+      0x600C000C,  //  0030  GETGBL	R3	G12
+      0x88100100,  //  0031  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0032  CALL	R3	1
+      0x14080403,  //  0033  LT	R2	R2	R3
+      0x780A0002,  //  0034  JMPF	R2	#0038
+      0x8C080121,  //  0035  GETMET	R2	R0	K33
+      0x5C100200,  //  0036  MOVE	R4	R1
+      0x7C080400,  //  0037  CALL	R2	2
+      0x80040000,  //  0038  RET	1	R0
     })
   )
 );
@@ -2448,16 +1835,16 @@ be_local_closure(class_SequenceManager_get_resolved_repeat_count,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x60040004,  //  0000  GETGBL	R1	G4
-      0x88080120,  //  0001  GETMBR	R2	R0	K32
+      0x8808011C,  //  0001  GETMBR	R2	R0	K28
       0x7C040200,  //  0002  CALL	R1	1
-      0x1C04032A,  //  0003  EQ	R1	R1	K42
+      0x1C040325,  //  0003  EQ	R1	R1	K37
       0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C040120,  //  0005  GETMET	R1	R0	K32
-      0x880C0106,  //  0006  GETMBR	R3	R0	K6
+      0x8C04011C,  //  0005  GETMET	R1	R0	K28
+      0x880C0109,  //  0006  GETMBR	R3	R0	K9
       0x7C040400,  //  0007  CALL	R1	2
       0x80040200,  //  0008  RET	1	R1
       0x70020001,  //  0009  JMP		#000C
-      0x88040120,  //  000A  GETMBR	R1	R0	K32
+      0x8804011C,  //  000A  GETMBR	R1	R0	K28
       0x80040200,  //  000B  RET	1	R1
       0x80000000,  //  000C  RET	0
     })
@@ -2467,11 +1854,51 @@ be_local_closure(class_SequenceManager_get_resolved_repeat_count,   /* name */
 
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: stop_all_subsequences
 ********************************************************************/
-be_local_closure(class_SequenceManager_start,   /* name */
+be_local_closure(class_SequenceManager_stop_all_subsequences,   /* name */
   be_nested_proto(
     6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(stop_all_subsequences),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0xA8020008,  //  0003  EXBLK	0	#000D
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x7C080000,  //  0005  CALL	R2	0
+      0x940C0502,  //  0006  GETIDX	R3	R2	K2
+      0x1C0C0712,  //  0007  EQ	R3	R3	K18
+      0x780E0002,  //  0008  JMPF	R3	#000C
+      0x940C0513,  //  0009  GETIDX	R3	R2	K19
+      0x8C10070F,  //  000A  GETMET	R4	R3	K15
+      0x7C100200,  //  000B  CALL	R4	1
+      0x7001FFF6,  //  000C  JMP		#0004
+      0x5804000B,  //  000D  LDCONST	R1	K11
+      0xAC040200,  //  000E  CATCH	R1	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x80040000,  //  0010  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: push_repeat_subsequence
+********************************************************************/
+be_local_closure(class_SequenceManager_push_repeat_subsequence,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -2480,66 +1907,126 @@ be_local_closure(class_SequenceManager_start,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_SequenceManager,     /* shared constants */
-    be_str_weak(start),
+    be_str_weak(push_repeat_subsequence),
     &be_const_str_solidified,
-    ( &(const binstruction[57]) {  /* code */
-      0x88080117,  //  0000  GETMBR	R2	R0	K23
-      0x780A0003,  //  0001  JMPF	R2	#0006
-      0x50080000,  //  0002  LDBOOL	R2	0	0
-      0x90022E02,  //  0003  SETMBR	R0	K23	R2
-      0x8C080128,  //  0004  GETMET	R2	R0	K40
-      0x7C080200,  //  0005  CALL	R2	1
-      0x90020114,  //  0006  SETMBR	R0	K0	K20
-      0x90022201,  //  0007  SETMBR	R0	K17	R1
-      0x90024314,  //  0008  SETMBR	R0	K33	K20
-      0x50080200,  //  0009  LDBOOL	R2	1	0
-      0x90022E02,  //  000A  SETMBR	R0	K23	R2
-      0x88080122,  //  000B  GETMBR	R2	R0	K34
-      0x780A0003,  //  000C  JMPF	R2	#0011
-      0x88080106,  //  000D  GETMBR	R2	R0	K6
-      0x8C08052B,  //  000E  GETMET	R2	R2	K43
-      0x88100121,  //  000F  GETMBR	R4	R0	K33
-      0x7C080400,  //  0010  CALL	R2	2
-      0x6008000C,  //  0011  GETGBL	R2	G12
-      0x880C0101,  //  0012  GETMBR	R3	R0	K1
-      0x7C080200,  //  0013  CALL	R2	1
-      0x24080514,  //  0014  GT	R2	R2	K20
-      0x780A0021,  //  0015  JMPF	R2	#0038
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
-      0x600C000C,  //  0017  GETGBL	R3	G12
-      0x88100101,  //  0018  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0019  CALL	R3	1
-      0x14080403,  //  001A  LT	R2	R2	R3
-      0x780A0012,  //  001B  JMPF	R2	#002F
-      0x88080101,  //  001C  GETMBR	R2	R0	K1
-      0x880C0100,  //  001D  GETMBR	R3	R0	K0
-      0x94080403,  //  001E  GETIDX	R2	R2	R3
-      0x940C0503,  //  001F  GETIDX	R3	R2	K3
-      0x1C0C070E,  //  0020  EQ	R3	R3	K14
-      0x780E000A,  //  0021  JMPF	R3	#002D
-      0x940C050E,  //  0022  GETIDX	R3	R2	K14
-      0x4C100000,  //  0023  LDNIL	R4
-      0x20100604,  //  0024  NE	R4	R3	R4
-      0x78120002,  //  0025  JMPF	R4	#0029
-      0x5C100600,  //  0026  MOVE	R4	R3
-      0x88140106,  //  0027  GETMBR	R5	R0	K6
-      0x7C100200,  //  0028  CALL	R4	1
-      0x88100100,  //  0029  GETMBR	R4	R0	K0
-      0x00100915,  //  002A  ADD	R4	R4	K21
-      0x90020004,  //  002B  SETMBR	R0	K0	R4
-      0x70020000,  //  002C  JMP		#002E
-      0x70020000,  //  002D  JMP		#002F
-      0x7001FFE6,  //  002E  JMP		#0016
-      0x88080100,  //  002F  GETMBR	R2	R0	K0
-      0x600C000C,  //  0030  GETGBL	R3	G12
-      0x88100101,  //  0031  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0032  CALL	R3	1
-      0x14080403,  //  0033  LT	R2	R2	R3
-      0x780A0002,  //  0034  JMPF	R2	#0038
-      0x8C080116,  //  0035  GETMET	R2	R0	K22
-      0x5C100200,  //  0036  MOVE	R4	R1
-      0x7C080400,  //  0037  CALL	R2	2
-      0x80040000,  //  0038  RET	1	R0
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x60100013,  //  0002  GETGBL	R4	G19
+      0x7C100000,  //  0003  CALL	R4	0
+      0x98120512,  //  0004  SETIDX	R4	K2	K18
+      0x98122601,  //  0005  SETIDX	R4	K19	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x80040000,  //  0007  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_sequence_running
+********************************************************************/
+be_local_closure(class_SequenceManager_is_sequence_running,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(is_sequence_running),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040115,  //  0000  GETMBR	R1	R0	K21
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: complete_iteration
+********************************************************************/
+be_local_closure(class_SequenceManager_complete_iteration,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_SequenceManager,     /* shared constants */
+    be_str_weak(complete_iteration),
+    &be_const_str_solidified,
+    ( &(const binstruction[61]) {  /* code */
+      0x8808011E,  //  0000  GETMBR	R2	R0	K30
+      0x0008051D,  //  0001  ADD	R2	R2	K29
+      0x90023C02,  //  0002  SETMBR	R0	K30	R2
+      0x8808011F,  //  0003  GETMBR	R2	R0	K31
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0x88080109,  //  0005  GETMBR	R2	R0	K9
+      0x8C080526,  //  0006  GETMET	R2	R2	K38
+      0x8810011E,  //  0007  GETMBR	R4	R0	K30
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080127,  //  0009  GETMET	R2	R0	K39
+      0x7C080200,  //  000A  CALL	R2	1
+      0x540DFFFE,  //  000B  LDINT	R3	-1
+      0x1C0C0403,  //  000C  EQ	R3	R2	R3
+      0x740E0002,  //  000D  JMPT	R3	#0011
+      0x880C011E,  //  000E  GETMBR	R3	R0	K30
+      0x140C0602,  //  000F  LT	R3	R3	R2
+      0x780E0023,  //  0010  JMPF	R3	#0035
+      0x90020F06,  //  0011  SETMBR	R0	K7	K6
+      0x880C0107,  //  0012  GETMBR	R3	R0	K7
+      0x6010000C,  //  0013  GETGBL	R4	G12
+      0x88140100,  //  0014  GETMBR	R5	R0	K0
+      0x7C100200,  //  0015  CALL	R4	1
+      0x140C0604,  //  0016  LT	R3	R3	R4
+      0x780E0012,  //  0017  JMPF	R3	#002B
+      0x880C0100,  //  0018  GETMBR	R3	R0	K0
+      0x88100107,  //  0019  GETMBR	R4	R0	K7
+      0x940C0604,  //  001A  GETIDX	R3	R3	R4
+      0x94100702,  //  001B  GETIDX	R4	R3	K2
+      0x1C100911,  //  001C  EQ	R4	R4	K17
+      0x7812000A,  //  001D  JMPF	R4	#0029
+      0x94100711,  //  001E  GETIDX	R4	R3	K17
+      0x4C140000,  //  001F  LDNIL	R5
+      0x20140805,  //  0020  NE	R5	R4	R5
+      0x78160002,  //  0021  JMPF	R5	#0025
+      0x5C140800,  //  0022  MOVE	R5	R4
+      0x88180109,  //  0023  GETMBR	R6	R0	K9
+      0x7C140200,  //  0024  CALL	R5	1
+      0x88140107,  //  0025  GETMBR	R5	R0	K7
+      0x00140B1D,  //  0026  ADD	R5	R5	K29
+      0x90020E05,  //  0027  SETMBR	R0	K7	R5
+      0x70020000,  //  0028  JMP		#002A
+      0x70020000,  //  0029  JMP		#002B
+      0x7001FFE6,  //  002A  JMP		#0012
+      0x880C0107,  //  002B  GETMBR	R3	R0	K7
+      0x6010000C,  //  002C  GETGBL	R4	G12
+      0x88140100,  //  002D  GETMBR	R5	R0	K0
+      0x7C100200,  //  002E  CALL	R4	1
+      0x140C0604,  //  002F  LT	R3	R3	R4
+      0x780E0002,  //  0030  JMPF	R3	#0034
+      0x8C0C0121,  //  0031  GETMET	R3	R0	K33
+      0x5C140200,  //  0032  MOVE	R5	R1
+      0x7C0C0400,  //  0033  CALL	R3	2
+      0x70020006,  //  0034  JMP		#003C
+      0x500C0000,  //  0035  LDBOOL	R3	0	0
+      0x90022A03,  //  0036  SETMBR	R0	K21	R3
+      0x880C011F,  //  0037  GETMBR	R3	R0	K31
+      0x780E0002,  //  0038  JMPF	R3	#003C
+      0x880C0109,  //  0039  GETMBR	R3	R0	K9
+      0x8C0C0722,  //  003A  GETMET	R3	R3	K34
+      0x7C0C0200,  //  003B  CALL	R3	1
+      0x80000000,  //  003C  RET	0
     })
   )
 );
@@ -2552,36 +2039,35 @@ be_local_closure(class_SequenceManager_start,   /* name */
 be_local_class(SequenceManager,
     10,
     NULL,
-    be_nested_map(28,
+    be_nested_map(27,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(active_sequence, 26), be_const_var(1) },
+        { be_const_key_weak(step_start_time, -1), be_const_var(4) },
+        { be_const_key_weak(repeat_count, -1), be_const_var(7) },
+        { be_const_key_weak(is_repeat_sequence, -1), be_const_var(9) },
+        { be_const_key_weak(push_step, 12), be_const_closure(class_SequenceManager_push_step_closure) },
         { be_const_key_weak(steps, -1), be_const_var(5) },
         { be_const_key_weak(execute_current_step, -1), be_const_closure(class_SequenceManager_execute_current_step_closure) },
-        { be_const_key_weak(stop_all_subsequences, -1), be_const_closure(class_SequenceManager_stop_all_subsequences_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_SequenceManager_start_closure) },
-        { be_const_key_weak(push_closure_step, -1), be_const_closure(class_SequenceManager_push_closure_step_closure) },
-        { be_const_key_weak(push_repeat_subsequence, -1), be_const_closure(class_SequenceManager_push_repeat_subsequence_closure) },
-        { be_const_key_weak(current_iteration, 4), be_const_var(8) },
-        { be_const_key_weak(execute_closure_steps_batch_atomic, -1), be_const_closure(class_SequenceManager_execute_closure_steps_batch_atomic_closure) },
-        { be_const_key_weak(update, 10), be_const_closure(class_SequenceManager_update_closure) },
-        { be_const_key_weak(is_running, -1), be_const_var(6) },
-        { be_const_key_weak(step_index, -1), be_const_var(3) },
+        { be_const_key_weak(update, -1), be_const_closure(class_SequenceManager_update_closure) },
+        { be_const_key_weak(complete_iteration, 9), be_const_closure(class_SequenceManager_complete_iteration_closure) },
         { be_const_key_weak(is_sequence_running, -1), be_const_closure(class_SequenceManager_is_sequence_running_closure) },
-        { be_const_key_weak(get_current_step_info, -1), be_const_closure(class_SequenceManager_get_current_step_info_closure) },
         { be_const_key_weak(execute_closure_steps_batch, -1), be_const_closure(class_SequenceManager_execute_closure_steps_batch_closure) },
-        { be_const_key_weak(push_wait_step, 25), be_const_closure(class_SequenceManager_push_wait_step_closure) },
-        { be_const_key_weak(is_repeat_sequence, 11), be_const_var(9) },
-        { be_const_key_weak(push_step, -1), be_const_closure(class_SequenceManager_push_step_closure) },
-        { be_const_key_weak(active_sequence, 21), be_const_var(1) },
-        { be_const_key_weak(complete_iteration, -1), be_const_closure(class_SequenceManager_complete_iteration_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_SequenceManager_init_closure) },
-        { be_const_key_weak(step_start_time, -1), be_const_var(4) },
-        { be_const_key_weak(stop, 12), be_const_closure(class_SequenceManager_stop_closure) },
-        { be_const_key_weak(repeat_count, 14), be_const_var(7) },
-        { be_const_key_weak(engine, -1), be_const_var(0) },
-        { be_const_key_weak(advance_to_next_step, -1), be_const_closure(class_SequenceManager_advance_to_next_step_closure) },
-        { be_const_key_weak(sequence_state, -1), be_const_var(2) },
+        { be_const_key_weak(stop, -1), be_const_closure(class_SequenceManager_stop_closure) },
+        { be_const_key_weak(push_wait_step, -1), be_const_closure(class_SequenceManager_push_wait_step_closure) },
+        { be_const_key_weak(is_running, -1), be_const_var(6) },
+        { be_const_key_weak(execute_closure_steps_batch_atomic, -1), be_const_closure(class_SequenceManager_execute_closure_steps_batch_atomic_closure) },
+        { be_const_key_weak(push_closure_step, -1), be_const_closure(class_SequenceManager_push_closure_step_closure) },
+        { be_const_key_weak(step_index, 25), be_const_var(3) },
+        { be_const_key_weak(engine, 15), be_const_var(0) },
+        { be_const_key_weak(advance_to_next_step, 16), be_const_closure(class_SequenceManager_advance_to_next_step_closure) },
+        { be_const_key_weak(current_iteration, -1), be_const_var(8) },
+        { be_const_key_weak(start, -1), be_const_closure(class_SequenceManager_start_closure) },
         { be_const_key_weak(get_resolved_repeat_count, -1), be_const_closure(class_SequenceManager_get_resolved_repeat_count_closure) },
-        { be_const_key_weak(push_play_step, 3), be_const_closure(class_SequenceManager_push_play_step_closure) },
+        { be_const_key_weak(stop_all_subsequences, -1), be_const_closure(class_SequenceManager_stop_all_subsequences_closure) },
+        { be_const_key_weak(push_repeat_subsequence, 3), be_const_closure(class_SequenceManager_push_repeat_subsequence_closure) },
+        { be_const_key_weak(init, 8), be_const_closure(class_SequenceManager_init_closure) },
+        { be_const_key_weak(sequence_state, -1), be_const_var(2) },
+        { be_const_key_weak(push_play_step, -1), be_const_closure(class_SequenceManager_push_play_step_closure) },
     })),
     be_str_weak(SequenceManager)
 );
@@ -2679,9 +2165,9 @@ be_local_closure(wave_single_sine,   /* name */
 
 
 /********************************************************************
-** Solidified function: gradient_two_color_linear
+** Solidified function: twinkle_classic
 ********************************************************************/
-be_local_closure(gradient_two_color_linear,   /* name */
+be_local_closure(twinkle_classic,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -2691,28 +2177,36 @@ be_local_closure(gradient_two_color_linear,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(gradient_animation),
+    /* K1   */  be_nested_str_weak(twinkle_animation),
     /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(gradient_type),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(direction),
-    /* K6   */  be_nested_str_weak(movement_speed),
+    /* K3   */  be_nested_str_weak(density),
+    /* K4   */  be_nested_str_weak(twinkle_speed),
+    /* K5   */  be_nested_str_weak(fade_speed),
+    /* K6   */  be_nested_str_weak(min_brightness),
+    /* K7   */  be_nested_str_weak(max_brightness),
     }),
-    be_str_weak(gradient_two_color_linear),
+    be_str_weak(twinkle_classic),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
+    ( &(const binstruction[17]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x5408FFFF,  //  0004  LDINT	R2	-65536
+      0x5409FFFE,  //  0004  LDINT	R2	-1
       0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x90060B04,  //  0007  SETMBR	R1	K5	K4
-      0x90060D04,  //  0008  SETMBR	R1	K6	K4
-      0x80040200,  //  0009  RET	1	R1
+      0x540A0095,  //  0006  LDINT	R2	150
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A0005,  //  0008  LDINT	R2	6
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x540A00B3,  //  000A  LDINT	R2	180
+      0x90060A02,  //  000B  SETMBR	R1	K5	R2
+      0x540A001F,  //  000C  LDINT	R2	32
+      0x90060C02,  //  000D  SETMBR	R1	K6	R2
+      0x540A00FE,  //  000E  LDINT	R2	255
+      0x90060E02,  //  000F  SETMBR	R1	K7	R2
+      0x80040200,  //  0010  RET	1	R1
     })
   )
 );
@@ -3102,45 +2596,11 @@ be_local_class(CometAnimation,
         { be_const_key_weak(PARAMS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fade_factor, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(179) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(wrap_around, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(direction, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(2,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(-1),
-        be_const_int(1),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(speed, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(2560) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(25600) },
-    }))    ) } )) },
-        { be_const_key_weak(tail_length, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(50) },
-    }))    ) } )) },
+        { be_const_key_weak(fade_factor, -1), be_const_bytes_instance(07000001FF0001B300) },
+        { be_const_key_weak(wrap_around, -1), be_const_bytes_instance(07000000010001) },
+        { be_const_key_weak(direction, -1), be_const_bytes_instance(1400010200FF0001) },
+        { be_const_key_weak(speed, 0), be_const_bytes_instance(07000101006401000A) },
+        { be_const_key_weak(tail_length, -1), be_const_bytes_instance(07000100320005) },
     }))    ) } )) },
         { be_const_key_weak(tostring, -1), be_const_closure(class_CometAnimation_tostring_closure) },
         { be_const_key_weak(render, 0), be_const_closure(class_CometAnimation_render_closure) },
@@ -3818,41 +3278,11 @@ be_local_class(FireAnimation,
         { be_const_key_weak(PARAMS, 10), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(flicker_amount, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(100) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(intensity, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(180) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(flicker_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(8) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(20) },
-    }))    ) } )) },
-        { be_const_key_weak(sparking_rate, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(120) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(cooling_rate, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(55) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(flicker_amount, 4), be_const_bytes_instance(07000001FF000064) },
+        { be_const_key_weak(intensity, 0), be_const_bytes_instance(07000001FF0001B400) },
+        { be_const_key_weak(flicker_speed, -1), be_const_bytes_instance(07000100140008) },
+        { be_const_key_weak(sparking_rate, -1), be_const_bytes_instance(07000001FF000078) },
+        { be_const_key_weak(cooling_rate, -1), be_const_bytes_instance(07000001FF000037) },
     }))    ) } )) },
         { be_const_key_weak(_random, 2), be_const_closure(class_FireAnimation__random_closure) },
         { be_const_key_weak(current_colors, -1), be_const_var(1) },
@@ -4831,46 +4261,12 @@ be_local_class(RichPaletteColorProvider,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(range_min, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(transition_type, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(2,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(1),
-        be_const_int(5),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(5) },
-    }))    ) } )) },
-        { be_const_key_weak(palette, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bytes) },
-    }))    ) } )) },
-        { be_const_key_weak(cycle_period, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5000) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(range_max, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(cycle_period, -1), be_const_bytes_instance(050000018813) },
+        { be_const_key_weak(range_min, 0), be_const_bytes_instance(040000) },
+        { be_const_key_weak(palette, -1), be_const_bytes_instance(0C0602) },
+        { be_const_key_weak(transition_type, 1), be_const_bytes_instance(1400050200010005) },
+        { be_const_key_weak(brightness, -1), be_const_bytes_instance(07000001FF0001FF00) },
+        { be_const_key_weak(range_max, -1), be_const_bytes_instance(0401FF00) },
     }))    ) } )) },
         { be_const_key_weak(tostring, 1), be_const_closure(class_RichPaletteColorProvider_tostring_closure) },
         { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_RichPaletteColorProvider_get_color_for_value_closure) },
@@ -5103,64 +4499,11 @@ be_local_class(StaticColorProvider,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(0400FF) },
     }))    ) } )) },
     })),
     be_str_weak(StaticColorProvider)
 );
-
-/********************************************************************
-** Solidified function: twinkle_classic
-********************************************************************/
-be_local_closure(twinkle_classic,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(twinkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(density),
-    /* K4   */  be_nested_str_weak(twinkle_speed),
-    /* K5   */  be_nested_str_weak(fade_speed),
-    /* K6   */  be_nested_str_weak(min_brightness),
-    /* K7   */  be_nested_str_weak(max_brightness),
-    }),
-    be_str_weak(twinkle_classic),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0095,  //  0006  LDINT	R2	150
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A0005,  //  0008  LDINT	R2	6
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x540A00B3,  //  000A  LDINT	R2	180
-      0x90060A02,  //  000B  SETMBR	R1	K5	R2
-      0x540A001F,  //  000C  LDINT	R2	32
-      0x90060C02,  //  000D  SETMBR	R1	K6	R2
-      0x540A00FE,  //  000E  LDINT	R2	255
-      0x90060E02,  //  000F  SETMBR	R1	K7	R2
-      0x80040200,  //  0010  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified function: gradient_rainbow_radial
@@ -5815,54 +5158,12 @@ be_local_class(OscillatorValueProvider,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(phase, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(100) },
-    }))    ) } )) },
-        { be_const_key_weak(form, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(9,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(1),
-        be_const_int(2),
-        be_const_int(3),
-        be_const_int(4),
-        be_const_int(5),
-        be_const_int(6),
-        be_const_int(7),
-        be_const_int(8),
-        be_const_int(9),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(duty_cycle, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(100) },
-    }))    ) } )) },
-        { be_const_key_weak(min_value, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(duration, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1000) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(max_value, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(100) },
-    }))    ) } )) },
+        { be_const_key_weak(phase, -1), be_const_bytes_instance(07000000640000) },
+        { be_const_key_weak(max_value, 4), be_const_bytes_instance(040064) },
+        { be_const_key_weak(duty_cycle, -1), be_const_bytes_instance(07000000640032) },
+        { be_const_key_weak(min_value, -1), be_const_bytes_instance(040000) },
+        { be_const_key_weak(duration, -1), be_const_bytes_instance(05000101E803) },
+        { be_const_key_weak(form, 1), be_const_bytes_instance(14000109000100020003000400050006000700080009) },
     }))    ) } )) },
         { be_const_key_weak(produce_value, -1), be_const_closure(class_OscillatorValueProvider_produce_value_closure) },
         { be_const_key_weak(form_names, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -5918,6 +5219,686 @@ be_local_closure(rich_palette_rainbow,   /* name */
       0x7C080400,  //  0006  CALL	R2	2
       0x900A0601,  //  0007  SETMBR	R2	K3	R1
       0x80040400,  //  0008  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+// compact class 'TwinkleAnimation' ktab size: 43, total: 74 (saved 248 bytes)
+static const bvalue be_ktab_class_TwinkleAnimation[43] = {
+  /* K0   */  be_nested_str_weak(on_param_changed),
+  /* K1   */  be_nested_str_weak(twinkle_speed),
+  /* K2   */  be_const_int(1),
+  /* K3   */  be_nested_str_weak(set_param),
+  /* K4   */  be_nested_str_weak(fade_speed),
+  /* K5   */  be_nested_str_weak(density),
+  /* K6   */  be_nested_str_weak(min_brightness),
+  /* K7   */  be_nested_str_weak(max_brightness),
+  /* K8   */  be_nested_str_weak(color),
+  /* K9   */  be_nested_str_weak(engine),
+  /* K10  */  be_nested_str_weak(get_strip_length),
+  /* K11  */  be_nested_str_weak(twinkle_states),
+  /* K12  */  be_nested_str_weak(current_colors),
+  /* K13  */  be_nested_str_weak(size),
+  /* K14  */  be_nested_str_weak(_initialize_arrays),
+  /* K15  */  be_const_int(0),
+  /* K16  */  be_nested_str_weak(get),
+  /* K17  */  be_nested_str_weak(tasmota),
+  /* K18  */  be_nested_str_weak(scale_uint),
+  /* K19  */  be_nested_str_weak(set),
+  /* K20  */  be_const_int(16777215),
+  /* K21  */  be_nested_str_weak(_random_range),
+  /* K22  */  be_nested_str_weak(get_param),
+  /* K23  */  be_nested_str_weak(animation),
+  /* K24  */  be_nested_str_weak(is_value_provider),
+  /* K25  */  be_nested_str_weak(0x_X2508x),
+  /* K26  */  be_nested_str_weak(TwinkleAnimation_X28color_X3D_X25s_X2C_X20density_X3D_X25s_X2C_X20twinkle_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
+  /* K27  */  be_nested_str_weak(priority),
+  /* K28  */  be_nested_str_weak(is_running),
+  /* K29  */  be_nested_str_weak(init),
+  /* K30  */  be_nested_str_weak(last_update),
+  /* K31  */  be_nested_str_weak(random_seed),
+  /* K32  */  be_nested_str_weak(time_ms),
+  /* K33  */  be_nested_str_weak(_fix_time_ms),
+  /* K34  */  be_nested_str_weak(width),
+  /* K35  */  be_nested_str_weak(set_pixel_color),
+  /* K36  */  be_nested_str_weak(update),
+  /* K37  */  be_nested_str_weak(_update_twinkle_simulation),
+  /* K38  */  be_nested_str_weak(resize),
+  /* K39  */  be_nested_str_weak(clear),
+  /* K40  */  be_const_int(1103515245),
+  /* K41  */  be_const_int(2147483647),
+  /* K42  */  be_nested_str_weak(_random),
+};
+
+
+extern const bclass be_class_TwinkleAnimation;
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_on_param_changed,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x1C0C0301,  //  0007  EQ	R3	R1	K1
+      0x780E0010,  //  0008  JMPF	R3	#001A
+      0x540E0031,  //  0009  LDINT	R3	50
+      0x280C0403,  //  000A  GE	R3	R2	R3
+      0x780E000D,  //  000B  JMPF	R3	#001A
+      0x540E03E7,  //  000C  LDINT	R3	1000
+      0x0C0C0602,  //  000D  DIV	R3	R3	R2
+      0x14100702,  //  000E  LT	R4	R3	K2
+      0x78120001,  //  000F  JMPF	R4	#0012
+      0x580C0002,  //  0010  LDCONST	R3	K2
+      0x70020003,  //  0011  JMP		#0016
+      0x54120013,  //  0012  LDINT	R4	20
+      0x24100604,  //  0013  GT	R4	R3	R4
+      0x78120000,  //  0014  JMPF	R4	#0016
+      0x540E0013,  //  0015  LDINT	R3	20
+      0x8C100103,  //  0016  GETMET	R4	R0	K3
+      0x58180001,  //  0017  LDCONST	R6	K1
+      0x5C1C0600,  //  0018  MOVE	R7	R3
+      0x7C100600,  //  0019  CALL	R4	3
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_twinkle_simulation
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__update_twinkle_simulation,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_update_twinkle_simulation),
+    &be_const_str_solidified,
+    ( &(const binstruction[118]) {  /* code */
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x880C0105,  //  0001  GETMBR	R3	R0	K5
+      0x88100106,  //  0002  GETMBR	R4	R0	K6
+      0x88140107,  //  0003  GETMBR	R5	R0	K7
+      0x88180108,  //  0004  GETMBR	R6	R0	K8
+      0x881C0109,  //  0005  GETMBR	R7	R0	K9
+      0x8C1C0F0A,  //  0006  GETMET	R7	R7	K10
+      0x7C1C0200,  //  0007  CALL	R7	1
+      0x6020000C,  //  0008  GETGBL	R8	G12
+      0x8824010B,  //  0009  GETMBR	R9	R0	K11
+      0x7C200200,  //  000A  CALL	R8	1
+      0x20201007,  //  000B  NE	R8	R8	R7
+      0x74220006,  //  000C  JMPT	R8	#0014
+      0x8820010C,  //  000D  GETMBR	R8	R0	K12
+      0x8C20110D,  //  000E  GETMET	R8	R8	K13
+      0x7C200200,  //  000F  CALL	R8	1
+      0x54260003,  //  0010  LDINT	R9	4
+      0x08240E09,  //  0011  MUL	R9	R7	R9
+      0x20201009,  //  0012  NE	R8	R8	R9
+      0x78220001,  //  0013  JMPF	R8	#0016
+      0x8C20010E,  //  0014  GETMET	R8	R0	K14
+      0x7C200200,  //  0015  CALL	R8	1
+      0x5820000F,  //  0016  LDCONST	R8	K15
+      0x14241007,  //  0017  LT	R9	R8	R7
+      0x7826002C,  //  0018  JMPF	R9	#0046
+      0x8824010C,  //  0019  GETMBR	R9	R0	K12
+      0x8C241310,  //  001A  GETMET	R9	R9	K16
+      0x542E0003,  //  001B  LDINT	R11	4
+      0x082C100B,  //  001C  MUL	R11	R8	R11
+      0x5431FFFB,  //  001D  LDINT	R12	-4
+      0x7C240600,  //  001E  CALL	R9	3
+      0x542A0017,  //  001F  LDINT	R10	24
+      0x3C28120A,  //  0020  SHR	R10	R9	R10
+      0x542E00FE,  //  0021  LDINT	R11	255
+      0x2C28140B,  //  0022  AND	R10	R10	R11
+      0x242C150F,  //  0023  GT	R11	R10	K15
+      0x782E001E,  //  0024  JMPF	R11	#0044
+      0xB82E2200,  //  0025  GETNGBL	R11	K17
+      0x8C2C1712,  //  0026  GETMET	R11	R11	K18
+      0x5C340400,  //  0027  MOVE	R13	R2
+      0x5838000F,  //  0028  LDCONST	R14	K15
+      0x543E00FE,  //  0029  LDINT	R15	255
+      0x58400002,  //  002A  LDCONST	R16	K2
+      0x54460013,  //  002B  LDINT	R17	20
+      0x7C2C0C00,  //  002C  CALL	R11	6
+      0x1830140B,  //  002D  LE	R12	R10	R11
+      0x78320009,  //  002E  JMPF	R12	#0039
+      0x8830010B,  //  002F  GETMBR	R12	R0	K11
+      0x9830110F,  //  0030  SETIDX	R12	R8	K15
+      0x8830010C,  //  0031  GETMBR	R12	R0	K12
+      0x8C301913,  //  0032  GETMET	R12	R12	K19
+      0x543A0003,  //  0033  LDINT	R14	4
+      0x0838100E,  //  0034  MUL	R14	R8	R14
+      0x583C000F,  //  0035  LDCONST	R15	K15
+      0x5441FFFB,  //  0036  LDINT	R16	-4
+      0x7C300800,  //  0037  CALL	R12	4
+      0x7002000A,  //  0038  JMP		#0044
+      0x0430140B,  //  0039  SUB	R12	R10	R11
+      0x2C341314,  //  003A  AND	R13	R9	K20
+      0x8838010C,  //  003B  GETMBR	R14	R0	K12
+      0x8C381D13,  //  003C  GETMET	R14	R14	K19
+      0x54420003,  //  003D  LDINT	R16	4
+      0x08401010,  //  003E  MUL	R16	R8	R16
+      0x54460017,  //  003F  LDINT	R17	24
+      0x38441811,  //  0040  SHL	R17	R12	R17
+      0x3044220D,  //  0041  OR	R17	R17	R13
+      0x5449FFFB,  //  0042  LDINT	R18	-4
+      0x7C380800,  //  0043  CALL	R14	4
+      0x00201102,  //  0044  ADD	R8	R8	K2
+      0x7001FFD0,  //  0045  JMP		#0017
+      0x5824000F,  //  0046  LDCONST	R9	K15
+      0x14281207,  //  0047  LT	R10	R9	R7
+      0x782A002B,  //  0048  JMPF	R10	#0075
+      0x8828010B,  //  0049  GETMBR	R10	R0	K11
+      0x94281409,  //  004A  GETIDX	R10	R10	R9
+      0x1C28150F,  //  004B  EQ	R10	R10	K15
+      0x782A0025,  //  004C  JMPF	R10	#0073
+      0x8C280115,  //  004D  GETMET	R10	R0	K21
+      0x543200FE,  //  004E  LDINT	R12	255
+      0x7C280400,  //  004F  CALL	R10	2
+      0x14281403,  //  0050  LT	R10	R10	R3
+      0x782A0020,  //  0051  JMPF	R10	#0073
+      0x8C280115,  //  0052  GETMET	R10	R0	K21
+      0x04300A04,  //  0053  SUB	R12	R5	R4
+      0x00301902,  //  0054  ADD	R12	R12	K2
+      0x7C280400,  //  0055  CALL	R10	2
+      0x0028080A,  //  0056  ADD	R10	R4	R10
+      0x5C2C0C00,  //  0057  MOVE	R11	R6
+      0x5432000F,  //  0058  LDINT	R12	16
+      0x3C30160C,  //  0059  SHR	R12	R11	R12
+      0x543600FE,  //  005A  LDINT	R13	255
+      0x2C30180D,  //  005B  AND	R12	R12	R13
+      0x54360007,  //  005C  LDINT	R13	8
+      0x3C34160D,  //  005D  SHR	R13	R11	R13
+      0x543A00FE,  //  005E  LDINT	R14	255
+      0x2C341A0E,  //  005F  AND	R13	R13	R14
+      0x543A00FE,  //  0060  LDINT	R14	255
+      0x2C38160E,  //  0061  AND	R14	R11	R14
+      0x883C010B,  //  0062  GETMBR	R15	R0	K11
+      0x983C1302,  //  0063  SETIDX	R15	R9	K2
+      0x883C010C,  //  0064  GETMBR	R15	R0	K12
+      0x8C3C1F13,  //  0065  GETMET	R15	R15	K19
+      0x54460003,  //  0066  LDINT	R17	4
+      0x08441211,  //  0067  MUL	R17	R9	R17
+      0x544A0017,  //  0068  LDINT	R18	24
+      0x38481412,  //  0069  SHL	R18	R10	R18
+      0x544E000F,  //  006A  LDINT	R19	16
+      0x384C1813,  //  006B  SHL	R19	R12	R19
+      0x30482413,  //  006C  OR	R18	R18	R19
+      0x544E0007,  //  006D  LDINT	R19	8
+      0x384C1A13,  //  006E  SHL	R19	R13	R19
+      0x30482413,  //  006F  OR	R18	R18	R19
+      0x3048240E,  //  0070  OR	R18	R18	R14
+      0x544DFFFB,  //  0071  LDINT	R19	-4
+      0x7C3C0800,  //  0072  CALL	R15	4
+      0x00241302,  //  0073  ADD	R9	R9	K2
+      0x7001FFD1,  //  0074  JMP		#0047
+      0x80000000,  //  0075  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_tostring,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x8C080116,  //  0001  GETMET	R2	R0	K22
+      0x58100008,  //  0002  LDCONST	R4	K8
+      0x7C080400,  //  0003  CALL	R2	2
+      0xB80E2E00,  //  0004  GETNGBL	R3	K23
+      0x8C0C0718,  //  0005  GETMET	R3	R3	K24
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x600C0008,  //  0009  GETGBL	R3	G8
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x5C040600,  //  000C  MOVE	R1	R3
+      0x70020004,  //  000D  JMP		#0013
+      0x600C0018,  //  000E  GETGBL	R3	G24
+      0x58100019,  //  000F  LDCONST	R4	K25
+      0x88140108,  //  0010  GETMBR	R5	R0	K8
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x5C040600,  //  0012  MOVE	R1	R3
+      0x600C0018,  //  0013  GETGBL	R3	G24
+      0x5810001A,  //  0014  LDCONST	R4	K26
+      0x5C140200,  //  0015  MOVE	R5	R1
+      0x88180105,  //  0016  GETMBR	R6	R0	K5
+      0x881C0101,  //  0017  GETMBR	R7	R0	K1
+      0x8820011B,  //  0018  GETMBR	R8	R0	K27
+      0x8824011C,  //  0019  GETMBR	R9	R0	K28
+      0x7C0C0C00,  //  001A  CALL	R3	6
+      0x80040600,  //  001B  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08051D,  //  0003  GETMET	R2	R2	K29
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90021602,  //  0008  SETMBR	R0	K11	R2
+      0x60080015,  //  0009  GETGBL	R2	G21
+      0x7C080000,  //  000A  CALL	R2	0
+      0x90021802,  //  000B  SETMBR	R0	K12	R2
+      0x90023D0F,  //  000C  SETMBR	R0	K30	K15
+      0x88080109,  //  000D  GETMBR	R2	R0	K9
+      0x88080520,  //  000E  GETMBR	R2	R2	K32
+      0x540EFFFF,  //  000F  LDINT	R3	65536
+      0x10080403,  //  0010  MOD	R2	R2	R3
+      0x90023E02,  //  0011  SETMBR	R0	K31	R2
+      0x8C08010E,  //  0012  GETMET	R2	R0	K14
+      0x7C080200,  //  0013  CALL	R2	1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: render
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_render,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(render),
+    &be_const_str_solidified,
+    ( &(const binstruction[55]) {  /* code */
+      0x880C011C,  //  0000  GETMBR	R3	R0	K28
+      0x780E0002,  //  0001  JMPF	R3	#0005
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C0C0203,  //  0003  EQ	R3	R1	R3
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x500C0000,  //  0005  LDBOOL	R3	0	0
+      0x80040600,  //  0006  RET	1	R3
+      0x8C0C0121,  //  0007  GETMET	R3	R0	K33
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x5C080600,  //  000A  MOVE	R2	R3
+      0x880C0109,  //  000B  GETMBR	R3	R0	K9
+      0x8C0C070A,  //  000C  GETMET	R3	R3	K10
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x6010000C,  //  000E  GETGBL	R4	G12
+      0x8814010B,  //  000F  GETMBR	R5	R0	K11
+      0x7C100200,  //  0010  CALL	R4	1
+      0x20100803,  //  0011  NE	R4	R4	R3
+      0x74120006,  //  0012  JMPT	R4	#001A
+      0x8810010C,  //  0013  GETMBR	R4	R0	K12
+      0x8C10090D,  //  0014  GETMET	R4	R4	K13
+      0x7C100200,  //  0015  CALL	R4	1
+      0x54160003,  //  0016  LDINT	R5	4
+      0x08140605,  //  0017  MUL	R5	R3	R5
+      0x20100805,  //  0018  NE	R4	R4	R5
+      0x78120001,  //  0019  JMPF	R4	#001C
+      0x8C10010E,  //  001A  GETMET	R4	R0	K14
+      0x7C100200,  //  001B  CALL	R4	1
+      0x50100000,  //  001C  LDBOOL	R4	0	0
+      0x5814000F,  //  001D  LDCONST	R5	K15
+      0x14180A03,  //  001E  LT	R6	R5	R3
+      0x781A0015,  //  001F  JMPF	R6	#0036
+      0x88180322,  //  0020  GETMBR	R6	R1	K34
+      0x14180A06,  //  0021  LT	R6	R5	R6
+      0x781A0010,  //  0022  JMPF	R6	#0034
+      0x8818010C,  //  0023  GETMBR	R6	R0	K12
+      0x8C180D10,  //  0024  GETMET	R6	R6	K16
+      0x54220003,  //  0025  LDINT	R8	4
+      0x08200A08,  //  0026  MUL	R8	R5	R8
+      0x5425FFFB,  //  0027  LDINT	R9	-4
+      0x7C180600,  //  0028  CALL	R6	3
+      0x541E0017,  //  0029  LDINT	R7	24
+      0x3C1C0C07,  //  002A  SHR	R7	R6	R7
+      0x542200FE,  //  002B  LDINT	R8	255
+      0x2C1C0E08,  //  002C  AND	R7	R7	R8
+      0x241C0F0F,  //  002D  GT	R7	R7	K15
+      0x781E0004,  //  002E  JMPF	R7	#0034
+      0x8C1C0323,  //  002F  GETMET	R7	R1	K35
+      0x5C240A00,  //  0030  MOVE	R9	R5
+      0x5C280C00,  //  0031  MOVE	R10	R6
+      0x7C1C0600,  //  0032  CALL	R7	3
+      0x50100200,  //  0033  LDBOOL	R4	1	0
+      0x00140B02,  //  0034  ADD	R5	R5	K2
+      0x7001FFE7,  //  0035  JMP		#001E
+      0x80040800,  //  0036  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(class_TwinkleAnimation_update,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080524,  //  0003  GETMET	R2	R2	K36
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0001,  //  0006  JMPT	R2	#0009
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x80040400,  //  0008  RET	1	R2
+      0x8C080121,  //  0009  GETMET	R2	R0	K33
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x5C040400,  //  000C  MOVE	R1	R2
+      0x88080101,  //  000D  GETMBR	R2	R0	K1
+      0x540E03E7,  //  000E  LDINT	R3	1000
+      0x0C0C0602,  //  000F  DIV	R3	R3	R2
+      0x8810011E,  //  0010  GETMBR	R4	R0	K30
+      0x04100204,  //  0011  SUB	R4	R1	R4
+      0x28100803,  //  0012  GE	R4	R4	R3
+      0x78120003,  //  0013  JMPF	R4	#0018
+      0x90023C01,  //  0014  SETMBR	R0	K30	R1
+      0x8C100125,  //  0015  GETMET	R4	R0	K37
+      0x5C180200,  //  0016  MOVE	R6	R1
+      0x7C100400,  //  0017  CALL	R4	2
+      0x50100200,  //  0018  LDBOOL	R4	1	0
+      0x80040800,  //  0019  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _initialize_arrays
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_initialize_arrays),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88040109,  //  0000  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0001  GETMET	R1	R1	K10
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8808010B,  //  0003  GETMBR	R2	R0	K11
+      0x8C080526,  //  0004  GETMET	R2	R2	K38
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x8808010C,  //  0007  GETMBR	R2	R0	K12
+      0x8C080527,  //  0008  GETMET	R2	R2	K39
+      0x7C080200,  //  0009  CALL	R2	1
+      0x8808010C,  //  000A  GETMBR	R2	R0	K12
+      0x8C080526,  //  000B  GETMET	R2	R2	K38
+      0x54120003,  //  000C  LDINT	R4	4
+      0x08100204,  //  000D  MUL	R4	R1	R4
+      0x7C080400,  //  000E  CALL	R2	2
+      0x5808000F,  //  000F  LDCONST	R2	K15
+      0x140C0401,  //  0010  LT	R3	R2	R1
+      0x780E000A,  //  0011  JMPF	R3	#001D
+      0x880C010B,  //  0012  GETMBR	R3	R0	K11
+      0x980C050F,  //  0013  SETIDX	R3	R2	K15
+      0x880C010C,  //  0014  GETMBR	R3	R0	K12
+      0x8C0C0713,  //  0015  GETMET	R3	R3	K19
+      0x54160003,  //  0016  LDINT	R5	4
+      0x08140405,  //  0017  MUL	R5	R2	R5
+      0x5818000F,  //  0018  LDCONST	R6	K15
+      0x541DFFFB,  //  0019  LDINT	R7	-4
+      0x7C0C0800,  //  001A  CALL	R3	4
+      0x00080502,  //  001B  ADD	R2	R2	K2
+      0x7001FFF2,  //  001C  JMP		#0010
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__random,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_random),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8804011F,  //  0000  GETMBR	R1	R0	K31
+      0x08040328,  //  0001  MUL	R1	R1	K40
+      0x540A3038,  //  0002  LDINT	R2	12345
+      0x00040202,  //  0003  ADD	R1	R1	R2
+      0x2C040329,  //  0004  AND	R1	R1	K41
+      0x90023E01,  //  0005  SETMBR	R0	K31	R1
+      0x8804011F,  //  0006  GETMBR	R1	R0	K31
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _random_range
+********************************************************************/
+be_local_closure(class_TwinkleAnimation__random_range,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_TwinkleAnimation,     /* shared constants */
+    be_str_weak(_random_range),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x1808030F,  //  0000  LE	R2	R1	K15
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80061E00,  //  0002  RET	1	K15
+      0x8C08012A,  //  0003  GETMET	R2	R0	K42
+      0x7C080200,  //  0004  CALL	R2	1
+      0x10080401,  //  0005  MOD	R2	R2	R1
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: TwinkleAnimation
+********************************************************************/
+extern const bclass be_class_Animation;
+be_local_class(TwinkleAnimation,
+    4,
+    &be_class_Animation,
+    be_nested_map(14,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(_random_range, -1), be_const_closure(class_TwinkleAnimation__random_range_closure) },
+        { be_const_key_weak(twinkle_states, -1), be_const_var(0) },
+        { be_const_key_weak(init, -1), be_const_closure(class_TwinkleAnimation_init_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_TwinkleAnimation_tostring_closure) },
+        { be_const_key_weak(random_seed, -1), be_const_var(3) },
+        { be_const_key_weak(PARAMS, 6), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(6,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(twinkle_speed, 1), be_const_bytes_instance(0700010188130006) },
+        { be_const_key_weak(min_brightness, -1), be_const_bytes_instance(07000001FF000020) },
+        { be_const_key_weak(density, -1), be_const_bytes_instance(07000001FF00018000) },
+        { be_const_key_weak(max_brightness, 2), be_const_bytes_instance(07000001FF0001FF00) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(fade_speed, 0), be_const_bytes_instance(07000001FF0001B400) },
+    }))    ) } )) },
+        { be_const_key_weak(_random, 9), be_const_closure(class_TwinkleAnimation__random_closure) },
+        { be_const_key_weak(last_update, -1), be_const_var(2) },
+        { be_const_key_weak(update, -1), be_const_closure(class_TwinkleAnimation_update_closure) },
+        { be_const_key_weak(_initialize_arrays, 10), be_const_closure(class_TwinkleAnimation__initialize_arrays_closure) },
+        { be_const_key_weak(render, 2), be_const_closure(class_TwinkleAnimation_render_closure) },
+        { be_const_key_weak(current_colors, -1), be_const_var(1) },
+        { be_const_key_weak(_update_twinkle_simulation, 1), be_const_closure(class_TwinkleAnimation__update_twinkle_simulation_closure) },
+        { be_const_key_weak(on_param_changed, 0), be_const_closure(class_TwinkleAnimation_on_param_changed_closure) },
+    })),
+    be_str_weak(TwinkleAnimation)
+);
+
+/********************************************************************
+** Solidified function: sine_osc
+********************************************************************/
+be_local_closure(sine_osc,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(SINE),
+    }),
+    be_str_weak(sine_osc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_value_provider
+********************************************************************/
+be_local_closure(is_value_provider,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(value_provider),
+    }),
+    be_str_weak(is_value_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x6004000F,  //  0000  GETGBL	R1	G15
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0x880C0701,  //  0003  GETMBR	R3	R3	K1
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -5989,78 +5970,6 @@ be_local_closure(animation_init_strip,   /* name */
       0x881C0504,  //  0022  GETMBR	R7	R2	K4
       0x981C0805,  //  0023  SETIDX	R7	R4	R5
       0x80040A00,  //  0024  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sine_osc
-********************************************************************/
-be_local_closure(sine_osc,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(SINE),
-    }),
-    be_str_weak(sine_osc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bounce
-********************************************************************/
-be_local_closure(bounce,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(BOUNCE),
-    }),
-    be_str_weak(bounce),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
     })
   )
 );
@@ -6274,46 +6183,12 @@ be_local_class(RichPaletteAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(range_min, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(transition_type, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(enum, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(2,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(1),
-        be_const_int(5),
-    }))    ) } )) },
-        { be_const_key_weak(default, -1), be_const_int(5) },
-    }))    ) } )) },
-        { be_const_key_weak(palette, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-        { be_const_key_weak(cycle_period, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5000) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(range_max, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(cycle_period, -1), be_const_bytes_instance(050000018813) },
+        { be_const_key_weak(range_min, 0), be_const_bytes_instance(040000) },
+        { be_const_key_weak(palette, -1), be_const_bytes_instance(0C0605) },
+        { be_const_key_weak(transition_type, 1), be_const_bytes_instance(1400050200010005) },
+        { be_const_key_weak(brightness, -1), be_const_bytes_instance(07000001FF0001FF00) },
+        { be_const_key_weak(range_max, -1), be_const_bytes_instance(0401FF00) },
     }))    ) } )) },
         { be_const_key_weak(init, 2), be_const_closure(class_RichPaletteAnimation_init_closure) },
         { be_const_key_weak(color_provider, -1), be_const_var(0) },
@@ -6357,488 +6232,13 @@ be_local_closure(linear,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'ColorCycleColorProvider' ktab size: 27, total: 52 (saved 200 bytes)
-static const bvalue be_ktab_class_ColorCycleColorProvider[27] = {
-  /* K0   */  be_nested_str_weak(palette),
-  /* K1   */  be_nested_str_weak(_get_param_def),
-  /* K2   */  be_nested_str_weak(contains),
-  /* K3   */  be_nested_str_weak(default),
-  /* K4   */  be_nested_str_weak(ColorCycleColorProvider_X28palette_size_X3D_X25s_X2C_X20cycle_period_X3D_X25s_X2C_X20mode_X3D_X25s_X2C_X20current_index_X3D_X25s_X29),
-  /* K5   */  be_nested_str_weak(_get_palette_size),
-  /* K6   */  be_nested_str_weak(cycle_period),
-  /* K7   */  be_nested_str_weak(manual),
-  /* K8   */  be_nested_str_weak(auto),
-  /* K9   */  be_nested_str_weak(current_index),
-  /* K10  */  be_nested_str_weak(_get_palette_bytes),
-  /* K11  */  be_nested_str_weak(on_param_changed),
-  /* K12  */  be_nested_str_weak(palette_size),
-  /* K13  */  be_nested_str_weak(values),
-  /* K14  */  be_nested_str_weak(value_error),
-  /* K15  */  be_nested_str_weak(Parameter_X20_X27palette_size_X27_X20is_X20read_X2Donly),
-  /* K16  */  be_const_int(0),
-  /* K17  */  be_nested_str_weak(current_color),
-  /* K18  */  be_nested_str_weak(_get_color_at_index),
-  /* K19  */  be_nested_str_weak(next),
-  /* K20  */  be_nested_str_weak(set_param),
-  /* K21  */  be_const_int(1),
-  /* K22  */  be_nested_str_weak(tasmota),
-  /* K23  */  be_nested_str_weak(scale_uint),
-  /* K24  */  be_nested_str_weak(init),
-  /* K25  */  be_nested_str_weak(get),
-  /* K26  */  be_const_int(-16777216),
-};
-
-
-extern const bclass be_class_ColorCycleColorProvider;
 
 /********************************************************************
-** Solidified function: _get_palette_bytes
+** Solidified function: noise_fractal
 ********************************************************************/
-be_local_closure(class_ColorCycleColorProvider__get_palette_bytes,   /* name */
+be_local_closure(noise_fractal,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(_get_palette_bytes),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C080202,  //  0002  EQ	R2	R1	R2
-      0x780A000A,  //  0003  JMPF	R2	#000F
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x58100000,  //  0005  LDCONST	R4	K0
-      0x7C080400,  //  0006  CALL	R2	2
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x200C0403,  //  0008  NE	R3	R2	R3
-      0x780E0004,  //  0009  JMPF	R3	#000F
-      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
-      0x58140003,  //  000B  LDCONST	R5	K3
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x780E0000,  //  000D  JMPF	R3	#000F
-      0x94040503,  //  000E  GETIDX	R1	R2	K3
-      0x80040200,  //  000F  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_tostring,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080004,  //  0001  LDCONST	R2	K4
-      0x8C0C0105,  //  0002  GETMET	R3	R0	K5
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x88100106,  //  0004  GETMBR	R4	R0	K6
-      0x88140106,  //  0005  GETMBR	R5	R0	K6
-      0x78160001,  //  0006  JMPF	R5	#0009
-      0x58140007,  //  0007  LDCONST	R5	K7
-      0x70020000,  //  0008  JMP		#000A
-      0x58140008,  //  0009  LDCONST	R5	K8
-      0x88180109,  //  000A  GETMBR	R6	R0	K9
-      0x7C040A00,  //  000B  CALL	R1	5
-      0x80040200,  //  000C  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _get_palette_size
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider__get_palette_size,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(_get_palette_size),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8C04010A,  //  0000  GETMET	R1	R0	K10
-      0x7C040200,  //  0001  CALL	R1	1
-      0x6008000C,  //  0002  GETGBL	R2	G12
-      0x5C0C0200,  //  0003  MOVE	R3	R1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x540E0003,  //  0005  LDINT	R3	4
-      0x0C080403,  //  0006  DIV	R2	R2	R3
-      0x80040400,  //  0007  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_on_param_changed,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C070B,  //  0003  GETMET	R3	R3	K11
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x1C0C030C,  //  0007  EQ	R3	R1	K12
-      0x780E0005,  //  0008  JMPF	R3	#000F
-      0x880C010D,  //  0009  GETMBR	R3	R0	K13
-      0x8C100105,  //  000A  GETMET	R4	R0	K5
-      0x7C100200,  //  000B  CALL	R4	1
-      0x980E1804,  //  000C  SETIDX	R3	K12	R4
-      0xB0061D0F,  //  000D  RAISE	1	K14	K15
-      0x70020027,  //  000E  JMP		#0037
-      0x1C0C0300,  //  000F  EQ	R3	R1	K0
-      0x780E000E,  //  0010  JMPF	R3	#0020
-      0x8C0C0105,  //  0011  GETMET	R3	R0	K5
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0x24100710,  //  0013  GT	R4	R3	K16
-      0x78120007,  //  0014  JMPF	R4	#001D
-      0x88100109,  //  0015  GETMBR	R4	R0	K9
-      0x28100803,  //  0016  GE	R4	R4	R3
-      0x78120000,  //  0017  JMPF	R4	#0019
-      0x90021310,  //  0018  SETMBR	R0	K9	K16
-      0x8C100112,  //  0019  GETMET	R4	R0	K18
-      0x88180109,  //  001A  GETMBR	R6	R0	K9
-      0x7C100400,  //  001B  CALL	R4	2
-      0x90022204,  //  001C  SETMBR	R0	K17	R4
-      0x8810010D,  //  001D  GETMBR	R4	R0	K13
-      0x98121803,  //  001E  SETIDX	R4	K12	R3
-      0x70020016,  //  001F  JMP		#0037
-      0x1C0C0313,  //  0020  EQ	R3	R1	K19
-      0x780E0014,  //  0021  JMPF	R3	#0037
-      0x200C0510,  //  0022  NE	R3	R2	K16
-      0x780E0012,  //  0023  JMPF	R3	#0037
-      0x8C0C0105,  //  0024  GETMET	R3	R0	K5
-      0x7C0C0200,  //  0025  CALL	R3	1
-      0x24100710,  //  0026  GT	R4	R3	K16
-      0x7812000A,  //  0027  JMPF	R4	#0033
-      0x88100109,  //  0028  GETMBR	R4	R0	K9
-      0x00100802,  //  0029  ADD	R4	R4	R2
-      0x10100803,  //  002A  MOD	R4	R4	R3
-      0x14140910,  //  002B  LT	R5	R4	K16
-      0x78160000,  //  002C  JMPF	R5	#002E
-      0x00100803,  //  002D  ADD	R4	R4	R3
-      0x90021204,  //  002E  SETMBR	R0	K9	R4
-      0x8C140112,  //  002F  GETMET	R5	R0	K18
-      0x881C0109,  //  0030  GETMBR	R7	R0	K9
-      0x7C140400,  //  0031  CALL	R5	2
-      0x90022205,  //  0032  SETMBR	R0	K17	R5
-      0x8C100114,  //  0033  GETMET	R4	R0	K20
-      0x58180013,  //  0034  LDCONST	R6	K19
-      0x581C0010,  //  0035  LDCONST	R7	K16
-      0x7C100600,  //  0036  CALL	R4	3
-      0x80000000,  //  0037  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_produce_value,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0x880C0106,  //  0000  GETMBR	R3	R0	K6
-      0x8C100105,  //  0001  GETMET	R4	R0	K5
-      0x7C100200,  //  0002  CALL	R4	1
-      0x1C140910,  //  0003  EQ	R5	R4	K16
-      0x78160001,  //  0004  JMPF	R5	#0007
-      0x5415FFFE,  //  0005  LDINT	R5	-1
-      0x80040A00,  //  0006  RET	1	R5
-      0x1C140915,  //  0007  EQ	R5	R4	K21
-      0x78160005,  //  0008  JMPF	R5	#000F
-      0x8C140112,  //  0009  GETMET	R5	R0	K18
-      0x581C0010,  //  000A  LDCONST	R7	K16
-      0x7C140400,  //  000B  CALL	R5	2
-      0x90022205,  //  000C  SETMBR	R0	K17	R5
-      0x88140111,  //  000D  GETMBR	R5	R0	K17
-      0x80040A00,  //  000E  RET	1	R5
-      0x1C140710,  //  000F  EQ	R5	R3	K16
-      0x78160001,  //  0010  JMPF	R5	#0013
-      0x88140111,  //  0011  GETMBR	R5	R0	K17
-      0x80040A00,  //  0012  RET	1	R5
-      0x10140403,  //  0013  MOD	R5	R2	R3
-      0xB81A2C00,  //  0014  GETNGBL	R6	K22
-      0x8C180D17,  //  0015  GETMET	R6	R6	K23
-      0x5C200A00,  //  0016  MOVE	R8	R5
-      0x58240010,  //  0017  LDCONST	R9	K16
-      0x04280715,  //  0018  SUB	R10	R3	K21
-      0x582C0010,  //  0019  LDCONST	R11	K16
-      0x04300915,  //  001A  SUB	R12	R4	K21
-      0x7C180C00,  //  001B  CALL	R6	6
-      0x281C0C04,  //  001C  GE	R7	R6	R4
-      0x781E0001,  //  001D  JMPF	R7	#0020
-      0x041C0915,  //  001E  SUB	R7	R4	K21
-      0x5C180E00,  //  001F  MOVE	R6	R7
-      0x90021206,  //  0020  SETMBR	R0	K9	R6
-      0x8C1C0112,  //  0021  GETMET	R7	R0	K18
-      0x5C240C00,  //  0022  MOVE	R9	R6
-      0x7C1C0400,  //  0023  CALL	R7	2
-      0x90022207,  //  0024  SETMBR	R0	K17	R7
-      0x881C0111,  //  0025  GETMBR	R7	R0	K17
-      0x80040E00,  //  0026  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color_for_value
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_get_color_for_value,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(get_color_for_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0x8C0C0105,  //  0000  GETMET	R3	R0	K5
-      0x7C0C0200,  //  0001  CALL	R3	1
-      0x1C100710,  //  0002  EQ	R4	R3	K16
-      0x78120001,  //  0003  JMPF	R4	#0006
-      0x5411FFFE,  //  0004  LDINT	R4	-1
-      0x80040800,  //  0005  RET	1	R4
-      0x1C100715,  //  0006  EQ	R4	R3	K21
-      0x78120003,  //  0007  JMPF	R4	#000C
-      0x8C100112,  //  0008  GETMET	R4	R0	K18
-      0x58180010,  //  0009  LDCONST	R6	K16
-      0x7C100400,  //  000A  CALL	R4	2
-      0x80040800,  //  000B  RET	1	R4
-      0x14100310,  //  000C  LT	R4	R1	K16
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x58040010,  //  000E  LDCONST	R1	K16
-      0x70020003,  //  000F  JMP		#0014
-      0x54120063,  //  0010  LDINT	R4	100
-      0x24100204,  //  0011  GT	R4	R1	R4
-      0x78120000,  //  0012  JMPF	R4	#0014
-      0x54060063,  //  0013  LDINT	R1	100
-      0xB8122C00,  //  0014  GETNGBL	R4	K22
-      0x8C100917,  //  0015  GETMET	R4	R4	K23
-      0x5C180200,  //  0016  MOVE	R6	R1
-      0x581C0010,  //  0017  LDCONST	R7	K16
-      0x54220063,  //  0018  LDINT	R8	100
-      0x58240010,  //  0019  LDCONST	R9	K16
-      0x04280715,  //  001A  SUB	R10	R3	K21
-      0x7C100C00,  //  001B  CALL	R4	6
-      0x28140803,  //  001C  GE	R5	R4	R3
-      0x78160001,  //  001D  JMPF	R5	#0020
-      0x04140715,  //  001E  SUB	R5	R3	K21
-      0x5C100A00,  //  001F  MOVE	R4	R5
-      0x8C140112,  //  0020  GETMET	R5	R0	K18
-      0x5C1C0800,  //  0021  MOVE	R7	R4
-      0x7C140400,  //  0022  CALL	R5	2
-      0x80040A00,  //  0023  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080518,  //  0003  GETMET	R2	R2	K24
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C08010A,  //  0006  GETMET	R2	R0	K10
-      0x7C080200,  //  0007  CALL	R2	1
-      0x8C0C0112,  //  0008  GETMET	R3	R0	K18
-      0x58140010,  //  0009  LDCONST	R5	K16
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x90022203,  //  000B  SETMBR	R0	K17	R3
-      0x90021310,  //  000C  SETMBR	R0	K9	K16
-      0x880C010D,  //  000D  GETMBR	R3	R0	K13
-      0x8C100105,  //  000E  GETMET	R4	R0	K5
-      0x7C100200,  //  000F  CALL	R4	1
-      0x980E1804,  //  0010  SETIDX	R3	K12	R4
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _get_color_at_index
-********************************************************************/
-be_local_closure(class_ColorCycleColorProvider__get_color_at_index,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
-    be_str_weak(_get_color_at_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x8C08010A,  //  0000  GETMET	R2	R0	K10
-      0x7C080200,  //  0001  CALL	R2	1
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100400,  //  0003  MOVE	R4	R2
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x54120003,  //  0005  LDINT	R4	4
-      0x0C0C0604,  //  0006  DIV	R3	R3	R4
-      0x1C100710,  //  0007  EQ	R4	R3	K16
-      0x74120003,  //  0008  JMPT	R4	#000D
-      0x14100310,  //  0009  LT	R4	R1	K16
-      0x74120001,  //  000A  JMPT	R4	#000D
-      0x28100203,  //  000B  GE	R4	R1	R3
-      0x78120001,  //  000C  JMPF	R4	#000F
-      0x5411FFFE,  //  000D  LDINT	R4	-1
-      0x80040800,  //  000E  RET	1	R4
-      0x8C100519,  //  000F  GETMET	R4	R2	K25
-      0x541A0003,  //  0010  LDINT	R6	4
-      0x08180206,  //  0011  MUL	R6	R1	R6
-      0x541DFFFB,  //  0012  LDINT	R7	-4
-      0x7C100600,  //  0013  CALL	R4	3
-      0x3010091A,  //  0014  OR	R4	R4	K26
-      0x80040800,  //  0015  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: ColorCycleColorProvider
-********************************************************************/
-extern const bclass be_class_ColorProvider;
-be_local_class(ColorCycleColorProvider,
-    2,
-    &be_class_ColorProvider,
-    be_nested_map(11,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_get_color_at_index, -1), be_const_closure(class_ColorCycleColorProvider__get_color_at_index_closure) },
-        { be_const_key_weak(_get_palette_size, -1), be_const_closure(class_ColorCycleColorProvider__get_palette_size_closure) },
-        { be_const_key_weak(current_color, 6), be_const_var(0) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_ColorCycleColorProvider_tostring_closure) },
-        { be_const_key_weak(_get_palette_bytes, 1), be_const_closure(class_ColorCycleColorProvider__get_palette_bytes_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ColorCycleColorProvider_on_param_changed_closure) },
-        { be_const_key_weak(current_index, -1), be_const_var(1) },
-        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorCycleColorProvider_get_color_for_value_closure) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(4,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(palette, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bytes_instance(FF0000FFFF00FF00FFFF0000) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bytes) },
-    }))    ) } )) },
-        { be_const_key_weak(palette_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(3) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(int) },
-    }))    ) } )) },
-        { be_const_key_weak(next, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(cycle_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5000) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_ColorCycleColorProvider_init_closure) },
-        { be_const_key_weak(produce_value, 0), be_const_closure(class_ColorCycleColorProvider_produce_value_closure) },
-    })),
-    be_str_weak(ColorCycleColorProvider)
-);
-
-/********************************************************************
-** Solidified function: is_value_provider
-********************************************************************/
-be_local_closure(is_value_provider,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -6846,19 +6246,57 @@ be_local_closure(is_value_provider,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(value_provider),
+    /* K1   */  be_nested_str_weak(noise_animation),
+    /* K2   */  be_nested_str_weak(rich_palette),
+    /* K3   */  be_nested_str_weak(palette),
+    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
+    /* K5   */  be_nested_str_weak(cycle_period),
+    /* K6   */  be_nested_str_weak(transition_type),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(brightness),
+    /* K9   */  be_nested_str_weak(range_min),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(range_max),
+    /* K12  */  be_nested_str_weak(color),
+    /* K13  */  be_nested_str_weak(scale),
+    /* K14  */  be_nested_str_weak(speed),
+    /* K15  */  be_nested_str_weak(octaves),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(persistence),
     }),
-    be_str_weak(is_value_provider),
+    be_str_weak(noise_fractal),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x6004000F,  //  0000  GETGBL	R1	G15
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
-      0x880C0701,  //  0003  GETMBR	R3	R3	K1
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
+    ( &(const binstruction[28]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0xB80E0000,  //  0008  GETNGBL	R3	K0
+      0x880C0704,  //  0009  GETMBR	R3	R3	K4
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0x540E1387,  //  000B  LDINT	R3	5000
+      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
+      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
+      0x540E00FE,  //  000E  LDINT	R3	255
+      0x900A1003,  //  000F  SETMBR	R2	K8	R3
+      0x900A130A,  //  0010  SETMBR	R2	K9	K10
+      0x540E00FE,  //  0011  LDINT	R3	255
+      0x900A1603,  //  0012  SETMBR	R2	K11	R3
+      0x90061802,  //  0013  SETMBR	R1	K12	R2
+      0x540E001D,  //  0014  LDINT	R3	30
+      0x90061A03,  //  0015  SETMBR	R1	K13	R3
+      0x540E0013,  //  0016  LDINT	R3	20
+      0x90061C03,  //  0017  SETMBR	R1	K14	R3
+      0x90061F10,  //  0018  SETMBR	R1	K15	K16
+      0x540E007F,  //  0019  LDINT	R3	128
+      0x90062203,  //  001A  SETMBR	R1	K17	R3
+      0x80040200,  //  001B  RET	1	R1
     })
   )
 );
@@ -7151,12 +6589,7 @@ be_local_class(StaticValueProvider,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(value, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(any) },
-    }))    ) } )) },
+        { be_const_key_weak(value, -1), be_const_bytes_instance(0C0604) },
     }))    ) } )) },
         { be_const_key_weak(produce_value, -1), be_const_closure(class_StaticValueProvider_produce_value_closure) },
         { be_const_key_weak(_X21_X3D, -1), be_const_closure(class_StaticValueProvider__X21_X3D_closure) },
@@ -7205,9 +6638,9 @@ be_local_closure(square,   /* name */
 
 
 /********************************************************************
-** Solidified function: sawtooth
+** Solidified function: pulsating_color_provider
 ********************************************************************/
-be_local_closure(sawtooth,   /* name */
+be_local_closure(pulsating_color_provider,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -7217,22 +6650,23 @@ be_local_closure(sawtooth,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(SAWTOOTH),
+    /* K1   */  be_nested_str_weak(breathe_color),
+    /* K2   */  be_nested_str_weak(curve_factor),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(duration),
     }),
-    be_str_weak(sawtooth),
+    be_str_weak(pulsating_color_provider),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A03E7,  //  0005  LDINT	R2	1000
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
       0x80040200,  //  0007  RET	1	R1
     })
   )
@@ -7988,46 +7422,12 @@ be_local_class(NoiseAnimation,
         { be_const_key_weak(PARAMS, 12), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(persistence, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(octaves, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(4) },
-    }))    ) } )) },
-        { be_const_key_weak(seed, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(12345) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(65535) },
-    }))    ) } )) },
-        { be_const_key_weak(speed, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(30) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-    }))    ) } )) },
-        { be_const_key_weak(scale, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(octaves, -1), be_const_bytes_instance(07000100040001) },
+        { be_const_key_weak(seed, 0), be_const_bytes_instance(07000002FFFF0000013930) },
+        { be_const_key_weak(speed, 3), be_const_bytes_instance(07000001FF00001E) },
+        { be_const_key_weak(persistence, 1), be_const_bytes_instance(07000001FF00018000) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(0406) },
+        { be_const_key_weak(scale, -1), be_const_bytes_instance(07000101FF000032) },
     }))    ) } )) },
         { be_const_key_weak(update, 6), be_const_closure(class_NoiseAnimation_update_closure) },
         { be_const_key_weak(time_offset, -1), be_const_var(1) },
@@ -8043,347 +7443,13 @@ be_local_class(NoiseAnimation,
     })),
     be_str_weak(NoiseAnimation)
 );
-extern const bclass be_class_AnimationMath;
-// compact class 'AnimationMath' ktab size: 13, total: 31 (saved 144 bytes)
-static const bvalue be_ktab_class_AnimationMath[13] = {
-  /* K0   */  be_const_class(be_class_AnimationMath),
-  /* K1   */  be_nested_str_weak(math),
-  /* K2   */  be_nested_str_weak(int),
-  /* K3   */  be_const_int(0),
-  /* K4   */  be_const_real_hex(0x437F0000),
-  /* K5   */  be_nested_str_weak(sqrt),
-  /* K6   */  be_nested_str_weak(max),
-  /* K7   */  be_nested_str_weak(round),
-  /* K8   */  be_nested_str_weak(abs),
-  /* K9   */  be_nested_str_weak(tasmota),
-  /* K10  */  be_nested_str_weak(scale_int),
-  /* K11  */  be_nested_str_weak(sine_int),
-  /* K12  */  be_nested_str_weak(min),
-};
-
-
-extern const bclass be_class_AnimationMath;
 
 /********************************************************************
-** Solidified function: sqrt
+** Solidified function: sawtooth
 ********************************************************************/
-be_local_closure(class_AnimationMath_sqrt,   /* name */
+be_local_closure(sawtooth,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(sqrt),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0004,  //  0002  GETGBL	R3	G4
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x1C0C0702,  //  0005  EQ	R3	R3	K2
-      0x780E000E,  //  0006  JMPF	R3	#0016
-      0x280C0103,  //  0007  GE	R3	R0	K3
-      0x780E000C,  //  0008  JMPF	R3	#0016
-      0x540E00FE,  //  0009  LDINT	R3	255
-      0x180C0003,  //  000A  LE	R3	R0	R3
-      0x780E0009,  //  000B  JMPF	R3	#0016
-      0x0C0C0104,  //  000C  DIV	R3	R0	K4
-      0x60100009,  //  000D  GETGBL	R4	G9
-      0x8C140505,  //  000E  GETMET	R5	R2	K5
-      0x5C1C0600,  //  000F  MOVE	R7	R3
-      0x7C140400,  //  0010  CALL	R5	2
-      0x541A00FE,  //  0011  LDINT	R6	255
-      0x08140A06,  //  0012  MUL	R5	R5	R6
-      0x7C100200,  //  0013  CALL	R4	1
-      0x80040800,  //  0014  RET	1	R4
-      0x70020003,  //  0015  JMP		#001A
-      0x8C0C0505,  //  0016  GETMET	R3	R2	K5
-      0x5C140000,  //  0017  MOVE	R5	R0
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x80040600,  //  0019  RET	1	R3
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: max
-********************************************************************/
-be_local_closure(class_AnimationMath_max,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    13,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(max),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0016,  //  0002  GETGBL	R3	G22
-      0x88100506,  //  0003  GETMBR	R4	R2	K6
-      0x5C140000,  //  0004  MOVE	R5	R0
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x80040600,  //  0006  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: round
-********************************************************************/
-be_local_closure(class_AnimationMath_round,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(round),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0009,  //  0002  GETGBL	R3	G9
-      0x8C100507,  //  0003  GETMET	R4	R2	K7
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x80040600,  //  0007  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: abs
-********************************************************************/
-be_local_closure(class_AnimationMath_abs,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(abs),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0508,  //  0002  GETMET	R3	R2	K8
-      0x5C140000,  //  0003  MOVE	R5	R0
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x80040600,  //  0005  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: cos
-********************************************************************/
-be_local_closure(class_AnimationMath_cos,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(cos),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xB80A1200,  //  0001  GETNGBL	R2	K9
-      0x8C08050A,  //  0002  GETMET	R2	R2	K10
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x58140003,  //  0004  LDCONST	R5	K3
-      0x541A00FE,  //  0005  LDINT	R6	255
-      0x581C0003,  //  0006  LDCONST	R7	K3
-      0x54227FFE,  //  0007  LDINT	R8	32767
-      0x7C080C00,  //  0008  CALL	R2	6
-      0xB80E1200,  //  0009  GETNGBL	R3	K9
-      0x8C0C070B,  //  000A  GETMET	R3	R3	K11
-      0x54161FFF,  //  000B  LDINT	R5	8192
-      0x04140405,  //  000C  SUB	R5	R2	R5
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0xB8121200,  //  000E  GETNGBL	R4	K9
-      0x8C10090A,  //  000F  GETMET	R4	R4	K10
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x541DEFFF,  //  0011  LDINT	R7	-4096
-      0x54220FFF,  //  0012  LDINT	R8	4096
-      0x5425FF00,  //  0013  LDINT	R9	-255
-      0x542A00FE,  //  0014  LDINT	R10	255
-      0x7C100C00,  //  0015  CALL	R4	6
-      0x80040800,  //  0016  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sin
-********************************************************************/
-be_local_closure(class_AnimationMath_sin,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(sin),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xB80A1200,  //  0001  GETNGBL	R2	K9
-      0x8C08050A,  //  0002  GETMET	R2	R2	K10
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x58140003,  //  0004  LDCONST	R5	K3
-      0x541A00FE,  //  0005  LDINT	R6	255
-      0x581C0003,  //  0006  LDCONST	R7	K3
-      0x54227FFE,  //  0007  LDINT	R8	32767
-      0x7C080C00,  //  0008  CALL	R2	6
-      0xB80E1200,  //  0009  GETNGBL	R3	K9
-      0x8C0C070B,  //  000A  GETMET	R3	R3	K11
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0xB8121200,  //  000D  GETNGBL	R4	K9
-      0x8C10090A,  //  000E  GETMET	R4	R4	K10
-      0x5C180600,  //  000F  MOVE	R6	R3
-      0x541DEFFF,  //  0010  LDINT	R7	-4096
-      0x54220FFF,  //  0011  LDINT	R8	4096
-      0x5425FF00,  //  0012  LDINT	R9	-255
-      0x542A00FE,  //  0013  LDINT	R10	255
-      0x7C100C00,  //  0014  CALL	R4	6
-      0x80040800,  //  0015  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: scale
-********************************************************************/
-be_local_closure(class_AnimationMath_scale,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    5,                          /* argc */
-    12,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(scale),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x58140000,  //  0000  LDCONST	R5	K0
-      0xB81A1200,  //  0001  GETNGBL	R6	K9
-      0x8C180D0A,  //  0002  GETMET	R6	R6	K10
-      0x5C200000,  //  0003  MOVE	R8	R0
-      0x5C240200,  //  0004  MOVE	R9	R1
-      0x5C280400,  //  0005  MOVE	R10	R2
-      0x5C2C0600,  //  0006  MOVE	R11	R3
-      0x5C300800,  //  0007  MOVE	R12	R4
-      0x7C180C00,  //  0008  CALL	R6	6
-      0x80040C00,  //  0009  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: min
-********************************************************************/
-be_local_closure(class_AnimationMath_min,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    13,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationMath,     /* shared constants */
-    be_str_weak(min),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0016,  //  0002  GETGBL	R3	G22
-      0x8810050C,  //  0003  GETMBR	R4	R2	K12
-      0x5C140000,  //  0004  MOVE	R5	R0
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x80040600,  //  0006  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: AnimationMath
-********************************************************************/
-be_local_class(AnimationMath,
-    0,
-    NULL,
-    be_nested_map(8,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(min, -1), be_const_static_closure(class_AnimationMath_min_closure) },
-        { be_const_key_weak(max, 2), be_const_static_closure(class_AnimationMath_max_closure) },
-        { be_const_key_weak(scale, -1), be_const_static_closure(class_AnimationMath_scale_closure) },
-        { be_const_key_weak(round, 6), be_const_static_closure(class_AnimationMath_round_closure) },
-        { be_const_key_weak(cos, -1), be_const_static_closure(class_AnimationMath_cos_closure) },
-        { be_const_key_weak(sin, -1), be_const_static_closure(class_AnimationMath_sin_closure) },
-        { be_const_key_weak(abs, -1), be_const_static_closure(class_AnimationMath_abs_closure) },
-        { be_const_key_weak(sqrt, 0), be_const_static_closure(class_AnimationMath_sqrt_closure) },
-    })),
-    be_str_weak(AnimationMath)
-);
-
-/********************************************************************
-** Solidified function: wave_rainbow_sine
-********************************************************************/
-be_local_closure(wave_rainbow_sine,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -8391,463 +7457,23 @@ be_local_closure(wave_rainbow_sine,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(wave_animation),
-    /* K2   */  be_nested_str_weak(rich_palette),
-    /* K3   */  be_nested_str_weak(palette),
-    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
-    /* K5   */  be_nested_str_weak(cycle_period),
-    /* K6   */  be_nested_str_weak(transition_type),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(brightness),
-    /* K9   */  be_nested_str_weak(range_min),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(range_max),
-    /* K12  */  be_nested_str_weak(color),
-    /* K13  */  be_nested_str_weak(wave_type),
-    /* K14  */  be_nested_str_weak(frequency),
-    /* K15  */  be_nested_str_weak(wave_speed),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(SAWTOOTH),
     }),
-    be_str_weak(wave_rainbow_sine),
+    be_str_weak(sawtooth),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
+    ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0xB80E0000,  //  0008  GETNGBL	R3	K0
-      0x880C0704,  //  0009  GETMBR	R3	R3	K4
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0x540E1387,  //  000B  LDINT	R3	5000
-      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
-      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
-      0x540E00FE,  //  000E  LDINT	R3	255
-      0x900A1003,  //  000F  SETMBR	R2	K8	R3
-      0x900A130A,  //  0010  SETMBR	R2	K9	K10
-      0x540E00FE,  //  0011  LDINT	R3	255
-      0x900A1603,  //  0012  SETMBR	R2	K11	R3
-      0x90061802,  //  0013  SETMBR	R1	K12	R2
-      0x90061B0A,  //  0014  SETMBR	R1	K13	K10
-      0x540E001F,  //  0015  LDINT	R3	32
-      0x90061C03,  //  0016  SETMBR	R1	K14	R3
-      0x540E0031,  //  0017  LDINT	R3	50
-      0x90061E03,  //  0018  SETMBR	R1	K15	R3
-      0x80040200,  //  0019  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gradient_rainbow_linear
-********************************************************************/
-be_local_closure(gradient_rainbow_linear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(gradient_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(gradient_type),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(direction),
-    /* K6   */  be_nested_str_weak(movement_speed),
-    }),
-    be_str_weak(gradient_rainbow_linear),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x90060704,  //  0006  SETMBR	R1	K3	K4
-      0x90060B04,  //  0007  SETMBR	R1	K5	K4
-      0x540A0031,  //  0008  LDINT	R2	50
-      0x90060C02,  //  0009  SETMBR	R1	K6	R2
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear_all_event_handlers
-********************************************************************/
-be_local_closure(clear_all_event_handlers,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    0,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(event_manager),
-    /* K2   */  be_nested_str_weak(clear_all_handlers),
-    }),
-    be_str_weak(clear_all_event_handlers),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8020000,  //  0000  GETNGBL	R0	K0
-      0x88000101,  //  0001  GETMBR	R0	R0	K1
-      0x8C000102,  //  0002  GETMET	R0	R0	K2
-      0x7C000200,  //  0003  CALL	R0	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_user_function
-********************************************************************/
-be_local_closure(get_user_function,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(_user_functions),
-    /* K2   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(get_user_function),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C040302,  //  0002  GETMET	R1	R1	K2
-      0x5C0C0000,  //  0003  MOVE	R3	R0
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: twinkle_rainbow
-********************************************************************/
-be_local_closure(twinkle_rainbow,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(twinkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(density),
-    /* K4   */  be_nested_str_weak(twinkle_speed),
-    /* K5   */  be_nested_str_weak(fade_speed),
-    /* K6   */  be_nested_str_weak(min_brightness),
-    /* K7   */  be_nested_str_weak(max_brightness),
-    }),
-    be_str_weak(twinkle_rainbow),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409FFFE,  //  0004  LDINT	R2	-1
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A0077,  //  0006  LDINT	R2	120
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x540A0005,  //  0008  LDINT	R2	6
-      0x90060802,  //  0009  SETMBR	R1	K4	R2
-      0x540A00B3,  //  000A  LDINT	R2	180
-      0x90060A02,  //  000B  SETMBR	R1	K5	R2
-      0x540A001F,  //  000C  LDINT	R2	32
-      0x90060C02,  //  000D  SETMBR	R1	K6	R2
-      0x540A00FE,  //  000E  LDINT	R2	255
-      0x90060E02,  //  000F  SETMBR	R1	K7	R2
-      0x80040200,  //  0010  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_engine
-********************************************************************/
-be_local_closure(create_engine,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(animation_engine),
-    }),
-    be_str_weak(create_engine),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-extern const bclass be_class_PaletteGradientAnimation;
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_PaletteGradientAnimation_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(name),
-    /* K2   */  be_nested_str_weak(palette_gradient),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020302,  //  0006  SETMBR	R0	K1	K2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_value_buffer
-********************************************************************/
-be_local_closure(class_PaletteGradientAnimation__update_value_buffer,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(shift_period),
-    /* K1   */  be_nested_str_weak(spatial_period),
-    /* K2   */  be_nested_str_weak(phase_shift),
-    /* K3   */  be_nested_str_weak(engine),
-    /* K4   */  be_nested_str_weak(get_strip_length),
-    /* K5   */  be_nested_str_weak(value_buffer),
-    /* K6   */  be_nested_str_weak(resize),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(scale_uint),
-    /* K10  */  be_const_real_hex(0x447A0000),
-    /* K11  */  be_const_int(1),
-    }),
-    be_str_weak(_update_value_buffer),
-    &be_const_str_solidified,
-    ( &(const binstruction[63]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x88140103,  //  0003  GETMBR	R5	R0	K3
-      0x8C140B04,  //  0004  GETMET	R5	R5	K4
-      0x7C140200,  //  0005  CALL	R5	1
-      0x6018000C,  //  0006  GETGBL	R6	G12
-      0x881C0105,  //  0007  GETMBR	R7	R0	K5
-      0x7C180200,  //  0008  CALL	R6	1
-      0x20180C05,  //  0009  NE	R6	R6	R5
-      0x781A0003,  //  000A  JMPF	R6	#000F
-      0x88180105,  //  000B  GETMBR	R6	R0	K5
-      0x8C180D06,  //  000C  GETMET	R6	R6	K6
-      0x5C200A00,  //  000D  MOVE	R8	R5
-      0x7C180400,  //  000E  CALL	R6	2
-      0x24180707,  //  000F  GT	R6	R3	K7
-      0x781A0001,  //  0010  JMPF	R6	#0013
-      0x5C180600,  //  0011  MOVE	R6	R3
-      0x70020000,  //  0012  JMP		#0014
-      0x5C180A00,  //  0013  MOVE	R6	R5
-      0x581C0007,  //  0014  LDCONST	R7	K7
-      0x24200507,  //  0015  GT	R8	R2	K7
-      0x7822000A,  //  0016  JMPF	R8	#0022
-      0xB8221000,  //  0017  GETNGBL	R8	K8
-      0x8C201109,  //  0018  GETMET	R8	R8	K9
-      0x10280202,  //  0019  MOD	R10	R1	R2
-      0x582C0007,  //  001A  LDCONST	R11	K7
-      0x5C300400,  //  001B  MOVE	R12	R2
-      0x58340007,  //  001C  LDCONST	R13	K7
-      0x543A03E7,  //  001D  LDINT	R14	1000
-      0x7C200C00,  //  001E  CALL	R8	6
-      0x0C20110A,  //  001F  DIV	R8	R8	K10
-      0x08241006,  //  0020  MUL	R9	R8	R6
-      0x5C1C1200,  //  0021  MOVE	R7	R9
-      0xB8221000,  //  0022  GETNGBL	R8	K8
-      0x8C201109,  //  0023  GETMET	R8	R8	K9
-      0x5C280800,  //  0024  MOVE	R10	R4
-      0x582C0007,  //  0025  LDCONST	R11	K7
-      0x54320063,  //  0026  LDINT	R12	100
-      0x58340007,  //  0027  LDCONST	R13	K7
-      0x5C380C00,  //  0028  MOVE	R14	R6
-      0x7C200C00,  //  0029  CALL	R8	6
-      0x58240007,  //  002A  LDCONST	R9	K7
-      0x14281205,  //  002B  LT	R10	R9	R5
-      0x782A0010,  //  002C  JMPF	R10	#003E
-      0x00281207,  //  002D  ADD	R10	R9	R7
-      0x00281408,  //  002E  ADD	R10	R10	R8
-      0x10281406,  //  002F  MOD	R10	R10	R6
-      0xB82E1000,  //  0030  GETNGBL	R11	K8
-      0x8C2C1709,  //  0031  GETMET	R11	R11	K9
-      0x60340009,  //  0032  GETGBL	R13	G9
-      0x5C381400,  //  0033  MOVE	R14	R10
-      0x7C340200,  //  0034  CALL	R13	1
-      0x58380007,  //  0035  LDCONST	R14	K7
-      0x043C0D0B,  //  0036  SUB	R15	R6	K11
-      0x58400007,  //  0037  LDCONST	R16	K7
-      0x544600FE,  //  0038  LDINT	R17	255
-      0x7C2C0C00,  //  0039  CALL	R11	6
-      0x88300105,  //  003A  GETMBR	R12	R0	K5
-      0x9830120B,  //  003B  SETIDX	R12	R9	R11
-      0x0024130B,  //  003C  ADD	R9	R9	K11
-      0x7001FFEC,  //  003D  JMP		#002B
-      0x80000000,  //  003E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: PaletteGradientAnimation
-********************************************************************/
-extern const bclass be_class_PalettePatternAnimation;
-be_local_class(PaletteGradientAnimation,
-    0,
-    &be_class_PalettePatternAnimation,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(shift_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(spatial_period, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(phase_shift, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(100) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(class_PaletteGradientAnimation_init_closure) },
-        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteGradientAnimation__update_value_buffer_closure) },
-    })),
-    be_str_weak(PaletteGradientAnimation)
-);
-
-/********************************************************************
-** Solidified function: twinkle_gentle
-********************************************************************/
-be_local_closure(twinkle_gentle,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(twinkle_animation),
-    /* K2   */  be_nested_str_weak(color),
-    /* K3   */  be_nested_str_weak(density),
-    /* K4   */  be_nested_str_weak(twinkle_speed),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(fade_speed),
-    /* K7   */  be_nested_str_weak(min_brightness),
-    /* K8   */  be_nested_str_weak(max_brightness),
-    }),
-    be_str_weak(twinkle_gentle),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x5409D6FF,  //  0004  LDINT	R2	-10496
-      0x90060402,  //  0005  SETMBR	R1	K2	R2
-      0x540A003F,  //  0006  LDINT	R2	64
-      0x90060602,  //  0007  SETMBR	R1	K3	R2
-      0x90060905,  //  0008  SETMBR	R1	K4	K5
-      0x540A0077,  //  0009  LDINT	R2	120
-      0x90060C02,  //  000A  SETMBR	R1	K6	R2
-      0x540A000F,  //  000B  LDINT	R2	16
-      0x90060E02,  //  000C  SETMBR	R1	K7	R2
-      0x540A00B3,  //  000D  LDINT	R2	180
-      0x90061002,  //  000E  SETMBR	R1	K8	R2
-      0x80040200,  //  000F  RET	1	R1
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
     })
   )
 );
@@ -9257,1573 +7883,6 @@ be_local_class(FrameBuffer,
     })),
     be_str_weak(FrameBuffer)
 );
-// compact class 'AnimationEngine' ktab size: 63, total: 170 (saved 856 bytes)
-static const bvalue be_ktab_class_AnimationEngine[63] = {
-  /* K0   */  be_nested_str_weak(animation),
-  /* K1   */  be_nested_str_weak(SequenceManager),
-  /* K2   */  be_nested_str_weak(remove_sequence_manager),
-  /* K3   */  be_nested_str_weak(remove_animation),
-  /* K4   */  be_nested_str_weak(Cannot_X20remove_X20object_X20of_X20type_X20_X27_X25s_X27_X20from_X20engine_X2E_X20Expected_X20Animation_X20or_X20SequenceManager_X2E),
-  /* K5   */  be_nested_str_weak(type_error),
-  /* K6   */  be_nested_str_weak(animations),
-  /* K7   */  be_const_int(0),
-  /* K8   */  be_nested_str_weak(update),
-  /* K9   */  be_nested_str_weak(is_running),
-  /* K10  */  be_const_int(1),
-  /* K11  */  be_nested_str_weak(remove),
-  /* K12  */  be_nested_str_weak(render_needed),
-  /* K13  */  be_nested_str_weak(_clear_strip),
-  /* K14  */  be_nested_str_weak(_render_animations),
-  /* K15  */  be_nested_str_weak(fast_loop_closure),
-  /* K16  */  be_nested_str_weak(tasmota),
-  /* K17  */  be_nested_str_weak(remove_fast_loop),
-  /* K18  */  be_nested_str_weak(stop),
-  /* K19  */  be_nested_str_weak(stop_iteration),
-  /* K20  */  be_nested_str_weak(find),
-  /* K21  */  be_nested_str_weak(push),
-  /* K22  */  be_nested_str_weak(_sort_animations),
-  /* K23  */  be_nested_str_weak(start),
-  /* K24  */  be_nested_str_weak(time_ms),
-  /* K25  */  be_nested_str_weak(AnimationEngine_X28running_X3D_X25s_X2C_X20animations_X3D_X25s_X2C_X20width_X3D_X25s_X29),
-  /* K26  */  be_nested_str_weak(width),
-  /* K27  */  be_nested_str_weak(iteration_stack),
-  /* K28  */  be_nested_str_weak(pop),
-  /* K29  */  be_nested_str_weak(strip),
-  /* K30  */  be_nested_str_weak(length),
-  /* K31  */  be_nested_str_weak(_handle_strip_length_change),
-  /* K32  */  be_nested_str_weak(frame_buffer),
-  /* K33  */  be_nested_str_weak(resize),
-  /* K34  */  be_nested_str_weak(temp_buffer),
-  /* K35  */  be_nested_str_weak(millis),
-  /* K36  */  be_nested_str_weak(check_strip_length),
-  /* K37  */  be_nested_str_weak(last_update),
-  /* K38  */  be_nested_str_weak(can_show),
-  /* K39  */  be_nested_str_weak(sequence_managers),
-  /* K40  */  be_nested_str_weak(_process_events),
-  /* K41  */  be_nested_str_weak(_update_and_render),
-  /* K42  */  be_nested_str_weak(clear),
-  /* K43  */  be_nested_str_weak(priority),
-  /* K44  */  be_nested_str_weak(show),
-  /* K45  */  be_nested_str_weak(value_error),
-  /* K46  */  be_nested_str_weak(strip_X20cannot_X20be_X20nil),
-  /* K47  */  be_nested_str_weak(name),
-  /* K48  */  be_nested_str_weak(render),
-  /* K49  */  be_nested_str_weak(post_render),
-  /* K50  */  be_nested_str_weak(blend_pixels),
-  /* K51  */  be_nested_str_weak(pixels),
-  /* K52  */  be_nested_str_weak(_output_to_strip),
-  /* K53  */  be_nested_str_weak(add_fast_loop),
-  /* K54  */  be_nested_str_weak(event_manager),
-  /* K55  */  be_nested_str_weak(_process_queued_events),
-  /* K56  */  be_nested_str_weak(resume),
-  /* K57  */  be_nested_str_weak(set_pixel_color),
-  /* K58  */  be_nested_str_weak(get_pixel_color),
-  /* K59  */  be_nested_str_weak(_add_sequence_manager),
-  /* K60  */  be_nested_str_weak(_add_animation),
-  /* K61  */  be_nested_str_weak(introspect),
-  /* K62  */  be_nested_str_weak(Cannot_X20add_X20object_X20of_X20type_X20_X27_X25s_X27_X20to_X20engine_X2E_X20Expected_X20Animation_X20or_X20SequenceManager_X2E),
-};
-
-
-extern const bclass be_class_AnimationEngine;
-
-/********************************************************************
-** Solidified function: remove
-********************************************************************/
-be_local_closure(class_AnimationEngine_remove,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(remove),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x780A0004,  //  0005  JMPF	R2	#000B
-      0x8C080102,  //  0006  GETMET	R2	R0	K2
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x80040400,  //  0009  RET	1	R2
-      0x70020011,  //  000A  JMP		#001D
-      0x6008000F,  //  000B  GETGBL	R2	G15
-      0x5C0C0200,  //  000C  MOVE	R3	R1
-      0xB8120000,  //  000D  GETNGBL	R4	K0
-      0x88100900,  //  000E  GETMBR	R4	R4	K0
-      0x7C080400,  //  000F  CALL	R2	2
-      0x780A0004,  //  0010  JMPF	R2	#0016
-      0x8C080103,  //  0011  GETMET	R2	R0	K3
-      0x5C100200,  //  0012  MOVE	R4	R1
-      0x7C080400,  //  0013  CALL	R2	2
-      0x80040400,  //  0014  RET	1	R2
-      0x70020006,  //  0015  JMP		#001D
-      0x60080018,  //  0016  GETGBL	R2	G24
-      0x580C0004,  //  0017  LDCONST	R3	K4
-      0x60100005,  //  0018  GETGBL	R4	G5
-      0x5C140200,  //  0019  MOVE	R5	R1
-      0x7C100200,  //  001A  CALL	R4	1
-      0x7C080400,  //  001B  CALL	R2	2
-      0xB0060A02,  //  001C  RAISE	1	K5	R2
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_animations
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_animations,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040106,  //  0000  GETMBR	R1	R0	K6
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_and_render
-********************************************************************/
-be_local_closure(class_AnimationEngine__update_and_render,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_update_and_render),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x58080007,  //  0000  LDCONST	R2	K7
-      0x580C0007,  //  0001  LDCONST	R3	K7
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140106,  //  0003  GETMBR	R5	R0	K6
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120011,  //  0006  JMPF	R4	#0019
-      0x88100106,  //  0007  GETMBR	R4	R0	K6
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x8C140908,  //  0009  GETMET	R5	R4	K8
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x78160004,  //  000C  JMPF	R5	#0012
-      0x88180909,  //  000D  GETMBR	R6	R4	K9
-      0x781A0002,  //  000E  JMPF	R6	#0012
-      0x0008050A,  //  000F  ADD	R2	R2	K10
-      0x000C070A,  //  0010  ADD	R3	R3	K10
-      0x70020005,  //  0011  JMP		#0018
-      0x88180106,  //  0012  GETMBR	R6	R0	K6
-      0x8C180D0B,  //  0013  GETMET	R6	R6	K11
-      0x5C200600,  //  0014  MOVE	R8	R3
-      0x7C180400,  //  0015  CALL	R6	2
-      0x50180200,  //  0016  LDBOOL	R6	1	0
-      0x90021806,  //  0017  SETMBR	R0	K12	R6
-      0x7001FFE8,  //  0018  JMP		#0002
-      0x1C100507,  //  0019  EQ	R4	R2	K7
-      0x78120006,  //  001A  JMPF	R4	#0022
-      0x8810010C,  //  001B  GETMBR	R4	R0	K12
-      0x78120003,  //  001C  JMPF	R4	#0021
-      0x8C10010D,  //  001D  GETMET	R4	R0	K13
-      0x7C100200,  //  001E  CALL	R4	1
-      0x50100000,  //  001F  LDBOOL	R4	0	0
-      0x90021804,  //  0020  SETMBR	R0	K12	R4
-      0x80000800,  //  0021  RET	0
-      0x8C10010E,  //  0022  GETMET	R4	R0	K14
-      0x88180106,  //  0023  GETMBR	R6	R0	K6
-      0x5C1C0200,  //  0024  MOVE	R7	R1
-      0x7C100600,  //  0025  CALL	R4	3
-      0x50100000,  //  0026  LDBOOL	R4	0	0
-      0x90021804,  //  0027  SETMBR	R0	K12	R4
-      0x80000000,  //  0028  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_AnimationEngine_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x78060009,  //  0001  JMPF	R1	#000C
-      0x50040000,  //  0002  LDBOOL	R1	0	0
-      0x90021201,  //  0003  SETMBR	R0	K9	R1
-      0x8804010F,  //  0004  GETMBR	R1	R0	K15
-      0x4C080000,  //  0005  LDNIL	R2
-      0x20040202,  //  0006  NE	R1	R1	R2
-      0x78060003,  //  0007  JMPF	R1	#000C
-      0xB8062000,  //  0008  GETNGBL	R1	K16
-      0x8C040311,  //  0009  GETMET	R1	R1	K17
-      0x880C010F,  //  000A  GETMBR	R3	R0	K15
-      0x7C040400,  //  000B  CALL	R1	2
-      0x80040000,  //  000C  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: interrupt_current
-********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_current,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_current),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080106,  //  0001  GETMBR	R2	R0	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0xA8020006,  //  0003  EXBLK	0	#000B
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x7C080000,  //  0005  CALL	R2	0
-      0x880C0509,  //  0006  GETMBR	R3	R2	K9
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x8C0C0512,  //  0008  GETMET	R3	R2	K18
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7001FFF8,  //  000A  JMP		#0004
-      0x58040013,  //  000B  LDCONST	R1	K19
-      0xAC040200,  //  000C  CATCH	R1	1	0
-      0xB0080000,  //  000D  RAISE	2	R0	R0
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _add_animation
-********************************************************************/
-be_local_closure(class_AnimationEngine__add_animation,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_add_animation),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x88080106,  //  0000  GETMBR	R2	R0	K6
-      0x8C080514,  //  0001  GETMET	R2	R2	K20
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C080403,  //  0005  EQ	R2	R2	R3
-      0x780A000F,  //  0006  JMPF	R2	#0017
-      0x88080106,  //  0007  GETMBR	R2	R0	K6
-      0x8C080515,  //  0008  GETMET	R2	R2	K21
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0x8C080116,  //  000B  GETMET	R2	R0	K22
-      0x7C080200,  //  000C  CALL	R2	1
-      0x88080109,  //  000D  GETMBR	R2	R0	K9
-      0x780A0002,  //  000E  JMPF	R2	#0012
-      0x8C080317,  //  000F  GETMET	R2	R1	K23
-      0x88100118,  //  0010  GETMBR	R4	R0	K24
-      0x7C080400,  //  0011  CALL	R2	2
-      0x50080200,  //  0012  LDBOOL	R2	1	0
-      0x90021802,  //  0013  SETMBR	R0	K12	R2
-      0x50080200,  //  0014  LDBOOL	R2	1	0
-      0x80040400,  //  0015  RET	1	R2
-      0x70020001,  //  0016  JMP		#0019
-      0x50080000,  //  0017  LDBOOL	R2	0	0
-      0x80040400,  //  0018  RET	1	R2
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_AnimationEngine_tostring,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080019,  //  0001  LDCONST	R2	K25
-      0x880C0109,  //  0002  GETMBR	R3	R0	K9
-      0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140106,  //  0004  GETMBR	R5	R0	K6
-      0x7C100200,  //  0005  CALL	R4	1
-      0x8814011A,  //  0006  GETMBR	R5	R0	K26
-      0x7C040800,  //  0007  CALL	R1	4
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pop_iteration_context
-********************************************************************/
-be_local_closure(class_AnimationEngine_pop_iteration_context,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(pop_iteration_context),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x8808011B,  //  0001  GETMBR	R2	R0	K27
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040307,  //  0003  GT	R1	R1	K7
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8804011B,  //  0005  GETMBR	R1	R0	K27
-      0x8C04031C,  //  0006  GETMET	R1	R1	K28
-      0x7C040200,  //  0007  CALL	R1	1
-      0x80040200,  //  0008  RET	1	R1
-      0x4C040000,  //  0009  LDNIL	R1
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_strip_length
-********************************************************************/
-be_local_closure(class_AnimationEngine_check_strip_length,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(check_strip_length),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8804011D,  //  0000  GETMBR	R1	R0	K29
-      0x8C04031E,  //  0001  GETMET	R1	R1	K30
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8808011A,  //  0003  GETMBR	R2	R0	K26
-      0x20080202,  //  0004  NE	R2	R1	R2
-      0x780A0004,  //  0005  JMPF	R2	#000B
-      0x8C08011F,  //  0006  GETMET	R2	R0	K31
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x50080200,  //  0009  LDBOOL	R2	1	0
-      0x80040400,  //  000A  RET	1	R2
-      0x50080000,  //  000B  LDBOOL	R2	0	0
-      0x80040400,  //  000C  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _handle_strip_length_change
-********************************************************************/
-be_local_closure(class_AnimationEngine__handle_strip_length_change,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_handle_strip_length_change),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x18080307,  //  0000  LE	R2	R1	K7
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x90023401,  //  0003  SETMBR	R0	K26	R1
-      0x88080120,  //  0004  GETMBR	R2	R0	K32
-      0x8C080521,  //  0005  GETMET	R2	R2	K33
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x88080122,  //  0008  GETMBR	R2	R0	K34
-      0x8C080521,  //  0009  GETMET	R2	R2	K33
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x50080200,  //  000C  LDBOOL	R2	1	0
-      0x90021802,  //  000D  SETMBR	R0	K12	R2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_tick
-********************************************************************/
-be_local_closure(class_AnimationEngine_on_tick,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(on_tick),
-    &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x88080109,  //  0000  GETMBR	R2	R0	K9
-      0x740A0001,  //  0001  JMPT	R2	#0004
-      0x50080000,  //  0002  LDBOOL	R2	0	0
-      0x80040400,  //  0003  RET	1	R2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x1C080202,  //  0005  EQ	R2	R1	R2
-      0x780A0003,  //  0006  JMPF	R2	#000B
-      0xB80A2000,  //  0007  GETNGBL	R2	K16
-      0x8C080523,  //  0008  GETMET	R2	R2	K35
-      0x7C080200,  //  0009  CALL	R2	1
-      0x5C040400,  //  000A  MOVE	R1	R2
-      0x8C080124,  //  000B  GETMET	R2	R0	K36
-      0x7C080200,  //  000C  CALL	R2	1
-      0x90023001,  //  000D  SETMBR	R0	K24	R1
-      0x88080125,  //  000E  GETMBR	R2	R0	K37
-      0x04080202,  //  000F  SUB	R2	R1	R2
-      0x540E0004,  //  0010  LDINT	R3	5
-      0x140C0403,  //  0011  LT	R3	R2	R3
-      0x780E0001,  //  0012  JMPF	R3	#0015
-      0x500C0200,  //  0013  LDBOOL	R3	1	0
-      0x80040600,  //  0014  RET	1	R3
-      0x90024A01,  //  0015  SETMBR	R0	K37	R1
-      0x880C011D,  //  0016  GETMBR	R3	R0	K29
-      0x880C0726,  //  0017  GETMBR	R3	R3	K38
-      0x4C100000,  //  0018  LDNIL	R4
-      0x200C0604,  //  0019  NE	R3	R3	R4
-      0x780E0005,  //  001A  JMPF	R3	#0021
-      0x880C011D,  //  001B  GETMBR	R3	R0	K29
-      0x8C0C0726,  //  001C  GETMET	R3	R3	K38
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0x740E0001,  //  001E  JMPT	R3	#0021
-      0x500C0200,  //  001F  LDBOOL	R3	1	0
-      0x80040600,  //  0020  RET	1	R3
-      0x580C0007,  //  0021  LDCONST	R3	K7
-      0x6010000C,  //  0022  GETGBL	R4	G12
-      0x88140127,  //  0023  GETMBR	R5	R0	K39
-      0x7C100200,  //  0024  CALL	R4	1
-      0x14100604,  //  0025  LT	R4	R3	R4
-      0x78120006,  //  0026  JMPF	R4	#002E
-      0x88100127,  //  0027  GETMBR	R4	R0	K39
-      0x94100803,  //  0028  GETIDX	R4	R4	R3
-      0x8C100908,  //  0029  GETMET	R4	R4	K8
-      0x5C180200,  //  002A  MOVE	R6	R1
-      0x7C100400,  //  002B  CALL	R4	2
-      0x000C070A,  //  002C  ADD	R3	R3	K10
-      0x7001FFF3,  //  002D  JMP		#0022
-      0x8C100128,  //  002E  GETMET	R4	R0	K40
-      0x5C180200,  //  002F  MOVE	R6	R1
-      0x7C100400,  //  0030  CALL	R4	2
-      0x8C100129,  //  0031  GETMET	R4	R0	K41
-      0x5C180200,  //  0032  MOVE	R6	R1
-      0x7C100400,  //  0033  CALL	R4	2
-      0x50100200,  //  0034  LDBOOL	R4	1	0
-      0x80040800,  //  0035  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: cleanup
-********************************************************************/
-be_local_closure(class_AnimationEngine_cleanup,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(cleanup),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x8C040112,  //  0000  GETMET	R1	R0	K18
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C04012A,  //  0002  GETMET	R1	R0	K42
-      0x7C040200,  //  0003  CALL	R1	1
-      0x4C040000,  //  0004  LDNIL	R1
-      0x90024001,  //  0005  SETMBR	R0	K32	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x90024401,  //  0007  SETMBR	R0	K34	R1
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90023A01,  //  0009  SETMBR	R0	K29	R1
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _sort_animations
-********************************************************************/
-be_local_closure(class_AnimationEngine__sort_animations,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_sort_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080106,  //  0001  GETMBR	R2	R0	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1808030A,  //  0003  LE	R2	R1	K10
-      0x780A0000,  //  0004  JMPF	R2	#0006
-      0x80000400,  //  0005  RET	0
-      0x5808000A,  //  0006  LDCONST	R2	K10
-      0x140C0401,  //  0007  LT	R3	R2	R1
-      0x780E0016,  //  0008  JMPF	R3	#0020
-      0x880C0106,  //  0009  GETMBR	R3	R0	K6
-      0x940C0602,  //  000A  GETIDX	R3	R3	R2
-      0x5C100400,  //  000B  MOVE	R4	R2
-      0x24140907,  //  000C  GT	R5	R4	K7
-      0x7816000D,  //  000D  JMPF	R5	#001C
-      0x0414090A,  //  000E  SUB	R5	R4	K10
-      0x88180106,  //  000F  GETMBR	R6	R0	K6
-      0x94140C05,  //  0010  GETIDX	R5	R6	R5
-      0x88140B2B,  //  0011  GETMBR	R5	R5	K43
-      0x8818072B,  //  0012  GETMBR	R6	R3	K43
-      0x14140A06,  //  0013  LT	R5	R5	R6
-      0x78160006,  //  0014  JMPF	R5	#001C
-      0x88140106,  //  0015  GETMBR	R5	R0	K6
-      0x0418090A,  //  0016  SUB	R6	R4	K10
-      0x881C0106,  //  0017  GETMBR	R7	R0	K6
-      0x94180E06,  //  0018  GETIDX	R6	R7	R6
-      0x98140806,  //  0019  SETIDX	R5	R4	R6
-      0x0410090A,  //  001A  SUB	R4	R4	K10
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x88140106,  //  001C  GETMBR	R5	R0	K6
-      0x98140803,  //  001D  SETIDX	R5	R4	R3
-      0x0008050A,  //  001E  ADD	R2	R2	K10
-      0x7001FFE6,  //  001F  JMP		#0007
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: interrupt_all
-********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_all,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_all),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C04012A,  //  0000  GETMET	R1	R0	K42
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _add_sequence_manager
-********************************************************************/
-be_local_closure(class_AnimationEngine__add_sequence_manager,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_add_sequence_manager),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080127,  //  0000  GETMBR	R2	R0	K39
-      0x8C080515,  //  0001  GETMET	R2	R2	K21
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040000,  //  0004  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _clear_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine__clear_strip,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_clear_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8804011D,  //  0000  GETMBR	R1	R0	K29
-      0x8C04032A,  //  0001  GETMET	R1	R1	K42
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8804011D,  //  0003  GETMBR	R1	R0	K29
-      0x8C04032C,  //  0004  GETMET	R1	R1	K44
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_AnimationEngine_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0xB0065B2E,  //  0003  RAISE	1	K45	K46
-      0x90023A01,  //  0004  SETMBR	R0	K29	R1
-      0x8C08031E,  //  0005  GETMET	R2	R1	K30
-      0x7C080200,  //  0006  CALL	R2	1
-      0x90023402,  //  0007  SETMBR	R0	K26	R2
-      0x60080012,  //  0008  GETGBL	R2	G18
-      0x7C080000,  //  0009  CALL	R2	0
-      0x90020C02,  //  000A  SETMBR	R0	K6	R2
-      0x60080012,  //  000B  GETGBL	R2	G18
-      0x7C080000,  //  000C  CALL	R2	0
-      0x90024E02,  //  000D  SETMBR	R0	K39	R2
-      0xB80A0000,  //  000E  GETNGBL	R2	K0
-      0x8C080520,  //  000F  GETMET	R2	R2	K32
-      0x8810011A,  //  0010  GETMBR	R4	R0	K26
-      0x7C080400,  //  0011  CALL	R2	2
-      0x90024002,  //  0012  SETMBR	R0	K32	R2
-      0xB80A0000,  //  0013  GETNGBL	R2	K0
-      0x8C080520,  //  0014  GETMET	R2	R2	K32
-      0x8810011A,  //  0015  GETMBR	R4	R0	K26
-      0x7C080400,  //  0016  CALL	R2	2
-      0x90024402,  //  0017  SETMBR	R0	K34	R2
-      0x50080000,  //  0018  LDBOOL	R2	0	0
-      0x90021202,  //  0019  SETMBR	R0	K9	R2
-      0x90024B07,  //  001A  SETMBR	R0	K37	K7
-      0x90023107,  //  001B  SETMBR	R0	K24	K7
-      0x4C080000,  //  001C  LDNIL	R2
-      0x90021E02,  //  001D  SETMBR	R0	K15	R2
-      0x50080000,  //  001E  LDBOOL	R2	0	0
-      0x90021802,  //  001F  SETMBR	R0	K12	R2
-      0x60080012,  //  0020  GETGBL	R2	G18
-      0x7C080000,  //  0021  CALL	R2	0
-      0x90023602,  //  0022  SETMBR	R0	K27	R2
-      0x80000000,  //  0023  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: interrupt_animation
-********************************************************************/
-be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(interrupt_animation),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080007,  //  0000  LDCONST	R2	K7
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100106,  //  0002  GETMBR	R4	R0	K6
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0106,  //  0006  GETMBR	R3	R0	K6
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8810072F,  //  0008  GETMBR	R4	R3	K47
-      0x4C140000,  //  0009  LDNIL	R5
-      0x20100805,  //  000A  NE	R4	R4	R5
-      0x7812000A,  //  000B  JMPF	R4	#0017
-      0x8810072F,  //  000C  GETMBR	R4	R3	K47
-      0x1C100801,  //  000D  EQ	R4	R4	R1
-      0x78120007,  //  000E  JMPF	R4	#0017
-      0x8C100712,  //  000F  GETMET	R4	R3	K18
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x88100106,  //  0012  GETMBR	R4	R0	K6
-      0x8C10090B,  //  0013  GETMET	R4	R4	K11
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000800,  //  0016  RET	0
-      0x0008050A,  //  0017  ADD	R2	R2	K10
-      0x7001FFE7,  //  0018  JMP		#0001
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _render_animations
-********************************************************************/
-be_local_closure(class_AnimationEngine__render_animations,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_render_animations),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x880C0120,  //  0000  GETMBR	R3	R0	K32
-      0x8C0C072A,  //  0001  GETMET	R3	R3	K42
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x580C0007,  //  0003  LDCONST	R3	K7
-      0x6010000C,  //  0004  GETGBL	R4	G12
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x14100604,  //  0007  LT	R4	R3	R4
-      0x78120015,  //  0008  JMPF	R4	#001F
-      0x94100203,  //  0009  GETIDX	R4	R1	R3
-      0x88140122,  //  000A  GETMBR	R5	R0	K34
-      0x8C140B2A,  //  000B  GETMET	R5	R5	K42
-      0x7C140200,  //  000C  CALL	R5	1
-      0x8C140930,  //  000D  GETMET	R5	R4	K48
-      0x881C0122,  //  000E  GETMBR	R7	R0	K34
-      0x5C200400,  //  000F  MOVE	R8	R2
-      0x7C140600,  //  0010  CALL	R5	3
-      0x7816000A,  //  0011  JMPF	R5	#001D
-      0x8C180931,  //  0012  GETMET	R6	R4	K49
-      0x88200122,  //  0013  GETMBR	R8	R0	K34
-      0x5C240400,  //  0014  MOVE	R9	R2
-      0x7C180600,  //  0015  CALL	R6	3
-      0x88180120,  //  0016  GETMBR	R6	R0	K32
-      0x8C180D32,  //  0017  GETMET	R6	R6	K50
-      0x88200120,  //  0018  GETMBR	R8	R0	K32
-      0x88201133,  //  0019  GETMBR	R8	R8	K51
-      0x88240122,  //  001A  GETMBR	R9	R0	K34
-      0x88241333,  //  001B  GETMBR	R9	R9	K51
-      0x7C180600,  //  001C  CALL	R6	3
-      0x000C070A,  //  001D  ADD	R3	R3	K10
-      0x7001FFE4,  //  001E  JMP		#0004
-      0x8C100134,  //  001F  GETMET	R4	R0	K52
-      0x7C100200,  //  0020  CALL	R4	1
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: run
-********************************************************************/
-be_local_closure(class_AnimationEngine_run,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(on_tick),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(run),
-    &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x7406002B,  //  0001  JMPT	R1	#002E
-      0xB8062000,  //  0002  GETNGBL	R1	K16
-      0x8C040323,  //  0003  GETMET	R1	R1	K35
-      0x7C040200,  //  0004  CALL	R1	1
-      0x50080200,  //  0005  LDBOOL	R2	1	0
-      0x90021202,  //  0006  SETMBR	R0	K9	R2
-      0x540A0009,  //  0007  LDINT	R2	10
-      0x04080202,  //  0008  SUB	R2	R1	R2
-      0x90024A02,  //  0009  SETMBR	R0	K37	R2
-      0x8808010F,  //  000A  GETMBR	R2	R0	K15
-      0x4C0C0000,  //  000B  LDNIL	R3
-      0x1C080403,  //  000C  EQ	R2	R2	R3
-      0x780A0001,  //  000D  JMPF	R2	#0010
-      0x84080000,  //  000E  CLOSURE	R2	P0
-      0x90021E02,  //  000F  SETMBR	R0	K15	R2
-      0x58080007,  //  0010  LDCONST	R2	K7
-      0x600C000C,  //  0011  GETGBL	R3	G12
-      0x88100106,  //  0012  GETMBR	R4	R0	K6
-      0x7C0C0200,  //  0013  CALL	R3	1
-      0x140C0403,  //  0014  LT	R3	R2	R3
-      0x780E0006,  //  0015  JMPF	R3	#001D
-      0x880C0106,  //  0016  GETMBR	R3	R0	K6
-      0x940C0602,  //  0017  GETIDX	R3	R3	R2
-      0x8C0C0717,  //  0018  GETMET	R3	R3	K23
-      0x5C140200,  //  0019  MOVE	R5	R1
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x0008050A,  //  001B  ADD	R2	R2	K10
-      0x7001FFF3,  //  001C  JMP		#0011
-      0x58080007,  //  001D  LDCONST	R2	K7
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x88100127,  //  001F  GETMBR	R4	R0	K39
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x140C0403,  //  0021  LT	R3	R2	R3
-      0x780E0006,  //  0022  JMPF	R3	#002A
-      0x880C0127,  //  0023  GETMBR	R3	R0	K39
-      0x940C0602,  //  0024  GETIDX	R3	R3	R2
-      0x8C0C0717,  //  0025  GETMET	R3	R3	K23
-      0x5C140200,  //  0026  MOVE	R5	R1
-      0x7C0C0400,  //  0027  CALL	R3	2
-      0x0008050A,  //  0028  ADD	R2	R2	K10
-      0x7001FFF3,  //  0029  JMP		#001E
-      0xB80E2000,  //  002A  GETNGBL	R3	K16
-      0x8C0C0735,  //  002B  GETMET	R3	R3	K53
-      0x8814010F,  //  002C  GETMBR	R5	R0	K15
-      0x7C0C0400,  //  002D  CALL	R3	2
-      0xA0000000,  //  002E  CLOSE	R0
-      0x80040000,  //  002F  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_current_iteration
-********************************************************************/
-be_local_closure(class_AnimationEngine_update_current_iteration,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(update_current_iteration),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C011B,  //  0001  GETMBR	R3	R0	K27
-      0x7C080200,  //  0002  CALL	R2	1
-      0x24080507,  //  0003  GT	R2	R2	K7
-      0x780A0002,  //  0004  JMPF	R2	#0008
-      0x8808011B,  //  0005  GETMBR	R2	R0	K27
-      0x540DFFFE,  //  0006  LDINT	R3	-1
-      0x98080601,  //  0007  SETIDX	R2	R3	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_current_iteration_number
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_current_iteration_number,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_current_iteration_number),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x8808011B,  //  0001  GETMBR	R2	R0	K27
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040307,  //  0003  GT	R1	R1	K7
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8804011B,  //  0005  GETMBR	R1	R0	K27
-      0x5409FFFE,  //  0006  LDINT	R2	-1
-      0x94040202,  //  0007  GETIDX	R1	R1	R2
-      0x80040200,  //  0008  RET	1	R1
-      0x4C040000,  //  0009  LDNIL	R1
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_active
-********************************************************************/
-be_local_closure(class_AnimationEngine_is_active,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(is_active),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _process_events
-********************************************************************/
-be_local_closure(class_AnimationEngine__process_events,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_process_events),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x88080536,  //  0001  GETMBR	R2	R2	K54
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x20080403,  //  0003  NE	R2	R2	R3
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0xB80A0000,  //  0005  GETNGBL	R2	K0
-      0x88080536,  //  0006  GETMBR	R2	R2	K54
-      0x8C080537,  //  0007  GETMET	R2	R2	K55
-      0x7C080200,  //  0008  CALL	R2	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_strip,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x8804011D,  //  0000  GETMBR	R1	R0	K29
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: size
-********************************************************************/
-be_local_closure(class_AnimationEngine_size,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(size),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x6004000C,  //  0000  GETGBL	R1	G12
-      0x88080106,  //  0001  GETMBR	R2	R0	K6
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resume_after
-********************************************************************/
-be_local_closure(class_AnimationEngine_resume_after,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(resume_after),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C080138,  //  0000  GETMET	R2	R0	K56
-      0x7C080200,  //  0001  CALL	R2	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _output_to_strip
-********************************************************************/
-be_local_closure(class_AnimationEngine__output_to_strip,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(_output_to_strip),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x58040007,  //  0000  LDCONST	R1	K7
-      0x8808011A,  //  0001  GETMBR	R2	R0	K26
-      0x14080202,  //  0002  LT	R2	R1	R2
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x8808011D,  //  0004  GETMBR	R2	R0	K29
-      0x8C080539,  //  0005  GETMET	R2	R2	K57
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x88140120,  //  0007  GETMBR	R5	R0	K32
-      0x8C140B3A,  //  0008  GETMET	R5	R5	K58
-      0x5C1C0200,  //  0009  MOVE	R7	R1
-      0x7C140400,  //  000A  CALL	R5	2
-      0x7C080600,  //  000B  CALL	R2	3
-      0x0004030A,  //  000C  ADD	R1	R1	K10
-      0x7001FFF2,  //  000D  JMP		#0001
-      0x8808011D,  //  000E  GETMBR	R2	R0	K29
-      0x8C08052C,  //  000F  GETMET	R2	R2	K44
-      0x7C080200,  //  0010  CALL	R2	1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resume
-********************************************************************/
-be_local_closure(class_AnimationEngine_resume,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(resume),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x74060001,  //  0001  JMPT	R1	#0004
-      0x8C040117,  //  0002  GETMET	R1	R0	K23
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_sequence_manager
-********************************************************************/
-be_local_closure(class_AnimationEngine_remove_sequence_manager,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(remove_sequence_manager),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x5409FFFE,  //  0000  LDINT	R2	-1
-      0x580C0007,  //  0001  LDCONST	R3	K7
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140127,  //  0003  GETMBR	R5	R0	K39
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x88100127,  //  0007  GETMBR	R4	R0	K39
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0x5C080600,  //  000B  MOVE	R2	R3
-      0x70020001,  //  000C  JMP		#000F
-      0x000C070A,  //  000D  ADD	R3	R3	K10
-      0x7001FFF2,  //  000E  JMP		#0002
-      0x28100507,  //  000F  GE	R4	R2	K7
-      0x78120005,  //  0010  JMPF	R4	#0017
-      0x88100127,  //  0011  GETMBR	R4	R0	K39
-      0x8C10090B,  //  0012  GETMET	R4	R4	K11
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x50100200,  //  0015  LDBOOL	R4	1	0
-      0x80040800,  //  0016  RET	1	R4
-      0x50100000,  //  0017  LDBOOL	R4	0	0
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(class_AnimationEngine_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(clear),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x90020C01,  //  0002  SETMBR	R0	K6	R1
-      0x58040007,  //  0003  LDCONST	R1	K7
-      0x6008000C,  //  0004  GETGBL	R2	G12
-      0x880C0127,  //  0005  GETMBR	R3	R0	K39
-      0x7C080200,  //  0006  CALL	R2	1
-      0x14080202,  //  0007  LT	R2	R1	R2
-      0x780A0005,  //  0008  JMPF	R2	#000F
-      0x88080127,  //  0009  GETMBR	R2	R0	K39
-      0x94080401,  //  000A  GETIDX	R2	R2	R1
-      0x8C080512,  //  000B  GETMET	R2	R2	K18
-      0x7C080200,  //  000C  CALL	R2	1
-      0x0004030A,  //  000D  ADD	R1	R1	K10
-      0x7001FFF4,  //  000E  JMP		#0004
-      0x60080012,  //  000F  GETGBL	R2	G18
-      0x7C080000,  //  0010  CALL	R2	0
-      0x90024E02,  //  0011  SETMBR	R0	K39	R2
-      0x50080200,  //  0012  LDBOOL	R2	1	0
-      0x90021802,  //  0013  SETMBR	R0	K12	R2
-      0x80040000,  //  0014  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_animation
-********************************************************************/
-be_local_closure(class_AnimationEngine_remove_animation,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(remove_animation),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x5409FFFE,  //  0000  LDINT	R2	-1
-      0x580C0007,  //  0001  LDCONST	R3	K7
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140106,  //  0003  GETMBR	R5	R0	K6
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x88100106,  //  0007  GETMBR	R4	R0	K6
-      0x94100803,  //  0008  GETIDX	R4	R4	R3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0x5C080600,  //  000B  MOVE	R2	R3
-      0x70020001,  //  000C  JMP		#000F
-      0x000C070A,  //  000D  ADD	R3	R3	K10
-      0x7001FFF2,  //  000E  JMP		#0002
-      0x28100507,  //  000F  GE	R4	R2	K7
-      0x78120007,  //  0010  JMPF	R4	#0019
-      0x88100106,  //  0011  GETMBR	R4	R0	K6
-      0x8C10090B,  //  0012  GETMET	R4	R4	K11
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x50100200,  //  0015  LDBOOL	R4	1	0
-      0x90021804,  //  0016  SETMBR	R0	K12	R4
-      0x50100200,  //  0017  LDBOOL	R4	1	0
-      0x80040800,  //  0018  RET	1	R4
-      0x50100000,  //  0019  LDBOOL	R4	0	0
-      0x80040800,  //  001A  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add
-********************************************************************/
-be_local_closure(class_AnimationEngine_add,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(add),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x780A0004,  //  0005  JMPF	R2	#000B
-      0x8C08013B,  //  0006  GETMET	R2	R0	K59
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x80040400,  //  0009  RET	1	R2
-      0x70020013,  //  000A  JMP		#001F
-      0x6008000F,  //  000B  GETGBL	R2	G15
-      0x5C0C0200,  //  000C  MOVE	R3	R1
-      0xB8120000,  //  000D  GETNGBL	R4	K0
-      0x88100900,  //  000E  GETMBR	R4	R4	K0
-      0x7C080400,  //  000F  CALL	R2	2
-      0x780A0004,  //  0010  JMPF	R2	#0016
-      0x8C08013C,  //  0011  GETMET	R2	R0	K60
-      0x5C100200,  //  0012  MOVE	R4	R1
-      0x7C080400,  //  0013  CALL	R2	2
-      0x80040400,  //  0014  RET	1	R2
-      0x70020008,  //  0015  JMP		#001F
-      0xA40A7A00,  //  0016  IMPORT	R2	K61
-      0x8C0C052F,  //  0017  GETMET	R3	R2	K47
-      0x5C140200,  //  0018  MOVE	R5	R1
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0x60100018,  //  001A  GETGBL	R4	G24
-      0x5814003E,  //  001B  LDCONST	R5	K62
-      0x5C180600,  //  001C  MOVE	R6	R3
-      0x7C100400,  //  001D  CALL	R4	2
-      0xB0060A04,  //  001E  RAISE	1	K5	R4
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: push_iteration_context
-********************************************************************/
-be_local_closure(class_AnimationEngine_push_iteration_context,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(push_iteration_context),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8808011B,  //  0000  GETMBR	R2	R0	K27
-      0x8C080515,  //  0001  GETMET	R2	R2	K21
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_strip_length
-********************************************************************/
-be_local_closure(class_AnimationEngine_get_strip_length,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_AnimationEngine,     /* shared constants */
-    be_str_weak(get_strip_length),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040124,  //  0000  GETMET	R1	R0	K36
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8804011A,  //  0002  GETMBR	R1	R0	K26
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: AnimationEngine
-********************************************************************/
-be_local_class(AnimationEngine,
-    12,
-    NULL,
-    be_nested_map(47,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(remove, 1), be_const_closure(class_AnimationEngine_remove_closure) },
-        { be_const_key_weak(_update_and_render, -1), be_const_closure(class_AnimationEngine__update_and_render_closure) },
-        { be_const_key_weak(is_running, -1), be_const_var(6) },
-        { be_const_key_weak(stop, 19), be_const_closure(class_AnimationEngine_stop_closure) },
-        { be_const_key_weak(sequence_managers, 22), be_const_var(3) },
-        { be_const_key_weak(interrupt_current, 17), be_const_closure(class_AnimationEngine_interrupt_current_closure) },
-        { be_const_key_weak(time_ms, -1), be_const_var(8) },
-        { be_const_key_weak(_add_animation, -1), be_const_closure(class_AnimationEngine__add_animation_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_AnimationEngine_tostring_closure) },
-        { be_const_key_weak(frame_buffer, -1), be_const_var(4) },
-        { be_const_key_weak(push_iteration_context, -1), be_const_closure(class_AnimationEngine_push_iteration_context_closure) },
-        { be_const_key_weak(animations, -1), be_const_var(2) },
-        { be_const_key_weak(_handle_strip_length_change, -1), be_const_closure(class_AnimationEngine__handle_strip_length_change_closure) },
-        { be_const_key_weak(strip, -1), be_const_var(0) },
-        { be_const_key_weak(add, -1), be_const_closure(class_AnimationEngine_add_closure) },
-        { be_const_key_weak(temp_buffer, -1), be_const_var(5) },
-        { be_const_key_weak(cleanup, 27), be_const_closure(class_AnimationEngine_cleanup_closure) },
-        { be_const_key_weak(pop_iteration_context, -1), be_const_closure(class_AnimationEngine_pop_iteration_context_closure) },
-        { be_const_key_weak(_sort_animations, 42), be_const_closure(class_AnimationEngine__sort_animations_closure) },
-        { be_const_key_weak(_clear_strip, -1), be_const_closure(class_AnimationEngine__clear_strip_closure) },
-        { be_const_key_weak(fast_loop_closure, 35), be_const_var(9) },
-        { be_const_key_weak(init, 24), be_const_closure(class_AnimationEngine_init_closure) },
-        { be_const_key_weak(_render_animations, 44), be_const_closure(class_AnimationEngine__render_animations_closure) },
-        { be_const_key_weak(remove_sequence_manager, -1), be_const_closure(class_AnimationEngine_remove_sequence_manager_closure) },
-        { be_const_key_weak(run, -1), be_const_closure(class_AnimationEngine_run_closure) },
-        { be_const_key_weak(update_current_iteration, -1), be_const_closure(class_AnimationEngine_update_current_iteration_closure) },
-        { be_const_key_weak(get_current_iteration_number, -1), be_const_closure(class_AnimationEngine_get_current_iteration_number_closure) },
-        { be_const_key_weak(render_needed, -1), be_const_var(10) },
-        { be_const_key_weak(iteration_stack, -1), be_const_var(11) },
-        { be_const_key_weak(is_active, 30), be_const_closure(class_AnimationEngine_is_active_closure) },
-        { be_const_key_weak(_process_events, -1), be_const_closure(class_AnimationEngine__process_events_closure) },
-        { be_const_key_weak(get_strip, -1), be_const_closure(class_AnimationEngine_get_strip_closure) },
-        { be_const_key_weak(size, 9), be_const_closure(class_AnimationEngine_size_closure) },
-        { be_const_key_weak(resume_after, -1), be_const_closure(class_AnimationEngine_resume_after_closure) },
-        { be_const_key_weak(_output_to_strip, -1), be_const_closure(class_AnimationEngine__output_to_strip_closure) },
-        { be_const_key_weak(last_update, -1), be_const_var(7) },
-        { be_const_key_weak(resume, -1), be_const_closure(class_AnimationEngine_resume_closure) },
-        { be_const_key_weak(get_animations, 23), be_const_closure(class_AnimationEngine_get_animations_closure) },
-        { be_const_key_weak(clear, -1), be_const_closure(class_AnimationEngine_clear_closure) },
-        { be_const_key_weak(interrupt_animation, 20), be_const_closure(class_AnimationEngine_interrupt_animation_closure) },
-        { be_const_key_weak(width, 14), be_const_var(1) },
-        { be_const_key_weak(remove_animation, -1), be_const_closure(class_AnimationEngine_remove_animation_closure) },
-        { be_const_key_weak(interrupt_all, -1), be_const_closure(class_AnimationEngine_interrupt_all_closure) },
-        { be_const_key_weak(on_tick, 10), be_const_closure(class_AnimationEngine_on_tick_closure) },
-        { be_const_key_weak(check_strip_length, -1), be_const_closure(class_AnimationEngine_check_strip_length_closure) },
-        { be_const_key_weak(_add_sequence_manager, 2), be_const_closure(class_AnimationEngine__add_sequence_manager_closure) },
-        { be_const_key_weak(get_strip_length, -1), be_const_closure(class_AnimationEngine_get_strip_length_closure) },
-    })),
-    be_str_weak(AnimationEngine)
-);
 
 /********************************************************************
 ** Solidified function: smooth
@@ -10860,6 +7919,1185 @@ be_local_closure(smooth,   /* name */
 );
 /*******************************************************************/
 
+
+/********************************************************************
+** Solidified function: gradient_rainbow_linear
+********************************************************************/
+be_local_closure(gradient_rainbow_linear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(gradient_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(gradient_type),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(direction),
+    /* K6   */  be_nested_str_weak(movement_speed),
+    }),
+    be_str_weak(gradient_rainbow_linear),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x4C080000,  //  0004  LDNIL	R2
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x90060704,  //  0006  SETMBR	R1	K3	K4
+      0x90060B04,  //  0007  SETMBR	R1	K5	K4
+      0x540A0031,  //  0008  LDINT	R2	50
+      0x90060C02,  //  0009  SETMBR	R1	K6	R2
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear_all_event_handlers
+********************************************************************/
+be_local_closure(clear_all_event_handlers,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    0,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(event_manager),
+    /* K2   */  be_nested_str_weak(clear_all_handlers),
+    }),
+    be_str_weak(clear_all_event_handlers),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8020000,  //  0000  GETNGBL	R0	K0
+      0x88000101,  //  0001  GETMBR	R0	R0	K1
+      0x8C000102,  //  0002  GETMET	R0	R0	K2
+      0x7C000200,  //  0003  CALL	R0	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: twinkle_rainbow
+********************************************************************/
+be_local_closure(twinkle_rainbow,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(twinkle_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(density),
+    /* K4   */  be_nested_str_weak(twinkle_speed),
+    /* K5   */  be_nested_str_weak(fade_speed),
+    /* K6   */  be_nested_str_weak(min_brightness),
+    /* K7   */  be_nested_str_weak(max_brightness),
+    }),
+    be_str_weak(twinkle_rainbow),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409FFFE,  //  0004  LDINT	R2	-1
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A0077,  //  0006  LDINT	R2	120
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x540A0005,  //  0008  LDINT	R2	6
+      0x90060802,  //  0009  SETMBR	R1	K4	R2
+      0x540A00B3,  //  000A  LDINT	R2	180
+      0x90060A02,  //  000B  SETMBR	R1	K5	R2
+      0x540A001F,  //  000C  LDINT	R2	32
+      0x90060C02,  //  000D  SETMBR	R1	K6	R2
+      0x540A00FE,  //  000E  LDINT	R2	255
+      0x90060E02,  //  000F  SETMBR	R1	K7	R2
+      0x80040200,  //  0010  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_registered_events
+********************************************************************/
+be_local_closure(get_registered_events,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    0,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(event_manager),
+    /* K2   */  be_nested_str_weak(get_registered_events),
+    }),
+    be_str_weak(get_registered_events),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8020000,  //  0000  GETNGBL	R0	K0
+      0x88000101,  //  0001  GETMBR	R0	R0	K1
+      0x8C000102,  //  0002  GETMET	R0	R0	K2
+      0x7C000200,  //  0003  CALL	R0	1
+      0x80040000,  //  0004  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+extern const bclass be_class_PaletteGradientAnimation;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_PaletteGradientAnimation_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(name),
+    /* K2   */  be_nested_str_weak(palette_gradient),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020302,  //  0006  SETMBR	R0	K1	K2
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_value_buffer
+********************************************************************/
+be_local_closure(class_PaletteGradientAnimation__update_value_buffer,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shift_period),
+    /* K1   */  be_nested_str_weak(spatial_period),
+    /* K2   */  be_nested_str_weak(phase_shift),
+    /* K3   */  be_nested_str_weak(engine),
+    /* K4   */  be_nested_str_weak(get_strip_length),
+    /* K5   */  be_nested_str_weak(value_buffer),
+    /* K6   */  be_nested_str_weak(resize),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(scale_uint),
+    /* K10  */  be_const_real_hex(0x447A0000),
+    /* K11  */  be_const_int(1),
+    }),
+    be_str_weak(_update_value_buffer),
+    &be_const_str_solidified,
+    ( &(const binstruction[63]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x88140103,  //  0003  GETMBR	R5	R0	K3
+      0x8C140B04,  //  0004  GETMET	R5	R5	K4
+      0x7C140200,  //  0005  CALL	R5	1
+      0x6018000C,  //  0006  GETGBL	R6	G12
+      0x881C0105,  //  0007  GETMBR	R7	R0	K5
+      0x7C180200,  //  0008  CALL	R6	1
+      0x20180C05,  //  0009  NE	R6	R6	R5
+      0x781A0003,  //  000A  JMPF	R6	#000F
+      0x88180105,  //  000B  GETMBR	R6	R0	K5
+      0x8C180D06,  //  000C  GETMET	R6	R6	K6
+      0x5C200A00,  //  000D  MOVE	R8	R5
+      0x7C180400,  //  000E  CALL	R6	2
+      0x24180707,  //  000F  GT	R6	R3	K7
+      0x781A0001,  //  0010  JMPF	R6	#0013
+      0x5C180600,  //  0011  MOVE	R6	R3
+      0x70020000,  //  0012  JMP		#0014
+      0x5C180A00,  //  0013  MOVE	R6	R5
+      0x581C0007,  //  0014  LDCONST	R7	K7
+      0x24200507,  //  0015  GT	R8	R2	K7
+      0x7822000A,  //  0016  JMPF	R8	#0022
+      0xB8221000,  //  0017  GETNGBL	R8	K8
+      0x8C201109,  //  0018  GETMET	R8	R8	K9
+      0x10280202,  //  0019  MOD	R10	R1	R2
+      0x582C0007,  //  001A  LDCONST	R11	K7
+      0x5C300400,  //  001B  MOVE	R12	R2
+      0x58340007,  //  001C  LDCONST	R13	K7
+      0x543A03E7,  //  001D  LDINT	R14	1000
+      0x7C200C00,  //  001E  CALL	R8	6
+      0x0C20110A,  //  001F  DIV	R8	R8	K10
+      0x08241006,  //  0020  MUL	R9	R8	R6
+      0x5C1C1200,  //  0021  MOVE	R7	R9
+      0xB8221000,  //  0022  GETNGBL	R8	K8
+      0x8C201109,  //  0023  GETMET	R8	R8	K9
+      0x5C280800,  //  0024  MOVE	R10	R4
+      0x582C0007,  //  0025  LDCONST	R11	K7
+      0x54320063,  //  0026  LDINT	R12	100
+      0x58340007,  //  0027  LDCONST	R13	K7
+      0x5C380C00,  //  0028  MOVE	R14	R6
+      0x7C200C00,  //  0029  CALL	R8	6
+      0x58240007,  //  002A  LDCONST	R9	K7
+      0x14281205,  //  002B  LT	R10	R9	R5
+      0x782A0010,  //  002C  JMPF	R10	#003E
+      0x00281207,  //  002D  ADD	R10	R9	R7
+      0x00281408,  //  002E  ADD	R10	R10	R8
+      0x10281406,  //  002F  MOD	R10	R10	R6
+      0xB82E1000,  //  0030  GETNGBL	R11	K8
+      0x8C2C1709,  //  0031  GETMET	R11	R11	K9
+      0x60340009,  //  0032  GETGBL	R13	G9
+      0x5C381400,  //  0033  MOVE	R14	R10
+      0x7C340200,  //  0034  CALL	R13	1
+      0x58380007,  //  0035  LDCONST	R14	K7
+      0x043C0D0B,  //  0036  SUB	R15	R6	K11
+      0x58400007,  //  0037  LDCONST	R16	K7
+      0x544600FE,  //  0038  LDINT	R17	255
+      0x7C2C0C00,  //  0039  CALL	R11	6
+      0x88300105,  //  003A  GETMBR	R12	R0	K5
+      0x9830120B,  //  003B  SETIDX	R12	R9	R11
+      0x0024130B,  //  003C  ADD	R9	R9	K11
+      0x7001FFEC,  //  003D  JMP		#002B
+      0x80000000,  //  003E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: PaletteGradientAnimation
+********************************************************************/
+extern const bclass be_class_PalettePatternAnimation;
+be_local_class(PaletteGradientAnimation,
+    0,
+    &be_class_PalettePatternAnimation,
+    be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(spatial_period, -1), be_const_bytes_instance(0500000000) },
+        { be_const_key_weak(shift_period, 0), be_const_bytes_instance(0500000000) },
+        { be_const_key_weak(phase_shift, -1), be_const_bytes_instance(07000000640000) },
+    }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_PaletteGradientAnimation_init_closure) },
+        { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteGradientAnimation__update_value_buffer_closure) },
+    })),
+    be_str_weak(PaletteGradientAnimation)
+);
+
+/********************************************************************
+** Solidified function: twinkle_gentle
+********************************************************************/
+be_local_closure(twinkle_gentle,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(twinkle_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(density),
+    /* K4   */  be_nested_str_weak(twinkle_speed),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(fade_speed),
+    /* K7   */  be_nested_str_weak(min_brightness),
+    /* K8   */  be_nested_str_weak(max_brightness),
+    }),
+    be_str_weak(twinkle_gentle),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5409D6FF,  //  0004  LDINT	R2	-10496
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x540A003F,  //  0006  LDINT	R2	64
+      0x90060602,  //  0007  SETMBR	R1	K3	R2
+      0x90060905,  //  0008  SETMBR	R1	K4	K5
+      0x540A0077,  //  0009  LDINT	R2	120
+      0x90060C02,  //  000A  SETMBR	R1	K6	R2
+      0x540A000F,  //  000B  LDINT	R2	16
+      0x90060E02,  //  000C  SETMBR	R1	K7	R2
+      0x540A00B3,  //  000D  LDINT	R2	180
+      0x90061002,  //  000E  SETMBR	R1	K8	R2
+      0x80040200,  //  000F  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: elastic
+********************************************************************/
+be_local_closure(elastic,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(ELASTIC),
+    }),
+    be_str_weak(elastic),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+extern const bclass be_class_AnimationMath;
+// compact class 'AnimationMath' ktab size: 13, total: 31 (saved 144 bytes)
+static const bvalue be_ktab_class_AnimationMath[13] = {
+  /* K0   */  be_const_class(be_class_AnimationMath),
+  /* K1   */  be_nested_str_weak(math),
+  /* K2   */  be_nested_str_weak(int),
+  /* K3   */  be_const_int(0),
+  /* K4   */  be_const_real_hex(0x437F0000),
+  /* K5   */  be_nested_str_weak(sqrt),
+  /* K6   */  be_nested_str_weak(max),
+  /* K7   */  be_nested_str_weak(round),
+  /* K8   */  be_nested_str_weak(abs),
+  /* K9   */  be_nested_str_weak(tasmota),
+  /* K10  */  be_nested_str_weak(scale_int),
+  /* K11  */  be_nested_str_weak(sine_int),
+  /* K12  */  be_nested_str_weak(min),
+};
+
+
+extern const bclass be_class_AnimationMath;
+
+/********************************************************************
+** Solidified function: sqrt
+********************************************************************/
+be_local_closure(class_AnimationMath_sqrt,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(sqrt),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0004,  //  0002  GETGBL	R3	G4
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x1C0C0702,  //  0005  EQ	R3	R3	K2
+      0x780E000E,  //  0006  JMPF	R3	#0016
+      0x280C0103,  //  0007  GE	R3	R0	K3
+      0x780E000C,  //  0008  JMPF	R3	#0016
+      0x540E00FE,  //  0009  LDINT	R3	255
+      0x180C0003,  //  000A  LE	R3	R0	R3
+      0x780E0009,  //  000B  JMPF	R3	#0016
+      0x0C0C0104,  //  000C  DIV	R3	R0	K4
+      0x60100009,  //  000D  GETGBL	R4	G9
+      0x8C140505,  //  000E  GETMET	R5	R2	K5
+      0x5C1C0600,  //  000F  MOVE	R7	R3
+      0x7C140400,  //  0010  CALL	R5	2
+      0x541A00FE,  //  0011  LDINT	R6	255
+      0x08140A06,  //  0012  MUL	R5	R5	R6
+      0x7C100200,  //  0013  CALL	R4	1
+      0x80040800,  //  0014  RET	1	R4
+      0x70020003,  //  0015  JMP		#001A
+      0x8C0C0505,  //  0016  GETMET	R3	R2	K5
+      0x5C140000,  //  0017  MOVE	R5	R0
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x80040600,  //  0019  RET	1	R3
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: max
+********************************************************************/
+be_local_closure(class_AnimationMath_max,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    13,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(max),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0016,  //  0002  GETGBL	R3	G22
+      0x88100506,  //  0003  GETMBR	R4	R2	K6
+      0x5C140000,  //  0004  MOVE	R5	R0
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x80040600,  //  0006  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: round
+********************************************************************/
+be_local_closure(class_AnimationMath_round,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(round),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0009,  //  0002  GETGBL	R3	G9
+      0x8C100507,  //  0003  GETMET	R4	R2	K7
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x80040600,  //  0007  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: abs
+********************************************************************/
+be_local_closure(class_AnimationMath_abs,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(abs),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x8C0C0508,  //  0002  GETMET	R3	R2	K8
+      0x5C140000,  //  0003  MOVE	R5	R0
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x80040600,  //  0005  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: cos
+********************************************************************/
+be_local_closure(class_AnimationMath_cos,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(cos),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xB80A1200,  //  0001  GETNGBL	R2	K9
+      0x8C08050A,  //  0002  GETMET	R2	R2	K10
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x541A00FE,  //  0005  LDINT	R6	255
+      0x581C0003,  //  0006  LDCONST	R7	K3
+      0x54227FFE,  //  0007  LDINT	R8	32767
+      0x7C080C00,  //  0008  CALL	R2	6
+      0xB80E1200,  //  0009  GETNGBL	R3	K9
+      0x8C0C070B,  //  000A  GETMET	R3	R3	K11
+      0x54161FFF,  //  000B  LDINT	R5	8192
+      0x04140405,  //  000C  SUB	R5	R2	R5
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0xB8121200,  //  000E  GETNGBL	R4	K9
+      0x8C10090A,  //  000F  GETMET	R4	R4	K10
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x541DEFFF,  //  0011  LDINT	R7	-4096
+      0x54220FFF,  //  0012  LDINT	R8	4096
+      0x5425FF00,  //  0013  LDINT	R9	-255
+      0x542A00FE,  //  0014  LDINT	R10	255
+      0x7C100C00,  //  0015  CALL	R4	6
+      0x80040800,  //  0016  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sin
+********************************************************************/
+be_local_closure(class_AnimationMath_sin,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(sin),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xB80A1200,  //  0001  GETNGBL	R2	K9
+      0x8C08050A,  //  0002  GETMET	R2	R2	K10
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x541A00FE,  //  0005  LDINT	R6	255
+      0x581C0003,  //  0006  LDCONST	R7	K3
+      0x54227FFE,  //  0007  LDINT	R8	32767
+      0x7C080C00,  //  0008  CALL	R2	6
+      0xB80E1200,  //  0009  GETNGBL	R3	K9
+      0x8C0C070B,  //  000A  GETMET	R3	R3	K11
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0xB8121200,  //  000D  GETNGBL	R4	K9
+      0x8C10090A,  //  000E  GETMET	R4	R4	K10
+      0x5C180600,  //  000F  MOVE	R6	R3
+      0x541DEFFF,  //  0010  LDINT	R7	-4096
+      0x54220FFF,  //  0011  LDINT	R8	4096
+      0x5425FF00,  //  0012  LDINT	R9	-255
+      0x542A00FE,  //  0013  LDINT	R10	255
+      0x7C100C00,  //  0014  CALL	R4	6
+      0x80040800,  //  0015  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: scale
+********************************************************************/
+be_local_closure(class_AnimationMath_scale,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    5,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(scale),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x58140000,  //  0000  LDCONST	R5	K0
+      0xB81A1200,  //  0001  GETNGBL	R6	K9
+      0x8C180D0A,  //  0002  GETMET	R6	R6	K10
+      0x5C200000,  //  0003  MOVE	R8	R0
+      0x5C240200,  //  0004  MOVE	R9	R1
+      0x5C280400,  //  0005  MOVE	R10	R2
+      0x5C2C0600,  //  0006  MOVE	R11	R3
+      0x5C300800,  //  0007  MOVE	R12	R4
+      0x7C180C00,  //  0008  CALL	R6	6
+      0x80040C00,  //  0009  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: min
+********************************************************************/
+be_local_closure(class_AnimationMath_min,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    13,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationMath,     /* shared constants */
+    be_str_weak(min),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0016,  //  0002  GETGBL	R3	G22
+      0x8810050C,  //  0003  GETMBR	R4	R2	K12
+      0x5C140000,  //  0004  MOVE	R5	R0
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x80040600,  //  0006  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: AnimationMath
+********************************************************************/
+be_local_class(AnimationMath,
+    0,
+    NULL,
+    be_nested_map(8,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(min, -1), be_const_static_closure(class_AnimationMath_min_closure) },
+        { be_const_key_weak(max, 2), be_const_static_closure(class_AnimationMath_max_closure) },
+        { be_const_key_weak(scale, -1), be_const_static_closure(class_AnimationMath_scale_closure) },
+        { be_const_key_weak(round, 6), be_const_static_closure(class_AnimationMath_round_closure) },
+        { be_const_key_weak(cos, -1), be_const_static_closure(class_AnimationMath_cos_closure) },
+        { be_const_key_weak(sin, -1), be_const_static_closure(class_AnimationMath_sin_closure) },
+        { be_const_key_weak(abs, -1), be_const_static_closure(class_AnimationMath_abs_closure) },
+        { be_const_key_weak(sqrt, 0), be_const_static_closure(class_AnimationMath_sqrt_closure) },
+    })),
+    be_str_weak(AnimationMath)
+);
+// compact class 'CompositeColorProvider' ktab size: 14, total: 24 (saved 80 bytes)
+static const bvalue be_ktab_class_CompositeColorProvider[14] = {
+  /* K0   */  be_nested_str_weak(providers),
+  /* K1   */  be_nested_str_weak(push),
+  /* K2   */  be_const_int(0),
+  /* K3   */  be_const_int(1),
+  /* K4   */  be_nested_str_weak(get_color_for_value),
+  /* K5   */  be_nested_str_weak(_blend_colors),
+  /* K6   */  be_nested_str_weak(produce_value),
+  /* K7   */  be_nested_str_weak(CompositeColorProvider_X28providers_X3D_X25s_X2C_X20blend_mode_X3D_X25s_X29),
+  /* K8   */  be_nested_str_weak(blend_mode),
+  /* K9   */  be_const_real_hex(0x437F0000),
+  /* K10  */  be_const_int(2),
+  /* K11  */  be_nested_str_weak(tasmota),
+  /* K12  */  be_nested_str_weak(scale_uint),
+  /* K13  */  be_nested_str_weak(init),
+};
+
+
+extern const bclass be_class_CompositeColorProvider;
+
+/********************************************************************
+** Solidified function: add_provider
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_add_provider,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(add_provider),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040000,  //  0004  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color_for_value
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_get_color_for_value,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(get_color_for_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x600C000C,  //  0000  GETGBL	R3	G12
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0702,  //  0003  EQ	R3	R3	K2
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x540DFFFE,  //  0005  LDINT	R3	-1
+      0x80040600,  //  0006  RET	1	R3
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x1C0C0703,  //  000A  EQ	R3	R3	K3
+      0x780E0006,  //  000B  JMPF	R3	#0013
+      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x940C0702,  //  000D  GETIDX	R3	R3	K2
+      0x8C0C0704,  //  000E  GETMET	R3	R3	K4
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0100,  //  0013  GETMBR	R3	R0	K0
+      0x940C0702,  //  0014  GETIDX	R3	R3	K2
+      0x8C0C0704,  //  0015  GETMET	R3	R3	K4
+      0x5C140200,  //  0016  MOVE	R5	R1
+      0x5C180400,  //  0017  MOVE	R6	R2
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x58100003,  //  0019  LDCONST	R4	K3
+      0x6014000C,  //  001A  GETGBL	R5	G12
+      0x88180100,  //  001B  GETMBR	R6	R0	K0
+      0x7C140200,  //  001C  CALL	R5	1
+      0x14140805,  //  001D  LT	R5	R4	R5
+      0x7816000C,  //  001E  JMPF	R5	#002C
+      0x88140100,  //  001F  GETMBR	R5	R0	K0
+      0x94140A04,  //  0020  GETIDX	R5	R5	R4
+      0x8C140B04,  //  0021  GETMET	R5	R5	K4
+      0x5C1C0200,  //  0022  MOVE	R7	R1
+      0x5C200400,  //  0023  MOVE	R8	R2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C180105,  //  0025  GETMET	R6	R0	K5
+      0x5C200600,  //  0026  MOVE	R8	R3
+      0x5C240A00,  //  0027  MOVE	R9	R5
+      0x7C180600,  //  0028  CALL	R6	3
+      0x5C0C0C00,  //  0029  MOVE	R3	R6
+      0x00100903,  //  002A  ADD	R4	R4	K3
+      0x7001FFED,  //  002B  JMP		#001A
+      0x80040600,  //  002C  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x600C000C,  //  0000  GETGBL	R3	G12
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0702,  //  0003  EQ	R3	R3	K2
+      0x780E0001,  //  0004  JMPF	R3	#0007
+      0x540DFFFE,  //  0005  LDINT	R3	-1
+      0x80040600,  //  0006  RET	1	R3
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x1C0C0703,  //  000A  EQ	R3	R3	K3
+      0x780E0006,  //  000B  JMPF	R3	#0013
+      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x940C0702,  //  000D  GETIDX	R3	R3	K2
+      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0100,  //  0013  GETMBR	R3	R0	K0
+      0x940C0702,  //  0014  GETIDX	R3	R3	K2
+      0x8C0C0706,  //  0015  GETMET	R3	R3	K6
+      0x5C140200,  //  0016  MOVE	R5	R1
+      0x5C180400,  //  0017  MOVE	R6	R2
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x58100003,  //  0019  LDCONST	R4	K3
+      0x6014000C,  //  001A  GETGBL	R5	G12
+      0x88180100,  //  001B  GETMBR	R6	R0	K0
+      0x7C140200,  //  001C  CALL	R5	1
+      0x14140805,  //  001D  LT	R5	R4	R5
+      0x7816000C,  //  001E  JMPF	R5	#002C
+      0x88140100,  //  001F  GETMBR	R5	R0	K0
+      0x94140A04,  //  0020  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0021  GETMET	R5	R5	K6
+      0x5C1C0200,  //  0022  MOVE	R7	R1
+      0x5C200400,  //  0023  MOVE	R8	R2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C180105,  //  0025  GETMET	R6	R0	K5
+      0x5C200600,  //  0026  MOVE	R8	R3
+      0x5C240A00,  //  0027  MOVE	R9	R5
+      0x7C180600,  //  0028  CALL	R6	3
+      0x5C0C0C00,  //  0029  MOVE	R3	R6
+      0x00100903,  //  002A  ADD	R4	R4	K3
+      0x7001FFED,  //  002B  JMP		#001A
+      0x80040600,  //  002C  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_tostring,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080007,  //  0001  LDCONST	R2	K7
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x88100108,  //  0005  GETMBR	R4	R0	K8
+      0x7C040600,  //  0006  CALL	R1	3
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _blend_colors
+********************************************************************/
+be_local_closure(class_CompositeColorProvider__blend_colors,   /* name */
+  be_nested_proto(
+    23,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(_blend_colors),
+    &be_const_str_solidified,
+    ( &(const binstruction[151]) {  /* code */
+      0x880C0108,  //  0000  GETMBR	R3	R0	K8
+      0x54120017,  //  0001  LDINT	R4	24
+      0x3C100204,  //  0002  SHR	R4	R1	R4
+      0x541600FE,  //  0003  LDINT	R5	255
+      0x2C100805,  //  0004  AND	R4	R4	R5
+      0x5416000F,  //  0005  LDINT	R5	16
+      0x3C140205,  //  0006  SHR	R5	R1	R5
+      0x541A00FE,  //  0007  LDINT	R6	255
+      0x2C140A06,  //  0008  AND	R5	R5	R6
+      0x541A0007,  //  0009  LDINT	R6	8
+      0x3C180206,  //  000A  SHR	R6	R1	R6
+      0x541E00FE,  //  000B  LDINT	R7	255
+      0x2C180C07,  //  000C  AND	R6	R6	R7
+      0x541E00FE,  //  000D  LDINT	R7	255
+      0x2C1C0207,  //  000E  AND	R7	R1	R7
+      0x54220017,  //  000F  LDINT	R8	24
+      0x3C200408,  //  0010  SHR	R8	R2	R8
+      0x542600FE,  //  0011  LDINT	R9	255
+      0x2C201009,  //  0012  AND	R8	R8	R9
+      0x5426000F,  //  0013  LDINT	R9	16
+      0x3C240409,  //  0014  SHR	R9	R2	R9
+      0x542A00FE,  //  0015  LDINT	R10	255
+      0x2C24120A,  //  0016  AND	R9	R9	R10
+      0x542A0007,  //  0017  LDINT	R10	8
+      0x3C28040A,  //  0018  SHR	R10	R2	R10
+      0x542E00FE,  //  0019  LDINT	R11	255
+      0x2C28140B,  //  001A  AND	R10	R10	R11
+      0x542E00FE,  //  001B  LDINT	R11	255
+      0x2C2C040B,  //  001C  AND	R11	R2	R11
+      0x4C300000,  //  001D  LDNIL	R12
+      0x4C340000,  //  001E  LDNIL	R13
+      0x4C380000,  //  001F  LDNIL	R14
+      0x4C3C0000,  //  0020  LDNIL	R15
+      0x1C400702,  //  0021  EQ	R16	R3	K2
+      0x7842001C,  //  0022  JMPF	R16	#0040
+      0x0C401109,  //  0023  DIV	R16	R8	K9
+      0x60440009,  //  0024  GETGBL	R17	G9
+      0x044A0610,  //  0025  SUB	R18	K3	R16
+      0x08480E12,  //  0026  MUL	R18	R7	R18
+      0x084C1610,  //  0027  MUL	R19	R11	R16
+      0x00482413,  //  0028  ADD	R18	R18	R19
+      0x7C440200,  //  0029  CALL	R17	1
+      0x5C342200,  //  002A  MOVE	R13	R17
+      0x60440009,  //  002B  GETGBL	R17	G9
+      0x044A0610,  //  002C  SUB	R18	K3	R16
+      0x08480C12,  //  002D  MUL	R18	R6	R18
+      0x084C1410,  //  002E  MUL	R19	R10	R16
+      0x00482413,  //  002F  ADD	R18	R18	R19
+      0x7C440200,  //  0030  CALL	R17	1
+      0x5C382200,  //  0031  MOVE	R14	R17
+      0x60440009,  //  0032  GETGBL	R17	G9
+      0x044A0610,  //  0033  SUB	R18	K3	R16
+      0x08480A12,  //  0034  MUL	R18	R5	R18
+      0x084C1210,  //  0035  MUL	R19	R9	R16
+      0x00482413,  //  0036  ADD	R18	R18	R19
+      0x7C440200,  //  0037  CALL	R17	1
+      0x5C3C2200,  //  0038  MOVE	R15	R17
+      0x24440808,  //  0039  GT	R17	R4	R8
+      0x78460001,  //  003A  JMPF	R17	#003D
+      0x5C440800,  //  003B  MOVE	R17	R4
+      0x70020000,  //  003C  JMP		#003E
+      0x5C441000,  //  003D  MOVE	R17	R8
+      0x5C302200,  //  003E  MOVE	R12	R17
+      0x7002004C,  //  003F  JMP		#008D
+      0x1C400703,  //  0040  EQ	R16	R3	K3
+      0x78420021,  //  0041  JMPF	R16	#0064
+      0x00400E0B,  //  0042  ADD	R16	R7	R11
+      0x5C342000,  //  0043  MOVE	R13	R16
+      0x00400C0A,  //  0044  ADD	R16	R6	R10
+      0x5C382000,  //  0045  MOVE	R14	R16
+      0x00400A09,  //  0046  ADD	R16	R5	R9
+      0x5C3C2000,  //  0047  MOVE	R15	R16
+      0x24400808,  //  0048  GT	R16	R4	R8
+      0x78420001,  //  0049  JMPF	R16	#004C
+      0x5C400800,  //  004A  MOVE	R16	R4
+      0x70020000,  //  004B  JMP		#004D
+      0x5C401000,  //  004C  MOVE	R16	R8
+      0x5C302000,  //  004D  MOVE	R12	R16
+      0x544200FE,  //  004E  LDINT	R16	255
+      0x24401A10,  //  004F  GT	R16	R13	R16
+      0x78420001,  //  0050  JMPF	R16	#0053
+      0x544200FE,  //  0051  LDINT	R16	255
+      0x70020000,  //  0052  JMP		#0054
+      0x5C401A00,  //  0053  MOVE	R16	R13
+      0x5C342000,  //  0054  MOVE	R13	R16
+      0x544200FE,  //  0055  LDINT	R16	255
+      0x24401C10,  //  0056  GT	R16	R14	R16
+      0x78420001,  //  0057  JMPF	R16	#005A
+      0x544200FE,  //  0058  LDINT	R16	255
+      0x70020000,  //  0059  JMP		#005B
+      0x5C401C00,  //  005A  MOVE	R16	R14
+      0x5C382000,  //  005B  MOVE	R14	R16
+      0x544200FE,  //  005C  LDINT	R16	255
+      0x24401E10,  //  005D  GT	R16	R15	R16
+      0x78420001,  //  005E  JMPF	R16	#0061
+      0x544200FE,  //  005F  LDINT	R16	255
+      0x70020000,  //  0060  JMP		#0062
+      0x5C401E00,  //  0061  MOVE	R16	R15
+      0x5C3C2000,  //  0062  MOVE	R15	R16
+      0x70020028,  //  0063  JMP		#008D
+      0x1C40070A,  //  0064  EQ	R16	R3	K10
+      0x78420026,  //  0065  JMPF	R16	#008D
+      0xB8421600,  //  0066  GETNGBL	R16	K11
+      0x8C40210C,  //  0067  GETMET	R16	R16	K12
+      0x08480E0B,  //  0068  MUL	R18	R7	R11
+      0x584C0002,  //  0069  LDCONST	R19	K2
+      0x545200FE,  //  006A  LDINT	R20	255
+      0x545600FE,  //  006B  LDINT	R21	255
+      0x08502815,  //  006C  MUL	R20	R20	R21
+      0x58540002,  //  006D  LDCONST	R21	K2
+      0x545A00FE,  //  006E  LDINT	R22	255
+      0x7C400C00,  //  006F  CALL	R16	6
+      0x5C342000,  //  0070  MOVE	R13	R16
+      0xB8421600,  //  0071  GETNGBL	R16	K11
+      0x8C40210C,  //  0072  GETMET	R16	R16	K12
+      0x08480C0A,  //  0073  MUL	R18	R6	R10
+      0x584C0002,  //  0074  LDCONST	R19	K2
+      0x545200FE,  //  0075  LDINT	R20	255
+      0x545600FE,  //  0076  LDINT	R21	255
+      0x08502815,  //  0077  MUL	R20	R20	R21
+      0x58540002,  //  0078  LDCONST	R21	K2
+      0x545A00FE,  //  0079  LDINT	R22	255
+      0x7C400C00,  //  007A  CALL	R16	6
+      0x5C382000,  //  007B  MOVE	R14	R16
+      0xB8421600,  //  007C  GETNGBL	R16	K11
+      0x8C40210C,  //  007D  GETMET	R16	R16	K12
+      0x08480A09,  //  007E  MUL	R18	R5	R9
+      0x584C0002,  //  007F  LDCONST	R19	K2
+      0x545200FE,  //  0080  LDINT	R20	255
+      0x545600FE,  //  0081  LDINT	R21	255
+      0x08502815,  //  0082  MUL	R20	R20	R21
+      0x58540002,  //  0083  LDCONST	R21	K2
+      0x545A00FE,  //  0084  LDINT	R22	255
+      0x7C400C00,  //  0085  CALL	R16	6
+      0x5C3C2000,  //  0086  MOVE	R15	R16
+      0x24400808,  //  0087  GT	R16	R4	R8
+      0x78420001,  //  0088  JMPF	R16	#008B
+      0x5C400800,  //  0089  MOVE	R16	R4
+      0x70020000,  //  008A  JMP		#008C
+      0x5C401000,  //  008B  MOVE	R16	R8
+      0x5C302000,  //  008C  MOVE	R12	R16
+      0x54420017,  //  008D  LDINT	R16	24
+      0x38401810,  //  008E  SHL	R16	R12	R16
+      0x5446000F,  //  008F  LDINT	R17	16
+      0x38441E11,  //  0090  SHL	R17	R15	R17
+      0x30402011,  //  0091  OR	R16	R16	R17
+      0x54460007,  //  0092  LDINT	R17	8
+      0x38441C11,  //  0093  SHL	R17	R14	R17
+      0x30402011,  //  0094  OR	R16	R16	R17
+      0x3040200D,  //  0095  OR	R16	R16	R13
+      0x80042000,  //  0096  RET	1	R16
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_CompositeColorProvider_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_CompositeColorProvider,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C08050D,  //  0003  GETMET	R2	R2	K13
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x90020002,  //  0008  SETMBR	R0	K0	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: CompositeColorProvider
+********************************************************************/
+extern const bclass be_class_ColorProvider;
+be_local_class(CompositeColorProvider,
+    1,
+    &be_class_ColorProvider,
+    be_nested_map(8,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(add_provider, -1), be_const_closure(class_CompositeColorProvider_add_provider_closure) },
+        { be_const_key_weak(get_color_for_value, 7), be_const_closure(class_CompositeColorProvider_get_color_for_value_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_CompositeColorProvider_init_closure) },
+        { be_const_key_weak(PARAMS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(blend_mode, -1), be_const_bytes_instance(14000003000000010002) },
+    }))    ) } )) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_CompositeColorProvider_tostring_closure) },
+        { be_const_key_weak(providers, 4), be_const_var(0) },
+        { be_const_key_weak(_blend_colors, -1), be_const_closure(class_CompositeColorProvider__blend_colors_closure) },
+        { be_const_key_weak(produce_value, -1), be_const_closure(class_CompositeColorProvider_produce_value_closure) },
+    })),
+    be_str_weak(CompositeColorProvider)
+);
 
 /********************************************************************
 ** Solidified function: cosine_osc
@@ -11607,58 +9845,14 @@ be_local_class(WaveAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(phase, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(frequency, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(32) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(amplitude, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-65536) },
-    }))    ) } )) },
-        { be_const_key_weak(wave_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(50) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(wave_type, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(3) },
-    }))    ) } )) },
-        { be_const_key_weak(back_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
-        { be_const_key_weak(center_level, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(phase, 7), be_const_bytes_instance(07000001FF000000) },
+        { be_const_key_weak(center_level, 3), be_const_bytes_instance(07000001FF00018000) },
+        { be_const_key_weak(amplitude, -1), be_const_bytes_instance(07000001FF00018000) },
+        { be_const_key_weak(frequency, 5), be_const_bytes_instance(07000001FF000020) },
+        { be_const_key_weak(wave_speed, -1), be_const_bytes_instance(07000001FF000032) },
+        { be_const_key_weak(wave_type, -1), be_const_bytes_instance(07000000030000) },
+        { be_const_key_weak(back_color, -1), be_const_bytes_instance(0402000000FF) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(04020000FFFF) },
     }))    ) } )) },
         { be_const_key_weak(_init_wave_table, 6), be_const_closure(class_WaveAnimation__init_wave_table_closure) },
         { be_const_key_weak(_calculate_wave, -1), be_const_closure(class_WaveAnimation__calculate_wave_closure) },
@@ -11667,11 +9861,11 @@ be_local_class(WaveAnimation,
 );
 
 /********************************************************************
-** Solidified function: elastic
+** Solidified function: wave_rainbow_sine
 ********************************************************************/
-be_local_closure(elastic,   /* name */
+be_local_closure(wave_rainbow_sine,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -11679,30 +9873,60 @@ be_local_closure(elastic,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(ELASTIC),
+    /* K1   */  be_nested_str_weak(wave_animation),
+    /* K2   */  be_nested_str_weak(rich_palette),
+    /* K3   */  be_nested_str_weak(palette),
+    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
+    /* K5   */  be_nested_str_weak(cycle_period),
+    /* K6   */  be_nested_str_weak(transition_type),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(brightness),
+    /* K9   */  be_nested_str_weak(range_min),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(range_max),
+    /* K12  */  be_nested_str_weak(color),
+    /* K13  */  be_nested_str_weak(wave_type),
+    /* K14  */  be_nested_str_weak(frequency),
+    /* K15  */  be_nested_str_weak(wave_speed),
     }),
-    be_str_weak(elastic),
+    be_str_weak(wave_rainbow_sine),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
       0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0xB80E0000,  //  0008  GETNGBL	R3	K0
+      0x880C0704,  //  0009  GETMBR	R3	R3	K4
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0x540E1387,  //  000B  LDINT	R3	5000
+      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
+      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
+      0x540E00FE,  //  000E  LDINT	R3	255
+      0x900A1003,  //  000F  SETMBR	R2	K8	R3
+      0x900A130A,  //  0010  SETMBR	R2	K9	K10
+      0x540E00FE,  //  0011  LDINT	R3	255
+      0x900A1603,  //  0012  SETMBR	R2	K11	R3
+      0x90061802,  //  0013  SETMBR	R1	K12	R2
+      0x90061B0A,  //  0014  SETMBR	R1	K13	K10
+      0x540E001F,  //  0015  LDINT	R3	32
+      0x90061C03,  //  0016  SETMBR	R1	K14	R3
+      0x540E0031,  //  0017  LDINT	R3	50
+      0x90061E03,  //  0018  SETMBR	R1	K15	R3
+      0x80040200,  //  0019  RET	1	R1
     })
   )
 );
 /*******************************************************************/
 
-// compact class 'EventHandler' ktab size: 8, total: 17 (saved 72 bytes)
-static const bvalue be_ktab_class_EventHandler[8] = {
+// compact class 'EventHandler' ktab size: 7, total: 11 (saved 32 bytes)
+static const bvalue be_ktab_class_EventHandler[7] = {
   /* K0   */  be_nested_str_weak(is_active),
   /* K1   */  be_nested_str_weak(condition),
   /* K2   */  be_nested_str_weak(callback_func),
@@ -11710,11 +9934,35 @@ static const bvalue be_ktab_class_EventHandler[8] = {
   /* K4   */  be_nested_str_weak(priority),
   /* K5   */  be_const_int(0),
   /* K6   */  be_nested_str_weak(metadata),
-  /* K7   */  be_nested_str_weak(has_condition),
 };
 
 
 extern const bclass be_class_EventHandler;
+
+/********************************************************************
+** Solidified function: set_active
+********************************************************************/
+be_local_closure(class_EventHandler_set_active,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_EventHandler,     /* shared constants */
+    be_str_weak(set_active),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: execute
@@ -11758,31 +10006,6 @@ be_local_closure(class_EventHandler_execute,   /* name */
       0x80040400,  //  0016  RET	1	R2
       0x50080000,  //  0017  LDBOOL	R2	0	0
       0x80040400,  //  0018  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_active
-********************************************************************/
-be_local_closure(class_EventHandler_set_active,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(set_active),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -11834,61 +10057,22 @@ be_local_closure(class_EventHandler_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_info
-********************************************************************/
-be_local_closure(class_EventHandler_get_info,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_EventHandler,     /* shared constants */
-    be_str_weak(get_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080103,  //  0002  GETMBR	R2	R0	K3
-      0x98060602,  //  0003  SETIDX	R1	K3	R2
-      0x88080104,  //  0004  GETMBR	R2	R0	K4
-      0x98060802,  //  0005  SETIDX	R1	K4	R2
-      0x88080100,  //  0006  GETMBR	R2	R0	K0
-      0x98060002,  //  0007  SETIDX	R1	K0	R2
-      0x88080101,  //  0008  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0009  LDNIL	R3
-      0x20080403,  //  000A  NE	R2	R2	R3
-      0x98060E02,  //  000B  SETIDX	R1	K7	R2
-      0x88080106,  //  000C  GETMBR	R2	R0	K6
-      0x98060C02,  //  000D  SETIDX	R1	K6	R2
-      0x80040200,  //  000E  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: EventHandler
 ********************************************************************/
 be_local_class(EventHandler,
     6,
     NULL,
-    be_nested_map(10,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(set_active, -1), be_const_closure(class_EventHandler_set_active_closure) },
-        { be_const_key_weak(metadata, 3), be_const_var(5) },
-        { be_const_key_weak(is_active, 0), be_const_var(4) },
-        { be_const_key_weak(condition, -1), be_const_var(2) },
-        { be_const_key_weak(init, -1), be_const_closure(class_EventHandler_init_closure) },
-        { be_const_key_weak(event_name, 4), be_const_var(0) },
-        { be_const_key_weak(get_info, -1), be_const_closure(class_EventHandler_get_info_closure) },
-        { be_const_key_weak(priority, -1), be_const_var(3) },
-        { be_const_key_weak(execute, 1), be_const_closure(class_EventHandler_execute_closure) },
+        { be_const_key_weak(execute, 2), be_const_closure(class_EventHandler_execute_closure) },
         { be_const_key_weak(callback_func, -1), be_const_var(1) },
+        { be_const_key_weak(init, -1), be_const_closure(class_EventHandler_init_closure) },
+        { be_const_key_weak(event_name, -1), be_const_var(0) },
+        { be_const_key_weak(condition, -1), be_const_var(2) },
+        { be_const_key_weak(priority, 3), be_const_var(3) },
+        { be_const_key_weak(metadata, -1), be_const_var(5) },
+        { be_const_key_weak(is_active, -1), be_const_var(4) },
     })),
     be_str_weak(EventHandler)
 );
@@ -12269,41 +10453,12 @@ be_local_class(Animation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(priority, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(10) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(opacity, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(any) },
-    }))    ) } )) },
-        { be_const_key_weak(name, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_nested_str_weak(animation) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(string) },
-    }))    ) } )) },
-        { be_const_key_weak(loop, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bool(0) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
-    }))    ) } )) },
-        { be_const_key_weak(color, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(duration, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
+        { be_const_key_weak(priority, -1), be_const_bytes_instance(050000000A) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(name, -1), be_const_bytes_instance(0C0309616E696D6174696F6E01) },
+        { be_const_key_weak(loop, 0), be_const_bytes_instance(0C050003) },
+        { be_const_key_weak(opacity, 1), be_const_bytes_instance(0C01FF0004) },
+        { be_const_key_weak(duration, -1), be_const_bytes_instance(0500000000) },
     }))    ) } )) },
         { be_const_key_weak(update, -1), be_const_closure(class_Animation_update_closure) },
         { be_const_key_weak(init, 6), be_const_closure(class_Animation_init_closure) },
@@ -12573,33 +10728,11 @@ be_local_class(BeaconAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(back_color, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(slew_size, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(beacon_size, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
+        { be_const_key_weak(slew_size, 4), be_const_bytes_instance(0500000000) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(back_color, 0), be_const_bytes_instance(0402000000FF) },
+        { be_const_key_weak(beacon_size, 1), be_const_bytes_instance(0500000001) },
+        { be_const_key_weak(pos, -1), be_const_bytes_instance(040000) },
     }))    ) } )) },
         { be_const_key_weak(render, 2), be_const_closure(class_BeaconAnimation_render_closure) },
         { be_const_key_weak(tostring, -1), be_const_closure(class_BeaconAnimation_tostring_closure) },
@@ -12652,6 +10785,42 @@ be_local_closure(animation_version_string,   /* name */
       0x5C200600,  //  0015  MOVE	R8	R3
       0x7C100800,  //  0016  CALL	R4	4
       0x80040800,  //  0017  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ease_in
+********************************************************************/
+be_local_closure(ease_in,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(EASE_IN),
+    }),
+    be_str_weak(ease_in),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
+      0x80040200,  //  0007  RET	1	R1
     })
   )
 );
@@ -12887,50 +11056,1559 @@ be_local_class(PaletteMeterAnimation,
         { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(value_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
-    }))    ) } )) },
+        { be_const_key_weak(value_func, -1), be_const_bytes_instance(0C0606) },
     }))    ) } )) },
         { be_const_key_weak(init, -1), be_const_closure(class_PaletteMeterAnimation_init_closure) },
         { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteMeterAnimation__update_value_buffer_closure) },
     })),
     be_str_weak(PaletteMeterAnimation)
 );
+// compact class 'AnimationEngine' ktab size: 61, total: 164 (saved 824 bytes)
+static const bvalue be_ktab_class_AnimationEngine[61] = {
+  /* K0   */  be_nested_str_weak(animation),
+  /* K1   */  be_nested_str_weak(SequenceManager),
+  /* K2   */  be_nested_str_weak(remove_sequence_manager),
+  /* K3   */  be_nested_str_weak(remove_animation),
+  /* K4   */  be_nested_str_weak(animations),
+  /* K5   */  be_const_int(0),
+  /* K6   */  be_nested_str_weak(update),
+  /* K7   */  be_nested_str_weak(is_running),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_nested_str_weak(remove),
+  /* K10  */  be_nested_str_weak(render_needed),
+  /* K11  */  be_nested_str_weak(_clear_strip),
+  /* K12  */  be_nested_str_weak(_render_animations),
+  /* K13  */  be_nested_str_weak(fast_loop_closure),
+  /* K14  */  be_nested_str_weak(tasmota),
+  /* K15  */  be_nested_str_weak(remove_fast_loop),
+  /* K16  */  be_nested_str_weak(stop),
+  /* K17  */  be_nested_str_weak(stop_iteration),
+  /* K18  */  be_nested_str_weak(find),
+  /* K19  */  be_nested_str_weak(push),
+  /* K20  */  be_nested_str_weak(_sort_animations),
+  /* K21  */  be_nested_str_weak(start),
+  /* K22  */  be_nested_str_weak(time_ms),
+  /* K23  */  be_nested_str_weak(AnimationEngine_X28running_X3D_X25s_X29),
+  /* K24  */  be_nested_str_weak(iteration_stack),
+  /* K25  */  be_nested_str_weak(pop),
+  /* K26  */  be_nested_str_weak(strip),
+  /* K27  */  be_nested_str_weak(length),
+  /* K28  */  be_nested_str_weak(width),
+  /* K29  */  be_nested_str_weak(_handle_strip_length_change),
+  /* K30  */  be_nested_str_weak(frame_buffer),
+  /* K31  */  be_nested_str_weak(resize),
+  /* K32  */  be_nested_str_weak(temp_buffer),
+  /* K33  */  be_nested_str_weak(millis),
+  /* K34  */  be_nested_str_weak(check_strip_length),
+  /* K35  */  be_nested_str_weak(last_update),
+  /* K36  */  be_nested_str_weak(can_show),
+  /* K37  */  be_nested_str_weak(sequence_managers),
+  /* K38  */  be_nested_str_weak(_process_events),
+  /* K39  */  be_nested_str_weak(_update_and_render),
+  /* K40  */  be_nested_str_weak(clear),
+  /* K41  */  be_nested_str_weak(priority),
+  /* K42  */  be_nested_str_weak(show),
+  /* K43  */  be_nested_str_weak(value_error),
+  /* K44  */  be_nested_str_weak(strip_X20cannot_X20be_X20nil),
+  /* K45  */  be_nested_str_weak(name),
+  /* K46  */  be_nested_str_weak(render),
+  /* K47  */  be_nested_str_weak(post_render),
+  /* K48  */  be_nested_str_weak(blend_pixels),
+  /* K49  */  be_nested_str_weak(pixels),
+  /* K50  */  be_nested_str_weak(_output_to_strip),
+  /* K51  */  be_nested_str_weak(add_fast_loop),
+  /* K52  */  be_nested_str_weak(event_manager),
+  /* K53  */  be_nested_str_weak(_process_queued_events),
+  /* K54  */  be_nested_str_weak(resume),
+  /* K55  */  be_nested_str_weak(set_pixel_color),
+  /* K56  */  be_nested_str_weak(get_pixel_color),
+  /* K57  */  be_nested_str_weak(_add_sequence_manager),
+  /* K58  */  be_nested_str_weak(_add_animation),
+  /* K59  */  be_nested_str_weak(type_error),
+  /* K60  */  be_nested_str_weak(only_X20Animation_X20or_X20SequenceManager),
+};
+
+
+extern const bclass be_class_AnimationEngine;
 
 /********************************************************************
-** Solidified function: get_registered_events
+** Solidified function: remove
 ********************************************************************/
-be_local_closure(get_registered_events,   /* name */
+be_local_closure(class_AnimationEngine_remove,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    0,                          /* argc */
-    0,                          /* varg */
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(event_manager),
-    /* K2   */  be_nested_str_weak(get_registered_events),
-    }),
-    be_str_weak(get_registered_events),
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x780A0004,  //  0005  JMPF	R2	#000B
+      0x8C080102,  //  0006  GETMET	R2	R0	K2
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x80040400,  //  0009  RET	1	R2
+      0x7002000A,  //  000A  JMP		#0016
+      0x6008000F,  //  000B  GETGBL	R2	G15
+      0x5C0C0200,  //  000C  MOVE	R3	R1
+      0xB8120000,  //  000D  GETNGBL	R4	K0
+      0x88100900,  //  000E  GETMBR	R4	R4	K0
+      0x7C080400,  //  000F  CALL	R2	2
+      0x780A0004,  //  0010  JMPF	R2	#0016
+      0x8C080103,  //  0011  GETMET	R2	R0	K3
+      0x5C100200,  //  0012  MOVE	R4	R1
+      0x7C080400,  //  0013  CALL	R2	2
+      0x80040400,  //  0014  RET	1	R2
+      0x7001FFFF,  //  0015  JMP		#0016
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_animations,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040104,  //  0000  GETMBR	R1	R0	K4
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _update_and_render
+********************************************************************/
+be_local_closure(class_AnimationEngine__update_and_render,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_update_and_render),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x58080005,  //  0000  LDCONST	R2	K5
+      0x580C0005,  //  0001  LDCONST	R3	K5
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140104,  //  0003  GETMBR	R5	R0	K4
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120011,  //  0006  JMPF	R4	#0019
+      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x8C140906,  //  0009  GETMET	R5	R4	K6
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x7C140400,  //  000B  CALL	R5	2
+      0x78160004,  //  000C  JMPF	R5	#0012
+      0x88180907,  //  000D  GETMBR	R6	R4	K7
+      0x781A0002,  //  000E  JMPF	R6	#0012
+      0x00080508,  //  000F  ADD	R2	R2	K8
+      0x000C0708,  //  0010  ADD	R3	R3	K8
+      0x70020005,  //  0011  JMP		#0018
+      0x88180104,  //  0012  GETMBR	R6	R0	K4
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x5C200600,  //  0014  MOVE	R8	R3
+      0x7C180400,  //  0015  CALL	R6	2
+      0x50180200,  //  0016  LDBOOL	R6	1	0
+      0x90021406,  //  0017  SETMBR	R0	K10	R6
+      0x7001FFE8,  //  0018  JMP		#0002
+      0x1C100505,  //  0019  EQ	R4	R2	K5
+      0x78120006,  //  001A  JMPF	R4	#0022
+      0x8810010A,  //  001B  GETMBR	R4	R0	K10
+      0x78120003,  //  001C  JMPF	R4	#0021
+      0x8C10010B,  //  001D  GETMET	R4	R0	K11
+      0x7C100200,  //  001E  CALL	R4	1
+      0x50100000,  //  001F  LDBOOL	R4	0	0
+      0x90021404,  //  0020  SETMBR	R0	K10	R4
+      0x80000800,  //  0021  RET	0
+      0x8C10010C,  //  0022  GETMET	R4	R0	K12
+      0x88180104,  //  0023  GETMBR	R6	R0	K4
+      0x5C1C0200,  //  0024  MOVE	R7	R1
+      0x7C100600,  //  0025  CALL	R4	3
+      0x50100000,  //  0026  LDBOOL	R4	0	0
+      0x90021404,  //  0027  SETMBR	R0	K10	R4
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_AnimationEngine_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x78060009,  //  0001  JMPF	R1	#000C
+      0x50040000,  //  0002  LDBOOL	R1	0	0
+      0x90020E01,  //  0003  SETMBR	R0	K7	R1
+      0x8804010D,  //  0004  GETMBR	R1	R0	K13
+      0x4C080000,  //  0005  LDNIL	R2
+      0x20040202,  //  0006  NE	R1	R1	R2
+      0x78060003,  //  0007  JMPF	R1	#000C
+      0xB8061C00,  //  0008  GETNGBL	R1	K14
+      0x8C04030F,  //  0009  GETMET	R1	R1	K15
+      0x880C010D,  //  000A  GETMBR	R3	R0	K13
+      0x7C040400,  //  000B  CALL	R1	2
+      0x80040000,  //  000C  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: interrupt_current
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_current,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_current),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080104,  //  0001  GETMBR	R2	R0	K4
+      0x7C040200,  //  0002  CALL	R1	1
+      0xA8020006,  //  0003  EXBLK	0	#000B
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x7C080000,  //  0005  CALL	R2	0
+      0x880C0507,  //  0006  GETMBR	R3	R2	K7
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x8C0C0510,  //  0008  GETMET	R3	R2	K16
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7001FFF8,  //  000A  JMP		#0004
+      0x58040011,  //  000B  LDCONST	R1	K17
+      0xAC040200,  //  000C  CATCH	R1	1	0
+      0xB0080000,  //  000D  RAISE	2	R0	R0
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _add_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine__add_animation,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_add_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x88080104,  //  0000  GETMBR	R2	R0	K4
+      0x8C080512,  //  0001  GETMET	R2	R2	K18
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A000F,  //  0006  JMPF	R2	#0017
+      0x88080104,  //  0007  GETMBR	R2	R0	K4
+      0x8C080513,  //  0008  GETMET	R2	R2	K19
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x8C080114,  //  000B  GETMET	R2	R0	K20
+      0x7C080200,  //  000C  CALL	R2	1
+      0x88080107,  //  000D  GETMBR	R2	R0	K7
+      0x780A0002,  //  000E  JMPF	R2	#0012
+      0x8C080315,  //  000F  GETMET	R2	R1	K21
+      0x88100116,  //  0010  GETMBR	R4	R0	K22
+      0x7C080400,  //  0011  CALL	R2	2
+      0x50080200,  //  0012  LDBOOL	R2	1	0
+      0x90021402,  //  0013  SETMBR	R0	K10	R2
+      0x50080200,  //  0014  LDBOOL	R2	1	0
+      0x80040400,  //  0015  RET	1	R2
+      0x70020001,  //  0016  JMP		#0019
+      0x50080000,  //  0017  LDBOOL	R2	0	0
+      0x80040400,  //  0018  RET	1	R2
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_AnimationEngine_tostring,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(tostring),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0xB8020000,  //  0000  GETNGBL	R0	K0
-      0x88000101,  //  0001  GETMBR	R0	R0	K1
-      0x8C000102,  //  0002  GETMET	R0	R0	K2
-      0x7C000200,  //  0003  CALL	R0	1
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080017,  //  0001  LDCONST	R2	K23
+      0x880C0107,  //  0002  GETMBR	R3	R0	K7
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pop_iteration_context
+********************************************************************/
+be_local_closure(class_AnimationEngine_pop_iteration_context,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(pop_iteration_context),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080118,  //  0001  GETMBR	R2	R0	K24
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040305,  //  0003  GT	R1	R1	K5
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x88040118,  //  0005  GETMBR	R1	R0	K24
+      0x8C040319,  //  0006  GETMET	R1	R1	K25
+      0x7C040200,  //  0007  CALL	R1	1
+      0x80040200,  //  0008  RET	1	R1
+      0x4C040000,  //  0009  LDNIL	R1
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_strip_length
+********************************************************************/
+be_local_closure(class_AnimationEngine_check_strip_length,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(check_strip_length),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8804011A,  //  0000  GETMBR	R1	R0	K26
+      0x8C04031B,  //  0001  GETMET	R1	R1	K27
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8808011C,  //  0003  GETMBR	R2	R0	K28
+      0x20080202,  //  0004  NE	R2	R1	R2
+      0x780A0004,  //  0005  JMPF	R2	#000B
+      0x8C08011D,  //  0006  GETMET	R2	R0	K29
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x50080200,  //  0009  LDBOOL	R2	1	0
+      0x80040400,  //  000A  RET	1	R2
+      0x50080000,  //  000B  LDBOOL	R2	0	0
+      0x80040400,  //  000C  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _handle_strip_length_change
+********************************************************************/
+be_local_closure(class_AnimationEngine__handle_strip_length_change,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_handle_strip_length_change),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x18080305,  //  0000  LE	R2	R1	K5
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x90023801,  //  0003  SETMBR	R0	K28	R1
+      0x8808011E,  //  0004  GETMBR	R2	R0	K30
+      0x8C08051F,  //  0005  GETMET	R2	R2	K31
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x88080120,  //  0008  GETMBR	R2	R0	K32
+      0x8C08051F,  //  0009  GETMET	R2	R2	K31
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x50080200,  //  000C  LDBOOL	R2	1	0
+      0x90021402,  //  000D  SETMBR	R0	K10	R2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_tick
+********************************************************************/
+be_local_closure(class_AnimationEngine_on_tick,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(on_tick),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0x88080107,  //  0000  GETMBR	R2	R0	K7
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x4C080000,  //  0004  LDNIL	R2
+      0x1C080202,  //  0005  EQ	R2	R1	R2
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0xB80A1C00,  //  0007  GETNGBL	R2	K14
+      0x8C080521,  //  0008  GETMET	R2	R2	K33
+      0x7C080200,  //  0009  CALL	R2	1
+      0x5C040400,  //  000A  MOVE	R1	R2
+      0x8C080122,  //  000B  GETMET	R2	R0	K34
+      0x7C080200,  //  000C  CALL	R2	1
+      0x90022C01,  //  000D  SETMBR	R0	K22	R1
+      0x88080123,  //  000E  GETMBR	R2	R0	K35
+      0x04080202,  //  000F  SUB	R2	R1	R2
+      0x540E0004,  //  0010  LDINT	R3	5
+      0x140C0403,  //  0011  LT	R3	R2	R3
+      0x780E0001,  //  0012  JMPF	R3	#0015
+      0x500C0200,  //  0013  LDBOOL	R3	1	0
+      0x80040600,  //  0014  RET	1	R3
+      0x90024601,  //  0015  SETMBR	R0	K35	R1
+      0x880C011A,  //  0016  GETMBR	R3	R0	K26
+      0x880C0724,  //  0017  GETMBR	R3	R3	K36
+      0x4C100000,  //  0018  LDNIL	R4
+      0x200C0604,  //  0019  NE	R3	R3	R4
+      0x780E0005,  //  001A  JMPF	R3	#0021
+      0x880C011A,  //  001B  GETMBR	R3	R0	K26
+      0x8C0C0724,  //  001C  GETMET	R3	R3	K36
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0x740E0001,  //  001E  JMPT	R3	#0021
+      0x500C0200,  //  001F  LDBOOL	R3	1	0
+      0x80040600,  //  0020  RET	1	R3
+      0x580C0005,  //  0021  LDCONST	R3	K5
+      0x6010000C,  //  0022  GETGBL	R4	G12
+      0x88140125,  //  0023  GETMBR	R5	R0	K37
+      0x7C100200,  //  0024  CALL	R4	1
+      0x14100604,  //  0025  LT	R4	R3	R4
+      0x78120006,  //  0026  JMPF	R4	#002E
+      0x88100125,  //  0027  GETMBR	R4	R0	K37
+      0x94100803,  //  0028  GETIDX	R4	R4	R3
+      0x8C100906,  //  0029  GETMET	R4	R4	K6
+      0x5C180200,  //  002A  MOVE	R6	R1
+      0x7C100400,  //  002B  CALL	R4	2
+      0x000C0708,  //  002C  ADD	R3	R3	K8
+      0x7001FFF3,  //  002D  JMP		#0022
+      0x8C100126,  //  002E  GETMET	R4	R0	K38
+      0x5C180200,  //  002F  MOVE	R6	R1
+      0x7C100400,  //  0030  CALL	R4	2
+      0x8C100127,  //  0031  GETMET	R4	R0	K39
+      0x5C180200,  //  0032  MOVE	R6	R1
+      0x7C100400,  //  0033  CALL	R4	2
+      0x50100200,  //  0034  LDBOOL	R4	1	0
+      0x80040800,  //  0035  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: cleanup
+********************************************************************/
+be_local_closure(class_AnimationEngine_cleanup,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(cleanup),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x8C040110,  //  0000  GETMET	R1	R0	K16
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040128,  //  0002  GETMET	R1	R0	K40
+      0x7C040200,  //  0003  CALL	R1	1
+      0x4C040000,  //  0004  LDNIL	R1
+      0x90023C01,  //  0005  SETMBR	R0	K30	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x90024001,  //  0007  SETMBR	R0	K32	R1
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90023401,  //  0009  SETMBR	R0	K26	R1
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _sort_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine__sort_animations,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_sort_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080104,  //  0001  GETMBR	R2	R0	K4
+      0x7C040200,  //  0002  CALL	R1	1
+      0x18080308,  //  0003  LE	R2	R1	K8
+      0x780A0000,  //  0004  JMPF	R2	#0006
+      0x80000400,  //  0005  RET	0
+      0x58080008,  //  0006  LDCONST	R2	K8
+      0x140C0401,  //  0007  LT	R3	R2	R1
+      0x780E0016,  //  0008  JMPF	R3	#0020
+      0x880C0104,  //  0009  GETMBR	R3	R0	K4
+      0x940C0602,  //  000A  GETIDX	R3	R3	R2
+      0x5C100400,  //  000B  MOVE	R4	R2
+      0x24140905,  //  000C  GT	R5	R4	K5
+      0x7816000D,  //  000D  JMPF	R5	#001C
+      0x04140908,  //  000E  SUB	R5	R4	K8
+      0x88180104,  //  000F  GETMBR	R6	R0	K4
+      0x94140C05,  //  0010  GETIDX	R5	R6	R5
+      0x88140B29,  //  0011  GETMBR	R5	R5	K41
+      0x88180729,  //  0012  GETMBR	R6	R3	K41
+      0x14140A06,  //  0013  LT	R5	R5	R6
+      0x78160006,  //  0014  JMPF	R5	#001C
+      0x88140104,  //  0015  GETMBR	R5	R0	K4
+      0x04180908,  //  0016  SUB	R6	R4	K8
+      0x881C0104,  //  0017  GETMBR	R7	R0	K4
+      0x94180E06,  //  0018  GETIDX	R6	R7	R6
+      0x98140806,  //  0019  SETIDX	R5	R4	R6
+      0x04100908,  //  001A  SUB	R4	R4	K8
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x88140104,  //  001C  GETMBR	R5	R0	K4
+      0x98140803,  //  001D  SETIDX	R5	R4	R3
+      0x00080508,  //  001E  ADD	R2	R2	K8
+      0x7001FFE6,  //  001F  JMP		#0007
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: interrupt_all
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_all,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_all),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040128,  //  0000  GETMET	R1	R0	K40
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _add_sequence_manager
+********************************************************************/
+be_local_closure(class_AnimationEngine__add_sequence_manager,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_add_sequence_manager),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080125,  //  0000  GETMBR	R2	R0	K37
+      0x8C080513,  //  0001  GETMET	R2	R2	K19
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
       0x80040000,  //  0004  RET	1	R0
     })
   )
 );
 /*******************************************************************/
 
+
+/********************************************************************
+** Solidified function: _clear_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine__clear_strip,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_clear_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804011A,  //  0000  GETMBR	R1	R0	K26
+      0x8C040328,  //  0001  GETMET	R1	R1	K40
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8804011A,  //  0003  GETMBR	R1	R0	K26
+      0x8C04032A,  //  0004  GETMET	R1	R1	K42
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_AnimationEngine_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0xB006572C,  //  0003  RAISE	1	K43	K44
+      0x90023401,  //  0004  SETMBR	R0	K26	R1
+      0x8C08031B,  //  0005  GETMET	R2	R1	K27
+      0x7C080200,  //  0006  CALL	R2	1
+      0x90023802,  //  0007  SETMBR	R0	K28	R2
+      0x60080012,  //  0008  GETGBL	R2	G18
+      0x7C080000,  //  0009  CALL	R2	0
+      0x90020802,  //  000A  SETMBR	R0	K4	R2
+      0x60080012,  //  000B  GETGBL	R2	G18
+      0x7C080000,  //  000C  CALL	R2	0
+      0x90024A02,  //  000D  SETMBR	R0	K37	R2
+      0xB80A0000,  //  000E  GETNGBL	R2	K0
+      0x8C08051E,  //  000F  GETMET	R2	R2	K30
+      0x8810011C,  //  0010  GETMBR	R4	R0	K28
+      0x7C080400,  //  0011  CALL	R2	2
+      0x90023C02,  //  0012  SETMBR	R0	K30	R2
+      0xB80A0000,  //  0013  GETNGBL	R2	K0
+      0x8C08051E,  //  0014  GETMET	R2	R2	K30
+      0x8810011C,  //  0015  GETMBR	R4	R0	K28
+      0x7C080400,  //  0016  CALL	R2	2
+      0x90024002,  //  0017  SETMBR	R0	K32	R2
+      0x50080000,  //  0018  LDBOOL	R2	0	0
+      0x90020E02,  //  0019  SETMBR	R0	K7	R2
+      0x90024705,  //  001A  SETMBR	R0	K35	K5
+      0x90022D05,  //  001B  SETMBR	R0	K22	K5
+      0x4C080000,  //  001C  LDNIL	R2
+      0x90021A02,  //  001D  SETMBR	R0	K13	R2
+      0x50080000,  //  001E  LDBOOL	R2	0	0
+      0x90021402,  //  001F  SETMBR	R0	K10	R2
+      0x60080012,  //  0020  GETGBL	R2	G18
+      0x7C080000,  //  0021  CALL	R2	0
+      0x90023002,  //  0022  SETMBR	R0	K24	R2
+      0x80000000,  //  0023  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: interrupt_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine_interrupt_animation,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(interrupt_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080005,  //  0000  LDCONST	R2	K5
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100104,  //  0002  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8810072D,  //  0008  GETMBR	R4	R3	K45
+      0x4C140000,  //  0009  LDNIL	R5
+      0x20100805,  //  000A  NE	R4	R4	R5
+      0x7812000A,  //  000B  JMPF	R4	#0017
+      0x8810072D,  //  000C  GETMBR	R4	R3	K45
+      0x1C100801,  //  000D  EQ	R4	R4	R1
+      0x78120007,  //  000E  JMPF	R4	#0017
+      0x8C100710,  //  000F  GETMET	R4	R3	K16
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x88100104,  //  0012  GETMBR	R4	R0	K4
+      0x8C100909,  //  0013  GETMET	R4	R4	K9
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x80000800,  //  0016  RET	0
+      0x00080508,  //  0017  ADD	R2	R2	K8
+      0x7001FFE7,  //  0018  JMP		#0001
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _render_animations
+********************************************************************/
+be_local_closure(class_AnimationEngine__render_animations,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_render_animations),
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0x880C011E,  //  0000  GETMBR	R3	R0	K30
+      0x8C0C0728,  //  0001  GETMET	R3	R3	K40
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x580C0005,  //  0003  LDCONST	R3	K5
+      0x6010000C,  //  0004  GETGBL	R4	G12
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x14100604,  //  0007  LT	R4	R3	R4
+      0x78120015,  //  0008  JMPF	R4	#001F
+      0x94100203,  //  0009  GETIDX	R4	R1	R3
+      0x88140120,  //  000A  GETMBR	R5	R0	K32
+      0x8C140B28,  //  000B  GETMET	R5	R5	K40
+      0x7C140200,  //  000C  CALL	R5	1
+      0x8C14092E,  //  000D  GETMET	R5	R4	K46
+      0x881C0120,  //  000E  GETMBR	R7	R0	K32
+      0x5C200400,  //  000F  MOVE	R8	R2
+      0x7C140600,  //  0010  CALL	R5	3
+      0x7816000A,  //  0011  JMPF	R5	#001D
+      0x8C18092F,  //  0012  GETMET	R6	R4	K47
+      0x88200120,  //  0013  GETMBR	R8	R0	K32
+      0x5C240400,  //  0014  MOVE	R9	R2
+      0x7C180600,  //  0015  CALL	R6	3
+      0x8818011E,  //  0016  GETMBR	R6	R0	K30
+      0x8C180D30,  //  0017  GETMET	R6	R6	K48
+      0x8820011E,  //  0018  GETMBR	R8	R0	K30
+      0x88201131,  //  0019  GETMBR	R8	R8	K49
+      0x88240120,  //  001A  GETMBR	R9	R0	K32
+      0x88241331,  //  001B  GETMBR	R9	R9	K49
+      0x7C180600,  //  001C  CALL	R6	3
+      0x000C0708,  //  001D  ADD	R3	R3	K8
+      0x7001FFE4,  //  001E  JMP		#0004
+      0x8C100132,  //  001F  GETMET	R4	R0	K50
+      0x7C100200,  //  0020  CALL	R4	1
+      0x80000000,  //  0021  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: run
+********************************************************************/
+be_local_closure(class_AnimationEngine_run,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(on_tick),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(run),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x7406002B,  //  0001  JMPT	R1	#002E
+      0xB8061C00,  //  0002  GETNGBL	R1	K14
+      0x8C040321,  //  0003  GETMET	R1	R1	K33
+      0x7C040200,  //  0004  CALL	R1	1
+      0x50080200,  //  0005  LDBOOL	R2	1	0
+      0x90020E02,  //  0006  SETMBR	R0	K7	R2
+      0x540A0009,  //  0007  LDINT	R2	10
+      0x04080202,  //  0008  SUB	R2	R1	R2
+      0x90024602,  //  0009  SETMBR	R0	K35	R2
+      0x8808010D,  //  000A  GETMBR	R2	R0	K13
+      0x4C0C0000,  //  000B  LDNIL	R3
+      0x1C080403,  //  000C  EQ	R2	R2	R3
+      0x780A0001,  //  000D  JMPF	R2	#0010
+      0x84080000,  //  000E  CLOSURE	R2	P0
+      0x90021A02,  //  000F  SETMBR	R0	K13	R2
+      0x58080005,  //  0010  LDCONST	R2	K5
+      0x600C000C,  //  0011  GETGBL	R3	G12
+      0x88100104,  //  0012  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0013  CALL	R3	1
+      0x140C0403,  //  0014  LT	R3	R2	R3
+      0x780E0006,  //  0015  JMPF	R3	#001D
+      0x880C0104,  //  0016  GETMBR	R3	R0	K4
+      0x940C0602,  //  0017  GETIDX	R3	R3	R2
+      0x8C0C0715,  //  0018  GETMET	R3	R3	K21
+      0x5C140200,  //  0019  MOVE	R5	R1
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x00080508,  //  001B  ADD	R2	R2	K8
+      0x7001FFF3,  //  001C  JMP		#0011
+      0x58080005,  //  001D  LDCONST	R2	K5
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x88100125,  //  001F  GETMBR	R4	R0	K37
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x140C0403,  //  0021  LT	R3	R2	R3
+      0x780E0006,  //  0022  JMPF	R3	#002A
+      0x880C0125,  //  0023  GETMBR	R3	R0	K37
+      0x940C0602,  //  0024  GETIDX	R3	R3	R2
+      0x8C0C0715,  //  0025  GETMET	R3	R3	K21
+      0x5C140200,  //  0026  MOVE	R5	R1
+      0x7C0C0400,  //  0027  CALL	R3	2
+      0x00080508,  //  0028  ADD	R2	R2	K8
+      0x7001FFF3,  //  0029  JMP		#001E
+      0xB80E1C00,  //  002A  GETNGBL	R3	K14
+      0x8C0C0733,  //  002B  GETMET	R3	R3	K51
+      0x8814010D,  //  002C  GETMBR	R5	R0	K13
+      0x7C0C0400,  //  002D  CALL	R3	2
+      0xA0000000,  //  002E  CLOSE	R0
+      0x80040000,  //  002F  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_current_iteration
+********************************************************************/
+be_local_closure(class_AnimationEngine_update_current_iteration,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(update_current_iteration),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x6008000C,  //  0000  GETGBL	R2	G12
+      0x880C0118,  //  0001  GETMBR	R3	R0	K24
+      0x7C080200,  //  0002  CALL	R2	1
+      0x24080505,  //  0003  GT	R2	R2	K5
+      0x780A0002,  //  0004  JMPF	R2	#0008
+      0x88080118,  //  0005  GETMBR	R2	R0	K24
+      0x540DFFFE,  //  0006  LDINT	R3	-1
+      0x98080601,  //  0007  SETIDX	R2	R3	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_current_iteration_number
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_current_iteration_number,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_current_iteration_number),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080118,  //  0001  GETMBR	R2	R0	K24
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040305,  //  0003  GT	R1	R1	K5
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x88040118,  //  0005  GETMBR	R1	R0	K24
+      0x5409FFFE,  //  0006  LDINT	R2	-1
+      0x94040202,  //  0007  GETIDX	R1	R1	R2
+      0x80040200,  //  0008  RET	1	R1
+      0x4C040000,  //  0009  LDNIL	R1
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_active
+********************************************************************/
+be_local_closure(class_AnimationEngine_is_active,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(is_active),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _process_events
+********************************************************************/
+be_local_closure(class_AnimationEngine__process_events,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_process_events),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x88080534,  //  0001  GETMBR	R2	R2	K52
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0xB80A0000,  //  0005  GETNGBL	R2	K0
+      0x88080534,  //  0006  GETMBR	R2	R2	K52
+      0x8C080535,  //  0007  GETMET	R2	R2	K53
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_strip,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x8804011A,  //  0000  GETMBR	R1	R0	K26
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: size
+********************************************************************/
+be_local_closure(class_AnimationEngine_size,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(size),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x6004000C,  //  0000  GETGBL	R1	G12
+      0x88080104,  //  0001  GETMBR	R2	R0	K4
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resume_after
+********************************************************************/
+be_local_closure(class_AnimationEngine_resume_after,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(resume_after),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C080136,  //  0000  GETMET	R2	R0	K54
+      0x7C080200,  //  0001  CALL	R2	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _output_to_strip
+********************************************************************/
+be_local_closure(class_AnimationEngine__output_to_strip,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(_output_to_strip),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x58040005,  //  0000  LDCONST	R1	K5
+      0x8808011C,  //  0001  GETMBR	R2	R0	K28
+      0x14080202,  //  0002  LT	R2	R1	R2
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x8808011A,  //  0004  GETMBR	R2	R0	K26
+      0x8C080537,  //  0005  GETMET	R2	R2	K55
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x8814011E,  //  0007  GETMBR	R5	R0	K30
+      0x8C140B38,  //  0008  GETMET	R5	R5	K56
+      0x5C1C0200,  //  0009  MOVE	R7	R1
+      0x7C140400,  //  000A  CALL	R5	2
+      0x7C080600,  //  000B  CALL	R2	3
+      0x00040308,  //  000C  ADD	R1	R1	K8
+      0x7001FFF2,  //  000D  JMP		#0001
+      0x8808011A,  //  000E  GETMBR	R2	R0	K26
+      0x8C08052A,  //  000F  GETMET	R2	R2	K42
+      0x7C080200,  //  0010  CALL	R2	1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resume
+********************************************************************/
+be_local_closure(class_AnimationEngine_resume,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(resume),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040107,  //  0000  GETMBR	R1	R0	K7
+      0x74060001,  //  0001  JMPT	R1	#0004
+      0x8C040115,  //  0002  GETMET	R1	R0	K21
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_sequence_manager
+********************************************************************/
+be_local_closure(class_AnimationEngine_remove_sequence_manager,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(remove_sequence_manager),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x5409FFFE,  //  0000  LDINT	R2	-1
+      0x580C0005,  //  0001  LDCONST	R3	K5
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140125,  //  0003  GETMBR	R5	R0	K37
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x88100125,  //  0007  GETMBR	R4	R0	K37
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0708,  //  000D  ADD	R3	R3	K8
+      0x7001FFF2,  //  000E  JMP		#0002
+      0x28100505,  //  000F  GE	R4	R2	K5
+      0x78120005,  //  0010  JMPF	R4	#0017
+      0x88100125,  //  0011  GETMBR	R4	R0	K37
+      0x8C100909,  //  0012  GETMET	R4	R4	K9
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x50100200,  //  0015  LDBOOL	R4	1	0
+      0x80040800,  //  0016  RET	1	R4
+      0x50100000,  //  0017  LDBOOL	R4	0	0
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(class_AnimationEngine_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(clear),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x90020801,  //  0002  SETMBR	R0	K4	R1
+      0x58040005,  //  0003  LDCONST	R1	K5
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C0125,  //  0005  GETMBR	R3	R0	K37
+      0x7C080200,  //  0006  CALL	R2	1
+      0x14080202,  //  0007  LT	R2	R1	R2
+      0x780A0005,  //  0008  JMPF	R2	#000F
+      0x88080125,  //  0009  GETMBR	R2	R0	K37
+      0x94080401,  //  000A  GETIDX	R2	R2	R1
+      0x8C080510,  //  000B  GETMET	R2	R2	K16
+      0x7C080200,  //  000C  CALL	R2	1
+      0x00040308,  //  000D  ADD	R1	R1	K8
+      0x7001FFF4,  //  000E  JMP		#0004
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90024A02,  //  0011  SETMBR	R0	K37	R2
+      0x50080200,  //  0012  LDBOOL	R2	1	0
+      0x90021402,  //  0013  SETMBR	R0	K10	R2
+      0x80040000,  //  0014  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_animation
+********************************************************************/
+be_local_closure(class_AnimationEngine_remove_animation,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(remove_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x5409FFFE,  //  0000  LDINT	R2	-1
+      0x580C0005,  //  0001  LDCONST	R3	K5
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140104,  //  0003  GETMBR	R5	R0	K4
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x94100803,  //  0008  GETIDX	R4	R4	R3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0708,  //  000D  ADD	R3	R3	K8
+      0x7001FFF2,  //  000E  JMP		#0002
+      0x28100505,  //  000F  GE	R4	R2	K5
+      0x78120007,  //  0010  JMPF	R4	#0019
+      0x88100104,  //  0011  GETMBR	R4	R0	K4
+      0x8C100909,  //  0012  GETMET	R4	R4	K9
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x50100200,  //  0015  LDBOOL	R4	1	0
+      0x90021404,  //  0016  SETMBR	R0	K10	R4
+      0x50100200,  //  0017  LDBOOL	R4	1	0
+      0x80040800,  //  0018  RET	1	R4
+      0x50100000,  //  0019  LDBOOL	R4	0	0
+      0x80040800,  //  001A  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add
+********************************************************************/
+be_local_closure(class_AnimationEngine_add,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(add),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x780A0004,  //  0005  JMPF	R2	#000B
+      0x8C080139,  //  0006  GETMET	R2	R0	K57
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x80040400,  //  0009  RET	1	R2
+      0x7002000B,  //  000A  JMP		#0017
+      0x6008000F,  //  000B  GETGBL	R2	G15
+      0x5C0C0200,  //  000C  MOVE	R3	R1
+      0xB8120000,  //  000D  GETNGBL	R4	K0
+      0x88100900,  //  000E  GETMBR	R4	R4	K0
+      0x7C080400,  //  000F  CALL	R2	2
+      0x780A0004,  //  0010  JMPF	R2	#0016
+      0x8C08013A,  //  0011  GETMET	R2	R0	K58
+      0x5C100200,  //  0012  MOVE	R4	R1
+      0x7C080400,  //  0013  CALL	R2	2
+      0x80040400,  //  0014  RET	1	R2
+      0x70020000,  //  0015  JMP		#0017
+      0xB006773C,  //  0016  RAISE	1	K59	K60
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: push_iteration_context
+********************************************************************/
+be_local_closure(class_AnimationEngine_push_iteration_context,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(push_iteration_context),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080118,  //  0000  GETMBR	R2	R0	K24
+      0x8C080513,  //  0001  GETMET	R2	R2	K19
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_strip_length
+********************************************************************/
+be_local_closure(class_AnimationEngine_get_strip_length,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_AnimationEngine,     /* shared constants */
+    be_str_weak(get_strip_length),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040122,  //  0000  GETMET	R1	R0	K34
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8804011C,  //  0002  GETMBR	R1	R0	K28
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: AnimationEngine
+********************************************************************/
+be_local_class(AnimationEngine,
+    12,
+    NULL,
+    be_nested_map(47,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(remove, 1), be_const_closure(class_AnimationEngine_remove_closure) },
+        { be_const_key_weak(_update_and_render, -1), be_const_closure(class_AnimationEngine__update_and_render_closure) },
+        { be_const_key_weak(is_running, -1), be_const_var(6) },
+        { be_const_key_weak(stop, 19), be_const_closure(class_AnimationEngine_stop_closure) },
+        { be_const_key_weak(sequence_managers, 22), be_const_var(3) },
+        { be_const_key_weak(interrupt_current, 17), be_const_closure(class_AnimationEngine_interrupt_current_closure) },
+        { be_const_key_weak(time_ms, -1), be_const_var(8) },
+        { be_const_key_weak(_add_animation, -1), be_const_closure(class_AnimationEngine__add_animation_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_AnimationEngine_tostring_closure) },
+        { be_const_key_weak(frame_buffer, -1), be_const_var(4) },
+        { be_const_key_weak(push_iteration_context, -1), be_const_closure(class_AnimationEngine_push_iteration_context_closure) },
+        { be_const_key_weak(animations, -1), be_const_var(2) },
+        { be_const_key_weak(_handle_strip_length_change, -1), be_const_closure(class_AnimationEngine__handle_strip_length_change_closure) },
+        { be_const_key_weak(strip, -1), be_const_var(0) },
+        { be_const_key_weak(add, -1), be_const_closure(class_AnimationEngine_add_closure) },
+        { be_const_key_weak(temp_buffer, -1), be_const_var(5) },
+        { be_const_key_weak(cleanup, 27), be_const_closure(class_AnimationEngine_cleanup_closure) },
+        { be_const_key_weak(pop_iteration_context, -1), be_const_closure(class_AnimationEngine_pop_iteration_context_closure) },
+        { be_const_key_weak(_sort_animations, 42), be_const_closure(class_AnimationEngine__sort_animations_closure) },
+        { be_const_key_weak(_clear_strip, -1), be_const_closure(class_AnimationEngine__clear_strip_closure) },
+        { be_const_key_weak(fast_loop_closure, 35), be_const_var(9) },
+        { be_const_key_weak(init, 24), be_const_closure(class_AnimationEngine_init_closure) },
+        { be_const_key_weak(_render_animations, 44), be_const_closure(class_AnimationEngine__render_animations_closure) },
+        { be_const_key_weak(remove_sequence_manager, -1), be_const_closure(class_AnimationEngine_remove_sequence_manager_closure) },
+        { be_const_key_weak(run, -1), be_const_closure(class_AnimationEngine_run_closure) },
+        { be_const_key_weak(update_current_iteration, -1), be_const_closure(class_AnimationEngine_update_current_iteration_closure) },
+        { be_const_key_weak(get_current_iteration_number, -1), be_const_closure(class_AnimationEngine_get_current_iteration_number_closure) },
+        { be_const_key_weak(render_needed, -1), be_const_var(10) },
+        { be_const_key_weak(iteration_stack, -1), be_const_var(11) },
+        { be_const_key_weak(is_active, 30), be_const_closure(class_AnimationEngine_is_active_closure) },
+        { be_const_key_weak(_process_events, -1), be_const_closure(class_AnimationEngine__process_events_closure) },
+        { be_const_key_weak(get_strip, -1), be_const_closure(class_AnimationEngine_get_strip_closure) },
+        { be_const_key_weak(size, 9), be_const_closure(class_AnimationEngine_size_closure) },
+        { be_const_key_weak(resume_after, -1), be_const_closure(class_AnimationEngine_resume_after_closure) },
+        { be_const_key_weak(_output_to_strip, -1), be_const_closure(class_AnimationEngine__output_to_strip_closure) },
+        { be_const_key_weak(last_update, -1), be_const_var(7) },
+        { be_const_key_weak(resume, -1), be_const_closure(class_AnimationEngine_resume_closure) },
+        { be_const_key_weak(get_animations, 23), be_const_closure(class_AnimationEngine_get_animations_closure) },
+        { be_const_key_weak(clear, -1), be_const_closure(class_AnimationEngine_clear_closure) },
+        { be_const_key_weak(interrupt_animation, 20), be_const_closure(class_AnimationEngine_interrupt_animation_closure) },
+        { be_const_key_weak(width, 14), be_const_var(1) },
+        { be_const_key_weak(remove_animation, -1), be_const_closure(class_AnimationEngine_remove_animation_closure) },
+        { be_const_key_weak(interrupt_all, -1), be_const_closure(class_AnimationEngine_interrupt_all_closure) },
+        { be_const_key_weak(on_tick, 10), be_const_closure(class_AnimationEngine_on_tick_closure) },
+        { be_const_key_weak(check_strip_length, -1), be_const_closure(class_AnimationEngine_check_strip_length_closure) },
+        { be_const_key_weak(_add_sequence_manager, 2), be_const_closure(class_AnimationEngine__add_sequence_manager_closure) },
+        { be_const_key_weak(get_strip_length, -1), be_const_closure(class_AnimationEngine_get_strip_length_closure) },
+    })),
+    be_str_weak(AnimationEngine)
+);
 
 /********************************************************************
 ** Solidified function: ramp
@@ -13012,9 +12690,9 @@ be_local_closure(wave_custom,   /* name */
 
 
 /********************************************************************
-** Solidified function: pulsating_animation
+** Solidified function: bounce
 ********************************************************************/
-be_local_closure(pulsating_animation,   /* name */
+be_local_closure(bounce,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -13024,57 +12702,23 @@ be_local_closure(pulsating_animation,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(breathe_animation),
-    /* K2   */  be_nested_str_weak(curve_factor),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(period),
+    /* K1   */  be_nested_str_weak(oscillator_value),
+    /* K2   */  be_nested_str_weak(form),
+    /* K3   */  be_nested_str_weak(BOUNCE),
     }),
-    be_str_weak(pulsating_animation),
+    be_str_weak(bounce),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A03E7,  //  0005  LDINT	R2	1000
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x90060402,  //  0006  SETMBR	R1	K2	R2
       0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: solid
-********************************************************************/
-be_local_closure(solid,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(name),
-    /* K2   */  be_nested_str_weak(solid),
-    }),
-    be_str_weak(solid),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040300,  //  0001  GETMET	R1	R1	K0
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90060302,  //  0004  SETMBR	R1	K1	K2
-      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -13448,18 +13092,8 @@ be_local_class(PalettePatternAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(color_source, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(instance) },
-    }))    ) } )) },
-        { be_const_key_weak(pattern_func, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
-    }))    ) } )) },
+        { be_const_key_weak(color_source, 1), be_const_bytes_instance(0C0605) },
+        { be_const_key_weak(pattern_func, -1), be_const_bytes_instance(0C0606) },
     }))    ) } )) },
         { be_const_key_weak(init, 5), be_const_closure(class_PalettePatternAnimation_init_closure) },
         { be_const_key_weak(render, 0), be_const_closure(class_PalettePatternAnimation_render_closure) },
@@ -13467,6 +13101,39 @@ be_local_class(PalettePatternAnimation,
     })),
     be_str_weak(PalettePatternAnimation)
 );
+
+/********************************************************************
+** Solidified function: solid
+********************************************************************/
+be_local_closure(solid,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(name),
+    /* K2   */  be_nested_str_weak(solid),
+    }),
+    be_str_weak(solid),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040300,  //  0001  GETMET	R1	R1	K0
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060302,  //  0004  SETMBR	R1	K1	K2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
 // compact class 'StripLengthProvider' ktab size: 5, total: 7 (saved 16 bytes)
 static const bvalue be_ktab_class_StripLengthProvider[5] = {
   /* K0   */  be_nested_str_weak(engine),
@@ -13699,57 +13366,150 @@ be_local_class(PaletteWaveAnimation,
         { be_const_key_weak(PARAMS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(wave_period, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(5000) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(wave_length, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(10) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-    }))    ) } )) },
+        { be_const_key_weak(wave_period, -1), be_const_bytes_instance(050001018813) },
+        { be_const_key_weak(wave_length, -1), be_const_bytes_instance(050001000A) },
     }))    ) } )) },
         { be_const_key_weak(init, -1), be_const_closure(class_PaletteWaveAnimation_init_closure) },
         { be_const_key_weak(_update_value_buffer, -1), be_const_closure(class_PaletteWaveAnimation__update_value_buffer_closure) },
     })),
     be_str_weak(PaletteWaveAnimation)
 );
+// compact class 'ClosureValueProvider' ktab size: 7, total: 9 (saved 16 bytes)
+static const bvalue be_ktab_class_ClosureValueProvider[7] = {
+  /* K0   */  be_nested_str_weak(ClosureValueProvider_X28_X25s_X29),
+  /* K1   */  be_nested_str_weak(_closure),
+  /* K2   */  be_nested_str_weak(closure_X20set),
+  /* K3   */  be_nested_str_weak(no_X20closure),
+  /* K4   */  be_nested_str_weak(on_param_changed),
+  /* K5   */  be_nested_str_weak(closure),
+  /* K6   */  be_nested_str_weak(engine),
+};
+
+
+extern const bclass be_class_ClosureValueProvider;
 
 /********************************************************************
-** Solidified function: create_closure_value
+** Solidified function: tostring
 ********************************************************************/
-be_local_closure(create_closure_value,   /* name */
+be_local_closure(class_ClosureValueProvider_tostring,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    0,                          /* varg */
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(closure_value),
-    /* K2   */  be_nested_str_weak(closure),
-    }),
-    be_str_weak(create_closure_value),
+    &be_ktab_class_ClosureValueProvider,     /* shared constants */
+    be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100000,  //  0002  MOVE	R4	R0
-      0x7C080400,  //  0003  CALL	R2	2
-      0x900A0401,  //  0004  SETMBR	R2	K2	R1
-      0x80040400,  //  0005  RET	1	R2
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x780E0001,  //  0003  JMPF	R3	#0006
+      0x580C0002,  //  0004  LDCONST	R3	K2
+      0x70020000,  //  0005  JMP		#0007
+      0x580C0003,  //  0006  LDCONST	R3	K3
+      0x7C040400,  //  0007  CALL	R1	2
+      0x80040200,  //  0008  RET	1	R1
     })
   )
 );
 /*******************************************************************/
 
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ClosureValueProvider_on_param_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ClosureValueProvider,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x1C0C0305,  //  0007  EQ	R3	R1	K5
+      0x780E0000,  //  0008  JMPF	R3	#000A
+      0x90020202,  //  0009  SETMBR	R0	K1	R2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_ClosureValueProvider_produce_value,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ClosureValueProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x880C0101,  //  0000  GETMBR	R3	R0	K1
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C100604,  //  0002  EQ	R4	R3	R4
+      0x78120001,  //  0003  JMPF	R4	#0006
+      0x4C100000,  //  0004  LDNIL	R4
+      0x80040800,  //  0005  RET	1	R4
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x88140106,  //  0007  GETMBR	R5	R0	K6
+      0x5C180200,  //  0008  MOVE	R6	R1
+      0x5C1C0400,  //  0009  MOVE	R7	R2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x80040800,  //  000B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: ClosureValueProvider
+********************************************************************/
+extern const bclass be_class_ValueProvider;
+be_local_class(ClosureValueProvider,
+    1,
+    &be_class_ValueProvider,
+    be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(tostring, -1), be_const_closure(class_ClosureValueProvider_tostring_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(closure, -1), be_const_bytes_instance(0C0606) },
+    }))    ) } )) },
+        { be_const_key_weak(_closure, 4), be_const_var(0) },
+        { be_const_key_weak(produce_value, 1), be_const_closure(class_ClosureValueProvider_produce_value_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ClosureValueProvider_on_param_changed_closure) },
+    })),
+    be_str_weak(ClosureValueProvider)
+);
 // compact class 'CrenelPositionAnimation' ktab size: 21, total: 27 (saved 48 bytes)
 static const bvalue be_ktab_class_CrenelPositionAnimation[21] = {
   /* K0   */  be_nested_str_weak(is_running),
@@ -13942,685 +13702,50 @@ be_local_class(CrenelPositionAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(nb_pulse, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(low_size, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(3) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(pos, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(pulse_size, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(1) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(back_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-16777216) },
-    }))    ) } )) },
+        { be_const_key_weak(nb_pulse, -1), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(low_size, 4), be_const_bytes_instance(0500000003) },
+        { be_const_key_weak(pos, 1), be_const_bytes_instance(040000) },
+        { be_const_key_weak(pulse_size, -1), be_const_bytes_instance(0500000001) },
+        { be_const_key_weak(back_color, -1), be_const_bytes_instance(0402000000FF) },
     }))    ) } )) },
         { be_const_key_weak(render, 2), be_const_closure(class_CrenelPositionAnimation_render_closure) },
         { be_const_key_weak(tostring, -1), be_const_closure(class_CrenelPositionAnimation_tostring_closure) },
     })),
     be_str_weak(CrenelPositionAnimation)
 );
-// compact class 'TwinkleAnimation' ktab size: 43, total: 74 (saved 248 bytes)
-static const bvalue be_ktab_class_TwinkleAnimation[43] = {
-  /* K0   */  be_nested_str_weak(on_param_changed),
-  /* K1   */  be_nested_str_weak(twinkle_speed),
-  /* K2   */  be_const_int(1),
-  /* K3   */  be_nested_str_weak(set_param),
-  /* K4   */  be_nested_str_weak(fade_speed),
-  /* K5   */  be_nested_str_weak(density),
-  /* K6   */  be_nested_str_weak(min_brightness),
-  /* K7   */  be_nested_str_weak(max_brightness),
-  /* K8   */  be_nested_str_weak(color),
-  /* K9   */  be_nested_str_weak(engine),
-  /* K10  */  be_nested_str_weak(get_strip_length),
-  /* K11  */  be_nested_str_weak(twinkle_states),
-  /* K12  */  be_nested_str_weak(current_colors),
-  /* K13  */  be_nested_str_weak(size),
-  /* K14  */  be_nested_str_weak(_initialize_arrays),
-  /* K15  */  be_const_int(0),
-  /* K16  */  be_nested_str_weak(get),
-  /* K17  */  be_nested_str_weak(tasmota),
-  /* K18  */  be_nested_str_weak(scale_uint),
-  /* K19  */  be_nested_str_weak(set),
-  /* K20  */  be_const_int(16777215),
-  /* K21  */  be_nested_str_weak(_random_range),
-  /* K22  */  be_nested_str_weak(get_param),
-  /* K23  */  be_nested_str_weak(animation),
-  /* K24  */  be_nested_str_weak(is_value_provider),
-  /* K25  */  be_nested_str_weak(0x_X2508x),
-  /* K26  */  be_nested_str_weak(TwinkleAnimation_X28color_X3D_X25s_X2C_X20density_X3D_X25s_X2C_X20twinkle_speed_X3D_X25s_X2C_X20priority_X3D_X25s_X2C_X20running_X3D_X25s_X29),
-  /* K27  */  be_nested_str_weak(priority),
-  /* K28  */  be_nested_str_weak(is_running),
-  /* K29  */  be_nested_str_weak(init),
-  /* K30  */  be_nested_str_weak(last_update),
-  /* K31  */  be_nested_str_weak(random_seed),
-  /* K32  */  be_nested_str_weak(time_ms),
-  /* K33  */  be_nested_str_weak(_fix_time_ms),
-  /* K34  */  be_nested_str_weak(width),
-  /* K35  */  be_nested_str_weak(set_pixel_color),
-  /* K36  */  be_nested_str_weak(update),
-  /* K37  */  be_nested_str_weak(_update_twinkle_simulation),
-  /* K38  */  be_nested_str_weak(resize),
-  /* K39  */  be_nested_str_weak(clear),
-  /* K40  */  be_const_int(1103515245),
-  /* K41  */  be_const_int(2147483647),
-  /* K42  */  be_nested_str_weak(_random),
-};
-
-
-extern const bclass be_class_TwinkleAnimation;
 
 /********************************************************************
-** Solidified function: on_param_changed
+** Solidified function: create_closure_value
 ********************************************************************/
-be_local_closure(class_TwinkleAnimation_on_param_changed,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x1C0C0301,  //  0007  EQ	R3	R1	K1
-      0x780E0010,  //  0008  JMPF	R3	#001A
-      0x540E0031,  //  0009  LDINT	R3	50
-      0x280C0403,  //  000A  GE	R3	R2	R3
-      0x780E000D,  //  000B  JMPF	R3	#001A
-      0x540E03E7,  //  000C  LDINT	R3	1000
-      0x0C0C0602,  //  000D  DIV	R3	R3	R2
-      0x14100702,  //  000E  LT	R4	R3	K2
-      0x78120001,  //  000F  JMPF	R4	#0012
-      0x580C0002,  //  0010  LDCONST	R3	K2
-      0x70020003,  //  0011  JMP		#0016
-      0x54120013,  //  0012  LDINT	R4	20
-      0x24100604,  //  0013  GT	R4	R3	R4
-      0x78120000,  //  0014  JMPF	R4	#0016
-      0x540E0013,  //  0015  LDINT	R3	20
-      0x8C100103,  //  0016  GETMET	R4	R0	K3
-      0x58180001,  //  0017  LDCONST	R6	K1
-      0x5C1C0600,  //  0018  MOVE	R7	R3
-      0x7C100600,  //  0019  CALL	R4	3
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _update_twinkle_simulation
-********************************************************************/
-be_local_closure(class_TwinkleAnimation__update_twinkle_simulation,   /* name */
-  be_nested_proto(
-    20,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_update_twinkle_simulation),
-    &be_const_str_solidified,
-    ( &(const binstruction[118]) {  /* code */
-      0x88080104,  //  0000  GETMBR	R2	R0	K4
-      0x880C0105,  //  0001  GETMBR	R3	R0	K5
-      0x88100106,  //  0002  GETMBR	R4	R0	K6
-      0x88140107,  //  0003  GETMBR	R5	R0	K7
-      0x88180108,  //  0004  GETMBR	R6	R0	K8
-      0x881C0109,  //  0005  GETMBR	R7	R0	K9
-      0x8C1C0F0A,  //  0006  GETMET	R7	R7	K10
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0x6020000C,  //  0008  GETGBL	R8	G12
-      0x8824010B,  //  0009  GETMBR	R9	R0	K11
-      0x7C200200,  //  000A  CALL	R8	1
-      0x20201007,  //  000B  NE	R8	R8	R7
-      0x74220006,  //  000C  JMPT	R8	#0014
-      0x8820010C,  //  000D  GETMBR	R8	R0	K12
-      0x8C20110D,  //  000E  GETMET	R8	R8	K13
-      0x7C200200,  //  000F  CALL	R8	1
-      0x54260003,  //  0010  LDINT	R9	4
-      0x08240E09,  //  0011  MUL	R9	R7	R9
-      0x20201009,  //  0012  NE	R8	R8	R9
-      0x78220001,  //  0013  JMPF	R8	#0016
-      0x8C20010E,  //  0014  GETMET	R8	R0	K14
-      0x7C200200,  //  0015  CALL	R8	1
-      0x5820000F,  //  0016  LDCONST	R8	K15
-      0x14241007,  //  0017  LT	R9	R8	R7
-      0x7826002C,  //  0018  JMPF	R9	#0046
-      0x8824010C,  //  0019  GETMBR	R9	R0	K12
-      0x8C241310,  //  001A  GETMET	R9	R9	K16
-      0x542E0003,  //  001B  LDINT	R11	4
-      0x082C100B,  //  001C  MUL	R11	R8	R11
-      0x5431FFFB,  //  001D  LDINT	R12	-4
-      0x7C240600,  //  001E  CALL	R9	3
-      0x542A0017,  //  001F  LDINT	R10	24
-      0x3C28120A,  //  0020  SHR	R10	R9	R10
-      0x542E00FE,  //  0021  LDINT	R11	255
-      0x2C28140B,  //  0022  AND	R10	R10	R11
-      0x242C150F,  //  0023  GT	R11	R10	K15
-      0x782E001E,  //  0024  JMPF	R11	#0044
-      0xB82E2200,  //  0025  GETNGBL	R11	K17
-      0x8C2C1712,  //  0026  GETMET	R11	R11	K18
-      0x5C340400,  //  0027  MOVE	R13	R2
-      0x5838000F,  //  0028  LDCONST	R14	K15
-      0x543E00FE,  //  0029  LDINT	R15	255
-      0x58400002,  //  002A  LDCONST	R16	K2
-      0x54460013,  //  002B  LDINT	R17	20
-      0x7C2C0C00,  //  002C  CALL	R11	6
-      0x1830140B,  //  002D  LE	R12	R10	R11
-      0x78320009,  //  002E  JMPF	R12	#0039
-      0x8830010B,  //  002F  GETMBR	R12	R0	K11
-      0x9830110F,  //  0030  SETIDX	R12	R8	K15
-      0x8830010C,  //  0031  GETMBR	R12	R0	K12
-      0x8C301913,  //  0032  GETMET	R12	R12	K19
-      0x543A0003,  //  0033  LDINT	R14	4
-      0x0838100E,  //  0034  MUL	R14	R8	R14
-      0x583C000F,  //  0035  LDCONST	R15	K15
-      0x5441FFFB,  //  0036  LDINT	R16	-4
-      0x7C300800,  //  0037  CALL	R12	4
-      0x7002000A,  //  0038  JMP		#0044
-      0x0430140B,  //  0039  SUB	R12	R10	R11
-      0x2C341314,  //  003A  AND	R13	R9	K20
-      0x8838010C,  //  003B  GETMBR	R14	R0	K12
-      0x8C381D13,  //  003C  GETMET	R14	R14	K19
-      0x54420003,  //  003D  LDINT	R16	4
-      0x08401010,  //  003E  MUL	R16	R8	R16
-      0x54460017,  //  003F  LDINT	R17	24
-      0x38441811,  //  0040  SHL	R17	R12	R17
-      0x3044220D,  //  0041  OR	R17	R17	R13
-      0x5449FFFB,  //  0042  LDINT	R18	-4
-      0x7C380800,  //  0043  CALL	R14	4
-      0x00201102,  //  0044  ADD	R8	R8	K2
-      0x7001FFD0,  //  0045  JMP		#0017
-      0x5824000F,  //  0046  LDCONST	R9	K15
-      0x14281207,  //  0047  LT	R10	R9	R7
-      0x782A002B,  //  0048  JMPF	R10	#0075
-      0x8828010B,  //  0049  GETMBR	R10	R0	K11
-      0x94281409,  //  004A  GETIDX	R10	R10	R9
-      0x1C28150F,  //  004B  EQ	R10	R10	K15
-      0x782A0025,  //  004C  JMPF	R10	#0073
-      0x8C280115,  //  004D  GETMET	R10	R0	K21
-      0x543200FE,  //  004E  LDINT	R12	255
-      0x7C280400,  //  004F  CALL	R10	2
-      0x14281403,  //  0050  LT	R10	R10	R3
-      0x782A0020,  //  0051  JMPF	R10	#0073
-      0x8C280115,  //  0052  GETMET	R10	R0	K21
-      0x04300A04,  //  0053  SUB	R12	R5	R4
-      0x00301902,  //  0054  ADD	R12	R12	K2
-      0x7C280400,  //  0055  CALL	R10	2
-      0x0028080A,  //  0056  ADD	R10	R4	R10
-      0x5C2C0C00,  //  0057  MOVE	R11	R6
-      0x5432000F,  //  0058  LDINT	R12	16
-      0x3C30160C,  //  0059  SHR	R12	R11	R12
-      0x543600FE,  //  005A  LDINT	R13	255
-      0x2C30180D,  //  005B  AND	R12	R12	R13
-      0x54360007,  //  005C  LDINT	R13	8
-      0x3C34160D,  //  005D  SHR	R13	R11	R13
-      0x543A00FE,  //  005E  LDINT	R14	255
-      0x2C341A0E,  //  005F  AND	R13	R13	R14
-      0x543A00FE,  //  0060  LDINT	R14	255
-      0x2C38160E,  //  0061  AND	R14	R11	R14
-      0x883C010B,  //  0062  GETMBR	R15	R0	K11
-      0x983C1302,  //  0063  SETIDX	R15	R9	K2
-      0x883C010C,  //  0064  GETMBR	R15	R0	K12
-      0x8C3C1F13,  //  0065  GETMET	R15	R15	K19
-      0x54460003,  //  0066  LDINT	R17	4
-      0x08441211,  //  0067  MUL	R17	R9	R17
-      0x544A0017,  //  0068  LDINT	R18	24
-      0x38481412,  //  0069  SHL	R18	R10	R18
-      0x544E000F,  //  006A  LDINT	R19	16
-      0x384C1813,  //  006B  SHL	R19	R12	R19
-      0x30482413,  //  006C  OR	R18	R18	R19
-      0x544E0007,  //  006D  LDINT	R19	8
-      0x384C1A13,  //  006E  SHL	R19	R13	R19
-      0x30482413,  //  006F  OR	R18	R18	R19
-      0x3048240E,  //  0070  OR	R18	R18	R14
-      0x544DFFFB,  //  0071  LDINT	R19	-4
-      0x7C3C0800,  //  0072  CALL	R15	4
-      0x00241302,  //  0073  ADD	R9	R9	K2
-      0x7001FFD1,  //  0074  JMP		#0047
-      0x80000000,  //  0075  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_tostring,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x8C080116,  //  0001  GETMET	R2	R0	K22
-      0x58100008,  //  0002  LDCONST	R4	K8
-      0x7C080400,  //  0003  CALL	R2	2
-      0xB80E2E00,  //  0004  GETNGBL	R3	K23
-      0x8C0C0718,  //  0005  GETMET	R3	R3	K24
-      0x5C140400,  //  0006  MOVE	R5	R2
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x600C0008,  //  0009  GETGBL	R3	G8
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x5C040600,  //  000C  MOVE	R1	R3
-      0x70020004,  //  000D  JMP		#0013
-      0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100019,  //  000F  LDCONST	R4	K25
-      0x88140108,  //  0010  GETMBR	R5	R0	K8
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x5C040600,  //  0012  MOVE	R1	R3
-      0x600C0018,  //  0013  GETGBL	R3	G24
-      0x5810001A,  //  0014  LDCONST	R4	K26
-      0x5C140200,  //  0015  MOVE	R5	R1
-      0x88180105,  //  0016  GETMBR	R6	R0	K5
-      0x881C0101,  //  0017  GETMBR	R7	R0	K1
-      0x8820011B,  //  0018  GETMBR	R8	R0	K27
-      0x8824011C,  //  0019  GETMBR	R9	R0	K28
-      0x7C0C0C00,  //  001A  CALL	R3	6
-      0x80040600,  //  001B  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_init,   /* name */
+be_local_closure(create_closure_value,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
-    10,                          /* varg */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(init),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(closure_value),
+    /* K2   */  be_nested_str_weak(closure),
+    }),
+    be_str_weak(create_closure_value),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C08051D,  //  0003  GETMET	R2	R2	K29
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x90021602,  //  0008  SETMBR	R0	K11	R2
-      0x60080015,  //  0009  GETGBL	R2	G21
-      0x7C080000,  //  000A  CALL	R2	0
-      0x90021802,  //  000B  SETMBR	R0	K12	R2
-      0x90023D0F,  //  000C  SETMBR	R0	K30	K15
-      0x88080109,  //  000D  GETMBR	R2	R0	K9
-      0x88080520,  //  000E  GETMBR	R2	R2	K32
-      0x540EFFFF,  //  000F  LDINT	R3	65536
-      0x10080403,  //  0010  MOD	R2	R2	R3
-      0x90023E02,  //  0011  SETMBR	R0	K31	R2
-      0x8C08010E,  //  0012  GETMET	R2	R0	K14
-      0x7C080200,  //  0013  CALL	R2	1
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100000,  //  0002  MOVE	R4	R0
+      0x7C080400,  //  0003  CALL	R2	2
+      0x900A0401,  //  0004  SETMBR	R2	K2	R1
+      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified function: render
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_render,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(render),
-    &be_const_str_solidified,
-    ( &(const binstruction[55]) {  /* code */
-      0x880C011C,  //  0000  GETMBR	R3	R0	K28
-      0x780E0002,  //  0001  JMPF	R3	#0005
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C0C0203,  //  0003  EQ	R3	R1	R3
-      0x780E0001,  //  0004  JMPF	R3	#0007
-      0x500C0000,  //  0005  LDBOOL	R3	0	0
-      0x80040600,  //  0006  RET	1	R3
-      0x8C0C0121,  //  0007  GETMET	R3	R0	K33
-      0x5C140400,  //  0008  MOVE	R5	R2
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x5C080600,  //  000A  MOVE	R2	R3
-      0x880C0109,  //  000B  GETMBR	R3	R0	K9
-      0x8C0C070A,  //  000C  GETMET	R3	R3	K10
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x6010000C,  //  000E  GETGBL	R4	G12
-      0x8814010B,  //  000F  GETMBR	R5	R0	K11
-      0x7C100200,  //  0010  CALL	R4	1
-      0x20100803,  //  0011  NE	R4	R4	R3
-      0x74120006,  //  0012  JMPT	R4	#001A
-      0x8810010C,  //  0013  GETMBR	R4	R0	K12
-      0x8C10090D,  //  0014  GETMET	R4	R4	K13
-      0x7C100200,  //  0015  CALL	R4	1
-      0x54160003,  //  0016  LDINT	R5	4
-      0x08140605,  //  0017  MUL	R5	R3	R5
-      0x20100805,  //  0018  NE	R4	R4	R5
-      0x78120001,  //  0019  JMPF	R4	#001C
-      0x8C10010E,  //  001A  GETMET	R4	R0	K14
-      0x7C100200,  //  001B  CALL	R4	1
-      0x50100000,  //  001C  LDBOOL	R4	0	0
-      0x5814000F,  //  001D  LDCONST	R5	K15
-      0x14180A03,  //  001E  LT	R6	R5	R3
-      0x781A0015,  //  001F  JMPF	R6	#0036
-      0x88180322,  //  0020  GETMBR	R6	R1	K34
-      0x14180A06,  //  0021  LT	R6	R5	R6
-      0x781A0010,  //  0022  JMPF	R6	#0034
-      0x8818010C,  //  0023  GETMBR	R6	R0	K12
-      0x8C180D10,  //  0024  GETMET	R6	R6	K16
-      0x54220003,  //  0025  LDINT	R8	4
-      0x08200A08,  //  0026  MUL	R8	R5	R8
-      0x5425FFFB,  //  0027  LDINT	R9	-4
-      0x7C180600,  //  0028  CALL	R6	3
-      0x541E0017,  //  0029  LDINT	R7	24
-      0x3C1C0C07,  //  002A  SHR	R7	R6	R7
-      0x542200FE,  //  002B  LDINT	R8	255
-      0x2C1C0E08,  //  002C  AND	R7	R7	R8
-      0x241C0F0F,  //  002D  GT	R7	R7	K15
-      0x781E0004,  //  002E  JMPF	R7	#0034
-      0x8C1C0323,  //  002F  GETMET	R7	R1	K35
-      0x5C240A00,  //  0030  MOVE	R9	R5
-      0x5C280C00,  //  0031  MOVE	R10	R6
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x50100200,  //  0033  LDBOOL	R4	1	0
-      0x00140B02,  //  0034  ADD	R5	R5	K2
-      0x7001FFE7,  //  0035  JMP		#001E
-      0x80040800,  //  0036  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(class_TwinkleAnimation_update,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080524,  //  0003  GETMET	R2	R2	K36
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0001,  //  0006  JMPT	R2	#0009
-      0x50080000,  //  0007  LDBOOL	R2	0	0
-      0x80040400,  //  0008  RET	1	R2
-      0x8C080121,  //  0009  GETMET	R2	R0	K33
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x5C040400,  //  000C  MOVE	R1	R2
-      0x88080101,  //  000D  GETMBR	R2	R0	K1
-      0x540E03E7,  //  000E  LDINT	R3	1000
-      0x0C0C0602,  //  000F  DIV	R3	R3	R2
-      0x8810011E,  //  0010  GETMBR	R4	R0	K30
-      0x04100204,  //  0011  SUB	R4	R1	R4
-      0x28100803,  //  0012  GE	R4	R4	R3
-      0x78120003,  //  0013  JMPF	R4	#0018
-      0x90023C01,  //  0014  SETMBR	R0	K30	R1
-      0x8C100125,  //  0015  GETMET	R4	R0	K37
-      0x5C180200,  //  0016  MOVE	R6	R1
-      0x7C100400,  //  0017  CALL	R4	2
-      0x50100200,  //  0018  LDBOOL	R4	1	0
-      0x80040800,  //  0019  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _initialize_arrays
-********************************************************************/
-be_local_closure(class_TwinkleAnimation__initialize_arrays,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_initialize_arrays),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x88040109,  //  0000  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0001  GETMET	R1	R1	K10
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8808010B,  //  0003  GETMBR	R2	R0	K11
-      0x8C080526,  //  0004  GETMET	R2	R2	K38
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x8808010C,  //  0007  GETMBR	R2	R0	K12
-      0x8C080527,  //  0008  GETMET	R2	R2	K39
-      0x7C080200,  //  0009  CALL	R2	1
-      0x8808010C,  //  000A  GETMBR	R2	R0	K12
-      0x8C080526,  //  000B  GETMET	R2	R2	K38
-      0x54120003,  //  000C  LDINT	R4	4
-      0x08100204,  //  000D  MUL	R4	R1	R4
-      0x7C080400,  //  000E  CALL	R2	2
-      0x5808000F,  //  000F  LDCONST	R2	K15
-      0x140C0401,  //  0010  LT	R3	R2	R1
-      0x780E000A,  //  0011  JMPF	R3	#001D
-      0x880C010B,  //  0012  GETMBR	R3	R0	K11
-      0x980C050F,  //  0013  SETIDX	R3	R2	K15
-      0x880C010C,  //  0014  GETMBR	R3	R0	K12
-      0x8C0C0713,  //  0015  GETMET	R3	R3	K19
-      0x54160003,  //  0016  LDINT	R5	4
-      0x08140405,  //  0017  MUL	R5	R2	R5
-      0x5818000F,  //  0018  LDCONST	R6	K15
-      0x541DFFFB,  //  0019  LDINT	R7	-4
-      0x7C0C0800,  //  001A  CALL	R3	4
-      0x00080502,  //  001B  ADD	R2	R2	K2
-      0x7001FFF2,  //  001C  JMP		#0010
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _random
-********************************************************************/
-be_local_closure(class_TwinkleAnimation__random,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_random),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8804011F,  //  0000  GETMBR	R1	R0	K31
-      0x08040328,  //  0001  MUL	R1	R1	K40
-      0x540A3038,  //  0002  LDINT	R2	12345
-      0x00040202,  //  0003  ADD	R1	R1	R2
-      0x2C040329,  //  0004  AND	R1	R1	K41
-      0x90023E01,  //  0005  SETMBR	R0	K31	R1
-      0x8804011F,  //  0006  GETMBR	R1	R0	K31
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _random_range
-********************************************************************/
-be_local_closure(class_TwinkleAnimation__random_range,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_TwinkleAnimation,     /* shared constants */
-    be_str_weak(_random_range),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x1808030F,  //  0000  LE	R2	R1	K15
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80061E00,  //  0002  RET	1	K15
-      0x8C08012A,  //  0003  GETMET	R2	R0	K42
-      0x7C080200,  //  0004  CALL	R2	1
-      0x10080401,  //  0005  MOD	R2	R2	R1
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: TwinkleAnimation
-********************************************************************/
-extern const bclass be_class_Animation;
-be_local_class(TwinkleAnimation,
-    4,
-    &be_class_Animation,
-    be_nested_map(14,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_random_range, -1), be_const_closure(class_TwinkleAnimation__random_range_closure) },
-        { be_const_key_weak(twinkle_states, -1), be_const_var(0) },
-        { be_const_key_weak(init, -1), be_const_closure(class_TwinkleAnimation_init_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_TwinkleAnimation_tostring_closure) },
-        { be_const_key_weak(random_seed, -1), be_const_var(3) },
-        { be_const_key_weak(PARAMS, 6), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(6,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fade_speed, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(180) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(twinkle_speed, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(6) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(5000) },
-    }))    ) } )) },
-        { be_const_key_weak(density, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(max_brightness, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(min_brightness, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(32) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(_random, 9), be_const_closure(class_TwinkleAnimation__random_closure) },
-        { be_const_key_weak(last_update, -1), be_const_var(2) },
-        { be_const_key_weak(update, -1), be_const_closure(class_TwinkleAnimation_update_closure) },
-        { be_const_key_weak(_initialize_arrays, 10), be_const_closure(class_TwinkleAnimation__initialize_arrays_closure) },
-        { be_const_key_weak(render, 2), be_const_closure(class_TwinkleAnimation_render_closure) },
-        { be_const_key_weak(current_colors, -1), be_const_var(1) },
-        { be_const_key_weak(_update_twinkle_simulation, 1), be_const_closure(class_TwinkleAnimation__update_twinkle_simulation_closure) },
-        { be_const_key_weak(on_param_changed, 0), be_const_closure(class_TwinkleAnimation_on_param_changed_closure) },
-    })),
-    be_str_weak(TwinkleAnimation)
-);
 
 /********************************************************************
 ** Solidified function: animation_init
@@ -14702,178 +13827,74 @@ be_local_closure(animation_init,   /* name */
 );
 /*******************************************************************/
 
-// compact class 'ParameterizedObject' ktab size: 49, total: 99 (saved 400 bytes)
-static const bvalue be_ktab_class_ParameterizedObject[49] = {
-  /* K0   */  be_nested_str_weak(introspect),
+extern const bclass be_class_ParameterizedObject;
+// compact class 'ParameterizedObject' ktab size: 54, total: 113 (saved 472 bytes)
+static const bvalue be_ktab_class_ParameterizedObject[54] = {
+  /* K0   */  be_nested_str_weak(values),
   /* K1   */  be_nested_str_weak(contains),
-  /* K2   */  be_nested_str_weak(PARAMS),
-  /* K3   */  be_nested_str_weak(keys),
-  /* K4   */  be_nested_str_weak(values),
-  /* K5   */  be_nested_str_weak(default),
-  /* K6   */  be_nested_str_weak(stop_iteration),
-  /* K7   */  be_nested_str_weak(_get_param_def),
-  /* K8   */  be_nested_str_weak(engine),
-  /* K9   */  be_nested_str_weak(time_ms),
-  /* K10  */  be_nested_str_weak(value_error),
-  /* K11  */  be_nested_str_weak(engine_X2Etime_ms_X20should_X20not_X20be_X20_X27nil_X27),
-  /* K12  */  be_nested_str_weak(start_time),
-  /* K13  */  be_nested_str_weak(is_running),
-  /* K14  */  be_nested_str_weak(toptr),
-  /* K15  */  be_nested_str_weak(animation),
-  /* K16  */  be_nested_str_weak(is_value_provider),
-  /* K17  */  be_nested_str_weak(_validate_param),
-  /* K18  */  be_nested_str_weak(on_param_changed),
-  /* K19  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20is_X20not_X20defined_X20for_X20class_X20_X27_X25s_X27),
-  /* K20  */  be_nested_str_weak(nillable),
-  /* K21  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20does_X20not_X20accept_X20nil_X20values),
-  /* K22  */  be_nested_str_weak(int),
-  /* K23  */  be_nested_str_weak(type),
-  /* K24  */  be_nested_str_weak(any),
-  /* K25  */  be_nested_str_weak(real),
-  /* K26  */  be_nested_str_weak(math),
-  /* K27  */  be_nested_str_weak(round),
-  /* K28  */  be_nested_str_weak(bytes),
-  /* K29  */  be_nested_str_weak(instance),
-  /* K30  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20expects_X20type_X20_X27_X25s_X27_X20but_X20got_X20_X27_X25s_X27_X20_X28value_X3A_X20_X25s_X29),
-  /* K31  */  be_nested_str_weak(min),
-  /* K32  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20value_X20_X25s_X20is_X20below_X20minimum_X20_X25s),
-  /* K33  */  be_nested_str_weak(max),
-  /* K34  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20value_X20_X25s_X20is_X20above_X20maximum_X20_X25s),
-  /* K35  */  be_nested_str_weak(enum),
-  /* K36  */  be_nested_str_weak(size),
-  /* K37  */  be_const_int(0),
-  /* K38  */  be_const_int(1),
-  /* K39  */  be_nested_str_weak(Parameter_X20_X27_X25s_X27_X20value_X20_X25s_X20is_X20not_X20in_X20allowed_X20values_X20_X25s),
-  /* K40  */  be_nested_str_weak(_has_param),
-  /* K41  */  be_nested_str_weak(_set_parameter_value),
-  /* K42  */  be_nested_str_weak(_X27_X25s_X27_X20object_X20has_X20no_X20attribute_X20_X27_X25s_X27),
-  /* K43  */  be_nested_str_weak(attribute_error),
-  /* K44  */  be_nested_str_weak(_resolve_parameter_value),
-  /* K45  */  be_nested_str_weak(ParameterizedObject_X20requires_X20an_X20engine_X20parameter),
-  /* K46  */  be_nested_str_weak(_init_parameter_values),
-  /* K47  */  be_nested_str_weak(produce_value),
-  /* K48  */  be_nested_str_weak(start),
+  /* K2   */  be_nested_str_weak(_has_param),
+  /* K3   */  be_nested_str_weak(_resolve_parameter_value),
+  /* K4   */  be_nested_str_weak(engine),
+  /* K5   */  be_nested_str_weak(time_ms),
+  /* K6   */  be_nested_str_weak(_X27_X25s_X27_X20object_X20has_X20no_X20attribute_X20_X27_X25s_X27),
+  /* K7   */  be_nested_str_weak(attribute_error),
+  /* K8   */  be_nested_str_weak(introspect),
+  /* K9   */  be_nested_str_weak(toptr),
+  /* K10  */  be_nested_str_weak(_set_parameter_value),
+  /* K11  */  be_nested_str_weak(value_error),
+  /* K12  */  be_nested_str_weak(PARAMS),
+  /* K13  */  be_nested_str_weak(keys),
+  /* K14  */  be_nested_str_weak(constraint_mask),
+  /* K15  */  be_nested_str_weak(default),
+  /* K16  */  be_nested_str_weak(constraint_find),
+  /* K17  */  be_nested_str_weak(stop_iteration),
+  /* K18  */  be_nested_str_weak(start_time),
+  /* K19  */  be_nested_str_weak(animation),
+  /* K20  */  be_nested_str_weak(is_value_provider),
+  /* K21  */  be_nested_str_weak(produce_value),
+  /* K22  */  be_nested_str_weak(_get_param_def),
+  /* K23  */  be_nested_str_weak(nillable),
+  /* K24  */  be_nested_str_weak(_X27_X25s_X27_X20does_X20not_X20accept_X20nil_X20values),
+  /* K25  */  be_nested_str_weak(type),
+  /* K26  */  be_nested_str_weak(int),
+  /* K27  */  be_nested_str_weak(any),
+  /* K28  */  be_nested_str_weak(real),
+  /* K29  */  be_nested_str_weak(math),
+  /* K30  */  be_nested_str_weak(round),
+  /* K31  */  be_nested_str_weak(bytes),
+  /* K32  */  be_nested_str_weak(instance),
+  /* K33  */  be_nested_str_weak(_X27_X25s_X27_X20expects_X20type_X20_X27_X25s_X27_X20but_X20got_X20_X27_X25s_X27_X20_X28value_X3A_X20_X25s_X29),
+  /* K34  */  be_nested_str_weak(min),
+  /* K35  */  be_nested_str_weak(_X27_X25s_X27_X20value_X20_X25s_X20is_X20below_X20minimum_X20_X25s),
+  /* K36  */  be_nested_str_weak(max),
+  /* K37  */  be_nested_str_weak(_X27_X25s_X27_X20value_X20_X25s_X20is_X20above_X20maximum_X20_X25s),
+  /* K38  */  be_nested_str_weak(enum),
+  /* K39  */  be_const_int(0),
+  /* K40  */  be_const_int(1),
+  /* K41  */  be_nested_str_weak(_X27_X25s_X27_X20value_X20_X25s_X20is_X20not_X20in_X20allowed_X20values_X20_X25s),
+  /* K42  */  be_nested_str_weak(_validate_param),
+  /* K43  */  be_nested_str_weak(on_param_changed),
+  /* K44  */  be_const_class(be_class_ParameterizedObject),
+  /* K45  */  be_nested_str_weak(_MASK),
+  /* K46  */  be_nested_str_weak(find),
+  /* K47  */  be_const_int(2),
+  /* K48  */  be_nested_str_weak(_TYPES),
+  /* K49  */  be_nested_str_weak(push),
+  /* K50  */  be_nested_str_weak(is_running),
+  /* K51  */  be_nested_str_weak(start),
+  /* K52  */  be_nested_str_weak(missing_X20engine_X20parameter),
+  /* K53  */  be_nested_str_weak(_init_parameter_values),
 };
 
 
 extern const bclass be_class_ParameterizedObject;
 
 /********************************************************************
-** Solidified function: _init_parameter_values
+** Solidified function: member
 ********************************************************************/
-be_local_closure(class_ParameterizedObject__init_parameter_values,   /* name */
+be_local_closure(class_ParameterizedObject_member,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_init_parameter_values),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x60080006,  //  0001  GETGBL	R2	G6
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x200C0403,  //  0005  NE	R3	R2	R3
-      0x780E0022,  //  0006  JMPF	R3	#002A
-      0x8C0C0301,  //  0007  GETMET	R3	R1	K1
-      0x5C140400,  //  0008  MOVE	R5	R2
-      0x58180002,  //  0009  LDCONST	R6	K2
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x780E0018,  //  000B  JMPF	R3	#0025
-      0x880C0502,  //  000C  GETMBR	R3	R2	K2
-      0x60100010,  //  000D  GETGBL	R4	G16
-      0x8C140703,  //  000E  GETMET	R5	R3	K3
-      0x7C140200,  //  000F  CALL	R5	1
-      0x7C100200,  //  0010  CALL	R4	1
-      0xA802000F,  //  0011  EXBLK	0	#0022
-      0x5C140800,  //  0012  MOVE	R5	R4
-      0x7C140000,  //  0013  CALL	R5	0
-      0x88180104,  //  0014  GETMBR	R6	R0	K4
-      0x8C180D01,  //  0015  GETMET	R6	R6	K1
-      0x5C200A00,  //  0016  MOVE	R8	R5
-      0x7C180400,  //  0017  CALL	R6	2
-      0x741A0007,  //  0018  JMPT	R6	#0021
-      0x94180605,  //  0019  GETIDX	R6	R3	R5
-      0x8C1C0D01,  //  001A  GETMET	R7	R6	K1
-      0x58240005,  //  001B  LDCONST	R9	K5
-      0x7C1C0400,  //  001C  CALL	R7	2
-      0x781E0002,  //  001D  JMPF	R7	#0021
-      0x881C0104,  //  001E  GETMBR	R7	R0	K4
-      0x94200D05,  //  001F  GETIDX	R8	R6	K5
-      0x981C0A08,  //  0020  SETIDX	R7	R5	R8
-      0x7001FFEF,  //  0021  JMP		#0012
-      0x58100006,  //  0022  LDCONST	R4	K6
-      0xAC100200,  //  0023  CATCH	R4	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x600C0003,  //  0025  GETGBL	R3	G3
-      0x5C100400,  //  0026  MOVE	R4	R2
-      0x7C0C0200,  //  0027  CALL	R3	1
-      0x5C080600,  //  0028  MOVE	R2	R3
-      0x7001FFD9,  //  0029  JMP		#0004
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_param
-********************************************************************/
-be_local_closure(class_ParameterizedObject_get_param,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(get_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x880C0104,  //  0000  GETMBR	R3	R0	K4
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0002,  //  0004  JMPF	R3	#0008
-      0x880C0104,  //  0005  GETMBR	R3	R0	K4
-      0x940C0601,  //  0006  GETIDX	R3	R3	R1
-      0x80040600,  //  0007  RET	1	R3
-      0x8C0C0107,  //  0008  GETMET	R3	R0	K7
-      0x5C140200,  //  0009  MOVE	R5	R1
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x78120005,  //  000D  JMPF	R4	#0014
-      0x8C100701,  //  000E  GETMET	R4	R3	K1
-      0x58180005,  //  000F  LDCONST	R6	K5
-      0x7C100400,  //  0010  CALL	R4	2
-      0x78120001,  //  0011  JMPF	R4	#0014
-      0x94100705,  //  0012  GETIDX	R4	R3	K5
-      0x80040800,  //  0013  RET	1	R4
-      0x80040400,  //  0014  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_ParameterizedObject_start,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -14882,76 +13903,33 @@ be_local_closure(class_ParameterizedObject_start,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(start),
+    be_str_weak(member),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x88080108,  //  0003  GETMBR	R2	R0	K8
-      0x88040509,  //  0004  GETMBR	R1	R2	K9
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C080202,  //  0006  EQ	R2	R1	R2
-      0x780A0000,  //  0007  JMPF	R2	#0009
-      0xB006150B,  //  0008  RAISE	1	K10	K11
-      0x8808010C,  //  0009  GETMBR	R2	R0	K12
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x20080403,  //  000B  NE	R2	R2	R3
-      0x780A0000,  //  000C  JMPF	R2	#000E
-      0x90021801,  //  000D  SETMBR	R0	K12	R1
-      0x88080104,  //  000E  GETMBR	R2	R0	K4
-      0x500C0200,  //  000F  LDBOOL	R3	1	0
-      0x980A1A03,  //  0010  SETIDX	R2	K13	R3
-      0x80040000,  //  0011  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _has_param
-********************************************************************/
-be_local_closure(class_ParameterizedObject__has_param,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_has_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0006,  //  0001  GETGBL	R3	G6
-      0x5C100000,  //  0002  MOVE	R4	R0
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x78120010,  //  0006  JMPF	R4	#0018
-      0x8C100501,  //  0007  GETMET	R4	R2	K1
-      0x5C180600,  //  0008  MOVE	R6	R3
-      0x581C0002,  //  0009  LDCONST	R7	K2
-      0x7C100600,  //  000A  CALL	R4	3
-      0x78120006,  //  000B  JMPF	R4	#0013
-      0x88100702,  //  000C  GETMBR	R4	R3	K2
-      0x8C140901,  //  000D  GETMET	R5	R4	K1
-      0x5C1C0200,  //  000E  MOVE	R7	R1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x78160001,  //  0010  JMPF	R5	#0013
-      0x50140200,  //  0011  LDBOOL	R5	1	0
-      0x80040A00,  //  0012  RET	1	R5
-      0x60100003,  //  0013  GETGBL	R4	G3
-      0x5C140600,  //  0014  MOVE	R5	R3
-      0x7C100200,  //  0015  CALL	R4	1
-      0x5C0C0800,  //  0016  MOVE	R3	R4
-      0x7001FFEB,  //  0017  JMP		#0004
-      0x50100000,  //  0018  LDBOOL	R4	0	0
-      0x80040800,  //  0019  RET	1	R4
+    ( &(const binstruction[24]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x740A0003,  //  0004  JMPT	R2	#0009
+      0x8C080102,  //  0005  GETMET	R2	R0	K2
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x780A0005,  //  0008  JMPF	R2	#000F
+      0x8C080103,  //  0009  GETMET	R2	R0	K3
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x88140104,  //  000B  GETMBR	R5	R0	K4
+      0x88140B05,  //  000C  GETMBR	R5	R5	K5
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80040400,  //  000E  RET	1	R2
+      0x60080018,  //  000F  GETGBL	R2	G24
+      0x580C0006,  //  0010  LDCONST	R3	K6
+      0x60100005,  //  0011  GETGBL	R4	G5
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x7C100200,  //  0013  CALL	R4	1
+      0x5C140200,  //  0014  MOVE	R5	R1
+      0x7C080600,  //  0015  CALL	R2	3
+      0xB0060E02,  //  0016  RAISE	1	K7	R2
+      0x80000000,  //  0017  RET	0
     })
   )
 );
@@ -14975,308 +13953,15 @@ be_local_closure(class_ParameterizedObject__X3D_X3D,   /* name */
     be_str_weak(_X3D_X3D),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C050E,  //  0001  GETMET	R3	R2	K14
+      0xA40A1000,  //  0000  IMPORT	R2	K8
+      0x8C0C0509,  //  0001  GETMET	R3	R2	K9
       0x5C140000,  //  0002  MOVE	R5	R0
       0x7C0C0400,  //  0003  CALL	R3	2
-      0x8C10050E,  //  0004  GETMET	R4	R2	K14
+      0x8C100509,  //  0004  GETMET	R4	R2	K9
       0x5C180200,  //  0005  MOVE	R6	R1
       0x7C100400,  //  0006  CALL	R4	2
       0x1C0C0604,  //  0007  EQ	R3	R3	R4
       0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_param_metadata
-********************************************************************/
-be_local_closure(class_ParameterizedObject_get_param_metadata,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(get_param_metadata),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080107,  //  0000  GETMET	R2	R0	K7
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80040400,  //  0003  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _set_parameter_value
-********************************************************************/
-be_local_closure(class_ParameterizedObject__set_parameter_value,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_set_parameter_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB80E1E00,  //  0000  GETNGBL	R3	K15
-      0x8C0C0710,  //  0001  GETMET	R3	R3	K16
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x740E0004,  //  0004  JMPT	R3	#000A
-      0x8C0C0111,  //  0005  GETMET	R3	R0	K17
-      0x5C140200,  //  0006  MOVE	R5	R1
-      0x5C180400,  //  0007  MOVE	R6	R2
-      0x7C0C0600,  //  0008  CALL	R3	3
-      0x5C080600,  //  0009  MOVE	R2	R3
-      0x880C0104,  //  000A  GETMBR	R3	R0	K4
-      0x980C0202,  //  000B  SETIDX	R3	R1	R2
-      0x8C0C0112,  //  000C  GETMET	R3	R0	K18
-      0x5C140200,  //  000D  MOVE	R5	R1
-      0x5C180400,  //  000E  MOVE	R6	R2
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _validate_param
-********************************************************************/
-be_local_closure(class_ParameterizedObject__validate_param,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_validate_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[162]) {  /* code */
-      0x8C0C0107,  //  0000  GETMET	R3	R0	K7
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100604,  //  0004  EQ	R4	R3	R4
-      0x78120007,  //  0005  JMPF	R4	#000E
-      0x60100018,  //  0006  GETGBL	R4	G24
-      0x58140013,  //  0007  LDCONST	R5	K19
-      0x5C180200,  //  0008  MOVE	R6	R1
-      0x601C0005,  //  0009  GETGBL	R7	G5
-      0x5C200000,  //  000A  MOVE	R8	R0
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x7C100600,  //  000C  CALL	R4	3
-      0xB0061404,  //  000D  RAISE	1	K10	R4
-      0xB8121E00,  //  000E  GETNGBL	R4	K15
-      0x8C100910,  //  000F  GETMET	R4	R4	K16
-      0x5C180400,  //  0010  MOVE	R6	R2
-      0x7C100400,  //  0011  CALL	R4	2
-      0x78120000,  //  0012  JMPF	R4	#0014
-      0x80040400,  //  0013  RET	1	R2
-      0x4C100000,  //  0014  LDNIL	R4
-      0x1C100404,  //  0015  EQ	R4	R2	R4
-      0x78120012,  //  0016  JMPF	R4	#002A
-      0x8C100701,  //  0017  GETMET	R4	R3	K1
-      0x58180014,  //  0018  LDCONST	R6	K20
-      0x7C100400,  //  0019  CALL	R4	2
-      0x78120004,  //  001A  JMPF	R4	#0020
-      0x94100714,  //  001B  GETIDX	R4	R3	K20
-      0x50140200,  //  001C  LDBOOL	R5	1	0
-      0x1C100805,  //  001D  EQ	R4	R4	R5
-      0x78120000,  //  001E  JMPF	R4	#0020
-      0x80040400,  //  001F  RET	1	R2
-      0x8C100701,  //  0020  GETMET	R4	R3	K1
-      0x58180005,  //  0021  LDCONST	R6	K5
-      0x7C100400,  //  0022  CALL	R4	2
-      0x78120000,  //  0023  JMPF	R4	#0025
-      0x80040400,  //  0024  RET	1	R2
-      0x60100018,  //  0025  GETGBL	R4	G24
-      0x58140015,  //  0026  LDCONST	R5	K21
-      0x5C180200,  //  0027  MOVE	R6	R1
-      0x7C100400,  //  0028  CALL	R4	2
-      0xB0061404,  //  0029  RAISE	1	K10	R4
-      0x58100016,  //  002A  LDCONST	R4	K22
-      0x8C140701,  //  002B  GETMET	R5	R3	K1
-      0x581C0017,  //  002C  LDCONST	R7	K23
-      0x7C140400,  //  002D  CALL	R5	2
-      0x78160000,  //  002E  JMPF	R5	#0030
-      0x94100717,  //  002F  GETIDX	R4	R3	K23
-      0x60140004,  //  0030  GETGBL	R5	G4
-      0x5C180400,  //  0031  MOVE	R6	R2
-      0x7C140200,  //  0032  CALL	R5	1
-      0x20180918,  //  0033  NE	R6	R4	K24
-      0x781A0031,  //  0034  JMPF	R6	#0067
-      0x1C180916,  //  0035  EQ	R6	R4	K22
-      0x781A000A,  //  0036  JMPF	R6	#0042
-      0x1C180B19,  //  0037  EQ	R6	R5	K25
-      0x781A0008,  //  0038  JMPF	R6	#0042
-      0xA41A3400,  //  0039  IMPORT	R6	K26
-      0x601C0009,  //  003A  GETGBL	R7	G9
-      0x8C200D1B,  //  003B  GETMET	R8	R6	K27
-      0x5C280400,  //  003C  MOVE	R10	R2
-      0x7C200400,  //  003D  CALL	R8	2
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x5C080E00,  //  003F  MOVE	R2	R7
-      0x58140016,  //  0040  LDCONST	R5	K22
-      0x70020024,  //  0041  JMP		#0067
-      0x1C18091C,  //  0042  EQ	R6	R4	K28
-      0x781A0018,  //  0043  JMPF	R6	#005D
-      0x1C180B1D,  //  0044  EQ	R6	R5	K29
-      0x781A0006,  //  0045  JMPF	R6	#004D
-      0x6018000F,  //  0046  GETGBL	R6	G15
-      0x5C1C0400,  //  0047  MOVE	R7	R2
-      0x60200015,  //  0048  GETGBL	R8	G21
-      0x7C180400,  //  0049  CALL	R6	2
-      0x781A0001,  //  004A  JMPF	R6	#004D
-      0x5814001C,  //  004B  LDCONST	R5	K28
-      0x7002000E,  //  004C  JMP		#005C
-      0x20180B1D,  //  004D  NE	R6	R5	K29
-      0x741A0004,  //  004E  JMPT	R6	#0054
-      0x6018000F,  //  004F  GETGBL	R6	G15
-      0x5C1C0400,  //  0050  MOVE	R7	R2
-      0x60200015,  //  0051  GETGBL	R8	G21
-      0x7C180400,  //  0052  CALL	R6	2
-      0x741A0007,  //  0053  JMPT	R6	#005C
-      0x60180018,  //  0054  GETGBL	R6	G24
-      0x581C001E,  //  0055  LDCONST	R7	K30
-      0x5C200200,  //  0056  MOVE	R8	R1
-      0x5C240800,  //  0057  MOVE	R9	R4
-      0x5C280A00,  //  0058  MOVE	R10	R5
-      0x5C2C0400,  //  0059  MOVE	R11	R2
-      0x7C180A00,  //  005A  CALL	R6	5
-      0xB0061406,  //  005B  RAISE	1	K10	R6
-      0x70020009,  //  005C  JMP		#0067
-      0x20180805,  //  005D  NE	R6	R4	R5
-      0x781A0007,  //  005E  JMPF	R6	#0067
-      0x60180018,  //  005F  GETGBL	R6	G24
-      0x581C001E,  //  0060  LDCONST	R7	K30
-      0x5C200200,  //  0061  MOVE	R8	R1
-      0x5C240800,  //  0062  MOVE	R9	R4
-      0x5C280A00,  //  0063  MOVE	R10	R5
-      0x5C2C0400,  //  0064  MOVE	R11	R2
-      0x7C180A00,  //  0065  CALL	R6	5
-      0xB0061406,  //  0066  RAISE	1	K10	R6
-      0x1C180B16,  //  0067  EQ	R6	R5	K22
-      0x781A001B,  //  0068  JMPF	R6	#0085
-      0x8C180701,  //  0069  GETMET	R6	R3	K1
-      0x5820001F,  //  006A  LDCONST	R8	K31
-      0x7C180400,  //  006B  CALL	R6	2
-      0x781A0009,  //  006C  JMPF	R6	#0077
-      0x9418071F,  //  006D  GETIDX	R6	R3	K31
-      0x14180406,  //  006E  LT	R6	R2	R6
-      0x781A0006,  //  006F  JMPF	R6	#0077
-      0x60180018,  //  0070  GETGBL	R6	G24
-      0x581C0020,  //  0071  LDCONST	R7	K32
-      0x5C200200,  //  0072  MOVE	R8	R1
-      0x5C240400,  //  0073  MOVE	R9	R2
-      0x9428071F,  //  0074  GETIDX	R10	R3	K31
-      0x7C180800,  //  0075  CALL	R6	4
-      0xB0061406,  //  0076  RAISE	1	K10	R6
-      0x8C180701,  //  0077  GETMET	R6	R3	K1
-      0x58200021,  //  0078  LDCONST	R8	K33
-      0x7C180400,  //  0079  CALL	R6	2
-      0x781A0009,  //  007A  JMPF	R6	#0085
-      0x94180721,  //  007B  GETIDX	R6	R3	K33
-      0x24180406,  //  007C  GT	R6	R2	R6
-      0x781A0006,  //  007D  JMPF	R6	#0085
-      0x60180018,  //  007E  GETGBL	R6	G24
-      0x581C0022,  //  007F  LDCONST	R7	K34
-      0x5C200200,  //  0080  MOVE	R8	R1
-      0x5C240400,  //  0081  MOVE	R9	R2
-      0x94280721,  //  0082  GETIDX	R10	R3	K33
-      0x7C180800,  //  0083  CALL	R6	4
-      0xB0061406,  //  0084  RAISE	1	K10	R6
-      0x8C180701,  //  0085  GETMET	R6	R3	K1
-      0x58200023,  //  0086  LDCONST	R8	K35
-      0x7C180400,  //  0087  CALL	R6	2
-      0x781A0017,  //  0088  JMPF	R6	#00A1
-      0x50180000,  //  0089  LDBOOL	R6	0	0
-      0xA41E0000,  //  008A  IMPORT	R7	K0
-      0x94200723,  //  008B  GETIDX	R8	R3	K35
-      0x8C241124,  //  008C  GETMET	R9	R8	K36
-      0x7C240200,  //  008D  CALL	R9	1
-      0x58280025,  //  008E  LDCONST	R10	K37
-      0x142C1409,  //  008F  LT	R11	R10	R9
-      0x782E0006,  //  0090  JMPF	R11	#0098
-      0x942C100A,  //  0091  GETIDX	R11	R8	R10
-      0x1C30040B,  //  0092  EQ	R12	R2	R11
-      0x78320001,  //  0093  JMPF	R12	#0096
-      0x50180200,  //  0094  LDBOOL	R6	1	0
-      0x70020001,  //  0095  JMP		#0098
-      0x00281526,  //  0096  ADD	R10	R10	K38
-      0x7001FFF6,  //  0097  JMP		#008F
-      0x5C2C0C00,  //  0098  MOVE	R11	R6
-      0x742E0006,  //  0099  JMPT	R11	#00A1
-      0x602C0018,  //  009A  GETGBL	R11	G24
-      0x58300027,  //  009B  LDCONST	R12	K39
-      0x5C340200,  //  009C  MOVE	R13	R1
-      0x5C380400,  //  009D  MOVE	R14	R2
-      0x5C3C1000,  //  009E  MOVE	R15	R8
-      0x7C2C0800,  //  009F  CALL	R11	4
-      0xB006140B,  //  00A0  RAISE	1	K10	R11
-      0x80040400,  //  00A1  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: setmember
-********************************************************************/
-be_local_closure(class_ParameterizedObject_setmember,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(setmember),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8C0C0128,  //  0000  GETMET	R3	R0	K40
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x780E0004,  //  0003  JMPF	R3	#0009
-      0x8C0C0129,  //  0004  GETMET	R3	R0	K41
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x70020007,  //  0008  JMP		#0011
-      0x600C0018,  //  0009  GETGBL	R3	G24
-      0x5810002A,  //  000A  LDCONST	R4	K42
-      0x60140005,  //  000B  GETGBL	R5	G5
-      0x5C180000,  //  000C  MOVE	R6	R0
-      0x7C140200,  //  000D  CALL	R5	1
-      0x5C180200,  //  000E  MOVE	R6	R1
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB0065603,  //  0010  RAISE	1	K43	R3
-      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -15300,7 +13985,7 @@ be_local_closure(class_ParameterizedObject_get_param_value,   /* name */
     be_str_weak(get_param_value),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x8C0C012C,  //  0000  GETMET	R3	R0	K44
+      0x8C0C0103,  //  0000  GETMET	R3	R0	K3
       0x5C140200,  //  0001  MOVE	R5	R1
       0x5C180400,  //  0002  MOVE	R6	R2
       0x7C0C0600,  //  0003  CALL	R3	3
@@ -15312,88 +13997,11 @@ be_local_closure(class_ParameterizedObject_get_param_value,   /* name */
 
 
 /********************************************************************
-** Solidified function: _fix_time_ms
+** Solidified function: set_param
 ********************************************************************/
-be_local_closure(class_ParameterizedObject__fix_time_ms,   /* name */
+be_local_closure(class_ParameterizedObject_set_param,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_fix_time_ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x88080108,  //  0003  GETMBR	R2	R0	K8
-      0x88040509,  //  0004  GETMBR	R1	R2	K9
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C080202,  //  0006  EQ	R2	R1	R2
-      0x780A0000,  //  0007  JMPF	R2	#0009
-      0xB006150B,  //  0008  RAISE	1	K10	K11
-      0x8808010C,  //  0009  GETMBR	R2	R0	K12
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x1C080403,  //  000B  EQ	R2	R2	R3
-      0x780A0000,  //  000C  JMPF	R2	#000E
-      0x90021801,  //  000D  SETMBR	R0	K12	R1
-      0x80040200,  //  000E  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_ParameterizedObject_init,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x740A0004,  //  0002  JMPT	R2	#0008
-      0x60080004,  //  0003  GETGBL	R2	G4
-      0x5C0C0200,  //  0004  MOVE	R3	R1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x2008051D,  //  0006  NE	R2	R2	K29
-      0x780A0000,  //  0007  JMPF	R2	#0009
-      0xB006152D,  //  0008  RAISE	1	K10	K45
-      0x90021001,  //  0009  SETMBR	R0	K8	R1
-      0x60080013,  //  000A  GETGBL	R2	G19
-      0x7C080000,  //  000B  CALL	R2	0
-      0x90020802,  //  000C  SETMBR	R0	K4	R2
-      0x8C08012E,  //  000D  GETMET	R2	R0	K46
-      0x7C080200,  //  000E  CALL	R2	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _resolve_parameter_value
-********************************************************************/
-be_local_closure(class_ParameterizedObject__resolve_parameter_value,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -15402,125 +14010,32 @@ be_local_closure(class_ParameterizedObject__resolve_parameter_value,   /* name *
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_resolve_parameter_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x880C0104,  //  0000  GETMBR	R3	R0	K4
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x740E000D,  //  0004  JMPT	R3	#0013
-      0x8C0C0107,  //  0005  GETMET	R3	R0	K7
-      0x5C140200,  //  0006  MOVE	R5	R1
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x4C100000,  //  0008  LDNIL	R4
-      0x20100604,  //  0009  NE	R4	R3	R4
-      0x78120005,  //  000A  JMPF	R4	#0011
-      0x8C100701,  //  000B  GETMET	R4	R3	K1
-      0x58180005,  //  000C  LDCONST	R6	K5
-      0x7C100400,  //  000D  CALL	R4	2
-      0x78120001,  //  000E  JMPF	R4	#0011
-      0x94100705,  //  000F  GETIDX	R4	R3	K5
-      0x80040800,  //  0010  RET	1	R4
-      0x4C100000,  //  0011  LDNIL	R4
-      0x80040800,  //  0012  RET	1	R4
-      0x880C0104,  //  0013  GETMBR	R3	R0	K4
-      0x940C0601,  //  0014  GETIDX	R3	R3	R1
-      0xB8121E00,  //  0015  GETNGBL	R4	K15
-      0x8C100910,  //  0016  GETMET	R4	R4	K16
-      0x5C180600,  //  0017  MOVE	R6	R3
-      0x7C100400,  //  0018  CALL	R4	2
-      0x78120005,  //  0019  JMPF	R4	#0020
-      0x8C10072F,  //  001A  GETMET	R4	R3	K47
-      0x5C180200,  //  001B  MOVE	R6	R1
-      0x5C1C0400,  //  001C  MOVE	R7	R2
-      0x7C100600,  //  001D  CALL	R4	3
-      0x80040800,  //  001E  RET	1	R4
-      0x70020000,  //  001F  JMP		#0021
-      0x80040600,  //  0020  RET	1	R3
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ParameterizedObject_on_param_changed,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x1C0C030D,  //  0000  EQ	R3	R1	K13
-      0x780E0009,  //  0001  JMPF	R3	#000C
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x1C0C0403,  //  0003  EQ	R3	R2	R3
-      0x780E0003,  //  0004  JMPF	R3	#0009
-      0x8C0C0130,  //  0005  GETMET	R3	R0	K48
-      0x4C140000,  //  0006  LDNIL	R5
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x70020002,  //  0008  JMP		#000C
-      0x500C0000,  //  0009  LDBOOL	R3	0	0
-      0x1C0C0403,  //  000A  EQ	R3	R2	R3
-      0x780DFFFF,  //  000B  JMPF	R3	#000C
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: member
-********************************************************************/
-be_local_closure(class_ParameterizedObject_member,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(member),
+    be_str_weak(set_param),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x88080104,  //  0000  GETMBR	R2	R0	K4
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x740A0003,  //  0004  JMPT	R2	#0009
-      0x8C080128,  //  0005  GETMET	R2	R0	K40
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x780A0005,  //  0008  JMPF	R2	#000F
-      0x8C08012C,  //  0009  GETMET	R2	R0	K44
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x88140108,  //  000B  GETMBR	R5	R0	K8
-      0x88140B09,  //  000C  GETMBR	R5	R5	K9
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80040400,  //  000E  RET	1	R2
-      0x60080018,  //  000F  GETGBL	R2	G24
-      0x580C002A,  //  0010  LDCONST	R3	K42
-      0x60100005,  //  0011  GETGBL	R4	G5
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x7C100200,  //  0013  CALL	R4	1
-      0x5C140200,  //  0014  MOVE	R5	R1
-      0x7C080600,  //  0015  CALL	R2	3
-      0xB0065602,  //  0016  RAISE	1	K43	R2
+      0x8C0C0102,  //  0000  GETMET	R3	R0	K2
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x740E0001,  //  0003  JMPT	R3	#0006
+      0x500C0000,  //  0004  LDBOOL	R3	0	0
+      0x80040600,  //  0005  RET	1	R3
+      0xA8020008,  //  0006  EXBLK	0	#0010
+      0x8C0C010A,  //  0007  GETMET	R3	R0	K10
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x5C180400,  //  0009  MOVE	R6	R2
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x500C0200,  //  000B  LDBOOL	R3	1	0
+      0xA8040001,  //  000C  EXBLK	1	1
+      0x80040600,  //  000D  RET	1	R3
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x70020006,  //  000F  JMP		#0017
+      0x580C000B,  //  0010  LDCONST	R3	K11
+      0xAC0C0201,  //  0011  CATCH	R3	1	1
+      0x70020002,  //  0012  JMP		#0016
+      0x50100000,  //  0013  LDBOOL	R4	0	0
+      0x80040800,  //  0014  RET	1	R4
+      0x70020000,  //  0015  JMP		#0017
+      0xB0080000,  //  0016  RAISE	2	R0	R0
       0x80000000,  //  0017  RET	0
     })
   )
@@ -15529,12 +14044,12 @@ be_local_closure(class_ParameterizedObject_member,   /* name */
 
 
 /********************************************************************
-** Solidified function: resolve_value
+** Solidified function: _get_param_def
 ********************************************************************/
-be_local_closure(class_ParameterizedObject_resolve_value,   /* name */
+be_local_closure(class_ParameterizedObject__get_param_def,   /* name */
   be_nested_proto(
     8,                          /* nstack */
-    4,                          /* argc */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -15542,27 +14057,154 @@ be_local_closure(class_ParameterizedObject_resolve_value,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(resolve_value),
+    be_str_weak(_get_param_def),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100204,  //  0001  EQ	R4	R1	R4
-      0x78120001,  //  0002  JMPF	R4	#0005
-      0x4C100000,  //  0003  LDNIL	R4
-      0x80040800,  //  0004  RET	1	R4
-      0xB8121E00,  //  0005  GETNGBL	R4	K15
-      0x8C100910,  //  0006  GETMET	R4	R4	K16
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x7C100400,  //  0008  CALL	R4	2
-      0x78120005,  //  0009  JMPF	R4	#0010
-      0x8C10032F,  //  000A  GETMET	R4	R1	K47
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x7C100600,  //  000D  CALL	R4	3
-      0x80040800,  //  000E  RET	1	R4
-      0x70020000,  //  000F  JMP		#0011
-      0x80040200,  //  0010  RET	1	R1
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[26]) {  /* code */
+      0xA40A1000,  //  0000  IMPORT	R2	K8
+      0x600C0006,  //  0001  GETGBL	R3	G6
+      0x5C100000,  //  0002  MOVE	R4	R0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100604,  //  0005  NE	R4	R3	R4
+      0x78120010,  //  0006  JMPF	R4	#0018
+      0x8C100501,  //  0007  GETMET	R4	R2	K1
+      0x5C180600,  //  0008  MOVE	R6	R3
+      0x581C000C,  //  0009  LDCONST	R7	K12
+      0x7C100600,  //  000A  CALL	R4	3
+      0x78120006,  //  000B  JMPF	R4	#0013
+      0x8810070C,  //  000C  GETMBR	R4	R3	K12
+      0x8C140901,  //  000D  GETMET	R5	R4	K1
+      0x5C1C0200,  //  000E  MOVE	R7	R1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x78160001,  //  0010  JMPF	R5	#0013
+      0x94140801,  //  0011  GETIDX	R5	R4	R1
+      0x80040A00,  //  0012  RET	1	R5
+      0x60100003,  //  0013  GETGBL	R4	G3
+      0x5C140600,  //  0014  MOVE	R5	R3
+      0x7C100200,  //  0015  CALL	R4	1
+      0x5C0C0800,  //  0016  MOVE	R3	R4
+      0x7001FFEB,  //  0017  JMP		#0004
+      0x4C100000,  //  0018  LDNIL	R4
+      0x80040800,  //  0019  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_parameter_values
+********************************************************************/
+be_local_closure(class_ParameterizedObject__init_parameter_values,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_init_parameter_values),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0xA4061000,  //  0000  IMPORT	R1	K8
+      0x60080006,  //  0001  GETGBL	R2	G6
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x200C0403,  //  0005  NE	R3	R2	R3
+      0x780E0026,  //  0006  JMPF	R3	#002E
+      0x8C0C0301,  //  0007  GETMET	R3	R1	K1
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x5818000C,  //  0009  LDCONST	R6	K12
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x780E001C,  //  000B  JMPF	R3	#0029
+      0x880C050C,  //  000C  GETMBR	R3	R2	K12
+      0x60100010,  //  000D  GETGBL	R4	G16
+      0x8C14070D,  //  000E  GETMET	R5	R3	K13
+      0x7C140200,  //  000F  CALL	R5	1
+      0x7C100200,  //  0010  CALL	R4	1
+      0xA8020013,  //  0011  EXBLK	0	#0026
+      0x5C140800,  //  0012  MOVE	R5	R4
+      0x7C140000,  //  0013  CALL	R5	0
+      0x88180100,  //  0014  GETMBR	R6	R0	K0
+      0x8C180D01,  //  0015  GETMET	R6	R6	K1
+      0x5C200A00,  //  0016  MOVE	R8	R5
+      0x7C180400,  //  0017  CALL	R6	2
+      0x741A000B,  //  0018  JMPT	R6	#0025
+      0x94180605,  //  0019  GETIDX	R6	R3	R5
+      0x8C1C010E,  //  001A  GETMET	R7	R0	K14
+      0x5C240C00,  //  001B  MOVE	R9	R6
+      0x5828000F,  //  001C  LDCONST	R10	K15
+      0x7C1C0600,  //  001D  CALL	R7	3
+      0x781E0005,  //  001E  JMPF	R7	#0025
+      0x881C0100,  //  001F  GETMBR	R7	R0	K0
+      0x8C200110,  //  0020  GETMET	R8	R0	K16
+      0x5C280C00,  //  0021  MOVE	R10	R6
+      0x582C000F,  //  0022  LDCONST	R11	K15
+      0x7C200600,  //  0023  CALL	R8	3
+      0x981C0A08,  //  0024  SETIDX	R7	R5	R8
+      0x7001FFEB,  //  0025  JMP		#0012
+      0x58100011,  //  0026  LDCONST	R4	K17
+      0xAC100200,  //  0027  CATCH	R4	1	0
+      0xB0080000,  //  0028  RAISE	2	R0	R0
+      0x600C0003,  //  0029  GETGBL	R3	G3
+      0x5C100400,  //  002A  MOVE	R4	R2
+      0x7C0C0200,  //  002B  CALL	R3	1
+      0x5C080600,  //  002C  MOVE	R2	R3
+      0x7001FFD5,  //  002D  JMP		#0004
+      0x80000000,  //  002E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _has_param
+********************************************************************/
+be_local_closure(class_ParameterizedObject__has_param,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_has_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0xA40A1000,  //  0000  IMPORT	R2	K8
+      0x600C0006,  //  0001  GETGBL	R3	G6
+      0x5C100000,  //  0002  MOVE	R4	R0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100604,  //  0005  NE	R4	R3	R4
+      0x78120010,  //  0006  JMPF	R4	#0018
+      0x8C100501,  //  0007  GETMET	R4	R2	K1
+      0x5C180600,  //  0008  MOVE	R6	R3
+      0x581C000C,  //  0009  LDCONST	R7	K12
+      0x7C100600,  //  000A  CALL	R4	3
+      0x78120006,  //  000B  JMPF	R4	#0013
+      0x8810070C,  //  000C  GETMBR	R4	R3	K12
+      0x8C140901,  //  000D  GETMET	R5	R4	K1
+      0x5C1C0200,  //  000E  MOVE	R7	R1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x78160001,  //  0010  JMPF	R5	#0013
+      0x50140200,  //  0011  LDBOOL	R5	1	0
+      0x80040A00,  //  0012  RET	1	R5
+      0x60100003,  //  0013  GETGBL	R4	G3
+      0x5C140600,  //  0014  MOVE	R5	R3
+      0x7C100200,  //  0015  CALL	R4	1
+      0x5C0C0800,  //  0016  MOVE	R3	R4
+      0x7001FFEB,  //  0017  JMP		#0004
+      0x50100000,  //  0018  LDBOOL	R4	0	0
+      0x80040800,  //  0019  RET	1	R4
     })
   )
 );
@@ -15598,9 +14240,273 @@ be_local_closure(class_ParameterizedObject__X21_X3D,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_param
+** Solidified function: _fix_time_ms
 ********************************************************************/
-be_local_closure(class_ParameterizedObject_set_param,   /* name */
+be_local_closure(class_ParameterizedObject__fix_time_ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_fix_time_ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x88080104,  //  0003  GETMBR	R2	R0	K4
+      0x88040505,  //  0004  GETMBR	R1	R2	K5
+      0x88080112,  //  0005  GETMBR	R2	R0	K18
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x1C080403,  //  0007  EQ	R2	R2	R3
+      0x780A0000,  //  0008  JMPF	R2	#000A
+      0x90022401,  //  0009  SETMBR	R0	K18	R1
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resolve_value
+********************************************************************/
+be_local_closure(class_ParameterizedObject_resolve_value,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(resolve_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0xB8122600,  //  0000  GETNGBL	R4	K19
+      0x8C100914,  //  0001  GETMET	R4	R4	K20
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x7C100400,  //  0003  CALL	R4	2
+      0x78120005,  //  0004  JMPF	R4	#000B
+      0x8C100315,  //  0005  GETMET	R4	R1	K21
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x5C1C0600,  //  0007  MOVE	R7	R3
+      0x7C100600,  //  0008  CALL	R4	3
+      0x80040800,  //  0009  RET	1	R4
+      0x70020000,  //  000A  JMP		#000C
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _validate_param
+********************************************************************/
+be_local_closure(class_ParameterizedObject__validate_param,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_validate_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[171]) {  /* code */
+      0x8C0C0116,  //  0000  GETMET	R3	R0	K22
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x1C100604,  //  0004  EQ	R4	R3	R4
+      0x78120007,  //  0005  JMPF	R4	#000E
+      0x60100018,  //  0006  GETGBL	R4	G24
+      0x58140006,  //  0007  LDCONST	R5	K6
+      0x60180005,  //  0008  GETGBL	R6	G5
+      0x5C1C0000,  //  0009  MOVE	R7	R0
+      0x7C180200,  //  000A  CALL	R6	1
+      0x5C1C0200,  //  000B  MOVE	R7	R1
+      0x7C100600,  //  000C  CALL	R4	3
+      0xB0060E04,  //  000D  RAISE	1	K7	R4
+      0xB8122600,  //  000E  GETNGBL	R4	K19
+      0x8C100914,  //  000F  GETMET	R4	R4	K20
+      0x5C180400,  //  0010  MOVE	R6	R2
+      0x7C100400,  //  0011  CALL	R4	2
+      0x78120000,  //  0012  JMPF	R4	#0014
+      0x80040400,  //  0013  RET	1	R2
+      0x4C100000,  //  0014  LDNIL	R4
+      0x1C100404,  //  0015  EQ	R4	R2	R4
+      0x78120010,  //  0016  JMPF	R4	#0028
+      0x8C10010E,  //  0017  GETMET	R4	R0	K14
+      0x5C180600,  //  0018  MOVE	R6	R3
+      0x581C0017,  //  0019  LDCONST	R7	K23
+      0x7C100600,  //  001A  CALL	R4	3
+      0x78120000,  //  001B  JMPF	R4	#001D
+      0x80040400,  //  001C  RET	1	R2
+      0x8C10010E,  //  001D  GETMET	R4	R0	K14
+      0x5C180600,  //  001E  MOVE	R6	R3
+      0x581C000F,  //  001F  LDCONST	R7	K15
+      0x7C100600,  //  0020  CALL	R4	3
+      0x78120000,  //  0021  JMPF	R4	#0023
+      0x80040400,  //  0022  RET	1	R2
+      0x60100018,  //  0023  GETGBL	R4	G24
+      0x58140018,  //  0024  LDCONST	R5	K24
+      0x5C180200,  //  0025  MOVE	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0xB0061604,  //  0027  RAISE	1	K11	R4
+      0x8C100110,  //  0028  GETMET	R4	R0	K16
+      0x5C180600,  //  0029  MOVE	R6	R3
+      0x581C0019,  //  002A  LDCONST	R7	K25
+      0x5820001A,  //  002B  LDCONST	R8	K26
+      0x7C100800,  //  002C  CALL	R4	4
+      0x60140004,  //  002D  GETGBL	R5	G4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C140200,  //  002F  CALL	R5	1
+      0x2018091B,  //  0030  NE	R6	R4	K27
+      0x781A0031,  //  0031  JMPF	R6	#0064
+      0x1C18091A,  //  0032  EQ	R6	R4	K26
+      0x781A000A,  //  0033  JMPF	R6	#003F
+      0x1C180B1C,  //  0034  EQ	R6	R5	K28
+      0x781A0008,  //  0035  JMPF	R6	#003F
+      0xA41A3A00,  //  0036  IMPORT	R6	K29
+      0x601C0009,  //  0037  GETGBL	R7	G9
+      0x8C200D1E,  //  0038  GETMET	R8	R6	K30
+      0x5C280400,  //  0039  MOVE	R10	R2
+      0x7C200400,  //  003A  CALL	R8	2
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x5C080E00,  //  003C  MOVE	R2	R7
+      0x5814001A,  //  003D  LDCONST	R5	K26
+      0x70020024,  //  003E  JMP		#0064
+      0x1C18091F,  //  003F  EQ	R6	R4	K31
+      0x781A0018,  //  0040  JMPF	R6	#005A
+      0x1C180B20,  //  0041  EQ	R6	R5	K32
+      0x781A0006,  //  0042  JMPF	R6	#004A
+      0x6018000F,  //  0043  GETGBL	R6	G15
+      0x5C1C0400,  //  0044  MOVE	R7	R2
+      0x60200015,  //  0045  GETGBL	R8	G21
+      0x7C180400,  //  0046  CALL	R6	2
+      0x781A0001,  //  0047  JMPF	R6	#004A
+      0x5814001F,  //  0048  LDCONST	R5	K31
+      0x7002000E,  //  0049  JMP		#0059
+      0x20180B20,  //  004A  NE	R6	R5	K32
+      0x741A0004,  //  004B  JMPT	R6	#0051
+      0x6018000F,  //  004C  GETGBL	R6	G15
+      0x5C1C0400,  //  004D  MOVE	R7	R2
+      0x60200015,  //  004E  GETGBL	R8	G21
+      0x7C180400,  //  004F  CALL	R6	2
+      0x741A0007,  //  0050  JMPT	R6	#0059
+      0x60180018,  //  0051  GETGBL	R6	G24
+      0x581C0021,  //  0052  LDCONST	R7	K33
+      0x5C200200,  //  0053  MOVE	R8	R1
+      0x5C240800,  //  0054  MOVE	R9	R4
+      0x5C280A00,  //  0055  MOVE	R10	R5
+      0x5C2C0400,  //  0056  MOVE	R11	R2
+      0x7C180A00,  //  0057  CALL	R6	5
+      0xB0061606,  //  0058  RAISE	1	K11	R6
+      0x70020009,  //  0059  JMP		#0064
+      0x20180805,  //  005A  NE	R6	R4	R5
+      0x781A0007,  //  005B  JMPF	R6	#0064
+      0x60180018,  //  005C  GETGBL	R6	G24
+      0x581C0021,  //  005D  LDCONST	R7	K33
+      0x5C200200,  //  005E  MOVE	R8	R1
+      0x5C240800,  //  005F  MOVE	R9	R4
+      0x5C280A00,  //  0060  MOVE	R10	R5
+      0x5C2C0400,  //  0061  MOVE	R11	R2
+      0x7C180A00,  //  0062  CALL	R6	5
+      0xB0061606,  //  0063  RAISE	1	K11	R6
+      0x1C180B1A,  //  0064  EQ	R6	R5	K26
+      0x781A0023,  //  0065  JMPF	R6	#008A
+      0x8C18010E,  //  0066  GETMET	R6	R0	K14
+      0x5C200600,  //  0067  MOVE	R8	R3
+      0x58240022,  //  0068  LDCONST	R9	K34
+      0x7C180600,  //  0069  CALL	R6	3
+      0x781A000C,  //  006A  JMPF	R6	#0078
+      0x8C180110,  //  006B  GETMET	R6	R0	K16
+      0x5C200600,  //  006C  MOVE	R8	R3
+      0x58240022,  //  006D  LDCONST	R9	K34
+      0x7C180600,  //  006E  CALL	R6	3
+      0x141C0406,  //  006F  LT	R7	R2	R6
+      0x781E0006,  //  0070  JMPF	R7	#0078
+      0x601C0018,  //  0071  GETGBL	R7	G24
+      0x58200023,  //  0072  LDCONST	R8	K35
+      0x5C240200,  //  0073  MOVE	R9	R1
+      0x5C280400,  //  0074  MOVE	R10	R2
+      0x5C2C0C00,  //  0075  MOVE	R11	R6
+      0x7C1C0800,  //  0076  CALL	R7	4
+      0xB0061607,  //  0077  RAISE	1	K11	R7
+      0x8C18010E,  //  0078  GETMET	R6	R0	K14
+      0x5C200600,  //  0079  MOVE	R8	R3
+      0x58240024,  //  007A  LDCONST	R9	K36
+      0x7C180600,  //  007B  CALL	R6	3
+      0x781A000C,  //  007C  JMPF	R6	#008A
+      0x8C180110,  //  007D  GETMET	R6	R0	K16
+      0x5C200600,  //  007E  MOVE	R8	R3
+      0x58240024,  //  007F  LDCONST	R9	K36
+      0x7C180600,  //  0080  CALL	R6	3
+      0x241C0406,  //  0081  GT	R7	R2	R6
+      0x781E0006,  //  0082  JMPF	R7	#008A
+      0x601C0018,  //  0083  GETGBL	R7	G24
+      0x58200025,  //  0084  LDCONST	R8	K37
+      0x5C240200,  //  0085  MOVE	R9	R1
+      0x5C280400,  //  0086  MOVE	R10	R2
+      0x5C2C0C00,  //  0087  MOVE	R11	R6
+      0x7C1C0800,  //  0088  CALL	R7	4
+      0xB0061607,  //  0089  RAISE	1	K11	R7
+      0x8C18010E,  //  008A  GETMET	R6	R0	K14
+      0x5C200600,  //  008B  MOVE	R8	R3
+      0x58240026,  //  008C  LDCONST	R9	K38
+      0x7C180600,  //  008D  CALL	R6	3
+      0x781A001A,  //  008E  JMPF	R6	#00AA
+      0x50180000,  //  008F  LDBOOL	R6	0	0
+      0x8C1C0110,  //  0090  GETMET	R7	R0	K16
+      0x5C240600,  //  0091  MOVE	R9	R3
+      0x58280026,  //  0092  LDCONST	R10	K38
+      0x7C1C0600,  //  0093  CALL	R7	3
+      0x6020000C,  //  0094  GETGBL	R8	G12
+      0x5C240E00,  //  0095  MOVE	R9	R7
+      0x7C200200,  //  0096  CALL	R8	1
+      0x58240027,  //  0097  LDCONST	R9	K39
+      0x14281208,  //  0098  LT	R10	R9	R8
+      0x782A0006,  //  0099  JMPF	R10	#00A1
+      0x94280E09,  //  009A  GETIDX	R10	R7	R9
+      0x1C2C040A,  //  009B  EQ	R11	R2	R10
+      0x782E0001,  //  009C  JMPF	R11	#009F
+      0x50180200,  //  009D  LDBOOL	R6	1	0
+      0x70020001,  //  009E  JMP		#00A1
+      0x00241328,  //  009F  ADD	R9	R9	K40
+      0x7001FFF6,  //  00A0  JMP		#0098
+      0x5C280C00,  //  00A1  MOVE	R10	R6
+      0x742A0006,  //  00A2  JMPT	R10	#00AA
+      0x60280018,  //  00A3  GETGBL	R10	G24
+      0x582C0029,  //  00A4  LDCONST	R11	K41
+      0x5C300200,  //  00A5  MOVE	R12	R1
+      0x5C340400,  //  00A6  MOVE	R13	R2
+      0x5C380E00,  //  00A7  MOVE	R14	R7
+      0x7C280800,  //  00A8  CALL	R10	4
+      0xB006160A,  //  00A9  RAISE	1	K11	R10
+      0x80040400,  //  00AA  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: setmember
+********************************************************************/
+be_local_closure(class_ParameterizedObject_setmember,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     3,                          /* argc */
@@ -15611,33 +14517,27 @@ be_local_closure(class_ParameterizedObject_set_param,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(set_param),
+    be_str_weak(setmember),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C0C0128,  //  0000  GETMET	R3	R0	K40
+    ( &(const binstruction[18]) {  /* code */
+      0x8C0C0102,  //  0000  GETMET	R3	R0	K2
       0x5C140200,  //  0001  MOVE	R5	R1
       0x7C0C0400,  //  0002  CALL	R3	2
-      0x740E0001,  //  0003  JMPT	R3	#0006
-      0x500C0000,  //  0004  LDBOOL	R3	0	0
-      0x80040600,  //  0005  RET	1	R3
-      0xA8020008,  //  0006  EXBLK	0	#0010
-      0x8C0C0129,  //  0007  GETMET	R3	R0	K41
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x5C180400,  //  0009  MOVE	R6	R2
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x500C0200,  //  000B  LDBOOL	R3	1	0
-      0xA8040001,  //  000C  EXBLK	1	1
-      0x80040600,  //  000D  RET	1	R3
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x70020006,  //  000F  JMP		#0017
-      0x580C000A,  //  0010  LDCONST	R3	K10
-      0xAC0C0201,  //  0011  CATCH	R3	1	1
-      0x70020002,  //  0012  JMP		#0016
-      0x50100000,  //  0013  LDBOOL	R4	0	0
-      0x80040800,  //  0014  RET	1	R4
-      0x70020000,  //  0015  JMP		#0017
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80000000,  //  0017  RET	0
+      0x780E0004,  //  0003  JMPF	R3	#0009
+      0x8C0C010A,  //  0004  GETMET	R3	R0	K10
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x70020007,  //  0008  JMP		#0011
+      0x600C0018,  //  0009  GETGBL	R3	G24
+      0x58100006,  //  000A  LDCONST	R4	K6
+      0x60140005,  //  000B  GETGBL	R5	G5
+      0x5C180000,  //  000C  MOVE	R6	R0
+      0x7C140200,  //  000D  CALL	R5	1
+      0x5C180200,  //  000E  MOVE	R6	R1
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0xB0060E03,  //  0010  RAISE	1	K7	R3
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -15645,11 +14545,457 @@ be_local_closure(class_ParameterizedObject_set_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: _get_param_def
+** Solidified function: _set_parameter_value
 ********************************************************************/
-be_local_closure(class_ParameterizedObject__get_param_def,   /* name */
+be_local_closure(class_ParameterizedObject__set_parameter_value,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_set_parameter_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xB80E2600,  //  0000  GETNGBL	R3	K19
+      0x8C0C0714,  //  0001  GETMET	R3	R3	K20
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x740E0004,  //  0004  JMPT	R3	#000A
+      0x8C0C012A,  //  0005  GETMET	R3	R0	K42
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x5C180400,  //  0007  MOVE	R6	R2
+      0x7C0C0600,  //  0008  CALL	R3	3
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x980C0202,  //  000B  SETIDX	R3	R1	R2
+      0x8C0C012B,  //  000C  GETMET	R3	R0	K43
+      0x5C140200,  //  000D  MOVE	R5	R1
+      0x5C180400,  //  000E  MOVE	R6	R2
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _resolve_parameter_value
+********************************************************************/
+be_local_closure(class_ParameterizedObject__resolve_parameter_value,   /* name */
   be_nested_proto(
     8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(_resolve_parameter_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x740E0011,  //  0004  JMPT	R3	#0017
+      0x8C0C0116,  //  0005  GETMET	R3	R0	K22
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x4C100000,  //  0008  LDNIL	R4
+      0x20100604,  //  0009  NE	R4	R3	R4
+      0x78120009,  //  000A  JMPF	R4	#0015
+      0x8C10010E,  //  000B  GETMET	R4	R0	K14
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x581C000F,  //  000D  LDCONST	R7	K15
+      0x7C100600,  //  000E  CALL	R4	3
+      0x78120004,  //  000F  JMPF	R4	#0015
+      0x8C100110,  //  0010  GETMET	R4	R0	K16
+      0x5C180600,  //  0011  MOVE	R6	R3
+      0x581C000F,  //  0012  LDCONST	R7	K15
+      0x7C100600,  //  0013  CALL	R4	3
+      0x80040800,  //  0014  RET	1	R4
+      0x4C100000,  //  0015  LDNIL	R4
+      0x80040800,  //  0016  RET	1	R4
+      0x880C0100,  //  0017  GETMBR	R3	R0	K0
+      0x940C0601,  //  0018  GETIDX	R3	R3	R1
+      0xB8122600,  //  0019  GETNGBL	R4	K19
+      0x8C100914,  //  001A  GETMET	R4	R4	K20
+      0x5C180600,  //  001B  MOVE	R6	R3
+      0x7C100400,  //  001C  CALL	R4	2
+      0x78120005,  //  001D  JMPF	R4	#0024
+      0x8C100715,  //  001E  GETMET	R4	R3	K21
+      0x5C180200,  //  001F  MOVE	R6	R1
+      0x5C1C0400,  //  0020  MOVE	R7	R2
+      0x7C100600,  //  0021  CALL	R4	3
+      0x80040800,  //  0022  RET	1	R4
+      0x70020000,  //  0023  JMP		#0025
+      0x80040600,  //  0024  RET	1	R3
+      0x80000000,  //  0025  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: constraint_find
+********************************************************************/
+be_local_closure(class_ParameterizedObject_constraint_find,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    3,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        7,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_const_int(0),
+        /* K1   */  be_const_int(1),
+        /* K2   */  be_const_int(2),
+        /* K3   */  be_const_int(3),
+        /* K4   */  be_nested_str_weak(get),
+        }),
+        be_str_weak(_skip_typed_value),
+        &be_const_str_solidified,
+        ( &(const binstruction[47]) {  /* code */
+          0x6008000C,  //  0000  GETGBL	R2	G12
+          0x5C0C0000,  //  0001  MOVE	R3	R0
+          0x7C080200,  //  0002  CALL	R2	1
+          0x28080202,  //  0003  GE	R2	R1	R2
+          0x780A0000,  //  0004  JMPF	R2	#0006
+          0x80060000,  //  0005  RET	1	K0
+          0x94080001,  //  0006  GETIDX	R2	R0	R1
+          0x540E0005,  //  0007  LDINT	R3	6
+          0x1C0C0403,  //  0008  EQ	R3	R2	R3
+          0x780E0001,  //  0009  JMPF	R3	#000C
+          0x80060200,  //  000A  RET	1	K1
+          0x70020021,  //  000B  JMP		#002E
+          0x540E0004,  //  000C  LDINT	R3	5
+          0x1C0C0403,  //  000D  EQ	R3	R2	R3
+          0x780E0001,  //  000E  JMPF	R3	#0011
+          0x80060400,  //  000F  RET	1	K2
+          0x7002001C,  //  0010  JMP		#002E
+          0x1C0C0500,  //  0011  EQ	R3	R2	K0
+          0x780E0001,  //  0012  JMPF	R3	#0015
+          0x80060400,  //  0013  RET	1	K2
+          0x70020018,  //  0014  JMP		#002E
+          0x1C0C0501,  //  0015  EQ	R3	R2	K1
+          0x780E0001,  //  0016  JMPF	R3	#0019
+          0x80060600,  //  0017  RET	1	K3
+          0x70020014,  //  0018  JMP		#002E
+          0x1C0C0502,  //  0019  EQ	R3	R2	K2
+          0x780E0002,  //  001A  JMPF	R3	#001E
+          0x540E0004,  //  001B  LDINT	R3	5
+          0x80040600,  //  001C  RET	1	R3
+          0x7002000F,  //  001D  JMP		#002E
+          0x1C0C0503,  //  001E  EQ	R3	R2	K3
+          0x780E0004,  //  001F  JMPF	R3	#0025
+          0x000C0301,  //  0020  ADD	R3	R1	K1
+          0x940C0003,  //  0021  GETIDX	R3	R0	R3
+          0x000E0403,  //  0022  ADD	R3	K2	R3
+          0x80040600,  //  0023  RET	1	R3
+          0x70020008,  //  0024  JMP		#002E
+          0x540E0003,  //  0025  LDINT	R3	4
+          0x1C0C0403,  //  0026  EQ	R3	R2	R3
+          0x780E0005,  //  0027  JMPF	R3	#002E
+          0x8C0C0104,  //  0028  GETMET	R3	R0	K4
+          0x00140301,  //  0029  ADD	R5	R1	K1
+          0x58180002,  //  002A  LDCONST	R6	K2
+          0x7C0C0600,  //  002B  CALL	R3	3
+          0x000E0603,  //  002C  ADD	R3	K3	R3
+          0x80040600,  //  002D  RET	1	R3
+          0x80060000,  //  002E  RET	1	K0
+        })
+      ),
+      be_nested_proto(
+        7,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 6]) {     /* constants */
+        /* K0   */  be_const_int(1),
+        /* K1   */  be_const_int(0),
+        /* K2   */  be_nested_str_weak(get),
+        /* K3   */  be_const_int(2),
+        /* K4   */  be_const_int(3),
+        /* K5   */  be_nested_str_weak(asstring),
+        }),
+        be_str_weak(_read_typed_value),
+        &be_const_str_solidified,
+        ( &(const binstruction[83]) {  /* code */
+          0x6008000C,  //  0000  GETGBL	R2	G12
+          0x5C0C0000,  //  0001  MOVE	R3	R0
+          0x7C080200,  //  0002  CALL	R2	1
+          0x28080202,  //  0003  GE	R2	R1	R2
+          0x780A0001,  //  0004  JMPF	R2	#0007
+          0x4C080000,  //  0005  LDNIL	R2
+          0x80040400,  //  0006  RET	1	R2
+          0x94080001,  //  0007  GETIDX	R2	R0	R1
+          0x00040300,  //  0008  ADD	R1	R1	K0
+          0x540E0005,  //  0009  LDINT	R3	6
+          0x1C0C0403,  //  000A  EQ	R3	R2	R3
+          0x780E0002,  //  000B  JMPF	R3	#000F
+          0x4C0C0000,  //  000C  LDNIL	R3
+          0x80040600,  //  000D  RET	1	R3
+          0x70020041,  //  000E  JMP		#0051
+          0x540E0004,  //  000F  LDINT	R3	5
+          0x1C0C0403,  //  0010  EQ	R3	R2	R3
+          0x780E0003,  //  0011  JMPF	R3	#0016
+          0x940C0001,  //  0012  GETIDX	R3	R0	R1
+          0x200C0701,  //  0013  NE	R3	R3	K1
+          0x80040600,  //  0014  RET	1	R3
+          0x7002003A,  //  0015  JMP		#0051
+          0x1C0C0501,  //  0016  EQ	R3	R2	K1
+          0x780E0009,  //  0017  JMPF	R3	#0022
+          0x940C0001,  //  0018  GETIDX	R3	R0	R1
+          0x5412007E,  //  0019  LDINT	R4	127
+          0x24100604,  //  001A  GT	R4	R3	R4
+          0x78120002,  //  001B  JMPF	R4	#001F
+          0x541200FF,  //  001C  LDINT	R4	256
+          0x04100604,  //  001D  SUB	R4	R3	R4
+          0x70020000,  //  001E  JMP		#0020
+          0x5C100600,  //  001F  MOVE	R4	R3
+          0x80040800,  //  0020  RET	1	R4
+          0x7002002E,  //  0021  JMP		#0051
+          0x1C0C0500,  //  0022  EQ	R3	R2	K0
+          0x780E000C,  //  0023  JMPF	R3	#0031
+          0x8C0C0102,  //  0024  GETMET	R3	R0	K2
+          0x5C140200,  //  0025  MOVE	R5	R1
+          0x58180003,  //  0026  LDCONST	R6	K3
+          0x7C0C0600,  //  0027  CALL	R3	3
+          0x54127FFE,  //  0028  LDINT	R4	32767
+          0x24100604,  //  0029  GT	R4	R3	R4
+          0x78120002,  //  002A  JMPF	R4	#002E
+          0x5412FFFF,  //  002B  LDINT	R4	65536
+          0x04100604,  //  002C  SUB	R4	R3	R4
+          0x70020000,  //  002D  JMP		#002F
+          0x5C100600,  //  002E  MOVE	R4	R3
+          0x80040800,  //  002F  RET	1	R4
+          0x7002001F,  //  0030  JMP		#0051
+          0x1C0C0503,  //  0031  EQ	R3	R2	K3
+          0x780E0005,  //  0032  JMPF	R3	#0039
+          0x8C0C0102,  //  0033  GETMET	R3	R0	K2
+          0x5C140200,  //  0034  MOVE	R5	R1
+          0x541A0003,  //  0035  LDINT	R6	4
+          0x7C0C0600,  //  0036  CALL	R3	3
+          0x80040600,  //  0037  RET	1	R3
+          0x70020017,  //  0038  JMP		#0051
+          0x1C0C0504,  //  0039  EQ	R3	R2	K4
+          0x780E0008,  //  003A  JMPF	R3	#0044
+          0x940C0001,  //  003B  GETIDX	R3	R0	R1
+          0x00100300,  //  003C  ADD	R4	R1	K0
+          0x00140203,  //  003D  ADD	R5	R1	R3
+          0x40100805,  //  003E  CONNECT	R4	R4	R5
+          0x94100004,  //  003F  GETIDX	R4	R0	R4
+          0x8C100905,  //  0040  GETMET	R4	R4	K5
+          0x7C100200,  //  0041  CALL	R4	1
+          0x80040800,  //  0042  RET	1	R4
+          0x7002000C,  //  0043  JMP		#0051
+          0x540E0003,  //  0044  LDINT	R3	4
+          0x1C0C0403,  //  0045  EQ	R3	R2	R3
+          0x780E0009,  //  0046  JMPF	R3	#0051
+          0x8C0C0102,  //  0047  GETMET	R3	R0	K2
+          0x5C140200,  //  0048  MOVE	R5	R1
+          0x58180003,  //  0049  LDCONST	R6	K3
+          0x7C0C0600,  //  004A  CALL	R3	3
+          0x00100303,  //  004B  ADD	R4	R1	K3
+          0x00140203,  //  004C  ADD	R5	R1	R3
+          0x00140B00,  //  004D  ADD	R5	R5	K0
+          0x40100805,  //  004E  CONNECT	R4	R4	R5
+          0x94100004,  //  004F  GETIDX	R4	R0	R4
+          0x80040800,  //  0050  RET	1	R4
+          0x4C0C0000,  //  0051  LDNIL	R3
+          0x80040600,  //  0052  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(constraint_find),
+    &be_const_str_solidified,
+    ( &(const binstruction[112]) {  /* code */
+      0x580C002C,  //  0000  LDCONST	R3	K44
+      0x84100000,  //  0001  CLOSURE	R4	P0
+      0x84140001,  //  0002  CLOSURE	R5	P1
+      0x6018000C,  //  0003  GETGBL	R6	G12
+      0x5C1C0000,  //  0004  MOVE	R7	R0
+      0x7C180200,  //  0005  CALL	R6	1
+      0x14180D28,  //  0006  LT	R6	R6	K40
+      0x781A0000,  //  0007  JMPF	R6	#0009
+      0x80040400,  //  0008  RET	1	R2
+      0x94180127,  //  0009  GETIDX	R6	R0	K39
+      0x581C0028,  //  000A  LDCONST	R7	K40
+      0x8820072D,  //  000B  GETMBR	R8	R3	K45
+      0x8C20112E,  //  000C  GETMET	R8	R8	K46
+      0x5C280200,  //  000D  MOVE	R10	R1
+      0x7C200400,  //  000E  CALL	R8	2
+      0x4C240000,  //  000F  LDNIL	R9
+      0x1C241009,  //  0010  EQ	R9	R8	R9
+      0x78260000,  //  0011  JMPF	R9	#0013
+      0x80040400,  //  0012  RET	1	R2
+      0x38225008,  //  0013  SHL	R8	K40	R8
+      0x2C240C08,  //  0014  AND	R9	R6	R8
+      0x74260000,  //  0015  JMPT	R9	#0017
+      0x80040400,  //  0016  RET	1	R2
+      0x5426001F,  //  0017  LDINT	R9	32
+      0x1C241009,  //  0018  EQ	R9	R8	R9
+      0x78260001,  //  0019  JMPF	R9	#001C
+      0x50240200,  //  001A  LDBOOL	R9	1	0
+      0x80041200,  //  001B  RET	1	R9
+      0x24241128,  //  001C  GT	R9	R8	K40
+      0x78260006,  //  001D  JMPF	R9	#0025
+      0x2C240D28,  //  001E  AND	R9	R6	K40
+      0x78260004,  //  001F  JMPF	R9	#0025
+      0x5C240800,  //  0020  MOVE	R9	R4
+      0x5C280000,  //  0021  MOVE	R10	R0
+      0x5C2C0E00,  //  0022  MOVE	R11	R7
+      0x7C240400,  //  0023  CALL	R9	2
+      0x001C0E09,  //  0024  ADD	R7	R7	R9
+      0x2424112F,  //  0025  GT	R9	R8	K47
+      0x78260006,  //  0026  JMPF	R9	#002E
+      0x2C240D2F,  //  0027  AND	R9	R6	K47
+      0x78260004,  //  0028  JMPF	R9	#002E
+      0x5C240800,  //  0029  MOVE	R9	R4
+      0x5C280000,  //  002A  MOVE	R10	R0
+      0x5C2C0E00,  //  002B  MOVE	R11	R7
+      0x7C240400,  //  002C  CALL	R9	2
+      0x001C0E09,  //  002D  ADD	R7	R7	R9
+      0x54260003,  //  002E  LDINT	R9	4
+      0x24241009,  //  002F  GT	R9	R8	R9
+      0x78260007,  //  0030  JMPF	R9	#0039
+      0x54260003,  //  0031  LDINT	R9	4
+      0x2C240C09,  //  0032  AND	R9	R6	R9
+      0x78260004,  //  0033  JMPF	R9	#0039
+      0x5C240800,  //  0034  MOVE	R9	R4
+      0x5C280000,  //  0035  MOVE	R10	R0
+      0x5C2C0E00,  //  0036  MOVE	R11	R7
+      0x7C240400,  //  0037  CALL	R9	2
+      0x001C0E09,  //  0038  ADD	R7	R7	R9
+      0x54260007,  //  0039  LDINT	R9	8
+      0x24241009,  //  003A  GT	R9	R8	R9
+      0x78260003,  //  003B  JMPF	R9	#0040
+      0x54260007,  //  003C  LDINT	R9	8
+      0x2C240C09,  //  003D  AND	R9	R6	R9
+      0x78260000,  //  003E  JMPF	R9	#0040
+      0x001C0F28,  //  003F  ADD	R7	R7	K40
+      0x6024000C,  //  0040  GETGBL	R9	G12
+      0x5C280000,  //  0041  MOVE	R10	R0
+      0x7C240200,  //  0042  CALL	R9	1
+      0x28240E09,  //  0043  GE	R9	R7	R9
+      0x78260000,  //  0044  JMPF	R9	#0046
+      0x80040400,  //  0045  RET	1	R2
+      0x54260007,  //  0046  LDINT	R9	8
+      0x1C241009,  //  0047  EQ	R9	R8	R9
+      0x78260009,  //  0048  JMPF	R9	#0053
+      0x94240007,  //  0049  GETIDX	R9	R0	R7
+      0x6028000C,  //  004A  GETGBL	R10	G12
+      0x882C0730,  //  004B  GETMBR	R11	R3	K48
+      0x7C280200,  //  004C  CALL	R10	1
+      0x1428120A,  //  004D  LT	R10	R9	R10
+      0x782A0002,  //  004E  JMPF	R10	#0052
+      0x88280730,  //  004F  GETMBR	R10	R3	K48
+      0x94281409,  //  0050  GETIDX	R10	R10	R9
+      0x80041400,  //  0051  RET	1	R10
+      0x80040400,  //  0052  RET	1	R2
+      0x5426000F,  //  0053  LDINT	R9	16
+      0x1C241009,  //  0054  EQ	R9	R8	R9
+      0x78260014,  //  0055  JMPF	R9	#006B
+      0x94240007,  //  0056  GETIDX	R9	R0	R7
+      0x001C0F28,  //  0057  ADD	R7	R7	K40
+      0x60280012,  //  0058  GETGBL	R10	G18
+      0x7C280000,  //  0059  CALL	R10	0
+      0x582C0027,  //  005A  LDCONST	R11	K39
+      0x14301609,  //  005B  LT	R12	R11	R9
+      0x7832000C,  //  005C  JMPF	R12	#006A
+      0x8C301531,  //  005D  GETMET	R12	R10	K49
+      0x5C380A00,  //  005E  MOVE	R14	R5
+      0x5C3C0000,  //  005F  MOVE	R15	R0
+      0x5C400E00,  //  0060  MOVE	R16	R7
+      0x7C380400,  //  0061  CALL	R14	2
+      0x7C300400,  //  0062  CALL	R12	2
+      0x5C340800,  //  0063  MOVE	R13	R4
+      0x5C380000,  //  0064  MOVE	R14	R0
+      0x5C3C0E00,  //  0065  MOVE	R15	R7
+      0x7C340400,  //  0066  CALL	R13	2
+      0x001C0E0D,  //  0067  ADD	R7	R7	R13
+      0x002C1728,  //  0068  ADD	R11	R11	K40
+      0x7001FFF0,  //  0069  JMP		#005B
+      0x80041400,  //  006A  RET	1	R10
+      0x5C240A00,  //  006B  MOVE	R9	R5
+      0x5C280000,  //  006C  MOVE	R10	R0
+      0x5C2C0E00,  //  006D  MOVE	R11	R7
+      0x7C240400,  //  006E  CALL	R9	2
+      0x80041200,  //  006F  RET	1	R9
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ParameterizedObject_on_param_changed,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x1C0C0332,  //  0000  EQ	R3	R1	K50
+      0x780E0009,  //  0001  JMPF	R3	#000C
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x1C0C0403,  //  0003  EQ	R3	R2	R3
+      0x780E0003,  //  0004  JMPF	R3	#0009
+      0x8C0C0133,  //  0005  GETMET	R3	R0	K51
+      0x4C140000,  //  0006  LDNIL	R5
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x70020002,  //  0008  JMP		#000C
+      0x500C0000,  //  0009  LDBOOL	R3	0	0
+      0x1C0C0403,  //  000A  EQ	R3	R2	R3
+      0x780DFFFF,  //  000B  JMPF	R3	#000C
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_ParameterizedObject_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
     2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -15658,35 +15004,152 @@ be_local_closure(class_ParameterizedObject__get_param_def,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_ParameterizedObject,     /* shared constants */
-    be_str_weak(_get_param_def),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x740A0004,  //  0002  JMPT	R2	#0008
+      0x60080004,  //  0003  GETGBL	R2	G4
+      0x5C0C0200,  //  0004  MOVE	R3	R1
+      0x7C080200,  //  0005  CALL	R2	1
+      0x20080520,  //  0006  NE	R2	R2	K32
+      0x780A0000,  //  0007  JMPF	R2	#0009
+      0xB0061734,  //  0008  RAISE	1	K11	K52
+      0x90020801,  //  0009  SETMBR	R0	K4	R1
+      0x60080013,  //  000A  GETGBL	R2	G19
+      0x7C080000,  //  000B  CALL	R2	0
+      0x90020002,  //  000C  SETMBR	R0	K0	R2
+      0x8C080135,  //  000D  GETMET	R2	R0	K53
+      0x7C080200,  //  000E  CALL	R2	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_ParameterizedObject_start,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x88080104,  //  0003  GETMBR	R2	R0	K4
+      0x88040505,  //  0004  GETMBR	R1	R2	K5
+      0x88080112,  //  0005  GETMBR	R2	R0	K18
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x20080403,  //  0007  NE	R2	R2	R3
+      0x780A0000,  //  0008  JMPF	R2	#000A
+      0x90022401,  //  0009  SETMBR	R0	K18	R1
+      0x88080100,  //  000A  GETMBR	R2	R0	K0
+      0x500C0200,  //  000B  LDBOOL	R3	1	0
+      0x980A6403,  //  000C  SETIDX	R2	K50	R3
+      0x80040000,  //  000D  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_param
+********************************************************************/
+be_local_closure(class_ParameterizedObject_get_param,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(get_param),
     &be_const_str_solidified,
     ( &(const binstruction[26]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0006,  //  0001  GETGBL	R3	G6
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0002,  //  0004  JMPF	R3	#0008
+      0x880C0100,  //  0005  GETMBR	R3	R0	K0
+      0x940C0601,  //  0006  GETIDX	R3	R3	R1
+      0x80040600,  //  0007  RET	1	R3
+      0x8C0C0116,  //  0008  GETMET	R3	R0	K22
+      0x5C140200,  //  0009  MOVE	R5	R1
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000A,  //  000D  JMPF	R4	#0019
+      0x8C10010E,  //  000E  GETMET	R4	R0	K14
+      0x5C180600,  //  000F  MOVE	R6	R3
+      0x581C000F,  //  0010  LDCONST	R7	K15
+      0x7C100600,  //  0011  CALL	R4	3
+      0x78120005,  //  0012  JMPF	R4	#0019
+      0x8C100110,  //  0013  GETMET	R4	R0	K16
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x581C000F,  //  0015  LDCONST	R7	K15
+      0x5C200400,  //  0016  MOVE	R8	R2
+      0x7C100800,  //  0017  CALL	R4	4
+      0x80040800,  //  0018  RET	1	R4
+      0x80040400,  //  0019  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: constraint_mask
+********************************************************************/
+be_local_closure(class_ParameterizedObject_constraint_mask,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ParameterizedObject,     /* shared constants */
+    be_str_weak(constraint_mask),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x5808002C,  //  0000  LDCONST	R2	K44
+      0x600C000C,  //  0001  GETGBL	R3	G12
       0x5C100000,  //  0002  MOVE	R4	R0
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x78120010,  //  0006  JMPF	R4	#0018
-      0x8C100501,  //  0007  GETMET	R4	R2	K1
-      0x5C180600,  //  0008  MOVE	R6	R3
-      0x581C0002,  //  0009  LDCONST	R7	K2
-      0x7C100600,  //  000A  CALL	R4	3
-      0x78120006,  //  000B  JMPF	R4	#0013
-      0x88100702,  //  000C  GETMBR	R4	R3	K2
-      0x8C140901,  //  000D  GETMET	R5	R4	K1
-      0x5C1C0200,  //  000E  MOVE	R7	R1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x78160001,  //  0010  JMPF	R5	#0013
-      0x94140801,  //  0011  GETIDX	R5	R4	R1
-      0x80040A00,  //  0012  RET	1	R5
-      0x60100003,  //  0013  GETGBL	R4	G3
-      0x5C140600,  //  0014  MOVE	R5	R3
-      0x7C100200,  //  0015  CALL	R4	1
-      0x5C0C0800,  //  0016  MOVE	R3	R4
-      0x7001FFEB,  //  0017  JMP		#0004
-      0x4C100000,  //  0018  LDNIL	R4
-      0x80040800,  //  0019  RET	1	R4
+      0x240C0727,  //  0004  GT	R3	R3	K39
+      0x780E000A,  //  0005  JMPF	R3	#0011
+      0x880C052D,  //  0006  GETMBR	R3	R2	K45
+      0x8C0C072E,  //  0007  GETMET	R3	R3	K46
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x4C100000,  //  000A  LDNIL	R4
+      0x20100604,  //  000B  NE	R4	R3	R4
+      0x78120003,  //  000C  JMPF	R4	#0011
+      0x94100127,  //  000D  GETIDX	R4	R0	K39
+      0x38165003,  //  000E  SHL	R5	K40	R3
+      0x2C100805,  //  000F  AND	R4	R4	R5
+      0x80040800,  //  0010  RET	1	R4
+      0x80064E00,  //  0011  RET	1	K39
     })
   )
 );
@@ -15699,42 +15162,522 @@ be_local_closure(class_ParameterizedObject__get_param_def,   /* name */
 be_local_class(ParameterizedObject,
     3,
     NULL,
-    be_nested_map(23,
+    be_nested_map(26,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_init_parameter_values, -1), be_const_closure(class_ParameterizedObject__init_parameter_values_closure) },
-        { be_const_key_weak(get_param, 3), be_const_closure(class_ParameterizedObject_get_param_closure) },
+        { be_const_key_weak(get_param_value, -1), be_const_closure(class_ParameterizedObject_get_param_value_closure) },
+        { be_const_key_weak(values, 2), be_const_var(0) },
         { be_const_key_weak(engine, -1), be_const_var(1) },
-        { be_const_key_weak(get_param_metadata, -1), be_const_closure(class_ParameterizedObject_get_param_metadata_closure) },
-        { be_const_key_weak(_has_param, 8), be_const_closure(class_ParameterizedObject__has_param_closure) },
-        { be_const_key_weak(_X3D_X3D, -1), be_const_closure(class_ParameterizedObject__X3D_X3D_closure) },
-        { be_const_key_weak(start_time, 13), be_const_var(2) },
-        { be_const_key_weak(values, -1), be_const_var(0) },
         { be_const_key_weak(set_param, -1), be_const_closure(class_ParameterizedObject_set_param_closure) },
-        { be_const_key_weak(PARAMS, 21), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(is_running, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_bool(0) },
-        { be_const_key_weak(type, -1), be_nested_str_weak(bool) },
+        { be_const_key_weak(_get_param_def, -1), be_const_closure(class_ParameterizedObject__get_param_def_closure) },
+        { be_const_key_weak(_TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(7,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_nested_str_weak(int),
+        be_nested_str_weak(string),
+        be_nested_str_weak(bytes),
+        be_nested_str_weak(bool),
+        be_nested_str_weak(any),
+        be_nested_str_weak(instance),
+        be_nested_str_weak(function),
     }))    ) } )) },
+        { be_const_key_weak(_MASK, 17), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_nested_str_weak(min),
+        be_nested_str_weak(max),
+        be_nested_str_weak(default),
+        be_nested_str_weak(type),
+        be_nested_str_weak(enum),
+        be_nested_str_weak(nillable),
     }))    ) } )) },
+        { be_const_key_weak(_init_parameter_values, 1), be_const_closure(class_ParameterizedObject__init_parameter_values_closure) },
+        { be_const_key_weak(get_param, 10), be_const_closure(class_ParameterizedObject_get_param_closure) },
+        { be_const_key_weak(start, 24), be_const_closure(class_ParameterizedObject_start_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(class_ParameterizedObject_init_closure) },
+        { be_const_key_weak(member, 22), be_const_closure(class_ParameterizedObject_member_closure) },
+        { be_const_key_weak(_has_param, 20), be_const_closure(class_ParameterizedObject__has_param_closure) },
+        { be_const_key_weak(resolve_value, -1), be_const_closure(class_ParameterizedObject_resolve_value_closure) },
         { be_const_key_weak(_validate_param, -1), be_const_closure(class_ParameterizedObject__validate_param_closure) },
         { be_const_key_weak(setmember, -1), be_const_closure(class_ParameterizedObject_setmember_closure) },
-        { be_const_key_weak(_X21_X3D, -1), be_const_closure(class_ParameterizedObject__X21_X3D_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ParameterizedObject_on_param_changed_closure) },
-        { be_const_key_weak(start, 20), be_const_closure(class_ParameterizedObject_start_closure) },
-        { be_const_key_weak(_resolve_parameter_value, -1), be_const_closure(class_ParameterizedObject__resolve_parameter_value_closure) },
-        { be_const_key_weak(_fix_time_ms, 6), be_const_closure(class_ParameterizedObject__fix_time_ms_closure) },
-        { be_const_key_weak(member, -1), be_const_closure(class_ParameterizedObject_member_closure) },
-        { be_const_key_weak(resolve_value, -1), be_const_closure(class_ParameterizedObject_resolve_value_closure) },
-        { be_const_key_weak(get_param_value, 12), be_const_closure(class_ParameterizedObject_get_param_value_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_ParameterizedObject_init_closure) },
         { be_const_key_weak(_set_parameter_value, -1), be_const_closure(class_ParameterizedObject__set_parameter_value_closure) },
-        { be_const_key_weak(_get_param_def, -1), be_const_closure(class_ParameterizedObject__get_param_def_closure) },
+        { be_const_key_weak(_resolve_parameter_value, -1), be_const_closure(class_ParameterizedObject__resolve_parameter_value_closure) },
+        { be_const_key_weak(constraint_find, -1), be_const_static_closure(class_ParameterizedObject_constraint_find_closure) },
+        { be_const_key_weak(on_param_changed, 8), be_const_closure(class_ParameterizedObject_on_param_changed_closure) },
+        { be_const_key_weak(_fix_time_ms, -1), be_const_closure(class_ParameterizedObject__fix_time_ms_closure) },
+        { be_const_key_weak(_X3D_X3D, 9), be_const_closure(class_ParameterizedObject__X3D_X3D_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(is_running, -1), be_const_bytes_instance(0C050003) },
+    }))    ) } )) },
+        { be_const_key_weak(start_time, -1), be_const_var(2) },
+        { be_const_key_weak(_X21_X3D, 0), be_const_closure(class_ParameterizedObject__X21_X3D_closure) },
+        { be_const_key_weak(constraint_mask, -1), be_const_static_closure(class_ParameterizedObject_constraint_mask_closure) },
     })),
     be_str_weak(ParameterizedObject)
+);
+// compact class 'ColorCycleColorProvider' ktab size: 28, total: 53 (saved 200 bytes)
+static const bvalue be_ktab_class_ColorCycleColorProvider[28] = {
+  /* K0   */  be_nested_str_weak(palette),
+  /* K1   */  be_nested_str_weak(_get_param_def),
+  /* K2   */  be_nested_str_weak(constraint_mask),
+  /* K3   */  be_nested_str_weak(default),
+  /* K4   */  be_nested_str_weak(constraint_find),
+  /* K5   */  be_nested_str_weak(ColorCycleColorProvider_X28palette_size_X3D_X25s_X2C_X20cycle_period_X3D_X25s_X2C_X20mode_X3D_X25s_X2C_X20current_index_X3D_X25s_X29),
+  /* K6   */  be_nested_str_weak(_get_palette_size),
+  /* K7   */  be_nested_str_weak(cycle_period),
+  /* K8   */  be_nested_str_weak(manual),
+  /* K9   */  be_nested_str_weak(auto),
+  /* K10  */  be_nested_str_weak(current_index),
+  /* K11  */  be_nested_str_weak(_get_palette_bytes),
+  /* K12  */  be_nested_str_weak(on_param_changed),
+  /* K13  */  be_nested_str_weak(palette_size),
+  /* K14  */  be_nested_str_weak(values),
+  /* K15  */  be_nested_str_weak(value_error),
+  /* K16  */  be_nested_str_weak(Parameter_X20_X27palette_size_X27_X20is_X20read_X2Donly),
+  /* K17  */  be_const_int(0),
+  /* K18  */  be_nested_str_weak(current_color),
+  /* K19  */  be_nested_str_weak(_get_color_at_index),
+  /* K20  */  be_nested_str_weak(next),
+  /* K21  */  be_nested_str_weak(set_param),
+  /* K22  */  be_const_int(1),
+  /* K23  */  be_nested_str_weak(tasmota),
+  /* K24  */  be_nested_str_weak(scale_uint),
+  /* K25  */  be_nested_str_weak(init),
+  /* K26  */  be_nested_str_weak(get),
+  /* K27  */  be_const_int(-16777216),
+};
+
+
+extern const bclass be_class_ColorCycleColorProvider;
+
+/********************************************************************
+** Solidified function: _get_palette_bytes
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider__get_palette_bytes,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(_get_palette_bytes),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C080202,  //  0002  EQ	R2	R1	R2
+      0x780A0010,  //  0003  JMPF	R2	#0015
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x58100000,  //  0005  LDCONST	R4	K0
+      0x7C080400,  //  0006  CALL	R2	2
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x200C0403,  //  0008  NE	R3	R2	R3
+      0x780E000A,  //  0009  JMPF	R3	#0015
+      0x8C0C0102,  //  000A  GETMET	R3	R0	K2
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x58180003,  //  000C  LDCONST	R6	K3
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x780E0005,  //  000E  JMPF	R3	#0015
+      0x8C0C0104,  //  000F  GETMET	R3	R0	K4
+      0x5C140400,  //  0010  MOVE	R5	R2
+      0x58180003,  //  0011  LDCONST	R6	K3
+      0x4C1C0000,  //  0012  LDNIL	R7
+      0x7C0C0800,  //  0013  CALL	R3	4
+      0x5C040600,  //  0014  MOVE	R1	R3
+      0x80040200,  //  0015  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_tostring,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60040018,  //  0000  GETGBL	R1	G24
+      0x58080005,  //  0001  LDCONST	R2	K5
+      0x8C0C0106,  //  0002  GETMET	R3	R0	K6
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x88100107,  //  0004  GETMBR	R4	R0	K7
+      0x88140107,  //  0005  GETMBR	R5	R0	K7
+      0x78160001,  //  0006  JMPF	R5	#0009
+      0x58140008,  //  0007  LDCONST	R5	K8
+      0x70020000,  //  0008  JMP		#000A
+      0x58140009,  //  0009  LDCONST	R5	K9
+      0x8818010A,  //  000A  GETMBR	R6	R0	K10
+      0x7C040A00,  //  000B  CALL	R1	5
+      0x80040200,  //  000C  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _get_palette_size
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider__get_palette_size,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(_get_palette_size),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8C04010B,  //  0000  GETMET	R1	R0	K11
+      0x7C040200,  //  0001  CALL	R1	1
+      0x6008000C,  //  0002  GETGBL	R2	G12
+      0x5C0C0200,  //  0003  MOVE	R3	R1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x540E0003,  //  0005  LDINT	R3	4
+      0x0C080403,  //  0006  DIV	R2	R2	R3
+      0x80040400,  //  0007  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: on_param_changed
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_on_param_changed,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(on_param_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C070C,  //  0003  GETMET	R3	R3	K12
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x1C0C030D,  //  0007  EQ	R3	R1	K13
+      0x780E0005,  //  0008  JMPF	R3	#000F
+      0x880C010E,  //  0009  GETMBR	R3	R0	K14
+      0x8C100106,  //  000A  GETMET	R4	R0	K6
+      0x7C100200,  //  000B  CALL	R4	1
+      0x980E1A04,  //  000C  SETIDX	R3	K13	R4
+      0xB0061F10,  //  000D  RAISE	1	K15	K16
+      0x70020027,  //  000E  JMP		#0037
+      0x1C0C0300,  //  000F  EQ	R3	R1	K0
+      0x780E000E,  //  0010  JMPF	R3	#0020
+      0x8C0C0106,  //  0011  GETMET	R3	R0	K6
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0x24100711,  //  0013  GT	R4	R3	K17
+      0x78120007,  //  0014  JMPF	R4	#001D
+      0x8810010A,  //  0015  GETMBR	R4	R0	K10
+      0x28100803,  //  0016  GE	R4	R4	R3
+      0x78120000,  //  0017  JMPF	R4	#0019
+      0x90021511,  //  0018  SETMBR	R0	K10	K17
+      0x8C100113,  //  0019  GETMET	R4	R0	K19
+      0x8818010A,  //  001A  GETMBR	R6	R0	K10
+      0x7C100400,  //  001B  CALL	R4	2
+      0x90022404,  //  001C  SETMBR	R0	K18	R4
+      0x8810010E,  //  001D  GETMBR	R4	R0	K14
+      0x98121A03,  //  001E  SETIDX	R4	K13	R3
+      0x70020016,  //  001F  JMP		#0037
+      0x1C0C0314,  //  0020  EQ	R3	R1	K20
+      0x780E0014,  //  0021  JMPF	R3	#0037
+      0x200C0511,  //  0022  NE	R3	R2	K17
+      0x780E0012,  //  0023  JMPF	R3	#0037
+      0x8C0C0106,  //  0024  GETMET	R3	R0	K6
+      0x7C0C0200,  //  0025  CALL	R3	1
+      0x24100711,  //  0026  GT	R4	R3	K17
+      0x7812000A,  //  0027  JMPF	R4	#0033
+      0x8810010A,  //  0028  GETMBR	R4	R0	K10
+      0x00100802,  //  0029  ADD	R4	R4	R2
+      0x10100803,  //  002A  MOD	R4	R4	R3
+      0x14140911,  //  002B  LT	R5	R4	K17
+      0x78160000,  //  002C  JMPF	R5	#002E
+      0x00100803,  //  002D  ADD	R4	R4	R3
+      0x90021404,  //  002E  SETMBR	R0	K10	R4
+      0x8C140113,  //  002F  GETMET	R5	R0	K19
+      0x881C010A,  //  0030  GETMBR	R7	R0	K10
+      0x7C140400,  //  0031  CALL	R5	2
+      0x90022405,  //  0032  SETMBR	R0	K18	R5
+      0x8C100115,  //  0033  GETMET	R4	R0	K21
+      0x58180014,  //  0034  LDCONST	R6	K20
+      0x581C0011,  //  0035  LDCONST	R7	K17
+      0x7C100600,  //  0036  CALL	R4	3
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0x880C0107,  //  0000  GETMBR	R3	R0	K7
+      0x8C100106,  //  0001  GETMET	R4	R0	K6
+      0x7C100200,  //  0002  CALL	R4	1
+      0x1C140911,  //  0003  EQ	R5	R4	K17
+      0x78160001,  //  0004  JMPF	R5	#0007
+      0x5415FFFE,  //  0005  LDINT	R5	-1
+      0x80040A00,  //  0006  RET	1	R5
+      0x1C140916,  //  0007  EQ	R5	R4	K22
+      0x78160005,  //  0008  JMPF	R5	#000F
+      0x8C140113,  //  0009  GETMET	R5	R0	K19
+      0x581C0011,  //  000A  LDCONST	R7	K17
+      0x7C140400,  //  000B  CALL	R5	2
+      0x90022405,  //  000C  SETMBR	R0	K18	R5
+      0x88140112,  //  000D  GETMBR	R5	R0	K18
+      0x80040A00,  //  000E  RET	1	R5
+      0x1C140711,  //  000F  EQ	R5	R3	K17
+      0x78160001,  //  0010  JMPF	R5	#0013
+      0x88140112,  //  0011  GETMBR	R5	R0	K18
+      0x80040A00,  //  0012  RET	1	R5
+      0x10140403,  //  0013  MOD	R5	R2	R3
+      0xB81A2E00,  //  0014  GETNGBL	R6	K23
+      0x8C180D18,  //  0015  GETMET	R6	R6	K24
+      0x5C200A00,  //  0016  MOVE	R8	R5
+      0x58240011,  //  0017  LDCONST	R9	K17
+      0x04280716,  //  0018  SUB	R10	R3	K22
+      0x582C0011,  //  0019  LDCONST	R11	K17
+      0x04300916,  //  001A  SUB	R12	R4	K22
+      0x7C180C00,  //  001B  CALL	R6	6
+      0x281C0C04,  //  001C  GE	R7	R6	R4
+      0x781E0001,  //  001D  JMPF	R7	#0020
+      0x041C0916,  //  001E  SUB	R7	R4	K22
+      0x5C180E00,  //  001F  MOVE	R6	R7
+      0x90021406,  //  0020  SETMBR	R0	K10	R6
+      0x8C1C0113,  //  0021  GETMET	R7	R0	K19
+      0x5C240C00,  //  0022  MOVE	R9	R6
+      0x7C1C0400,  //  0023  CALL	R7	2
+      0x90022407,  //  0024  SETMBR	R0	K18	R7
+      0x881C0112,  //  0025  GETMBR	R7	R0	K18
+      0x80040E00,  //  0026  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color_for_value
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_get_color_for_value,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(get_color_for_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0x8C0C0106,  //  0000  GETMET	R3	R0	K6
+      0x7C0C0200,  //  0001  CALL	R3	1
+      0x1C100711,  //  0002  EQ	R4	R3	K17
+      0x78120001,  //  0003  JMPF	R4	#0006
+      0x5411FFFE,  //  0004  LDINT	R4	-1
+      0x80040800,  //  0005  RET	1	R4
+      0x1C100716,  //  0006  EQ	R4	R3	K22
+      0x78120003,  //  0007  JMPF	R4	#000C
+      0x8C100113,  //  0008  GETMET	R4	R0	K19
+      0x58180011,  //  0009  LDCONST	R6	K17
+      0x7C100400,  //  000A  CALL	R4	2
+      0x80040800,  //  000B  RET	1	R4
+      0x14100311,  //  000C  LT	R4	R1	K17
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x58040011,  //  000E  LDCONST	R1	K17
+      0x70020003,  //  000F  JMP		#0014
+      0x54120063,  //  0010  LDINT	R4	100
+      0x24100204,  //  0011  GT	R4	R1	R4
+      0x78120000,  //  0012  JMPF	R4	#0014
+      0x54060063,  //  0013  LDINT	R1	100
+      0xB8122E00,  //  0014  GETNGBL	R4	K23
+      0x8C100918,  //  0015  GETMET	R4	R4	K24
+      0x5C180200,  //  0016  MOVE	R6	R1
+      0x581C0011,  //  0017  LDCONST	R7	K17
+      0x54220063,  //  0018  LDINT	R8	100
+      0x58240011,  //  0019  LDCONST	R9	K17
+      0x04280716,  //  001A  SUB	R10	R3	K22
+      0x7C100C00,  //  001B  CALL	R4	6
+      0x28140803,  //  001C  GE	R5	R4	R3
+      0x78160001,  //  001D  JMPF	R5	#0020
+      0x04140716,  //  001E  SUB	R5	R3	K22
+      0x5C100A00,  //  001F  MOVE	R4	R5
+      0x8C140113,  //  0020  GETMET	R5	R0	K19
+      0x5C1C0800,  //  0021  MOVE	R7	R4
+      0x7C140400,  //  0022  CALL	R5	2
+      0x80040A00,  //  0023  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080519,  //  0003  GETMET	R2	R2	K25
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C08010B,  //  0006  GETMET	R2	R0	K11
+      0x7C080200,  //  0007  CALL	R2	1
+      0x8C0C0113,  //  0008  GETMET	R3	R0	K19
+      0x58140011,  //  0009  LDCONST	R5	K17
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x90022403,  //  000B  SETMBR	R0	K18	R3
+      0x90021511,  //  000C  SETMBR	R0	K10	K17
+      0x880C010E,  //  000D  GETMBR	R3	R0	K14
+      0x8C100106,  //  000E  GETMET	R4	R0	K6
+      0x7C100200,  //  000F  CALL	R4	1
+      0x980E1A04,  //  0010  SETIDX	R3	K13	R4
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _get_color_at_index
+********************************************************************/
+be_local_closure(class_ColorCycleColorProvider__get_color_at_index,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_ColorCycleColorProvider,     /* shared constants */
+    be_str_weak(_get_color_at_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x8C08010B,  //  0000  GETMET	R2	R0	K11
+      0x7C080200,  //  0001  CALL	R2	1
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100400,  //  0003  MOVE	R4	R2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x54120003,  //  0005  LDINT	R4	4
+      0x0C0C0604,  //  0006  DIV	R3	R3	R4
+      0x1C100711,  //  0007  EQ	R4	R3	K17
+      0x74120003,  //  0008  JMPT	R4	#000D
+      0x14100311,  //  0009  LT	R4	R1	K17
+      0x74120001,  //  000A  JMPT	R4	#000D
+      0x28100203,  //  000B  GE	R4	R1	R3
+      0x78120001,  //  000C  JMPF	R4	#000F
+      0x5411FFFE,  //  000D  LDINT	R4	-1
+      0x80040800,  //  000E  RET	1	R4
+      0x8C10051A,  //  000F  GETMET	R4	R2	K26
+      0x541A0003,  //  0010  LDINT	R6	4
+      0x08180206,  //  0011  MUL	R6	R1	R6
+      0x541DFFFB,  //  0012  LDINT	R7	-4
+      0x7C100600,  //  0013  CALL	R4	3
+      0x3010091B,  //  0014  OR	R4	R4	K27
+      0x80040800,  //  0015  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: ColorCycleColorProvider
+********************************************************************/
+extern const bclass be_class_ColorProvider;
+be_local_class(ColorCycleColorProvider,
+    2,
+    &be_class_ColorProvider,
+    be_nested_map(11,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(_get_color_at_index, -1), be_const_closure(class_ColorCycleColorProvider__get_color_at_index_closure) },
+        { be_const_key_weak(_get_palette_size, -1), be_const_closure(class_ColorCycleColorProvider__get_palette_size_closure) },
+        { be_const_key_weak(current_color, 6), be_const_var(0) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_ColorCycleColorProvider_tostring_closure) },
+        { be_const_key_weak(_get_palette_bytes, 1), be_const_closure(class_ColorCycleColorProvider__get_palette_bytes_closure) },
+        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ColorCycleColorProvider_on_param_changed_closure) },
+        { be_const_key_weak(current_index, -1), be_const_var(1) },
+        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorCycleColorProvider_get_color_for_value_closure) },
+        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(4,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(palette, 2), be_const_bytes_instance(0C040C00FF0000FFFF00FF00FFFF000002) },
+        { be_const_key_weak(palette_size, -1), be_const_bytes_instance(0C000300) },
+        { be_const_key_weak(next, 1), be_const_bytes_instance(040000) },
+        { be_const_key_weak(cycle_period, -1), be_const_bytes_instance(050000018813) },
+    }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(class_ColorCycleColorProvider_init_closure) },
+        { be_const_key_weak(produce_value, 0), be_const_closure(class_ColorCycleColorProvider_produce_value_closure) },
+    })),
+    be_str_weak(ColorCycleColorProvider)
 );
 // compact class 'GradientAnimation' ktab size: 45, total: 84 (saved 312 bytes)
 static const bvalue be_ktab_class_GradientAnimation[45] = {
@@ -16400,199 +16343,54 @@ be_local_class(GradientAnimation,
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(direction, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(center_pos, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(128) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(gradient_type, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(1) },
-    }))    ) } )) },
-        { be_const_key_weak(color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, 1), be_const_nil() },
-        { be_const_key_weak(nillable, -1), be_const_bool(1) },
-    }))    ) } )) },
-        { be_const_key_weak(movement_speed, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(spread, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(spread, -1), be_const_bytes_instance(07000101FF0001FF00) },
+        { be_const_key_weak(center_pos, -1), be_const_bytes_instance(07000001FF00018000) },
+        { be_const_key_weak(gradient_type, 0), be_const_bytes_instance(07000000010000) },
+        { be_const_key_weak(movement_speed, 5), be_const_bytes_instance(07000001FF000000) },
+        { be_const_key_weak(direction, 3), be_const_bytes_instance(07000001FF000000) },
+        { be_const_key_weak(color, -1), be_const_bytes_instance(2406) },
     }))    ) } )) },
         { be_const_key_weak(init, -1), be_const_closure(class_GradientAnimation_init_closure) },
         { be_const_key_weak(_calculate_radial_position, -1), be_const_closure(class_GradientAnimation__calculate_radial_position_closure) },
     })),
     be_str_weak(GradientAnimation)
 );
-// compact class 'IterationNumberProvider' ktab size: 4, total: 6 (saved 16 bytes)
-static const bvalue be_ktab_class_IterationNumberProvider[4] = {
-  /* K0   */  be_nested_str_weak(engine),
-  /* K1   */  be_nested_str_weak(get_current_iteration_number),
-  /* K2   */  be_nested_str_weak(IterationNumberProvider_X28current_X3A_X20_X25s_X29),
-  /* K3   */  be_nested_str_weak(IterationNumberProvider_X28not_in_sequence_X29),
-};
-
-
-extern const bclass be_class_IterationNumberProvider;
 
 /********************************************************************
-** Solidified function: produce_value
+** Solidified function: gradient_two_color_linear
 ********************************************************************/
-be_local_closure(class_IterationNumberProvider_produce_value,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_IterationNumberProvider,     /* shared constants */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x80040600,  //  0003  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_IterationNumberProvider_tostring,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_IterationNumberProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x4C080000,  //  0003  LDNIL	R2
-      0x20080202,  //  0004  NE	R2	R1	R2
-      0x780A0005,  //  0005  JMPF	R2	#000C
-      0x60080018,  //  0006  GETGBL	R2	G24
-      0x580C0002,  //  0007  LDCONST	R3	K2
-      0x5C100200,  //  0008  MOVE	R4	R1
-      0x7C080400,  //  0009  CALL	R2	2
-      0x80040400,  //  000A  RET	1	R2
-      0x70020000,  //  000B  JMP		#000D
-      0x80060600,  //  000C  RET	1	K3
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: IterationNumberProvider
-********************************************************************/
-extern const bclass be_class_ValueProvider;
-be_local_class(IterationNumberProvider,
-    0,
-    &be_class_ValueProvider,
-    be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(produce_value, 2), be_const_closure(class_IterationNumberProvider_produce_value_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(class_IterationNumberProvider_tostring_closure) },
-        { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(0,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-    }))    ) } )) },
-    })),
-    be_str_weak(IterationNumberProvider)
-);
-
-extern const bclass be_class_ColorProvider;
-
-/********************************************************************
-** Solidified function: produce_value
-********************************************************************/
-be_local_closure(class_ColorProvider_produce_value,   /* name */
+be_local_closure(gradient_two_color_linear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(produce_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x540DFFFE,  //  0000  LDINT	R3	-1
-      0x80040600,  //  0001  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_color_for_value
-********************************************************************/
-be_local_closure(class_ColorProvider_get_color_for_value,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
+    1,                          /* argc */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(produce_value),
-    /* K1   */  be_nested_str_weak(color),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(gradient_animation),
+    /* K2   */  be_nested_str_weak(color),
+    /* K3   */  be_nested_str_weak(gradient_type),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(direction),
+    /* K6   */  be_nested_str_weak(movement_speed),
     }),
-    be_str_weak(get_color_for_value),
+    be_str_weak(gradient_two_color_linear),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x58140001,  //  0001  LDCONST	R5	K1
-      0x5C180400,  //  0002  MOVE	R6	R2
-      0x7C0C0600,  //  0003  CALL	R3	3
-      0x80040600,  //  0004  RET	1	R3
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x5408FFFF,  //  0004  LDINT	R2	-65536
+      0x90060402,  //  0005  SETMBR	R1	K2	R2
+      0x90060704,  //  0006  SETMBR	R1	K3	K4
+      0x90060B04,  //  0007  SETMBR	R1	K5	K4
+      0x90060D04,  //  0008  SETMBR	R1	K6	K4
+      0x80040200,  //  0009  RET	1	R1
     })
   )
 );
@@ -16600,19 +16398,41 @@ be_local_closure(class_ColorProvider_get_color_for_value,   /* name */
 
 
 /********************************************************************
-** Solidified class: ColorProvider
+** Solidified function: pulsating_animation
 ********************************************************************/
-extern const bclass be_class_ValueProvider;
-be_local_class(ColorProvider,
-    0,
-    &be_class_ValueProvider,
-    be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorProvider_get_color_for_value_closure) },
-        { be_const_key_weak(produce_value, 0), be_const_closure(class_ColorProvider_produce_value_closure) },
-    })),
-    be_str_weak(ColorProvider)
+be_local_closure(pulsating_animation,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animation),
+    /* K1   */  be_nested_str_weak(breathe_animation),
+    /* K2   */  be_nested_str_weak(curve_factor),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(period),
+    }),
+    be_str_weak(pulsating_animation),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90060503,  //  0004  SETMBR	R1	K2	K3
+      0x540A03E7,  //  0005  LDINT	R2	1000
+      0x90060802,  //  0006  SETMBR	R1	K4	R2
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
 );
+/*******************************************************************/
+
 // compact class 'BreatheColorProvider' ktab size: 18, total: 29 (saved 88 bytes)
 static const bvalue be_ktab_class_BreatheColorProvider[18] = {
   /* K0   */  be_nested_str_weak(BreatheColorProvider_X28base_color_X3D0x_X2508x_X2C_X20min_brightness_X3D_X25s_X2C_X20max_brightness_X3D_X25s_X2C_X20duration_X3D_X25s_X2C_X20curve_factor_X3D_X25s_X29),
@@ -16885,230 +16705,32 @@ be_local_class(BreatheColorProvider,
         { be_const_key_weak(PARAMS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(base_color, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(-1) },
-    }))    ) } )) },
-        { be_const_key_weak(max_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(255) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
-        { be_const_key_weak(curve_factor, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(2) },
-        { be_const_key_weak(min, -1), be_const_int(1) },
-        { be_const_key_weak(max, 1), be_const_int(5) },
-    }))    ) } )) },
-        { be_const_key_weak(min_brightness, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(3,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_int(0) },
-        { be_const_key_weak(min, -1), be_const_int(0) },
-        { be_const_key_weak(max, 1), be_const_int(255) },
-    }))    ) } )) },
+        { be_const_key_weak(base_color, -1), be_const_bytes_instance(0400FF) },
+        { be_const_key_weak(max_brightness, -1), be_const_bytes_instance(07000001FF0001FF00) },
+        { be_const_key_weak(curve_factor, -1), be_const_bytes_instance(07000100050002) },
+        { be_const_key_weak(min_brightness, -1), be_const_bytes_instance(07000001FF000000) },
     }))    ) } )) },
         { be_const_key_weak(produce_value, -1), be_const_closure(class_BreatheColorProvider_produce_value_closure) },
     })),
     be_str_weak(BreatheColorProvider)
 );
-
-/********************************************************************
-** Solidified function: pulsating_color_provider
-********************************************************************/
-be_local_closure(pulsating_color_provider,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(breathe_color),
-    /* K2   */  be_nested_str_weak(curve_factor),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(duration),
-    }),
-    be_str_weak(pulsating_color_provider),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90060503,  //  0004  SETMBR	R1	K2	K3
-      0x540A03E7,  //  0005  LDINT	R2	1000
-      0x90060802,  //  0006  SETMBR	R1	K4	R2
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: noise_fractal
-********************************************************************/
-be_local_closure(noise_fractal,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(noise_animation),
-    /* K2   */  be_nested_str_weak(rich_palette),
-    /* K3   */  be_nested_str_weak(palette),
-    /* K4   */  be_nested_str_weak(PALETTE_RAINBOW),
-    /* K5   */  be_nested_str_weak(cycle_period),
-    /* K6   */  be_nested_str_weak(transition_type),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(brightness),
-    /* K9   */  be_nested_str_weak(range_min),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(range_max),
-    /* K12  */  be_nested_str_weak(color),
-    /* K13  */  be_nested_str_weak(scale),
-    /* K14  */  be_nested_str_weak(speed),
-    /* K15  */  be_nested_str_weak(octaves),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(persistence),
-    }),
-    be_str_weak(noise_fractal),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0xB80E0000,  //  0008  GETNGBL	R3	K0
-      0x880C0704,  //  0009  GETMBR	R3	R3	K4
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0x540E1387,  //  000B  LDINT	R3	5000
-      0x900A0A03,  //  000C  SETMBR	R2	K5	R3
-      0x900A0D07,  //  000D  SETMBR	R2	K6	K7
-      0x540E00FE,  //  000E  LDINT	R3	255
-      0x900A1003,  //  000F  SETMBR	R2	K8	R3
-      0x900A130A,  //  0010  SETMBR	R2	K9	K10
-      0x540E00FE,  //  0011  LDINT	R3	255
-      0x900A1603,  //  0012  SETMBR	R2	K11	R3
-      0x90061802,  //  0013  SETMBR	R1	K12	R2
-      0x540E001D,  //  0014  LDINT	R3	30
-      0x90061A03,  //  0015  SETMBR	R1	K13	R3
-      0x540E0013,  //  0016  LDINT	R3	20
-      0x90061C03,  //  0017  SETMBR	R1	K14	R3
-      0x90061F10,  //  0018  SETMBR	R1	K15	K16
-      0x540E007F,  //  0019  LDINT	R3	128
-      0x90062203,  //  001A  SETMBR	R1	K17	R3
-      0x80040200,  //  001B  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-// compact class 'ClosureValueProvider' ktab size: 7, total: 9 (saved 16 bytes)
-static const bvalue be_ktab_class_ClosureValueProvider[7] = {
-  /* K0   */  be_nested_str_weak(ClosureValueProvider_X28_X25s_X29),
-  /* K1   */  be_nested_str_weak(_closure),
-  /* K2   */  be_nested_str_weak(closure_X20set),
-  /* K3   */  be_nested_str_weak(no_X20closure),
-  /* K4   */  be_nested_str_weak(on_param_changed),
-  /* K5   */  be_nested_str_weak(closure),
-  /* K6   */  be_nested_str_weak(engine),
+// compact class 'IterationNumberProvider' ktab size: 4, total: 6 (saved 16 bytes)
+static const bvalue be_ktab_class_IterationNumberProvider[4] = {
+  /* K0   */  be_nested_str_weak(engine),
+  /* K1   */  be_nested_str_weak(get_current_iteration_number),
+  /* K2   */  be_nested_str_weak(IterationNumberProvider_X28current_X3A_X20_X25s_X29),
+  /* K3   */  be_nested_str_weak(IterationNumberProvider_X28not_in_sequence_X29),
 };
 
 
-extern const bclass be_class_ClosureValueProvider;
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(class_ClosureValueProvider_tostring,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ClosureValueProvider,     /* shared constants */
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040018,  //  0000  GETGBL	R1	G24
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x780E0001,  //  0003  JMPF	R3	#0006
-      0x580C0002,  //  0004  LDCONST	R3	K2
-      0x70020000,  //  0005  JMP		#0007
-      0x580C0003,  //  0006  LDCONST	R3	K3
-      0x7C040400,  //  0007  CALL	R1	2
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: on_param_changed
-********************************************************************/
-be_local_closure(class_ClosureValueProvider_on_param_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_ClosureValueProvider,     /* shared constants */
-    be_str_weak(on_param_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x1C0C0305,  //  0007  EQ	R3	R1	K5
-      0x780E0000,  //  0008  JMPF	R3	#000A
-      0x90020202,  //  0009  SETMBR	R0	K1	R2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
+extern const bclass be_class_IterationNumberProvider;
 
 /********************************************************************
 ** Solidified function: produce_value
 ********************************************************************/
-be_local_closure(class_ClosureValueProvider_produce_value,   /* name */
+be_local_closure(class_IterationNumberProvider_produce_value,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    5,                          /* nstack */
     3,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -17116,22 +16738,14 @@ be_local_closure(class_ClosureValueProvider_produce_value,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    &be_ktab_class_ClosureValueProvider,     /* shared constants */
+    &be_ktab_class_IterationNumberProvider,     /* shared constants */
     be_str_weak(produce_value),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x880C0101,  //  0000  GETMBR	R3	R0	K1
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C100604,  //  0002  EQ	R4	R3	R4
-      0x78120001,  //  0003  JMPF	R4	#0006
-      0x4C100000,  //  0004  LDNIL	R4
-      0x80040800,  //  0005  RET	1	R4
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x88140106,  //  0007  GETMBR	R5	R0	K6
-      0x5C180200,  //  0008  MOVE	R6	R1
-      0x5C1C0400,  //  0009  MOVE	R7	R2
-      0x7C100600,  //  000A  CALL	R4	3
-      0x80040800,  //  000B  RET	1	R4
+    ( &(const binstruction[ 4]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x80040600,  //  0003  RET	1	R3
     })
   )
 );
@@ -17139,30 +16753,132 @@ be_local_closure(class_ClosureValueProvider_produce_value,   /* name */
 
 
 /********************************************************************
-** Solidified class: ClosureValueProvider
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(class_IterationNumberProvider_tostring,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_IterationNumberProvider,     /* shared constants */
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x20080202,  //  0004  NE	R2	R1	R2
+      0x780A0005,  //  0005  JMPF	R2	#000C
+      0x60080018,  //  0006  GETGBL	R2	G24
+      0x580C0002,  //  0007  LDCONST	R3	K2
+      0x5C100200,  //  0008  MOVE	R4	R1
+      0x7C080400,  //  0009  CALL	R2	2
+      0x80040400,  //  000A  RET	1	R2
+      0x70020000,  //  000B  JMP		#000D
+      0x80060600,  //  000C  RET	1	K3
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: IterationNumberProvider
 ********************************************************************/
 extern const bclass be_class_ValueProvider;
-be_local_class(ClosureValueProvider,
-    1,
+be_local_class(IterationNumberProvider,
+    0,
     &be_class_ValueProvider,
-    be_nested_map(5,
+    be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(tostring, -1), be_const_closure(class_ClosureValueProvider_tostring_closure) },
+        { be_const_key_weak(produce_value, 2), be_const_closure(class_IterationNumberProvider_produce_value_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(class_IterationNumberProvider_tostring_closure) },
         { be_const_key_weak(PARAMS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
+        be_const_map( *     be_nested_map(0,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(closure, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(default, -1), be_const_nil() },
-        { be_const_key_weak(type, -1), be_nested_str_weak(function) },
     }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(_closure, 4), be_const_var(0) },
-        { be_const_key_weak(produce_value, 1), be_const_closure(class_ClosureValueProvider_produce_value_closure) },
-        { be_const_key_weak(on_param_changed, -1), be_const_closure(class_ClosureValueProvider_on_param_changed_closure) },
     })),
-    be_str_weak(ClosureValueProvider)
+    be_str_weak(IterationNumberProvider)
+);
+
+extern const bclass be_class_ColorProvider;
+
+/********************************************************************
+** Solidified function: produce_value
+********************************************************************/
+be_local_closure(class_ColorProvider_produce_value,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(produce_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x540DFFFE,  //  0000  LDINT	R3	-1
+      0x80040600,  //  0001  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_color_for_value
+********************************************************************/
+be_local_closure(class_ColorProvider_get_color_for_value,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(produce_value),
+    /* K1   */  be_nested_str_weak(color),
+    }),
+    be_str_weak(get_color_for_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x58140001,  //  0001  LDCONST	R5	K1
+      0x5C180400,  //  0002  MOVE	R6	R2
+      0x7C0C0600,  //  0003  CALL	R3	3
+      0x80040600,  //  0004  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: ColorProvider
+********************************************************************/
+extern const bclass be_class_ValueProvider;
+be_local_class(ColorProvider,
+    0,
+    &be_class_ValueProvider,
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(get_color_for_value, -1), be_const_closure(class_ColorProvider_get_color_for_value_closure) },
+        { be_const_key_weak(produce_value, 0), be_const_closure(class_ColorProvider_produce_value_closure) },
+    })),
+    be_str_weak(ColorProvider)
 );
 
 extern const bclass be_class_ValueProvider;
@@ -17248,148 +16964,111 @@ be_local_class(ValueProvider,
 );
 
 /********************************************************************
-** Solidified function: ease_in
-********************************************************************/
-be_local_closure(ease_in,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animation),
-    /* K1   */  be_nested_str_weak(oscillator_value),
-    /* K2   */  be_nested_str_weak(form),
-    /* K3   */  be_nested_str_weak(EASE_IN),
-    }),
-    be_str_weak(ease_in),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0xB80A0000,  //  0004  GETNGBL	R2	K0
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x90060402,  //  0006  SETMBR	R1	K2	R2
-      0x80040200,  //  0007  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified module: animation
 ********************************************************************/
 be_local_module(animation,
     "animation",
-    be_nested_map(100,
+    be_nested_map(99,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(ease_in, -1), be_const_closure(ease_in_closure) },
-        { be_const_key_weak(PALETTE_OCEAN, -1), be_const_bytes_instance(00000080400000FF8000FFFFC000FF80FF008000) },
-        { be_const_key_weak(noise_single_color, 61), be_const_closure(noise_single_color_closure) },
-        { be_const_key_weak(register_user_function, -1), be_const_closure(register_user_function_closure) },
-        { be_const_key_weak(register_event_handler, 31), be_const_closure(register_event_handler_closure) },
-        { be_const_key_weak(animation, -1), be_const_class(be_class_Animation) },
-        { be_const_key_weak(comet_animation, 19), be_const_class(be_class_CometAnimation) },
-        { be_const_key_weak(clear_all_event_handlers, 18), be_const_closure(clear_all_event_handlers_closure) },
-        { be_const_key_weak(BOUNCE, -1), be_const_int(9) },
-        { be_const_key_weak(closure_value, -1), be_const_class(be_class_ClosureValueProvider) },
-        { be_const_key_weak(gradient_rainbow_radial, 90), be_const_closure(gradient_rainbow_radial_closure) },
-        { be_const_key_weak(list_user_functions, -1), be_const_closure(list_user_functions_closure) },
-        { be_const_key_weak(get_user_function, 45), be_const_closure(get_user_function_closure) },
-        { be_const_key_weak(wave_animation, -1), be_const_class(be_class_WaveAnimation) },
-        { be_const_key_weak(COSINE, -1), be_const_int(4) },
-        { be_const_key_weak(set_event_active, 69), be_const_closure(set_event_active_closure) },
-        { be_const_key_weak(noise_rainbow, 23), be_const_closure(noise_rainbow_closure) },
-        { be_const_key_weak(crenel_position_animation, -1), be_const_class(be_class_CrenelPositionAnimation) },
-        { be_const_key_weak(noise_fractal, 3), be_const_closure(noise_fractal_closure) },
-        { be_const_key_weak(pulsating_color, 39), be_const_closure(pulsating_color_provider_closure) },
-        { be_const_key_weak(SINE, 77), be_const_int(5) },
-        { be_const_key_weak(trigger_event, -1), be_const_closure(trigger_event_closure) },
-        { be_const_key_weak(PALETTE_SUNSET_TICKS, 37), be_const_bytes_instance(28FF450028FF8C0028FFD70028FF69B4288000802819197000000080) },
-        { be_const_key_weak(PALETTE_FOREST, 42), be_const_bytes_instance(0000640040228B228032CD32C09AFF9AFF90EE90) },
-        { be_const_key_weak(gradient_animation, -1), be_const_class(be_class_GradientAnimation) },
-        { be_const_key_weak(frame_buffer, -1), be_const_class(be_class_FrameBuffer) },
-        { be_const_key_weak(SQUARE, -1), be_const_int(3) },
-        { be_const_key_weak(static_color, -1), be_const_class(be_class_StaticColorProvider) },
-        { be_const_key_weak(composite_color, 86), be_const_class(be_class_CompositeColorProvider) },
-        { be_const_key_weak(color_provider, 21), be_const_class(be_class_ColorProvider) },
-        { be_const_key_weak(iteration_number, -1), be_const_class(be_class_IterationNumberProvider) },
-        { be_const_key_weak(parameterized_object, 64), be_const_class(be_class_ParameterizedObject) },
-        { be_const_key_weak(ELASTIC, 29), be_const_int(8) },
-        { be_const_key_weak(TRIANGLE, 38), be_const_int(2) },
-        { be_const_key_weak(init, -1), be_const_closure(animation_init_closure) },
-        { be_const_key_weak(breathe_animation, 0), be_const_class(be_class_BreatheAnimation) },
-        { be_const_key_weak(PALETTE_RGB, -1), be_const_bytes_instance(00FF00008000FF00FF0000FF) },
-        { be_const_key_weak(twinkle_animation, 75), be_const_class(be_class_TwinkleAnimation) },
-        { be_const_key_weak(create_closure_value, -1), be_const_closure(create_closure_value_closure) },
-        { be_const_key_weak(strip_length, -1), be_const_class(be_class_StripLengthProvider) },
-        { be_const_key_weak(gradient_two_color_linear, -1), be_const_closure(gradient_two_color_linear_closure) },
-        { be_const_key_weak(palette_wave_animation, -1), be_const_class(be_class_PaletteWaveAnimation) },
-        { be_const_key_weak(event_handler, -1), be_const_class(be_class_EventHandler) },
-        { be_const_key_weak(smooth, -1), be_const_closure(smooth_closure) },
-        { be_const_key_weak(sawtooth, 89), be_const_closure(sawtooth_closure) },
-        { be_const_key_weak(solid, 87), be_const_closure(solid_closure) },
-        { be_const_key_weak(rich_palette_rainbow, -1), be_const_closure(rich_palette_rainbow_closure) },
-        { be_const_key_weak(rich_palette, 97), be_const_class(be_class_RichPaletteColorProvider) },
-        { be_const_key_weak(beacon_animation, -1), be_const_class(be_class_BeaconAnimation) },
-        { be_const_key_weak(get_event_handlers, -1), be_const_closure(get_event_handlers_closure) },
-        { be_const_key_weak(cosine_osc, -1), be_const_closure(cosine_osc_closure) },
-        { be_const_key_weak(SequenceManager, 67), be_const_class(be_class_SequenceManager) },
-        { be_const_key_weak(twinkle_classic, -1), be_const_closure(twinkle_classic_closure) },
-        { be_const_key_weak(bounce, 91), be_const_closure(bounce_closure) },
-        { be_const_key_weak(rich_palette_animation, -1), be_const_class(be_class_RichPaletteAnimation) },
-        { be_const_key_weak(wave_single_sine, 34), be_const_closure(wave_single_sine_closure) },
-        { be_const_key_weak(SAWTOOTH, -1), be_const_int(1) },
-        { be_const_key_weak(color_cycle, 85), be_const_class(be_class_ColorCycleColorProvider) },
-        { be_const_key_weak(EventManager, -1), be_const_class(be_class_EventManager) },
-        { be_const_key_weak(wave_rainbow_sine, -1), be_const_closure(wave_rainbow_sine_closure) },
-        { be_const_key_weak(ease_out, -1), be_const_closure(ease_out_closure) },
-        { be_const_key_weak(wave_custom, -1), be_const_closure(wave_custom_closure) },
-        { be_const_key_weak(twinkle_intense, 94), be_const_closure(twinkle_intense_closure) },
-        { be_const_key_weak(ramp, 70), be_const_closure(ramp_closure) },
-        { be_const_key_weak(get_registered_events, -1), be_const_closure(get_registered_events_closure) },
-        { be_const_key_weak(triangle, 71), be_const_closure(triangle_closure) },
-        { be_const_key_weak(VERSION, -1), be_const_int(65536) },
-        { be_const_key_weak(is_color_provider, 66), be_const_closure(is_color_provider_closure) },
-        { be_const_key_weak(noise_animation, -1), be_const_class(be_class_NoiseAnimation) },
-        { be_const_key_weak(twinkle_solid, -1), be_const_closure(twinkle_solid_closure) },
-        { be_const_key_weak(PALETTE_RAINBOW, -1), be_const_bytes_instance(00FF000024FFA50049FFFF006E00FF00920000FFB74B0082DBEE82EEFFFF0000) },
-        { be_const_key_weak(version_string, -1), be_const_closure(animation_version_string_closure) },
-        { be_const_key_weak(LINEAR, 49), be_const_int(1) },
-        { be_const_key_weak(PALETTE_FIRE, 63), be_const_bytes_instance(000000004080000080FF0000C0FF8000FFFFFF00) },
-        { be_const_key_weak(value_provider, -1), be_const_class(be_class_ValueProvider) },
-        { be_const_key_weak(is_user_function, -1), be_const_closure(is_user_function_closure) },
-        { be_const_key_weak(palette_pattern_animation, -1), be_const_class(be_class_PalettePatternAnimation) },
-        { be_const_key_weak(elastic, -1), be_const_closure(elastic_closure) },
-        { be_const_key_weak(twinkle_rainbow, -1), be_const_closure(twinkle_rainbow_closure) },
+        { be_const_key_weak(rich_palette, 89), be_const_class(be_class_RichPaletteColorProvider) },
         { be_const_key_weak(pulsating_animation, -1), be_const_closure(pulsating_animation_closure) },
-        { be_const_key_weak(EASE_OUT, -1), be_const_int(7) },
-        { be_const_key_weak(static_value, 8), be_const_class(be_class_StaticValueProvider) },
-        { be_const_key_weak(sine_osc, -1), be_const_closure(sine_osc_closure) },
-        { be_const_key_weak(EASE_IN, -1), be_const_int(6) },
-        { be_const_key_weak(_math, -1), be_const_class(be_class_AnimationMath) },
-        { be_const_key_weak(twinkle_gentle, -1), be_const_closure(twinkle_gentle_closure) },
-        { be_const_key_weak(palette_gradient_animation, 82), be_const_class(be_class_PaletteGradientAnimation) },
-        { be_const_key_weak(create_engine, -1), be_const_closure(create_engine_closure) },
-        { be_const_key_weak(linear, -1), be_const_closure(linear_closure) },
-        { be_const_key_weak(gradient_rainbow_linear, -1), be_const_closure(gradient_rainbow_linear_closure) },
-        { be_const_key_weak(square, -1), be_const_closure(square_closure) },
-        { be_const_key_weak(is_value_provider, -1), be_const_closure(is_value_provider_closure) },
-        { be_const_key_weak(animation_engine, 9), be_const_class(be_class_AnimationEngine) },
-        { be_const_key_weak(oscillator_value, -1), be_const_class(be_class_OscillatorValueProvider) },
-        { be_const_key_weak(init_strip, -1), be_const_closure(animation_init_strip_closure) },
-        { be_const_key_weak(palette_meter_animation, -1), be_const_class(be_class_PaletteMeterAnimation) },
-        { be_const_key_weak(fire_animation, 30), be_const_class(be_class_FireAnimation) },
-        { be_const_key_weak(unregister_event_handler, -1), be_const_closure(unregister_event_handler_closure) },
+        { be_const_key_weak(register_user_function, -1), be_const_closure(register_user_function_closure) },
+        { be_const_key_weak(SequenceManager, -1), be_const_class(be_class_SequenceManager) },
+        { be_const_key_weak(noise_rainbow, -1), be_const_closure(noise_rainbow_closure) },
+        { be_const_key_weak(is_user_function, -1), be_const_closure(is_user_function_closure) },
+        { be_const_key_weak(palette_gradient_animation, 26), be_const_class(be_class_PaletteGradientAnimation) },
+        { be_const_key_weak(PALETTE_RGB, 83), be_const_bytes_instance(00FF00008000FF00FF0000FF) },
+        { be_const_key_weak(EASE_IN, 81), be_const_int(6) },
+        { be_const_key_weak(elastic, 27), be_const_closure(elastic_closure) },
+        { be_const_key_weak(ELASTIC, 51), be_const_int(8) },
+        { be_const_key_weak(EventManager, 13), be_const_class(be_class_EventManager) },
+        { be_const_key_weak(get_event_handlers, -1), be_const_closure(get_event_handlers_closure) },
+        { be_const_key_weak(strip_length, 98), be_const_class(be_class_StripLengthProvider) },
+        { be_const_key_weak(color_provider, -1), be_const_class(be_class_ColorProvider) },
+        { be_const_key_weak(iteration_number, 76), be_const_class(be_class_IterationNumberProvider) },
         { be_const_key_weak(breathe_color, -1), be_const_class(be_class_BreatheColorProvider) },
-        { be_const_key_weak(resolve, -1), be_const_closure(animation_resolve_closure) },
+        { be_const_key_weak(PALETTE_SUNSET_TICKS, -1), be_const_bytes_instance(28FF450028FF8C0028FFD70028FF69B4288000802819197000000080) },
+        { be_const_key_weak(ease_in, -1), be_const_closure(ease_in_closure) },
+        { be_const_key_weak(twinkle_classic, -1), be_const_closure(twinkle_classic_closure) },
+        { be_const_key_weak(_math, -1), be_const_class(be_class_AnimationMath) },
+        { be_const_key_weak(static_value, -1), be_const_class(be_class_StaticValueProvider) },
+        { be_const_key_weak(VERSION, -1), be_const_int(65536) },
+        { be_const_key_weak(is_color_provider, 64), be_const_closure(is_color_provider_closure) },
+        { be_const_key_weak(TRIANGLE, -1), be_const_int(2) },
+        { be_const_key_weak(solid, -1), be_const_closure(solid_closure) },
+        { be_const_key_weak(gradient_two_color_linear, 48), be_const_closure(gradient_two_color_linear_closure) },
+        { be_const_key_weak(PALETTE_RAINBOW, -1), be_const_bytes_instance(00FF000024FFA50049FFFF006E00FF00920000FFB74B0082DBEE82EEFFFF0000) },
+        { be_const_key_weak(color_cycle, -1), be_const_class(be_class_ColorCycleColorProvider) },
+        { be_const_key_weak(rich_palette_animation, -1), be_const_class(be_class_RichPaletteAnimation) },
+        { be_const_key_weak(LINEAR, -1), be_const_int(1) },
+        { be_const_key_weak(triangle, -1), be_const_closure(triangle_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(animation_init_closure) },
+        { be_const_key_weak(fire_animation, -1), be_const_class(be_class_FireAnimation) },
+        { be_const_key_weak(animation, 14), be_const_class(be_class_Animation) },
+        { be_const_key_weak(frame_buffer, -1), be_const_class(be_class_FrameBuffer) },
+        { be_const_key_weak(closure_value, -1), be_const_class(be_class_ClosureValueProvider) },
+        { be_const_key_weak(smooth, -1), be_const_closure(smooth_closure) },
+        { be_const_key_weak(crenel_position_animation, -1), be_const_class(be_class_CrenelPositionAnimation) },
+        { be_const_key_weak(BOUNCE, -1), be_const_int(9) },
+        { be_const_key_weak(palette_wave_animation, -1), be_const_class(be_class_PaletteWaveAnimation) },
+        { be_const_key_weak(ramp, -1), be_const_closure(ramp_closure) },
+        { be_const_key_weak(unregister_event_handler, 32), be_const_closure(unregister_event_handler_closure) },
+        { be_const_key_weak(palette_pattern_animation, 46), be_const_class(be_class_PalettePatternAnimation) },
+        { be_const_key_weak(static_color, 50), be_const_class(be_class_StaticColorProvider) },
+        { be_const_key_weak(SAWTOOTH, -1), be_const_int(1) },
+        { be_const_key_weak(bounce, 58), be_const_closure(bounce_closure) },
+        { be_const_key_weak(twinkle_animation, -1), be_const_class(be_class_TwinkleAnimation) },
+        { be_const_key_weak(wave_custom, -1), be_const_closure(wave_custom_closure) },
+        { be_const_key_weak(list_user_functions, -1), be_const_closure(list_user_functions_closure) },
+        { be_const_key_weak(twinkle_gentle, -1), be_const_closure(twinkle_gentle_closure) },
+        { be_const_key_weak(palette_meter_animation, 93), be_const_class(be_class_PaletteMeterAnimation) },
+        { be_const_key_weak(EASE_OUT, -1), be_const_int(7) },
+        { be_const_key_weak(sawtooth, -1), be_const_closure(sawtooth_closure) },
+        { be_const_key_weak(SINE, 67), be_const_int(5) },
+        { be_const_key_weak(is_value_provider, 21), be_const_closure(is_value_provider_closure) },
+        { be_const_key_weak(parameterized_object, -1), be_const_class(be_class_ParameterizedObject) },
+        { be_const_key_weak(twinkle_rainbow, 65), be_const_closure(twinkle_rainbow_closure) },
+        { be_const_key_weak(resolve, 33), be_const_closure(animation_resolve_closure) },
+        { be_const_key_weak(beacon_animation, 16), be_const_class(be_class_BeaconAnimation) },
+        { be_const_key_weak(breathe_animation, 12), be_const_class(be_class_BreatheAnimation) },
+        { be_const_key_weak(comet_animation, 43), be_const_class(be_class_CometAnimation) },
+        { be_const_key_weak(get_user_function, -1), be_const_closure(get_user_function_closure) },
+        { be_const_key_weak(oscillator_value, -1), be_const_class(be_class_OscillatorValueProvider) },
+        { be_const_key_weak(wave_animation, -1), be_const_class(be_class_WaveAnimation) },
+        { be_const_key_weak(event_handler, -1), be_const_class(be_class_EventHandler) },
+        { be_const_key_weak(square, -1), be_const_closure(square_closure) },
+        { be_const_key_weak(wave_rainbow_sine, -1), be_const_closure(wave_rainbow_sine_closure) },
+        { be_const_key_weak(version_string, -1), be_const_closure(animation_version_string_closure) },
+        { be_const_key_weak(COSINE, -1), be_const_int(4) },
+        { be_const_key_weak(twinkle_solid, -1), be_const_closure(twinkle_solid_closure) },
+        { be_const_key_weak(rich_palette_rainbow, 75), be_const_closure(rich_palette_rainbow_closure) },
+        { be_const_key_weak(gradient_rainbow_radial, -1), be_const_closure(gradient_rainbow_radial_closure) },
+        { be_const_key_weak(value_provider, -1), be_const_class(be_class_ValueProvider) },
+        { be_const_key_weak(pulsating_color, 38), be_const_closure(pulsating_color_provider_closure) },
+        { be_const_key_weak(cosine_osc, 85), be_const_closure(cosine_osc_closure) },
+        { be_const_key_weak(composite_color, -1), be_const_class(be_class_CompositeColorProvider) },
+        { be_const_key_weak(gradient_animation, -1), be_const_class(be_class_GradientAnimation) },
+        { be_const_key_weak(sine_osc, 29), be_const_closure(sine_osc_closure) },
+        { be_const_key_weak(create_engine, -1), be_const_class(be_class_AnimationEngine) },
+        { be_const_key_weak(trigger_event, -1), be_const_closure(trigger_event_closure) },
+        { be_const_key_weak(clear_all_event_handlers, -1), be_const_closure(clear_all_event_handlers_closure) },
+        { be_const_key_weak(linear, 15), be_const_closure(linear_closure) },
+        { be_const_key_weak(noise_fractal, -1), be_const_closure(noise_fractal_closure) },
+        { be_const_key_weak(twinkle_intense, 8), be_const_closure(twinkle_intense_closure) },
+        { be_const_key_weak(noise_animation, -1), be_const_class(be_class_NoiseAnimation) },
+        { be_const_key_weak(SQUARE, -1), be_const_int(3) },
+        { be_const_key_weak(init_strip, -1), be_const_closure(animation_init_strip_closure) },
+        { be_const_key_weak(PALETTE_FOREST, -1), be_const_bytes_instance(0000640040228B228032CD32C09AFF9AFF90EE90) },
+        { be_const_key_weak(register_event_handler, 80), be_const_closure(register_event_handler_closure) },
+        { be_const_key_weak(ease_out, -1), be_const_closure(ease_out_closure) },
+        { be_const_key_weak(gradient_rainbow_linear, -1), be_const_closure(gradient_rainbow_linear_closure) },
+        { be_const_key_weak(noise_single_color, 28), be_const_closure(noise_single_color_closure) },
+        { be_const_key_weak(PALETTE_FIRE, 96), be_const_bytes_instance(000000004080000080FF0000C0FF8000FFFFFF00) },
+        { be_const_key_weak(get_registered_events, -1), be_const_closure(get_registered_events_closure) },
+        { be_const_key_weak(set_event_active, -1), be_const_closure(set_event_active_closure) },
+        { be_const_key_weak(PALETTE_OCEAN, -1), be_const_bytes_instance(00000080400000FF8000FFFFC000FF80FF008000) },
+        { be_const_key_weak(create_closure_value, -1), be_const_closure(create_closure_value_closure) },
+        { be_const_key_weak(wave_single_sine, -1), be_const_closure(wave_single_sine_closure) },
     }))
 );
 BE_EXPORT_VARIABLE be_define_const_native_module(animation);

--- a/lib/libesp32/berry_animation/src/tests/animation_engine_test.be
+++ b/lib/libesp32/berry_animation/src/tests/animation_engine_test.be
@@ -30,7 +30,7 @@ end
 # Test 1: Engine Creation
 print("\n--- Test 1: Engine Creation ---")
 var strip = global.Leds(20)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 assert_not_nil(engine, "Engine should be created")
 assert_equals(engine.width, 20, "Engine width should match strip length")
@@ -155,7 +155,7 @@ assert_test(render_time < 200, f"10 render cycles should be fast (took {render_t
 # Test 8: Error Handling
 print("\n--- Test 8: Error Handling ---")
 try
-  var bad_engine = animation.animation_engine(nil)
+  var bad_engine = animation.create_engine(nil)
   assert_test(false, "Should throw error for nil strip")
 except "value_error"
   assert_test(true, "Should throw value_error for nil strip")
@@ -167,7 +167,7 @@ var engine2 = animation.create_engine(strip)
 assert_not_nil(engine2, "Second engine should be created")
 assert_equals(engine2.width, strip.length(), "Second engine width should match strip")
 
-var engine3 = animation.animation_engine(strip)
+var engine3 = animation.create_engine(strip)
 assert_not_nil(engine3, "Direct engine creation should work")
 assert_equals(engine3.width, strip.length(), "Direct engine width should match strip")
 
@@ -221,7 +221,7 @@ end
 
 # Create engine with dynamic strip
 var dynamic_strip = MockDynamicStrip(15)
-var dynamic_engine = animation.animation_engine(dynamic_strip)
+var dynamic_engine = animation.create_engine(dynamic_strip)
 
 # Test initial state
 assert_equals(dynamic_engine.width, 15, "Engine should start with strip length 15")

--- a/lib/libesp32/berry_animation/src/tests/animation_opacity_test.be
+++ b/lib/libesp32/berry_animation/src/tests/animation_opacity_test.be
@@ -32,7 +32,7 @@ print("\n--- Test 11: Animation Opacity with Animation Masks ---")
 
 # Create a fresh engine for opacity tests
 var opacity_strip = global.Leds(10)
-var opacity_engine = animation.animation_engine(opacity_strip)
+var opacity_engine = animation.create_engine(opacity_strip)
 
 # Test 11a: Basic numeric opacity
 print("\n--- Test 11a: Basic numeric opacity ---")

--- a/lib/libesp32/berry_animation/src/tests/animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/animation_test.be
@@ -12,7 +12,7 @@ import animation
 
 # Create animation engine for testing
 var strip = global.Leds()
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test Animation class
 assert(animation.animation != nil, "Animation class should be defined")
@@ -129,10 +129,13 @@ assert(param_anim.set_param("priority", -1) == false, "Value below min should be
 assert(param_anim.get_param("unknown", "default") == "default", "Unknown parameter should return default")
 assert(param_anim.get_param("priority", 0) == 75, "Known parameter should return current value")
 
-# Test parameter metadata
-var metadata = param_anim.get_param_metadata("priority")
-assert(metadata != nil, "Metadata should exist for static parameter")
-assert(metadata["min"] == 0, "Metadata should contain correct min value")
+# Test parameter definition using _has_param and _get_param_def
+assert(param_anim._has_param("priority") == true, "Should have priority parameter")
+var param_def = param_anim._get_param_def("priority")
+assert(param_def != nil, "Parameter definition should exist for static parameter")
+# Use static methods to access encoded constraint data
+assert(param_anim.constraint_mask(param_def, "min") == 0x01, "Parameter definition should have min constraint")
+assert(param_anim.constraint_find(param_def, "min", nil) == 0, "Parameter definition should contain correct min value")
 
 # Test updating multiple static parameters
 # Test individual parameter updates using existing static parameters

--- a/lib/libesp32/berry_animation/src/tests/beacon_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/beacon_animation_test.be
@@ -14,7 +14,7 @@ var passed_count = 0
 
 # Create LED strip and engine for testing
 var strip = global.Leds(10)  # Use built-in LED strip for testing
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 def test_assert(condition, message)
   test_count += 1

--- a/lib/libesp32/berry_animation/src/tests/bounce_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/bounce_animation_test.be
@@ -14,7 +14,7 @@ def test_bounce_animation_basic()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a simple source animation
   var source = animation.solid(engine)
@@ -42,7 +42,7 @@ def test_bounce_animation_custom()
   
   # Create LED strip and engine
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FF00
@@ -79,7 +79,7 @@ def test_bounce_animation_parameters()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF0000FF
@@ -114,7 +114,7 @@ def test_bounce_animation_physics()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFFFF00
@@ -154,7 +154,7 @@ def test_bounce_animation_update_render()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFF00FF
@@ -203,7 +203,7 @@ def test_bounce_constructors()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FFFF
@@ -243,7 +243,7 @@ def test_bounce_animation_gravity()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFFFFFF
@@ -278,7 +278,7 @@ def test_bounce_tostring()
   
   # Create LED strip and engine
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF888888

--- a/lib/libesp32/berry_animation/src/tests/breathe_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/breathe_animation_test.be
@@ -13,7 +13,7 @@ print("Imported animation module")
 
 # Create LED strip and animation engine following specification
 var strip = global.Leds(10)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 print("Created LED strip and animation engine")
 
 # Create a breathe animation with engine-only parameter

--- a/lib/libesp32/berry_animation/src/tests/breathe_color_provider_test.be
+++ b/lib/libesp32/berry_animation/src/tests/breathe_color_provider_test.be
@@ -13,7 +13,7 @@ print("Imported animation module")
 
 # Create LED strip and animation engine following specification
 var strip = global.Leds(10)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 print("Created LED strip and animation engine")
 
 # Create a breathe color provider with engine-only parameter

--- a/lib/libesp32/berry_animation/src/tests/bytes_type_test.be
+++ b/lib/libesp32/berry_animation/src/tests/bytes_type_test.be
@@ -4,13 +4,15 @@
 import animation
 import animation_dsl
 
+import "./core/param_encoder" as encode_constraints
+
 # Test class that uses bytes parameter
 class BytesTestClass : animation.parameterized_object
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "data": {"type": "bytes", "default": nil, "nillable": true},
     "required_data": {"type": "bytes"},
     "name": {"type": "string", "default": "test"}
-  }
+  })
   
   def init(engine)
     super(self).init(engine)
@@ -76,14 +78,16 @@ def test_bytes_type_validation()
   success = obj.set_param("data", "invalid")
   assert(success == false, "Method setting with invalid type should fail")
   
-  # Test 5: Parameter metadata
-  var metadata = obj.get_param_metadata("data")
-  assert(metadata["type"] == "bytes", "Data parameter should have bytes type")
-  assert(metadata["nillable"] == true, "Data parameter should be nillable")
+  # Test 5: Parameter definition
+  assert(obj._has_param("data") == true, "data parameter should exist")
+  var param_def = obj._get_param_def("data")
+  assert(obj.constraint_find(param_def, "type", nil) == "bytes", "Data parameter should have bytes type")
+  assert(obj.constraint_mask(param_def, "nillable") == 0x20, "Data parameter should be nillable")
   
-  var req_metadata = obj.get_param_metadata("required_data")
-  assert(req_metadata["type"] == "bytes", "Required data should have bytes type")
-  assert(req_metadata.find("nillable", false) == false, "Required data should not be nillable")
+  assert(obj._has_param("required_data") == true, "required_data parameter should exist")
+  var req_param_def = obj._get_param_def("required_data")
+  assert(obj.constraint_find(req_param_def, "type", nil) == "bytes", "Required data should have bytes type")
+  assert(obj.constraint_mask(req_param_def, "nillable") == 0x00, "Required data should not be nillable")
   
   print("✓ All bytes type validation tests passed!")
 end

--- a/lib/libesp32/berry_animation/src/tests/color_cycle_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/color_cycle_animation_test.be
@@ -10,7 +10,7 @@ import animation
 
 # Create a real engine for testing using global.Leds()
 var strip = global.Leds(10)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Create a test class
 class ColorCycleAnimationTest

--- a/lib/libesp32/berry_animation/src/tests/color_cycle_palette_size_test.be
+++ b/lib/libesp32/berry_animation/src/tests/color_cycle_palette_size_test.be
@@ -167,16 +167,17 @@ def test_palette_size_parameter_metadata()
   var engine = MockEngine()
   var provider = animation.color_cycle(engine)
   
-  # Test 1: Parameter should exist in metadata
-  var metadata = provider.get_param_metadata("palette_size")
-  assert(metadata != nil, "palette_size should have metadata")
+  # Test 1: Parameter should exist
+  assert(provider._has_param("palette_size") == true, "palette_size parameter should exist")
+  var param_def = provider._get_param_def("palette_size")
+  assert(param_def != nil, "palette_size should have parameter definition")
   
-  # Test 2: Check parameter definition
-  assert(metadata.contains("type"), "palette_size metadata should have type")
-  assert(metadata["type"] == "int", f"palette_size type should be 'int', got '{metadata['type']}'")
+  # Test 2: Check parameter definition using static methods
+  assert(provider.constraint_mask(param_def, "type") == 0x08, "palette_size definition should have type")
+  assert(provider.constraint_find(param_def, "type", nil) == "int", f"palette_size type should be 'int', got '{provider.constraint_find(param_def, 'type', nil)}'")
   
-  assert(metadata.contains("default"), "palette_size metadata should have default")
-  assert(metadata["default"] == 3, f"palette_size default should be 3, got {metadata['default']}")
+  assert(provider.constraint_mask(param_def, "default") == 0x04, "palette_size definition should have default")
+  assert(provider.constraint_find(param_def, "default", nil) == 3, f"palette_size default should be 3, got {provider.constraint_find(param_def, 'default', nil)}")
     
   print("✓ Parameter metadata tests passed!")
 end

--- a/lib/libesp32/berry_animation/src/tests/comet_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/comet_animation_test.be
@@ -39,7 +39,7 @@ end
 
 # Create LED strip and animation engine following specification
 var strip = global.Leds(30)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 print("Created LED strip and animation engine")
 
 # Test 1: Basic Construction
@@ -188,7 +188,7 @@ print("\n--- Test 6: Wrap Around vs Bounce ---")
 
 # Create smaller strip for faster testing
 var small_strip = global.Leds(10)
-var small_engine = animation.animation_engine(small_strip)
+var small_engine = animation.create_engine(small_strip)
 
 # Test wrap around
 var wrap_comet = animation.comet_animation(small_engine)

--- a/lib/libesp32/berry_animation/src/tests/constraint_encoding_test.be
+++ b/lib/libesp32/berry_animation/src/tests/constraint_encoding_test.be
@@ -1,0 +1,336 @@
+# Constraint Encoding Test Suite
+#
+# Comprehensive tests for encode_constraints() and ParameterizedObject static methods:
+# - constraint_mask()
+# - constraint_find()
+#
+# Tests all PARAMS patterns found in the Berry Animation Framework codebase.
+
+import "./core/param_encoder" as encode_constraints
+
+# Test counter
+var test_count = 0
+var pass_count = 0
+var fail_count = 0
+
+# Test helper function
+def assert_equal(actual, expected, test_name)
+  test_count += 1
+  if actual == expected
+    pass_count += 1
+    print(f"✓ Test {test_count}: {test_name}")
+    return true
+  else
+    fail_count += 1
+    print(f"✗ Test {test_count}: {test_name}")
+    print(f"  Expected: {expected}")
+    print(f"  Actual:   {actual}")
+    return false
+  end
+end
+
+# Test helper for array equality
+def assert_array_equal(actual, expected, test_name)
+  test_count += 1
+  if size(actual) != size(expected)
+    fail_count += 1
+    print(f"✗ Test {test_count}: {test_name}")
+    print(f"  Expected size: {size(expected)}, Actual size: {size(actual)}")
+    return false
+  end
+  var i = 0
+  while i < size(actual)
+    if actual[i] != expected[i]
+      fail_count += 1
+      print(f"✗ Test {test_count}: {test_name}")
+      print(f"  Mismatch at index {i}: expected {expected[i]}, got {actual[i]}")
+      return false
+    end
+    i += 1
+  end
+  pass_count += 1
+  print(f"✓ Test {test_count}: {test_name}")
+  return true
+end
+
+print("=" * 70)
+print("CONSTRAINT ENCODING TEST SUITE")
+print("=" * 70)
+
+# ============================================================================
+# TEST GROUP 1: Basic Integer Constraints (min/max/default)
+# ============================================================================
+print("\n--- Test Group 1: Basic Integer Constraints ---")
+
+# Test 1.1: Simple min/max/default (int8 range)
+var params_1_1 = {"min": 0, "max": 255, "default": 128}
+var encoded_1_1 = encode_constraints({"test": params_1_1})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_1, "min"), 0x01, "1.1a: has min")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_1, "max"), 0x02, "1.1b: has max")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_1, "default"), 0x04, "1.1c: has default")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_1, "min", nil), 0, "1.1d: min value")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_1, "max", nil), 255, "1.1e: max value")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_1, "default", nil), 128, "1.1f: default value")
+
+# Test 1.2: Only default (no min/max)
+var params_1_2 = {"default": 0xFFFFFFFF}
+var encoded_1_2 = encode_constraints({"test": params_1_2})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_2, "min"), 0x00, "1.2a: no min")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_2, "max"), 0x00, "1.2b: no max")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_2, "default"), 0x04, "1.2c: has default")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_2, "default", nil), 0xFFFFFFFF, "1.2d: default value")
+
+# Test 1.3: Min only
+var params_1_3 = {"min": 1, "default": 1000}
+var encoded_1_3 = encode_constraints({"test": params_1_3})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_3, "min"), 0x01, "1.3a: has min")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_1_3, "max"), 0x00, "1.3b: no max")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_3, "min", nil), 1, "1.3c: min value")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_3, "default", nil), 1000, "1.3d: default value")
+
+# Test 1.4: Negative values
+var params_1_4 = {"min": -128, "max": 127, "default": 0}
+var encoded_1_4 = encode_constraints({"test": params_1_4})["test"]
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_4, "min", nil), -128, "1.4a: negative min")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_4, "max", nil), 127, "1.4b: positive max")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_4, "default", nil), 0, "1.4c: zero default")
+
+# Test 1.5: Large int32 values
+var params_1_5 = {"min": 0, "max": 25600, "default": 2560}
+var encoded_1_5 = encode_constraints({"test": params_1_5})["test"]
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_5, "max", nil), 25600, "1.5a: large max")
+assert_equal(animation.parameterized_object.constraint_find(encoded_1_5, "default", nil), 2560, "1.5b: large default")
+
+# ============================================================================
+# TEST GROUP 2: Enum Constraints
+# ============================================================================
+print("\n--- Test Group 2: Enum Constraints ---")
+
+# Test 2.1: Simple enum with positive values
+var params_2_1 = {"enum": [1, 2, 3, 4, 5, 6, 7, 8, 9], "default": 1}
+var encoded_2_1 = encode_constraints({"test": params_2_1})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_2_1, "enum"), 0x10, "2.1a: has enum")
+assert_equal(animation.parameterized_object.constraint_find(encoded_2_1, "default", nil), 1, "2.1b: default value")
+var enum_2_1 = animation.parameterized_object.constraint_find(encoded_2_1, "enum", nil)
+assert_array_equal(enum_2_1, [1, 2, 3, 4, 5, 6, 7, 8, 9], "2.1c: enum values")
+
+# Test 2.2: Enum with negative values
+var params_2_2 = {"enum": [-1, 1], "default": 1}
+var encoded_2_2 = encode_constraints({"test": params_2_2})["test"]
+var enum_2_2 = animation.parameterized_object.constraint_find(encoded_2_2, "enum", nil)
+assert_array_equal(enum_2_2, [-1, 1], "2.2a: enum with negative values")
+
+# Test 2.3: Enum with min/max/default
+var params_2_3 = {"min": 0, "max": 3, "enum": [0, 1, 2, 3], "default": 0}
+var encoded_2_3 = encode_constraints({"test": params_2_3})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_2_3, "min"), 0x01, "2.3a: has min")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_2_3, "max"), 0x02, "2.3b: has max")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_2_3, "enum"), 0x10, "2.3c: has enum")
+var enum_2_3 = animation.parameterized_object.constraint_find(encoded_2_3, "enum", nil)
+assert_array_equal(enum_2_3, [0, 1, 2, 3], "2.3d: enum values")
+
+# ============================================================================
+# TEST GROUP 3: Type Annotations
+# ============================================================================
+print("\n--- Test Group 3: Type Annotations ---")
+
+# Test 3.1: Bool type
+var params_3_1 = {"type": "bool", "default": false}
+var encoded_3_1 = encode_constraints({"test": params_3_1})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_1, "type"), 0x08, "3.1a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_1, "type", nil), "bool", "3.1b: type is bool")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_1, "default", nil), false, "3.1c: default is false")
+
+# Test 3.2: String type
+var params_3_2 = {"type": "string", "default": "animation"}
+var encoded_3_2 = encode_constraints({"test": params_3_2})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_2, "type"), 0x08, "3.2a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_2, "type", nil), "string", "3.2b: type is string")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_2, "default", nil), "animation", "3.2c: default string")
+
+# Test 3.3: Int type (explicit)
+var params_3_3 = {"type": "int", "default": 3}
+var encoded_3_3 = encode_constraints({"test": params_3_3})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_3, "type"), 0x08, "3.3a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_3, "type", nil), "int", "3.3b: type is int")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_3, "default", nil), 3, "3.3c: default int")
+
+# Test 3.4: Any type
+var params_3_4 = {"type": "any", "default": 255}
+var encoded_3_4 = encode_constraints({"test": params_3_4})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_4, "type"), 0x08, "3.4a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_4, "type", nil), "any", "3.4b: type is any")
+
+# Test 3.5: Instance type
+var params_3_5 = {"type": "instance", "default": nil}
+var encoded_3_5 = encode_constraints({"test": params_3_5})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_5, "type"), 0x08, "3.5a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_5, "type", nil), "instance", "3.5b: type is instance")
+
+# Test 3.6: Function type
+var params_3_6 = {"type": "function"}
+var encoded_3_6 = encode_constraints({"test": params_3_6})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_6, "type"), 0x08, "3.6a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_6, "type", nil), "function", "3.6b: type is function")
+
+# Test 3.7: Bytes type
+var params_3_7 = {"type": "bytes", "default": bytes("FF0000FF")}
+var encoded_3_7 = encode_constraints({"test": params_3_7})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_3_7, "type"), 0x08, "3.7a: has type")
+assert_equal(animation.parameterized_object.constraint_find(encoded_3_7, "type", nil), "bytes", "3.7b: type is bytes")
+# Note: bytes comparison would need special handling
+
+# ============================================================================
+# TEST GROUP 4: Nillable Constraints
+# ============================================================================
+print("\n--- Test Group 4: Nillable Constraints ---")
+
+# Test 4.1: Nillable with nil default
+var params_4_1 = {"default": nil, "nillable": true}
+var encoded_4_1 = encode_constraints({"test": params_4_1})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_4_1, "nillable"), 0x20, "4.1a: has nillable")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_4_1, "default"), 0x04, "4.1b: has default")
+assert_equal(animation.parameterized_object.constraint_find(encoded_4_1, "nillable", false), true, "4.1c: nillable is true")
+assert_equal(animation.parameterized_object.constraint_find(encoded_4_1, "default", 999), nil, "4.1d: default is nil")
+
+# Test 4.2: Nillable without explicit default
+var params_4_2 = {"nillable": true}
+var encoded_4_2 = encode_constraints({"test": params_4_2})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_4_2, "nillable"), 0x20, "4.2a: has nillable")
+assert_equal(animation.parameterized_object.constraint_find(encoded_4_2, "nillable", false), true, "4.2b: nillable is true")
+
+# Test 4.3: Non-nillable (default behavior)
+var params_4_3 = {"default": 0}
+var encoded_4_3 = encode_constraints({"test": params_4_3})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_4_3, "nillable"), 0x00, "4.3a: no nillable flag")
+
+# ============================================================================
+# TEST GROUP 5: Real-World PARAMS from Codebase
+# ============================================================================
+print("\n--- Test Group 5: Real-World PARAMS ---")
+
+# Test 5.1: BeaconAnimation PARAMS
+var beacon_params = {
+  "color": {"default": 0xFFFFFFFF},
+  "back_color": {"default": 0xFF000000},
+  "pos": {"default": 0},
+  "beacon_size": {"min": 0, "default": 1},
+  "slew_size": {"min": 0, "default": 0}
+}
+var beacon_encoded = encode_constraints(beacon_params)
+assert_equal(animation.parameterized_object.constraint_find(beacon_encoded["color"], "default", nil), 0xFFFFFFFF, "5.1a: beacon color")
+assert_equal(animation.parameterized_object.constraint_find(beacon_encoded["beacon_size"], "min", nil), 0, "5.1b: beacon_size min")
+
+# Test 5.2: CometAnimation PARAMS
+var comet_params = {
+  "tail_length": {"min": 1, "max": 50, "default": 5},
+  "speed": {"min": 1, "max": 25600, "default": 2560},
+  "direction": {"enum": [-1, 1], "default": 1},
+  "wrap_around": {"min": 0, "max": 1, "default": 1},
+  "fade_factor": {"min": 0, "max": 255, "default": 179}
+}
+var comet_encoded = encode_constraints(comet_params)
+assert_equal(animation.parameterized_object.constraint_find(comet_encoded["tail_length"], "max", nil), 50, "5.2a: tail_length max")
+assert_equal(animation.parameterized_object.constraint_find(comet_encoded["speed"], "max", nil), 25600, "5.2b: speed max")
+var direction_enum = animation.parameterized_object.constraint_find(comet_encoded["direction"], "enum", nil)
+assert_array_equal(direction_enum, [-1, 1], "5.2c: direction enum")
+
+# Test 5.3: Animation base class PARAMS
+var animation_params = {
+  "name": {"type": "string", "default": "animation"},
+  "priority": {"min": 0, "default": 10},
+  "duration": {"min": 0, "default": 0},
+  "loop": {"type": "bool", "default": false},
+  "opacity": {"type": "any", "default": 255},
+  "color": {"default": 0xFFFFFFFF}
+}
+var animation_encoded = encode_constraints(animation_params)
+assert_equal(animation.parameterized_object.constraint_find(animation_encoded["name"], "type", nil), "string", "5.3a: name type")
+assert_equal(animation.parameterized_object.constraint_find(animation_encoded["name"], "default", nil), "animation", "5.3b: name default")
+assert_equal(animation.parameterized_object.constraint_find(animation_encoded["loop"], "type", nil), "bool", "5.3c: loop type")
+assert_equal(animation.parameterized_object.constraint_find(animation_encoded["opacity"], "type", nil), "any", "5.3d: opacity type")
+
+# Test 5.4: GradientAnimation PARAMS (with nillable)
+var gradient_params = {
+  "color": {"default": nil, "nillable": true},
+  "gradient_type": {"min": 0, "max": 1, "default": 0},
+  "direction": {"min": 0, "max": 255, "default": 0}
+}
+var gradient_encoded = encode_constraints(gradient_params)
+assert_equal(animation.parameterized_object.constraint_mask(gradient_encoded["color"], "nillable"), 0x20, "5.4a: color nillable")
+assert_equal(animation.parameterized_object.constraint_find(gradient_encoded["color"], "default", 999), nil, "5.4b: color default nil")
+
+# Test 5.5: OscillatorValueProvider PARAMS (large enum)
+var oscillator_params = {
+  "min_value": {"default": 0},
+  "max_value": {"default": 100},
+  "duration": {"min": 1, "default": 1000},
+  "form": {"enum": [1, 2, 3, 4, 5, 6, 7, 8, 9], "default": 1},
+  "phase": {"min": 0, "max": 100, "default": 0}
+}
+var oscillator_encoded = encode_constraints(oscillator_params)
+var form_enum = animation.parameterized_object.constraint_find(oscillator_encoded["form"], "enum", nil)
+assert_array_equal(form_enum, [1, 2, 3, 4, 5, 6, 7, 8, 9], "5.5a: form enum")
+
+# Test 5.6: BreatheAnimation PARAMS
+var breathe_params = {
+  "base_color": {"default": 0xFFFFFFFF},
+  "min_brightness": {"min": 0, "max": 255, "default": 0},
+  "max_brightness": {"min": 0, "max": 255, "default": 255},
+  "period": {"min": 100, "default": 3000},
+  "curve_factor": {"min": 1, "max": 5, "default": 2}
+}
+var breathe_encoded = encode_constraints(breathe_params)
+assert_equal(animation.parameterized_object.constraint_find(breathe_encoded["period"], "min", nil), 100, "5.6a: period min")
+assert_equal(animation.parameterized_object.constraint_find(breathe_encoded["curve_factor"], "max", nil), 5, "5.6b: curve_factor max")
+
+# ============================================================================
+# TEST GROUP 6: Edge Cases and Special Scenarios
+# ============================================================================
+print("\n--- Test Group 6: Edge Cases ---")
+
+# Test 6.1: Empty constraints (only default)
+var params_6_1 = {"default": 42}
+var encoded_6_1 = encode_constraints({"test": params_6_1})["test"]
+assert_equal(animation.parameterized_object.constraint_mask(encoded_6_1, "min"), 0x00, "6.1a: no min")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_6_1, "max"), 0x00, "6.1b: no max")
+assert_equal(animation.parameterized_object.constraint_mask(encoded_6_1, "enum"), 0x00, "6.1c: no enum")
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_1, "default", nil), 42, "6.1d: default value")
+
+# Test 6.2: Zero values
+var params_6_2 = {"min": 0, "max": 0, "default": 0}
+var encoded_6_2 = encode_constraints({"test": params_6_2})["test"]
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_2, "min", nil), 0, "6.2a: zero min")
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_2, "max", nil), 0, "6.2b: zero max")
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_2, "default", nil), 0, "6.2c: zero default")
+
+# Test 6.3: Single-element enum
+var params_6_3 = {"enum": [42], "default": 42}
+var encoded_6_3 = encode_constraints({"test": params_6_3})["test"]
+var enum_6_3 = animation.parameterized_object.constraint_find(encoded_6_3, "enum", nil)
+assert_array_equal(enum_6_3, [42], "6.3a: single-element enum")
+
+# Test 6.4: Default not found (should return provided default)
+var params_6_4 = {"min": 0, "max": 100}
+var encoded_6_4 = encode_constraints({"test": params_6_4})["test"]
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_4, "default", 999), 999, "6.4a: missing default returns fallback")
+
+# Test 6.5: Field not found (should return provided default)
+assert_equal(animation.parameterized_object.constraint_find(encoded_6_4, "nonexistent", 777), 777, "6.5a: nonexistent field returns fallback")
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+print("\n" + "=" * 70)
+print("TEST SUMMARY")
+print("=" * 70)
+print(f"Total tests: {test_count}")
+print(f"Passed: {pass_count}")
+print(f"Failed: {fail_count}")
+if fail_count == 0
+  print("\n✓ ALL TESTS PASSED!")
+else
+  print(f"\n✗ {fail_count} TEST(S) FAILED")
+  raise "test_failed"
+end
+print("=" * 70)

--- a/lib/libesp32/berry_animation/src/tests/crenel_position_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/crenel_position_animation_test.be
@@ -28,7 +28,7 @@ def run_tests()
   
   # Create engine and strip for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test 1: Basic construction with new parameterized pattern
   var crenel = animation.crenel_position_animation(engine)

--- a/lib/libesp32/berry_animation/src/tests/crenel_position_color_test.be
+++ b/lib/libesp32/berry_animation/src/tests/crenel_position_color_test.be
@@ -12,7 +12,7 @@ def test_crenel_with_integer_color()
   
   # Create engine and strip for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var frame = animation.frame_buffer(10)
   var red_color = 0xFFFF0000  # Red
@@ -51,7 +51,7 @@ def test_crenel_with_color_provider()
   
   # Create engine and strip for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var frame = animation.frame_buffer(10)
   var blue_color = 0xFF0000FF  # Blue
@@ -94,7 +94,7 @@ def test_crenel_with_dynamic_color_provider()
   
   # Create engine and strip for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var frame = animation.frame_buffer(10)
   
@@ -144,7 +144,7 @@ def test_crenel_with_generic_value_provider()
   
   # Create engine and strip for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var frame = animation.frame_buffer(10)
   
@@ -186,7 +186,7 @@ def test_crenel_set_color_methods()
   
   # Create engine and strip for testing
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var frame = animation.frame_buffer(5)
   
@@ -233,7 +233,7 @@ def test_crenel_tostring()
   
   # Create engine and strip for testing
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with integer color
   var crenel_int = animation.crenel_position_animation(engine)

--- a/lib/libesp32/berry_animation/src/tests/event_system_test.be
+++ b/lib/libesp32/berry_animation/src/tests/event_system_test.be
@@ -210,23 +210,6 @@ def test_animation_engine_event_integration()
          introspect.contains(engine, "resume")
 end
 
-# Test 12: Event Metadata Handling
-def test_event_metadata_handling()
-  var manager = animation.event_manager
-  var received_metadata = nil
-  
-  var metadata = {"interval": 1000, "repeat": true}
-  var handler = manager.register_handler("metadata_test", def(data) 
-    received_metadata = data
-  end, 0, nil, metadata)
-  
-  # Check handler info includes metadata
-  var handler_info = handler.get_info()
-  
-  return handler_info["metadata"]["interval"] == 1000 &&
-         handler_info["metadata"]["repeat"] == true
-end
-
 # Run all tests
 def run_all_tests()
   print("=== Event System Test Suite ===")
@@ -243,7 +226,6 @@ def run_all_tests()
   run_test("Event Handler Deactivation", test_event_handler_deactivation)
   run_test("Event Queue Processing", test_event_queue_processing)
   run_test("Animation Engine Event Integration", test_animation_engine_event_integration)
-  run_test("Event Metadata Handling", test_event_metadata_handling)
   
   print("=== Test Results ===")
   print(f"Total tests: {test_count}")

--- a/lib/libesp32/berry_animation/src/tests/fire_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/fire_animation_test.be
@@ -7,7 +7,7 @@ print("=== Fire Animation Test ===")
 
 # Create engine and LED strip for testing
 var strip = global.Leds(30)  # Use built-in LED strip for testing
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test 1: Basic Fire Animation Creation
 print("\n1. Testing basic fire animation creation...")
@@ -148,7 +148,7 @@ print("\n10. Testing edge cases...")
 
 # Very small strip
 var tiny_strip = global.Leds(1)
-var tiny_engine = animation.animation_engine(tiny_strip)
+var tiny_engine = animation.create_engine(tiny_strip)
 var tiny_fire = animation.fire_animation(tiny_engine)
 tiny_fire.intensity = 180
 tiny_fire.priority = 1
@@ -161,7 +161,7 @@ print("Tiny fire (1 pixel) created and rendered successfully")
 
 # Zero intensity
 var dim_strip = global.Leds(10)
-var dim_engine = animation.animation_engine(dim_strip)
+var dim_engine = animation.create_engine(dim_strip)
 var dim_fire = animation.fire_animation(dim_engine)
 dim_fire.intensity = 0
 dim_fire.priority = 10

--- a/lib/libesp32/berry_animation/src/tests/gradient_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/gradient_animation_test.be
@@ -11,7 +11,7 @@ def test_gradient_creation()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test default gradient (rainbow linear)
   var gradient = animation.gradient_animation(engine)
@@ -47,7 +47,7 @@ def test_gradient_parameters()
   print("Testing GradientAnimation parameters...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var gradient = animation.gradient_animation(engine)
   gradient.color = 0xFFFFFFFF
   gradient.name = "test"
@@ -80,7 +80,7 @@ def test_gradient_updates()
   print("Testing GradientAnimation updates...")
   
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var gradient = animation.gradient_animation(engine)
   gradient.color = 0xFF00FF00
   gradient.movement_speed = 100
@@ -109,7 +109,7 @@ def test_gradient_rendering()
   print("Testing GradientAnimation rendering...")
   
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var gradient = animation.gradient_animation(engine)
   gradient.color = 0xFFFF0000
   gradient.movement_speed = 0
@@ -141,7 +141,7 @@ def test_gradient_factory_methods()
   print("Testing GradientAnimation factory methods...")
   
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test rainbow linear factory
   var rainbow_linear = animation.gradient_rainbow_linear(engine)
@@ -170,7 +170,7 @@ def test_gradient_position_calculations()
   print("Testing GradientAnimation position calculations...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test linear gradient with different directions
   var linear_gradient = animation.gradient_animation(engine)
@@ -212,7 +212,7 @@ def test_gradient_color_refactoring()
   print("Testing GradientAnimation color refactoring...")
   
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with static color
   var static_gradient = animation.gradient_animation(engine)
@@ -250,7 +250,7 @@ def test_gradient_virtual_parameters()
   print("Testing GradientAnimation virtual parameters...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var gradient = animation.gradient_animation(engine)
   gradient.name = "test"
   
@@ -283,7 +283,7 @@ def test_gradient_tostring()
   import string
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with static color
   var static_gradient = animation.gradient_animation(engine)

--- a/lib/libesp32/berry_animation/src/tests/gradient_rainbow_test.be
+++ b/lib/libesp32/berry_animation/src/tests/gradient_rainbow_test.be
@@ -5,7 +5,7 @@ print("Testing gradient rainbow with light_state HSV conversion...")
 
 # Create LED strip and engine
 var strip = global.Leds(10)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test rainbow gradient (nil color)
 var rainbow_gradient = animation.gradient_animation(engine)

--- a/lib/libesp32/berry_animation/src/tests/gradient_simple_test.be
+++ b/lib/libesp32/berry_animation/src/tests/gradient_simple_test.be
@@ -5,7 +5,7 @@ print("Testing basic GradientAnimation functionality...")
 
 # Create LED strip and engine
 var strip = global.Leds(5)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test basic creation
 var gradient = animation.gradient_animation(engine)

--- a/lib/libesp32/berry_animation/src/tests/jitter_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/jitter_animation_test.be
@@ -12,7 +12,7 @@ def test_jitter_animation_basic()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a simple source animation
   var source = animation.solid(engine)
@@ -39,7 +39,7 @@ def test_jitter_animation_custom()
   
   # Create LED strip and engine
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FF00
@@ -70,7 +70,7 @@ def test_jitter_animation_parameters()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF0000FF
@@ -110,7 +110,7 @@ def test_jitter_animation_types()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFFFF00
@@ -144,7 +144,7 @@ def test_jitter_animation_update_render()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFF00FF
@@ -182,7 +182,7 @@ def test_jitter_animation_random()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FFFF
@@ -211,7 +211,7 @@ def test_jitter_constructors()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFAAAAAA
@@ -262,7 +262,7 @@ def test_jitter_animation_color_effects()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF808080
@@ -290,7 +290,7 @@ def test_jitter_tostring()
   
   # Create LED strip and engine
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF666666

--- a/lib/libesp32/berry_animation/src/tests/motion_effects_test.be
+++ b/lib/libesp32/berry_animation/src/tests/motion_effects_test.be
@@ -12,7 +12,7 @@ def test_bounce_animation_basic()
   
   # Create engine and source animation
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFFFF0000
   
@@ -37,7 +37,7 @@ def test_scale_animation_basic()
   
   # Create engine and source animation
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFF00FF00
   
@@ -62,7 +62,7 @@ def test_jitter_animation_basic()
   
   # Create engine and source animation
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFF0000FF
   
@@ -87,7 +87,7 @@ def test_motion_effects_custom()
   print("Testing motion effects with custom parameters...")
   
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFFFFFF00
   
@@ -156,7 +156,7 @@ def test_motion_effects_update_render()
   print("Testing motion effects update and render...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFFFF00FF
   var frame = animation.frame_buffer(10)
@@ -223,7 +223,7 @@ def test_motion_effects_constructors()
   print("Testing motion effects constructor functions...")
   
   var strip = global.Leds(30)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFF00FFFF
   
@@ -279,7 +279,7 @@ def test_motion_effects_tostring()
   print("Testing motion effects string representations...")
   
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var source = animation.solid(engine)
   source.color = 0xFFFFFFFF
   

--- a/lib/libesp32/berry_animation/src/tests/nillable_parameter_test.be
+++ b/lib/libesp32/berry_animation/src/tests/nillable_parameter_test.be
@@ -1,14 +1,16 @@
 # Test for nillable parameter attribute
 import animation
 
+import "./core/param_encoder" as encode_constraints
+
 print("Testing nillable parameter attribute...")
 
 # Create a test class with nillable and non-nillable parameters
 class TestParameterizedClass : animation.parameterized_object
-  static var PARAMS = {
+  static var PARAMS = encode_constraints({
     "nillable_param": {"type": "int", "nillable": true},
     "non_nillable_param": {"type": "int"}  # No default, no nillable
-  }
+  })
   
   def init(engine)
     super(self).init(engine)
@@ -17,7 +19,7 @@ end
 
 # Create LED strip and engine
 var strip = global.Leds(5)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test nillable parameter
 var test_obj = TestParameterizedClass(engine)

--- a/lib/libesp32/berry_animation/src/tests/noise_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/noise_animation_test.be
@@ -12,7 +12,7 @@ def test_noise_animation_basic()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with default parameters
   var noise_anim = animation.noise_animation(engine)
@@ -32,7 +32,7 @@ def test_noise_animation_custom()
   
   # Create LED strip and engine
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with custom parameters
   var noise_anim = animation.noise_animation(engine)
@@ -64,7 +64,7 @@ def test_noise_animation_parameters()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var noise_anim = animation.noise_animation(engine)
   
@@ -91,7 +91,7 @@ def test_noise_animation_update_render()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var noise_anim = animation.noise_animation(engine)
   noise_anim.color = 0xFFFF0000
@@ -133,7 +133,7 @@ def test_noise_constructors()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test noise_rainbow
   var rainbow_noise = animation.noise_rainbow(engine)
@@ -164,7 +164,7 @@ def test_noise_tostring()
   
   # Create LED strip and engine
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var noise_anim = animation.noise_animation(engine)
   noise_anim.scale = 75
@@ -188,7 +188,7 @@ def test_noise_integer_color_conversion()
   
   # Create LED strip and engine
   var strip = global.Leds(5)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var noise_anim = animation.noise_animation(engine)
   

--- a/lib/libesp32/berry_animation/src/tests/oscillator_ease_test.be
+++ b/lib/libesp32/berry_animation/src/tests/oscillator_ease_test.be
@@ -8,7 +8,7 @@ import string
 
 # Create a real engine for testing using global.Leds()
 var strip = global.Leds(10)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test the EASE_IN waveform
 def test_ease_in_waveform()

--- a/lib/libesp32/berry_animation/src/tests/oscillator_elastic_bounce_test.be
+++ b/lib/libesp32/berry_animation/src/tests/oscillator_elastic_bounce_test.be
@@ -8,7 +8,7 @@ import string
 
 # Create a real engine for testing using global.Leds()
 var strip = global.Leds(10)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 # Test the ELASTIC waveform
 def test_elastic_waveform()

--- a/lib/libesp32/berry_animation/src/tests/parameter_validation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/parameter_validation_test.be
@@ -6,13 +6,15 @@
 import animation
 import global
 
+import "./core/param_encoder" as encode_constraints
+
 # Test that parameters accept ValueProviders and integers only
 def test_parameter_accepts_value_providers()
   print("Testing parameter validation with ValueProviders...")
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a test animation using new constructor pattern
   var test_anim = animation.animation(engine)
@@ -48,7 +50,7 @@ def test_loop_boolean_validation()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a test animation
   var test_anim = animation.animation(engine)
@@ -77,7 +79,7 @@ def test_range_validation()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a test animation
   var test_anim = animation.animation(engine)
@@ -96,7 +98,7 @@ def test_range_validation_with_providers()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a test animation
   var test_anim = animation.animation(engine)
@@ -123,18 +125,18 @@ def test_type_validation()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a test class with different parameter types
   class TestClass : animation.parameterized_object
-    static var PARAMS = {
+    static var PARAMS = encode_constraints({
       "int_param": {"default": 42},                    # Default type is "int"
       "explicit_int_param": {"type": "int", "default": 10},
       "string_param": {"type": "string", "default": "hello"},
       "bool_param": {"type": "bool", "default": true},
       "instance_param": {"type": "instance", "default": nil},
       "any_param": {"type": "any", "default": nil}
-    }
+    })
     
     def init(engine)
       super(self).init(engine)

--- a/lib/libesp32/berry_animation/src/tests/plasma_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/plasma_animation_test.be
@@ -12,7 +12,7 @@ def test_plasma_animation_basic()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with default parameters
   var plasma_anim = animation.plasma_animation(engine)
@@ -36,7 +36,7 @@ def test_plasma_animation_custom()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with custom parameters using virtual member assignment
   var plasma_anim = animation.plasma_animation(engine)
@@ -71,7 +71,7 @@ def test_plasma_animation_parameters()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var plasma_anim = animation.plasma_animation(engine)
   plasma_anim.name = "param_test"
@@ -102,7 +102,7 @@ def test_plasma_animation_update_render()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var plasma_anim = animation.plasma_animation(engine)
   plasma_anim.color = 0xFFFF0000
@@ -146,7 +146,7 @@ def test_plasma_constructors()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test plasma_rainbow
   var rainbow_plasma = animation.plasma_rainbow(engine)
@@ -170,7 +170,7 @@ def test_plasma_tostring()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var plasma_anim = animation.plasma_animation(engine)
   plasma_anim.freq_x = 55

--- a/lib/libesp32/berry_animation/src/tests/pulse_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/pulse_animation_test.be
@@ -13,7 +13,7 @@ print("Imported animation module")
 
 # Create LED strip and engine for testing
 var strip = global.Leds(10)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 print("Created engine and LED strip")
 
 # Create a pulse animation with new constructor (engine only)

--- a/lib/libesp32/berry_animation/src/tests/rich_palette_animation_class_test.be
+++ b/lib/libesp32/berry_animation/src/tests/rich_palette_animation_class_test.be
@@ -11,7 +11,7 @@ print("Imported animation module")
 
 # Create LED strip and engine for testing (following specification)
 var strip = global.Leds(10)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 print("Created test engine with 10 LEDs")
 

--- a/lib/libesp32/berry_animation/src/tests/scale_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/scale_animation_test.be
@@ -12,7 +12,7 @@ def test_scale_animation_basic()
   
   # Create LED strip and engine using global.Leds
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a simple source animation
   var source = animation.solid(engine)
@@ -38,7 +38,7 @@ def test_scale_animation_custom()
   
   # Create LED strip and engine
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FF00
@@ -67,7 +67,7 @@ def test_scale_animation_parameters()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF0000FF
@@ -104,7 +104,7 @@ def test_scale_animation_modes()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFFFF00
@@ -155,7 +155,7 @@ def test_scale_animation_interpolation()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF808080
@@ -184,7 +184,7 @@ def test_scale_animation_sine()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF000000
@@ -217,7 +217,7 @@ def test_scale_animation_update_render()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFF00FF
@@ -257,7 +257,7 @@ def test_scale_constructors()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FFFF
@@ -296,7 +296,7 @@ def test_scale_tostring()
   
   # Create LED strip and engine
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF444444

--- a/lib/libesp32/berry_animation/src/tests/sequence_manager_test.be
+++ b/lib/libesp32/berry_animation/src/tests/sequence_manager_test.be
@@ -34,7 +34,7 @@ def test_sequence_manager_step_creation()
   
   # Create test animation using new parameterized API
   var strip = global.Leds(30)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var color_provider = animation.static_color(engine)
   color_provider.color = 0xFFFF0000
   var test_anim = animation.solid(engine)
@@ -183,10 +183,6 @@ def test_sequence_manager_step_info()
   var engine = animation.create_engine(strip)
   var seq_manager = animation.SequenceManager(engine)
   
-  # Test step info when not running
-  var step_info = seq_manager.get_current_step_info()
-  assert(step_info == nil, "Step info should be nil when not running")
-  
   # Create test sequence using new parameterized API
   var color_provider = animation.static_color(engine)
   color_provider.color = 0xFFFF0000
@@ -205,14 +201,6 @@ def test_sequence_manager_step_info()
   engine.add(seq_manager)
   engine.run()  # Start the engine
   engine.on_tick(30000)  # Update engine time
-  
-  # Get step info
-  step_info = seq_manager.get_current_step_info()
-  assert(step_info != nil, "Step info should not be nil when running")
-  assert(step_info["step_index"] == 0, "Step info should show correct step index")
-  assert(step_info["total_steps"] == 2, "Step info should show correct total steps")
-  assert(step_info["current_step"]["type"] == "play", "Step info should show correct step type")
-  assert(step_info["elapsed_ms"] >= 0, "Step info should show elapsed time")
   
   print("✓ Step info tests passed")
 end

--- a/lib/libesp32/berry_animation/src/tests/shift_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/shift_animation_test.be
@@ -12,7 +12,7 @@ def test_shift_animation_basic()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a simple source animation
   var source = animation.solid(engine)
@@ -37,7 +37,7 @@ def test_shift_animation_custom()
   
   # Create LED strip and engine
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FF00
@@ -68,7 +68,7 @@ def test_shift_animation_parameters()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF0000FF
@@ -100,7 +100,7 @@ def test_shift_animation_update_render()
   
   # Create LED strip and engine
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFFFF00
@@ -144,7 +144,7 @@ def test_shift_constructors()
   
   # Create LED strip and engine
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFFFF00FF
@@ -183,7 +183,7 @@ def test_shift_tostring()
   
   # Create LED strip and engine
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var source = animation.solid(engine)
   source.color = 0xFF00FFFF

--- a/lib/libesp32/berry_animation/src/tests/solid_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/solid_animation_test.be
@@ -11,7 +11,7 @@ print("Imported animation module")
 
 # Create LED strip and engine for testing (following specification)
 var strip = global.Leds(10)  # Use global.Leds() for testing as per specification
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 print("Created test engine with 10 LEDs")
 

--- a/lib/libesp32/berry_animation/src/tests/solid_unification_test.be
+++ b/lib/libesp32/berry_animation/src/tests/solid_unification_test.be
@@ -6,7 +6,7 @@ import animation
 
 # Create test engine (following specification)
 var strip = global.Leds(10)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 
 def test_unified_solid_function()
   print("Testing unified solid() function...")

--- a/lib/libesp32/berry_animation/src/tests/sparkle_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/sparkle_animation_test.be
@@ -12,7 +12,7 @@ def test_sparkle_animation_basic()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with default parameters
   var sparkle_anim = animation.sparkle_animation(engine)
@@ -35,7 +35,7 @@ def test_sparkle_animation_custom()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with custom parameters using new parameterized pattern
   var sparkle_anim = animation.sparkle_animation(engine)
@@ -70,7 +70,7 @@ def test_sparkle_animation_parameters()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var sparkle_anim = animation.sparkle_animation(engine)
   sparkle_anim.name = "param_test"
@@ -102,7 +102,7 @@ def test_sparkle_animation_update_render()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var sparkle_anim = animation.sparkle_animation(engine)
   sparkle_anim.color = 0xFFFF0000
@@ -153,7 +153,7 @@ def test_sparkle_constructors()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test sparkle_white
   var white_sparkle = animation.sparkle_white(engine)
@@ -185,7 +185,7 @@ def test_sparkle_tostring()
   
   # Create LED strip and engine for testing
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var sparkle_anim = animation.sparkle_animation(engine)
   sparkle_anim.density = 75

--- a/lib/libesp32/berry_animation/src/tests/static_value_provider_test.be
+++ b/lib/libesp32/berry_animation/src/tests/static_value_provider_test.be
@@ -12,7 +12,7 @@ def test_static_value_provider_interface()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   
@@ -34,7 +34,7 @@ def test_static_value_provider_types()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test with integer
   var int_provider = animation.static_value(engine)
@@ -60,7 +60,7 @@ def test_universal_get_methods()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   provider.value = 99
@@ -96,7 +96,7 @@ def test_comparison_operators()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   provider.value = 50
@@ -118,7 +118,7 @@ def test_parameterized_object_integration()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   
@@ -144,7 +144,7 @@ def test_value_changes()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   
@@ -170,7 +170,7 @@ def test_string_representation()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.static_value(engine)
   provider.value = 42

--- a/lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be
+++ b/lib/libesp32/berry_animation/src/tests/strip_length_provider_test.be
@@ -49,7 +49,7 @@ def test_basic_functionality()
   for length : test_lengths
     # Create mock strip and engine
     var strip = MockStrip(length)
-    var engine = animation.animation_engine(strip)
+    var engine = animation.create_engine(strip)
     
     # Create StripLengthProvider
     var provider = animation.strip_length(engine)
@@ -75,7 +75,7 @@ def test_string_representation()
   print("  Testing string representation...")
   
   var strip = MockStrip(42)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var provider = animation.strip_length(engine)
   
   var str_repr = str(provider)
@@ -106,7 +106,7 @@ def test_integration()
   print("  Testing integration with animation system...")
   
   var strip = MockStrip(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var provider = animation.strip_length(engine)
   
   # Test that it's recognized as a value provider
@@ -128,7 +128,7 @@ def test_engine_consistency()
   print("  Testing consistency with engine properties...")
   
   var strip = MockStrip(100)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var provider = animation.strip_length(engine)
   
   # Test that provider returns same value as engine properties

--- a/lib/libesp32/berry_animation/src/tests/test_all.be
+++ b/lib/libesp32/berry_animation/src/tests/test_all.be
@@ -47,6 +47,7 @@ def run_all_tests()
 
     # Core framework tests
     "lib/libesp32/berry_animation/src/tests/frame_buffer_test.be",
+    "lib/libesp32/berry_animation/src/tests/constraint_encoding_test.be",  # Tests parameter constraint encoding/decoding
     "lib/libesp32/berry_animation/src/tests/nillable_parameter_test.be",
     "lib/libesp32/berry_animation/src/tests/parameterized_object_test.be",  # Tests parameter management base class
     "lib/libesp32/berry_animation/src/tests/bytes_type_test.be",  # Tests bytes type validation in parameterized objects

--- a/lib/libesp32/berry_animation/src/tests/twinkle_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/twinkle_animation_test.be
@@ -13,7 +13,7 @@ print("=== Comprehensive Twinkle Animation Test ===")
 # Test 1: Basic Twinkle Animation Creation
 print("\n1. Testing basic twinkle animation creation...")
 var strip = global.Leds(30)
-var engine = animation.animation_engine(strip)
+var engine = animation.create_engine(strip)
 var twinkle = animation.twinkle_animation(engine)
 twinkle.color = 0xFFFFFFFF
 twinkle.density = 128
@@ -384,7 +384,7 @@ print("\n16. Testing edge cases...")
 
 # Very small strip
 var tiny_strip = global.Leds(1)
-var tiny_engine = animation.animation_engine(tiny_strip)
+var tiny_engine = animation.create_engine(tiny_strip)
 var tiny_twinkle = animation.twinkle_classic(tiny_engine)
 tiny_twinkle.density = 200
 tiny_twinkle.start()

--- a/lib/libesp32/berry_animation/src/tests/value_provider_test.be
+++ b/lib/libesp32/berry_animation/src/tests/value_provider_test.be
@@ -5,13 +5,15 @@
 
 import animation
 
+import "./core/param_encoder" as encode_constraints
+
 # Test the basic ValueProvider interface
 def test_value_provider_interface()
   print("Testing ValueProvider interface...")
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.value_provider(engine)
   
@@ -32,14 +34,14 @@ def test_custom_value_provider()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a simple time-based provider using new API
   class TimeBasedProvider : animation.value_provider
     # Parameter definitions
-    static var PARAMS = {
+    static var PARAMS = encode_constraints({
       "multiplier": {"default": 1}
-    }
+    })
     
     def init(engine)
       super(self).init(engine)
@@ -71,7 +73,7 @@ def test_is_value_provider()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var base_provider = animation.value_provider(engine)
   
@@ -89,7 +91,7 @@ def test_parameterized_object_integration()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   var provider = animation.value_provider(engine)
   
@@ -113,7 +115,7 @@ def test_lifecycle_methods()
   
   # Create engine for testing
   var strip = global.Leds()
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Create a provider that tracks start calls
   class LifecycleProvider : animation.value_provider

--- a/lib/libesp32/berry_animation/src/tests/wave_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/wave_animation_test.be
@@ -12,7 +12,7 @@ def test_wave_animation_basic()
   
   # Create engine and animation
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var wave_anim = animation.wave_animation(engine)
   
   assert(wave_anim != nil, "WaveAnimation should be created")
@@ -34,7 +34,7 @@ def test_wave_animation_custom()
   
   # Create engine and animation with custom parameters
   var strip = global.Leds(20)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var wave_anim = animation.wave_animation(engine)
   
   # Set custom parameters using virtual member access
@@ -69,7 +69,7 @@ def test_wave_animation_parameters()
   print("Testing WaveAnimation parameter changes...")
   
   var strip = global.Leds(15)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var wave_anim = animation.wave_animation(engine)
   
   # Test parameter changes using virtual member access
@@ -96,7 +96,7 @@ def test_wave_animation_update_render()
   print("Testing WaveAnimation update and render...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var wave_anim = animation.wave_animation(engine)
   
   # Set parameters
@@ -141,7 +141,7 @@ def test_wave_types()
   print("Testing different wave types...")
   
   var strip = global.Leds(10)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var frame = animation.frame_buffer(10)
   
   # Test each wave type
@@ -172,7 +172,7 @@ def test_wave_constructors()
   print("Testing wave constructor functions...")
   
   var strip = global.Leds(30)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   
   # Test wave_rainbow_sine
   var rainbow_wave = animation.wave_rainbow_sine(engine)
@@ -203,7 +203,7 @@ def test_wave_tostring()
   print("Testing WaveAnimation string representation...")
   
   var strip = global.Leds(12)
-  var engine = animation.animation_engine(strip)
+  var engine = animation.create_engine(strip)
   var wave_anim = animation.wave_animation(engine)
   
   # Set parameters

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -621,8 +621,8 @@
   #define USE_LIGHT_ARTNET_MCAST 239,255,25,54   // Multicast address used to listen: 239.255.25.54
 
   #define USE_BERRY_ANIMATE                      // Legacy tentative for LED animation framework, DEPRECATED
-  // #define USE_BERRY_ANIMATION                    // New animation framework with dedicated language (ESP32x only, experimental, 117k not yet optimized)
-    // #define USE_BERRY_ANIMATION_DSL                // DSL transpiler for new animation framework (not mandatory if DSL is transpiled externally, +59k not optimized yet)
+  // #define USE_BERRY_ANIMATION                    // New animation framework with dedicated language (ESP32x only, experimental, 94k not yet optimized)
+    // #define USE_BERRY_ANIMATION_DSL                // DSL transpiler for new animation framework (not mandatory if DSL is transpiled externally, +98k not optimized yet)
 
 // -- Counter input -------------------------------
 #define USE_COUNTER                              // Enable inputs as counter (+0k8 code)


### PR DESCRIPTION
## Description:

Berry animation optimizations:
- use `C` native pixel implementation in `frame_buffer`, reduces size and improves performance
- encode `PARAMS` as `bytes()` instead of `map`
- more optimizations

Overall code reduction 6k, no functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
