### PR TITLE
Add type checking to byteslib

### DIFF
--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -854,8 +854,12 @@ static int m_add(bvm *vm)
     if (argc >= 2 && be_isint(vm, 2)) {
         int32_t v = be_toint(vm, 2);
         int vsize = 1;
-        if (argc >= 3 && be_isint(vm, 3)) {
-            vsize = be_toint(vm, 3);
+        if (argc >= 3) {
+            if (be_isint(vm, 3)) {
+                vsize = be_toint(vm, 3);
+            } else {
+                goto type_error;
+            }
         }
         switch (vsize) {
             case 0:                               break;
@@ -873,6 +877,8 @@ static int m_add(bvm *vm)
         m_write_attributes(vm, 1, &attr);  /* update attributes */
         be_return(vm);
     }
+type_error:
+    be_raise(vm, "type_error", "operands must be int");
     be_return_nil(vm);
 }
 
@@ -928,6 +934,7 @@ static int m_get(bvm *vm, bbool sign)
         be_pushint(vm, ret);
         be_return(vm);
     }
+    be_raise(vm, "type_error", "operands must be int");
     be_return_nil(vm);
 }
 
@@ -958,6 +965,7 @@ static int m_getfloat(bvm *vm)
         be_pushreal(vm, ret_f);
         be_return(vm);
     }
+    be_raise(vm, "type_error", "operands must be int");
     be_return_nil(vm);
 }
 
@@ -990,8 +998,12 @@ static int m_set(bvm *vm)
         int32_t idx = be_toint(vm, 2);
         int32_t value = be_toint(vm, 3);
         int vsize = 1;
-        if (argc >= 4 && be_isint(vm, 4)) {
-            vsize = be_toint(vm, 4);
+        if (argc >= 4) {
+            if (be_isint(vm, 4)) {
+                vsize = be_toint(vm, 4);
+            } else {
+                goto type_error;
+            }
         }
         if (idx < 0) {
             idx = attr.len + idx;       /* if index is negative, count from end */
@@ -1015,6 +1027,8 @@ static int m_set(bvm *vm)
         // m_write_attributes(vm, 1, &attr);  /* update attributes */
         be_return_nil(vm);
     }
+type_error:
+    be_raise(vm, "type_error", "operands must be int");
     be_return_nil(vm);
 }
 
@@ -1046,6 +1060,7 @@ static int m_setfloat(bvm *vm)
         }
         be_return_nil(vm);
     }
+    be_raise(vm, "type_error", "operands must be int or float");
     be_return_nil(vm);
 }
 
@@ -1072,6 +1087,7 @@ static int m_addfloat(bvm *vm)
         m_write_attributes(vm, 1, &attr);  /* update attributes */
         be_return(vm);
     }
+    be_raise(vm, "type_error", "operands must be int or float");
     be_return_nil(vm);
 }
 
@@ -1117,6 +1133,8 @@ static int m_setbytes(bvm *vm)
         if (from_len > 0) {
             memmove(attr.bufptr + idx, buf_ptr + from_byte, from_len);
         }
+    } else {
+        be_raise(vm, "type_error", "operands must be int and bytes");
     }
     be_return_nil(vm);
 }

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -53,11 +53,6 @@ b.add(0x12345678, -2)
 assert(str(b) == "bytes('2278785678563412785678')")
 b.add(0x12345678, -4)
 assert(str(b) == "bytes('227878567856341278567812345678')")
-b.add(0xAABBCC, 3)
-assert(str(b) == "bytes('227878567856341278567812345678CCBBAA')")
-b.add(0x998877, -3)
-assert(str(b) == "bytes('227878567856341278567812345678CCBBAA998877')")
-
 
 #- get -#
 b=bytes("000102030405")
@@ -355,8 +350,34 @@ b = bytes("AABBCC")
 assert(bytes().fromstring(bytes("11").tob64()) == bytes('45513D3D'))
 assert(b.appendb64(c, 1, 1) == bytes("AABBCC45513D3D"))
 
-#- asstring truncates if NULL is present -#
-s=bytes("414243").asstring()
-assert(size(s) == 3)
-s=bytes("410000").asstring()
-assert(size(s) == 1)
+# bytes assign 3-byte values
+b = bytes("1122")
+assert(b.add(0x334455, 3) == bytes('1122554433'))
+assert(b.add(0x334455, -3) == bytes('1122554433334455'))
+
+# new type testing in set/add methods
+b = bytes("0000000000")
+
+assert_error(def () b.set(0, 0.5, 4) end, 'type_error')
+assert_error(def () b.set(0, nil, 4) end, 'type_error')
+assert_error(def () b.set(0, 1, nil) end, 'type_error')
+assert_error(def () b.set(0, 1, 3.5) end, 'type_error')
+assert_error(def () b.set(0, 'foo', 4) end, 'type_error')
+assert_error(def () b.set(0, 4, 'foo') end, 'type_error')
+assert_error(def () b.set(0, 0.5) end, 'type_error')
+assert_error(def () b.set(0, nil) end, 'type_error')
+assert_error(def () b.set(0, 'foo') end, 'type_error')
+assert_error(def () b.set() end, 'type_error')
+
+assert_error(def () b.add(0.5, 4) end, 'type_error')
+assert_error(def () b.add(nil, 4) end, 'type_error')
+assert_error(def () b.add(5, 1.5) end, 'type_error')
+assert_error(def () b.add(5, nil) end, 'type_error')
+assert_error(def () b.add('foo', 4) end, 'type_error')
+assert_error(def () b.add(5, 'foo') end, 'type_error')
+assert_error(def () b.add() end, 'type_error')
+
+assert_error(def () b.addfloat(true) end, 'type_error')
+assert_error(def () b.addfloat(nil) end, 'type_error')
+assert_error(def () b.addfloat('foo') end, 'type_error')
+assert_error(def () b.addfloat() end, 'type_error')


### PR DESCRIPTION
## Description:

Add stricter type checking to byteslib functions, from upstream https://github.com/berry-lang/berry/pull/490.
No functional change

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
