### PR TITLE
add PSRAM speed seeting for P4

### DIFF
--- a/boards/esp32p4.json
+++ b/boards/esp32p4.json
@@ -6,6 +6,7 @@
     ],
     "f_cpu": "360000000L",
     "f_flash": "80000000L",
+    "f_psram": "200000000L",
     "flash_mode": "qio",
     "mcu": "esp32p4",
     "variant": "esp32p4",

--- a/boards/esp32p4_ev.json
+++ b/boards/esp32p4_ev.json
@@ -6,6 +6,7 @@
     ],
     "f_cpu": "360000000L",
     "f_flash": "80000000L",
+    "f_psram": "200000000L",
     "flash_mode": "qio",
     "mcu": "esp32p4",
     "variant": "esp32p4",

--- a/boards/esp32p4ser.json
+++ b/boards/esp32p4ser.json
@@ -6,6 +6,7 @@
     ],
     "f_cpu": "360000000L",
     "f_flash": "80000000L",
+    "f_psram": "200000000L",
     "flash_mode": "qio",
     "mcu": "esp32p4",
     "variant": "esp32p4",


### PR DESCRIPTION
## Description:

needed for HybridCompile. No change in standard Arduino framework

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
