### PR TITLE
i2c_driver.be - Added a read_bit function as there is also a write_bit function.

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/i2c_driver.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/i2c_driver.be
@@ -118,6 +118,13 @@ class I2C_Driver
     var buf = self.wire.read_bytes(self.addr, reg, 4)
     return (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3]
   end
+
+  # Reads a specific bit from a register
+  # read_bit(reg:int, bit:int) -> bool
+  def read_bit(reg, bit)
+    if bit < 0 || bit > 7 return end
+    return bool(self.read8(reg) & 1 << bit)
+  end
 end
 
 #- Example


### PR DESCRIPTION
Added a read_bit function as there is also a write_bit function.

## Description:

Berry class I2C_Driver had a write_bit function and should have also a read_bit function. Not because it's complex to implement it directly, but more to have consistent class following the principle of least surprise.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
