### PR TITLE
TLS fix ECDSA and add 'SetOption165 1' to enable ECDSA in addition to RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Berry fixed 'be_top is non zero' warning when calling C mapped functions (#23989)
 - Berry fixed 'be_top is non zero' when `Br` command fails (#23990)
+- TLS fix ECDSA and add `SetOption165 1` to enable ECDSA in addition to RSA
 
 ### Removed
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -930,8 +930,8 @@ extern "C" {
     br_ssl_engine_set_ghash(&cc->eng, &br_ghash_ctmul32);
 
     // we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
-    br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15); // TODO
-#ifndef ESP8266
+    br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);
+#ifdef ESP32
     br_ssl_engine_set_ecdsa(&cc->eng, &br_ecdsa_i15_vrfy_asn1);
 #endif
   }
@@ -986,6 +986,9 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
       br_x509_minimal_init(x509_minimal, &br_sha256_vtable, _ta_P, _ta_size);
       br_x509_minimal_set_rsa(x509_minimal, br_ssl_engine_get_rsavrfy(_eng));
       br_x509_minimal_set_hash(x509_minimal, br_sha256_ID, &br_sha256_vtable);
+#ifdef ESP32
+      br_x509_minimal_set_ecdsa(x509_minimal, &br_ec_all_m15, &br_ecdsa_i15_vrfy_asn1);
+#endif // ESP32
       br_ssl_engine_set_x509(_eng, &x509_minimal->vtable);
       uint32_t now = UtcTime();
       uint32_t cfg_time = CfgTime();

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -120,6 +120,9 @@ class WiFiClientSecure_light : public WiFiClient {
         return br_ssl_engine_last_error(_eng);
       }
     }
+    int32_t getLastCipherSuite(void) {
+      return _eng->session.cipher_suite;
+    }
     inline void setLastError(int32_t err) {
       _last_error = err;
     }
@@ -131,6 +134,9 @@ class WiFiClientSecure_light : public WiFiClient {
     }
 
     void setInsecure();
+    void setECDSA(bool ecdsa) {
+      _rsa_only = !ecdsa;
+    };
 
     void setDomainName(const char * domain) {
       _domain = domain;

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -199,7 +199,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t no_export_energy_today : 1;   // bit 16 (v14.3.0.7) - SetOption162 - (Energy) Do not add export energy to energy today (1)
     uint32_t gui_device_name : 1;          // bit 17 (v14.4.1.1) - SetOption163 - GUI_NOSHOW_DEVICENAME - (GUI) Disable display of GUI device name (1)
     uint32_t wizmote_enabled : 1;          // bit 18 (v14.4.1.4) - SetOption164 - (WizMote) Enable WiZ Smart Remote support (1)
-    uint32_t spare19 : 1;                  // bit 19
+    uint32_t tls_use_ecdsa : 1;            // bit 19 (v15.0.1.0) - SetOption165 - (TLS) Enable ECDSA validation in addition to RSA
     uint32_t spare20 : 1;                  // bit 20
     uint32_t spare21 : 1;                  // bit 21
     uint32_t spare22 : 1;                  // bit 22

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -173,8 +173,9 @@
 #define MQTT_INDEX_SEPARATOR   false             // [SetOption64] Enable "_" instead of "-" as sensor index separator
 #define MQTT_TUYA_RECEIVED     false             // [SetOption66] Enable TuyaMcuReceived messages over Mqtt
 #define MQTT_ONLY_JSON_OUTPUT  false             // [SetOption90] Disable non-json messages
-#define MQTT_TLS_ENABLED       false             // [SetOption103] Enable TLS mode (requires TLS version)
-#define MQTT_TLS_FINGERPRINT   false             // [SetOption132] Force TLS fingerprint validation instead of CA (requires TLS version)
+#define MQTT_TLS_ENABLED       false             // [SetOption103] Enable TLS mode
+#define MQTT_TLS_FINGERPRINT   false             // [SetOption132] Force TLS fingerprint validation instead of CA
+#define MQTT_TLS_ECDSA         false             // [SetOption165] Enable TLS ECDSA validation in addition to RSA, false by default but automatically set to 'true' in case of a cipher error '296'
 
 // -- HTTP ----------------------------------------
 #define WEB_SERVER             2                 // [WebServer] Web server (0 = Off, 1 = Start as User, 2 = Start as Admin)

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -1448,6 +1448,7 @@ void SettingsDefaultSet2(void) {
 
   // Matter
   flag6.matter_enabled |= MATTER_ENABLED;
+  flag6.tls_use_ecdsa |= MQTT_TLS_ECDSA;
 
   Settings->flag = flag;
   Settings->flag2 = flag2;


### PR DESCRIPTION
## Description:

Multiple fixes to TLS ECDSA:
- ECDSA is enabled for EC certificates which is now the default in letsencrypt. However the current implementation was failing with error 49 - now fixed.
- ECDSA is disabled by default to avoid regression with fingerprint validation, since fingerprints are different from RSA to ECDSA certificates, and it's the server that decides which certificate to use if both are present. See #22656
- `SetOption165 1` enables ECDSA in addition to RSA. `SetOption165 1` is automatically done if a TLS error 296 (incorrect cipher) is detected, to ensure smooth compatibility with letsencrypt. When using letsencrypt/EC, the first connection (RSA only) will fail, then `SetOption165 1` is enabled and the second connection succeeds.
- Added logs to indicate which cipher is used, Example:

```
MQT: TLS cipher suite: ECDHE_RSA_AES_128_GCM_SHA256
```

Note: ECDSA is not enabled on ESP8266 (yet, maybe next to come)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
