### PR TITLE
Berry fixed 'be_top is non zero' warning when calling C mapped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Platform from 2025.09.30 to 2025.10.30, Framework (Arduino Core) from v3.1.3.250808 to v3.1.4 and IDF from v5.3.3.250801 to v5.3.4.250826 (#23971)
 
 ### Fixed
+- Berry fixed 'be_top is non zero' warning when calling C mapped functions
 
 ### Removed
 

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -11,6 +11,7 @@
 
 #include "be_mapping.h"
 #include "be_exec.h"
+#include "be_vm.h"
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -580,8 +581,15 @@ int be_call_c_func(bvm *vm, const void * func, const char * return_type, const c
   if (return_type != NULL && return_type[0] == '&') {
     if (c_args < 8) { p[c_args] = (intptr_t) &return_len; }
   }
+  // We do some special trickery here, we need to set be_top to zero
+  // but in the same time we need to keep argument '1' to set the instance
+  // later. So we increment first vm->reg and we set vm->top to the same value
+  vm->reg++;
+  vm->top = vm->reg;
   intptr_t ret = 0;
   if (f) ret = (*f)(p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+  // now we restore vm->reg
+  vm->reg--;
   // berry_log_C("be_call_c_func '%s' -> '%s': (%i,%i,%i,%i,%i,%i) -> %i", return_type, arg_type, p[0], p[1], p[2], p[3], p[4], p[5], ret);
 
   if ((return_type == NULL) || (strlen(return_type) == 0))       { be_return_nil(vm); }  // does not return

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -584,12 +584,14 @@ int be_call_c_func(bvm *vm, const void * func, const char * return_type, const c
   // We do some special trickery here, we need to set be_top to zero
   // but in the same time we need to keep argument '1' to set the instance
   // later. So we increment first vm->reg and we set vm->top to the same value
-  vm->reg++;
+  uint32_t reg_save = (argc > 0) ? 1 : 0;
+  vm->reg += reg_save;
   vm->top = vm->reg;
   intptr_t ret = 0;
   if (f) ret = (*f)(p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
   // now we restore vm->reg
-  vm->reg--;
+  vm->reg -= reg_save;
+  vm->top = vm->reg + reg_save;
   // berry_log_C("be_call_c_func '%s' -> '%s': (%i,%i,%i,%i,%i,%i) -> %i", return_type, arg_type, p[0], p[1], p[2], p[3], p[4], p[5], ret);
 
   if ((return_type == NULL) || (strlen(return_type) == 0))       { be_return_nil(vm); }  // does not return


### PR DESCRIPTION
## Description:

Berry, fixed occasional warning showing 'be_top is non zero'. This would happen when calling C mapped functions that indirectly call other Berry vm functions.
No functional impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
